### PR TITLE
Optimize MoE routing top-k reduction and non-power-of-two sorting

### DIFF
--- a/csrc/fused_moe/moeTopKFuncs.cuh
+++ b/csrc/fused_moe/moeTopKFuncs.cuh
@@ -84,14 +84,14 @@ struct TopKRedType {
       uint32_t hi = static_cast<uint32_t>(compValIdx >> 32);
       uint32_t lo = static_cast<uint32_t>(compValIdx & 0xffffffffu);
       uint32_t maxHi;
-      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxHi) : "r"(hi));
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxHi) : "r"(hi));
       uint32_t loContrib = (hi == maxHi) ? lo : 0u;
       uint32_t maxLo;
-      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxLo) : "r"(loContrib));
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxLo) : "r"(loContrib));
       return (static_cast<TypeCmp>(maxHi) << 32) | static_cast<TypeCmp>(maxLo);
     } else {
       TypeCmp result;
-      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(result) : "r"(compValIdx));
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(result) : "r"(compValIdx));
       return result;
     }
   }

--- a/csrc/fused_moe/moeTopKFuncs.cuh
+++ b/csrc/fused_moe/moeTopKFuncs.cuh
@@ -73,8 +73,22 @@ struct TopKRedType {
   __host__ __device__ operator TypeCmp() const noexcept { return compValIdx; }
 
   __device__ inline TypeCmp reduce(cg::thread_block_tile<kWARP_SIZE> const& warp) {
-    if constexpr (!kTLLM_GEN_HAS_FAST_REDUX || sizeof(TypeCmp) == 8) {
+    // 32-bit keys (bf16/fp16) reduce with redux.sync.max.u32 directly. 64-bit keys
+    // (float/int) split into hi=value / lo=idx-complement and take two
+    // redux.sync.max.u32 (masking non-winning lanes' lo to 0), re-packed to the
+    // lexicographic 64-bit max -- bit-identical to cg::reduce, used as the fallback
+    // when fast redux is unavailable.
+    if constexpr (!kTLLM_GEN_HAS_FAST_REDUX) {
       return cg::reduce(warp, compValIdx, cg::greater<TypeCmp>{});
+    } else if constexpr (sizeof(TypeCmp) == 8) {
+      uint32_t hi = static_cast<uint32_t>(compValIdx >> 32);
+      uint32_t lo = static_cast<uint32_t>(compValIdx & 0xffffffffu);
+      uint32_t maxHi;
+      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxHi) : "r"(hi));
+      uint32_t loContrib = (hi == maxHi) ? lo : 0u;
+      uint32_t maxLo;
+      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxLo) : "r"(loContrib));
+      return (static_cast<TypeCmp>(maxHi) << 32) | static_cast<TypeCmp>(maxLo);
     } else {
       TypeCmp result;
       asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(result) : "r"(compValIdx));

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernelTopK.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernelTopK.cuh
@@ -93,14 +93,14 @@ struct TopKRedType {
       uint32_t hi = static_cast<uint32_t>(compVal >> 32);
       uint32_t lo = static_cast<uint32_t>(compVal & 0xffffffffu);
       uint32_t maxHi;
-      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxHi) : "r"(hi));
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxHi) : "r"(hi));
       uint32_t loContrib = (hi == maxHi) ? lo : 0u;
       uint32_t maxLo;
-      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxLo) : "r"(loContrib));
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxLo) : "r"(loContrib));
       return (static_cast<TypeCmp>(maxHi) << 32) | static_cast<TypeCmp>(maxLo);
     } else {
       TypeCmp result;
-      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(result) : "r"(compVal));
+      asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(result) : "r"(compVal));
       return result;
     }
   }

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernelTopK.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernelTopK.cuh
@@ -77,15 +77,27 @@ struct TopKRedType {
   __host__ __device__ operator TypeCmp() const noexcept { return compVal; }
 
   __device__ inline TypeCmp reduce(cg::thread_block_tile<WarpSize> const& warp) {
-    // Use fast redux.sync.max.u32 on SM100+ for 32-bit packed types only.
-    // For 64-bit packed types (float scores), fall back to cg::reduce.
+    // 32-bit keys (bf16/fp16) reduce with redux.sync.max.u32 directly. 64-bit keys
+    // (float) split into hi=value / lo=idx-complement and take two
+    // redux.sync.max.u32 (masking non-winning lanes' lo to 0), re-packed to the
+    // lexicographic 64-bit max -- bit-identical to cg::reduce, used as the fallback
+    // when fast redux is unavailable.
 #ifdef __CUDA_ARCH__
     static constexpr bool hasFastRedux = (__CUDA_ARCH__ / 100) >= 10;
 #else
     static constexpr bool hasFastRedux = false;
 #endif
-    if constexpr (!hasFastRedux || sizeof(TypeCmp) == 8) {
+    if constexpr (!hasFastRedux) {
       return cg::reduce(warp, compVal, cg::greater<TypeCmp>{});
+    } else if constexpr (sizeof(TypeCmp) == 8) {
+      uint32_t hi = static_cast<uint32_t>(compVal >> 32);
+      uint32_t lo = static_cast<uint32_t>(compVal & 0xffffffffu);
+      uint32_t maxHi;
+      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxHi) : "r"(hi));
+      uint32_t loContrib = (hi == maxHi) ? lo : 0u;
+      uint32_t maxLo;
+      asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxLo) : "r"(loContrib));
+      return (static_cast<TypeCmp>(maxHi) << 32) | static_cast<TypeCmp>(maxLo);
     } else {
       TypeCmp result;
       asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(result) : "r"(compVal));
@@ -109,6 +121,78 @@ template <int N>
 struct IsPowerOf2 {
   static constexpr bool value = (N > 0) && ((N & (N - 1)) == 0);
 };
+
+// Helper to compute the next power of 2 (>= N).
+template <int N>
+struct NextPow2 {
+ private:
+  static constexpr unsigned u = static_cast<unsigned>(N - 1);
+  static constexpr unsigned s1 = u | (u >> 1);
+  static constexpr unsigned s2 = s1 | (s1 >> 2);
+  static constexpr unsigned s3 = s2 | (s2 >> 4);
+  static constexpr unsigned s4 = s3 | (s3 >> 8);
+  static constexpr unsigned s5 = s4 | (s4 >> 16);
+
+ public:
+  static constexpr int value = (N <= 1) ? 1 : static_cast<int>(s5 + 1);
+};
+
+// Batcher's odd-even mergesort as compile-time template recursion (straight-line
+// SASS). Built on the span P = NextPow2<Size>; any comparator touching the padded
+// tail [Size, P) is dropped at compile time, so every N (incl. non-pow-2) sorts
+// the real elements with no runtime padding or storage.
+template <int A, int B, int Size, typename T>
+__device__ __forceinline__ void topkCompareSwap(T* a) {
+  if constexpr (A < Size && B < Size) {
+    if (a[A] < a[B]) {
+      T tmp = a[A];
+      a[A] = a[B];
+      a[B] = tmp;
+    }
+  } else {
+    (void)a;
+  }
+}
+
+// Inner pair-merge loop unrolled as template recursion.
+template <int I, int End, int Step, int PairStride, int Size, typename T>
+__device__ __forceinline__ void topkMergePairs(T* a) {
+  if constexpr (I + Step < End) {
+    topkCompareSwap<I, I + Step, Size, T>(a);
+    topkMergePairs<I + PairStride, End, Step, PairStride, Size, T>(a);
+  } else {
+    (void)a;
+  }
+}
+
+// Batcher's odd-even merge of two sorted halves spanning [Lo, Lo+N) at stride R.
+template <int Lo, int N, int R, int Size, typename T>
+__device__ __forceinline__ void topkOEM(T* a) {
+  constexpr int M = R * 2;
+  if constexpr (M < N) {
+    topkOEM<Lo, N, M, Size, T>(a);
+    topkOEM<Lo + R, N - R, M, Size, T>(a);
+    topkMergePairs<Lo + R, Lo + N, R, M, Size, T>(a);
+  } else if constexpr (R < N) {
+    topkCompareSwap<Lo, Lo + R, Size, T>(a);
+  } else {
+    (void)a;
+  }
+}
+
+// Recursive Batcher's odd-even mergesort over the span [Lo, Lo+N). Size is the
+// number of real (non-sentinel) elements used to drop padded comparators.
+template <int Lo, int N, int Size, typename T>
+__device__ __forceinline__ void topkSortBatcher(T* a) {
+  if constexpr (N > 1) {
+    constexpr int Half = N / 2;
+    topkSortBatcher<Lo, Half, Size, T>(a);
+    topkSortBatcher<Lo + Half, N - Half, Size, T>(a);
+    topkOEM<Lo, N, 1, Size, T>(a);
+  } else {
+    (void)a;
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <int N, typename RedType>
@@ -144,26 +228,10 @@ struct Sort {
         }
       }
     } else {
-// Odd-even transposition sort for non-power-of-2 sizes
-#pragma unroll
-      for (int pass = 0; pass < N; ++pass) {
-#pragma unroll
-        for (int i = 0; i < N - 1; i += 2) {
-          if (topK[i].compVal < topK[i + 1].compVal) {
-            auto tmp = topK[i].compVal;
-            topK[i].compVal = topK[i + 1].compVal;
-            topK[i + 1].compVal = tmp;
-          }
-        }
-#pragma unroll
-        for (int i = 1; i < N - 1; i += 2) {
-          if (topK[i].compVal < topK[i + 1].compVal) {
-            auto tmp = topK[i].compVal;
-            topK[i].compVal = topK[i + 1].compVal;
-            topK[i + 1].compVal = tmp;
-          }
-        }
-      }
+      // Non-power-of-2: Batcher OEM over NextPow2<N>, preserving the same
+      // descending order as the prior odd-even transposition sort.
+      constexpr int P = NextPow2<N>::value;
+      topkSortBatcher<0, P, N, RedType>(topK);
     }
   }
 };


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

 Improves TRT-LLM MoE routing top-k performance by using a two-step fast warp reduction for 64-bit packed FP32 keys on SM100+, and replacing non-power-of-two odd-even transposition sorting with a padded Batcher odd-even merge network. The new sort path preserves descending order while reducing comparator count for non-power-of-two candidate sizes.

This speeds up Large N/T, and non pow of 2 K perf 
| K | N | T | before opt p50 (us) | after opt p50 (us) | Speedup |
|---:|---:|---:|---:|---:|---:|
| 10 | 2048 | 512 | 6.151 | 6.144 | 1.001x |
| 10 | 2048 | 2048 | 12.286 | 8.199 | 1.498x |
| 10 | 2048 | 4096 | 18.443 | 12.297 | 1.500x |
| 22 | 2048 | 512 | 10.249 | 6.150 | 1.666x |
| 22 | 2048 | 2048 | 20.499 | 10.249 | 2.000x |
| 22 | 2048 | 4096 | 34.808 | 16.380 | 2.125x |

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected 64-bit key comparison to ensure accurate TopK selection in MOE routing.

* **Performance**
  * Optimized TopK reduction for faster reductions where supported.
  * Replaced the non-power-of-two sorting path with a more efficient merge-based sorter, improving sorting performance and stability for atypical K values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->