### PR TITLE
chore: explicitly set mMultiCtasKvMode in ragged attention launcher

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -724,6 +724,7 @@ void trtllm_ragged_attention_launcher(
 
   runner_params.mKernelType = FmhaKernelType::Context;
   runner_params.mTileScheduler = TileScheduler::Persistent;
+  runner_params.mMultiCtasKvMode = false;
   runner_params.mMaskType =
       is_causal ? TrtllmGenAttentionMaskType::Causal : TrtllmGenAttentionMaskType::Dense;
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Explicitly set `mMultiCtasKvMode = false` in `trtllm_ragged_attention_launcher` for clarity, matching the paged context path. Confirmed this is a no-op: `TllmGenSelectKernelParams` already forces `Disabled` for `Context`-type kernels regardless of this field, and the struct is zero-initialized by default anyway.

## 🔍 Related Issues



## 🚀 Pull Request Checklist

- [x] `pre-commit install`
- [x] `pre-commit run --all-files`

## 🧪 Tests

- [x] `pytest tests/attention/` with `is_causal=False` ragged attention cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ragged attention processing during context handling.
  * Enhanced inference reliability by ensuring attention execution uses the appropriate key-value processing configuration.
  * No interface changes are required; existing integrations continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->