### PR TITLE
NFC: replace deprecated API: cute.make_fragment

### DIFF
--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
@@ -1339,7 +1339,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 )
             )
 
-            tTR_rC = cute.make_fragment(tTR_rAcc.shape, self.c_dtype)
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
             tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
                 tiled_copy_t2r, tTR_rC, epi_tidx, sC
             )
@@ -1630,7 +1630,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
         tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
         # (T2R, T2R_M, T2R_N)
-        tTR_rAcc = cute.make_fragment(
+        tTR_rAcc = cute.make_rmem_tensor(
             tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
         )
         return tiled_copy_t2r, tTR_tAcc, tTR_rAcc

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -1803,7 +1803,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 )
             )
 
-            tTR_rC = cute.make_fragment(tTR_rAcc.shape, self.c_dtype)
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
             tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
                 tiled_copy_t2r, tTR_rC, epi_tidx, sC
             )
@@ -1820,7 +1820,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 )
                 topk_tiled_s2r = cute.make_tiled_copy_D(topk_s2r_atom, tiled_copy_t2r)
                 topk_thr_s2r = topk_tiled_s2r.get_slice(epi_tidx)
-                topk_rFrag = cute.make_fragment(tTR_rAcc.shape, self.acc_dtype)
+                topk_rFrag = cute.make_rmem_tensor(tTR_rAcc.shape, self.acc_dtype)
                 topk_rRetiled = topk_tiled_s2r.retile(topk_rFrag)
 
             #
@@ -2284,7 +2284,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
         tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
         # (T2R, T2R_M, T2R_N)
-        tTR_rAcc = cute.make_fragment(
+        tTR_rAcc = cute.make_rmem_tensor(
             tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
         )
         return tiled_copy_t2r, tTR_tAcc, tTR_rAcc


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

More mechanical change to replace deprecated API:

- cute.make_fragment --> cute.make_rmem_tensor

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

N/A

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

N/A

## Reviewer Notes

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal tensor representation in GPU kernel epilogue operations for block-scaled matrix computations to improve implementation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->