### PR TITLE
feat: add sm120 delta rule dsl prefill

### DIFF
--- a/flashinfer/gdn_kernels/__init__.py
+++ b/flashinfer/gdn_kernels/__init__.py
@@ -63,9 +63,13 @@ except (ImportError, RuntimeError):
     chunk_gated_delta_rule_sm100 = None  # type: ignore
 
 try:
-    from .delta_rule_dsl import chunk_gated_delta_rule_sm90
+    from .delta_rule_dsl import (
+        chunk_gated_delta_rule_sm90,
+        chunk_gated_delta_rule_sm120,
+    )
 except (ImportError, RuntimeError):
     chunk_gated_delta_rule_sm90 = None  # type: ignore
+    chunk_gated_delta_rule_sm120 = None  # type: ignore
 
 __all__ = [
     "gated_delta_rule",
@@ -80,4 +84,5 @@ __all__ = [
     "get_mtp_config",
     "chunk_gated_delta_rule_sm90",
     "chunk_gated_delta_rule_sm100",
+    "chunk_gated_delta_rule_sm120",
 ]

--- a/flashinfer/gdn_kernels/delta_rule_dsl/__init__.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/__init__.py
@@ -5,7 +5,12 @@ try:
 except ImportError:
     chunk_gated_delta_rule_sm90 = None  # type: ignore
 
+try:
+    from .delta_rule_sm120 import delta_rule_prefill_dsl as chunk_gated_delta_rule_sm120
+except (ImportError, RuntimeError):
+    chunk_gated_delta_rule_sm120 = None  # type: ignore
 
 __all__ = [
     "chunk_gated_delta_rule_sm90",
+    "chunk_gated_delta_rule_sm120",
 ]

--- a/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import tempfile
 import types
 import typing
@@ -75,17 +74,22 @@ def _option_value(options, option_type):
     return None
 
 
+def _has_option_value(options, option_type, option_value):
+    for option in _as_options_tuple(options):
+        if isinstance(option, option_type) and option.value == option_value:
+            return True
+    return False
+
+
 def _needs_sm120a_tma_patch(options):
-    return _option_value(options, cute.GPUArch) == "sm_120a"
+    return _has_option_value(options, cute.GPUArch, "sm_120a")
 
 
-def _patched_compile_options(options):
+def _patched_compile_options(options, dump_dir):
     options = _as_options_tuple(options)
-    if not _needs_sm120a_tma_patch(options):
-        return options
 
-    has_keep_ptx = any(isinstance(option, cute.KeepPTX) for option in options)
-    has_dump_dir = any(isinstance(option, DumpDir) for option in options)
+    has_keep_ptx = _has_option_value(options, cute.KeepPTX, True)
+    has_dump_dir = _option_value(options, DumpDir)
     extras = []
     if not has_keep_ptx:
         extras.append(cute.KeepPTX(True))
@@ -94,10 +98,6 @@ def _patched_compile_options(options):
         if dump_dir:
             os.makedirs(dump_dir, exist_ok=True)
     else:
-        dump_dir = os.environ.get(
-            "FLASHINFER_DSL_TMA_PATCH_DIR", "/tmp/flashinfer_dsl_tma_patch"
-        )
-        os.makedirs(dump_dir, exist_ok=True)
         extras.append(DumpDir(dump_dir))
     return options + tuple(extras)
 
@@ -128,41 +128,20 @@ def _patch_sm120a_tma_ptx(ptx_text: str) -> str:
             lines.append(line_body + line_end)
         patched = "".join(lines)
 
-    if patched == ptx_text:
-        return ptx_text
-    return patched.replace("\x00", "")
+    return patched
 
 
-def _assemble_sm120a_cubin(ptx: str) -> bytes:
-    with tempfile.TemporaryDirectory(prefix="flashinfer_dsl_tma_patch_") as tmp_dir:
-        ptx_path = os.path.join(tmp_dir, "kernel.ptx")
-        cubin_path = os.path.join(tmp_dir, "kernel.cubin")
-        with open(ptx_path, "w", encoding="utf-8") as f:
-            f.write(ptx)
-
-        cuda_path = os.environ.get("CUDA_PATH", "/usr/local/cuda")
-        ptxas = os.path.join(cuda_path, "bin", "ptxas")
-        cmd = [ptxas, "-arch=sm_120a", ptx_path, "-o", cubin_path]
-        result = subprocess.run(cmd, check=False, text=True, capture_output=True)
-        if result.returncode != 0:
-            raise RuntimeError(
-                "failed to assemble patched sm120a TMA PTX\n"
-                f"command: {' '.join(cmd)}\n"
-                f"stdout:\n{result.stdout}\n"
-                f"stderr:\n{result.stderr}"
-            )
-
-        with open(cubin_path, "rb") as f:
-            return f.read()
-
-
-def _install_patched_cubin_loader(compiled_fn, patched_cubin: bytes):
+def _install_patched_ptx_loader(compiled_fn, patched_ptx: str):
     import ctypes
 
+    import cuda.bindings.driver as cuda_driver
     import cuda.bindings.runtime as cuda_runtime
 
     from cutlass.base_dsl.common import DSLRuntimeError
     from cutlass.base_dsl.runtime.cuda import checkCudaErrors
+
+    jit_options = [cuda_driver.CUjit_option.CU_JIT_TARGET]
+    jit_option_values = [cuda_driver.CUjit_target.CU_TARGET_COMPUTE_120A]
 
     def _load_cuda_library(self):
         if self.engine is None:
@@ -176,8 +155,14 @@ def _install_patched_cubin_loader(compiled_fn, patched_cubin: bytes):
         )
 
         library_obj = checkCudaErrors(
-            cuda_runtime.cudaLibraryLoadData(
-                patched_cubin, None, None, 0, None, None, 0
+            cuda_driver.cuLibraryLoadData(
+                patched_ptx.encode("utf-8"),
+                jit_options,
+                jit_option_values,
+                len(jit_options),
+                None,
+                None,
+                0,
             )
         )
         library = ctypes.c_void_p(int(library_obj))
@@ -204,23 +189,20 @@ def _install_patched_cubin_loader(compiled_fn, patched_cubin: bytes):
 
         return [library_obj]
 
-    compiled_fn._flat_patched_cubin = patched_cubin
+    compiled_fn._flat_patched_ptx = patched_ptx
+    compiled_fn._flat_patched_ptx_jit_options = tuple(jit_options)
+    compiled_fn._flat_patched_ptx_jit_option_values = tuple(jit_option_values)
     compiled_fn._load_cuda_library = types.MethodType(_load_cuda_library, compiled_fn)
-    if compiled_fn.artifacts is not None:
-        compiled_fn.artifacts.CUBIN = patched_cubin
 
 
-def _maybe_patch_sm120a_tma(compiled_fn, options):
-    if not _needs_sm120a_tma_patch(options):
-        return compiled_fn
+def _patch_sm120a_tma(compiled_fn, options):
     ptx = _read_ptx_text(getattr(compiled_fn, "__ptx__", None))
     if not ptx:
         return compiled_fn
     patched_ptx = _patch_sm120a_tma_ptx(ptx)
     if patched_ptx == ptx:
         return compiled_fn
-    patched_cubin = _assemble_sm120a_cubin(patched_ptx)
-    _install_patched_cubin_loader(compiled_fn, patched_cubin)
+    _install_patched_ptx_loader(compiled_fn, patched_ptx)
     return compiled_fn
 
 
@@ -230,11 +212,18 @@ def cached_compile(func, *args, compile_options=None, **kwargs):
 
     if compiled_fn is None:
         compiler = cute.compile
-        effective_compile_options = _patched_compile_options(compile_options)
+        effective_compile_options = compile_options
+        if _needs_sm120a_tma_patch(compile_options):
+            tempdir = tempfile.TemporaryDirectory(prefix="cutedsl_patch_")
+            effective_compile_options = _patched_compile_options(
+                compile_options, tempdir.name
+            )
         if effective_compile_options:
             compiler = cute.compile[effective_compile_options]
         compiled_fn = compiler(func, *args, **kwargs)
-        compiled_fn = _maybe_patch_sm120a_tma(compiled_fn, effective_compile_options)
+        if _needs_sm120a_tma_patch(compile_options):
+            compiled_fn = _patch_sm120a_tma(compiled_fn, effective_compile_options)
+            tempdir.cleanup()
         _in_mem_compile_cache[cache_key] = compiled_fn
 
     return compiled_fn

--- a/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
@@ -211,19 +211,15 @@ def cached_compile(func, *args, compile_options=None, **kwargs):
     compiled_fn = _in_mem_compile_cache.get(cache_key)
 
     if compiled_fn is None:
-        compiler = cute.compile
-        effective_compile_options = compile_options
-        if _needs_sm120a_tma_patch(compile_options):
-            tempdir = tempfile.TemporaryDirectory(prefix="cutedsl_patch_")
-            effective_compile_options = _patched_compile_options(
-                compile_options, tempdir.name
-            )
-        if effective_compile_options:
-            compiler = cute.compile[effective_compile_options]
-        compiled_fn = compiler(func, *args, **kwargs)
-        if _needs_sm120a_tma_patch(compile_options):
-            compiled_fn = _patch_sm120a_tma(compiled_fn, effective_compile_options)
-            tempdir.cleanup()
+        _needs_patch = _needs_sm120a_tma_patch(compile_options)
+        if not _needs_patch:
+            compiled_fn = cute.compile[compile_options](func, *args, **kwargs)
+        else:
+            with tempfile.TemporaryDirectory(prefix="cutedsl_patch_") as tempdir:
+                compile_options = _patched_compile_options(compile_options, tempdir)
+                compiled_fn = cute.compile[compile_options](func, *args, **kwargs)
+                compiled_fn = _patch_sm120a_tma(compiled_fn, compile_options)
+
         _in_mem_compile_cache[cache_key] = compiled_fn
 
     return compiled_fn

--- a/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
@@ -1,10 +1,29 @@
+import os
+import subprocess
+import tempfile
 import types
 import typing
 
 import cutlass.cute as cute
+from cutlass.base_dsl.compiler import DumpDir
 
 
 _in_mem_compile_cache: dict = {}
+
+
+_TMA_CLUSTER_LOAD = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global.tile."
+    "mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_TMA_CTA_LOAD = (
+    "cp.async.bulk.tensor.3d.shared::cta.global.tile."
+    "mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+_TMA_TILE_STORE = (
+    "cp.async.bulk.tensor.3d.global.shared::cta.tile."
+    "bulk_group.L2::cache_hint"
+)
+_TMA_CTA_STORE = "cp.async.bulk.tensor.3d.global.shared::cta.bulk_group"
 
 
 def _as_options_tuple(options):
@@ -50,16 +69,173 @@ def _compile_options_key(options):
     return tuple((type(option), option.value) for option in options)
 
 
+def _option_value(options, option_type):
+    for option in _as_options_tuple(options):
+        if isinstance(option, option_type):
+            return option.value
+    return None
+
+
+def _needs_sm120a_tma_patch(options):
+    return _option_value(options, cute.GPUArch) == "sm_120a"
+
+
+def _patched_compile_options(options):
+    options = _as_options_tuple(options)
+    if not _needs_sm120a_tma_patch(options):
+        return options
+
+    has_keep_ptx = any(isinstance(option, cute.KeepPTX) for option in options)
+    has_dump_dir = any(isinstance(option, DumpDir) for option in options)
+    extras = []
+    if not has_keep_ptx:
+        extras.append(cute.KeepPTX(True))
+    if has_dump_dir:
+        dump_dir = _option_value(options, DumpDir)
+        if dump_dir:
+            os.makedirs(dump_dir, exist_ok=True)
+    else:
+        dump_dir = os.environ.get("FLASHINFER_DSL_TMA_PATCH_DIR", "/tmp/flashinfer_dsl_tma_patch")
+        os.makedirs(dump_dir, exist_ok=True)
+        extras.append(DumpDir(dump_dir))
+    return options + tuple(extras)
+
+
+def _read_ptx_text(ptx_artifact):
+    if isinstance(ptx_artifact, str) and os.path.exists(ptx_artifact):
+        with open(ptx_artifact, "r", encoding="utf-8") as f:
+            return f.read()
+    return ptx_artifact
+
+
+def _patch_sm120a_tma_ptx(ptx_text: str) -> str:
+    patched = ptx_text.replace(_TMA_CLUSTER_LOAD, _TMA_CTA_LOAD)
+    if _TMA_TILE_STORE in patched:
+        lines = []
+        for line in patched.splitlines(keepends=True):
+            if _TMA_TILE_STORE not in line:
+                lines.append(line)
+                continue
+
+            line_body = line.rstrip("\r\n")
+            line_end = line[len(line_body):]
+            line_body = line_body.replace(_TMA_TILE_STORE, _TMA_CTA_STORE)
+            if line_body.endswith(";"):
+                operands, separator, _cache_policy = line_body[:-1].rpartition(", %rd")
+                if separator:
+                    line_body = operands + ";"
+            lines.append(line_body + line_end)
+        patched = "".join(lines)
+
+    if patched == ptx_text:
+        return ptx_text
+    return patched.replace("\x00", "")
+
+
+def _assemble_sm120a_cubin(ptx: str) -> bytes:
+    with tempfile.TemporaryDirectory(prefix="flashinfer_dsl_tma_patch_") as tmp_dir:
+        ptx_path = os.path.join(tmp_dir, "kernel.ptx")
+        cubin_path = os.path.join(tmp_dir, "kernel.cubin")
+        with open(ptx_path, "w", encoding="utf-8") as f:
+            f.write(ptx)
+
+        cuda_path = os.environ.get("CUDA_PATH", "/usr/local/cuda")
+        ptxas = os.path.join(cuda_path, "bin", "ptxas")
+        cmd = [ptxas, "-arch=sm_120a", ptx_path, "-o", cubin_path]
+        result = subprocess.run(cmd, check=False, text=True, capture_output=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                "failed to assemble patched sm120a TMA PTX\n"
+                f"command: {' '.join(cmd)}\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+
+        with open(cubin_path, "rb") as f:
+            return f.read()
+
+
+def _install_patched_cubin_loader(compiled_fn, patched_cubin: bytes):
+    import ctypes
+
+    import cuda.bindings.runtime as cuda_runtime
+
+    from cutlass.base_dsl.common import DSLRuntimeError
+    from cutlass.base_dsl.runtime.cuda import checkCudaErrors
+
+    def _load_cuda_library(self):
+        if self.engine is None:
+            raise DSLRuntimeError("CUDA JIT engine is not available")
+
+        cuda_load_to_device = self.engine.raw_lookup("cuda_load_to_device")
+        if cuda_load_to_device is None:
+            raise DSLRuntimeError("cuda_load_to_device not found")
+        cuda_load_to_device = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_void_p)(
+            cuda_load_to_device
+        )
+
+        library_obj = checkCudaErrors(
+            cuda_runtime.cudaLibraryLoadData(
+                patched_cubin, None, None, 0, None, None, 0
+            )
+        )
+        library = ctypes.c_void_p(int(library_obj))
+        pointer_to_library = ctypes.pointer(library)
+        pointer_to_pointer_to_library = ctypes.pointer(pointer_to_library)
+        err = ctypes.c_int32(0)
+        pointer_to_err = ctypes.pointer(err)
+        device_id = ctypes.c_int32(0)
+        pointer_to_device_id = ctypes.pointer(device_id)
+
+        cuda_load_args = [
+            pointer_to_pointer_to_library,
+            pointer_to_device_id,
+            pointer_to_err,
+        ]
+        packed_args = (ctypes.c_void_p * len(cuda_load_args))()
+        for i, arg in enumerate(cuda_load_args):
+            packed_args[i] = ctypes.cast(arg, ctypes.c_void_p)
+
+        for dev in range(self.num_devices):
+            device_id.value = dev
+            cuda_load_to_device(packed_args)
+            checkCudaErrors((cuda_runtime.cudaError_t(err.value),))
+
+        return [library_obj]
+
+    compiled_fn._flat_patched_cubin = patched_cubin
+    compiled_fn._load_cuda_library = types.MethodType(_load_cuda_library, compiled_fn)
+    if compiled_fn.artifacts is not None:
+        compiled_fn.artifacts.CUBIN = patched_cubin
+
+
+def _maybe_patch_sm120a_tma(compiled_fn, options):
+    if not _needs_sm120a_tma_patch(options):
+        return compiled_fn
+    ptx = _read_ptx_text(getattr(compiled_fn, "__ptx__", None))
+    if not ptx:
+        return compiled_fn
+    patched_ptx = _patch_sm120a_tma_ptx(ptx)
+    if patched_ptx == ptx:
+        return compiled_fn
+    patched_cubin = _assemble_sm120a_cubin(patched_ptx)
+    _install_patched_cubin_loader(compiled_fn, patched_cubin)
+    return compiled_fn
+
+
 def cached_compile(func, *args, compile_options=None, **kwargs):
     cache_key = (func._get_compile_key(), _compile_options_key(compile_options))
     compiled_fn = _in_mem_compile_cache.get(cache_key)
 
     if compiled_fn is None:
         compiler = cute.compile
-        effective_compile_options = compile_options
+        effective_compile_options = _patched_compile_options(compile_options)
         if effective_compile_options:
             compiler = cute.compile[effective_compile_options]
         compiled_fn = compiler(func, *args, **kwargs)
+        compiled_fn = _maybe_patch_sm120a_tma(
+            compiled_fn, effective_compile_options
+        )
         _in_mem_compile_cache[cache_key] = compiled_fn
 
     return compiled_fn

--- a/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
@@ -20,8 +20,7 @@ _TMA_CTA_LOAD = (
     "mbarrier::complete_tx::bytes.L2::cache_hint"
 )
 _TMA_TILE_STORE = (
-    "cp.async.bulk.tensor.3d.global.shared::cta.tile."
-    "bulk_group.L2::cache_hint"
+    "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group.L2::cache_hint"
 )
 _TMA_CTA_STORE = "cp.async.bulk.tensor.3d.global.shared::cta.bulk_group"
 
@@ -95,7 +94,9 @@ def _patched_compile_options(options):
         if dump_dir:
             os.makedirs(dump_dir, exist_ok=True)
     else:
-        dump_dir = os.environ.get("FLASHINFER_DSL_TMA_PATCH_DIR", "/tmp/flashinfer_dsl_tma_patch")
+        dump_dir = os.environ.get(
+            "FLASHINFER_DSL_TMA_PATCH_DIR", "/tmp/flashinfer_dsl_tma_patch"
+        )
         os.makedirs(dump_dir, exist_ok=True)
         extras.append(DumpDir(dump_dir))
     return options + tuple(extras)
@@ -118,7 +119,7 @@ def _patch_sm120a_tma_ptx(ptx_text: str) -> str:
                 continue
 
             line_body = line.rstrip("\r\n")
-            line_end = line[len(line_body):]
+            line_end = line[len(line_body) :]
             line_body = line_body.replace(_TMA_TILE_STORE, _TMA_CTA_STORE)
             if line_body.endswith(";"):
                 operands, separator, _cache_policy = line_body[:-1].rpartition(", %rd")
@@ -233,9 +234,7 @@ def cached_compile(func, *args, compile_options=None, **kwargs):
         if effective_compile_options:
             compiler = cute.compile[effective_compile_options]
         compiled_fn = compiler(func, *args, **kwargs)
-        compiled_fn = _maybe_patch_sm120a_tma(
-            compiled_fn, effective_compile_options
-        )
+        compiled_fn = _maybe_patch_sm120a_tma(compiled_fn, effective_compile_options)
         _in_mem_compile_cache[cache_key] = compiled_fn
 
     return compiled_fn

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -768,9 +768,6 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         ldsm_t4 = cute.make_copy_atom(
             warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype
         )
-        stsm_n4 = cute.make_copy_atom(
-            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype
-        )
 
         # ── Active smem slices (extract 2D from staged tensors) ───────────────
         sQ_k = sQ_SD[None, None, q_stage]  # (BlkQ, D)

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -286,7 +286,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             s, t = coord_tensor[i]
             pred = s >= t
             if cutlass.const_expr(is_final_block):
-                pred = pred and (s < B or t < B)
+                pred = pred and (s < B and t < B)
             if not pred:
                 frag[i] = cutlass.Float32(0.0)
 

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -1962,71 +1962,105 @@ def delta_rule_prefill_dsl(
     if kernel_dtype is None:
         raise RuntimeError(f"DSL kernel only supports fp16/bf16 inputs, got {q.dtype}")
 
-    q_t = q.contiguous()
-    k_t = k.contiguous()
-    v_t = v.contiguous()
-    o_t = o
+    if k.dtype != q.dtype or v.dtype != q.dtype or o.dtype != q.dtype:
+        raise RuntimeError(
+            f"q/k/v/o dtypes must match, got {q.dtype}, {k.dtype}, {v.dtype}, {o.dtype}"
+        )
+    if alpha is not None and alpha.dtype != torch.float32:
+        raise RuntimeError(f"alpha must have dtype torch.float32, got {alpha.dtype}")
+    if beta is not None and beta.dtype != torch.float32:
+        raise RuntimeError(f"beta must have dtype torch.float32, got {beta.dtype}")
+    if init_state is not None and init_state.dtype != torch.float32:
+        raise RuntimeError(
+            f"init_state must have dtype torch.float32, got {init_state.dtype}"
+        )
+    if state.dtype != torch.float32:
+        raise RuntimeError(f"state must have dtype torch.float32, got {state.dtype}")
+    if cu_seqlens.dtype != torch.int64:
+        raise RuntimeError(
+            f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+        )
 
-    total_seqlen = q_t.shape[0]
-    num_o_heads = o_t.shape[1]
-    q_tma = q_t.as_strided(
+    for name, tensor in (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("o", o),
+        ("state", state),
+        ("cu_seqlens", cu_seqlens),
+    ):
+        if not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+    for name, tensor in (("alpha", alpha), ("beta", beta), ("init_state", init_state)):
+        if tensor is not None and not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+
+    total_seqlen = q.shape[0]
+    num_o_heads = o.shape[1]
+    q_tma = q.as_strided(
         (total_seqlen, D, num_q_heads),
         (num_q_heads * D, 1, D),
     )
-    k_tma = k_t.as_strided(
+    k_tma = k.as_strided(
         (D, total_seqlen, num_k_heads),
         (1, num_k_heads * D, D),
     )
-    v_tma = v_t.as_strided(
+    v_tma = v.as_strided(
         (D, total_seqlen, num_v_heads),
         (1, num_v_heads * D, D),
     )
-    o_tma = o_t.as_strided(
+    o_tma = o.as_strided(
         (D, total_seqlen, num_o_heads),
         (1, num_o_heads * D, D),
     )
-    _dummy_f32 = torch.zeros(1, dtype=torch.float32, device=q.device)
-    _dummy_i64 = torch.zeros(1, dtype=torch.int64, device=q.device)
-    alpha_t = alpha.contiguous() if needs_alpha else _dummy_f32
-    beta_t = beta.contiguous() if needs_beta else _dummy_f32
-    init_state_t = init_state.contiguous() if needs_init_state else _dummy_f32
-    state_checkpoints_t = (
-        state_checkpoints.contiguous() if needs_checkpointing else _dummy_f32
-    )
-    checkpoint_cu_t = (
-        checkpoint_cu_starts.to(torch.int64).contiguous()
-        if needs_checkpointing
-        else _dummy_i64
-    )
-    total_checkpoints = state_checkpoints_t.shape[0] if needs_checkpointing else 1
+    total_checkpoints = state_checkpoints.shape[0] if needs_checkpointing else 1
     sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
     tensormaps_t = torch.empty(sm_count * 128, dtype=torch.uint8, device=q.device)
-    cu_int64 = cu_seqlens.to(torch.int64).contiguous()
 
     stream_val = torch.cuda.current_stream().cuda_stream
     stream = cuda_driver.CUstream(stream_val)
+
+    enable_tvm_ffi = True
+    if enable_tvm_ffi:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
 
     # Keep head counts and varlen extents runtime values across cached compiles.
     q_cute = from_dlpack(q_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1)
     k_cute = from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
     v_cute = from_dlpack(v_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
     o_cute = from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
-    alpha_cute = from_dlpack(
-        alpha_t.reshape(-1), assumed_align=16
-    ).mark_layout_dynamic()
-    beta_cute = from_dlpack(beta_t.reshape(-1), assumed_align=16).mark_layout_dynamic()
+    alpha_cute = (
+        from_dlpack(alpha.reshape(-1), assumed_align=16).mark_layout_dynamic()
+        if needs_alpha
+        else None
+    )
+    beta_cute = (
+        from_dlpack(beta.reshape(-1), assumed_align=16).mark_layout_dynamic()
+        if needs_beta
+        else None
+    )
     state_cute = from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic()
-    init_state_cute = from_dlpack(
-        init_state_t.reshape(-1), assumed_align=16
-    ).mark_layout_dynamic()
-    state_checkpoints_cute = from_dlpack(
-        state_checkpoints_t.reshape(-1), assumed_align=16
-    ).mark_layout_dynamic()
-    checkpoint_cu_cute = from_dlpack(
-        checkpoint_cu_t, assumed_align=8
-    ).mark_layout_dynamic()
+    init_state_cute = (
+        from_dlpack(init_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
+        if needs_init_state
+        else None
+    )
+    state_checkpoints_cute = (
+        from_dlpack(
+            state_checkpoints.reshape(-1), assumed_align=16
+        ).mark_layout_dynamic()
+        if needs_checkpointing
+        else None
+    )
+    checkpoint_cu_cute = (
+        from_dlpack(checkpoint_cu_starts, assumed_align=8).mark_layout_dynamic()
+        if needs_checkpointing
+        else None
+    )
     tensormaps_cute = from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic()
-    cu_cute = from_dlpack(cu_int64, assumed_align=8).mark_layout_dynamic()
+    cu_cute = from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic()
 
     delta_rule_kernel = _FullyFusedDeltaRuleSm120(
         needs_alpha, needs_beta, needs_init_state, needs_checkpointing, kernel_dtype

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -109,12 +109,14 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         needs_alpha: bool,
         needs_beta: bool,
         needs_init_state: bool,
+        needs_checkpointing: bool,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
     ):
         self.needs_alpha      = needs_alpha
         self.needs_beta       = needs_beta
         self.needs_init_state = needs_init_state
+        self.needs_checkpointing = needs_checkpointing
         self.dtype            = dtype
         self.acc_dtype        = acc_dtype
         self.inverse_dtype    = cutlass.Float16
@@ -596,6 +598,35 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             v_idx, k_idx = tKVcKV[i]
             gKV[k_idx, v_idx] = tKVrKV[i]
 
+    @cute.jit
+    def maybe_store_checkpoint(
+        self,
+        tKVrKV: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
+        checkpoint_every_n_tokens: cutlass.Int32,
+        kv_thr_mma,
+        seq_idx: cutlass.Int32,
+        o_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        block_end: cutlass.Int32,
+        seq_len: cutlass.Int32,
+    ):
+        if cutlass.const_expr(self.needs_checkpointing):
+            if block_end <= seq_len and block_end % checkpoint_every_n_tokens == cutlass.Int32(0):
+                checkpoint_idx = (
+                    cutlass.Int32(checkpoint_cu_starts[seq_idx])
+                    + block_end // checkpoint_every_n_tokens
+                    - cutlass.Int32(1)
+                )
+                checkpoint_layout = cute.make_ordered_layout(
+                    (self.D, self.D, num_sab_heads, total_checkpoints), order=(0, 1, 2, 3)
+                )
+                mCheckpoint = cute.make_tensor(g_state_checkpoints.iterator, checkpoint_layout)
+                gCheckpointKV = mCheckpoint[None, None, o_head_idx, checkpoint_idx]
+                self.kv_store(tKVrKV, gCheckpointKV, kv_thr_mma)
+
     # ─── compute_loop_body ───────────────────────────────────────────────────
     # Translates the C++ compute_loop_body lambda captured inside compute().
     # Called by Math WGs (tidx >= 128) for one block iteration.
@@ -1056,6 +1087,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         beta_pipeline,
         g_state: cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         work_desc: WorkDesc,
         scale: cutlass.Float32,
         wg_idx: cutlass.Int32,
@@ -1065,6 +1098,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         num_v_heads: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         num_seqs: cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
     ):
         self._math_order_init(wg_idx)
         q_consumer_state = pipeline.make_pipeline_state(
@@ -1147,6 +1182,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 True, True, first_B,
                 tKVrKV, scale, wg_idx,
             )
+        self.maybe_store_checkpoint(
+            tKVrKV, g_state_checkpoints, checkpoint_cu_starts, checkpoint_every_n_tokens,
+            kv_thr_mma, work_desc.seq_idx, o_head_idx, num_sab_heads, total_checkpoints,
+            cutlass.Int32(self.BLK_KV), work_desc.seq_len,
+        )
 
         for blk in cutlass.range(cutlass.Int32(1), num_blocks - cutlass.Int32(1), cutlass.Int32(1), unroll=1):
             (
@@ -1167,6 +1207,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 beta_pipeline, beta_consumer_state,
                 False, False, cutlass.Int32(self.BLK_KV),
                 tKVrKV, scale, wg_idx,
+            )
+            self.maybe_store_checkpoint(
+                tKVrKV, g_state_checkpoints, checkpoint_cu_starts, checkpoint_every_n_tokens,
+                kv_thr_mma, work_desc.seq_idx, o_head_idx, num_sab_heads, total_checkpoints,
+                (blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV), work_desc.seq_len,
             )
 
         if num_blocks != cutlass.Int32(1):
@@ -1191,6 +1236,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 False, True, last_B,
                 tKVrKV, scale, wg_idx,
             )
+            self.maybe_store_checkpoint(
+                tKVrKV, g_state_checkpoints, checkpoint_cu_starts, checkpoint_every_n_tokens,
+                kv_thr_mma, work_desc.seq_idx, o_head_idx, num_sab_heads, total_checkpoints,
+                (last_blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV), work_desc.seq_len,
+            )
         self.kv_store(tKVrKV, gStateKV, kv_thr_mma)
 
     # ─── Kernel entry point ───────────────────────────────────────────────────
@@ -1206,6 +1256,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         g_beta:       cute.Tensor,
         g_state:      cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
         cu_seqlens:   cute.Tensor,
         scale:        cutlass.Float32,
@@ -1214,6 +1266,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         num_v_heads:   cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         num_seqs:      cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
         grid_x: int,
         stream,
     ):
@@ -1338,8 +1392,10 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             tma_atom_k, tma_tensor_k,
             tma_atom_v, tma_tensor_v,
             tma_atom_o, tma_tensor_o,
-            g_state, g_init_state, g_tensormaps, cu_seqlens,
+            g_state, g_init_state, g_state_checkpoints, checkpoint_cu_starts,
+            g_tensormaps, cu_seqlens,
             scale, num_q_heads, num_k_heads, num_v_heads, num_sab_heads, num_seqs,
+            total_checkpoints, checkpoint_every_n_tokens,
         ).launch(
             grid=(grid_x, 1, 1),
             block=(384, 1, 1),
@@ -1363,6 +1419,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         tma_tensor_o: cute.Tensor,
         g_state:      cute.Tensor,
         g_init_state: cute.Tensor,
+        g_state_checkpoints: cute.Tensor,
+        checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
         cu_seqlens:   cute.Tensor,
         scale:        cutlass.Float32,
@@ -1371,6 +1429,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         num_v_heads:   cutlass.Int32,
         num_sab_heads: cutlass.Int32,
         num_seqs:      cutlass.Int32,
+        total_checkpoints: cutlass.Int32,
+        checkpoint_every_n_tokens: cutlass.Int32,
     ):
         NUM_LOAD_WARP_GROUPS = 1
         NUM_MMA_WARP_GROUPS = 2
@@ -1571,9 +1631,10 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
                 q_pipeline, k_pipeline, v_pipeline,
                 o_pipeline, alpha_pipeline, beta_pipeline,
-                g_state, g_init_state, work_desc,
+                g_state, g_init_state, g_state_checkpoints, checkpoint_cu_starts, work_desc,
                 scale, wg_idx, math_tidx, num_blocks,
                 num_q_heads, num_v_heads, num_sab_heads, num_seqs,
+                total_checkpoints, checkpoint_every_n_tokens,
             )
 
 
@@ -1591,6 +1652,9 @@ def delta_rule_prefill_dsl(
     beta:       torch.Tensor | None,
     cu_seqlens: torch.Tensor,          # (num_seqs+1,) int64
     scale:      float,
+    state_checkpoints: torch.Tensor | None = None,
+    checkpoint_cu_starts: torch.Tensor | None = None,
+    checkpoint_every_n_tokens: int = 0,
 ):
     from cutlass.cute.runtime import from_dlpack
     import cuda.bindings.driver as cuda_driver
@@ -1613,6 +1677,7 @@ def delta_rule_prefill_dsl(
     needs_alpha      = alpha      is not None
     needs_beta       = beta       is not None
     needs_init_state = init_state is not None
+    needs_checkpointing = checkpoint_every_n_tokens > 0
     kernel_dtype = {
         torch.float16: cutlass.Float16,
         torch.bfloat16: cutlass.BFloat16,
@@ -1644,9 +1709,13 @@ def delta_rule_prefill_dsl(
         (1, num_o_heads * D, D),
     )
     _dummy_f32   = torch.zeros(1, dtype=torch.float32, device=q.device)
+    _dummy_i64   = torch.zeros(1, dtype=torch.int64, device=q.device)
     alpha_t      = alpha.contiguous()      if needs_alpha      else _dummy_f32
     beta_t       = beta.contiguous()       if needs_beta       else _dummy_f32
     init_state_t = init_state.contiguous() if needs_init_state else _dummy_f32
+    state_checkpoints_t = state_checkpoints.contiguous() if needs_checkpointing else _dummy_f32
+    checkpoint_cu_t = checkpoint_cu_starts.to(torch.int64).contiguous() if needs_checkpointing else _dummy_i64
+    total_checkpoints = state_checkpoints_t.shape[0] if needs_checkpointing else 1
     sm_count     = torch.cuda.get_device_properties(q.device).multi_processor_count
     tensormaps_t = torch.empty(sm_count * 128, dtype=torch.uint8, device=q.device)
     cu_int64     = cu_seqlens.to(torch.int64).contiguous()
@@ -1665,11 +1734,15 @@ def delta_rule_prefill_dsl(
     init_state_cute = from_dlpack(
         init_state_t.reshape(-1), assumed_align=16
     ).mark_layout_dynamic()
+    state_checkpoints_cute = from_dlpack(
+        state_checkpoints_t.reshape(-1), assumed_align=16
+    ).mark_layout_dynamic()
+    checkpoint_cu_cute = from_dlpack(checkpoint_cu_t, assumed_align=8).mark_layout_dynamic()
     tensormaps_cute = from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic()
     cu_cute = from_dlpack(cu_int64, assumed_align=8).mark_layout_dynamic()
 
     delta_rule_kernel = _FullyFusedDeltaRuleSm120(
-        needs_alpha, needs_beta, needs_init_state, kernel_dtype
+        needs_alpha, needs_beta, needs_init_state, needs_checkpointing, kernel_dtype
     )
 
     kernel_args = (
@@ -1681,12 +1754,16 @@ def delta_rule_prefill_dsl(
         beta_cute,
         state_cute,
         init_state_cute,
+        state_checkpoints_cute,
+        checkpoint_cu_cute,
         tensormaps_cute,
         cu_cute,
         cutlass.Float32(scale),
         cutlass.Int32(num_q_heads), cutlass.Int32(num_k_heads),
         cutlass.Int32(num_v_heads), cutlass.Int32(num_sab_heads),
         cutlass.Int32(num_seqs),
+        cutlass.Int32(total_checkpoints),
+        cutlass.Int32(checkpoint_every_n_tokens),
         num_seqs * num_sab_heads,
         stream,
     )

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -1,0 +1,1698 @@
+from enum import IntEnum
+
+import torch
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+from cutlass.cute.nvgpu import warp, warpgroup, cpasync
+from .alpha import AlphaProcessor
+from .collective_store_tma import CollectiveStoreTma
+from .custom_compile_cache import KeyedCompileMixin, cached_compile
+from .collective_inverse_hmma import CollectiveInverse
+from .helpers import SM80, round_down
+from .schedule import WorkDesc
+
+
+# ─── Named-barrier IDs used by the compute kernel ────────────────────────────
+# Must not conflict with each other or with pipeline barrier storage.
+
+class NamedBarrier(IntEnum):
+    MATH_WG0 = 4   # OrderedMathBarriers: StreamkBarrier0
+    MATH_WG1 = 5   # OrderedMathBarriers: StreamkBarrier1
+    KK_SYNC  = 13  # sync all 128 WG0 threads before collective_inverse
+
+
+class WarpGroupRole(IntEnum):
+    LDST = 0
+    MATH_KK = 1
+    MATH_QK = 2
+
+
+class LoadStoreWarpRole(IntEnum):
+    LOAD_QKV = 0
+    STORE_O = 1
+    LOAD_BETA = 2
+    LOAD_ALPHA = 3
+
+
+class MathWarpGroupRole(IntEnum):
+    KK = 0
+    QK = 1
+
+# ─── Warp-specialized delta-rule kernel ───────────────────────────────────────
+# Grid: (num_seqs * num_sab_heads, 1, 1)
+# Block: 384 threads → WG0=[0,127], WG1=[128,255], WG2=[256,383]
+#
+# needs_alpha / needs_beta / needs_init_state are class attributes set in __init__.
+# The JIT compiler specialises per instance, so they are compile-time booleans
+# inside the kernel without any parameter-passing trickery.
+
+class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
+
+    @staticmethod
+    def get_register_requirements(
+        max_threads_per_block: int,
+        min_blocks_per_multiprocessor: int,
+        num_mma_warp_groups: int,
+        threads_per_warp_group: int,
+    ) -> tuple[int, int]:
+        reg_alloc_granularity = 8
+        load_registers = 40 - 2 * reg_alloc_granularity
+        total_registers = (
+            round_down(
+                64 * 1024 // min_blocks_per_multiprocessor,
+                max_threads_per_block * reg_alloc_granularity,
+            )
+            // threads_per_warp_group
+        )
+        mma_registers = round_down(
+            (total_registers - load_registers) // num_mma_warp_groups,
+            reg_alloc_granularity,
+        )
+        return min(248, load_registers), min(248, mma_registers)
+
+    @staticmethod
+    def can_implement(
+        num_q_heads: int,
+        num_k_heads: int,
+        num_v_heads: int,
+        head_size: int,
+        element_size: int,
+    ) -> bool:
+        ratio = (
+            num_q_heads // num_v_heads
+            if num_q_heads > num_v_heads
+            else num_v_heads // num_q_heads
+        )
+        is_gva_enabled = num_v_heads > num_q_heads
+
+        is_gqa_like = (
+            (num_k_heads == num_v_heads)
+            and (num_q_heads == ratio * num_k_heads)
+            and (num_q_heads == ratio * num_v_heads)
+        )
+        is_gva_like = (
+            (num_q_heads == num_k_heads)
+            and (num_v_heads == ratio * num_q_heads)
+            and (num_v_heads == ratio * num_k_heads)
+        )
+
+        alignment = 16 // element_size
+        return (
+            ((not is_gva_enabled and is_gqa_like) or (is_gva_enabled and is_gva_like))
+            and (head_size <= 128)
+            and ((head_size % alignment) == 0)
+        )
+
+    def __init__(
+        self,
+        needs_alpha: bool,
+        needs_beta: bool,
+        needs_init_state: bool,
+        dtype: type[cutlass.Numeric] = cutlass.Float16,
+        acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+    ):
+        self.needs_alpha      = needs_alpha
+        self.needs_beta       = needs_beta
+        self.needs_init_state = needs_init_state
+        self.dtype            = dtype
+        self.acc_dtype        = acc_dtype
+        self.inverse_dtype    = cutlass.Float16
+        self.BLK_Q           = 64
+        self.BLK_KV          = 64
+        self.D               = 128
+        self.q_stage          = 1
+        self.k_stage          = 2
+        self.v_stage          = 1
+        self.o_stage          = 1
+        self.alpha_beta_stage = 2
+
+    def get_next_work(
+        self,
+        cu_seqlens: cute.Tensor,
+        num_q_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+    ) -> WorkDesc:
+        bx, _, _ = cute.arch.block_idx()
+        seq_idx      = bx // num_sab_heads
+        o_head_idx   = bx  % num_sab_heads
+        q_head_idx   = o_head_idx * num_q_heads // num_sab_heads
+        v_head_idx   = o_head_idx * num_v_heads // num_sab_heads
+        tok_start    = cutlass.Int32(cu_seqlens[seq_idx])
+        tok_end      = cutlass.Int32(cu_seqlens[seq_idx + 1])
+
+        return WorkDesc(
+            seq_idx=seq_idx,
+            private_q_head_idx=q_head_idx,
+            private_v_head_idx=v_head_idx,
+            tok_offset=tok_start,
+            seq_len=tok_end - tok_start,
+            tile_idx=cutlass.Int32(0),
+        )
+
+    # ─── Ordered 2-WG math barriers ───────────────────────────────────────────
+    # Translates flat::OrderedNamedBarriers<UseReservedNB, NB0, NB1>.
+    # wg_idx: MathWarpGroupRole.KK or MathWarpGroupRole.QK.
+
+    @cute.jit
+    def _math_order_init(self, wg_idx: cutlass.Int32):
+        """Pre-arrive at WG0's barrier so WG0 is unblocked on the first wait."""
+        if wg_idx == MathWarpGroupRole.QK:
+            cute.arch.barrier_arrive(
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+
+    @cute.jit
+    def _math_order_wait(self, wg_idx: cutlass.Int32):
+        """Arrive+wait on this WG's own ordered barrier."""
+        if wg_idx == MathWarpGroupRole.KK:
+            cute.arch.barrier(
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+        else:
+            cute.arch.barrier(
+                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+
+    @cute.jit
+    def _math_order_notify(self, wg_idx: cutlass.Int32):
+        """Arrive at the other WG's barrier to unblock it."""
+        if wg_idx == MathWarpGroupRole.KK:
+            cute.arch.barrier_arrive(
+                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+        else:
+            cute.arch.barrier_arrive(
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+
+    # ─── kk_store_and_inv ─────────────────────────────────────────────────────
+
+    @cute.jit
+    def _kk_store_and_inv(
+        self,
+        tKKrKK: cute.Tensor,      # fp32 KK accumulator (from 128-thread kk_tiled_mma)
+        kk_tiled_mma,
+        kk_thread_idx: cutlass.Int32,
+        sKK_inv: cute.Tensor,     # (BlkKV, BlkKV)
+        sKK_opd: cute.Tensor,     # sKK_inv storage recast as Element for MMA operand
+        sBeta: cute.Tensor,       # (BlkKV, StagesBeta) - used when needs_beta
+        beta_pipe_idx: cutlass.Int32,
+        tKKcMkk: cute.Tensor,     # coordinate mapping for KK fragment
+    ):
+        """Store tKKrKK → sKK_inv, Inverse, optionally reload+beta."""
+        stsm_atom = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+        tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
+        thr_store   = tiled_store.get_slice(kk_thread_idx)
+        tKKsKK      = thr_store.partition_D(sKK_inv)
+        tKKrKK_inv  = cute.make_fragment_like(tKKrKK, self.inverse_dtype)
+        tKKrKK_cv   = thr_store.retile(tKKrKK_inv)
+        for i in cutlass.range_constexpr(cute.size(tKKrKK)):
+            tKKrKK_inv[i] = self.inverse_dtype(tKKrKK[i])
+        cute.copy(tiled_store, tKKrKK_cv, tKKsKK)
+
+        cute.arch.barrier(barrier_id=NamedBarrier.KK_SYNC, number_of_threads=128)
+        CollectiveInverse().run(sKK_inv, NamedBarrier.KK_SYNC)
+
+        if cutlass.const_expr(self.needs_beta or self.dtype != self.inverse_dtype):
+            cute.arch.barrier(barrier_id=NamedBarrier.KK_SYNC, number_of_threads=128)
+            ldsm_atom  = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+            tiled_load = cute.make_tiled_copy_C(ldsm_atom, kk_tiled_mma)
+            thr_load   = tiled_load.get_slice(kk_thread_idx)
+            tKKrKK_cpy = cute.make_fragment_like(tKKrKK_inv)
+            tKKrKK_cvt = cute.make_fragment_like(tKKrKK_inv, self.dtype)
+            tKKrKK_cv2 = thr_load.retile(tKKrKK_cpy)
+            cute.copy(tiled_load, thr_load.partition_S(sKK_inv), tKKrKK_cv2)
+            tKKcMkk_cv = thr_load.retile(tKKcMkk)
+
+            for i in cutlass.range_constexpr(cute.size(tKKrKK_cpy)):
+                if cutlass.const_expr(self.needs_beta):
+                    _, t = tKKcMkk_cv[i]
+                    tKKrKK_cvt[i] = self.dtype(
+                        cutlass.Float32(tKKrKK_cpy[i]) * cutlass.Float32(sBeta[t, beta_pipe_idx])
+                    )
+                else:
+                    tKKrKK_cvt[i] = self.dtype(tKKrKK_cpy[i])
+
+            tKKsKK2 = thr_store.partition_D(sKK_opd)
+            tKKrKK_cv3 = thr_store.retile(tKKrKK_cvt)
+            cute.copy(tiled_store, tKKrKK_cv3, tKKsKK2)
+
+    # ─── kk_epi ───────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def kk_epi(
+        self,
+        tKKrKK:      cute.Tensor,
+        tKKcMkk:     cute.Tensor,
+        sAlpha:      cute.Tensor,
+        sBeta:       cute.Tensor,
+        alpha_stage: cutlass.Int32,
+        beta_stage:  cutlass.Int32,
+    ):
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cumlog = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
+            for i in cutlass.range_constexpr(cute.size(tKKrKK)):
+                s, t = tKKcMkk[i]
+                tKKrKK[i] = tKKrKK[i] * cute.math.exp2(
+                    cutlass.Float32(alpha_cumlog[s]) - cutlass.Float32(alpha_cumlog[t]),
+                    fastmath=True)
+        if cutlass.const_expr(self.needs_beta):
+            beta_row = sBeta[None, beta_stage]
+            for i in cutlass.range_constexpr(cute.size(tKKrKK)):
+                s, _ = tKKcMkk[i]
+                tKKrKK[i] = tKKrKK[i] * cutlass.Float32(beta_row[s])
+
+    # ─── qk_or_kk_mask ────────────────────────────────────────────────────────
+
+    @cute.jit
+    def qk_or_kk_mask(
+        self,
+        frag:           cute.Tensor,
+        coord_tensor:   cute.Tensor,
+        is_final_block: bool,
+        B:              cutlass.Int32,
+    ):
+        for i in cutlass.range_constexpr(cute.size(frag)):
+            s, t = coord_tensor[i]
+            pred = s >= t
+            if cutlass.const_expr(is_final_block):
+                pred = pred and (s < B or t < B)
+            if not pred:
+                frag[i] = cutlass.Float32(0.0)
+
+    # ─── qk_epi ───────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def qk_epi(
+        self,
+        tQKrQK:      cute.Tensor,
+        tQKcMqk:     cute.Tensor,
+        sAlpha:      cute.Tensor,
+        alpha_stage: cutlass.Int32,
+        scale:       cutlass.Float32,
+    ):
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cumlog = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
+            for i in cutlass.range_constexpr(cute.size(tQKrQK)):
+                s, t = tQKcMqk[i]
+                tQKrQK[i] = tQKrQK[i] * cute.math.exp2(
+                    cutlass.Float32(alpha_cumlog[s]) - cutlass.Float32(alpha_cumlog[t]),
+                    fastmath=True) * scale
+        else:
+            for i in cutlass.range_constexpr(cute.size(tQKrQK)):
+                tQKrQK[i] = tQKrQK[i] * scale
+
+    # ─── qk_store ─────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def qk_store(
+        self,
+        tQKrQK:        cute.Tensor,
+        sQK:           cute.Tensor,
+        qk_tiled_mma,
+        qk_thread_idx: cutlass.Int32,
+    ):
+        stsm_atom    = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+        qk_tiled_copy = cute.make_tiled_copy_C(stsm_atom, qk_tiled_mma)
+        qk_thr_copy   = qk_tiled_copy.get_slice(qk_thread_idx)
+        tQKsQK        = qk_thr_copy.partition_D(sQK)
+        tQKrQK_cvt    = cute.make_fragment_like(tQKrQK, self.dtype)
+        tQKrQK_cvt_cv = qk_thr_copy.retile(tQKrQK_cvt)
+        for i in cutlass.range_constexpr(cute.size(tQKrQK)):
+            tQKrQK_cvt[i] = self.dtype(tQKrQK[i])
+        cute.copy(qk_tiled_copy, tQKrQK_cvt_cv, tQKsQK)
+
+    # ─── o1_epi ───────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def o1_epi(
+        self,
+        tOrO:        cute.Tensor,
+        tOcO:        cute.Tensor,
+        sAlpha:      cute.Tensor,
+        alpha_stage: cutlass.Int32,
+        scale:       cutlass.Float32,
+    ):
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cpscale = sAlpha[None, AlphaProcessor.CUMPROD_SCALE, alpha_stage]
+            for i in cutlass.range_constexpr(cute.size(tOrO)):
+                _, tok_q = tOcO[i]
+                tOrO[i] = cutlass.Float32(alpha_cpscale[tok_q]) * tOrO[i]
+        else:
+            for i in cutlass.range_constexpr(cute.size(tOrO)):
+                tOrO[i] = scale * tOrO[i]
+
+    # ─── sk_epi ───────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def sk_epi(
+        self,
+        tSKrSK:      cute.Tensor,
+        tSKcSK:      cute.Tensor,
+        sAlpha:      cute.Tensor,
+        alpha_stage: cutlass.Int32,
+    ):
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cp = sAlpha[None, AlphaProcessor.CUMPROD, alpha_stage]
+            for i in cutlass.range_constexpr(cute.size(tSKrSK)):
+                _, tok_kv = tSKcSK[i]
+                tSKrSK[i] = tSKrSK[i] * cutlass.Float32(alpha_cp[tok_kv])
+
+    # ─── sk_load_v ────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def sk_load_v(
+        self,
+        tSKrSK:  cute.Tensor,
+        sV_DS:   cute.Tensor,
+        sk_tiled_copy_C,
+        sk_thr_copy_C,
+        v_stage: cutlass.Int32,
+    ) -> cute.Tensor:
+        tSKrV    = cute.make_fragment_like(tSKrSK, self.dtype)
+        tSKrV_cv = sk_thr_copy_C.retile(tSKrV)
+        tSKsV    = sk_thr_copy_C.partition_S(sV_DS)
+        cute.copy(sk_tiled_copy_C, tSKsV[None, None, None, v_stage], tSKrV_cv)
+        return tSKrV
+
+    # ─── kv_decay_v ───────────────────────────────────────────────────────────
+
+    @cute.jit
+    def kv_decay_v(
+        self,
+        tKVrV:          cute.Tensor,
+        tKVcV:          cute.Tensor,
+        sAlpha:         cute.Tensor,
+        alpha_stage:    cutlass.Int32,
+        is_final_block: bool,
+        B:              cutlass.Int32,
+    ):
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_cumlog = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
+            block_log    = cutlass.Float32(alpha_cumlog[B - cutlass.Int32(1)])
+            for i in cutlass.range_constexpr(cute.size(tKVrV)):
+                _, tok = tKVcV[i]
+                coeff = cute.math.exp2(
+                    block_log - cutlass.Float32(alpha_cumlog[tok]), fastmath=True)
+                if cutlass.const_expr(is_final_block):
+                    if tok >= B:
+                        coeff = cutlass.Float32(0.0)
+                tKVrV[i] = self.dtype(cutlass.Float32(tKVrV[i]) * coeff)
+        else:
+            for i in cutlass.range_constexpr(cute.size(tKVrV)):
+                _, tok = tKVcV[i]
+                if cutlass.const_expr(is_final_block):
+                    if tok >= B:
+                        tKVrV[i] = self.dtype(0.0)
+
+    # ─── o_store ──────────────────────────────────────────────────────────────
+
+    @cute.jit
+    def o_store(
+        self,
+        tOrO:    cute.Tensor,
+        tOsO:    cute.Tensor,
+        o_tiled_copy_r2s,
+        o_thr_copy_r2s,
+    ):
+        tOrO_f16 = cute.make_fragment_like(tOrO, self.dtype)
+        for i in cutlass.range_constexpr(cute.size(tOrO)):
+            tOrO_f16[i] = self.dtype(tOrO[i])
+        tOrO_cv = o_thr_copy_r2s.retile(tOrO_f16)
+        cute.arch.fence_view_async_shared()
+        cute.copy(o_tiled_copy_r2s, tOrO_cv, tOsO)
+        cute.arch.fence_view_async_shared()
+
+    # ─── TMA load helpers ────────────────────────────────────────────────────
+
+    @cute.jit
+    def load_qkv_tma(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sV_DS: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        tma_tensor_q: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        q_pipeline,
+        q_producer_state,
+        k_pipeline,
+        k_producer_state,
+        v_pipeline,
+        v_producer_state,
+        blk:          cutlass.Int32,
+        tok_start:    cutlass.Int32,
+        q_head_idx:   cutlass.Int32,
+        k_head_idx:   cutlass.Int32,
+        v_head_idx:   cutlass.Int32,
+    ):
+
+        blk_tok = tok_start + blk * cutlass.Int32(self.BLK_KV)
+
+        sK = sK_DS[None, None, k_producer_state.index]
+        mK = cute.domain_offset(
+            (cutlass.Int32(0), blk_tok),
+            tma_tensor_k[None, None, k_head_idx],
+        )
+        gK = cute.zipped_divide(mK, (self.D, self.BLK_KV))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        tKsK, tKgK = cpasync.tma_partition(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sK, 0, 2),
+            cute.group_modes(gK, 0, 2),
+        )
+        k_pipeline.producer_acquire(k_producer_state)
+        cute.copy(
+            tma_atom_k, tKgK, tKsK,
+            tma_bar_ptr=k_pipeline.producer_get_barrier(k_producer_state),
+        )
+        k_pipeline.producer_commit(k_producer_state)
+        k_producer_state.advance()
+
+        sQ = sQ_SD[None, None, q_producer_state.index]
+        mQ = cute.domain_offset(
+            (blk_tok, cutlass.Int32(0)),
+            tma_tensor_q[None, None, q_head_idx],
+        )
+        gQ = cute.zipped_divide(mQ, (self.BLK_Q, self.D))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        tQsQ, tQgQ = cpasync.tma_partition(
+            tma_atom_q,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sQ, 0, 2),
+            cute.group_modes(gQ, 0, 2),
+        )
+        q_pipeline.producer_acquire(q_producer_state)
+        cute.copy(
+            tma_atom_q, tQgQ, tQsQ,
+            tma_bar_ptr=q_pipeline.producer_get_barrier(q_producer_state),
+        )
+        q_pipeline.producer_commit(q_producer_state)
+        q_producer_state.advance()
+
+        sV = sV_DS[None, None, v_producer_state.index]
+        mV = cute.domain_offset(
+            (cutlass.Int32(0), blk_tok),
+            tma_tensor_v[None, None, v_head_idx],
+        )
+        gV = cute.zipped_divide(mV, (self.D, self.BLK_KV))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        tVsV, tVgV = cpasync.tma_partition(
+            tma_atom_v,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sV, 0, 2),
+            cute.group_modes(gV, 0, 2),
+        )
+        v_pipeline.producer_acquire(v_producer_state)
+        cute.copy(
+            tma_atom_v, tVgV, tVsV,
+            tma_bar_ptr=v_pipeline.producer_get_barrier(v_producer_state),
+        )
+        v_pipeline.producer_commit(v_producer_state)
+        v_producer_state.advance()
+        return q_producer_state, k_producer_state, v_producer_state
+
+    # ─── load_alpha ───────────────────────────────────────────────────────────
+    # Translates FlatMainloopTmaWarpSpecializedDeltaRule::load_alpha (scalar load).
+    # Caller must sync before calling AlphaProcessor on the loaded data.
+
+    @cute.jit
+    def load_alpha(
+        self,
+        sAlpha:       cute.Tensor,
+        g_alpha:      cute.Tensor,
+        blk_tok:      cutlass.Int32,
+        tok_end:      cutlass.Int32,
+        sab_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        alpha_stage:  cutlass.Int32,
+    ):
+        lane_id = cute.arch.lane_idx()
+        sAlpha_k = sAlpha[None, None, alpha_stage]
+        num_iters = self.BLK_Q // 32
+        for i in cutlass.range_constexpr(num_iters):
+            row = cutlass.Int32(i * 32) + lane_id
+            tok = blk_tok + row
+            if tok < tok_end:
+                sAlpha_k[row, AlphaProcessor.CUMSUM_LOG] = g_alpha[
+                    tok * num_sab_heads + sab_head_idx]
+            else:
+                sAlpha_k[row, AlphaProcessor.CUMSUM_LOG] = cutlass.Float32(1.0)
+
+    # ─── load_beta ────────────────────────────────────────────────────────────
+    # Translates FlatMainloopTmaWarpSpecializedDeltaRule::load_beta.
+
+    @cute.jit
+    def load_beta(
+        self,
+        sBeta:        cute.Tensor,
+        g_beta:       cute.Tensor,
+        blk_tok:      cutlass.Int32,
+        tok_end:      cutlass.Int32,
+        sab_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        beta_stage:   cutlass.Int32,
+    ):
+        lane_id = cute.arch.lane_idx()
+        sBeta_k = sBeta[None, beta_stage]
+        num_iters = self.BLK_KV // 32
+        for i in cutlass.range_constexpr(num_iters):
+            row = cutlass.Int32(i * 32) + lane_id
+            tok = blk_tok + row
+            if tok < tok_end:
+                sBeta_k[row] = g_beta[tok * num_sab_heads + sab_head_idx]
+            else:
+                sBeta_k[row] = cutlass.Float32(0.0)
+
+    # ─── kv_load / kv_store ───────────────────────────────────────────────────
+
+    @cute.jit
+    def kv_load(
+        self,
+        tKVrKV:      cute.Tensor,
+        gKV:         cute.Tensor,
+        kv_thr_mma,
+    ):
+        c_kv   = cute.make_identity_tensor((self.D, self.D))
+        tKVcKV = kv_thr_mma.partition_C(c_kv)
+        for i in cutlass.range_constexpr(cute.size(tKVrKV)):
+            v_idx, k_idx = tKVcKV[i]
+            tKVrKV[i] = gKV[k_idx, v_idx]
+
+    @cute.jit
+    def kv_store(
+        self,
+        tKVrKV:    cute.Tensor,
+        gKV:       cute.Tensor,
+        kv_thr_mma,
+    ):
+        c_kv   = cute.make_identity_tensor((self.D, self.D))
+        tKVcKV = kv_thr_mma.partition_C(c_kv)
+        for i in cutlass.range_constexpr(cute.size(tKVrKV)):
+            v_idx, k_idx = tKVcKV[i]
+            gKV[k_idx, v_idx] = tKVrKV[i]
+
+    # ─── compute_loop_body ───────────────────────────────────────────────────
+    # Translates the C++ compute_loop_body lambda captured inside compute().
+    # Called by Math WGs (tidx >= 128) for one block iteration.
+
+    @cute.jit
+    def compute_loop_body(
+        self,
+        # Smem tensors (staged; caller indexes the active stage)
+        sQ_SD:   cute.Tensor,    # (BlkQ, D, StagesQ)  – row-major atom, swizzled
+        sK_SD:   cute.Tensor,    # (BlkKV, D, StagesK) – same atom
+        sK_DS:   cute.Tensor,    # (D, BlkKV, StagesK) – K transposed
+        sV_DS:   cute.Tensor,    # (D, BlkKV, StagesV) – V transposed
+        sQK:     cute.Tensor,    # (BlkQ, BlkKV)
+        sKK_inv: cute.Tensor,    # (BlkKV, BlkKV)
+        sKK_opd: cute.Tensor,    # sKK_inv storage recast as Element
+        sO:      cute.Tensor,    # O output smem (staged)
+        sAlpha:  cute.Tensor,    # (BlkQ, AlphaProcessor.NUM_CHANNELS, StagesAlpha) or zero-shaped
+        sBeta:   cute.Tensor,    # (BlkKV, StagesBeta) or zero-shaped
+        kv_tiled_mma,
+        # Mainloop pipelines and active read states
+        q_pipeline,
+        q_consumer_state,
+        k_pipeline,
+        k_consumer_state,
+        v_pipeline,
+        v_consumer_state,
+        o_pipeline,
+        o_producer_state,
+        alpha_pipeline,
+        alpha_consumer_state,
+        beta_pipeline,
+        beta_consumer_state,
+        # Compile-time flags
+        is_first_block: bool,
+        is_final_block: bool,
+        # Valid token count for masking on final block
+        B: cutlass.Int32,
+        # Running KV state (D×D fp32, in registers across all blocks)
+        tKVrKV: cute.Tensor,
+        # Scale factor
+        scale: cutlass.Float32,
+        # WG role: MathWarpGroupRole.KK or MathWarpGroupRole.QK.
+        wg_idx: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx    = tidx - cutlass.Int32(128)        # relative to compute threads
+        kk_thread_idx = thread_idx % cutlass.Int32(128)
+        qk_thread_idx = thread_idx % cutlass.Int32(128)
+
+        # ── TiledMMAs ─────────────────────────────────────────────────────────
+        blk_q  = cute.size(sQ_SD, mode=[0])
+        blk_kv = cute.size(sK_SD, mode=[0])
+        d      = cute.size(sQ_SD, mode=[1])
+        tile_shape_qk = (blk_q, blk_kv, d)
+        tile_shape_kk = tile_shape_qk
+        tile_shape_o1 = (d, blk_q, d)
+        tile_shape_o2 = (d, blk_q, blk_kv)
+        tile_shape_sk = (d, blk_kv, d)
+        tile_shape_newv = (d, blk_kv, blk_kv)
+        k_stage = k_consumer_state.index
+        q_stage = q_consumer_state.index
+        v_stage = v_consumer_state.index
+        o_stage = cutlass.Int32(0)
+        alpha_stage = alpha_consumer_state.index
+        beta_stage = beta_consumer_state.index
+
+        mma_atom_4w = warp.MmaF16BF16Op(self.dtype, self.acc_dtype, (16, 8, 16))
+        mma_atom_8w = warp.MmaF16BF16Op(self.dtype, self.acc_dtype, (16, 8, 16))
+
+        # QK/KK: 4 warps × 16M = 64M  (1 warpgroup, 128 threads)
+        qk_tiled_mma = cute.make_tiled_mma(
+            mma_atom_4w, cute.make_layout((4, 1, 1)),
+            permutation_mnk=tile_shape_qk)
+        kk_tiled_mma = cute.make_tiled_mma(
+            mma_atom_4w, cute.make_layout((4, 1, 1)),
+            permutation_mnk=tile_shape_kk)
+
+        # O1/O2/SK/NewV: 8 warps × 16M = 128M (both warpgroups, 256 threads)
+        o1_tiled_mma = cute.make_tiled_mma(
+            mma_atom_8w, cute.make_layout((8, 1, 1)),
+            permutation_mnk=tile_shape_o1)
+        o2_tiled_mma = cute.make_tiled_mma(
+            mma_atom_8w, cute.make_layout((8, 1, 1)),
+            permutation_mnk=tile_shape_o2)
+        sk_tiled_mma = cute.make_tiled_mma(
+            mma_atom_8w, cute.make_layout((8, 1, 1)),
+            permutation_mnk=tile_shape_sk)
+        newv_tiled_mma = cute.make_tiled_mma(
+            mma_atom_8w, cute.make_layout((8, 1, 1)),
+            permutation_mnk=tile_shape_newv)
+
+        # ── Thread slices ─────────────────────────────────────────────────────
+        qk_thr_mma   = qk_tiled_mma.get_slice(qk_thread_idx)
+        kk_thr_mma   = kk_tiled_mma.get_slice(kk_thread_idx)
+        sk_thr_mma   = sk_tiled_mma.get_slice(thread_idx)
+        newv_thr_mma = newv_tiled_mma.get_slice(thread_idx)
+        o1_thr_mma   = o1_tiled_mma.get_slice(thread_idx)
+        o2_thr_mma   = o2_tiled_mma.get_slice(thread_idx)
+        kv_thr_mma   = kv_tiled_mma.get_slice(thread_idx)
+
+        # ── Copy atoms ────────────────────────────────────────────────────────
+        ldsm_n4 = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+        ldsm_t4 = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=True,  num_matrices=4), self.dtype)
+        stsm_n4 = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+
+        # ── Active smem slices (extract 2D from staged tensors) ───────────────
+        sQ_k    = sQ_SD[None, None, q_stage]    # (BlkQ, D)
+        sK_SD_k = sK_SD[None, None, k_stage]   # (BlkKV, D)
+        sK_DS_k = sK_DS[None, None, k_stage]   # (D, BlkKV)
+
+        # ── QK copies ─────────────────────────────────────────────────────────
+        qk_tiled_copy_A = cute.make_tiled_copy_A(ldsm_n4, qk_tiled_mma)
+        qk_tiled_copy_B = cute.make_tiled_copy_B(ldsm_n4, qk_tiled_mma)
+        qk_thr_copy_A = qk_tiled_copy_A.get_slice(qk_thread_idx)
+        qk_thr_copy_B = qk_tiled_copy_B.get_slice(qk_thread_idx)
+
+        tQKrQ    = qk_thr_mma.make_fragment_A(qk_thr_mma.partition_A(sQ_k))
+        tQKrQ_cv = qk_thr_copy_A.retile(tQKrQ)
+        tQKsQ    = qk_thr_copy_A.partition_S(sQ_SD)
+        tQKrK    = qk_thr_mma.make_fragment_B(qk_thr_mma.partition_B(sK_SD_k))
+        tQKrK_cv = qk_thr_copy_B.retile(tQKrK)
+        tQKsK    = qk_thr_copy_B.partition_S(sK_SD)
+
+        # ── KK copies (same atom as QK) ───────────────────────────────────────
+        kk_tiled_copy_A = cute.make_tiled_copy_A(ldsm_n4, kk_tiled_mma)
+        kk_tiled_copy_B = cute.make_tiled_copy_B(ldsm_n4, kk_tiled_mma)
+        kk_thr_copy_A = kk_tiled_copy_A.get_slice(kk_thread_idx)
+        kk_thr_copy_B = kk_tiled_copy_B.get_slice(kk_thread_idx)
+
+        tKKrA    = kk_thr_mma.make_fragment_A(kk_thr_mma.partition_A(sK_SD_k))
+        tKKrA_cv = kk_thr_copy_A.retile(tKKrA)
+        tKKsA    = kk_thr_copy_A.partition_S(sK_SD)
+        tKKrB    = kk_thr_mma.make_fragment_B(kk_thr_mma.partition_B(sK_SD_k))
+        tKKrB_cv = kk_thr_copy_B.retile(tKKrB)
+        tKKsB    = kk_thr_copy_B.partition_S(sK_SD)
+
+        # ── SK copies ─────────────────────────────────────────────────────────
+        # SK B: K loaded from sK_SD (row-major BlkKV×D) with LDSM_N — matches C++ SK B-operand
+        # SK C: V loaded from sV_DS (col-major D×BlkKV) with LDSM_T
+        sk_tiled_copy_B = cute.make_tiled_copy_B(ldsm_n4, sk_tiled_mma)
+        sk_tiled_copy_C = cute.make_tiled_copy_C(ldsm_t4, sk_tiled_mma)
+        sk_thr_copy_B = sk_tiled_copy_B.get_slice(thread_idx)
+        sk_thr_copy_C = sk_tiled_copy_C.get_slice(thread_idx)
+
+        # Work around DSL make_fragment_B not accepting partition_shape_B output directly.
+        tSKrK    = cute.make_rmem_tensor(
+            sk_thr_mma.partition_shape_B(cute.slice_(tile_shape_sk, (0, None, None))), self.dtype)
+        tSKrK_cv = sk_thr_copy_B.retile(tSKrK)
+        tSKsK    = sk_thr_copy_B.partition_S(sK_SD)
+
+        # ── NewV copies ───────────────────────────────────────────────────────
+        newv_tiled_copy_B = cute.make_tiled_copy_B(ldsm_n4, newv_tiled_mma)
+        newv_thr_copy_B = newv_tiled_copy_B.get_slice(thread_idx)
+        tNewVrB    = newv_thr_mma.make_fragment_B(newv_thr_mma.partition_B(sKK_opd))
+        tNewVrB_cv = newv_thr_copy_B.retile(tNewVrB)
+        tNewVsB    = newv_thr_copy_B.partition_S(sKK_opd)
+
+        # ── KV copies ─────────────────────────────────────────────────────────
+        kv_tiled_copy_B = cute.make_tiled_copy_B(ldsm_t4, kv_tiled_mma)
+        kv_thr_copy_B = kv_tiled_copy_B.get_slice(thread_idx)
+        tKVrK    = kv_thr_mma.make_fragment_B(kv_thr_mma.partition_B(sK_DS_k))
+        tKVrK_cv = kv_thr_copy_B.retile(tKVrK)
+        tKVsK    = kv_thr_copy_B.partition_S(sK_DS)
+
+        # ── O1/O2 copies ──────────────────────────────────────────────────────
+        o1_tiled_copy_B = cute.make_tiled_copy_B(ldsm_n4, o1_tiled_mma)
+        o2_tiled_copy_B = cute.make_tiled_copy_B(ldsm_n4, o2_tiled_mma)
+        o1_thr_copy_B = o1_tiled_copy_B.get_slice(thread_idx)
+        o2_thr_copy_B = o2_tiled_copy_B.get_slice(thread_idx)
+
+        # Direct partition_B(sQ_k) preserves the swizzled Q layout here and produces
+        # a non-C++ B fragment shape; derive the fragment from TileShapeO1 instead.
+        tOrQ    = cute.make_rmem_tensor(
+            o1_thr_mma.partition_shape_B(cute.slice_(tile_shape_o1, (0, None, None))), self.dtype)
+        tOrQ_cv = o1_thr_copy_B.retile(tOrQ)
+        tOsQ    = o1_thr_copy_B.partition_S(sQ_SD)
+        tOrQK    = o2_thr_mma.make_fragment_B(o2_thr_mma.partition_B(sQK))
+        tOrQK_cv = o2_thr_copy_B.retile(tOrQK)
+        tOsQK    = o2_thr_copy_B.partition_S(sQK)
+
+        # ── O store (R→S STSM) ────────────────────────────────────────────────
+        o_stsm   = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype)
+        o_tiled_copy_r2s = cute.make_tiled_copy_C(o_stsm, o1_tiled_mma)
+        o_thr_copy_r2s = o_tiled_copy_r2s.get_slice(thread_idx)
+        tOsO = o_thr_copy_r2s.partition_D(sO)
+
+        # ── Coordinate tensors for masking / alpha/beta indexing ──────────────
+        cMqk    = cute.make_identity_tensor((blk_q, blk_kv))
+        tQKcMqk = qk_thr_mma.partition_C(cMqk)
+        cMkk    = cMqk   # same shape (BlkKV == BlkQ == 64)
+        tKKcMkk = kk_thr_mma.partition_C(cMkk)
+        cO      = cute.make_identity_tensor((d, blk_q))
+        tOcO    = o1_thr_mma.partition_C(cO)
+        cSK     = cute.make_identity_tensor((d, blk_kv))
+        tSKcSK  = sk_thr_mma.partition_C(cSK)
+        cV      = cute.make_identity_tensor((d, blk_kv))
+        tKVcV   = kv_thr_mma.partition_A(cV)
+
+        # ── KK GEMM (WG0 only) ────────────────────────────────────────────────
+        k_pipeline.consumer_wait(k_consumer_state)
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_pipeline.consumer_wait(alpha_consumer_state)
+            cute.arch.fence_view_async_shared()
+        if cutlass.const_expr(self.needs_beta):
+            beta_pipeline.consumer_wait(beta_consumer_state)
+            cute.arch.fence_view_async_shared()
+        # Match the C++ reject-non-role-first shape; ptxas keeps BRA.U around
+        # the role body instead of predicating the HMMA/LDSM/STSM sequence.
+        if wg_idx != MathWarpGroupRole.KK:
+            cute.arch.sync_warp()
+        else:
+            cute.copy(kk_tiled_copy_A, tKKsA[None, None, None, k_stage], tKKrA_cv)
+            cute.copy(kk_tiled_copy_B, tKKsB[None, None, None, k_stage], tKKrB_cv)
+            tKKrKK = cute.make_rmem_tensor(
+                kk_thr_mma.partition_shape_C((blk_kv, blk_kv)),
+                self.acc_dtype)
+            tKKrKK.fill(self.acc_dtype(0.0))
+            cute.gemm(kk_tiled_mma, tKKrKK, tKKrA, tKKrB, tKKrKK)
+            self.kk_epi(tKKrKK, tKKcMkk, sAlpha, sBeta, alpha_stage, beta_stage)
+            self.qk_or_kk_mask(tKKrKK, tKKcMkk, is_final_block, B)
+            self._kk_store_and_inv(
+                tKKrKK, kk_tiled_mma, kk_thread_idx, sKK_inv, sKK_opd,
+                sBeta, beta_stage, tKKcMkk)
+        if cutlass.const_expr(self.needs_beta):
+            beta_pipeline.consumer_release(beta_consumer_state)
+            beta_consumer_state.advance()
+
+        # ── QK GEMM (WG1 only) ────────────────────────────────────────────────
+        q_pipeline.consumer_wait(q_consumer_state)
+        if wg_idx != MathWarpGroupRole.QK:
+            cute.arch.sync_warp()
+        else:
+            cute.copy(qk_tiled_copy_A, tQKsQ[None, None, None, q_stage], tQKrQ_cv)
+            cute.copy(qk_tiled_copy_B, tQKsK[None, None, None, k_stage], tQKrK_cv)
+            tQKrQK = cute.make_rmem_tensor(
+                qk_thr_mma.partition_shape_C((blk_q, blk_kv)),
+                self.acc_dtype)
+            tQKrQK.fill(self.acc_dtype(0.0))
+            cute.gemm(qk_tiled_mma, tQKrQK, tQKrQ, tQKrK, tQKrQK)
+            self.qk_epi(tQKrQK, tQKcMqk, sAlpha, alpha_stage, scale)
+            self.qk_or_kk_mask(tQKrQK, tQKcMqk, is_final_block, B)
+            self.qk_store(tQKrQK, sQK, qk_tiled_mma, qk_thread_idx)
+
+        # ── O1: KV_state @ Q (both WGs, skip on first block) ─────────────────
+        tOrO = cute.make_rmem_tensor(
+            o1_thr_mma.partition_shape_C((d, blk_q)), self.acc_dtype)
+        tOrO.fill(self.acc_dtype(0.0))
+        if cutlass.const_expr(not is_first_block):
+            cute.copy(o1_tiled_copy_B, tOsQ[None, None, None, q_stage], tOrQ_cv)
+            tOrKV = SM80.make_acc_into_op(tKVrKV, o1_tiled_mma, self.dtype)
+            cute.gemm(o1_tiled_mma, tOrO, tOrKV, tOrQ, tOrO)
+            self.o1_epi(tOrO, tOcO, sAlpha, alpha_stage, scale)
+        q_pipeline.consumer_release(q_consumer_state)
+        q_consumer_state.advance()
+
+        # ── SK: KV_state @ K^T (result negated below via V - SK) ─────────────
+        tSKrSK = cute.make_rmem_tensor(
+            sk_thr_mma.partition_shape_C((d, blk_kv)), self.acc_dtype)
+        tSKrSK.fill(self.acc_dtype(0.0))
+        if cutlass.const_expr(not is_first_block):
+            tSKrS = SM80.make_acc_into_op(tKVrKV, sk_tiled_mma, self.dtype)
+            cute.copy(sk_tiled_copy_B, tSKsK[None, None, None, k_stage], tSKrK_cv)
+            cute.gemm(sk_tiled_mma, tSKrSK, tSKrS, tSKrK, tSKrSK)
+
+        # ── Load V from smem ──────────────────────────────────────────────────
+        v_pipeline.consumer_wait(v_consumer_state)
+        tSKrV = self.sk_load_v(
+            tSKrSK, sV_DS, sk_tiled_copy_C, sk_thr_copy_C, v_stage)
+
+        # sk_epi + V - SK  (SK=0 on first block, so V - SK = V)
+        if cutlass.const_expr(not is_first_block):
+            self.sk_epi(tSKrSK, tSKcSK, sAlpha, alpha_stage)
+            for i in cutlass.range_constexpr(cute.size(tSKrV)):
+                tSKrV[i] = tSKrV[i] - self.dtype(tSKrSK[i])
+
+        # ── NewV = (V - SK) @ T^T  (ordered: WG0 first) ──────────────────────
+        tNewVrA = SM80.make_acc_into_op(tSKrV, newv_tiled_mma, self.dtype)
+        tNewVrC = cute.make_rmem_tensor(
+            newv_thr_mma.partition_shape_C((d, blk_kv)), self.acc_dtype)
+        self._math_order_wait(wg_idx)
+        cute.copy(newv_tiled_copy_B, tNewVsB, tNewVrB_cv)
+        tNewVrC.fill(self.acc_dtype(0.0))
+        cute.gemm(newv_tiled_mma, tNewVrC, tNewVrA, tNewVrB, tNewVrC)
+        self._math_order_notify(wg_idx)
+        v_pipeline.consumer_release(v_consumer_state)
+        v_consumer_state.advance()
+
+        # ── O2 = O1 + NewV @ QK  (ordered: WG0 first) ────────────────────────
+        tOrNewV = SM80.make_acc_into_op(tNewVrC, o2_tiled_mma, self.dtype)
+        self._math_order_wait(wg_idx)
+        cute.copy(o2_tiled_copy_B, tOsQK, tOrQK_cv)
+        cute.gemm(o2_tiled_mma, tOrO, tOrNewV, tOrQK, tOrO)
+        self._math_order_notify(wg_idx)
+
+        # ── O store to smem ───────────────────────────────────────────────────
+        o_pipeline.producer_acquire(o_producer_state)
+        self.o_store(
+            tOrO, tOsO[None, None, None, o_stage],
+            o_tiled_copy_r2s, o_thr_copy_r2s,
+        )
+        o_pipeline.producer_commit(o_producer_state)
+        o_producer_state.advance()
+
+        # ── KV state update ───────────────────────────────────────────────────
+        block_coeff = cutlass.Float32(1.0)
+        if cutlass.const_expr(self.needs_alpha):
+            block_coeff = cutlass.Float32(
+                sAlpha[B - cutlass.Int32(1), AlphaProcessor.CUMPROD, alpha_stage])
+
+        for i in cutlass.range_constexpr(cute.size(tKVrKV)):
+            tKVrKV[i] = block_coeff * tKVrKV[i]
+
+        self.kv_decay_v(tOrNewV, tKVcV, sAlpha, alpha_stage, is_final_block, B)
+
+        # KV += NewV @ K
+        cute.copy(kv_tiled_copy_B, tKVsK[None, None, None, k_stage], tKVrK_cv)
+        cute.gemm(kv_tiled_mma, tKVrKV, tOrNewV, tKVrK, tKVrKV)
+        k_pipeline.consumer_release(k_consumer_state)
+        k_consumer_state.advance()
+        if cutlass.const_expr(self.needs_alpha):
+            alpha_pipeline.consumer_release(alpha_consumer_state)
+            alpha_consumer_state.advance()
+        return (
+            q_consumer_state,
+            k_consumer_state,
+            v_consumer_state,
+            o_producer_state,
+            alpha_consumer_state,
+            beta_consumer_state,
+        )
+
+    # ─── Warp role entry points ──────────────────────────────────────────────
+    # The current DSL bridge still uses CTA-wide sync epochs, but each role owns
+    # its own loop, matching the C++ warp-specialized dispatch shape.
+
+    @cute.jit
+    def run_load_qkv_role(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sV_DS: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        tma_tensor_q: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        q_pipeline,
+        k_pipeline,
+        v_pipeline,
+        num_blocks: cutlass.Int32,
+        tok_start: cutlass.Int32,
+        q_head_idx: cutlass.Int32,
+        k_head_idx: cutlass.Int32,
+        v_head_idx: cutlass.Int32,
+    ):
+        q_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.q_stage)
+        k_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.k_stage)
+        v_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.v_stage)
+        for blk in cutlass.range(num_blocks, unroll=1):
+            (
+                q_producer_state,
+                k_producer_state,
+                v_producer_state,
+            ) = self.load_qkv_tma(
+                sQ_SD, sK_DS, sV_DS,
+                tma_atom_q, tma_tensor_q,
+                tma_atom_k, tma_tensor_k,
+                tma_atom_v, tma_tensor_v,
+                q_pipeline, q_producer_state,
+                k_pipeline, k_producer_state,
+                v_pipeline, v_producer_state,
+                blk, tok_start,
+                q_head_idx, k_head_idx, v_head_idx,
+            )
+
+    @cute.jit
+    def run_load_alpha_role(
+        self,
+        sAlpha: cute.Tensor,
+        g_alpha: cute.Tensor,
+        alpha_pipeline,
+        scale: cutlass.Float32,
+        num_blocks: cutlass.Int32,
+        tok_start: cutlass.Int32,
+        tok_end: cutlass.Int32,
+        sab_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+    ):
+        alpha_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.alpha_beta_stage)
+        for blk in cutlass.range(num_blocks, unroll=1):
+            blk_tok = tok_start + blk * cutlass.Int32(self.BLK_Q)
+            if cutlass.const_expr(self.needs_alpha):
+                alpha_pipeline.producer_acquire(alpha_producer_state)
+                cute.arch.fence_view_async_shared()
+                self.load_alpha(
+                    sAlpha, g_alpha, blk_tok, tok_end, sab_head_idx,
+                    num_sab_heads, alpha_producer_state.index,
+                )
+                AlphaProcessor().run(sAlpha[None, None, alpha_producer_state.index], scale)
+                cute.arch.fence_view_async_shared()
+                alpha_pipeline.producer_commit(alpha_producer_state)
+                alpha_producer_state.advance()
+
+    @cute.jit
+    def run_load_beta_role(
+        self,
+        sBeta: cute.Tensor,
+        g_beta: cute.Tensor,
+        beta_pipeline,
+        num_blocks: cutlass.Int32,
+        tok_start: cutlass.Int32,
+        tok_end: cutlass.Int32,
+        sab_head_idx: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+    ):
+        beta_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.alpha_beta_stage)
+        for blk in cutlass.range(num_blocks, unroll=1):
+            blk_tok = tok_start + blk * cutlass.Int32(self.BLK_KV)
+            if cutlass.const_expr(self.needs_beta):
+                beta_pipeline.producer_acquire(beta_producer_state)
+                cute.arch.fence_view_async_shared()
+                self.load_beta(
+                    sBeta, g_beta, blk_tok, tok_end, sab_head_idx,
+                    num_sab_heads, beta_producer_state.index,
+                )
+                cute.arch.fence_view_async_shared()
+                beta_pipeline.producer_commit(beta_producer_state)
+                beta_producer_state.advance()
+
+    @cute.jit
+    def run_math_role(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_SD: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sV_DS: cute.Tensor,
+        sQK: cute.Tensor,
+        sKK_inv: cute.Tensor,
+        sKK_opd: cute.Tensor,
+        sO: cute.Tensor,
+        sAlpha: cute.Tensor,
+        sBeta: cute.Tensor,
+        q_pipeline,
+        k_pipeline,
+        v_pipeline,
+        o_pipeline,
+        alpha_pipeline,
+        beta_pipeline,
+        g_state: cute.Tensor,
+        g_init_state: cute.Tensor,
+        work_desc: WorkDesc,
+        scale: cutlass.Float32,
+        wg_idx: cutlass.Int32,
+        math_tidx: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+        num_q_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+    ):
+        self._math_order_init(wg_idx)
+        q_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.q_stage)
+        k_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.k_stage)
+        v_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.v_stage)
+        o_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.o_stage)
+        alpha_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+        beta_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+
+        kv_tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(self.dtype, self.acc_dtype, (16, 8, 16)),
+            cute.make_layout((8, 1, 1)),
+            permutation_mnk=(self.D, self.D, self.BLK_KV))
+        kv_thr_mma = kv_tiled_mma.get_slice(math_tidx)
+        tKVrKV = cute.make_rmem_tensor(
+            kv_thr_mma.partition_shape_C((self.D, self.D)), self.acc_dtype)
+        tKVrKV.fill(self.acc_dtype(0.0))
+
+        state_layout = cute.make_ordered_layout(
+            (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
+        )
+        o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
+        mState = cute.make_tensor(g_state.iterator, state_layout)
+        gStateKV = mState[
+            None, None, o_head_idx, work_desc.seq_idx
+        ]
+        if cutlass.const_expr(self.needs_init_state):
+            mInitState = cute.make_tensor(g_init_state.iterator, state_layout)
+            gInitKV = mInitState[
+                None, None, o_head_idx, work_desc.seq_idx
+            ]
+            self.kv_load(tKVrKV, gInitKV, kv_thr_mma)
+
+        first_B = work_desc.seq_len
+        if first_B > cutlass.Int32(self.BLK_KV):
+            first_B = cutlass.Int32(self.BLK_KV)
+        if cutlass.const_expr(self.needs_init_state):
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                alpha_consumer_state,
+                beta_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                kv_tiled_mma,
+                q_pipeline, q_consumer_state,
+                k_pipeline, k_consumer_state,
+                v_pipeline, v_consumer_state,
+                o_pipeline, o_producer_state,
+                alpha_pipeline, alpha_consumer_state,
+                beta_pipeline, beta_consumer_state,
+                False, True, first_B,
+                tKVrKV, scale, wg_idx,
+            )
+        else:
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                alpha_consumer_state,
+                beta_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                kv_tiled_mma,
+                q_pipeline, q_consumer_state,
+                k_pipeline, k_consumer_state,
+                v_pipeline, v_consumer_state,
+                o_pipeline, o_producer_state,
+                alpha_pipeline, alpha_consumer_state,
+                beta_pipeline, beta_consumer_state,
+                True, True, first_B,
+                tKVrKV, scale, wg_idx,
+            )
+
+        for blk in cutlass.range(cutlass.Int32(1), num_blocks - cutlass.Int32(1), cutlass.Int32(1), unroll=1):
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                alpha_consumer_state,
+                beta_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                kv_tiled_mma,
+                q_pipeline, q_consumer_state,
+                k_pipeline, k_consumer_state,
+                v_pipeline, v_consumer_state,
+                o_pipeline, o_producer_state,
+                alpha_pipeline, alpha_consumer_state,
+                beta_pipeline, beta_consumer_state,
+                False, False, cutlass.Int32(self.BLK_KV),
+                tKVrKV, scale, wg_idx,
+            )
+
+        if num_blocks != cutlass.Int32(1):
+            last_blk = num_blocks - cutlass.Int32(1)
+            last_B = work_desc.seq_len - last_blk * cutlass.Int32(self.BLK_KV)
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                alpha_consumer_state,
+                beta_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                kv_tiled_mma,
+                q_pipeline, q_consumer_state,
+                k_pipeline, k_consumer_state,
+                v_pipeline, v_consumer_state,
+                o_pipeline, o_producer_state,
+                alpha_pipeline, alpha_consumer_state,
+                beta_pipeline, beta_consumer_state,
+                False, True, last_B,
+                tKVrKV, scale, wg_idx,
+            )
+        self.kv_store(tKVrKV, gStateKV, kv_thr_mma)
+
+    # ─── Kernel entry point ───────────────────────────────────────────────────
+
+    @cute.jit
+    def __call__(
+        self,
+        g_q:          cute.Tensor,
+        g_k:          cute.Tensor,
+        g_v:          cute.Tensor,
+        g_o:          cute.Tensor,
+        g_alpha:      cute.Tensor,
+        g_beta:       cute.Tensor,
+        g_state:      cute.Tensor,
+        g_init_state: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        cu_seqlens:   cute.Tensor,
+        scale:        cutlass.Float32,
+        num_q_heads:   cutlass.Int32,
+        num_k_heads:   cutlass.Int32,
+        num_v_heads:   cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        num_seqs:      cutlass.Int32,
+        grid_x: int,
+        stream,
+    ):
+
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        q_storage_layout = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_Q, self.D, self.q_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        q_smem_layout = cute.slice_(q_storage_layout, (None, None, 0))
+        k_storage_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.k_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0, 2])
+        v_storage_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.v_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        v_storage_layout_ds = cute.select(v_storage_layout_sd, [1, 0, 2])
+        k_smem_layout = cute.slice_(k_storage_layout_ds, (None, None, 0))
+        v_smem_layout = cute.slice_(v_storage_layout_ds, (None, None, 0))
+        o_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.MN_SW32,
+            self.dtype,
+        )
+        o_storage_layout = cute.tile_to_shape(
+            o_smem_layout_atom,
+            (self.D, self.BLK_Q, self.o_stage),
+            order=(1, 0, 2),
+        )
+        o_smem_layout = cute.slice_(o_storage_layout, (None, None, 0))
+
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_q, q_smem_layout, (self.BLK_Q, self.D))
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_k, k_smem_layout, (self.D, self.BLK_KV))
+        tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_v, v_smem_layout, (self.D, self.BLK_KV))
+
+        tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
+        tma_atom_o, tma_tensor_o = cpasync.make_tiled_tma_atom(
+            tma_store_op, g_o, o_smem_layout, (self.D, self.BLK_Q))
+
+        dtype_bytes = self.dtype.width // 8
+        self.tma_load_q_bytes = cute.size(q_smem_layout) * dtype_bytes
+        self.tma_load_k_bytes = cute.size(k_smem_layout) * dtype_bytes
+        self.tma_load_v_bytes = cute.size(v_smem_layout) * dtype_bytes
+
+        qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        qk_storage_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_Q, self.BLK_KV), order=(1, 0))
+        kk_storage_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV), order=(1, 0))
+        alpha_storage_layout = cute.make_layout(
+            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+        beta_storage_layout = cute.make_layout((self.BLK_KV, self.alpha_beta_stage))
+
+        @cute.struct
+        class SharedStorage:
+            q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.q_stage * 2]
+            k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.k_stage * 2]
+            v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.v_stage * 2]
+            o_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.o_stage * 2]
+            alpha_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_beta_stage * 2]
+            beta_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_beta_stage * 2]
+
+            smem_q: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(q_storage_layout)],
+                128,
+            ]
+            smem_k: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)],
+                128,
+            ]
+            smem_v: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(v_storage_layout_sd)],
+                128,
+            ]
+            smem_qk: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(qk_storage_layout)],
+                16,
+            ]
+            smem_kk: cute.struct.Align[
+                cute.struct.MemRange[self.inverse_dtype, cute.cosize(kk_storage_layout)],
+                16,
+            ]
+            smem_o: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(o_storage_layout)],
+                128,
+            ]
+            smem_alpha: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(alpha_storage_layout)],
+                16,
+            ]
+            smem_beta: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_storage_layout)],
+                16,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        self.kernel(
+            g_alpha, g_beta,
+            tma_atom_q, tma_tensor_q,
+            tma_atom_k, tma_tensor_k,
+            tma_atom_v, tma_tensor_v,
+            tma_atom_o, tma_tensor_o,
+            g_state, g_init_state, g_tensormaps, cu_seqlens,
+            scale, num_q_heads, num_k_heads, num_v_heads, num_sab_heads, num_seqs,
+        ).launch(
+            grid=(grid_x, 1, 1),
+            block=(384, 1, 1),
+            max_number_threads=(384, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        g_alpha:      cute.Tensor,
+        g_beta:       cute.Tensor,
+        tma_atom_q:   cute.CopyAtom,
+        tma_tensor_q: cute.Tensor,
+        tma_atom_k:   cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_v:   cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        tma_atom_o:   cute.CopyAtom,
+        tma_tensor_o: cute.Tensor,
+        g_state:      cute.Tensor,
+        g_init_state: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        cu_seqlens:   cute.Tensor,
+        scale:        cutlass.Float32,
+        num_q_heads:   cutlass.Int32,
+        num_k_heads:   cutlass.Int32,
+        num_v_heads:   cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        num_seqs:      cutlass.Int32,
+    ):
+        NUM_LOAD_WARP_GROUPS = 1
+        NUM_MMA_WARP_GROUPS = 2
+        THREADS_PER_WARP_GROUP = 128
+        WARPS_PER_WARP_GROUP = 4
+        MIN_BLOCKS_PER_MP = 1
+        MAX_THREADS_PER_BLOCK = (
+            NUM_LOAD_WARP_GROUPS + NUM_MMA_WARP_GROUPS
+        ) * THREADS_PER_WARP_GROUP
+        load_registers, mma_registers = self.get_register_requirements(
+            MAX_THREADS_PER_BLOCK,
+            MIN_BLOCKS_PER_MP,
+            NUM_MMA_WARP_GROUPS,
+            THREADS_PER_WARP_GROUP,
+        )
+
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group_idx = cute.arch.make_warp_uniform(
+            tidx // cutlass.Int32(THREADS_PER_WARP_GROUP))
+        ldst_warp_role = cute.arch.make_warp_uniform(
+            warp_idx % cutlass.Int32(WARPS_PER_WARP_GROUP))
+
+        if warp_idx == LoadStoreWarpRole.LOAD_QKV:
+            cpasync.prefetch_descriptor(tma_atom_q)
+            cpasync.prefetch_descriptor(tma_atom_k)
+            cpasync.prefetch_descriptor(tma_atom_v)
+            cpasync.prefetch_descriptor(tma_atom_o)
+
+        work_desc = self.get_next_work(
+            cu_seqlens, num_q_heads, num_v_heads, num_sab_heads,
+        )
+        tok_end = work_desc.tok_offset + work_desc.seq_len
+        num_blocks = (
+            work_desc.seq_len + cutlass.Int32(self.BLK_KV) - cutlass.Int32(1)
+        ) // cutlass.Int32(self.BLK_KV)
+
+        # math_tidx / wg_idx: valid for Math WG threads; LdSt WG gets negative values (unused)
+        math_tidx = tidx - cutlass.Int32(THREADS_PER_WARP_GROUP)
+        wg_idx    = math_tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
+
+        # ── Smem allocation ───────────────────────────────────────────────────
+        allocator = cutlass.utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        q_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_Q, self.D, self.q_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        sQ_SD = storage.smem_q.get_tensor(q_layout_sd.outer, swizzle=q_layout_sd.inner)
+
+        k_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.k_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        k_layout_ds = cute.select(k_layout_sd, [1, 0, 2])
+        sK_SD = storage.smem_k.get_tensor(k_layout_sd.outer, swizzle=k_layout_sd.inner)
+        sK_DS = storage.smem_k.get_tensor(k_layout_ds.outer, swizzle=k_layout_ds.inner)
+
+        v_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.v_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        v_layout_ds = cute.select(v_layout_sd, [1, 0, 2])
+        sV_DS = storage.smem_v.get_tensor(v_layout_ds.outer, swizzle=v_layout_ds.inner)
+
+        qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        qk_layout = cute.tile_to_shape(qk_layout_atom, (self.BLK_Q, self.BLK_KV), order=(1, 0))
+        sQK = storage.smem_qk.get_tensor(qk_layout)
+
+        kk_layout = cute.tile_to_shape(qk_layout_atom, (self.BLK_KV, self.BLK_KV), order=(1, 0))
+        sKK_inv = storage.smem_kk.get_tensor(kk_layout)
+        kk_opd_ptr = cute.recast_ptr(storage.smem_kk.data_ptr(), dtype=self.dtype)
+        sKK_opd = cute.make_tensor(kk_opd_ptr, kk_layout)
+
+        o_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.MN_SW32,
+            self.dtype,
+        )
+        o_layout = cute.tile_to_shape(
+            o_smem_layout_atom,
+            (self.D, self.BLK_Q, self.o_stage),
+            order=(1, 0, 2),
+        )
+        sO = storage.smem_o.get_tensor(o_layout.outer, swizzle=o_layout.inner)
+        alpha_layout = cute.make_layout(
+            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+        sAlpha = storage.smem_alpha.get_tensor(alpha_layout)
+
+        beta_layout = cute.make_layout((self.BLK_KV, self.alpha_beta_stage))
+        sBeta = storage.smem_beta.get_tensor(beta_layout)
+
+        load_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        load_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 8)
+        vector_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        vector_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, NUM_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP
+        )
+        o_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, NUM_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP
+        )
+        o_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        q_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.q_mbar_ptr.data_ptr(),
+            num_stages=self.q_stage,
+            producer_group=load_producer_group,
+            consumer_group=load_consumer_group,
+            tx_count=self.tma_load_q_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        k_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.k_mbar_ptr.data_ptr(),
+            num_stages=self.k_stage,
+            producer_group=load_producer_group,
+            consumer_group=load_consumer_group,
+            tx_count=self.tma_load_k_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        v_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.v_mbar_ptr.data_ptr(),
+            num_stages=self.v_stage,
+            producer_group=load_producer_group,
+            consumer_group=load_consumer_group,
+            tx_count=self.tma_load_v_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        o_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.o_mbar_ptr.data_ptr(),
+            num_stages=self.o_stage,
+            producer_group=o_producer_group,
+            consumer_group=o_consumer_group,
+        )
+        alpha_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.alpha_mbar_ptr.data_ptr(),
+            num_stages=self.alpha_beta_stage,
+            producer_group=vector_producer_group,
+            consumer_group=vector_consumer_group,
+        )
+        beta_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.beta_mbar_ptr.data_ptr(),
+            num_stages=self.alpha_beta_stage,
+            producer_group=vector_producer_group,
+            consumer_group=vector_consumer_group,
+        )
+        cute.arch.mbarrier_init_fence()
+        cute.arch.sync_threads()
+
+        if warp_group_idx == WarpGroupRole.LDST:
+            cute.arch.setmaxregister_decrease(load_registers)
+            if ldst_warp_role == LoadStoreWarpRole.LOAD_QKV:
+                self.run_load_qkv_role(
+                    sQ_SD, sK_DS, sV_DS,
+                    tma_atom_q, tma_tensor_q,
+                    tma_atom_k, tma_tensor_k,
+                    tma_atom_v, tma_tensor_v,
+                    q_pipeline, k_pipeline, v_pipeline,
+                    num_blocks, work_desc.tok_offset,
+                    work_desc.q_head_idx(),
+                    work_desc.k_head_idx(num_q_heads, num_v_heads),
+                    work_desc.v_head_idx(),
+                )
+            elif ldst_warp_role == LoadStoreWarpRole.STORE_O:
+                CollectiveStoreTma(self.BLK_Q, self.D).run(
+                    sO, tma_atom_o, tma_tensor_o, g_tensormaps,
+                    o_pipeline, num_blocks, work_desc, num_seqs, self.o_stage,
+                    num_q_heads, num_v_heads,
+                )
+            elif ldst_warp_role == LoadStoreWarpRole.LOAD_BETA:
+                self.run_load_beta_role(
+                    sBeta, g_beta, beta_pipeline, num_blocks, work_desc.tok_offset, tok_end,
+                    work_desc.o_head_idx(num_q_heads, num_v_heads), num_sab_heads,
+                )
+            elif ldst_warp_role == LoadStoreWarpRole.LOAD_ALPHA:
+                self.run_load_alpha_role(
+                    sAlpha, g_alpha, alpha_pipeline, scale, num_blocks, work_desc.tok_offset,
+                    tok_end, work_desc.o_head_idx(num_q_heads, num_v_heads), num_sab_heads,
+                )
+        else:
+            cute.arch.setmaxregister_increase(mma_registers)
+
+            self.run_math_role(
+                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                q_pipeline, k_pipeline, v_pipeline,
+                o_pipeline, alpha_pipeline, beta_pipeline,
+                g_state, g_init_state, work_desc,
+                scale, wg_idx, math_tidx, num_blocks,
+                num_q_heads, num_v_heads, num_sab_heads, num_seqs,
+            )
+
+
+# ─── Public API ──────────────────────────────────────────────────────────────
+
+
+def delta_rule_prefill_dsl(
+    o:          torch.Tensor,          # (total_seqlen, num_o_heads, D) fp16/bf16, output
+    state:      torch.Tensor,          # (num_seqs, num_sab_heads, D, D) fp32, output
+    q:          torch.Tensor,          # (total_seqlen, num_q_heads, D)
+    k:          torch.Tensor,          # (total_seqlen, num_k_heads, D)
+    v:          torch.Tensor,          # (total_seqlen, num_v_heads, D)
+    init_state: torch.Tensor | None,   # (num_seqs, num_sab_heads, D, D) fp32, optional
+    alpha:      torch.Tensor | None,
+    beta:       torch.Tensor | None,
+    cu_seqlens: torch.Tensor,          # (num_seqs+1,) int64
+    scale:      float,
+):
+    from cutlass.cute.runtime import from_dlpack
+    import cuda.bindings.driver as cuda_driver
+
+    D = q.shape[-1]
+
+    num_seqs      = cu_seqlens.shape[0] - 1
+    num_q_heads   = q.shape[1]
+    num_k_heads   = k.shape[1]
+    num_v_heads   = v.shape[1]
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    if not _FullyFusedDeltaRuleSm120.can_implement(
+        num_q_heads, num_k_heads, num_v_heads, D, q.element_size()
+    ):
+        raise RuntimeError("can_implement failed")
+    if D != 128:
+        raise RuntimeError(f"DSL kernel only supports D=128, got {D}")
+
+    needs_alpha      = alpha      is not None
+    needs_beta       = beta       is not None
+    needs_init_state = init_state is not None
+    kernel_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+    }.get(q.dtype)
+    if kernel_dtype is None:
+        raise RuntimeError(f"DSL kernel only supports fp16/bf16 inputs, got {q.dtype}")
+
+    q_t = q.contiguous()
+    k_t = k.contiguous()
+    v_t = v.contiguous()
+    o_t = o
+
+    total_seqlen = q_t.shape[0]
+    num_o_heads = o_t.shape[1]
+    q_tma = q_t.as_strided(
+        (total_seqlen, D, num_q_heads),
+        (num_q_heads * D, 1, D),
+    )
+    k_tma = k_t.as_strided(
+        (D, total_seqlen, num_k_heads),
+        (1, num_k_heads * D, D),
+    )
+    v_tma = v_t.as_strided(
+        (D, total_seqlen, num_v_heads),
+        (1, num_v_heads * D, D),
+    )
+    o_tma = o_t.as_strided(
+        (D, total_seqlen, num_o_heads),
+        (1, num_o_heads * D, D),
+    )
+    _dummy_f32   = torch.zeros(1, dtype=torch.float32, device=q.device)
+    alpha_t      = alpha.contiguous()      if needs_alpha      else _dummy_f32
+    beta_t       = beta.contiguous()       if needs_beta       else _dummy_f32
+    init_state_t = init_state.contiguous() if needs_init_state else _dummy_f32
+    sm_count     = torch.cuda.get_device_properties(q.device).multi_processor_count
+    tensormaps_t = torch.empty(sm_count * 128, dtype=torch.uint8, device=q.device)
+    cu_int64     = cu_seqlens.to(torch.int64).contiguous()
+
+    stream_val = torch.cuda.current_stream().cuda_stream
+    stream     = cuda_driver.CUstream(stream_val)
+
+    # Keep head counts and varlen extents runtime values across cached compiles.
+    q_cute = from_dlpack(q_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+    k_cute = from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
+    v_cute = from_dlpack(v_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
+    o_cute = from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
+    alpha_cute = from_dlpack(alpha_t.reshape(-1), assumed_align=16).mark_layout_dynamic()
+    beta_cute = from_dlpack(beta_t.reshape(-1), assumed_align=16).mark_layout_dynamic()
+    state_cute = from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic()
+    init_state_cute = from_dlpack(
+        init_state_t.reshape(-1), assumed_align=16
+    ).mark_layout_dynamic()
+    tensormaps_cute = from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic()
+    cu_cute = from_dlpack(cu_int64, assumed_align=8).mark_layout_dynamic()
+
+    delta_rule_kernel = _FullyFusedDeltaRuleSm120(
+        needs_alpha, needs_beta, needs_init_state, kernel_dtype
+    )
+
+    kernel_args = (
+        q_cute,
+        k_cute,
+        v_cute,
+        o_cute,
+        alpha_cute,
+        beta_cute,
+        state_cute,
+        init_state_cute,
+        tensormaps_cute,
+        cu_cute,
+        cutlass.Float32(scale),
+        cutlass.Int32(num_q_heads), cutlass.Int32(num_k_heads),
+        cutlass.Int32(num_v_heads), cutlass.Int32(num_sab_heads),
+        cutlass.Int32(num_seqs),
+        num_seqs * num_sab_heads,
+        stream,
+    )
+    compiled_delta_rule_kernel = cached_compile(
+        delta_rule_kernel,
+        *kernel_args,
+        compile_options=(cute.GPUArch("sm_120a"),),
+    )
+    compiled_delta_rule_kernel(*kernel_args)

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -1819,7 +1819,10 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         cute.arch.mbarrier_init_fence()
         cute.arch.sync_threads()
 
-        if warp_group_idx == WarpGroupRole.LDST:
+        if (
+            work_desc.seq_len != cutlass.Int32(0)
+            and warp_group_idx == WarpGroupRole.LDST
+        ):
             cute.arch.setmaxregister_decrease(load_registers)
             if ldst_warp_role == LoadStoreWarpRole.LOAD_QKV:
                 self.run_load_qkv_role(
@@ -1878,7 +1881,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                     work_desc.o_head_idx(num_q_heads, num_v_heads),
                     num_sab_heads,
                 )
-        else:
+        elif work_desc.seq_len != cutlass.Int32(0):
             cute.arch.setmaxregister_increase(mma_registers)
 
             self.run_math_role(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -579,7 +579,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     ):
         c_kv   = cute.make_identity_tensor((self.D, self.D))
         tKVcKV = kv_thr_mma.partition_C(c_kv)
-        for i in cutlass.range_constexpr(cute.size(tKVrKV)):
+        for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
             tKVrKV[i] = gKV[k_idx, v_idx]
 
@@ -592,7 +592,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     ):
         c_kv   = cute.make_identity_tensor((self.D, self.D))
         tKVcKV = kv_thr_mma.partition_C(c_kv)
-        for i in cutlass.range_constexpr(cute.size(tKVrKV)):
+        for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
             gKV[k_idx, v_idx] = tKVrKV[i]
 
@@ -909,7 +909,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             block_coeff = cutlass.Float32(
                 sAlpha[B - cutlass.Int32(1), AlphaProcessor.CUMPROD, alpha_stage])
 
-        for i in cutlass.range_constexpr(cute.size(tKVrKV)):
+        for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             tKVrKV[i] = block_coeff * tKVrKV[i]
 
         self.kv_decay_v(tOrNewV, tKVcV, sAlpha, alpha_stage, is_final_block, B)

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -16,10 +16,11 @@ from .schedule import WorkDesc
 # ─── Named-barrier IDs used by the compute kernel ────────────────────────────
 # Must not conflict with each other or with pipeline barrier storage.
 
+
 class NamedBarrier(IntEnum):
-    MATH_WG0 = 4   # OrderedMathBarriers: StreamkBarrier0
-    MATH_WG1 = 5   # OrderedMathBarriers: StreamkBarrier1
-    KK_SYNC  = 13  # sync all 128 WG0 threads before collective_inverse
+    MATH_WG0 = 4  # OrderedMathBarriers: StreamkBarrier0
+    MATH_WG1 = 5  # OrderedMathBarriers: StreamkBarrier1
+    KK_SYNC = 13  # sync all 128 WG0 threads before collective_inverse
 
 
 class WarpGroupRole(IntEnum):
@@ -39,6 +40,7 @@ class MathWarpGroupRole(IntEnum):
     KK = 0
     QK = 1
 
+
 # ─── Warp-specialized delta-rule kernel ───────────────────────────────────────
 # Grid: (num_seqs * num_sab_heads, 1, 1)
 # Block: 384 threads → WG0=[0,127], WG1=[128,255], WG2=[256,383]
@@ -47,8 +49,8 @@ class MathWarpGroupRole(IntEnum):
 # The JIT compiler specialises per instance, so they are compile-time booleans
 # inside the kernel without any parameter-passing trickery.
 
-class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
+class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @staticmethod
     def get_register_requirements(
         max_threads_per_block: int,
@@ -113,20 +115,20 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
     ):
-        self.needs_alpha      = needs_alpha
-        self.needs_beta       = needs_beta
+        self.needs_alpha = needs_alpha
+        self.needs_beta = needs_beta
         self.needs_init_state = needs_init_state
         self.needs_checkpointing = needs_checkpointing
-        self.dtype            = dtype
-        self.acc_dtype        = acc_dtype
-        self.inverse_dtype    = cutlass.Float16
-        self.BLK_Q           = 64
-        self.BLK_KV          = 64
-        self.D               = 128
-        self.q_stage          = 1
-        self.k_stage          = 2
-        self.v_stage          = 1
-        self.o_stage          = 1
+        self.dtype = dtype
+        self.acc_dtype = acc_dtype
+        self.inverse_dtype = cutlass.Float16
+        self.BLK_Q = 64
+        self.BLK_KV = 64
+        self.D = 128
+        self.q_stage = 1
+        self.k_stage = 2
+        self.v_stage = 1
+        self.o_stage = 1
         self.alpha_beta_stage = 2
 
     def get_next_work(
@@ -137,12 +139,12 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         num_sab_heads: cutlass.Int32,
     ) -> WorkDesc:
         bx, _, _ = cute.arch.block_idx()
-        seq_idx      = bx // num_sab_heads
-        o_head_idx   = bx  % num_sab_heads
-        q_head_idx   = o_head_idx * num_q_heads // num_sab_heads
-        v_head_idx   = o_head_idx * num_v_heads // num_sab_heads
-        tok_start    = cutlass.Int32(cu_seqlens[seq_idx])
-        tok_end      = cutlass.Int32(cu_seqlens[seq_idx + 1])
+        seq_idx = bx // num_sab_heads
+        o_head_idx = bx % num_sab_heads
+        q_head_idx = o_head_idx * num_q_heads // num_sab_heads
+        v_head_idx = o_head_idx * num_v_heads // num_sab_heads
+        tok_start = cutlass.Int32(cu_seqlens[seq_idx])
+        tok_end = cutlass.Int32(cu_seqlens[seq_idx + 1])
 
         return WorkDesc(
             seq_idx=seq_idx,
@@ -162,50 +164,52 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         """Pre-arrive at WG0's barrier so WG0 is unblocked on the first wait."""
         if wg_idx == MathWarpGroupRole.QK:
             cute.arch.barrier_arrive(
-                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256
+            )
 
     @cute.jit
     def _math_order_wait(self, wg_idx: cutlass.Int32):
         """Arrive+wait on this WG's own ordered barrier."""
         if wg_idx == MathWarpGroupRole.KK:
-            cute.arch.barrier(
-                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+            cute.arch.barrier(barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
         else:
-            cute.arch.barrier(
-                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+            cute.arch.barrier(barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
 
     @cute.jit
     def _math_order_notify(self, wg_idx: cutlass.Int32):
         """Arrive at the other WG's barrier to unblock it."""
         if wg_idx == MathWarpGroupRole.KK:
             cute.arch.barrier_arrive(
-                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256
+            )
         else:
             cute.arch.barrier_arrive(
-                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256
+            )
 
     # ─── kk_store_and_inv ─────────────────────────────────────────────────────
 
     @cute.jit
     def _kk_store_and_inv(
         self,
-        tKKrKK: cute.Tensor,      # fp32 KK accumulator (from 128-thread kk_tiled_mma)
+        tKKrKK: cute.Tensor,  # fp32 KK accumulator (from 128-thread kk_tiled_mma)
         kk_tiled_mma,
         kk_thread_idx: cutlass.Int32,
-        sKK_inv: cute.Tensor,     # (BlkKV, BlkKV)
-        sKK_opd: cute.Tensor,     # sKK_inv storage recast as Element for MMA operand
-        sBeta: cute.Tensor,       # (BlkKV, StagesBeta) - used when needs_beta
+        sKK_inv: cute.Tensor,  # (BlkKV, BlkKV)
+        sKK_opd: cute.Tensor,  # sKK_inv storage recast as Element for MMA operand
+        sBeta: cute.Tensor,  # (BlkKV, StagesBeta) - used when needs_beta
         beta_pipe_idx: cutlass.Int32,
-        tKKcMkk: cute.Tensor,     # coordinate mapping for KK fragment
+        tKKcMkk: cute.Tensor,  # coordinate mapping for KK fragment
     ):
         """Store tKKrKK → sKK_inv, Inverse, optionally reload+beta."""
         stsm_atom = cute.make_copy_atom(
-            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype
+        )
         tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
-        thr_store   = tiled_store.get_slice(kk_thread_idx)
-        tKKsKK      = thr_store.partition_D(sKK_inv)
-        tKKrKK_inv  = cute.make_fragment_like(tKKrKK, self.inverse_dtype)
-        tKKrKK_cv   = thr_store.retile(tKKrKK_inv)
+        thr_store = tiled_store.get_slice(kk_thread_idx)
+        tKKsKK = thr_store.partition_D(sKK_inv)
+        tKKrKK_inv = cute.make_fragment_like(tKKrKK, self.inverse_dtype)
+        tKKrKK_cv = thr_store.retile(tKKrKK_inv)
         for i in cutlass.range_constexpr(cute.size(tKKrKK)):
             tKKrKK_inv[i] = self.inverse_dtype(tKKrKK[i])
         cute.copy(tiled_store, tKKrKK_cv, tKKsKK)
@@ -215,10 +219,12 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         if cutlass.const_expr(self.needs_beta or self.dtype != self.inverse_dtype):
             cute.arch.barrier(barrier_id=NamedBarrier.KK_SYNC, number_of_threads=128)
-            ldsm_atom  = cute.make_copy_atom(
-                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+            ldsm_atom = cute.make_copy_atom(
+                warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4),
+                self.inverse_dtype,
+            )
             tiled_load = cute.make_tiled_copy_C(ldsm_atom, kk_tiled_mma)
-            thr_load   = tiled_load.get_slice(kk_thread_idx)
+            thr_load = tiled_load.get_slice(kk_thread_idx)
             tKKrKK_cpy = cute.make_fragment_like(tKKrKK_inv)
             tKKrKK_cvt = cute.make_fragment_like(tKKrKK_inv, self.dtype)
             tKKrKK_cv2 = thr_load.retile(tKKrKK_cpy)
@@ -229,7 +235,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 if cutlass.const_expr(self.needs_beta):
                     _, t = tKKcMkk_cv[i]
                     tKKrKK_cvt[i] = self.dtype(
-                        cutlass.Float32(tKKrKK_cpy[i]) * cutlass.Float32(sBeta[t, beta_pipe_idx])
+                        cutlass.Float32(tKKrKK_cpy[i])
+                        * cutlass.Float32(sBeta[t, beta_pipe_idx])
                     )
                 else:
                     tKKrKK_cvt[i] = self.dtype(tKKrKK_cpy[i])
@@ -243,12 +250,12 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def kk_epi(
         self,
-        tKKrKK:      cute.Tensor,
-        tKKcMkk:     cute.Tensor,
-        sAlpha:      cute.Tensor,
-        sBeta:       cute.Tensor,
+        tKKrKK: cute.Tensor,
+        tKKcMkk: cute.Tensor,
+        sAlpha: cute.Tensor,
+        sBeta: cute.Tensor,
         alpha_stage: cutlass.Int32,
-        beta_stage:  cutlass.Int32,
+        beta_stage: cutlass.Int32,
     ):
         if cutlass.const_expr(self.needs_alpha):
             alpha_cumlog = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
@@ -256,7 +263,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 s, t = tKKcMkk[i]
                 tKKrKK[i] = tKKrKK[i] * cute.math.exp2(
                     cutlass.Float32(alpha_cumlog[s]) - cutlass.Float32(alpha_cumlog[t]),
-                    fastmath=True)
+                    fastmath=True,
+                )
         if cutlass.const_expr(self.needs_beta):
             beta_row = sBeta[None, beta_stage]
             for i in cutlass.range_constexpr(cute.size(tKKrKK)):
@@ -268,10 +276,10 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def qk_or_kk_mask(
         self,
-        frag:           cute.Tensor,
-        coord_tensor:   cute.Tensor,
+        frag: cute.Tensor,
+        coord_tensor: cute.Tensor,
         is_final_block: bool,
-        B:              cutlass.Int32,
+        B: cutlass.Int32,
     ):
         for i in cutlass.range_constexpr(cute.size(frag)):
             s, t = coord_tensor[i]
@@ -286,19 +294,25 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def qk_epi(
         self,
-        tQKrQK:      cute.Tensor,
-        tQKcMqk:     cute.Tensor,
-        sAlpha:      cute.Tensor,
+        tQKrQK: cute.Tensor,
+        tQKcMqk: cute.Tensor,
+        sAlpha: cute.Tensor,
         alpha_stage: cutlass.Int32,
-        scale:       cutlass.Float32,
+        scale: cutlass.Float32,
     ):
         if cutlass.const_expr(self.needs_alpha):
             alpha_cumlog = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
             for i in cutlass.range_constexpr(cute.size(tQKrQK)):
                 s, t = tQKcMqk[i]
-                tQKrQK[i] = tQKrQK[i] * cute.math.exp2(
-                    cutlass.Float32(alpha_cumlog[s]) - cutlass.Float32(alpha_cumlog[t]),
-                    fastmath=True) * scale
+                tQKrQK[i] = (
+                    tQKrQK[i]
+                    * cute.math.exp2(
+                        cutlass.Float32(alpha_cumlog[s])
+                        - cutlass.Float32(alpha_cumlog[t]),
+                        fastmath=True,
+                    )
+                    * scale
+                )
         else:
             for i in cutlass.range_constexpr(cute.size(tQKrQK)):
                 tQKrQK[i] = tQKrQK[i] * scale
@@ -308,17 +322,18 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def qk_store(
         self,
-        tQKrQK:        cute.Tensor,
-        sQK:           cute.Tensor,
+        tQKrQK: cute.Tensor,
+        sQK: cute.Tensor,
         qk_tiled_mma,
         qk_thread_idx: cutlass.Int32,
     ):
-        stsm_atom    = cute.make_copy_atom(
-            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+        stsm_atom = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype
+        )
         qk_tiled_copy = cute.make_tiled_copy_C(stsm_atom, qk_tiled_mma)
-        qk_thr_copy   = qk_tiled_copy.get_slice(qk_thread_idx)
-        tQKsQK        = qk_thr_copy.partition_D(sQK)
-        tQKrQK_cvt    = cute.make_fragment_like(tQKrQK, self.dtype)
+        qk_thr_copy = qk_tiled_copy.get_slice(qk_thread_idx)
+        tQKsQK = qk_thr_copy.partition_D(sQK)
+        tQKrQK_cvt = cute.make_fragment_like(tQKrQK, self.dtype)
         tQKrQK_cvt_cv = qk_thr_copy.retile(tQKrQK_cvt)
         for i in cutlass.range_constexpr(cute.size(tQKrQK)):
             tQKrQK_cvt[i] = self.dtype(tQKrQK[i])
@@ -329,11 +344,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def o1_epi(
         self,
-        tOrO:        cute.Tensor,
-        tOcO:        cute.Tensor,
-        sAlpha:      cute.Tensor,
+        tOrO: cute.Tensor,
+        tOcO: cute.Tensor,
+        sAlpha: cute.Tensor,
         alpha_stage: cutlass.Int32,
-        scale:       cutlass.Float32,
+        scale: cutlass.Float32,
     ):
         if cutlass.const_expr(self.needs_alpha):
             alpha_cpscale = sAlpha[None, AlphaProcessor.CUMPROD_SCALE, alpha_stage]
@@ -349,9 +364,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def sk_epi(
         self,
-        tSKrSK:      cute.Tensor,
-        tSKcSK:      cute.Tensor,
-        sAlpha:      cute.Tensor,
+        tSKrSK: cute.Tensor,
+        tSKcSK: cute.Tensor,
+        sAlpha: cute.Tensor,
         alpha_stage: cutlass.Int32,
     ):
         if cutlass.const_expr(self.needs_alpha):
@@ -365,15 +380,15 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def sk_load_v(
         self,
-        tSKrSK:  cute.Tensor,
-        sV_DS:   cute.Tensor,
+        tSKrSK: cute.Tensor,
+        sV_DS: cute.Tensor,
         sk_tiled_copy_C,
         sk_thr_copy_C,
         v_stage: cutlass.Int32,
     ) -> cute.Tensor:
-        tSKrV    = cute.make_fragment_like(tSKrSK, self.dtype)
+        tSKrV = cute.make_fragment_like(tSKrSK, self.dtype)
         tSKrV_cv = sk_thr_copy_C.retile(tSKrV)
-        tSKsV    = sk_thr_copy_C.partition_S(sV_DS)
+        tSKsV = sk_thr_copy_C.partition_S(sV_DS)
         cute.copy(sk_tiled_copy_C, tSKsV[None, None, None, v_stage], tSKrV_cv)
         return tSKrV
 
@@ -382,20 +397,21 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def kv_decay_v(
         self,
-        tKVrV:          cute.Tensor,
-        tKVcV:          cute.Tensor,
-        sAlpha:         cute.Tensor,
-        alpha_stage:    cutlass.Int32,
+        tKVrV: cute.Tensor,
+        tKVcV: cute.Tensor,
+        sAlpha: cute.Tensor,
+        alpha_stage: cutlass.Int32,
         is_final_block: bool,
-        B:              cutlass.Int32,
+        B: cutlass.Int32,
     ):
         if cutlass.const_expr(self.needs_alpha):
             alpha_cumlog = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
-            block_log    = cutlass.Float32(alpha_cumlog[B - cutlass.Int32(1)])
+            block_log = cutlass.Float32(alpha_cumlog[B - cutlass.Int32(1)])
             for i in cutlass.range_constexpr(cute.size(tKVrV)):
                 _, tok = tKVcV[i]
                 coeff = cute.math.exp2(
-                    block_log - cutlass.Float32(alpha_cumlog[tok]), fastmath=True)
+                    block_log - cutlass.Float32(alpha_cumlog[tok]), fastmath=True
+                )
                 if cutlass.const_expr(is_final_block):
                     if tok >= B:
                         coeff = cutlass.Float32(0.0)
@@ -412,8 +428,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def o_store(
         self,
-        tOrO:    cute.Tensor,
-        tOsO:    cute.Tensor,
+        tOrO: cute.Tensor,
+        tOsO: cute.Tensor,
         o_tiled_copy_r2s,
         o_thr_copy_r2s,
     ):
@@ -445,13 +461,12 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         k_producer_state,
         v_pipeline,
         v_producer_state,
-        blk:          cutlass.Int32,
-        tok_start:    cutlass.Int32,
-        q_head_idx:   cutlass.Int32,
-        k_head_idx:   cutlass.Int32,
-        v_head_idx:   cutlass.Int32,
+        blk: cutlass.Int32,
+        tok_start: cutlass.Int32,
+        q_head_idx: cutlass.Int32,
+        k_head_idx: cutlass.Int32,
+        v_head_idx: cutlass.Int32,
     ):
-
         blk_tok = tok_start + blk * cutlass.Int32(self.BLK_KV)
 
         sK = sK_DS[None, None, k_producer_state.index]
@@ -459,7 +474,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             (cutlass.Int32(0), blk_tok),
             tma_tensor_k[None, None, k_head_idx],
         )
-        gK = cute.zipped_divide(mK, (self.D, self.BLK_KV))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        gK = cute.zipped_divide(mK, (self.D, self.BLK_KV))[
+            ((None, None), (cutlass.Int32(0), cutlass.Int32(0)))
+        ]
         tKsK, tKgK = cpasync.tma_partition(
             tma_atom_k,
             0,
@@ -469,7 +486,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         )
         k_pipeline.producer_acquire(k_producer_state)
         cute.copy(
-            tma_atom_k, tKgK, tKsK,
+            tma_atom_k,
+            tKgK,
+            tKsK,
             tma_bar_ptr=k_pipeline.producer_get_barrier(k_producer_state),
         )
         k_pipeline.producer_commit(k_producer_state)
@@ -480,7 +499,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             (blk_tok, cutlass.Int32(0)),
             tma_tensor_q[None, None, q_head_idx],
         )
-        gQ = cute.zipped_divide(mQ, (self.BLK_Q, self.D))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        gQ = cute.zipped_divide(mQ, (self.BLK_Q, self.D))[
+            ((None, None), (cutlass.Int32(0), cutlass.Int32(0)))
+        ]
         tQsQ, tQgQ = cpasync.tma_partition(
             tma_atom_q,
             0,
@@ -490,7 +511,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         )
         q_pipeline.producer_acquire(q_producer_state)
         cute.copy(
-            tma_atom_q, tQgQ, tQsQ,
+            tma_atom_q,
+            tQgQ,
+            tQsQ,
             tma_bar_ptr=q_pipeline.producer_get_barrier(q_producer_state),
         )
         q_pipeline.producer_commit(q_producer_state)
@@ -501,7 +524,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             (cutlass.Int32(0), blk_tok),
             tma_tensor_v[None, None, v_head_idx],
         )
-        gV = cute.zipped_divide(mV, (self.D, self.BLK_KV))[((None, None), (cutlass.Int32(0), cutlass.Int32(0)))]
+        gV = cute.zipped_divide(mV, (self.D, self.BLK_KV))[
+            ((None, None), (cutlass.Int32(0), cutlass.Int32(0)))
+        ]
         tVsV, tVgV = cpasync.tma_partition(
             tma_atom_v,
             0,
@@ -511,7 +536,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         )
         v_pipeline.producer_acquire(v_producer_state)
         cute.copy(
-            tma_atom_v, tVgV, tVsV,
+            tma_atom_v,
+            tVgV,
+            tVsV,
             tma_bar_ptr=v_pipeline.producer_get_barrier(v_producer_state),
         )
         v_pipeline.producer_commit(v_producer_state)
@@ -525,13 +552,13 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def load_alpha(
         self,
-        sAlpha:       cute.Tensor,
-        g_alpha:      cute.Tensor,
-        blk_tok:      cutlass.Int32,
-        tok_end:      cutlass.Int32,
+        sAlpha: cute.Tensor,
+        g_alpha: cute.Tensor,
+        blk_tok: cutlass.Int32,
+        tok_end: cutlass.Int32,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
-        alpha_stage:  cutlass.Int32,
+        alpha_stage: cutlass.Int32,
     ):
         lane_id = cute.arch.lane_idx()
         sAlpha_k = sAlpha[None, None, alpha_stage]
@@ -541,7 +568,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             tok = blk_tok + row
             if tok < tok_end:
                 sAlpha_k[row, AlphaProcessor.CUMSUM_LOG] = g_alpha[
-                    tok * num_sab_heads + sab_head_idx]
+                    tok * num_sab_heads + sab_head_idx
+                ]
             else:
                 sAlpha_k[row, AlphaProcessor.CUMSUM_LOG] = cutlass.Float32(1.0)
 
@@ -551,13 +579,13 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def load_beta(
         self,
-        sBeta:        cute.Tensor,
-        g_beta:       cute.Tensor,
-        blk_tok:      cutlass.Int32,
-        tok_end:      cutlass.Int32,
+        sBeta: cute.Tensor,
+        g_beta: cute.Tensor,
+        blk_tok: cutlass.Int32,
+        tok_end: cutlass.Int32,
         sab_head_idx: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
-        beta_stage:   cutlass.Int32,
+        beta_stage: cutlass.Int32,
     ):
         lane_id = cute.arch.lane_idx()
         sBeta_k = sBeta[None, beta_stage]
@@ -575,11 +603,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def kv_load(
         self,
-        tKVrKV:      cute.Tensor,
-        gKV:         cute.Tensor,
+        tKVrKV: cute.Tensor,
+        gKV: cute.Tensor,
         kv_thr_mma,
     ):
-        c_kv   = cute.make_identity_tensor((self.D, self.D))
+        c_kv = cute.make_identity_tensor((self.D, self.D))
         tKVcKV = kv_thr_mma.partition_C(c_kv)
         for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
@@ -588,11 +616,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def kv_store(
         self,
-        tKVrKV:    cute.Tensor,
-        gKV:       cute.Tensor,
+        tKVrKV: cute.Tensor,
+        gKV: cute.Tensor,
         kv_thr_mma,
     ):
-        c_kv   = cute.make_identity_tensor((self.D, self.D))
+        c_kv = cute.make_identity_tensor((self.D, self.D))
         tKVcKV = kv_thr_mma.partition_C(c_kv)
         for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             v_idx, k_idx = tKVcKV[i]
@@ -614,16 +642,22 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         seq_len: cutlass.Int32,
     ):
         if cutlass.const_expr(self.needs_checkpointing):
-            if block_end <= seq_len and block_end % checkpoint_every_n_tokens == cutlass.Int32(0):
+            if (
+                block_end <= seq_len
+                and block_end % checkpoint_every_n_tokens == cutlass.Int32(0)
+            ):
                 checkpoint_idx = (
                     cutlass.Int32(checkpoint_cu_starts[seq_idx])
                     + block_end // checkpoint_every_n_tokens
                     - cutlass.Int32(1)
                 )
                 checkpoint_layout = cute.make_ordered_layout(
-                    (self.D, self.D, num_sab_heads, total_checkpoints), order=(0, 1, 2, 3)
+                    (self.D, self.D, num_sab_heads, total_checkpoints),
+                    order=(0, 1, 2, 3),
                 )
-                mCheckpoint = cute.make_tensor(g_state_checkpoints.iterator, checkpoint_layout)
+                mCheckpoint = cute.make_tensor(
+                    g_state_checkpoints.iterator, checkpoint_layout
+                )
                 gCheckpointKV = mCheckpoint[None, None, o_head_idx, checkpoint_idx]
                 self.kv_store(tKVrKV, gCheckpointKV, kv_thr_mma)
 
@@ -635,16 +669,16 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     def compute_loop_body(
         self,
         # Smem tensors (staged; caller indexes the active stage)
-        sQ_SD:   cute.Tensor,    # (BlkQ, D, StagesQ)  – row-major atom, swizzled
-        sK_SD:   cute.Tensor,    # (BlkKV, D, StagesK) – same atom
-        sK_DS:   cute.Tensor,    # (D, BlkKV, StagesK) – K transposed
-        sV_DS:   cute.Tensor,    # (D, BlkKV, StagesV) – V transposed
-        sQK:     cute.Tensor,    # (BlkQ, BlkKV)
-        sKK_inv: cute.Tensor,    # (BlkKV, BlkKV)
-        sKK_opd: cute.Tensor,    # sKK_inv storage recast as Element
-        sO:      cute.Tensor,    # O output smem (staged)
-        sAlpha:  cute.Tensor,    # (BlkQ, AlphaProcessor.NUM_CHANNELS, StagesAlpha) or zero-shaped
-        sBeta:   cute.Tensor,    # (BlkKV, StagesBeta) or zero-shaped
+        sQ_SD: cute.Tensor,  # (BlkQ, D, StagesQ)  – row-major atom, swizzled
+        sK_SD: cute.Tensor,  # (BlkKV, D, StagesK) – same atom
+        sK_DS: cute.Tensor,  # (D, BlkKV, StagesK) – K transposed
+        sV_DS: cute.Tensor,  # (D, BlkKV, StagesV) – V transposed
+        sQK: cute.Tensor,  # (BlkQ, BlkKV)
+        sKK_inv: cute.Tensor,  # (BlkKV, BlkKV)
+        sKK_opd: cute.Tensor,  # sKK_inv storage recast as Element
+        sO: cute.Tensor,  # O output smem (staged)
+        sAlpha: cute.Tensor,  # (BlkQ, AlphaProcessor.NUM_CHANNELS, StagesAlpha) or zero-shaped
+        sBeta: cute.Tensor,  # (BlkKV, StagesBeta) or zero-shaped
         kv_tiled_mma,
         # Mainloop pipelines and active read states
         q_pipeline,
@@ -672,14 +706,14 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         wg_idx: cutlass.Int32,
     ):
         tidx, _, _ = cute.arch.thread_idx()
-        thread_idx    = tidx - cutlass.Int32(128)        # relative to compute threads
+        thread_idx = tidx - cutlass.Int32(128)  # relative to compute threads
         kk_thread_idx = thread_idx % cutlass.Int32(128)
         qk_thread_idx = thread_idx % cutlass.Int32(128)
 
         # ── TiledMMAs ─────────────────────────────────────────────────────────
-        blk_q  = cute.size(sQ_SD, mode=[0])
+        blk_q = cute.size(sQ_SD, mode=[0])
         blk_kv = cute.size(sK_SD, mode=[0])
-        d      = cute.size(sQ_SD, mode=[1])
+        d = cute.size(sQ_SD, mode=[1])
         tile_shape_qk = (blk_q, blk_kv, d)
         tile_shape_kk = tile_shape_qk
         tile_shape_o1 = (d, blk_q, d)
@@ -698,47 +732,50 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         # QK/KK: 4 warps × 16M = 64M  (1 warpgroup, 128 threads)
         qk_tiled_mma = cute.make_tiled_mma(
-            mma_atom_4w, cute.make_layout((4, 1, 1)),
-            permutation_mnk=tile_shape_qk)
+            mma_atom_4w, cute.make_layout((4, 1, 1)), permutation_mnk=tile_shape_qk
+        )
         kk_tiled_mma = cute.make_tiled_mma(
-            mma_atom_4w, cute.make_layout((4, 1, 1)),
-            permutation_mnk=tile_shape_kk)
+            mma_atom_4w, cute.make_layout((4, 1, 1)), permutation_mnk=tile_shape_kk
+        )
 
         # O1/O2/SK/NewV: 8 warps × 16M = 128M (both warpgroups, 256 threads)
         o1_tiled_mma = cute.make_tiled_mma(
-            mma_atom_8w, cute.make_layout((8, 1, 1)),
-            permutation_mnk=tile_shape_o1)
+            mma_atom_8w, cute.make_layout((8, 1, 1)), permutation_mnk=tile_shape_o1
+        )
         o2_tiled_mma = cute.make_tiled_mma(
-            mma_atom_8w, cute.make_layout((8, 1, 1)),
-            permutation_mnk=tile_shape_o2)
+            mma_atom_8w, cute.make_layout((8, 1, 1)), permutation_mnk=tile_shape_o2
+        )
         sk_tiled_mma = cute.make_tiled_mma(
-            mma_atom_8w, cute.make_layout((8, 1, 1)),
-            permutation_mnk=tile_shape_sk)
+            mma_atom_8w, cute.make_layout((8, 1, 1)), permutation_mnk=tile_shape_sk
+        )
         newv_tiled_mma = cute.make_tiled_mma(
-            mma_atom_8w, cute.make_layout((8, 1, 1)),
-            permutation_mnk=tile_shape_newv)
+            mma_atom_8w, cute.make_layout((8, 1, 1)), permutation_mnk=tile_shape_newv
+        )
 
         # ── Thread slices ─────────────────────────────────────────────────────
-        qk_thr_mma   = qk_tiled_mma.get_slice(qk_thread_idx)
-        kk_thr_mma   = kk_tiled_mma.get_slice(kk_thread_idx)
-        sk_thr_mma   = sk_tiled_mma.get_slice(thread_idx)
+        qk_thr_mma = qk_tiled_mma.get_slice(qk_thread_idx)
+        kk_thr_mma = kk_tiled_mma.get_slice(kk_thread_idx)
+        sk_thr_mma = sk_tiled_mma.get_slice(thread_idx)
         newv_thr_mma = newv_tiled_mma.get_slice(thread_idx)
-        o1_thr_mma   = o1_tiled_mma.get_slice(thread_idx)
-        o2_thr_mma   = o2_tiled_mma.get_slice(thread_idx)
-        kv_thr_mma   = kv_tiled_mma.get_slice(thread_idx)
+        o1_thr_mma = o1_tiled_mma.get_slice(thread_idx)
+        o2_thr_mma = o2_tiled_mma.get_slice(thread_idx)
+        kv_thr_mma = kv_tiled_mma.get_slice(thread_idx)
 
         # ── Copy atoms ────────────────────────────────────────────────────────
         ldsm_n4 = cute.make_copy_atom(
-            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype
+        )
         ldsm_t4 = cute.make_copy_atom(
-            warp.LdMatrix8x8x16bOp(transpose=True,  num_matrices=4), self.dtype)
+            warp.LdMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype
+        )
         stsm_n4 = cute.make_copy_atom(
-            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype
+        )
 
         # ── Active smem slices (extract 2D from staged tensors) ───────────────
-        sQ_k    = sQ_SD[None, None, q_stage]    # (BlkQ, D)
-        sK_SD_k = sK_SD[None, None, k_stage]   # (BlkKV, D)
-        sK_DS_k = sK_DS[None, None, k_stage]   # (D, BlkKV)
+        sQ_k = sQ_SD[None, None, q_stage]  # (BlkQ, D)
+        sK_SD_k = sK_SD[None, None, k_stage]  # (BlkKV, D)
+        sK_DS_k = sK_DS[None, None, k_stage]  # (D, BlkKV)
 
         # ── QK copies ─────────────────────────────────────────────────────────
         qk_tiled_copy_A = cute.make_tiled_copy_A(ldsm_n4, qk_tiled_mma)
@@ -746,12 +783,12 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         qk_thr_copy_A = qk_tiled_copy_A.get_slice(qk_thread_idx)
         qk_thr_copy_B = qk_tiled_copy_B.get_slice(qk_thread_idx)
 
-        tQKrQ    = qk_thr_mma.make_fragment_A(qk_thr_mma.partition_A(sQ_k))
+        tQKrQ = qk_thr_mma.make_fragment_A(qk_thr_mma.partition_A(sQ_k))
         tQKrQ_cv = qk_thr_copy_A.retile(tQKrQ)
-        tQKsQ    = qk_thr_copy_A.partition_S(sQ_SD)
-        tQKrK    = qk_thr_mma.make_fragment_B(qk_thr_mma.partition_B(sK_SD_k))
+        tQKsQ = qk_thr_copy_A.partition_S(sQ_SD)
+        tQKrK = qk_thr_mma.make_fragment_B(qk_thr_mma.partition_B(sK_SD_k))
         tQKrK_cv = qk_thr_copy_B.retile(tQKrK)
-        tQKsK    = qk_thr_copy_B.partition_S(sK_SD)
+        tQKsK = qk_thr_copy_B.partition_S(sK_SD)
 
         # ── KK copies (same atom as QK) ───────────────────────────────────────
         kk_tiled_copy_A = cute.make_tiled_copy_A(ldsm_n4, kk_tiled_mma)
@@ -759,12 +796,12 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         kk_thr_copy_A = kk_tiled_copy_A.get_slice(kk_thread_idx)
         kk_thr_copy_B = kk_tiled_copy_B.get_slice(kk_thread_idx)
 
-        tKKrA    = kk_thr_mma.make_fragment_A(kk_thr_mma.partition_A(sK_SD_k))
+        tKKrA = kk_thr_mma.make_fragment_A(kk_thr_mma.partition_A(sK_SD_k))
         tKKrA_cv = kk_thr_copy_A.retile(tKKrA)
-        tKKsA    = kk_thr_copy_A.partition_S(sK_SD)
-        tKKrB    = kk_thr_mma.make_fragment_B(kk_thr_mma.partition_B(sK_SD_k))
+        tKKsA = kk_thr_copy_A.partition_S(sK_SD)
+        tKKrB = kk_thr_mma.make_fragment_B(kk_thr_mma.partition_B(sK_SD_k))
         tKKrB_cv = kk_thr_copy_B.retile(tKKrB)
-        tKKsB    = kk_thr_copy_B.partition_S(sK_SD)
+        tKKsB = kk_thr_copy_B.partition_S(sK_SD)
 
         # ── SK copies ─────────────────────────────────────────────────────────
         # SK B: K loaded from sK_SD (row-major BlkKV×D) with LDSM_N — matches C++ SK B-operand
@@ -775,24 +812,26 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         sk_thr_copy_C = sk_tiled_copy_C.get_slice(thread_idx)
 
         # Work around DSL make_fragment_B not accepting partition_shape_B output directly.
-        tSKrK    = cute.make_rmem_tensor(
-            sk_thr_mma.partition_shape_B(cute.slice_(tile_shape_sk, (0, None, None))), self.dtype)
+        tSKrK = cute.make_rmem_tensor(
+            sk_thr_mma.partition_shape_B(cute.slice_(tile_shape_sk, (0, None, None))),
+            self.dtype,
+        )
         tSKrK_cv = sk_thr_copy_B.retile(tSKrK)
-        tSKsK    = sk_thr_copy_B.partition_S(sK_SD)
+        tSKsK = sk_thr_copy_B.partition_S(sK_SD)
 
         # ── NewV copies ───────────────────────────────────────────────────────
         newv_tiled_copy_B = cute.make_tiled_copy_B(ldsm_n4, newv_tiled_mma)
         newv_thr_copy_B = newv_tiled_copy_B.get_slice(thread_idx)
-        tNewVrB    = newv_thr_mma.make_fragment_B(newv_thr_mma.partition_B(sKK_opd))
+        tNewVrB = newv_thr_mma.make_fragment_B(newv_thr_mma.partition_B(sKK_opd))
         tNewVrB_cv = newv_thr_copy_B.retile(tNewVrB)
-        tNewVsB    = newv_thr_copy_B.partition_S(sKK_opd)
+        tNewVsB = newv_thr_copy_B.partition_S(sKK_opd)
 
         # ── KV copies ─────────────────────────────────────────────────────────
         kv_tiled_copy_B = cute.make_tiled_copy_B(ldsm_t4, kv_tiled_mma)
         kv_thr_copy_B = kv_tiled_copy_B.get_slice(thread_idx)
-        tKVrK    = kv_thr_mma.make_fragment_B(kv_thr_mma.partition_B(sK_DS_k))
+        tKVrK = kv_thr_mma.make_fragment_B(kv_thr_mma.partition_B(sK_DS_k))
         tKVrK_cv = kv_thr_copy_B.retile(tKVrK)
-        tKVsK    = kv_thr_copy_B.partition_S(sK_DS)
+        tKVsK = kv_thr_copy_B.partition_S(sK_DS)
 
         # ── O1/O2 copies ──────────────────────────────────────────────────────
         o1_tiled_copy_B = cute.make_tiled_copy_B(ldsm_n4, o1_tiled_mma)
@@ -802,32 +841,35 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         # Direct partition_B(sQ_k) preserves the swizzled Q layout here and produces
         # a non-C++ B fragment shape; derive the fragment from TileShapeO1 instead.
-        tOrQ    = cute.make_rmem_tensor(
-            o1_thr_mma.partition_shape_B(cute.slice_(tile_shape_o1, (0, None, None))), self.dtype)
+        tOrQ = cute.make_rmem_tensor(
+            o1_thr_mma.partition_shape_B(cute.slice_(tile_shape_o1, (0, None, None))),
+            self.dtype,
+        )
         tOrQ_cv = o1_thr_copy_B.retile(tOrQ)
-        tOsQ    = o1_thr_copy_B.partition_S(sQ_SD)
-        tOrQK    = o2_thr_mma.make_fragment_B(o2_thr_mma.partition_B(sQK))
+        tOsQ = o1_thr_copy_B.partition_S(sQ_SD)
+        tOrQK = o2_thr_mma.make_fragment_B(o2_thr_mma.partition_B(sQK))
         tOrQK_cv = o2_thr_copy_B.retile(tOrQK)
-        tOsQK    = o2_thr_copy_B.partition_S(sQK)
+        tOsQK = o2_thr_copy_B.partition_S(sQK)
 
         # ── O store (R→S STSM) ────────────────────────────────────────────────
-        o_stsm   = cute.make_copy_atom(
-            warp.StMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype)
+        o_stsm = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype
+        )
         o_tiled_copy_r2s = cute.make_tiled_copy_C(o_stsm, o1_tiled_mma)
         o_thr_copy_r2s = o_tiled_copy_r2s.get_slice(thread_idx)
         tOsO = o_thr_copy_r2s.partition_D(sO)
 
         # ── Coordinate tensors for masking / alpha/beta indexing ──────────────
-        cMqk    = cute.make_identity_tensor((blk_q, blk_kv))
+        cMqk = cute.make_identity_tensor((blk_q, blk_kv))
         tQKcMqk = qk_thr_mma.partition_C(cMqk)
-        cMkk    = cMqk   # same shape (BlkKV == BlkQ == 64)
+        cMkk = cMqk  # same shape (BlkKV == BlkQ == 64)
         tKKcMkk = kk_thr_mma.partition_C(cMkk)
-        cO      = cute.make_identity_tensor((d, blk_q))
-        tOcO    = o1_thr_mma.partition_C(cO)
-        cSK     = cute.make_identity_tensor((d, blk_kv))
-        tSKcSK  = sk_thr_mma.partition_C(cSK)
-        cV      = cute.make_identity_tensor((d, blk_kv))
-        tKVcV   = kv_thr_mma.partition_A(cV)
+        cO = cute.make_identity_tensor((d, blk_q))
+        tOcO = o1_thr_mma.partition_C(cO)
+        cSK = cute.make_identity_tensor((d, blk_kv))
+        tSKcSK = sk_thr_mma.partition_C(cSK)
+        cV = cute.make_identity_tensor((d, blk_kv))
+        tKVcV = kv_thr_mma.partition_A(cV)
 
         # ── KK GEMM (WG0 only) ────────────────────────────────────────────────
         k_pipeline.consumer_wait(k_consumer_state)
@@ -845,15 +887,22 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             cute.copy(kk_tiled_copy_A, tKKsA[None, None, None, k_stage], tKKrA_cv)
             cute.copy(kk_tiled_copy_B, tKKsB[None, None, None, k_stage], tKKrB_cv)
             tKKrKK = cute.make_rmem_tensor(
-                kk_thr_mma.partition_shape_C((blk_kv, blk_kv)),
-                self.acc_dtype)
+                kk_thr_mma.partition_shape_C((blk_kv, blk_kv)), self.acc_dtype
+            )
             tKKrKK.fill(self.acc_dtype(0.0))
             cute.gemm(kk_tiled_mma, tKKrKK, tKKrA, tKKrB, tKKrKK)
             self.kk_epi(tKKrKK, tKKcMkk, sAlpha, sBeta, alpha_stage, beta_stage)
             self.qk_or_kk_mask(tKKrKK, tKKcMkk, is_final_block, B)
             self._kk_store_and_inv(
-                tKKrKK, kk_tiled_mma, kk_thread_idx, sKK_inv, sKK_opd,
-                sBeta, beta_stage, tKKcMkk)
+                tKKrKK,
+                kk_tiled_mma,
+                kk_thread_idx,
+                sKK_inv,
+                sKK_opd,
+                sBeta,
+                beta_stage,
+                tKKcMkk,
+            )
         if cutlass.const_expr(self.needs_beta):
             beta_pipeline.consumer_release(beta_consumer_state)
             beta_consumer_state.advance()
@@ -866,8 +915,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             cute.copy(qk_tiled_copy_A, tQKsQ[None, None, None, q_stage], tQKrQ_cv)
             cute.copy(qk_tiled_copy_B, tQKsK[None, None, None, k_stage], tQKrK_cv)
             tQKrQK = cute.make_rmem_tensor(
-                qk_thr_mma.partition_shape_C((blk_q, blk_kv)),
-                self.acc_dtype)
+                qk_thr_mma.partition_shape_C((blk_q, blk_kv)), self.acc_dtype
+            )
             tQKrQK.fill(self.acc_dtype(0.0))
             cute.gemm(qk_tiled_mma, tQKrQK, tQKrQ, tQKrK, tQKrQK)
             self.qk_epi(tQKrQK, tQKcMqk, sAlpha, alpha_stage, scale)
@@ -876,7 +925,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         # ── O1: KV_state @ Q (both WGs, skip on first block) ─────────────────
         tOrO = cute.make_rmem_tensor(
-            o1_thr_mma.partition_shape_C((d, blk_q)), self.acc_dtype)
+            o1_thr_mma.partition_shape_C((d, blk_q)), self.acc_dtype
+        )
         tOrO.fill(self.acc_dtype(0.0))
         if cutlass.const_expr(not is_first_block):
             cute.copy(o1_tiled_copy_B, tOsQ[None, None, None, q_stage], tOrQ_cv)
@@ -888,7 +938,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         # ── SK: KV_state @ K^T (result negated below via V - SK) ─────────────
         tSKrSK = cute.make_rmem_tensor(
-            sk_thr_mma.partition_shape_C((d, blk_kv)), self.acc_dtype)
+            sk_thr_mma.partition_shape_C((d, blk_kv)), self.acc_dtype
+        )
         tSKrSK.fill(self.acc_dtype(0.0))
         if cutlass.const_expr(not is_first_block):
             tSKrS = SM80.make_acc_into_op(tKVrKV, sk_tiled_mma, self.dtype)
@@ -897,8 +948,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         # ── Load V from smem ──────────────────────────────────────────────────
         v_pipeline.consumer_wait(v_consumer_state)
-        tSKrV = self.sk_load_v(
-            tSKrSK, sV_DS, sk_tiled_copy_C, sk_thr_copy_C, v_stage)
+        tSKrV = self.sk_load_v(tSKrSK, sV_DS, sk_tiled_copy_C, sk_thr_copy_C, v_stage)
 
         # sk_epi + V - SK  (SK=0 on first block, so V - SK = V)
         if cutlass.const_expr(not is_first_block):
@@ -909,7 +959,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         # ── NewV = (V - SK) @ T^T  (ordered: WG0 first) ──────────────────────
         tNewVrA = SM80.make_acc_into_op(tSKrV, newv_tiled_mma, self.dtype)
         tNewVrC = cute.make_rmem_tensor(
-            newv_thr_mma.partition_shape_C((d, blk_kv)), self.acc_dtype)
+            newv_thr_mma.partition_shape_C((d, blk_kv)), self.acc_dtype
+        )
         self._math_order_wait(wg_idx)
         cute.copy(newv_tiled_copy_B, tNewVsB, tNewVrB_cv)
         tNewVrC.fill(self.acc_dtype(0.0))
@@ -928,8 +979,10 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         # ── O store to smem ───────────────────────────────────────────────────
         o_pipeline.producer_acquire(o_producer_state)
         self.o_store(
-            tOrO, tOsO[None, None, None, o_stage],
-            o_tiled_copy_r2s, o_thr_copy_r2s,
+            tOrO,
+            tOsO[None, None, None, o_stage],
+            o_tiled_copy_r2s,
+            o_thr_copy_r2s,
         )
         o_pipeline.producer_commit(o_producer_state)
         o_producer_state.advance()
@@ -938,7 +991,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         block_coeff = cutlass.Float32(1.0)
         if cutlass.const_expr(self.needs_alpha):
             block_coeff = cutlass.Float32(
-                sAlpha[B - cutlass.Int32(1), AlphaProcessor.CUMPROD, alpha_stage])
+                sAlpha[B - cutlass.Int32(1), AlphaProcessor.CUMPROD, alpha_stage]
+            )
 
         for i in cutlass.range(cute.size(tKVrKV), unroll_full=True):
             tKVrKV[i] = block_coeff * tKVrKV[i]
@@ -988,26 +1042,40 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         v_head_idx: cutlass.Int32,
     ):
         q_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.q_stage)
+            pipeline.PipelineUserType.Producer, self.q_stage
+        )
         k_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.k_stage)
+            pipeline.PipelineUserType.Producer, self.k_stage
+        )
         v_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.v_stage)
+            pipeline.PipelineUserType.Producer, self.v_stage
+        )
         for blk in cutlass.range(num_blocks, unroll=1):
             (
                 q_producer_state,
                 k_producer_state,
                 v_producer_state,
             ) = self.load_qkv_tma(
-                sQ_SD, sK_DS, sV_DS,
-                tma_atom_q, tma_tensor_q,
-                tma_atom_k, tma_tensor_k,
-                tma_atom_v, tma_tensor_v,
-                q_pipeline, q_producer_state,
-                k_pipeline, k_producer_state,
-                v_pipeline, v_producer_state,
-                blk, tok_start,
-                q_head_idx, k_head_idx, v_head_idx,
+                sQ_SD,
+                sK_DS,
+                sV_DS,
+                tma_atom_q,
+                tma_tensor_q,
+                tma_atom_k,
+                tma_tensor_k,
+                tma_atom_v,
+                tma_tensor_v,
+                q_pipeline,
+                q_producer_state,
+                k_pipeline,
+                k_producer_state,
+                v_pipeline,
+                v_producer_state,
+                blk,
+                tok_start,
+                q_head_idx,
+                k_head_idx,
+                v_head_idx,
             )
 
     @cute.jit
@@ -1024,17 +1092,25 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         num_sab_heads: cutlass.Int32,
     ):
         alpha_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.alpha_beta_stage)
+            pipeline.PipelineUserType.Producer, self.alpha_beta_stage
+        )
         for blk in cutlass.range(num_blocks, unroll=1):
             blk_tok = tok_start + blk * cutlass.Int32(self.BLK_Q)
             if cutlass.const_expr(self.needs_alpha):
                 alpha_pipeline.producer_acquire(alpha_producer_state)
                 cute.arch.fence_view_async_shared()
                 self.load_alpha(
-                    sAlpha, g_alpha, blk_tok, tok_end, sab_head_idx,
-                    num_sab_heads, alpha_producer_state.index,
+                    sAlpha,
+                    g_alpha,
+                    blk_tok,
+                    tok_end,
+                    sab_head_idx,
+                    num_sab_heads,
+                    alpha_producer_state.index,
                 )
-                AlphaProcessor().run(sAlpha[None, None, alpha_producer_state.index], scale)
+                AlphaProcessor().run(
+                    sAlpha[None, None, alpha_producer_state.index], scale
+                )
                 cute.arch.fence_view_async_shared()
                 alpha_pipeline.producer_commit(alpha_producer_state)
                 alpha_producer_state.advance()
@@ -1052,15 +1128,21 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         num_sab_heads: cutlass.Int32,
     ):
         beta_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.alpha_beta_stage)
+            pipeline.PipelineUserType.Producer, self.alpha_beta_stage
+        )
         for blk in cutlass.range(num_blocks, unroll=1):
             blk_tok = tok_start + blk * cutlass.Int32(self.BLK_KV)
             if cutlass.const_expr(self.needs_beta):
                 beta_pipeline.producer_acquire(beta_producer_state)
                 cute.arch.fence_view_async_shared()
                 self.load_beta(
-                    sBeta, g_beta, blk_tok, tok_end, sab_head_idx,
-                    num_sab_heads, beta_producer_state.index,
+                    sBeta,
+                    g_beta,
+                    blk_tok,
+                    tok_end,
+                    sab_head_idx,
+                    num_sab_heads,
+                    beta_producer_state.index,
                 )
                 cute.arch.fence_view_async_shared()
                 beta_pipeline.producer_commit(beta_producer_state)
@@ -1103,25 +1185,33 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     ):
         self._math_order_init(wg_idx)
         q_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.q_stage)
+            pipeline.PipelineUserType.Consumer, self.q_stage
+        )
         k_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.k_stage)
+            pipeline.PipelineUserType.Consumer, self.k_stage
+        )
         v_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.v_stage)
+            pipeline.PipelineUserType.Consumer, self.v_stage
+        )
         o_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.o_stage)
+            pipeline.PipelineUserType.Producer, self.o_stage
+        )
         alpha_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage
+        )
         beta_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage
+        )
 
         kv_tiled_mma = cute.make_tiled_mma(
             warp.MmaF16BF16Op(self.dtype, self.acc_dtype, (16, 8, 16)),
             cute.make_layout((8, 1, 1)),
-            permutation_mnk=(self.D, self.D, self.BLK_KV))
+            permutation_mnk=(self.D, self.D, self.BLK_KV),
+        )
         kv_thr_mma = kv_tiled_mma.get_slice(math_tidx)
         tKVrKV = cute.make_rmem_tensor(
-            kv_thr_mma.partition_shape_C((self.D, self.D)), self.acc_dtype)
+            kv_thr_mma.partition_shape_C((self.D, self.D)), self.acc_dtype
+        )
         tKVrKV.fill(self.acc_dtype(0.0))
 
         state_layout = cute.make_ordered_layout(
@@ -1129,14 +1219,10 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         )
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
-        gStateKV = mState[
-            None, None, o_head_idx, work_desc.seq_idx
-        ]
+        gStateKV = mState[None, None, o_head_idx, work_desc.seq_idx]
         if cutlass.const_expr(self.needs_init_state):
             mInitState = cute.make_tensor(g_init_state.iterator, state_layout)
-            gInitKV = mInitState[
-                None, None, o_head_idx, work_desc.seq_idx
-            ]
+            gInitKV = mInitState[None, None, o_head_idx, work_desc.seq_idx]
             self.kv_load(tKVrKV, gInitKV, kv_thr_mma)
 
         first_B = work_desc.seq_len
@@ -1151,16 +1237,35 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 alpha_consumer_state,
                 beta_consumer_state,
             ) = self.compute_loop_body(
-                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                sBeta,
                 kv_tiled_mma,
-                q_pipeline, q_consumer_state,
-                k_pipeline, k_consumer_state,
-                v_pipeline, v_consumer_state,
-                o_pipeline, o_producer_state,
-                alpha_pipeline, alpha_consumer_state,
-                beta_pipeline, beta_consumer_state,
-                False, True, first_B,
-                tKVrKV, scale, wg_idx,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                beta_pipeline,
+                beta_consumer_state,
+                False,
+                True,
+                first_B,
+                tKVrKV,
+                scale,
+                wg_idx,
             )
         else:
             (
@@ -1171,24 +1276,53 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 alpha_consumer_state,
                 beta_consumer_state,
             ) = self.compute_loop_body(
-                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                sBeta,
                 kv_tiled_mma,
-                q_pipeline, q_consumer_state,
-                k_pipeline, k_consumer_state,
-                v_pipeline, v_consumer_state,
-                o_pipeline, o_producer_state,
-                alpha_pipeline, alpha_consumer_state,
-                beta_pipeline, beta_consumer_state,
-                True, True, first_B,
-                tKVrKV, scale, wg_idx,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                beta_pipeline,
+                beta_consumer_state,
+                True,
+                True,
+                first_B,
+                tKVrKV,
+                scale,
+                wg_idx,
             )
         self.maybe_store_checkpoint(
-            tKVrKV, g_state_checkpoints, checkpoint_cu_starts, checkpoint_every_n_tokens,
-            kv_thr_mma, work_desc.seq_idx, o_head_idx, num_sab_heads, total_checkpoints,
-            cutlass.Int32(self.BLK_KV), work_desc.seq_len,
+            tKVrKV,
+            g_state_checkpoints,
+            checkpoint_cu_starts,
+            checkpoint_every_n_tokens,
+            kv_thr_mma,
+            work_desc.seq_idx,
+            o_head_idx,
+            num_sab_heads,
+            total_checkpoints,
+            cutlass.Int32(self.BLK_KV),
+            work_desc.seq_len,
         )
 
-        for blk in cutlass.range(cutlass.Int32(1), num_blocks - cutlass.Int32(1), cutlass.Int32(1), unroll=1):
+        for blk in cutlass.range(
+            cutlass.Int32(1), num_blocks - cutlass.Int32(1), cutlass.Int32(1), unroll=1
+        ):
             (
                 q_consumer_state,
                 k_consumer_state,
@@ -1197,21 +1331,48 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 alpha_consumer_state,
                 beta_consumer_state,
             ) = self.compute_loop_body(
-                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                sBeta,
                 kv_tiled_mma,
-                q_pipeline, q_consumer_state,
-                k_pipeline, k_consumer_state,
-                v_pipeline, v_consumer_state,
-                o_pipeline, o_producer_state,
-                alpha_pipeline, alpha_consumer_state,
-                beta_pipeline, beta_consumer_state,
-                False, False, cutlass.Int32(self.BLK_KV),
-                tKVrKV, scale, wg_idx,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                beta_pipeline,
+                beta_consumer_state,
+                False,
+                False,
+                cutlass.Int32(self.BLK_KV),
+                tKVrKV,
+                scale,
+                wg_idx,
             )
             self.maybe_store_checkpoint(
-                tKVrKV, g_state_checkpoints, checkpoint_cu_starts, checkpoint_every_n_tokens,
-                kv_thr_mma, work_desc.seq_idx, o_head_idx, num_sab_heads, total_checkpoints,
-                (blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV), work_desc.seq_len,
+                tKVrKV,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                checkpoint_every_n_tokens,
+                kv_thr_mma,
+                work_desc.seq_idx,
+                o_head_idx,
+                num_sab_heads,
+                total_checkpoints,
+                (blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV),
+                work_desc.seq_len,
             )
 
         if num_blocks != cutlass.Int32(1):
@@ -1225,21 +1386,48 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 alpha_consumer_state,
                 beta_consumer_state,
             ) = self.compute_loop_body(
-                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                sBeta,
                 kv_tiled_mma,
-                q_pipeline, q_consumer_state,
-                k_pipeline, k_consumer_state,
-                v_pipeline, v_consumer_state,
-                o_pipeline, o_producer_state,
-                alpha_pipeline, alpha_consumer_state,
-                beta_pipeline, beta_consumer_state,
-                False, True, last_B,
-                tKVrKV, scale, wg_idx,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                beta_pipeline,
+                beta_consumer_state,
+                False,
+                True,
+                last_B,
+                tKVrKV,
+                scale,
+                wg_idx,
             )
             self.maybe_store_checkpoint(
-                tKVrKV, g_state_checkpoints, checkpoint_cu_starts, checkpoint_every_n_tokens,
-                kv_thr_mma, work_desc.seq_idx, o_head_idx, num_sab_heads, total_checkpoints,
-                (last_blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV), work_desc.seq_len,
+                tKVrKV,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                checkpoint_every_n_tokens,
+                kv_thr_mma,
+                work_desc.seq_idx,
+                o_head_idx,
+                num_sab_heads,
+                total_checkpoints,
+                (last_blk + cutlass.Int32(1)) * cutlass.Int32(self.BLK_KV),
+                work_desc.seq_len,
             )
         self.kv_store(tKVrKV, gStateKV, kv_thr_mma)
 
@@ -1248,30 +1436,29 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.jit
     def __call__(
         self,
-        g_q:          cute.Tensor,
-        g_k:          cute.Tensor,
-        g_v:          cute.Tensor,
-        g_o:          cute.Tensor,
-        g_alpha:      cute.Tensor,
-        g_beta:       cute.Tensor,
-        g_state:      cute.Tensor,
+        g_q: cute.Tensor,
+        g_k: cute.Tensor,
+        g_v: cute.Tensor,
+        g_o: cute.Tensor,
+        g_alpha: cute.Tensor,
+        g_beta: cute.Tensor,
+        g_state: cute.Tensor,
         g_init_state: cute.Tensor,
         g_state_checkpoints: cute.Tensor,
         checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
-        cu_seqlens:   cute.Tensor,
-        scale:        cutlass.Float32,
-        num_q_heads:   cutlass.Int32,
-        num_k_heads:   cutlass.Int32,
-        num_v_heads:   cutlass.Int32,
+        cu_seqlens: cute.Tensor,
+        scale: cutlass.Float32,
+        num_q_heads: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
-        num_seqs:      cutlass.Int32,
+        num_seqs: cutlass.Int32,
         total_checkpoints: cutlass.Int32,
         checkpoint_every_n_tokens: cutlass.Int32,
         grid_x: int,
         stream,
     ):
-
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
             warpgroup.SmemLayoutAtomKind.K_SW128,
             self.dtype,
@@ -1318,15 +1505,19 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
         tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_q, q_smem_layout, (self.BLK_Q, self.D))
+            tma_load_op, g_q, q_smem_layout, (self.BLK_Q, self.D)
+        )
         tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_k, k_smem_layout, (self.D, self.BLK_KV))
+            tma_load_op, g_k, k_smem_layout, (self.D, self.BLK_KV)
+        )
         tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_v, v_smem_layout, (self.D, self.BLK_KV))
+            tma_load_op, g_v, v_smem_layout, (self.D, self.BLK_KV)
+        )
 
         tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
         tma_atom_o, tma_tensor_o = cpasync.make_tiled_tma_atom(
-            tma_store_op, g_o, o_smem_layout, (self.D, self.BLK_Q))
+            tma_store_op, g_o, o_smem_layout, (self.D, self.BLK_Q)
+        )
 
         dtype_bytes = self.dtype.width // 8
         self.tma_load_q_bytes = cute.size(q_smem_layout) * dtype_bytes
@@ -1335,11 +1526,14 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
         qk_storage_layout = cute.tile_to_shape(
-            qk_layout_atom, (self.BLK_Q, self.BLK_KV), order=(1, 0))
+            qk_layout_atom, (self.BLK_Q, self.BLK_KV), order=(1, 0)
+        )
         kk_storage_layout = cute.tile_to_shape(
-            qk_layout_atom, (self.BLK_KV, self.BLK_KV), order=(1, 0))
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV), order=(1, 0)
+        )
         alpha_storage_layout = cute.make_layout(
-            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage)
+        )
         beta_storage_layout = cute.make_layout((self.BLK_KV, self.alpha_beta_stage))
 
         @cute.struct
@@ -1348,8 +1542,12 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.k_stage * 2]
             v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.v_stage * 2]
             o_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.o_stage * 2]
-            alpha_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_beta_stage * 2]
-            beta_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_beta_stage * 2]
+            alpha_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.alpha_beta_stage * 2
+            ]
+            beta_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.alpha_beta_stage * 2
+            ]
 
             smem_q: cute.struct.Align[
                 cute.struct.MemRange[self.dtype, cute.cosize(q_storage_layout)],
@@ -1368,7 +1566,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 16,
             ]
             smem_kk: cute.struct.Align[
-                cute.struct.MemRange[self.inverse_dtype, cute.cosize(kk_storage_layout)],
+                cute.struct.MemRange[
+                    self.inverse_dtype, cute.cosize(kk_storage_layout)
+                ],
                 16,
             ]
             smem_o: cute.struct.Align[
@@ -1376,7 +1576,9 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
                 128,
             ]
             smem_alpha: cute.struct.Align[
-                cute.struct.MemRange[cutlass.Float32, cute.cosize(alpha_storage_layout)],
+                cute.struct.MemRange[
+                    cutlass.Float32, cute.cosize(alpha_storage_layout)
+                ],
                 16,
             ]
             smem_beta: cute.struct.Align[
@@ -1387,15 +1589,30 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         self.shared_storage = SharedStorage
 
         self.kernel(
-            g_alpha, g_beta,
-            tma_atom_q, tma_tensor_q,
-            tma_atom_k, tma_tensor_k,
-            tma_atom_v, tma_tensor_v,
-            tma_atom_o, tma_tensor_o,
-            g_state, g_init_state, g_state_checkpoints, checkpoint_cu_starts,
-            g_tensormaps, cu_seqlens,
-            scale, num_q_heads, num_k_heads, num_v_heads, num_sab_heads, num_seqs,
-            total_checkpoints, checkpoint_every_n_tokens,
+            g_alpha,
+            g_beta,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_o,
+            tma_tensor_o,
+            g_state,
+            g_init_state,
+            g_state_checkpoints,
+            checkpoint_cu_starts,
+            g_tensormaps,
+            cu_seqlens,
+            scale,
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            num_sab_heads,
+            num_seqs,
+            total_checkpoints,
+            checkpoint_every_n_tokens,
         ).launch(
             grid=(grid_x, 1, 1),
             block=(384, 1, 1),
@@ -1407,28 +1624,28 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
     @cute.kernel
     def kernel(
         self,
-        g_alpha:      cute.Tensor,
-        g_beta:       cute.Tensor,
-        tma_atom_q:   cute.CopyAtom,
+        g_alpha: cute.Tensor,
+        g_beta: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
         tma_tensor_q: cute.Tensor,
-        tma_atom_k:   cute.CopyAtom,
+        tma_atom_k: cute.CopyAtom,
         tma_tensor_k: cute.Tensor,
-        tma_atom_v:   cute.CopyAtom,
+        tma_atom_v: cute.CopyAtom,
         tma_tensor_v: cute.Tensor,
-        tma_atom_o:   cute.CopyAtom,
+        tma_atom_o: cute.CopyAtom,
         tma_tensor_o: cute.Tensor,
-        g_state:      cute.Tensor,
+        g_state: cute.Tensor,
         g_init_state: cute.Tensor,
         g_state_checkpoints: cute.Tensor,
         checkpoint_cu_starts: cute.Tensor,
         g_tensormaps: cute.Tensor,
-        cu_seqlens:   cute.Tensor,
-        scale:        cutlass.Float32,
-        num_q_heads:   cutlass.Int32,
-        num_k_heads:   cutlass.Int32,
-        num_v_heads:   cutlass.Int32,
+        cu_seqlens: cute.Tensor,
+        scale: cutlass.Float32,
+        num_q_heads: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
         num_sab_heads: cutlass.Int32,
-        num_seqs:      cutlass.Int32,
+        num_seqs: cutlass.Int32,
         total_checkpoints: cutlass.Int32,
         checkpoint_every_n_tokens: cutlass.Int32,
     ):
@@ -1450,9 +1667,11 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         tidx, _, _ = cute.arch.thread_idx()
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         warp_group_idx = cute.arch.make_warp_uniform(
-            tidx // cutlass.Int32(THREADS_PER_WARP_GROUP))
+            tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
+        )
         ldst_warp_role = cute.arch.make_warp_uniform(
-            warp_idx % cutlass.Int32(WARPS_PER_WARP_GROUP))
+            warp_idx % cutlass.Int32(WARPS_PER_WARP_GROUP)
+        )
 
         if warp_idx == LoadStoreWarpRole.LOAD_QKV:
             cpasync.prefetch_descriptor(tma_atom_q)
@@ -1461,7 +1680,10 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             cpasync.prefetch_descriptor(tma_atom_o)
 
         work_desc = self.get_next_work(
-            cu_seqlens, num_q_heads, num_v_heads, num_sab_heads,
+            cu_seqlens,
+            num_q_heads,
+            num_v_heads,
+            num_sab_heads,
         )
         tok_end = work_desc.tok_offset + work_desc.seq_len
         num_blocks = (
@@ -1470,7 +1692,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
         # math_tidx / wg_idx: valid for Math WG threads; LdSt WG gets negative values (unused)
         math_tidx = tidx - cutlass.Int32(THREADS_PER_WARP_GROUP)
-        wg_idx    = math_tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
+        wg_idx = math_tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
 
         # ── Smem allocation ───────────────────────────────────────────────────
         allocator = cutlass.utils.SmemAllocator()
@@ -1514,10 +1736,14 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         sV_DS = storage.smem_v.get_tensor(v_layout_ds.outer, swizzle=v_layout_ds.inner)
 
         qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
-        qk_layout = cute.tile_to_shape(qk_layout_atom, (self.BLK_Q, self.BLK_KV), order=(1, 0))
+        qk_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_Q, self.BLK_KV), order=(1, 0)
+        )
         sQK = storage.smem_qk.get_tensor(qk_layout)
 
-        kk_layout = cute.tile_to_shape(qk_layout_atom, (self.BLK_KV, self.BLK_KV), order=(1, 0))
+        kk_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV), order=(1, 0)
+        )
         sKK_inv = storage.smem_kk.get_tensor(kk_layout)
         kk_opd_ptr = cute.recast_ptr(storage.smem_kk.data_ptr(), dtype=self.dtype)
         sKK_opd = cute.make_tensor(kk_opd_ptr, kk_layout)
@@ -1533,7 +1759,8 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         )
         sO = storage.smem_o.get_tensor(o_layout.outer, swizzle=o_layout.inner)
         alpha_layout = cute.make_layout(
-            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage)
+        )
         sAlpha = storage.smem_alpha.get_tensor(alpha_layout)
 
         beta_layout = cute.make_layout((self.BLK_KV, self.alpha_beta_stage))
@@ -1598,43 +1825,96 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
             cute.arch.setmaxregister_decrease(load_registers)
             if ldst_warp_role == LoadStoreWarpRole.LOAD_QKV:
                 self.run_load_qkv_role(
-                    sQ_SD, sK_DS, sV_DS,
-                    tma_atom_q, tma_tensor_q,
-                    tma_atom_k, tma_tensor_k,
-                    tma_atom_v, tma_tensor_v,
-                    q_pipeline, k_pipeline, v_pipeline,
-                    num_blocks, work_desc.tok_offset,
+                    sQ_SD,
+                    sK_DS,
+                    sV_DS,
+                    tma_atom_q,
+                    tma_tensor_q,
+                    tma_atom_k,
+                    tma_tensor_k,
+                    tma_atom_v,
+                    tma_tensor_v,
+                    q_pipeline,
+                    k_pipeline,
+                    v_pipeline,
+                    num_blocks,
+                    work_desc.tok_offset,
                     work_desc.q_head_idx(),
                     work_desc.k_head_idx(num_q_heads, num_v_heads),
                     work_desc.v_head_idx(),
                 )
             elif ldst_warp_role == LoadStoreWarpRole.STORE_O:
                 CollectiveStoreTma(self.BLK_Q, self.D).run(
-                    sO, tma_atom_o, tma_tensor_o, g_tensormaps,
-                    o_pipeline, num_blocks, work_desc, num_seqs, self.o_stage,
-                    num_q_heads, num_v_heads,
+                    sO,
+                    tma_atom_o,
+                    tma_tensor_o,
+                    g_tensormaps,
+                    o_pipeline,
+                    num_blocks,
+                    work_desc,
+                    num_seqs,
+                    self.o_stage,
+                    num_q_heads,
+                    num_v_heads,
                 )
             elif ldst_warp_role == LoadStoreWarpRole.LOAD_BETA:
                 self.run_load_beta_role(
-                    sBeta, g_beta, beta_pipeline, num_blocks, work_desc.tok_offset, tok_end,
-                    work_desc.o_head_idx(num_q_heads, num_v_heads), num_sab_heads,
+                    sBeta,
+                    g_beta,
+                    beta_pipeline,
+                    num_blocks,
+                    work_desc.tok_offset,
+                    tok_end,
+                    work_desc.o_head_idx(num_q_heads, num_v_heads),
+                    num_sab_heads,
                 )
             elif ldst_warp_role == LoadStoreWarpRole.LOAD_ALPHA:
                 self.run_load_alpha_role(
-                    sAlpha, g_alpha, alpha_pipeline, scale, num_blocks, work_desc.tok_offset,
-                    tok_end, work_desc.o_head_idx(num_q_heads, num_v_heads), num_sab_heads,
+                    sAlpha,
+                    g_alpha,
+                    alpha_pipeline,
+                    scale,
+                    num_blocks,
+                    work_desc.tok_offset,
+                    tok_end,
+                    work_desc.o_head_idx(num_q_heads, num_v_heads),
+                    num_sab_heads,
                 )
         else:
             cute.arch.setmaxregister_increase(mma_registers)
 
             self.run_math_role(
-                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha, sBeta,
-                q_pipeline, k_pipeline, v_pipeline,
-                o_pipeline, alpha_pipeline, beta_pipeline,
-                g_state, g_init_state, g_state_checkpoints, checkpoint_cu_starts, work_desc,
-                scale, wg_idx, math_tidx, num_blocks,
-                num_q_heads, num_v_heads, num_sab_heads, num_seqs,
-                total_checkpoints, checkpoint_every_n_tokens,
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
+                sBeta,
+                q_pipeline,
+                k_pipeline,
+                v_pipeline,
+                o_pipeline,
+                alpha_pipeline,
+                beta_pipeline,
+                g_state,
+                g_init_state,
+                g_state_checkpoints,
+                checkpoint_cu_starts,
+                work_desc,
+                scale,
+                wg_idx,
+                math_tidx,
+                num_blocks,
+                num_q_heads,
+                num_v_heads,
+                num_sab_heads,
+                num_seqs,
+                total_checkpoints,
+                checkpoint_every_n_tokens,
             )
 
 
@@ -1642,16 +1922,16 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
 
 
 def delta_rule_prefill_dsl(
-    o:          torch.Tensor,          # (total_seqlen, num_o_heads, D) fp16/bf16, output
-    state:      torch.Tensor,          # (num_seqs, num_sab_heads, D, D) fp32, output
-    q:          torch.Tensor,          # (total_seqlen, num_q_heads, D)
-    k:          torch.Tensor,          # (total_seqlen, num_k_heads, D)
-    v:          torch.Tensor,          # (total_seqlen, num_v_heads, D)
-    init_state: torch.Tensor | None,   # (num_seqs, num_sab_heads, D, D) fp32, optional
-    alpha:      torch.Tensor | None,
-    beta:       torch.Tensor | None,
-    cu_seqlens: torch.Tensor,          # (num_seqs+1,) int64
-    scale:      float,
+    o: torch.Tensor,  # (total_seqlen, num_o_heads, D) fp16/bf16, output
+    state: torch.Tensor,  # (num_seqs, num_sab_heads, D, D) fp32, output
+    q: torch.Tensor,  # (total_seqlen, num_q_heads, D)
+    k: torch.Tensor,  # (total_seqlen, num_k_heads, D)
+    v: torch.Tensor,  # (total_seqlen, num_v_heads, D)
+    init_state: torch.Tensor | None,  # (num_seqs, num_sab_heads, D, D) fp32, optional
+    alpha: torch.Tensor | None,
+    beta: torch.Tensor | None,
+    cu_seqlens: torch.Tensor,  # (num_seqs+1,) int64
+    scale: float,
     state_checkpoints: torch.Tensor | None = None,
     checkpoint_cu_starts: torch.Tensor | None = None,
     checkpoint_every_n_tokens: int = 0,
@@ -1661,10 +1941,10 @@ def delta_rule_prefill_dsl(
 
     D = q.shape[-1]
 
-    num_seqs      = cu_seqlens.shape[0] - 1
-    num_q_heads   = q.shape[1]
-    num_k_heads   = k.shape[1]
-    num_v_heads   = v.shape[1]
+    num_seqs = cu_seqlens.shape[0] - 1
+    num_q_heads = q.shape[1]
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
     num_sab_heads = max(num_q_heads, num_v_heads)
 
     if not _FullyFusedDeltaRuleSm120.can_implement(
@@ -1674,8 +1954,8 @@ def delta_rule_prefill_dsl(
     if D != 128:
         raise RuntimeError(f"DSL kernel only supports D=128, got {D}")
 
-    needs_alpha      = alpha      is not None
-    needs_beta       = beta       is not None
+    needs_alpha = alpha is not None
+    needs_beta = beta is not None
     needs_init_state = init_state is not None
     needs_checkpointing = checkpoint_every_n_tokens > 0
     kernel_dtype = {
@@ -1708,27 +1988,35 @@ def delta_rule_prefill_dsl(
         (D, total_seqlen, num_o_heads),
         (1, num_o_heads * D, D),
     )
-    _dummy_f32   = torch.zeros(1, dtype=torch.float32, device=q.device)
-    _dummy_i64   = torch.zeros(1, dtype=torch.int64, device=q.device)
-    alpha_t      = alpha.contiguous()      if needs_alpha      else _dummy_f32
-    beta_t       = beta.contiguous()       if needs_beta       else _dummy_f32
+    _dummy_f32 = torch.zeros(1, dtype=torch.float32, device=q.device)
+    _dummy_i64 = torch.zeros(1, dtype=torch.int64, device=q.device)
+    alpha_t = alpha.contiguous() if needs_alpha else _dummy_f32
+    beta_t = beta.contiguous() if needs_beta else _dummy_f32
     init_state_t = init_state.contiguous() if needs_init_state else _dummy_f32
-    state_checkpoints_t = state_checkpoints.contiguous() if needs_checkpointing else _dummy_f32
-    checkpoint_cu_t = checkpoint_cu_starts.to(torch.int64).contiguous() if needs_checkpointing else _dummy_i64
+    state_checkpoints_t = (
+        state_checkpoints.contiguous() if needs_checkpointing else _dummy_f32
+    )
+    checkpoint_cu_t = (
+        checkpoint_cu_starts.to(torch.int64).contiguous()
+        if needs_checkpointing
+        else _dummy_i64
+    )
     total_checkpoints = state_checkpoints_t.shape[0] if needs_checkpointing else 1
-    sm_count     = torch.cuda.get_device_properties(q.device).multi_processor_count
+    sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
     tensormaps_t = torch.empty(sm_count * 128, dtype=torch.uint8, device=q.device)
-    cu_int64     = cu_seqlens.to(torch.int64).contiguous()
+    cu_int64 = cu_seqlens.to(torch.int64).contiguous()
 
     stream_val = torch.cuda.current_stream().cuda_stream
-    stream     = cuda_driver.CUstream(stream_val)
+    stream = cuda_driver.CUstream(stream_val)
 
     # Keep head counts and varlen extents runtime values across cached compiles.
     q_cute = from_dlpack(q_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1)
     k_cute = from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
     v_cute = from_dlpack(v_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
     o_cute = from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0)
-    alpha_cute = from_dlpack(alpha_t.reshape(-1), assumed_align=16).mark_layout_dynamic()
+    alpha_cute = from_dlpack(
+        alpha_t.reshape(-1), assumed_align=16
+    ).mark_layout_dynamic()
     beta_cute = from_dlpack(beta_t.reshape(-1), assumed_align=16).mark_layout_dynamic()
     state_cute = from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic()
     init_state_cute = from_dlpack(
@@ -1737,7 +2025,9 @@ def delta_rule_prefill_dsl(
     state_checkpoints_cute = from_dlpack(
         state_checkpoints_t.reshape(-1), assumed_align=16
     ).mark_layout_dynamic()
-    checkpoint_cu_cute = from_dlpack(checkpoint_cu_t, assumed_align=8).mark_layout_dynamic()
+    checkpoint_cu_cute = from_dlpack(
+        checkpoint_cu_t, assumed_align=8
+    ).mark_layout_dynamic()
     tensormaps_cute = from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic()
     cu_cute = from_dlpack(cu_int64, assumed_align=8).mark_layout_dynamic()
 
@@ -1759,8 +2049,10 @@ def delta_rule_prefill_dsl(
         tensormaps_cute,
         cu_cute,
         cutlass.Float32(scale),
-        cutlass.Int32(num_q_heads), cutlass.Int32(num_k_heads),
-        cutlass.Int32(num_v_heads), cutlass.Int32(num_sab_heads),
+        cutlass.Int32(num_q_heads),
+        cutlass.Int32(num_k_heads),
+        cutlass.Int32(num_v_heads),
+        cutlass.Int32(num_sab_heads),
         cutlass.Int32(num_seqs),
         cutlass.Int32(total_checkpoints),
         cutlass.Int32(checkpoint_every_n_tokens),

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -5,6 +5,7 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
 from cutlass.cute.nvgpu import warp, warpgroup, cpasync
+from ...utils import get_device_sm_count, _get_cache_buf
 from .alpha import AlphaProcessor
 from .collective_store_tma import CollectiveStoreTma
 from .custom_compile_cache import KeyedCompileMixin, cached_compile
@@ -2014,8 +2015,9 @@ def delta_rule_prefill_dsl(
         (1, num_o_heads * D, D),
     )
     total_checkpoints = state_checkpoints.shape[0] if needs_checkpointing else 1
-    sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
-    tensormaps_t = torch.empty(sm_count * 128, dtype=torch.uint8, device=q.device)
+
+    workspace_size = get_device_sm_count(q.device) * 128
+    tensormaps_t = _get_cache_buf("gdn_prefill_tensormaps", workspace_size, q.device)
 
     stream_val = torch.cuda.current_stream().cuda_stream
     stream = cuda_driver.CUstream(stream_val)

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -26,6 +26,7 @@ from .utils import (
 from .gdn_kernels import (
     chunk_gated_delta_rule_sm90,
     chunk_gated_delta_rule_sm100,
+    chunk_gated_delta_rule_sm120,
 )
 
 
@@ -275,7 +276,35 @@ def chunk_gated_delta_rule(
             cu_checkpoints=_cu_checkpoints,
             output_checkpoints=state_checkpoints,
         )
+    elif _arch_major == 12:
+        # SM120 Blackwell path (CuTe DSL kernel)
+        if chunk_gated_delta_rule_sm120 is None:
+            raise NotImplementedError("SM120 GDN prefill DSL kernel is unavailable")
+        if checkpoint_every_n_tokens > 0:
+            raise NotImplementedError(
+                "SM120 GDN prefill DSL checkpointing is introduced in the "
+                "delta_rule_sm120_state_checkpointing branch"
+            )
+        if output_state is None:
+            output_state = torch.empty(
+                (num_seqs, num_sab_heads, head_size, head_size),
+                dtype=torch.float32,
+                device=device,
+            )
+        chunk_gated_delta_rule_sm120(
+            output,
+            output_state,
+            q,
+            k,
+            v,
+            initial_state,
+            g,
+            beta,
+            cu_seqlens.to(torch.int64),
+            _scale,
+        )
     elif _arch_major == 9:
+        # SM90 Hopper path (CuTe DSL kernel)
         if chunk_gated_delta_rule_sm90 is None:
             raise NotImplementedError("SM90 GDN prefill DSL kernel is unavailable")
 

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -280,11 +280,6 @@ def chunk_gated_delta_rule(
         # SM120 Blackwell path (CuTe DSL kernel)
         if chunk_gated_delta_rule_sm120 is None:
             raise NotImplementedError("SM120 GDN prefill DSL kernel is unavailable")
-        if checkpoint_every_n_tokens > 0:
-            raise NotImplementedError(
-                "SM120 GDN prefill DSL checkpointing is introduced in the "
-                "delta_rule_sm120_state_checkpointing branch"
-            )
         if output_state is None:
             output_state = torch.empty(
                 (num_seqs, num_sab_heads, head_size, head_size),
@@ -302,6 +297,11 @@ def chunk_gated_delta_rule(
             beta,
             cu_seqlens.to(torch.int64),
             _scale,
+            state_checkpoints,
+            checkpoint_cu_starts.to(torch.int64)
+            if checkpoint_cu_starts is not None
+            else None,
+            checkpoint_every_n_tokens,
         )
     elif _arch_major == 9:
         # SM90 Hopper path (CuTe DSL kernel)

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -25,7 +25,11 @@ import pytest
 
 from .reference_delta_rule import exclusive_cumsum, blockwise_delta_rule
 
-from flashinfer.utils import is_sm90a_supported, is_sm100a_supported, is_sm120a_supported
+from flashinfer.utils import (
+    is_sm90a_supported,
+    is_sm100a_supported,
+    is_sm120a_supported,
+)
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -25,21 +25,21 @@ import pytest
 
 from .reference_delta_rule import exclusive_cumsum, blockwise_delta_rule
 
-from flashinfer.utils import is_sm90a_supported, is_sm100a_supported
+from flashinfer.utils import is_sm90a_supported, is_sm100a_supported, is_sm120a_supported
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 
 def _skip_if_unsupported():
-    """Skip test if not SM90 or SM100 (with CUDA 13+) architecture."""
+    """Skip test if not SM90, SM100, or SM120 (with CUDA 13+) architecture."""
     device = torch.device("cuda")
-    if is_sm100a_supported(device):
+    if is_sm100a_supported(device) or is_sm120a_supported(device):
         cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
         if cuda_major < 13:
             pytest.skip(
-                f"SM100 GDN prefill requires CUDA 13+, got {torch.version.cuda}"
+                f"Blackwell GDN prefill requires CUDA 13+, got {torch.version.cuda}"
             )
     elif not is_sm90a_supported(device):
-        pytest.skip("GDN prefill requires SM90 or SM100")
+        pytest.skip("GDN prefill requires SM90, SM100, or SM120")
 
 
 def _skip_if_not_sm100():

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -36,13 +36,15 @@ from flashinfer.gdn_prefill import chunk_gated_delta_rule
 def _skip_if_unsupported():
     """Skip test if not SM90, SM100, or SM120 (with CUDA 13+) architecture."""
     device = torch.device("cuda")
-    if is_sm100a_supported(device) or is_sm120a_supported(device):
+    if is_sm100a_supported(device):
         cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
         if cuda_major < 13:
             pytest.skip(
-                f"Blackwell GDN prefill requires CUDA 13+, got {torch.version.cuda}"
+                f"SM100 GDN prefill requires CUDA 13+, got {torch.version.cuda}"
             )
-    elif not is_sm90a_supported(device):
+    elif is_sm120a_supported(device) or is_sm90a_supported(device):
+        pass  # No additional CUDA version requirement
+    else:
         pytest.skip("GDN prefill requires SM90, SM100, or SM120")
 
 


### PR DESCRIPTION
## 📌 Description

- [x] depends on #3477
- [x] depends on #3478

## 🔍 Related Issues

- [x] #3491 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

The fully fused scheme is severely limited by parallelism when B*H is small, this problem will be largely addressed in #3659 with a context parallel scheme.
```
GPU: NVIDIA RTX PRO 6000 Blackwell Server Edition [SM120]
Models: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128

Heads            Seqlens           h_qk  h_v                FI SM120   TFLOPS  FLA/Triton   Speedup
---------------------------------------------------------------------------------------------------
397B/122B TP8    1x65536              2    8                  5.922ms     5.8      2.629ms     0.44x -
397B/122B TP8    1x32768              2    8                  2.966ms     5.8      1.305ms     0.44x -
397B/122B TP8    1x16384              2    8                  1.488ms     5.8      0.640ms     0.43x -
397B/122B TP8    1x8192               2    8                  0.749ms     5.7      0.277ms     0.37x -
397B/122B TP8    1x4096               2    8                  0.379ms     5.7      0.146ms     0.38x -
397B/122B TP8    1x2048               2    8                  0.194ms     5.5      0.084ms     0.43x -
397B/122B TP8    6144+2048            2    8                  0.565ms     7.6      0.237ms     0.42x -
397B/122B TP8    4096+4096            2    8                  0.380ms    11.3      0.192ms     0.51x -
397B/122B TP8    2048+6144            2    8                  0.566ms     7.6      0.236ms     0.42x -
397B/122B TP8    1024+7168            2    8                  0.659ms     6.5      0.259ms     0.39x -
397B/122B TP8    2048x4               2    8                  0.195ms    22.1      0.161ms     0.83x -
397B/122B TP8    1024x8               2    8                  0.102ms    42.0      0.153ms     1.50x +
397B/122B TP8    8192x8               2    8                  0.679ms    50.6      1.728ms     2.54x +
397B/122B TP8    8192x16              2    8                  0.688ms   100.0      3.512ms     5.11x +
397B/122B TP8    8192x32              2    8                  1.433ms    95.9      7.116ms     4.97x +

397B/122B TP4    1x65536              4   16                  5.332ms    12.9      3.939ms     0.74x -
397B/122B TP4    1x32768              4   16                  2.670ms    12.9      1.980ms     0.74x -
397B/122B TP4    1x16384              4   16                  1.340ms    12.8      0.976ms     0.73x -
397B/122B TP4    1x8192               4   16                  0.674ms    12.7      0.452ms     0.67x -
397B/122B TP4    1x4096               4   16                  0.342ms    12.6      0.183ms     0.54x -
397B/122B TP4    1x2048               4   16                  0.175ms    12.3      0.099ms     0.57x -
397B/122B TP4    6144+2048            4   16                  0.508ms    16.9      0.428ms     0.84x -
397B/122B TP4    4096+4096            4   16                  0.342ms    25.1      0.389ms     1.14x +
397B/122B TP4    2048+6144            4   16                  0.510ms    16.8      0.425ms     0.83x -
397B/122B TP4    1024+7168            4   16                  0.595ms    14.4      0.441ms     0.74x -
397B/122B TP4    2048x4               4   16                  0.176ms    48.9      0.369ms     2.10x +
397B/122B TP4    1024x8               4   16                  0.096ms    89.6      0.389ms     4.06x +
397B/122B TP4    8192x8               4   16                  0.688ms    99.9      3.463ms     5.03x +
397B/122B TP4    8192x16              4   16                  1.433ms    95.9      7.109ms     4.96x +
397B/122B TP4    8192x32              4   16                  2.328ms   118.1     14.083ms     6.05x +

397B/122B TP2    1x65536              8   32                  5.346ms    25.7      6.939ms     1.30x +
397B/122B TP2    1x32768              8   32                  2.673ms    25.7      3.476ms     1.30x +
397B/122B TP2    1x16384              8   32                  1.344ms    25.6      1.757ms     1.31x +
397B/122B TP2    1x8192               8   32                  0.677ms    25.4      0.868ms     1.28x +
397B/122B TP2    1x4096               8   32                  0.343ms    25.1      0.403ms     1.18x +
397B/122B TP2    1x2048               8   32                  0.175ms    24.5      0.156ms     0.89x -
397B/122B TP2    6144+2048            8   32                  0.512ms    33.6      0.860ms     1.68x +
397B/122B TP2    4096+4096            8   32                  0.346ms    49.7      0.852ms     2.46x +
397B/122B TP2    2048+6144            8   32                  0.516ms    33.3      0.862ms     1.67x +
397B/122B TP2    1024+7168            8   32                  0.599ms    28.7      0.870ms     1.45x +
397B/122B TP2    2048x4               8   32                  0.187ms    91.9      0.871ms     4.66x +
397B/122B TP2    1024x8               8   32                  0.210ms    81.9      0.887ms     4.23x +
397B/122B TP2    8192x8               8   32                  1.437ms    95.7      6.971ms     4.85x +
397B/122B TP2    8192x16              8   32                  2.334ms   117.8     14.160ms     6.07x +
397B/122B TP2    8192x32              8   32                  4.695ms   117.1     28.687ms     6.11x +

397B/122B TP1    1x65536             16   64                  5.341ms    51.5     13.799ms     2.58x +
397B/122B TP1    1x32768             16   64                  2.674ms    51.4      6.846ms     2.56x +
397B/122B TP1    1x16384             16   64                  1.344ms    51.1      3.435ms     2.56x +
397B/122B TP1    1x8192              16   64                  0.679ms    50.6      1.736ms     2.56x +
397B/122B TP1    1x4096              16   64                  0.345ms    49.8      0.851ms     2.47x +
397B/122B TP1    1x2048              16   64                  0.175ms    49.0      0.385ms     2.19x +
397B/122B TP1    6144+2048           16   64                  0.522ms    65.9      1.745ms     3.34x +
397B/122B TP1    4096+4096           16   64                  0.353ms    97.3      1.775ms     5.03x +
397B/122B TP1    2048+6144           16   64                  0.524ms    65.6      1.763ms     3.37x +
397B/122B TP1    1024+7168           16   64                  0.606ms    56.7      1.753ms     2.89x +
397B/122B TP1    2048x4              16   64                  0.384ms    89.4      1.761ms     4.58x +
397B/122B TP1    1024x8              16   64                  0.323ms   106.3      1.803ms     5.58x +
397B/122B TP1    8192x8              16   64                  2.346ms   117.2     13.875ms     5.91x +
397B/122B TP1    8192x16             16   64                  4.720ms   116.5     28.366ms     6.01x +
397B/122B TP1    8192x32             16   64                  8.988ms   122.3     57.482ms     6.40x +

35B/9B/4B TP1    1x65536             16   32                  5.346ms    25.7      6.966ms     1.30x +
35B/9B/4B TP1    1x32768             16   32                  2.674ms    25.7      3.473ms     1.30x +
35B/9B/4B TP1    1x16384             16   32                  1.345ms    25.6      1.753ms     1.30x +
35B/9B/4B TP1    1x8192              16   32                  0.677ms    25.4      0.869ms     1.28x +
35B/9B/4B TP1    1x4096              16   32                  0.342ms    25.1      0.401ms     1.17x +
35B/9B/4B TP1    1x2048              16   32                  0.175ms    24.5      0.156ms     0.89x -
35B/9B/4B TP1    6144+2048           16   32                  0.513ms    33.5      0.859ms     1.68x +
35B/9B/4B TP1    4096+4096           16   32                  0.347ms    49.6      0.851ms     2.46x +
35B/9B/4B TP1    2048+6144           16   32                  0.513ms    33.5      0.863ms     1.68x +
35B/9B/4B TP1    1024+7168           16   32                  0.595ms    28.9      0.868ms     1.46x +
35B/9B/4B TP1    2048x4              16   32                  0.189ms    91.1      0.872ms     4.62x +
35B/9B/4B TP1    1024x8              16   32                  0.214ms    80.4      0.887ms     4.15x +
35B/9B/4B TP1    8192x8              16   32                  1.485ms    92.5      6.991ms     4.71x +
35B/9B/4B TP1    8192x16             16   32                  2.398ms   114.6     14.152ms     5.90x +
35B/9B/4B TP1    8192x32             16   32                  4.808ms   114.3     28.719ms     5.97x +

27B TP1          1x65536             16   48                  5.345ms    38.6     10.513ms     1.97x +
27B TP1          1x32768             16   48                  2.679ms    38.5      5.219ms     1.95x +
27B TP1          1x16384             16   48                  1.345ms    38.3      2.598ms     1.93x +
27B TP1          1x8192              16   48                  0.677ms    38.0      1.299ms     1.92x +
27B TP1          1x4096              16   48                  0.343ms    37.5      0.619ms     1.80x +
27B TP1          1x2048              16   48                  0.175ms    36.8      0.265ms     1.51x +
27B TP1          6144+2048           16   48                  0.516ms    49.9      1.307ms     2.53x +
27B TP1          4096+4096           16   48                  0.348ms    74.0      1.391ms     3.99x +
27B TP1          2048+6144           16   48                  0.516ms    49.9      1.346ms     2.61x +
27B TP1          1024+7168           16   48                  0.599ms    43.0      1.326ms     2.21x +
27B TP1          2048x4              16   48                  0.384ms    67.1      1.357ms     3.53x +
27B TP1          1024x8              16   48                  0.318ms    81.0      1.358ms     4.27x +
27B TP1          8192x8              16   48                  2.186ms    94.3     10.637ms     4.87x +
27B TP1          8192x16             16   48                  3.780ms   109.1     21.723ms     5.75x +
27B TP1          8192x32             16   48                  7.138ms   115.5     43.755ms     6.13x +

2B/0.8B TP1      1x65536             16   16                  5.331ms    12.9      3.941ms     0.74x -
2B/0.8B TP1      1x32768             16   16                  2.670ms    12.9      1.974ms     0.74x -
2B/0.8B TP1      1x16384             16   16                  1.339ms    12.8      0.973ms     0.73x -
2B/0.8B TP1      1x8192              16   16                  0.675ms    12.7      0.452ms     0.67x -
2B/0.8B TP1      1x4096              16   16                  0.341ms    12.6      0.181ms     0.53x -
2B/0.8B TP1      1x2048              16   16                  0.175ms    12.3      0.096ms     0.55x -
2B/0.8B TP1      6144+2048           16   16                  0.509ms    16.9      0.424ms     0.83x -
2B/0.8B TP1      4096+4096           16   16                  0.343ms    25.0      0.385ms     1.12x +
2B/0.8B TP1      2048+6144           16   16                  0.510ms    16.9      0.420ms     0.82x -
2B/0.8B TP1      1024+7168           16   16                  0.593ms    14.5      0.437ms     0.74x -
2B/0.8B TP1      2048x4              16   16                  0.179ms    47.9      0.367ms     2.05x +
2B/0.8B TP1      1024x8              16   16                  0.106ms    81.2      0.383ms     3.62x +
2B/0.8B TP1      8192x8              16   16                  0.756ms    90.9      3.457ms     4.57x +
2B/0.8B TP1      8192x16             16   16                  1.752ms    78.5      7.101ms     4.05x +
2B/0.8B TP1      8192x32             16   16                  3.012ms    91.3     14.076ms     4.67x +

Sym h32          1x65536             32   32                  5.350ms    25.7      6.956ms     1.30x +
Sym h32          1x32768             32   32                  2.674ms    25.7      3.472ms     1.30x +
Sym h32          1x16384             32   32                  1.346ms    25.5      1.754ms     1.30x +
Sym h32          1x8192              32   32                  0.677ms    25.4      0.870ms     1.28x +
Sym h32          1x4096              32   32                  0.345ms    24.9      0.402ms     1.17x +
Sym h32          1x2048              32   32                  0.175ms    24.5      0.156ms     0.89x -
Sym h32          6144+2048           32   32                  0.514ms    33.4      0.861ms     1.67x +
Sym h32          4096+4096           32   32                  0.347ms    49.5      0.852ms     2.46x +
Sym h32          2048+6144           32   32                  0.513ms    33.5      0.863ms     1.68x +
Sym h32          1024+7168           32   32                  0.596ms    28.8      0.868ms     1.46x +
Sym h32          2048x4              32   32                  0.205ms    83.8      0.870ms     4.25x +
Sym h32          1024x8              32   32                  0.249ms    69.0      0.885ms     3.56x +
Sym h32          8192x8              32   32                  1.745ms    78.8      6.985ms     4.00x +
Sym h32          8192x16             32   32                  3.093ms    88.9     14.144ms     4.57x +
Sym h32          8192x32             32   32                  6.100ms    90.1     28.708ms     4.71x +
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Blackwell (SM120A) delta-rule kernel support, including SM120A-specific prefill dispatch on compatible GPUs.
  * Extended SM120A gated delta-rule variants so they’re available when supported, and safely disabled when not.

* **Improvements**
  * Improved SM120A kernel compilation/loading by applying targeted PTX adjustments when required for better hardware compatibility.

* **Tests**
  * Updated GPU architecture skip logic to recognize SM120A, and refined CUDA-version gating behavior for relevant architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->