### PR TITLE
fix: add custom_mask shape validation in single_prefill_with_kv_cache

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1277,6 +1277,13 @@ def single_prefill_with_kv_cache(
     if rope_theta is None:
         rope_theta = 1e4
     if custom_mask is not None and packed_custom_mask is None:
+        # Validate custom_mask shape matches (qo_len, kv_len)
+        kv_len = k.size(0) if kv_layout == "NHD" else k.size(1)
+        if custom_mask.shape != (q.size(0), kv_len):
+            raise ValueError(
+                f"custom_mask tensor must have shape ({q.size(0)}, {kv_len}) "
+                f"matching (qo_len, kv_len), but got {custom_mask.shape}."
+            )
         # create packed custom mask from custom mask
         packed_custom_mask = packbits(
             custom_mask.contiguous().view(-1), bitorder="little"

--- a/tests/attention/test_custom_mask_validation.py
+++ b/tests/attention/test_custom_mask_validation.py
@@ -25,9 +25,7 @@ pytestmark = pytest.mark.skipif(
 
 def _make_qkv(qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, kv_layout):
     """Create ``q``/``k``/``v`` tensors honoring the requested ``kv_layout``."""
-    q = torch.randn(
-        qo_len, num_qo_heads, head_dim, dtype=torch.float16, device=DEVICE
-    )
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=torch.float16, device=DEVICE)
     if kv_layout == "NHD":
         kv_shape = (kv_len, num_kv_heads, head_dim)
     else:  # HND
@@ -45,9 +43,7 @@ def test_custom_mask_valid_shape_passes(kv_layout):
     qo_len, kv_len = 16, 32
     num_qo_heads = num_kv_heads = 4
     head_dim = 128
-    q, k, v = _make_qkv(
-        qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, kv_layout
-    )
+    q, k, v = _make_qkv(qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, kv_layout)
     mask = torch.ones(qo_len, kv_len, dtype=torch.bool, device=DEVICE)
 
     o = flashinfer.single_prefill_with_kv_cache(
@@ -74,9 +70,7 @@ def test_custom_mask_invalid_shape_raises(kv_layout, bad_shape_fn):
     qo_len, kv_len = 16, 32
     num_qo_heads = num_kv_heads = 4
     head_dim = 128
-    q, k, v = _make_qkv(
-        qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, kv_layout
-    )
+    q, k, v = _make_qkv(qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, kv_layout)
     bad_shape = bad_shape_fn(qo_len, kv_len)
     mask = torch.ones(*bad_shape, dtype=torch.bool, device=DEVICE)
 
@@ -93,9 +87,7 @@ def test_custom_mask_none_skips_validation():
     qo_len, kv_len = 16, 32
     num_qo_heads = num_kv_heads = 4
     head_dim = 128
-    q, k, v = _make_qkv(
-        qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, "NHD"
-    )
+    q, k, v = _make_qkv(qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, "NHD")
 
     o = flashinfer.single_prefill_with_kv_cache(q, k, v, custom_mask=None)
     assert o.shape == (qo_len, num_qo_heads, head_dim)
@@ -105,14 +97,10 @@ def test_packed_custom_mask_skips_validation():
     qo_len, kv_len = 16, 32
     num_qo_heads = num_kv_heads = 4
     head_dim = 128
-    q, k, v = _make_qkv(
-        qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, "NHD"
-    )
+    q, k, v = _make_qkv(qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, "NHD")
 
     full_mask = torch.ones(qo_len, kv_len, dtype=torch.bool, device=DEVICE)
-    packed = flashinfer.packbits(
-        full_mask.contiguous().view(-1), bitorder="little"
-    )
+    packed = flashinfer.packbits(full_mask.contiguous().view(-1), bitorder="little")
     # A deliberately wrong-shaped ``custom_mask`` must be ignored when a packed
     # mask is supplied, so no ValueError should be raised.
     wrong_mask = torch.ones(qo_len - 1, kv_len, dtype=torch.bool, device=DEVICE)

--- a/tests/attention/test_custom_mask_validation.py
+++ b/tests/attention/test_custom_mask_validation.py
@@ -1,0 +1,123 @@
+"""Unit tests for ``custom_mask`` shape validation in
+``single_prefill_with_kv_cache``.
+
+These tests cover the input validation added in PR #3467, which checks that a
+provided ``custom_mask`` has shape ``(qo_len, kv_len)`` before it is packed and
+forwarded to the attention kernel. An invalid shape must raise a ``ValueError``
+with a descriptive message, while ``None`` or an already-packed mask must skip
+the validation entirely.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+
+DEVICE = "cuda:0"
+
+# The validation lives in the Python entry of the API, but the "valid shape"
+# and "skip validation" paths fall through to the actual attention kernel, which
+# requires a CUDA device. Skip the whole module when no GPU is available.
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA not available"
+)
+
+
+def _make_qkv(qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, kv_layout):
+    """Create ``q``/``k``/``v`` tensors honoring the requested ``kv_layout``."""
+    q = torch.randn(
+        qo_len, num_qo_heads, head_dim, dtype=torch.float16, device=DEVICE
+    )
+    if kv_layout == "NHD":
+        kv_shape = (kv_len, num_kv_heads, head_dim)
+    else:  # HND
+        kv_shape = (num_kv_heads, kv_len, head_dim)
+    k = torch.randn(*kv_shape, dtype=torch.float16, device=DEVICE)
+    v = torch.randn(*kv_shape, dtype=torch.float16, device=DEVICE)
+    return q, k, v
+
+
+# ---------------------------------------------------------------------------
+# Valid scenarios: a correctly shaped (qo_len, kv_len) mask must pass.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+def test_custom_mask_valid_shape_passes(kv_layout):
+    qo_len, kv_len = 16, 32
+    num_qo_heads = num_kv_heads = 4
+    head_dim = 128
+    q, k, v = _make_qkv(
+        qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, kv_layout
+    )
+    mask = torch.ones(qo_len, kv_len, dtype=torch.bool, device=DEVICE)
+
+    o = flashinfer.single_prefill_with_kv_cache(
+        q, k, v, custom_mask=mask, kv_layout=kv_layout
+    )
+    assert o.shape == (qo_len, num_qo_heads, head_dim)
+
+
+# ---------------------------------------------------------------------------
+# Invalid scenarios: a wrong shape must raise ValueError before the kernel runs.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "bad_shape_fn",
+    [
+        lambda qo, kv: (qo - 1, kv),  # row count mismatch
+        lambda qo, kv: (qo, kv - 5),  # column count mismatch
+        lambda qo, kv: (1, qo, kv),  # extra dimension
+        lambda qo, kv: (kv, qo),  # transposed rows/cols
+    ],
+    ids=["row-mismatch", "col-mismatch", "extra-dim", "transposed"],
+)
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+def test_custom_mask_invalid_shape_raises(kv_layout, bad_shape_fn):
+    qo_len, kv_len = 16, 32
+    num_qo_heads = num_kv_heads = 4
+    head_dim = 128
+    q, k, v = _make_qkv(
+        qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, kv_layout
+    )
+    bad_shape = bad_shape_fn(qo_len, kv_len)
+    mask = torch.ones(*bad_shape, dtype=torch.bool, device=DEVICE)
+
+    with pytest.raises(ValueError, match="custom_mask tensor must have shape"):
+        flashinfer.single_prefill_with_kv_cache(
+            q, k, v, custom_mask=mask, kv_layout=kv_layout
+        )
+
+
+# ---------------------------------------------------------------------------
+# Boundary scenarios: validation must be skipped entirely.
+# ---------------------------------------------------------------------------
+def test_custom_mask_none_skips_validation():
+    qo_len, kv_len = 16, 32
+    num_qo_heads = num_kv_heads = 4
+    head_dim = 128
+    q, k, v = _make_qkv(
+        qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, "NHD"
+    )
+
+    o = flashinfer.single_prefill_with_kv_cache(q, k, v, custom_mask=None)
+    assert o.shape == (qo_len, num_qo_heads, head_dim)
+
+
+def test_packed_custom_mask_skips_validation():
+    qo_len, kv_len = 16, 32
+    num_qo_heads = num_kv_heads = 4
+    head_dim = 128
+    q, k, v = _make_qkv(
+        qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, "NHD"
+    )
+
+    full_mask = torch.ones(qo_len, kv_len, dtype=torch.bool, device=DEVICE)
+    packed = flashinfer.packbits(
+        full_mask.contiguous().view(-1), bitorder="little"
+    )
+    # A deliberately wrong-shaped ``custom_mask`` must be ignored when a packed
+    # mask is supplied, so no ValueError should be raised.
+    wrong_mask = torch.ones(qo_len - 1, kv_len, dtype=torch.bool, device=DEVICE)
+
+    o = flashinfer.single_prefill_with_kv_cache(
+        q, k, v, custom_mask=wrong_mask, packed_custom_mask=packed
+    )
+    assert o.shape == (qo_len, num_qo_heads, head_dim)


### PR DESCRIPTION
## Summary

- Adds input shape validation for `custom_mask` tensors before the packed_custom_mask conversion in `single_prefill_with_kv_cache`
- Verifies `custom_mask.shape == (qo_len, kv_len)` to match documented expectations
- Prevents silent memory corruption in the CUDA kernel when users pass incorrectly shaped masks

Fixes #3176

## Test Plan

- [x] Verified Python syntax is valid
- [ ] Existing attention tests should continue to pass (no behavior change for valid inputs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of custom-mask inputs to detect dimension mismatches and raise clear errors instead of proceeding with invalid shapes, preventing incorrect processing.

* **Tests**
  * Added CUDA-gated tests exercising valid and invalid custom-mask shapes, None and packed-mask bypass behaviors, and multiple layout variants to guard against regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->