### PR TITLE
feat: add sm90 cp delta rule dsl

### DIFF
--- a/flashinfer/gdn_kernels/__init__.py
+++ b/flashinfer/gdn_kernels/__init__.py
@@ -66,10 +66,12 @@ try:
     from .delta_rule_dsl import (
         chunk_gated_delta_rule_sm90,
         chunk_gated_delta_rule_sm120,
+        cp_delta_rule_dsl_sm90,
     )
 except (ImportError, RuntimeError):
     chunk_gated_delta_rule_sm90 = None  # type: ignore
     chunk_gated_delta_rule_sm120 = None  # type: ignore
+    cp_delta_rule_dsl_sm90 = None  # type: ignore
 
 __all__ = [
     "gated_delta_rule",
@@ -85,4 +87,5 @@ __all__ = [
     "chunk_gated_delta_rule_sm90",
     "chunk_gated_delta_rule_sm100",
     "chunk_gated_delta_rule_sm120",
+    "cp_delta_rule_dsl_sm90",
 ]

--- a/flashinfer/gdn_kernels/delta_rule_dsl/__init__.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/__init__.py
@@ -10,7 +10,13 @@ try:
 except (ImportError, RuntimeError):
     chunk_gated_delta_rule_sm120 = None  # type: ignore
 
+try:
+    from .delta_rule_cp_sm90 import cp_delta_rule_dsl_sm90
+except (ImportError, RuntimeError):
+    cp_delta_rule_dsl_sm90 = None  # type: ignore
+
 __all__ = [
     "chunk_gated_delta_rule_sm90",
     "chunk_gated_delta_rule_sm120",
+    "cp_delta_rule_dsl_sm90",
 ]

--- a/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
@@ -1,7 +1,8 @@
 import os
 import tempfile
 import types
-import typing
+import warnings
+from collections.abc import Hashable
 
 import cutlass.cute as cute
 from cutlass.base_dsl.compiler import DumpDir
@@ -33,29 +34,39 @@ def _as_options_tuple(options):
 
 
 class KeyedCompileMixin:
+    def manual_cache_key(self, *attr_names):
+        collected_attrs = tuple(
+            (attr_name, getattr(self, attr_name)) for attr_name in attr_names
+        )
+        compile_key = (type(self).__mro__,) + collected_attrs
+        hash(compile_key)
+        setattr(self, "_KeyedCompileMixin_compile_key", compile_key)
+
     def _get_compile_key(self):
         compile_key = getattr(self, "_KeyedCompileMixin_compile_key", None)
         if compile_key is None:
-            collected_attrs = []
-            for attr_name in sorted(dir(self)):
-                attr_value = getattr(self, attr_name)
-                if attr_name.startswith("__"):
-                    continue
-                if isinstance(
-                    attr_value,
-                    (
-                        types.MethodType,
-                        types.BuiltinMethodType,
-                        types.MethodWrapperType,
-                    ),
-                ):
-                    continue
-
-                if isinstance(attr_value, typing.Hashable):
-                    collected_attrs.append((attr_name, attr_value))
-
+            warnings.warn(
+                f"{type(self).__name__} is using automatic DSL compile-cache key generation; "
+                "call manual_cache_key(...) at the end of __init__ to avoid host launch overhead.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            collected_attrs = tuple(
+                (attr_name, attr_value)
+                for attr_name, attr_value in sorted(self.__dict__.items())
+                if not attr_name.startswith("_")
+            )
             compile_key = (str(type(self).__mro__),) + tuple(collected_attrs)
-            setattr(self, "_KeyedCompileMixin_compile_key", compile_key)  # noqa: B010
+            try:
+                hash(compile_key)
+            except TypeError:
+                collected_attrs = tuple(
+                    (attr_name, attr_value)
+                    for attr_name, attr_value in collected_attrs
+                    if isinstance(attr_value, Hashable)
+                )
+                compile_key = (str(type(self).__mro__),) + tuple(collected_attrs)
+            setattr(self, "_KeyedCompileMixin_compile_key", compile_key)
 
         return compile_key
 

--- a/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
@@ -40,7 +40,7 @@ class KeyedCompileMixin:
         )
         compile_key = (type(self).__mro__,) + collected_attrs
         hash(compile_key)
-        setattr(self, "_KeyedCompileMixin_compile_key", compile_key)
+        setattr(self, "_KeyedCompileMixin_compile_key", compile_key)  # noqa: B010
 
     def _get_compile_key(self):
         compile_key = getattr(self, "_KeyedCompileMixin_compile_key", None)
@@ -66,7 +66,7 @@ class KeyedCompileMixin:
                     if isinstance(attr_value, Hashable)
                 )
                 compile_key = (str(type(self).__mro__),) + tuple(collected_attrs)
-            setattr(self, "_KeyedCompileMixin_compile_key", compile_key)
+            setattr(self, "_KeyedCompileMixin_compile_key", compile_key)  # noqa: B010
 
         return compile_key
 

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -445,12 +445,15 @@ def cp_delta_rule_t_precompute_dsl_sm90(
             raise RuntimeError(f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}")
         if total_seqlen != k.shape[0]:
             raise RuntimeError(f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}")
-        if max_seqlen is not None and max_seqlen <= 0:
-            raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
         if cu_seqlens.dtype != torch.int64:
             raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+    if max_seqlen is None:
+        raise RuntimeError("max_seqlen must be provided")
+    if not _skip_check and max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
     _, num_k_heads, d = k.shape
     num_sab_heads = beta.shape[1]
     if not _skip_check:
@@ -468,10 +471,8 @@ def cp_delta_rule_t_precompute_dsl_sm90(
         for name, tensor in (("k", k), ("beta", beta)):
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
-
-    num_seqs = cu_seqlens.shape[0] - 1
     total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
-    max_t_blocks_per_seq = max_num_chunks_host(cu_seqlens, 64, max_seqlen)
+    max_t_blocks_per_seq = max_num_chunks_host(max_seqlen, 64)
     t = torch.empty((total_t_blocks, num_sab_heads, 64, 64), dtype=k.dtype, device=k.device)
     if total_t_blocks == 0:
         return t
@@ -1364,14 +1365,17 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
             raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
         if total_seqlen != k.shape[0]:
             raise RuntimeError(f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}")
-        if max_seqlen is not None and max_seqlen <= 0:
-            raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
         if cp_chunk_len % 64 != 0:
             raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
         if cu_seqlens.dtype != torch.int64:
             raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+    if max_seqlen is None:
+        raise RuntimeError("max_seqlen must be provided")
+    if not _skip_check and max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
     _, num_k_heads, d = k.shape
     num_v_heads = v.shape[1]
     num_sab_heads = alpha.shape[1]
@@ -1403,9 +1407,7 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
         for name, tensor in (("k", k), ("v", v), ("t", t), ("alpha", alpha)):
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
-
-    num_seqs = cu_seqlens.shape[0] - 1
-    max_cp_chunks_per_seq = max_num_chunks_host(cu_seqlens, cp_chunk_len, max_seqlen)
+    max_cp_chunks_per_seq = max_num_chunks_host(max_seqlen, cp_chunk_len)
     k_tma = k.as_strided(
         (d, total_seqlen, num_k_heads),
         (1, num_k_heads * d, d),
@@ -2963,8 +2965,6 @@ def cp_delta_rule_prefill_dsl_sm90(
             raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
         if total_seqlen != q.shape[0]:
             raise RuntimeError(f"total_seqlen must match q.shape[0], got {total_seqlen} and {q.shape[0]}")
-        if max_seqlen is not None and max_seqlen <= 0:
-            raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
         if cp_chunk_len % 64 != 0:
             raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
         if cu_seqlens.dtype != torch.int64:
@@ -2972,6 +2972,10 @@ def cp_delta_rule_prefill_dsl_sm90(
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
     num_seqs = cu_seqlens.shape[0] - 1
+    if max_seqlen is None:
+        raise RuntimeError("max_seqlen must be provided")
+    if not _skip_check and max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
     _, num_q_heads, d = q.shape
     num_k_heads = k.shape[1]
     num_v_heads = v.shape[1]
@@ -3024,8 +3028,7 @@ def cp_delta_rule_prefill_dsl_sm90(
                 continue
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
-
-    max_cp_chunks_per_seq = max_num_chunks_host(cu_seqlens, cp_chunk_len, max_seqlen)
+    max_cp_chunks_per_seq = max_num_chunks_host(max_seqlen, cp_chunk_len)
     if total_cp_chunks == 0:
         return
     q_tma = q.as_strided(
@@ -3117,7 +3120,7 @@ def cp_delta_rule_dsl_sm90(
     scale: float,
     *,
     initial_state: torch.Tensor | None = None,
-    max_seqlen: int,
+    max_seqlen: int | None = None,
     cp_chunk_len: int | None = None,
     cp_chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
 ):
@@ -3128,6 +3131,13 @@ def cp_delta_rule_dsl_sm90(
     workspace layout.
     """
     total_seqlen = q.shape[0]
+    num_seqs = cu_seqlens.shape[0] - 1
+    if max_seqlen is None and num_seqs == 1:
+        max_seqlen = total_seqlen
+    if max_seqlen is None:
+        raise RuntimeError("max_seqlen must be provided when num_seqs != 1")
+    if max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
     if cp_chunk_len is None:
         num_heads = max(q.shape[1], v.shape[1])
         num_sms = torch.cuda.get_device_properties(q.device).multi_processor_count
@@ -3152,15 +3162,12 @@ def cp_delta_rule_dsl_sm90(
         raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
     if beta.ndim != 2 or beta.shape[0] != q.shape[0]:
         raise RuntimeError(f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}")
-    if max_seqlen <= 0:
-        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
     if cp_chunk_len % 64 != 0:
         raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
     if cu_seqlens.dtype != torch.int64:
         raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
     if not cu_seqlens.is_contiguous():
         raise RuntimeError("cu_seqlens must be contiguous")
-    num_seqs = cu_seqlens.shape[0] - 1
     _, num_q_heads, d = q.shape
     num_k_heads = k.shape[1]
     num_v_heads = v.shape[1]

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -3255,7 +3255,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                 16,
             ]
 
-        self.shared_storage = SharedStorage
+        self.shared_storage = SharedStorage  # type: ignore
         self.kernel(
             g_alpha,
             tma_atom_q,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -98,6 +98,7 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         self.inverse_dtype = cutlass.Float16
         self.BLK          = 64
         self.D            = 128
+        self.manual_cache_key("dtype", "acc_dtype", "inverse_dtype", "BLK", "D")
 
     @cute.jit
     def load_k_tile_tma(
@@ -562,6 +563,10 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         self.v_stage     = 2
         self.t_stage     = 2
         self.alpha_stage = 4
+        self.manual_cache_key(
+            "dtype", "acc_dtype", "BLK", "D",
+            "k_stage", "v_stage", "t_stage", "alpha_stage",
+        )
 
     @cute.jit
     def _math_order_init(self, wg_idx: cutlass.Int32):
@@ -1510,6 +1515,12 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             self.min_blocks_per_mp,
         )
         self.use_3xtf32 = False
+        self.manual_cache_key(
+            "needs_initial_state", "D", "rows_per_cta", "row_ctas",
+            "threads_per_cta", "num_warps", "m_stage", "n_stage",
+            "num_col_tiles", "num_row_tiles", "num_tiles", "k_tiles",
+            "min_blocks_per_mp", "registers_per_thread", "use_3xtf32",
+        )
 
     @cute.jit
     def load_fixup_tma(
@@ -2020,6 +2031,13 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         super().__init__(True, False, True, False, dtype, acc_dtype)
         self.needs_initial_state = needs_initial_state
         self.t_stage = 2
+        self.manual_cache_key(
+            "needs_alpha", "needs_beta", "needs_init_state", "needs_checkpointing",
+            "needs_initial_state", "dtype", "acc_dtype", "inverse_dtype",
+            "BLK_Q", "BLK_KV", "D",
+            "q_stage", "k_stage", "v_stage", "o_stage",
+            "qk_stage", "kk_stage", "alpha_beta_stage", "t_stage",
+        )
 
     @cute.jit
     def load_t_tma(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -1425,8 +1425,9 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
             num_sab_heads * 64 * 64,
         ),
     )
-    transfer_t = torch.zeros((total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device)
-    state_t = torch.zeros((total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device)
+    workspace_ctor = torch.empty if num_seqs == 1 else torch.zeros
+    transfer_t = workspace_ctor((total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device)
+    state_t = workspace_ctor((total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device)
     if total_cp_chunks == 0:
         return transfer_t, state_t
 
@@ -1962,7 +1963,7 @@ def cp_delta_rule_fixup_dsl_sm90(
             raise RuntimeError("cu_seqlens must be contiguous")
     num_seqs = cu_seqlens.shape[0] - 1
 
-    fixed_state = torch.zeros_like(local_state)
+    fixed_state = torch.empty_like(local_state) if num_seqs == 1 else torch.zeros_like(local_state)
     if total_cp_chunks == 0:
         return fixed_state
 
@@ -3219,7 +3220,8 @@ def cp_delta_rule_dsl_sm90(
         local_transfer, local_state, cu_seqlens, total_seqlen,
         cp_chunk_len=cp_chunk_len, initial_state=initial_state, _skip_check=True)
 
-    state.zero_()
+    if num_seqs != 1:
+        state.zero_()
     cp_delta_rule_prefill_dsl_sm90(
         o, state, q, k, v, t, fixed_state, alpha, scale,
         cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -1,0 +1,3121 @@
+from dataclasses import dataclass
+from enum import IntEnum
+
+import torch
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import T
+from cutlass._mlir.dialects import llvm
+import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
+import cutlass.pipeline as pipeline
+from cutlass.cute import core as cute_core
+from cutlass.cute.atom import Trait, make_atom
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.nvgpu import warp
+from cutlass.cute.nvgpu import warpgroup
+from cutlass.cute.typing import Shape
+
+from .alpha import AlphaProcessor
+from .collective_inverse_hmma import CollectiveInverse
+from .collective_store_tma import CollectiveStoreTma
+from .custom_compile_cache import KeyedCompileMixin, cached_compile
+from .helpers import SM90, load_tensor_as_c, load_tensor_as_a, round_down, select_tensor_10
+from .varlen_helper import (
+    CP_CHUNK_LEN_GRANULARITY,
+    choose_cp_chunk_len_host,
+    chunks_for_len,
+    max_num_chunks_host,
+    varlen_chunk_idx,
+    varlen_chunk_valid_len,
+    workspace_num_chunks_host,
+)
+from .delta_rule_sm90 import (
+    _FullyFusedDeltaRuleSm90,
+    WarpGroupRole,
+    LoadStoreWarpRole,
+    MathWarpGroupRole,
+)
+from .schedule import WorkDesc
+
+
+class NamedBarrier(IntEnum):
+    MATH_WG0 = 4
+    MATH_WG1 = 5
+    MATH_SYNC = 6
+
+
+@dataclass(frozen=True)
+class WarpMmaTF32Op(warp.WarpMmaOp):
+    shape_mnk: Shape
+
+    def __post_init__(self) -> None:
+        if self.shape_mnk != (16, 8, 8):
+            raise ValueError(f"WarpMmaTF32Op only supports (16, 8, 8), got {self.shape_mnk}")
+
+    def _make_trait(self, *, loc=None, ip=None, **kwargs):
+        shape_mnk = cute_core._pack_shape(self.shape_mnk, loc=loc, ip=ip)
+        ty = _cute_nvgpu_ir.MmaAtomSM80Type.get(
+            shape_mnk.type.attribute,
+            cutlass.TFloat32.mlir_type,
+            cutlass.TFloat32.mlir_type,
+            cutlass.Float32.mlir_type,
+        )
+        return WarpMmaTF32Trait(make_atom(ty, loc=loc, ip=ip))
+
+    def _verify_fragment_A(self, input, *, loc=None, ip=None):
+        return True
+
+    def _verify_fragment_B(self, input, *, loc=None, ip=None):
+        return True
+
+
+class WarpMmaTF32Trait(Trait):
+    pass
+
+
+@cute.jit
+def round_to_tf32_f32(value: cutlass.Float32) -> cutlass.Float32:
+    bits = llvm.inline_asm(
+        T.i32(),
+        [value.ir_value()],
+        "cvt.rz.tf32.f32 $0, $1;",
+        "=r,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    return cutlass.Float32(llvm.bitcast(T.f32(), bits))
+
+
+class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
+    def __init__(
+        self,
+        dtype: type[cutlass.Numeric] = cutlass.Float16,
+        acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+    ):
+        self.dtype         = dtype
+        self.acc_dtype     = acc_dtype
+        self.inverse_dtype = cutlass.Float16
+        self.BLK          = 64
+        self.D            = 128
+
+    @cute.jit
+    def load_k_tile_tma(
+        self,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        sK_DS: cute.Tensor,
+        k_pipeline,
+        k_producer_state,
+        tok_offset: cutlass.Int32,
+        head_idx: cutlass.Int32,
+    ):
+        mK = cute.domain_offset(
+            (0, tok_offset),
+            tma_tensor_k[None, None, head_idx],
+        )
+        gK = cute.zipped_divide(mK, (self.D, self.BLK))[
+            ((None, None), (0, 0))
+        ]
+        tKsK, tKgK = cpasync.tma_partition(
+            tma_atom_k,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sK_DS, 0, 2),
+            cute.group_modes(gK, 0, 2),
+        )
+        k_pipeline.producer_acquire(k_producer_state)
+        cute.copy(
+            tma_atom_k,
+            tKgK,
+            tKsK,
+            tma_bar_ptr=k_pipeline.producer_get_barrier(k_producer_state),
+        )
+        k_pipeline.producer_commit(k_producer_state)
+
+    @cute.jit
+    def load_beta_tile(
+        self,
+        g_beta: cute.Tensor,
+        sBeta: cute.Tensor,
+        beta_pipeline,
+        beta_producer_state,
+        tok_offset: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        valid_len: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ):
+        lane = tidx % 32
+        beta_pipeline.producer_acquire(beta_producer_state)
+        for i in cutlass.range_constexpr(2):
+            row = lane + i * 32
+            beta = cutlass.Float32(0.0)
+            if row < valid_len:
+                offset = (tok_offset + row) * num_heads + head_idx
+                beta = cutlass.Float32(g_beta[offset])
+            sBeta[row] = beta
+        cute.arch.fence_view_async_shared()
+        beta_pipeline.producer_commit(beta_producer_state)
+
+    @cute.jit
+    def store_ikk_to_smem(
+        self,
+        tKKrKK: cute.Tensor,
+        kk_tiled_mma,
+        thread_idx: cutlass.Int32,
+        sKK_inv: cute.Tensor,
+        tKKcMkk: cute.Tensor,
+    ):
+        stsm_atom = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+        tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
+        thr_store   = tiled_store.get_slice(thread_idx)
+        tKKsKK      = thr_store.partition_D(sKK_inv)
+        tKKrKK_cv   = thr_store.retile(tKKrKK)
+        tKKcMkk_cv  = thr_store.retile(tKKcMkk)
+        tKKrIKK     = cute.make_fragment_like(tKKrKK_cv, self.inverse_dtype)
+        for i in cutlass.range_constexpr(cute.size(tKKrKK_cv)):
+            row, col = tKKcMkk_cv[i]
+            value = cutlass.Float32(0.0)
+            if row > col:
+                value = cutlass.Float32(tKKrKK_cv[i])
+            tKKrIKK[i] = self.inverse_dtype(value)
+        cute.copy(tiled_store, tKKrIKK, tKKsKK)
+
+    @cute.jit
+    def kk_epi(
+        self,
+        tKKrKK: cute.Tensor,
+        tKKcMkk: cute.Tensor,
+        sBeta: cute.Tensor,
+    ):
+        for i in cutlass.range_constexpr(cute.size(tKKrKK)):
+            row, col = tKKcMkk[i]
+            value = cutlass.Float32(0.0)
+            if row > col:
+                beta = cutlass.Float32(sBeta[row])
+                value = cutlass.Float32(tKKrKK[i]) * beta
+            tKKrKK[i] = value
+
+    @cute.jit
+    def store_t_to_gmem(
+        self,
+        sKK_inv: cute.Tensor,
+        sBeta: cute.Tensor,
+        gT_CR: cute.Tensor,
+        valid_len: cutlass.Int32,
+        kk_tiled_mma,
+        tidx: cutlass.Int32,
+    ):
+        ldsm_atom = cute.make_copy_atom(
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+        tiled_load = cute.make_tiled_copy_C(ldsm_atom, kk_tiled_mma)
+        thr_load   = tiled_load.get_slice(tidx)
+        tTsT       = thr_load.partition_S(sKK_inv)
+        tTrInv     = cute.make_rmem_tensor(kk_tiled_mma.partition_shape_C((self.BLK, self.BLK)), self.inverse_dtype)
+        tTrInv_cv  = thr_load.retile(tTrInv)
+        cute.copy(tiled_load, tTsT, tTrInv_cv)
+
+        store_atom  = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.dtype)
+        tiled_store = cute.make_tiled_copy_C(store_atom, kk_tiled_mma)
+        thr_store   = tiled_store.get_slice(tidx)
+        tTgT        = thr_store.partition_D(gT_CR)
+        cT_CR       = cute.make_identity_tensor((self.BLK, self.BLK))
+        tTcT        = thr_store.partition_D(cT_CR)
+        tTrInv_store = thr_store.retile(tTrInv)
+        tTrT        = cute.make_rmem_tensor(kk_tiled_mma.partition_shape_C((self.BLK, self.BLK)), self.dtype)
+        tTrT_store  = thr_store.retile(tTrT)
+
+        for i in cutlass.range_constexpr(cute.size(tTrT_store)):
+            col, row = tTcT[i]
+            value = cutlass.Float32(0.0)
+            if row < valid_len and col < valid_len:
+                beta = cutlass.Float32(sBeta[row])
+                value = -beta * cutlass.Float32(tTrInv_store[i])
+            tTrT_store[i] = self.dtype(value)
+        cute.autovec_copy(tTrT_store, tTgT)
+
+    @cute.jit
+    def __call__(
+        self,
+        g_k_tma: cute.Tensor,
+        g_beta: cute.Tensor,
+        g_t: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        num_k_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        total_t_blocks: cutlass.Int32,
+        max_t_blocks_per_seq: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        stream,
+    ):
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        k_storage_layout_sd = cute.tile_to_shape(qkv_smem_layout_atom, (self.BLK, self.D), order=(0, 1))
+        k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0])
+        kk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        kk_layout = cute.tile_to_shape(kk_layout_atom, (self.BLK, self.BLK), order=(0, 1))
+        beta_layout = cute.make_layout(self.BLK)
+
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            tma_load_op,
+            g_k_tma,
+            k_storage_layout_ds,
+            (self.D, self.BLK),
+        )
+        self.tma_load_k_bytes = cute.size(k_storage_layout_ds) * (self.dtype.width // 8)
+
+        @cute.struct
+        class SharedStorage:
+            k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            beta_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            smem_k: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128]
+            smem_kk: cute.struct.Align[cute.struct.MemRange[self.inverse_dtype, cute.cosize(kk_layout)], 16]
+            smem_beta: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_layout)], 16]
+
+        self.shared_storage = SharedStorage
+        self.kernel(
+            tma_atom_k, tma_tensor_k, g_beta, g_t, cu_seqlens,
+            num_k_heads, num_sab_heads, total_t_blocks, num_seqs,
+        ).launch(
+            grid=(num_sab_heads * max_t_blocks_per_seq, num_seqs, 1),
+            block=(128, 1, 1),
+            max_number_threads=(128, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=8,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        g_beta: cute.Tensor,
+        g_t: cute.Tensor,
+        cu_seqlens: cute.Tensor,
+        num_k_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        total_t_blocks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        bx, seq_idx, _ = cute.arch.block_idx()
+        sab_head_idx = bx % num_sab_heads
+        k_head_idx = sab_head_idx * num_k_heads // num_sab_heads
+        block_idx_in_seq = bx // num_sab_heads
+        seq_start = cutlass.Int32(cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(cu_seqlens[seq_idx + 1])
+        seq_len = seq_end - seq_start
+        num_blocks = chunks_for_len(seq_len, self.BLK)
+        if block_idx_in_seq < num_blocks:
+            tok_offset = seq_start + block_idx_in_seq * self.BLK
+            t_block_idx = varlen_chunk_idx(seq_idx, seq_start, block_idx_in_seq, self.BLK)
+            valid_len = varlen_chunk_valid_len(seq_len, block_idx_in_seq, self.BLK)
+            mT = cute.make_tensor(
+                g_t.iterator,
+                cute.make_ordered_layout(
+                    (self.BLK, self.BLK, num_sab_heads, total_t_blocks), order=(0, 1, 2, 3)),
+            )
+            gT = mT[None, None, sab_head_idx, t_block_idx]
+
+            qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+                warpgroup.SmemLayoutAtomKind.K_SW128,
+                self.dtype,
+            )
+            k_storage_layout_sd = cute.tile_to_shape(qkv_smem_layout_atom, (self.BLK, self.D), order=(0, 1))
+            k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0])
+            kk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+            kk_layout = cute.tile_to_shape(kk_layout_atom, (self.BLK, self.BLK), order=(0, 1))
+            beta_layout = cute.make_layout(self.BLK)
+
+            allocator = cutlass.utils.SmemAllocator()
+            storage = allocator.allocate(self.shared_storage)
+            sK_DS = storage.smem_k.get_tensor(k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner)
+            sK_SD = select_tensor_10(sK_DS)
+            sKK_inv = storage.smem_kk.get_tensor(kk_layout)
+            sBeta = storage.smem_beta.get_tensor(beta_layout)
+
+            load_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+            tma_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 4)
+            vector_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+            vector_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 128)
+            k_pipeline = pipeline.PipelineTmaAsync.create(
+                barrier_storage=storage.k_mbar_ptr.data_ptr(),
+                num_stages=1,
+                producer_group=load_producer_group,
+                consumer_group=tma_consumer_group,
+                tx_count=self.tma_load_k_bytes,
+                cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+            )
+            beta_pipeline = pipeline.PipelineAsync.create(
+                barrier_storage=storage.beta_mbar_ptr.data_ptr(),
+                num_stages=1,
+                producer_group=vector_producer_group,
+                consumer_group=vector_consumer_group,
+            )
+            k_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
+            beta_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
+            k_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+            beta_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+            cute.arch.mbarrier_init_fence()
+            cute.arch.sync_threads()
+
+            if warp_idx == 1:
+                cpasync.prefetch_descriptor(tma_atom_k)
+                self.load_k_tile_tma(
+                    tma_atom_k, tma_tensor_k, sK_DS, k_pipeline, k_producer_state,
+                    tok_offset, k_head_idx,
+                )
+            elif warp_idx == 2:
+                self.load_beta_tile(
+                    g_beta, sBeta, beta_pipeline, beta_producer_state,
+                    tok_offset, sab_head_idx, valid_len, num_sab_heads, tidx,
+                )
+
+            k_pipeline.consumer_wait(k_consumer_state)
+            beta_pipeline.consumer_wait(beta_consumer_state)
+            cute.arch.fence_view_async_shared()
+            cute.arch.sync_threads()
+
+            kk_tiled_mma = cute.make_tiled_mma(
+                cute.make_mma_atom(warpgroup.MmaF16BF16Op(
+                    self.dtype, self.acc_dtype, (self.BLK, self.BLK, 16),
+                    warpgroup.OperandSource.SMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.K,
+                )),
+                cute.make_layout((1, 1, 1)),
+            )
+            kk_thr_mma = kk_tiled_mma.get_slice(tidx)
+            tKKsA = kk_thr_mma.partition_A(sK_SD)
+            tKKsB = kk_thr_mma.partition_B(sK_SD)
+            tKKrA = kk_thr_mma.make_fragment_A(tKKsA)
+            tKKrB = kk_thr_mma.make_fragment_B(tKKsB)
+            tKKrKK = kk_thr_mma.make_fragment_C(kk_thr_mma.partition_shape_C((self.BLK, self.BLK)))
+            cMkk = cute.make_identity_tensor((self.BLK, self.BLK))
+            tKKcMkk = kk_thr_mma.partition_C(cMkk)
+
+            cute.nvgpu.warpgroup.fence()
+            SM90.wgmma_gemm_zero_acc(kk_tiled_mma, tKKrKK, tKKrA, tKKrB)
+            cute.nvgpu.warpgroup.commit_group()
+            cute.nvgpu.warpgroup.wait_group(0)
+            k_pipeline.consumer_release(k_consumer_state)
+
+            self.kk_epi(tKKrKK, tKKcMkk, sBeta)
+            self.store_ikk_to_smem(tKKrKK, kk_tiled_mma, tidx, sKK_inv, tKKcMkk)
+            cute.arch.barrier(barrier_id=NamedBarrier.MATH_SYNC, number_of_threads=128)
+            CollectiveInverse().run(sKK_inv, NamedBarrier.MATH_SYNC)
+            cute.arch.barrier(barrier_id=NamedBarrier.MATH_SYNC, number_of_threads=128)
+            self.store_t_to_gmem(
+                sKK_inv, sBeta, gT, valid_len, kk_tiled_mma, tidx,
+            )
+            beta_pipeline.consumer_release(beta_consumer_state)
+
+
+def cp_delta_rule_t_precompute_dsl_sm90(
+    k: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    total_seqlen: int,
+    max_seqlen: int | None = None,
+    *,
+    _skip_check: bool = False,
+):
+    """Precompute signed, beta-folded CP T tiles on SM90.
+
+    Flat varlen input returns `T := -(inv(IKK) beta)^T` with shape
+    `(total_t_blocks, num_heads, 64, 64)`, where
+    `total_t_blocks = chunk_bound(num_seqs, total_seqlen, 64)`.
+
+    Inputs must already be contiguous. This wrapper validates that contract but
+    does not materialize contiguous copies.
+    """
+    from cutlass.cute.runtime import from_dlpack
+    import cuda.bindings.driver as cuda_driver
+
+    if not _skip_check:
+        if k.ndim != 3:
+            raise RuntimeError(f"k must have shape (total_seqlen, num_k_heads, D), got {tuple(k.shape)}")
+        if beta.ndim != 2 or beta.shape[0] != k.shape[0]:
+            raise RuntimeError(f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}")
+        if total_seqlen != k.shape[0]:
+            raise RuntimeError(f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}")
+        if max_seqlen is not None and max_seqlen <= 0:
+            raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
+        if cu_seqlens.dtype != torch.int64:
+            raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+        if not cu_seqlens.is_contiguous():
+            raise RuntimeError("cu_seqlens must be contiguous")
+    _, num_k_heads, d = k.shape
+    num_sab_heads = beta.shape[1]
+    if not _skip_check:
+        if num_sab_heads < num_k_heads or num_sab_heads % num_k_heads != 0:
+            raise RuntimeError(
+                "beta heads must be a positive multiple of k heads, "
+                f"got beta heads={num_sab_heads} and k heads={num_k_heads}"
+            )
+        if k.shape[-1] != 128:
+            raise RuntimeError(f"CPDeltaRuleTPrecomputeSm90 only supports D=128, got {k.shape[-1]}")
+        if k.dtype not in (torch.float16, torch.bfloat16):
+            raise RuntimeError(f"CPDeltaRuleTPrecomputeSm90 only supports fp16/bf16 inputs, got {k.dtype}")
+        if beta.dtype != torch.float32:
+            raise RuntimeError(f"beta must have dtype torch.float32, got {beta.dtype}")
+        for name, tensor in (("k", k), ("beta", beta)):
+            if not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+
+    num_seqs = cu_seqlens.shape[0] - 1
+    total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
+    max_t_blocks_per_seq = max_num_chunks_host(cu_seqlens, 64, max_seqlen)
+    t = torch.empty((total_t_blocks, num_sab_heads, 64, 64), dtype=k.dtype, device=k.device)
+    if total_t_blocks == 0:
+        return t
+    k_tma = k.as_strided(
+        (d, total_seqlen, num_k_heads),
+        (1, num_k_heads * d, d),
+    )
+
+    kernel_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+    }[k.dtype]
+
+    stream_val = torch.cuda.current_stream().cuda_stream
+    stream = cuda_driver.CUstream(stream_val)
+
+    enable_tvm_ffi = True
+    if enable_tvm_ffi:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
+
+    kernel = CPDeltaRuleTPrecomputeSm90(kernel_dtype)
+    kernel_args = (
+        from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+        from_dlpack(beta.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(t.view(-1), assumed_align=128).mark_layout_dynamic(),
+        from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+        cutlass.Int32(num_k_heads),
+        cutlass.Int32(num_sab_heads),
+        cutlass.Int32(total_t_blocks),
+        cutlass.Int32(max_t_blocks_per_seq),
+        cutlass.Int32(num_seqs),
+        stream,
+    )
+    compiled = cached_compile(
+        kernel,
+        *kernel_args,
+        compile_options=(cute.GPUArch("sm_90a"),),
+    )
+    compiled(*kernel_args)
+    return t
+
+
+class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
+    class WarpGroupRole(IntEnum):
+        LOAD = 0
+        MATH0 = 1
+        MATH1 = 2
+
+    class LoadWarpRole(IntEnum):
+        LOAD_K = 0
+        LOAD_V = 1
+        LOAD_T = 2
+        LOAD_ALPHA = 3
+
+    @staticmethod
+    def get_register_requirements(
+        max_threads_per_block: int,
+        min_blocks_per_multiprocessor: int,
+        num_mma_warp_groups: int,
+        threads_per_warp_group: int,
+    ) -> tuple[int, int]:
+        reg_alloc_granularity = 8
+        load_registers = 40 - 2 * reg_alloc_granularity
+        total_registers = (
+            round_down(
+                64 * 1024 // min_blocks_per_multiprocessor,
+                max_threads_per_block * reg_alloc_granularity,
+            )
+            // threads_per_warp_group
+        )
+        mma_registers = round_down(
+            (total_registers - load_registers) // num_mma_warp_groups,
+            reg_alloc_granularity,
+        )
+        return min(248, load_registers), min(248, mma_registers)
+
+    def __init__(
+        self,
+        dtype: type[cutlass.Numeric] = cutlass.Float16,
+        acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+    ):
+        self.dtype       = dtype
+        self.acc_dtype   = acc_dtype
+        self.BLK         = 64
+        self.D           = 128
+        self.k_stage     = 3
+        self.v_stage     = 2
+        self.t_stage     = 2
+        self.alpha_stage = 4
+
+    @cute.jit
+    def _math_order_init(self, wg_idx: cutlass.Int32):
+        if cutlass.const_expr(wg_idx == self.WarpGroupRole.MATH1):
+            cute.arch.barrier_arrive(
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+
+    @cute.jit
+    def _math_order_wait(self, wg_idx: cutlass.Int32):
+        if cutlass.const_expr(wg_idx == self.WarpGroupRole.MATH0):
+            cute.arch.barrier(
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+        else:
+            cute.arch.barrier(
+                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+
+    @cute.jit
+    def _math_order_notify(self, wg_idx: cutlass.Int32):
+        if cutlass.const_expr(wg_idx == self.WarpGroupRole.MATH0):
+            cute.arch.barrier_arrive(
+                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+        else:
+            cute.arch.barrier_arrive(
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+
+    @cute.jit
+    def store_acc_to_smem(
+        self,
+        tCrC: cute.Tensor,
+        sC: cute.Tensor,
+        tiled_mma,
+        thread_idx: cutlass.Int32,
+    ):
+        stsm_atom = cute.make_copy_atom(warp.StMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype)
+        tiled_copy = cute.make_tiled_copy_C(stsm_atom, tiled_mma)
+        thr_copy   = tiled_copy.get_slice(thread_idx)
+        tCsC       = thr_copy.partition_D(sC)
+        tCsC_align = cute.make_tensor(tCsC.iterator.align(16), tCsC.layout)
+        tCrC_cvt   = cute.make_fragment_like(tCrC, self.dtype)
+        for i in cutlass.range(cute.size(tCrC), unroll_full=True):
+            tCrC_cvt[i] = self.dtype(tCrC[i])
+        tCrC_cvt_cv = thr_copy.retile(tCrC_cvt)
+        cute.copy(tiled_copy, tCrC_cvt_cv, tCsC_align)
+
+    @cute.jit
+    def store_acc_to_gmem(
+        self,
+        tCrC: cute.Tensor,
+        gC: cute.Tensor,
+        tiled_mma,
+        thread_idx: cutlass.Int32,
+    ):
+        copy_atom  = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        tiled_copy = cute.make_tiled_copy_C(copy_atom, tiled_mma)
+        thr_copy   = tiled_copy.get_slice(thread_idx)
+        tCgC    = thr_copy.partition_D(gC)
+        tCrC_cv = thr_copy.retile(tCrC)
+        cute.autovec_copy(tCrC_cv, tCgC)
+
+    @cute.jit
+    def load_tensor_block_tma(
+        self,
+        tma_atom: cute.CopyAtom,
+        tma_tensor: cute.Tensor,
+        sTensor: cute.Tensor,
+        tensor_pipeline,
+        tensor_producer_state,
+        tok_offset: cutlass.Int32,
+        t_block_start: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        blk: cutlass.Int32,
+        is_transfer: bool,
+    ):
+        sTensor_stage = sTensor[None, None, tensor_producer_state.index]
+        if cutlass.const_expr(is_transfer):
+            mTensor = tma_tensor[None, None, head_idx, t_block_start + blk]
+            gTensor = cute.zipped_divide(mTensor, (self.BLK, self.BLK))[
+                ((None, None), (0, 0))
+            ]
+        else:
+            block_tok = blk * self.BLK
+            mTensor = cute.domain_offset(
+                (0, tok_offset + block_tok),
+                tma_tensor[None, None, head_idx],
+            )
+            gTensor = cute.zipped_divide(mTensor, (self.D, self.BLK))[
+                ((None, None), (0, 0))
+            ]
+
+        tTsT, tTgT = cpasync.tma_partition(
+            tma_atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sTensor_stage, 0, 2),
+            cute.group_modes(gTensor, 0, 2),
+        )
+
+        tensor_pipeline.producer_acquire(tensor_producer_state)
+        cute.copy(
+            tma_atom,
+            tTgT,
+            tTsT,
+            tma_bar_ptr=tensor_pipeline.producer_get_barrier(tensor_producer_state),
+        )
+        tensor_pipeline.producer_commit(tensor_producer_state)
+        tensor_producer_state.advance()
+        return tensor_producer_state
+
+    @cute.jit
+    def load_alpha_block(
+        self,
+        g_alpha: cute.Tensor,
+        sAlpha: cute.Tensor,
+        tok_offset: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        blk: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        alpha_stage: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ):
+        lane = tidx % 32
+        sAlpha_stage = sAlpha[None, None, alpha_stage]
+        for i in cutlass.range_constexpr(2):
+            row = lane + i * 32
+            tok = blk * self.BLK + row
+            alpha = cutlass.Float32(1.0)
+            if tok < chunk_len:
+                alpha = cutlass.Float32(
+                    g_alpha[(tok_offset + tok) * num_heads + head_idx]
+                )
+            sAlpha_stage[row, AlphaProcessor.CUMSUM_LOG] = alpha
+
+    @cute.jit
+    def scale_acc_by_scalar(
+        self,
+        tCrC: cute.Tensor,
+        coeff: cutlass.Float32,
+    ):
+        for i in cutlass.range(cute.size(tCrC), unroll_full=True):
+            tCrC[i] = cutlass.Float32(tCrC[i]) * coeff
+
+    @cute.jit
+    def compute_loop_body(
+        self,
+        sV_DS: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sT: cute.Tensor,
+        sX_DS: cute.Tensor,
+        sAlpha: cute.Tensor,
+        k_pipeline,
+        k_consumer_state,
+        v_pipeline,
+        v_consumer_state,
+        t_pipeline,
+        t_consumer_state,
+        alpha_pipeline,
+        alpha_consumer_state,
+        tTransferT: cute.Tensor,
+        tStateT: cute.Tensor,
+        valid_len: cutlass.Int32,
+        thread_idx: cutlass.Int32,
+        wg_idx: cutlass.Int32,
+        is_first_block: bool,
+    ):
+        # ── Tiled MMAs ───────────────────────────────────────────────────────
+        x_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
+                self.dtype, self.acc_dtype, (64, self.BLK, 16),
+                warpgroup.OperandSource.SMEM,
+                cute.nvgpu.OperandMajorMode.MN,
+                cute.nvgpu.OperandMajorMode.K,
+            )),
+            cute.make_layout((2, 1, 1)),
+        )
+        z_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
+                self.dtype, self.acc_dtype, (64, self.BLK, 16),
+                warpgroup.OperandSource.RMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )),
+            cute.make_layout((2, 1, 1)),
+        )
+        y_tiled_mma = z_tiled_mma
+        trans_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
+                self.dtype, self.acc_dtype, (64, self.D, 16),
+                warpgroup.OperandSource.RMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.MN,
+            )),
+            cute.make_layout((2, 1, 1)),
+        )
+        state_tiled_mma = trans_tiled_mma
+
+        x_thr_mma     = x_tiled_mma.get_slice(thread_idx)
+        z_thr_mma     = z_tiled_mma.get_slice(thread_idx)
+        y_thr_mma     = z_thr_mma
+        trans_thr_mma = trans_tiled_mma.get_slice(thread_idx)
+        state_thr_mma = trans_thr_mma
+
+        cK = cute.make_identity_tensor((self.D, self.BLK))
+
+        # ── Load current block ───────────────────────────────────────────────
+        k_pipeline.consumer_wait(k_consumer_state)
+        v_pipeline.consumer_wait(v_consumer_state)
+        t_pipeline.consumer_wait(t_consumer_state)
+        alpha_pipeline.consumer_wait(alpha_consumer_state)
+        cute.arch.fence_view_async_shared()
+
+        sK     = sK_DS[None, None, k_consumer_state.index]
+        sV     = sV_DS[None, None, v_consumer_state.index]
+        sT_blk = sT[None, None, t_consumer_state.index]
+        sAlpha_blk = sAlpha[None, None, alpha_consumer_state.index]
+        sK_SD = select_tensor_10(sK)
+
+        block_coeff = cutlass.Float32(
+            sAlpha_blk[valid_len - 1, AlphaProcessor.CUMPROD]
+        )
+
+        # ── X = T_fused K, stored as Xt = X^T for state and transfer ────────
+        tXrK = x_thr_mma.make_fragment_A(x_thr_mma.partition_A(sK))
+        tXrT = x_thr_mma.make_fragment_B(x_thr_mma.partition_B(sT_blk))
+        tXrX = x_thr_mma.make_fragment_C(x_thr_mma.partition_shape_C((self.D, self.BLK)))
+        SM90.warpgroup_fence_operand(tXrX)
+        cute.nvgpu.warpgroup.fence()
+        self._math_order_wait(wg_idx)
+        SM90.wgmma_gemm_zero_acc(x_tiled_mma, tXrX, tXrK, tXrT)
+        cute.nvgpu.warpgroup.commit_group()
+        self._math_order_notify(wg_idx)
+        cute.nvgpu.warpgroup.wait_group(0)
+        self.store_acc_to_smem(tXrX, sX_DS, x_tiled_mma, thread_idx)
+        # ensure X is visible in shared memory for WGMMA (async proxy).
+        # 2 math order barrier can guarantee it, so we don't need an extra barrier here
+        cute.arch.fence_view_async_shared()
+
+        # ── Transfer: Z = M K^T, M <- gamma_end (M + Z X) ───────────────────
+        tZrK = z_thr_mma.make_fragment_B(z_thr_mma.partition_B(sK_SD))
+        if cutlass.const_expr(is_first_block):  # first iter transfer matrix is identity, skip MMA
+            self._math_order_wait(wg_idx)
+            tTRANSrZ = load_tensor_as_a(sK, trans_thr_mma, thread_idx, (self.D, self.BLK), self.dtype, False)
+            self._math_order_notify(wg_idx)
+        else:
+            tZrTrans = SM90.make_acc_into_op(tTransferT, z_tiled_mma, self.dtype)
+            tZrZ     = z_thr_mma.make_fragment_C(z_thr_mma.partition_shape_C((self.D, self.BLK)))
+            SM90.warpgroup_fence_operand(tZrTrans)
+            SM90.warpgroup_fence_operand(tZrZ)
+            cute.nvgpu.warpgroup.fence()
+            self._math_order_wait(wg_idx)
+            SM90.wgmma_gemm_zero_acc(z_tiled_mma, tZrZ, tZrTrans, tZrK)
+            cute.nvgpu.warpgroup.commit_group()
+            self._math_order_notify(wg_idx)
+            cute.nvgpu.warpgroup.wait_group(0)
+            tTRANSrZ = SM90.make_acc_into_op(tZrZ, trans_tiled_mma, self.dtype)
+
+        tTRANSrX = trans_thr_mma.make_fragment_B(trans_thr_mma.partition_B(sX_DS))
+        SM90.warpgroup_fence_operand(tTRANSrZ)
+        SM90.warpgroup_fence_operand(tTransferT)
+        cute.nvgpu.warpgroup.fence()
+        self._math_order_wait(wg_idx)
+        SM90.wgmma_gemm(trans_tiled_mma, tTransferT, tTRANSrZ, tTRANSrX, True)
+        cute.nvgpu.warpgroup.commit_group()
+        self._math_order_notify(wg_idx)
+        cute.nvgpu.warpgroup.wait_group(0)
+        self.scale_acc_by_scalar(tTransferT, block_coeff)
+
+        # ── State: Y = gamma_end S K^T - gamma_end V^T Gamma^-1, S <- gamma_end S + Y X
+        tYrY = y_thr_mma.make_fragment_C(y_thr_mma.partition_shape_C((self.D, self.BLK)))
+        tYcK = y_thr_mma.partition_C(cK)
+        tYrV = load_tensor_as_c(sV, y_tiled_mma, thread_idx, (self.D, self.BLK), self.dtype, False, self.acc_dtype)
+        for i in cutlass.range(cute.size(tYrY), unroll_full=True):
+            _, token = tYcK[i]
+            neg_end_rcp = sAlpha_blk[token, AlphaProcessor.CUMPROD_NEG_END_RCP]
+            tYrV[i] = tYrV[i] * neg_end_rcp
+
+        tYrK = tZrK
+        if cutlass.const_expr(not is_first_block):
+            tYrS = SM90.make_acc_into_op(tStateT, y_tiled_mma, self.dtype)
+            SM90.warpgroup_fence_operand(tYrS)
+            SM90.warpgroup_fence_operand(tYrY)
+            cute.nvgpu.warpgroup.fence()
+            self._math_order_wait(wg_idx)
+            SM90.wgmma_gemm_zero_acc(y_tiled_mma, tYrY, tYrS, tYrK)
+            cute.nvgpu.warpgroup.commit_group()
+            self._math_order_notify(wg_idx)
+            cute.nvgpu.warpgroup.wait_group(0)
+
+            for i in cutlass.range(cute.size(tYrY), unroll_full=True):
+                tYrY[i] = block_coeff * tYrY[i] + tYrV[i]
+        else:
+            cute.basic_copy(tYrV, tYrY)
+
+        tSTATErY = SM90.make_acc_into_op(tYrY, state_tiled_mma, self.dtype)
+        tSTATErX = state_thr_mma.make_fragment_B(state_thr_mma.partition_B(sX_DS))
+        SM90.warpgroup_fence_operand(tSTATErY)
+        self.scale_acc_by_scalar(tStateT, block_coeff)
+        SM90.warpgroup_fence_operand(tStateT)
+        cute.nvgpu.warpgroup.fence()
+        self._math_order_wait(wg_idx)
+        SM90.wgmma_gemm(state_tiled_mma, tStateT, tSTATErY, tSTATErX, True)
+        cute.nvgpu.warpgroup.commit_group()
+        self._math_order_notify(wg_idx)
+        cute.nvgpu.warpgroup.wait_group(0)
+
+        k_pipeline.consumer_release(k_consumer_state)
+        k_consumer_state.advance()
+        v_pipeline.consumer_release(v_consumer_state)
+        v_consumer_state.advance()
+        t_pipeline.consumer_release(t_consumer_state)
+        t_consumer_state.advance()
+        alpha_pipeline.consumer_release(alpha_consumer_state)
+        alpha_consumer_state.advance()
+        return k_consumer_state, v_consumer_state, t_consumer_state, alpha_consumer_state
+
+    @cute.jit
+    def run_load_tensor_role(
+        self,
+        tma_atom: cute.CopyAtom,
+        tma_tensor: cute.Tensor,
+        sTensor: cute.Tensor,
+        tensor_pipeline,
+        tensor_producer_state,
+        tok_offset: cutlass.Int32,
+        t_block_start: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+        is_transfer: bool,
+    ):
+        for blk in cutlass.range(num_blocks, unroll=1):
+            tensor_producer_state = self.load_tensor_block_tma(
+                tma_atom, tma_tensor, sTensor, tensor_pipeline, tensor_producer_state,
+                tok_offset, t_block_start, head_idx, blk, is_transfer,
+            )
+        return tensor_producer_state
+
+    @cute.jit
+    def run_load_alpha_role(
+        self,
+        g_alpha: cute.Tensor,
+        sAlpha: cute.Tensor,
+        alpha_pipeline,
+        alpha_producer_state,
+        tok_offset: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ):
+        for blk in cutlass.range(num_blocks, unroll=1):
+            alpha_pipeline.producer_acquire(alpha_producer_state)
+            cute.arch.fence_view_async_shared()
+            self.load_alpha_block(
+                g_alpha, sAlpha,
+                tok_offset, head_idx, blk,
+                chunk_len, num_heads,
+                alpha_producer_state.index, tidx,
+            )
+            AlphaProcessor().run(sAlpha[None, None, alpha_producer_state.index], cutlass.Float32(1.0), True)
+            cute.arch.fence_view_async_shared()
+            alpha_pipeline.producer_commit(alpha_producer_state)
+            alpha_producer_state.advance()
+        return alpha_producer_state
+
+    @cute.jit
+    def run_math_role(
+        self,
+        sV_DS: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sT: cute.Tensor,
+        sX_DS: cute.Tensor,
+        sAlpha: cute.Tensor,
+        k_pipeline,
+        k_consumer_state,
+        v_pipeline,
+        v_consumer_state,
+        t_pipeline,
+        t_consumer_state,
+        alpha_pipeline,
+        alpha_consumer_state,
+        g_transfer_t: cute.Tensor,
+        g_state_t: cute.Tensor,
+        chunk_idx: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        num_chunks: cutlass.Int32,
+        wg_idx: cutlass.Int32,
+        tidx: cutlass.Int32,
+    ):
+        acc_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
+                self.dtype, self.acc_dtype, (64, self.D, 16),
+                warpgroup.OperandSource.RMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.MN,
+            )),
+            cute.make_layout((2, 1, 1)),
+        )
+        acc_thr = acc_mma.get_slice(tidx)
+        tTransferT = acc_thr.make_fragment_C(acc_thr.partition_shape_C((self.D, self.D)))
+        tStateT    = acc_thr.make_fragment_C(acc_thr.partition_shape_C((self.D, self.D)))
+        cTransfer  = cute.make_identity_tensor((self.D, self.D))
+        tTransferC = acc_thr.partition_C(cTransfer)
+        tStateT.fill(self.acc_dtype(0.0))
+        for i in cutlass.range(cute.size(tTransferT), unroll_full=True):
+            row, col = tTransferC[i]
+            value = cutlass.Float32(0.0)
+            if row == col:
+                value = cutlass.Float32(1.0)
+            tTransferT[i] = value
+
+        valid_len = chunk_len
+        if valid_len > self.BLK:
+            valid_len = self.BLK
+
+        (
+            k_consumer_state,
+            v_consumer_state,
+            t_consumer_state,
+            alpha_consumer_state,
+        ) = self.compute_loop_body(
+            sV_DS, sK_DS, sT, sX_DS, sAlpha,
+            k_pipeline, k_consumer_state,
+            v_pipeline, v_consumer_state,
+            t_pipeline, t_consumer_state,
+            alpha_pipeline, alpha_consumer_state,
+            tTransferT, tStateT,
+            valid_len, tidx, wg_idx, True,
+        )
+
+        for blk in cutlass.range(1, num_blocks, 1, unroll=1):
+            block_start = blk * self.BLK
+            valid_len = chunk_len - block_start
+            if valid_len > self.BLK:
+                valid_len = self.BLK
+
+            (
+                k_consumer_state,
+                v_consumer_state,
+                t_consumer_state,
+                alpha_consumer_state,
+            ) = self.compute_loop_body(
+                sV_DS, sK_DS, sT, sX_DS, sAlpha,
+                k_pipeline, k_consumer_state,
+                v_pipeline, v_consumer_state,
+                t_pipeline, t_consumer_state,
+                alpha_pipeline, alpha_consumer_state,
+                tTransferT, tStateT,
+                valid_len, tidx, wg_idx, False,
+            )
+
+        out_layout = cute.make_layout(
+            (self.D, self.D, num_heads, num_chunks),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        mTransferT = cute.make_tensor(g_transfer_t.iterator, out_layout)
+        mStateT = cute.make_tensor(g_state_t.iterator, out_layout)
+        self.store_acc_to_gmem(tTransferT, mTransferT[None, None, head_idx, chunk_idx], acc_mma, tidx)
+        self.store_acc_to_gmem(tStateT, mStateT[None, None, head_idx, chunk_idx], acc_mma, tidx)
+        return k_consumer_state, v_consumer_state, t_consumer_state, alpha_consumer_state
+
+    @cute.jit
+    def __call__(
+        self,
+        g_k: cute.Tensor,
+        g_v: cute.Tensor,
+        g_t: cute.Tensor,
+        g_alpha: cute.Tensor,
+        g_transfer_t: cute.Tensor,
+        g_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        max_cp_chunks_per_seq: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        stream,
+    ):
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        k_storage_layout_sd = cute.tile_to_shape(
+            qkv_smem_layout_atom,
+            (self.BLK, self.D, self.k_stage),
+            order=(0, 1, 2),
+        )
+        k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0, 2])
+        k_tma_layout_ds = cute.slice_(k_storage_layout_ds, (None, None, 0))
+        v_storage_layout_sd = cute.tile_to_shape(
+            qkv_smem_layout_atom,
+            (self.BLK, self.D, self.v_stage),
+            order=(0, 1, 2),
+        )
+        v_storage_layout_ds = cute.select(v_storage_layout_sd, [1, 0, 2])
+        v_tma_layout_ds = cute.slice_(v_storage_layout_ds, (None, None, 0))
+        x_smem_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        x_storage_layout_sd = cute.tile_to_shape(
+            x_smem_layout_atom,
+            (self.BLK, self.D),
+            order=(0, 1),
+        )
+        x_storage_layout_ds = cute.select(x_storage_layout_sd, [1, 0])
+        t_storage_layout = cute.tile_to_shape(
+            qkv_smem_layout_atom,
+            (self.BLK, self.BLK, self.t_stage),
+            order=(0, 1, 2),
+        )
+        t_tma_layout = cute.slice_(t_storage_layout, (None, None, 0))
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_k, k_tma_layout_ds, (self.D, self.BLK)
+        )
+        tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_v, v_tma_layout_ds, (self.D, self.BLK)
+        )
+        tma_atom_t, tma_tensor_t = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_t, t_tma_layout, (self.BLK, self.BLK)
+        )
+        dtype_bytes = self.dtype.width // 8
+        self.tma_load_k_bytes = cute.size(k_tma_layout_ds) * dtype_bytes
+        self.tma_load_v_bytes = cute.size(v_tma_layout_ds) * dtype_bytes
+        self.tma_load_t_bytes = cute.size(t_tma_layout) * dtype_bytes
+
+        @cute.struct
+        class SharedStorage:
+            k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.k_stage * 2]
+            v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.v_stage * 2]
+            t_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.t_stage * 2]
+            alpha_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_stage * 2]
+            smem_v: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(v_storage_layout_sd)], 128]
+            smem_k: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128]
+            smem_x: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(x_storage_layout_ds)], 128]
+            smem_t: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(t_storage_layout)], 16]
+            smem_alpha: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, self.BLK * AlphaProcessor.NUM_CHANNELS * self.alpha_stage], 16]
+
+        self.shared_storage = SharedStorage
+        self.kernel(
+            g_alpha,
+            tma_atom_k, tma_tensor_k,
+            tma_atom_v, tma_tensor_v,
+            tma_atom_t, tma_tensor_t,
+            g_transfer_t, g_state_t, g_cu_seqlens,
+            chunk_len, num_k_heads, num_v_heads, num_sab_heads, total_cp_chunks, num_seqs,
+        ).launch(
+            grid=(num_sab_heads * max_cp_chunks_per_seq, num_seqs, 1),
+            block=(384, 1, 1),
+            max_number_threads=(384, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        g_alpha: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        tma_atom_t: cute.CopyAtom,
+        tma_tensor_t: cute.Tensor,
+        g_transfer_t: cute.Tensor,
+        g_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+    ):
+        NUM_LOAD_WARP_GROUPS = 1
+        NUM_MMA_WARP_GROUPS = 2
+        THREADS_PER_WARP_GROUP = 128
+        MIN_BLOCKS_PER_MP = 1
+        MAX_THREADS_PER_BLOCK = (NUM_LOAD_WARP_GROUPS + NUM_MMA_WARP_GROUPS) * THREADS_PER_WARP_GROUP
+        load_registers, mma_registers = self.get_register_requirements(
+            MAX_THREADS_PER_BLOCK,
+            MIN_BLOCKS_PER_MP,
+            NUM_MMA_WARP_GROUPS,
+            THREADS_PER_WARP_GROUP,
+        )
+
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group_idx = cute.arch.make_warp_uniform(tidx // THREADS_PER_WARP_GROUP)
+        local_tidx = tidx % THREADS_PER_WARP_GROUP
+        bx, seq_idx, _ = cute.arch.block_idx()
+        sab_head_idx = bx % num_sab_heads
+        k_head_idx = sab_head_idx * num_k_heads // num_sab_heads
+        v_head_idx = sab_head_idx * num_v_heads // num_sab_heads
+        chunk_idx_in_seq = bx // num_sab_heads
+        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
+        seq_len = seq_end - seq_start
+        num_cp_chunks = chunks_for_len(seq_len, chunk_len)
+        is_valid_chunk = chunk_idx_in_seq < num_cp_chunks
+
+        tok_offset = seq_start + chunk_idx_in_seq * chunk_len
+        cp_chunk_idx = varlen_chunk_idx(seq_idx, seq_start, chunk_idx_in_seq, chunk_len)
+        valid_chunk_len = varlen_chunk_valid_len(seq_len, chunk_idx_in_seq, chunk_len)
+        num_blocks = (valid_chunk_len + self.BLK - 1) // self.BLK
+        t_blocks_per_cp_chunk = (chunk_len + self.BLK - 1) // self.BLK
+        t_block_start = varlen_chunk_idx(
+            seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK)
+
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        k_storage_layout_sd = cute.tile_to_shape(
+            qkv_smem_layout_atom,
+            (self.BLK, self.D, self.k_stage),
+            order=(0, 1, 2),
+        )
+        k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0, 2])
+        v_storage_layout_sd = cute.tile_to_shape(
+            qkv_smem_layout_atom,
+            (self.BLK, self.D, self.v_stage),
+            order=(0, 1, 2),
+        )
+        v_storage_layout_ds = cute.select(v_storage_layout_sd, [1, 0, 2])
+        x_smem_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        x_storage_layout_sd = cute.tile_to_shape(
+            x_smem_layout_atom,
+            (self.BLK, self.D),
+            order=(0, 1),
+        )
+        x_storage_layout_ds = cute.select(x_storage_layout_sd, [1, 0])
+        t_storage_layout = cute.tile_to_shape(
+            qkv_smem_layout_atom,
+            (self.BLK, self.BLK, self.t_stage),
+            order=(0, 1, 2),
+        )
+
+        alpha_layout = cute.make_layout((self.BLK, AlphaProcessor.NUM_CHANNELS, self.alpha_stage))
+
+        allocator = cutlass.utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+        sV_DS = storage.smem_v.get_tensor(v_storage_layout_ds.outer, swizzle=v_storage_layout_ds.inner)
+        sK_DS = storage.smem_k.get_tensor(k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner)
+        sX_DS = storage.smem_x.get_tensor(x_storage_layout_ds)
+        sT = storage.smem_t.get_tensor(t_storage_layout.outer, swizzle=t_storage_layout.inner)
+        sAlpha = storage.smem_alpha.get_tensor(alpha_layout)
+
+        ldst_warp_role = cute.arch.make_warp_uniform(warp_idx % 4)
+        if ldst_warp_role == self.LoadWarpRole.LOAD_K:
+            cpasync.prefetch_descriptor(tma_atom_k)
+        elif ldst_warp_role == self.LoadWarpRole.LOAD_V:
+            cpasync.prefetch_descriptor(tma_atom_v)
+        elif ldst_warp_role == self.LoadWarpRole.LOAD_T:
+            cpasync.prefetch_descriptor(tma_atom_t)
+
+        load_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        load_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 8)
+        alpha_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        alpha_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 256)
+        k_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.k_mbar_ptr.data_ptr(),
+            num_stages=self.k_stage,
+            producer_group=load_producer_group,
+            consumer_group=load_consumer_group,
+            tx_count=self.tma_load_k_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        v_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.v_mbar_ptr.data_ptr(),
+            num_stages=self.v_stage,
+            producer_group=load_producer_group,
+            consumer_group=load_consumer_group,
+            tx_count=self.tma_load_v_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        t_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.t_mbar_ptr.data_ptr(),
+            num_stages=self.t_stage,
+            producer_group=load_producer_group,
+            consumer_group=load_consumer_group,
+            tx_count=self.tma_load_t_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        alpha_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.alpha_mbar_ptr.data_ptr(),
+            num_stages=self.alpha_stage,
+            producer_group=alpha_producer_group,
+            consumer_group=alpha_consumer_group,
+        )
+        k_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.k_stage)
+        v_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.v_stage)
+        t_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.t_stage)
+        alpha_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.alpha_stage)
+        k_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.k_stage)
+        v_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.v_stage)
+        t_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.t_stage)
+        alpha_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.alpha_stage)
+        cute.arch.mbarrier_init_fence()
+        if warp_group_idx == self.WarpGroupRole.MATH1:
+            self._math_order_init(self.WarpGroupRole.MATH1)
+        cute.arch.sync_threads()
+
+        if is_valid_chunk:
+            if warp_group_idx == self.WarpGroupRole.LOAD:
+                cute.arch.setmaxregister_decrease(load_registers)
+                if ldst_warp_role == self.LoadWarpRole.LOAD_K:
+                    k_producer_state = self.run_load_tensor_role(
+                        tma_atom_k, tma_tensor_k, sK_DS, k_pipeline,
+                        k_producer_state, tok_offset, t_block_start, k_head_idx, num_blocks, False,
+                    )
+                elif ldst_warp_role == self.LoadWarpRole.LOAD_V:
+                    v_producer_state = self.run_load_tensor_role(
+                        tma_atom_v, tma_tensor_v, sV_DS, v_pipeline,
+                        v_producer_state, tok_offset, t_block_start, v_head_idx, num_blocks, False,
+                    )
+                elif ldst_warp_role == self.LoadWarpRole.LOAD_T:
+                    t_producer_state = self.run_load_tensor_role(
+                        tma_atom_t, tma_tensor_t, sT, t_pipeline,
+                        t_producer_state, tok_offset, t_block_start, sab_head_idx, num_blocks, True,
+                    )
+                else:
+                    alpha_producer_state = self.run_load_alpha_role(
+                        g_alpha, sAlpha, alpha_pipeline, alpha_producer_state,
+                        tok_offset, sab_head_idx, valid_chunk_len, num_blocks, num_sab_heads, local_tidx,
+                    )
+            elif warp_group_idx == self.WarpGroupRole.MATH0:
+                cute.arch.setmaxregister_increase(mma_registers)
+                math_tidx = tidx - THREADS_PER_WARP_GROUP
+                (
+                    k_consumer_state,
+                    v_consumer_state,
+                    t_consumer_state,
+                    alpha_consumer_state,
+                ) = self.run_math_role(
+                    sV_DS, sK_DS, sT, sX_DS, sAlpha,
+                    k_pipeline, k_consumer_state,
+                    v_pipeline, v_consumer_state,
+                    t_pipeline, t_consumer_state,
+                    alpha_pipeline, alpha_consumer_state,
+                    g_transfer_t, g_state_t,
+                    cp_chunk_idx, sab_head_idx,
+                    valid_chunk_len, num_blocks, num_sab_heads, total_cp_chunks,
+                    self.WarpGroupRole.MATH0, math_tidx,
+                )
+            else:
+                cute.arch.setmaxregister_increase(mma_registers)
+                math_tidx = tidx - THREADS_PER_WARP_GROUP
+                (
+                    k_consumer_state,
+                    v_consumer_state,
+                    t_consumer_state,
+                    alpha_consumer_state,
+                ) = self.run_math_role(
+                    sV_DS, sK_DS, sT, sX_DS, sAlpha,
+                    k_pipeline, k_consumer_state,
+                    v_pipeline, v_consumer_state,
+                    t_pipeline, t_consumer_state,
+                    alpha_pipeline, alpha_consumer_state,
+                    g_transfer_t, g_state_t,
+                    cp_chunk_idx, sab_head_idx,
+                    valid_chunk_len, num_blocks, num_sab_heads, total_cp_chunks,
+                    self.WarpGroupRole.MATH1, math_tidx,
+                )
+
+
+def cp_delta_rule_mn_precompute_dsl_sm90(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    t: torch.Tensor,
+    alpha: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    total_seqlen: int,
+    cp_chunk_len: int = 4096,
+    max_seqlen: int | None = None,
+    *,
+    _skip_check: bool = False,
+):
+    """Run the SM90 CP preprocess kernel and return its native output layout.
+
+    Flat varlen input returns transfer/state workspaces with shape
+    `(total_cp_chunks, num_heads, DimV, DimK)`, where
+    `total_cp_chunks = chunk_bound(num_seqs, total_seqlen, cp_chunk_len)`.
+
+    Inputs must already be contiguous. This wrapper validates that contract but
+    does not materialize contiguous copies.
+    """
+    from cutlass.cute.runtime import from_dlpack
+    import cuda.bindings.driver as cuda_driver
+
+    if not _skip_check:
+        if k.ndim != 3:
+            raise RuntimeError(f"k must have shape (total_seqlen, num_k_heads, D), got {tuple(k.shape)}")
+        if v.ndim != 3 or v.shape[0] != k.shape[0] or v.shape[2] != k.shape[2]:
+            raise RuntimeError(f"v must have shape (total_seqlen, num_v_heads, D), got {tuple(v.shape)}")
+        if alpha.ndim != 2 or alpha.shape[0] != k.shape[0]:
+            raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
+        if total_seqlen != k.shape[0]:
+            raise RuntimeError(f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}")
+        if max_seqlen is not None and max_seqlen <= 0:
+            raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
+        if cp_chunk_len % 64 != 0:
+            raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
+        if cu_seqlens.dtype != torch.int64:
+            raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+        if not cu_seqlens.is_contiguous():
+            raise RuntimeError("cu_seqlens must be contiguous")
+    _, num_k_heads, d = k.shape
+    num_v_heads = v.shape[1]
+    num_sab_heads = alpha.shape[1]
+    if not _skip_check:
+        if num_sab_heads < num_k_heads or num_sab_heads % num_k_heads != 0:
+            raise RuntimeError(
+                "alpha heads must be a positive multiple of k heads, "
+                f"got alpha heads={num_sab_heads} and k heads={num_k_heads}"
+            )
+        if num_sab_heads < num_v_heads or num_sab_heads % num_v_heads != 0:
+            raise RuntimeError(
+                "alpha heads must be a positive multiple of v heads, "
+                f"got alpha heads={num_sab_heads} and v heads={num_v_heads}"
+            )
+    total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
+    if not _skip_check and t.shape != (total_t_blocks, num_sab_heads, 64, 64):
+        raise RuntimeError(
+            "t must have shape "
+            f"{(total_t_blocks, num_sab_heads, 64, 64)}, got {tuple(t.shape)}"
+        )
+    total_cp_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
+    if not _skip_check:
+        if k.shape[-1] != 128:
+            raise RuntimeError(f"CPDeltaRuleMNPrecomputeSm90 only supports D=128, got {k.shape[-1]}")
+        if k.dtype not in (torch.float16, torch.bfloat16):
+            raise RuntimeError(f"CPDeltaRuleMNPrecomputeSm90 only supports fp16/bf16 inputs, got {k.dtype}")
+        if t.dtype != k.dtype:
+            raise RuntimeError(f"t dtype must match k dtype, got {t.dtype} and {k.dtype}")
+        for name, tensor in (("k", k), ("v", v), ("t", t), ("alpha", alpha)):
+            if not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+
+    num_seqs = cu_seqlens.shape[0] - 1
+    max_cp_chunks_per_seq = max_num_chunks_host(cu_seqlens, cp_chunk_len, max_seqlen)
+    k_tma = k.as_strided(
+        (d, total_seqlen, num_k_heads),
+        (1, num_k_heads * d, d),
+    )
+    v_tma = v.as_strided(
+        (d, total_seqlen, num_v_heads),
+        (1, num_v_heads * d, d),
+    )
+    t_tma = t.as_strided(
+        (64, 64, num_sab_heads, total_t_blocks),
+        (
+            64,
+            1,
+            64 * 64,
+            num_sab_heads * 64 * 64,
+        ),
+    )
+    transfer_t = torch.zeros((total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device)
+    state_t = torch.zeros((total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device)
+    if total_cp_chunks == 0:
+        return transfer_t, state_t
+
+    kernel_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+    }[k.dtype]
+
+    stream_val = torch.cuda.current_stream().cuda_stream
+    stream = cuda_driver.CUstream(stream_val)
+
+    enable_tvm_ffi = True
+    if enable_tvm_ffi:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
+
+    kernel = CPDeltaRuleMNPrecomputeSm90(kernel_dtype)
+    kernel_args = (
+        from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+        from_dlpack(v_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+        from_dlpack(t_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
+        from_dlpack(alpha.view(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(transfer_t.view(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(state_t.view(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+        cutlass.Int32(cp_chunk_len),
+        cutlass.Int32(num_k_heads),
+        cutlass.Int32(num_v_heads),
+        cutlass.Int32(num_sab_heads),
+        cutlass.Int32(total_cp_chunks),
+        cutlass.Int32(max_cp_chunks_per_seq),
+        cutlass.Int32(num_seqs),
+        stream,
+    )
+    compiled = cached_compile(
+        kernel,
+        *kernel_args,
+        compile_options=(cute.GPUArch("sm_90a"),),
+    )
+    compiled(*kernel_args)
+    return transfer_t, state_t
+
+
+class CPDeltaRuleFixupSm90(KeyedCompileMixin):
+    class WarpGroupRole(IntEnum):
+        LOAD = 0
+        MATH = 1
+
+    class LoadWarpRole(IntEnum):
+        LOAD_M = 0
+        LOAD_N = 1
+
+    @staticmethod
+    def get_register_requirement(
+        max_threads_per_block: int,
+        min_blocks_per_multiprocessor: int,
+    ) -> int:
+        reg_alloc_granularity = 8
+        registers_per_thread = round_down(
+            64 * 1024 // min_blocks_per_multiprocessor,
+            max_threads_per_block * reg_alloc_granularity,
+        ) // max_threads_per_block
+        return min(248, registers_per_thread)
+
+    def __init__(self):
+        self.D = 128
+        self.rows_per_cta = 64
+        self.row_ctas = 2
+        self.threads_per_cta = 256
+        self.num_warps = 8
+        self.m_stage = 2
+        self.n_stage = 2
+        self.num_col_tiles = 16
+        self.num_row_tiles = 4
+        self.num_tiles = 64
+        self.k_tiles = 16
+        self.min_blocks_per_mp = 1
+        self.registers_per_thread = self.get_register_requirement(
+            self.threads_per_cta,
+            self.min_blocks_per_mp,
+        )
+        self.use_3xtf32 = False
+
+    @cute.jit
+    def load_fixup_tma(
+        self,
+        tma_atom: cute.CopyAtom,
+        tma_tensor: cute.Tensor,
+        sTensor: cute.Tensor,
+        tensor_pipeline,
+        tensor_producer_state,
+        chunk_start: cutlass.Int32,
+        chunk_idx_in_seq: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        row_cta_idx: cutlass.Int32,
+        is_state: bool,
+    ):
+        chunk_idx = chunk_start + chunk_idx_in_seq
+        sTensor_stage = sTensor[None, None, tensor_producer_state.index]
+        if cutlass.const_expr(is_state):
+            row_offset = row_cta_idx * self.rows_per_cta
+            mTensor = cute.domain_offset(
+                (row_offset, 0),
+                tma_tensor[None, None, head_idx, chunk_idx],
+            )
+            gTensor = cute.zipped_divide(mTensor, (self.rows_per_cta, self.D))[
+                ((None, None), (0, 0))
+            ]
+        else:
+            gTensor = cute.zipped_divide(tma_tensor[None, None, head_idx, chunk_idx], (self.D, self.D))[
+                ((None, None), (0, 0))
+            ]
+
+        tTsT, tTgT = cpasync.tma_partition(
+            tma_atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sTensor_stage, 0, 2),
+            cute.group_modes(gTensor, 0, 2),
+        )
+        tensor_pipeline.producer_acquire(tensor_producer_state)
+        cute.copy(
+            tma_atom,
+            tTgT,
+            tTsT,
+            tma_bar_ptr=tensor_pipeline.producer_get_barrier(tensor_producer_state),
+        )
+        tensor_pipeline.producer_commit(tensor_producer_state)
+        tensor_producer_state.advance()
+        return tensor_producer_state
+
+    @cute.jit
+    def convert_fp32_to_tf32_residual(
+        self,
+        tensor: cute.Tensor,
+    ):
+        residual = cute.make_rmem_tensor_like(tensor, cutlass.Float32)
+        for i in cutlass.range_constexpr(cute.size(residual)):
+            value = tensor[i]
+            residual[i] = value - round_to_tf32_f32(value)
+        return cute.recast_tensor(residual, cutlass.TFloat32)
+
+    @cute.jit
+    def convert_tf32_c_to_kpermuted_a(
+        self,
+        tCrC: cute.Tensor,
+        tCrA: cute.Tensor,
+    ):
+        for i in cutlass.range(cute.size(tCrA), unroll_full=True):
+            tCrA[i] = tCrC[i]
+        for m in cutlass.range_constexpr(cute.size(tCrA, mode=[1])):
+            for k in cutlass.range_constexpr(cute.size(tCrA, mode=[2])):
+                tmp = tCrA[(1, 0), m, k]
+                tCrA[(1, 0), m, k] = tCrA[(0, 1), m, k]
+                tCrA[(0, 1), m, k] = tmp
+
+    @cute.jit
+    def load_tf32_kpermuted_b(
+        self,
+        tCrB: cute.Tensor,
+        sB_NK: cute.Tensor,
+        lane_idx: cutlass.Int32,
+    ):
+        sB_8x8 = cute.flat_divide(sB_NK, (8, 8))
+        n = lane_idx // 4
+        k = lane_idx - n * 4
+        for iter_n in cutlass.range_constexpr(cute.size(tCrB, mode=[1])):
+            for iter_k in cutlass.range_constexpr(cute.size(tCrB, mode=[2])):
+                tCrB[0, iter_n, iter_k] = sB_8x8[n, k * 2, iter_n, iter_k]
+                tCrB[1, iter_n, iter_k] = sB_8x8[n, k * 2 + 1, iter_n, iter_k]
+
+    @cute.jit
+    def store_fixed_state(
+        self,
+        tiled_store_C,
+        tSMrState_store: cute.Tensor,
+        tSMgFixedState: cute.Tensor,
+        chunk_idx: cutlass.Int32,
+    ):
+        tSMgFixedState_stage = tSMgFixedState[None, None, None, chunk_idx]
+        tSMgFixedState_stage = cute.make_tensor(
+            tSMgFixedState_stage.iterator.align(8),
+            tSMgFixedState_stage.layout,
+        )
+        cute.copy(tiled_store_C, tSMrState_store, tSMgFixedState_stage)
+
+    @cute.jit
+    def run_fixup_loop(
+        self,
+        sM: cute.Tensor,
+        sN: cute.Tensor,
+        m_pipeline,
+        m_consumer_state,
+        n_pipeline,
+        n_consumer_state,
+        gFixedState: cute.Tensor,
+        num_chunks: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        chunk_start: cutlass.Int32,
+        head_idx: cutlass.Int32,
+        row_cta_idx: cutlass.Int32,
+        math_tidx: cutlass.Int32,
+    ):
+        warp_idx = math_tidx // 32
+        lane_idx = math_tidx - warp_idx * 32
+        tiled_mma  = cute.make_tiled_mma(WarpMmaTF32Op((16, 8, 8)))
+        copy_atom  = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32)
+        store_atom = cute.make_copy_atom(cute.nvgpu.CopyR2GOp(), cutlass.Float32, num_bits_per_copy=64)
+        tiled_copy_C  = cute.make_tiled_copy_C(copy_atom, tiled_mma)
+        tiled_store_C = cute.make_tiled_copy_C(store_atom, tiled_mma)
+        thr_copy_C  = tiled_copy_C.get_slice(lane_idx)  # for N, local state
+        thr_store_C = tiled_store_C.get_slice(lane_idx)
+
+        tSMrS = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, self.D)), cutlass.Float32)
+        tSMrM = cute.make_rmem_tensor(tiled_mma.partition_shape_B((self.D, self.D)), cutlass.Float32)
+        sM_NK = select_tensor_10(sM)
+        tSMrState = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, self.D)), cutlass.Float32)
+        tSMrState_cv = thr_copy_C.retile(tSMrState)
+        tSMrState_store = thr_store_C.retile(tSMrState)
+
+        row_base = warp_idx * 16
+        global_row_base = row_cta_idx * self.rows_per_cta + row_base
+        sN_warp = cute.local_tile(sN, (16, self.D, self.n_stage), (warp_idx, 0, 0))
+        gFixedState_warp = cute.local_tile(
+            gFixedState[None, None, head_idx, None],
+            (16, self.D, total_cp_chunks),
+            (global_row_base // 16, 0, 0),
+        )
+        tSMsN = thr_copy_C.partition_S(sN_warp)
+        tSMgFixedState = thr_store_C.partition_D(gFixedState_warp)
+
+        # NOTE: assume initial state is always zero, S_c1 = S_init @ M + N,
+        # then the state after fixup for the first chunk is N automatically.
+        n_pipeline.consumer_wait(n_consumer_state)
+        cute.arch.fence_view_async_shared()
+        cute.autovec_copy(tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv)
+        n_pipeline.consumer_release(n_consumer_state)
+        n_consumer_state.advance()
+        self.store_fixed_state(tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start)
+
+        for chunk_idx in cutlass.range(1, num_chunks, 1, unroll=1):
+            self.convert_tf32_c_to_kpermuted_a(tSMrState, tSMrS)
+            n_pipeline.consumer_wait(n_consumer_state)
+            m_pipeline.consumer_wait(m_consumer_state)
+            cute.arch.fence_view_async_shared()
+            cute.autovec_copy(tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv)
+
+            self.load_tf32_kpermuted_b(tSMrM, sM_NK[None, None, m_consumer_state.index], lane_idx)
+            for iter_k in cutlass.range_constexpr(self.k_tiles):
+                tSMrS_h = cute.recast_tensor(tSMrS[None, None, iter_k], cutlass.TFloat32)
+                tSMrM_h = cute.recast_tensor(tSMrM[None, None, iter_k], cutlass.TFloat32)
+                cute.gemm(tiled_mma, tSMrState, tSMrS_h, tSMrM_h, tSMrState)
+                if cutlass.const_expr(self.use_3xtf32):
+                    tSMrM_l = self.convert_fp32_to_tf32_residual(tSMrM[None, None, iter_k])
+                    cute.gemm(tiled_mma, tSMrState, tSMrS_h, tSMrM_l, tSMrState)
+                    tSMrS_l = self.convert_fp32_to_tf32_residual(tSMrS[None, None, iter_k])
+                    tSMrM_h = cute.recast_tensor(tSMrM[None, None, iter_k], cutlass.TFloat32)
+                    cute.gemm(tiled_mma, tSMrState, tSMrS_l, tSMrM_h, tSMrState)
+
+            n_pipeline.consumer_release(n_consumer_state)
+            n_consumer_state.advance()
+            m_pipeline.consumer_release(m_consumer_state)
+            m_consumer_state.advance()
+
+            self.store_fixed_state(tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start + chunk_idx)
+
+        return m_consumer_state, n_consumer_state
+
+    @cute.jit
+    def __call__(
+        self,
+        g_transfer_t: cute.Tensor,
+        g_local_state_t: cute.Tensor,
+        g_fixed_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        stream,
+    ):
+        smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_INTER,
+            cutlass.Float32,
+        )
+        transfer_layout = cute.tile_to_shape(smem_layout_atom, (self.D, self.D, self.m_stage), order=(0, 1, 2))
+        state_layout = cute.tile_to_shape(smem_layout_atom, (self.rows_per_cta, self.D, self.n_stage), order=(0, 1, 2))
+        transfer_tma_layout = cute.slice_(transfer_layout, (None, None, 0))
+        state_tma_layout = cute.slice_(state_layout, (None, None, 0))
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_m, tma_tensor_m = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_transfer_t, transfer_tma_layout, (self.D, self.D),
+        )
+        tma_atom_n, tma_tensor_n = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_local_state_t, state_tma_layout, (self.rows_per_cta, self.D),
+        )
+        self.tma_load_m_bytes = cute.size(transfer_tma_layout) * 4
+        self.tma_load_n_bytes = cute.size(state_tma_layout) * 4
+
+        @cute.struct
+        class SharedStorage:
+            m_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.m_stage * 2]
+            n_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.n_stage * 2]
+            smem_m: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, cute.cosize(transfer_layout)], 128]
+            smem_n: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, cute.cosize(state_layout)], 128]
+
+        self.shared_storage = SharedStorage
+        self.kernel(
+            tma_atom_m, tma_tensor_m,
+            tma_atom_n, tma_tensor_n,
+            g_fixed_state_t,
+            g_cu_seqlens,
+            chunk_len, total_cp_chunks, num_seqs, num_heads,
+        ).launch(
+            grid=(num_seqs * num_heads * self.row_ctas, 1, 1),
+            block=(self.threads_per_cta, 1, 1),
+            max_number_threads=(self.threads_per_cta, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=self.min_blocks_per_mp,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        tma_atom_m: cute.CopyAtom,
+        tma_tensor_m: cute.Tensor,
+        tma_atom_n: cute.CopyAtom,
+        tma_tensor_n: cute.Tensor,
+        g_fixed_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        num_heads: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group_idx = cute.arch.make_warp_uniform(tidx // 128)
+        local_tidx = tidx % 128
+        bx, _, _ = cute.arch.block_idx()
+        row_cta_idx = bx % self.row_ctas
+        head_seq_idx = bx // self.row_ctas
+        head_idx = head_seq_idx % num_heads
+        seq_idx = head_seq_idx // num_heads
+        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
+        seq_len = seq_end - seq_start
+        num_chunks = chunks_for_len(seq_len, chunk_len)
+        chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
+
+        smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_INTER,
+            cutlass.Float32,
+        )
+        transfer_layout = cute.tile_to_shape(smem_layout_atom, (self.D, self.D, self.m_stage), order=(0, 1, 2))
+        state_layout = cute.tile_to_shape(smem_layout_atom, (self.rows_per_cta, self.D, self.n_stage), order=(0, 1, 2))
+        out_layout = cute.make_layout(
+            (self.D, self.D, num_heads, total_cp_chunks),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        allocator = cutlass.utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+        sM = storage.smem_m.get_tensor(transfer_layout.outer, swizzle=transfer_layout.inner)
+        sN = storage.smem_n.get_tensor(state_layout.outer, swizzle=state_layout.inner)
+        gFixedState = cute.make_tensor(g_fixed_state_t.iterator.align(128), out_layout)
+
+        ldst_warp_role = cute.arch.make_warp_uniform(warp_idx % 4)
+        if warp_group_idx == self.WarpGroupRole.LOAD:
+            if ldst_warp_role == self.LoadWarpRole.LOAD_M:
+                cpasync.prefetch_descriptor(tma_atom_m)
+            elif ldst_warp_role == self.LoadWarpRole.LOAD_N:
+                cpasync.prefetch_descriptor(tma_atom_n)
+
+        producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 4)
+        m_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.m_mbar_ptr.data_ptr(),
+            num_stages=self.m_stage,
+            producer_group=producer_group,
+            consumer_group=consumer_group,
+            tx_count=self.tma_load_m_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        n_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.n_mbar_ptr.data_ptr(),
+            num_stages=self.n_stage,
+            producer_group=producer_group,
+            consumer_group=consumer_group,
+            tx_count=self.tma_load_n_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        m_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.m_stage)
+        n_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.n_stage)
+        m_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.m_stage)
+        n_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.n_stage)
+        cute.arch.mbarrier_init_fence()
+        cute.arch.sync_threads()
+
+        if warp_group_idx == self.WarpGroupRole.LOAD:
+            cute.arch.setmaxregister_decrease(40)
+            if ldst_warp_role == self.LoadWarpRole.LOAD_M and num_chunks > 0:
+                for chunk_idx in cutlass.range(1, num_chunks, 1, unroll=1):
+                    m_producer_state = self.load_fixup_tma(
+                        tma_atom_m, tma_tensor_m, sM, m_pipeline, m_producer_state,
+                        chunk_start, chunk_idx, head_idx, row_cta_idx, False,
+                    )
+            elif ldst_warp_role == self.LoadWarpRole.LOAD_N and num_chunks > 0:
+                for chunk_idx in cutlass.range(0, num_chunks, 1, unroll=1):
+                    n_producer_state = self.load_fixup_tma(
+                        tma_atom_n, tma_tensor_n, sN, n_pipeline, n_producer_state,
+                        chunk_start, chunk_idx, head_idx, row_cta_idx, True,
+                    )
+        else:
+            cute.arch.setmaxregister_increase(self.registers_per_thread)
+            if num_chunks > 0:
+                math_tidx = local_tidx
+                self.run_fixup_loop(
+                    sM, sN,
+                    m_pipeline, m_consumer_state,
+                    n_pipeline, n_consumer_state,
+                    gFixedState, num_chunks, total_cp_chunks, chunk_start, head_idx, row_cta_idx, math_tidx,
+                )
+
+
+def cp_delta_rule_fixup_dsl_sm90(
+    local_transfer: torch.Tensor,
+    local_state: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    total_seqlen: int,
+    cp_chunk_len: int = 4096,
+    *,
+    _skip_check: bool = False,
+):
+    """Fix CP precompute chunk artifacts into global chunk-boundary states.
+
+    Flat varlen workspaces use the native
+    `(total_cp_chunks, num_heads, DimV, DimK)` layout produced by
+    `cp_delta_rule_mn_precompute_dsl_sm90`.
+    """
+    from cutlass.cute.runtime import from_dlpack
+    import cuda.bindings.driver as cuda_driver
+
+    if not _skip_check:
+        if local_transfer.ndim != 4:
+            raise RuntimeError(
+                "local_transfer must have shape (num_chunks, num_heads, DimV, DimK), "
+                f"got {tuple(local_transfer.shape)}"
+            )
+        if local_state.shape != local_transfer.shape:
+            raise RuntimeError(
+                "local_state shape must match local_transfer shape, "
+                f"got {tuple(local_state.shape)} and {tuple(local_transfer.shape)}"
+            )
+        if local_transfer.shape[-2:] != (128, 128):
+            raise RuntimeError(f"CPDeltaRuleFixupSm90 only supports D=128, got {tuple(local_transfer.shape[-2:])}")
+        if local_transfer.dtype != torch.float32 or local_state.dtype != torch.float32:
+            raise RuntimeError(
+                "CPDeltaRuleFixupSm90 only supports float32 inputs, "
+                f"got {local_transfer.dtype} and {local_state.dtype}"
+            )
+        for name, tensor in (("local_transfer", local_transfer), ("local_state", local_state)):
+            if not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+    total_cp_chunks, num_heads, _, _ = local_transfer.shape
+    if not _skip_check:
+        if cp_chunk_len <= 0:
+            raise RuntimeError(f"cp_chunk_len must be positive, got {cp_chunk_len}")
+        if cu_seqlens.dtype != torch.int64:
+            raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+        expected_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
+        if expected_chunks != total_cp_chunks:
+            raise RuntimeError(
+                "local_transfer/local_state first dim must equal "
+                f"chunk_bound(num_seqs, total_seqlen, cp_chunk_len)={expected_chunks}, got {total_cp_chunks}"
+            )
+        if not cu_seqlens.is_contiguous():
+            raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+
+    fixed_state = torch.zeros_like(local_state)
+    if total_cp_chunks == 0:
+        return fixed_state
+
+    stream_val = torch.cuda.current_stream().cuda_stream
+    stream = cuda_driver.CUstream(stream_val)
+    d = local_transfer.shape[-1]
+    local_transfer_tma = local_transfer.as_strided(
+        (d, d, num_heads, total_cp_chunks),
+        (d, 1, d * d, num_heads * d * d),
+    )
+    local_state_tma = local_state.as_strided(
+        (d, d, num_heads, total_cp_chunks),
+        (d, 1, d * d, num_heads * d * d),
+    )
+
+    enable_tvm_ffi = True
+    if enable_tvm_ffi:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
+
+    kernel = CPDeltaRuleFixupSm90()
+    kernel_args = (
+        from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(leading_dim=1),
+        from_dlpack(local_state_tma, assumed_align=128).mark_layout_dynamic(leading_dim=1),
+        from_dlpack(fixed_state.reshape(-1), assumed_align=128).mark_layout_dynamic(),
+        from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+        cutlass.Int32(cp_chunk_len),
+        cutlass.Int32(total_cp_chunks),
+        cutlass.Int32(num_seqs),
+        cutlass.Int32(num_heads),
+        stream,
+    )
+    compiled = cached_compile(
+        kernel,
+        *kernel_args,
+        compile_options=(cute.GPUArch("sm_90a"),),
+    )
+    compiled(*kernel_args)
+    return fixed_state
+
+
+class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
+    def __init__(
+        self,
+        dtype: type[cutlass.Numeric] = cutlass.Float16,
+        acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+    ):
+        super().__init__(True, False, True, False, dtype, acc_dtype)
+        self.t_stage = 2
+
+    @cute.jit
+    def load_t_tma(
+        self,
+        sT: cute.Tensor,
+        tma_atom_t: cute.CopyAtom,
+        tma_tensor_t: cute.Tensor,
+        t_pipeline,
+        t_producer_state,
+        blk: cutlass.Int32,
+        t_block_start: cutlass.Int32,
+        head_idx: cutlass.Int32,
+    ):
+        sT_stage = sT[None, None, t_producer_state.index]
+        mT = tma_tensor_t[None, None, head_idx, t_block_start + blk]
+        gT = cute.zipped_divide(mT, (self.BLK_KV, self.BLK_KV))[
+            ((None, None), (0, 0))
+        ]
+        tTsT, tTgT = cpasync.tma_partition(
+            tma_atom_t,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sT_stage, 0, 2),
+            cute.group_modes(gT, 0, 2),
+        )
+        t_pipeline.producer_acquire(t_producer_state)
+        cute.copy(
+            tma_atom_t, tTgT, tTsT,
+            tma_bar_ptr=t_pipeline.producer_get_barrier(t_producer_state),
+        )
+        t_pipeline.producer_commit(t_producer_state)
+        t_producer_state.advance()
+        return t_producer_state
+
+    @cute.jit
+    def run_load_t_role(
+        self,
+        sT: cute.Tensor,
+        tma_atom_t: cute.CopyAtom,
+        tma_tensor_t: cute.Tensor,
+        t_pipeline,
+        num_blocks: cutlass.Int32,
+        t_block_start: cutlass.Int32,
+        head_idx: cutlass.Int32,
+    ):
+        t_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.t_stage)
+        for blk in cutlass.range(num_blocks, unroll=1):
+            t_producer_state = self.load_t_tma(
+                sT, tma_atom_t, tma_tensor_t, t_pipeline,
+                t_producer_state, blk, t_block_start, head_idx,
+            )
+
+    @cute.jit
+    def cp_qk_and_t_epi(
+        self,
+        tQKrQK: cute.Tensor,
+        tQKcMqk: cute.Tensor,
+        sT: cute.Tensor,
+        sKK_opd: cute.Tensor,
+        sAlpha: cute.Tensor,
+        alpha_stage: cutlass.Int32,
+        is_final_block: bool,
+        B: cutlass.Int32,
+        scale: cutlass.Float32,
+        kk_tiled_mma,
+        tKKcMkk: cute.Tensor,
+        aux_tidx: cutlass.Int32,
+    ):
+        alpha_log = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
+        for i in cutlass.range_constexpr(cute.size(tQKrQK)):
+            s, t = tQKcMqk[i]
+            alpha = cute.math.exp2(
+                cutlass.Float32(alpha_log[s]) - cutlass.Float32(alpha_log[t]),
+                fastmath=True,
+            )
+            pred = s >= t
+            if cutlass.const_expr(is_final_block):
+                pred = pred and (s < B or t < B)
+            tQKrQK[i] = tQKrQK[i] * alpha * scale if pred else cutlass.Float32(0.0)
+
+        stsm_atom = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+        tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
+        thr_store   = tiled_store.get_slice(aux_tidx)
+        tKKsKK      = thr_store.partition_D(sKK_opd)
+        tKKcMkk_cv  = thr_store.retile(tKKcMkk)
+        tKKrT       = cute.make_fragment_like(tKKsKK, self.dtype)
+
+        for i in cutlass.range_constexpr(cute.size(tKKrT)):
+            s, t = tKKcMkk_cv[i]
+            value = cutlass.Float32(0.0)
+            pred = True
+            if cutlass.const_expr(is_final_block):
+                pred = s < B and t < B
+            if pred:
+                gamma = cute.math.exp2(
+                    cutlass.Float32(alpha_log[s]) - cutlass.Float32(alpha_log[t]),
+                    fastmath=True,
+                )
+                value = -gamma * cutlass.Float32(sT[t, s])
+            tKKrT[i] = self.dtype(value)
+        cute.copy(tiled_store, tKKrT, tKKsKK)
+
+    @cute.jit
+    def run_aux_loop_body(
+        self,
+        sQK: cute.Tensor,
+        sT: cute.Tensor,
+        sKK_opd: cute.Tensor,
+        sAlpha: cute.Tensor,
+        q_pipeline,
+        q_consumer_state,
+        k_pipeline,
+        k_consumer_state,
+        t_pipeline,
+        t_consumer_state,
+        qk_pipeline,
+        qk_producer_state,
+        kk_pipeline,
+        kk_producer_state,
+        alpha_pipeline,
+        alpha_consumer_state,
+        work_desc: WorkDesc,
+        scale: cutlass.Float32,
+        blk: cutlass.Int32,
+        is_final_block: bool,
+        qk_tiled_mma,
+        kk_tiled_mma,
+        tQKrQ: cute.Tensor,
+        tQKrK: cute.Tensor,
+        tQKcMqk: cute.Tensor,
+        tKKcMkk: cute.Tensor,
+        aux_tidx: cutlass.Int32,
+    ):
+        B = self.BLK_KV
+        if cutlass.const_expr(is_final_block):
+            B = work_desc.seq_len - blk * self.BLK_KV
+
+        k_pipeline.consumer_wait(k_consumer_state)
+        q_pipeline.consumer_wait(q_consumer_state)
+        tQKrQK = qk_tiled_mma.get_slice(aux_tidx).make_fragment_C(
+            qk_tiled_mma.get_slice(aux_tidx).partition_shape_C((self.BLK_Q, self.BLK_KV)))
+        cute.nvgpu.warpgroup.fence()
+        SM90.wgmma_gemm_zero_acc(
+            qk_tiled_mma,
+            tQKrQK,
+            tQKrQ[None, None, None, q_consumer_state.index],
+            tQKrK[None, None, None, k_consumer_state.index],
+        )
+        cute.nvgpu.warpgroup.commit_group()
+        cute.nvgpu.warpgroup.wait_group(0)
+        k_pipeline.consumer_release(k_consumer_state)
+        k_consumer_state.advance()
+        q_pipeline.consumer_release(q_consumer_state)
+        q_consumer_state.advance()
+
+        alpha_pipeline.consumer_wait(alpha_consumer_state)
+        t_pipeline.consumer_wait(t_consumer_state)
+        cute.arch.fence_view_async_shared()
+
+        kk_pipeline.producer_acquire(kk_producer_state)
+        self.cp_qk_and_t_epi(
+            tQKrQK, tQKcMqk,
+            sT[None, None, t_consumer_state.index],
+            sKK_opd[None, None, kk_producer_state.index],
+            sAlpha, alpha_consumer_state.index,
+            is_final_block, B, scale,
+            kk_tiled_mma, tKKcMkk, aux_tidx,
+        )
+        cute.arch.fence_view_async_shared()
+        kk_pipeline.producer_commit(kk_producer_state)
+        kk_producer_state.advance()
+        t_pipeline.consumer_release(t_consumer_state)
+        t_consumer_state.advance()
+
+        qk_pipeline.producer_acquire(qk_producer_state)
+        self.qk_store(
+            tQKrQK,
+            sQK[None, None, qk_producer_state.index],
+            qk_tiled_mma,
+            aux_tidx,
+        )
+        cute.arch.fence_view_async_shared()
+        qk_pipeline.producer_commit(qk_producer_state)
+        qk_producer_state.advance()
+
+        alpha_pipeline.consumer_release(alpha_consumer_state)
+        alpha_consumer_state.advance()
+        return (
+            q_consumer_state,
+            k_consumer_state,
+            t_consumer_state,
+            qk_producer_state,
+            kk_producer_state,
+            alpha_consumer_state,
+        )
+
+    @cute.jit
+    def run_aux_math_role(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_SD: cute.Tensor,
+        sQK: cute.Tensor,
+        sT: cute.Tensor,
+        sKK_opd: cute.Tensor,
+        sAlpha: cute.Tensor,
+        q_pipeline,
+        k_pipeline,
+        t_pipeline,
+        qk_pipeline,
+        kk_pipeline,
+        alpha_pipeline,
+        work_desc: WorkDesc,
+        scale: cutlass.Float32,
+        math_tidx: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+    ):
+        aux_tidx = math_tidx % 128
+
+        qk_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
+                self.dtype, self.acc_dtype, (self.BLK_Q, self.BLK_KV, 16),
+                warpgroup.OperandSource.SMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )),
+            cute.make_layout((1, 1, 1)),
+        )
+        kk_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
+                self.dtype, self.acc_dtype, (self.BLK_KV, self.BLK_KV, 16),
+                warpgroup.OperandSource.SMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.K,
+            )),
+            cute.make_layout((1, 1, 1)),
+        )
+
+        qk_thr_mma = qk_tiled_mma.get_slice(aux_tidx)
+        kk_thr_mma = kk_tiled_mma.get_slice(aux_tidx)
+
+        tQKsQ = qk_thr_mma.partition_A(sQ_SD)
+        tQKsK = qk_thr_mma.partition_B(sK_SD)
+        tQKrQ = qk_thr_mma.make_fragment_A(tQKsQ)
+        tQKrK = qk_thr_mma.make_fragment_B(tQKsK)
+
+        cMqk = cute.make_identity_tensor((self.BLK_Q, self.BLK_KV))
+        tQKcMqk = qk_thr_mma.partition_C(cMqk)
+        tKKcMkk = kk_thr_mma.partition_C(cMqk)
+
+        q_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.q_stage)
+        k_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.k_stage)
+        t_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.t_stage)
+        qk_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.qk_stage)
+        kk_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.kk_stage)
+        alpha_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+
+        for blk in cutlass.range(num_blocks - 1, unroll=1):
+            (
+                q_consumer_state,
+                k_consumer_state,
+                t_consumer_state,
+                qk_producer_state,
+                kk_producer_state,
+                alpha_consumer_state,
+            ) = self.run_aux_loop_body(
+                sQK, sT, sKK_opd, sAlpha,
+                q_pipeline, q_consumer_state,
+                k_pipeline, k_consumer_state,
+                t_pipeline, t_consumer_state,
+                qk_pipeline, qk_producer_state,
+                kk_pipeline, kk_producer_state,
+                alpha_pipeline, alpha_consumer_state,
+                work_desc, scale, blk, False,
+                qk_tiled_mma, kk_tiled_mma,
+                tQKrQ, tQKrK, tQKcMqk, tKKcMkk, aux_tidx,
+            )
+
+        last_blk = num_blocks - 1
+        self.run_aux_loop_body(
+            sQK, sT, sKK_opd, sAlpha,
+            q_pipeline, q_consumer_state,
+            k_pipeline, k_consumer_state,
+            t_pipeline, t_consumer_state,
+            qk_pipeline, qk_producer_state,
+            kk_pipeline, kk_producer_state,
+            alpha_pipeline, alpha_consumer_state,
+            work_desc, scale, last_blk, True,
+            qk_tiled_mma, kk_tiled_mma,
+            tQKrQ, tQKrK, tQKcMqk, tKKcMkk, aux_tidx,
+        )
+
+    @cute.jit
+    def run_cp_state_math_role(
+        self,
+        sQ_SD: cute.Tensor,
+        sK_SD: cute.Tensor,
+        sK_DS: cute.Tensor,
+        sV_DS: cute.Tensor,
+        sQK: cute.Tensor,
+        sKK_inv: cute.Tensor,
+        sKK_opd: cute.Tensor,
+        sO: cute.Tensor,
+        sAlpha: cute.Tensor,
+        q_pipeline,
+        k_pipeline,
+        v_pipeline,
+        o_pipeline,
+        qk_pipeline,
+        kk_pipeline,
+        alpha_pipeline,
+        g_state: cute.Tensor,
+        g_init_state: cute.Tensor,
+        work_desc: WorkDesc,
+        public_seq_idx: cutlass.Int32,
+        init_state_idx: cutlass.Int32,
+        load_init_state,
+        store_state,
+        scale: cutlass.Float32,
+        wg_idx: cutlass.Int32,
+        math_tidx: cutlass.Int32,
+        num_blocks: cutlass.Int32,
+        num_q_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        num_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+    ):
+        self._math_order_init(wg_idx)
+        q_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.q_stage)
+        k_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.k_stage)
+        v_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.v_stage)
+        o_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.o_stage)
+        qk_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.qk_stage)
+        kk_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.kk_stage)
+        alpha_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+
+        kv_tiled_mma = cute.make_tiled_mma(
+            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
+                self.dtype, self.acc_dtype, (64, self.D, 16),
+                warpgroup.OperandSource.RMEM,
+                cute.nvgpu.OperandMajorMode.K,
+                cute.nvgpu.OperandMajorMode.MN,
+            )),
+            cute.make_layout((2, 1, 1)),
+        )
+        kv_thr_mma = kv_tiled_mma.get_slice(math_tidx)
+        tKVrKV = kv_thr_mma.make_fragment_C(kv_thr_mma.partition_shape_C((self.D, self.D)))
+        tKVrKV.fill(self.acc_dtype(0.0))
+
+        state_layout = cute.make_ordered_layout((self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3))
+        o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
+        mState = cute.make_tensor(g_state.iterator, state_layout)
+        gStateKV = mState[None, None, o_head_idx, public_seq_idx]
+        init_state_layout = cute.make_ordered_layout((self.D, self.D, num_sab_heads, num_chunks), order=(0, 1, 2, 3))
+        mInitState = cute.make_tensor(g_init_state.iterator, init_state_layout)
+        gInitKV = mInitState[None, None, o_head_idx, init_state_idx]
+        if load_init_state:
+            self.kv_load(tKVrKV, gInitKV, kv_tiled_mma, math_tidx)
+
+        first_B = work_desc.seq_len
+        if first_B > self.BLK_KV:
+            first_B = self.BLK_KV
+        (
+            q_consumer_state,
+            k_consumer_state,
+            v_consumer_state,
+            o_producer_state,
+            qk_consumer_state,
+            kk_consumer_state,
+            alpha_consumer_state,
+        ) = self.compute_loop_body(
+            sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha,
+            kv_tiled_mma,
+            q_pipeline, q_consumer_state,
+            k_pipeline, k_consumer_state,
+            v_pipeline, v_consumer_state,
+            o_pipeline, o_producer_state,
+            qk_pipeline, qk_consumer_state,
+            kk_pipeline, kk_consumer_state,
+            alpha_pipeline, alpha_consumer_state,
+            False, True, first_B,
+            tKVrKV, scale, wg_idx,
+        )
+
+        for blk in cutlass.range(1, num_blocks - 1, 1, unroll=1):
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                qk_consumer_state,
+                kk_consumer_state,
+                alpha_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha,
+                kv_tiled_mma,
+                q_pipeline, q_consumer_state,
+                k_pipeline, k_consumer_state,
+                v_pipeline, v_consumer_state,
+                o_pipeline, o_producer_state,
+                qk_pipeline, qk_consumer_state,
+                kk_pipeline, kk_consumer_state,
+                alpha_pipeline, alpha_consumer_state,
+                False, False, self.BLK_KV,
+                tKVrKV, scale, wg_idx,
+            )
+
+        if num_blocks != 1:
+            last_blk = num_blocks - 1
+            last_B = work_desc.seq_len - last_blk * self.BLK_KV
+            (
+                q_consumer_state,
+                k_consumer_state,
+                v_consumer_state,
+                o_producer_state,
+                qk_consumer_state,
+                kk_consumer_state,
+                alpha_consumer_state,
+            ) = self.compute_loop_body(
+                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha,
+                kv_tiled_mma,
+                q_pipeline, q_consumer_state,
+                k_pipeline, k_consumer_state,
+                v_pipeline, v_consumer_state,
+                o_pipeline, o_producer_state,
+                qk_pipeline, qk_consumer_state,
+                kk_pipeline, kk_consumer_state,
+                alpha_pipeline, alpha_consumer_state,
+                False, True, last_B,
+                tKVrKV, scale, wg_idx,
+            )
+        if store_state:
+            self.kv_store(tKVrKV, gStateKV, kv_tiled_mma, math_tidx)
+
+    @cute.jit
+    def __call__(
+        self,
+        g_q: cute.Tensor,
+        g_k: cute.Tensor,
+        g_v: cute.Tensor,
+        g_t: cute.Tensor,
+        g_o: cute.Tensor,
+        g_alpha: cute.Tensor,
+        g_state: cute.Tensor,
+        g_init_state: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        scale: cutlass.Float32,
+        num_q_heads: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        max_cp_chunks_per_seq: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        stream,
+    ):
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        q_storage_layout = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_Q, self.D, self.q_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        q_smem_layout = cute.slice_(q_storage_layout, (None, None, 0))
+        k_storage_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.k_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0, 2])
+        v_storage_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.v_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        v_storage_layout_ds = cute.select(v_storage_layout_sd, [1, 0, 2])
+        k_smem_layout = cute.slice_(k_storage_layout_ds, (None, None, 0))
+        v_smem_layout = cute.slice_(v_storage_layout_ds, (None, None, 0))
+        o_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.MN_SW32,
+            self.dtype,
+        )
+        o_storage_layout = cute.tile_to_shape(
+            o_smem_layout_atom,
+            (self.D, self.BLK_Q, self.o_stage),
+            order=(1, 0, 2),
+        )
+        o_smem_layout = cute.slice_(o_storage_layout, (None, None, 0))
+
+        qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        t_storage_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.t_stage), order=(0, 1, 2))
+        t_smem_layout = cute.slice_(t_storage_layout, (None, None, 0))
+
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_q, q_smem_layout, (self.BLK_Q, self.D))
+        tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_k, k_smem_layout, (self.D, self.BLK_KV))
+        tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_v, v_smem_layout, (self.D, self.BLK_KV))
+        tma_atom_t, tma_tensor_t = cpasync.make_tiled_tma_atom(
+            tma_load_op, g_t, t_smem_layout, (self.BLK_KV, self.BLK_KV))
+
+        tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
+        tma_atom_o, tma_tensor_o = cpasync.make_tiled_tma_atom(
+            tma_store_op, g_o, o_smem_layout, (self.D, self.BLK_Q))
+
+        dtype_bytes = self.dtype.width // 8
+        self.tma_load_q_bytes = cute.size(q_smem_layout) * dtype_bytes
+        self.tma_load_k_bytes = cute.size(k_smem_layout) * dtype_bytes
+        self.tma_load_v_bytes = cute.size(v_smem_layout) * dtype_bytes
+        self.tma_load_t_bytes = cute.size(t_smem_layout) * dtype_bytes
+
+        qk_storage_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_Q, self.BLK_KV, self.qk_stage), order=(0, 1, 2))
+        kk_storage_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.kk_stage), order=(0, 1, 2))
+        alpha_storage_layout = cute.make_layout(
+            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+
+        @cute.struct
+        class SharedStorage:
+            q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.q_stage * 2]
+            k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.k_stage * 2]
+            v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.v_stage * 2]
+            t_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.t_stage * 2]
+            o_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.o_stage * 2]
+            qk_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.qk_stage * 2]
+            kk_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.kk_stage * 2]
+            alpha_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_beta_stage * 2]
+
+            smem_q: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(q_storage_layout)], 128]
+            smem_k: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128]
+            smem_v: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(v_storage_layout_sd)], 128]
+            smem_t: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(t_storage_layout)], 16]
+            smem_qk: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(qk_storage_layout)], 16]
+            smem_kk: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(kk_storage_layout)], 16]
+            smem_o: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(o_storage_layout)], 128]
+            smem_alpha: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(alpha_storage_layout)], 16]
+
+        self.shared_storage = SharedStorage
+        self.kernel(
+            g_alpha,
+            tma_atom_q, tma_tensor_q,
+            tma_atom_k, tma_tensor_k,
+            tma_atom_v, tma_tensor_v,
+            tma_atom_t, tma_tensor_t,
+            tma_atom_o, tma_tensor_o,
+            g_state, g_init_state, g_tensormaps, g_cu_seqlens,
+            scale, num_q_heads, num_k_heads, num_v_heads, num_sab_heads, chunk_len, total_cp_chunks, num_seqs,
+        ).launch(
+            grid=(num_sab_heads * max_cp_chunks_per_seq, num_seqs, 1),
+            block=(512, 1, 1),
+            max_number_threads=(512, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        g_alpha: cute.Tensor,
+        tma_atom_q: cute.CopyAtom,
+        tma_tensor_q: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        tma_tensor_k: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        tma_tensor_v: cute.Tensor,
+        tma_atom_t: cute.CopyAtom,
+        tma_tensor_t: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        tma_tensor_o: cute.Tensor,
+        g_state: cute.Tensor,
+        g_init_state: cute.Tensor,
+        g_tensormaps: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        scale: cutlass.Float32,
+        num_q_heads: cutlass.Int32,
+        num_k_heads: cutlass.Int32,
+        num_v_heads: cutlass.Int32,
+        num_sab_heads: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+    ):
+        NUM_LOAD_WARP_GROUPS = 1
+        NUM_STATE_MMA_WARP_GROUPS = 2
+        NUM_AUX_MMA_WARP_GROUPS = 1
+        THREADS_PER_WARP_GROUP = 128
+        WARPS_PER_WARP_GROUP = 4
+        MIN_BLOCKS_PER_MP = 1
+        MAX_THREADS_PER_BLOCK = (
+            NUM_LOAD_WARP_GROUPS
+            + NUM_STATE_MMA_WARP_GROUPS
+            + NUM_AUX_MMA_WARP_GROUPS
+        ) * THREADS_PER_WARP_GROUP
+        (
+            load_registers,
+            state_mma_registers,
+            aux_mma_registers,
+        ) = self.get_register_requirements(
+            MAX_THREADS_PER_BLOCK,
+            MIN_BLOCKS_PER_MP,
+            NUM_STATE_MMA_WARP_GROUPS,
+            THREADS_PER_WARP_GROUP,
+        )
+
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        warp_group_idx = cute.arch.make_warp_uniform(
+            tidx // THREADS_PER_WARP_GROUP)
+        ldst_warp_role = cute.arch.make_warp_uniform(
+            warp_idx % WARPS_PER_WARP_GROUP)
+
+        bx, seq_idx, _ = cute.arch.block_idx()
+        o_head_idx = bx % num_sab_heads
+        q_head_idx = o_head_idx * num_q_heads // num_sab_heads
+        k_head_idx = o_head_idx * num_k_heads // num_sab_heads
+        v_head_idx = o_head_idx * num_v_heads // num_sab_heads
+        chunk_idx_in_seq = bx // num_sab_heads
+        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
+        seq_len = seq_end - seq_start
+        num_cp_chunks = chunks_for_len(seq_len, chunk_len)
+        is_valid_chunk = chunk_idx_in_seq < num_cp_chunks
+
+        tok_offset = seq_start + chunk_idx_in_seq * chunk_len
+        cp_chunk_idx = varlen_chunk_idx(seq_idx, seq_start, chunk_idx_in_seq, chunk_len)
+        valid_chunk_len = varlen_chunk_valid_len(seq_len, chunk_idx_in_seq, chunk_len)
+        num_blocks = (valid_chunk_len + self.BLK_KV - 1) // self.BLK_KV
+        t_blocks_per_cp_chunk = (chunk_len + self.BLK_KV - 1) // self.BLK_KV
+        t_block_start = varlen_chunk_idx(
+            seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK_KV)
+        work_desc = WorkDesc(
+            seq_idx=cp_chunk_idx,
+            private_q_head_idx=q_head_idx,
+            private_v_head_idx=v_head_idx,
+            tok_offset=tok_offset,
+            seq_len=valid_chunk_len,
+            tile_idx=0,
+        )
+        load_init_state = chunk_idx_in_seq != 0
+        init_state_idx = cp_chunk_idx
+        if load_init_state:
+            init_state_idx = cp_chunk_idx - 1
+        store_state = chunk_idx_in_seq == num_cp_chunks - 1
+
+        if warp_idx == LoadStoreWarpRole.LOAD_QKV:
+            cpasync.prefetch_descriptor(tma_atom_q)
+            cpasync.prefetch_descriptor(tma_atom_k)
+            cpasync.prefetch_descriptor(tma_atom_v)
+            cpasync.prefetch_descriptor(tma_atom_o)
+        elif warp_idx == LoadStoreWarpRole.LOAD_BETA:
+            cpasync.prefetch_descriptor(tma_atom_t)
+
+        math_tidx = tidx - THREADS_PER_WARP_GROUP
+        wg_idx    = math_tidx // THREADS_PER_WARP_GROUP
+
+        allocator = cutlass.utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+
+        qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.K_SW128,
+            self.dtype,
+        )
+        q_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_Q, self.D, self.q_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        sQ_SD = storage.smem_q.get_tensor(q_layout_sd.outer, swizzle=q_layout_sd.inner)
+
+        k_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.k_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        k_layout_ds = cute.select(k_layout_sd, [1, 0, 2])
+        sK_SD = storage.smem_k.get_tensor(k_layout_sd.outer, swizzle=k_layout_sd.inner)
+        sK_DS = storage.smem_k.get_tensor(k_layout_ds.outer, swizzle=k_layout_ds.inner)
+
+        v_layout_sd = cute.coalesce(
+            cute.tile_to_shape(
+                qkv_smem_layout_atom,
+                (self.BLK_KV, self.D, self.v_stage),
+                order=(0, 1, 2),
+            ),
+            target_profile=(1, 1, 1),
+        )
+        v_layout_ds = cute.select(v_layout_sd, [1, 0, 2])
+        sV_DS = storage.smem_v.get_tensor(v_layout_ds.outer, swizzle=v_layout_ds.inner)
+
+        qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
+        qk_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_Q, self.BLK_KV, self.qk_stage), order=(0, 1, 2))
+        kk_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.kk_stage), order=(0, 1, 2))
+        t_layout = cute.tile_to_shape(
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.t_stage), order=(0, 1, 2))
+        sQK = storage.smem_qk.get_tensor(qk_layout)
+        sKK_opd = storage.smem_kk.get_tensor(kk_layout)
+        sKK_inv = sKK_opd
+        sT = storage.smem_t.get_tensor(t_layout)
+
+        o_smem_layout_atom = warpgroup.make_smem_layout_atom(
+            warpgroup.SmemLayoutAtomKind.MN_SW32,
+            self.dtype,
+        )
+        o_layout = cute.tile_to_shape(
+            o_smem_layout_atom,
+            (self.D, self.BLK_Q, self.o_stage),
+            order=(1, 0, 2),
+        )
+        sO = storage.smem_o.get_tensor(o_layout.outer, swizzle=o_layout.inner)
+        alpha_layout = cute.make_layout(
+            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+        sAlpha = storage.smem_alpha.get_tensor(alpha_layout)
+
+        load_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        qk_load_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            (NUM_STATE_MMA_WARP_GROUPS + NUM_AUX_MMA_WARP_GROUPS) * WARPS_PER_WARP_GROUP,
+        )
+        v_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            NUM_STATE_MMA_WARP_GROUPS * WARPS_PER_WARP_GROUP,
+        )
+        t_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            NUM_AUX_MMA_WARP_GROUPS * WARPS_PER_WARP_GROUP,
+        )
+        vector_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        alpha_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            (NUM_AUX_MMA_WARP_GROUPS + NUM_STATE_MMA_WARP_GROUPS)
+            * THREADS_PER_WARP_GROUP,
+        )
+        o_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, NUM_STATE_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP
+        )
+        o_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        q_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.q_mbar_ptr.data_ptr(),
+            num_stages=self.q_stage,
+            producer_group=load_producer_group,
+            consumer_group=qk_load_consumer_group,
+            tx_count=self.tma_load_q_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        k_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.k_mbar_ptr.data_ptr(),
+            num_stages=self.k_stage,
+            producer_group=load_producer_group,
+            consumer_group=qk_load_consumer_group,
+            tx_count=self.tma_load_k_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        v_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.v_mbar_ptr.data_ptr(),
+            num_stages=self.v_stage,
+            producer_group=load_producer_group,
+            consumer_group=v_consumer_group,
+            tx_count=self.tma_load_v_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        t_pipeline = pipeline.PipelineTmaAsync.create(
+            barrier_storage=storage.t_mbar_ptr.data_ptr(),
+            num_stages=self.t_stage,
+            producer_group=load_producer_group,
+            consumer_group=t_consumer_group,
+            tx_count=self.tma_load_t_bytes,
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        o_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.o_mbar_ptr.data_ptr(),
+            num_stages=self.o_stage,
+            producer_group=o_producer_group,
+            consumer_group=o_consumer_group,
+        )
+        qk_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.qk_mbar_ptr.data_ptr(),
+            num_stages=self.qk_stage,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_AUX_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP,
+            ),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_STATE_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP,
+            ),
+        )
+        kk_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.kk_mbar_ptr.data_ptr(),
+            num_stages=self.kk_stage,
+            producer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_AUX_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP,
+            ),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                NUM_STATE_MMA_WARP_GROUPS * THREADS_PER_WARP_GROUP,
+            ),
+        )
+        alpha_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.alpha_mbar_ptr.data_ptr(),
+            num_stages=self.alpha_beta_stage,
+            producer_group=vector_producer_group,
+            consumer_group=alpha_consumer_group,
+        )
+        cute.arch.mbarrier_init_fence()
+        cute.arch.sync_threads()
+
+        if is_valid_chunk:
+            if warp_group_idx == WarpGroupRole.LDST:
+                cute.arch.setmaxregister_decrease(load_registers)
+                if ldst_warp_role == LoadStoreWarpRole.LOAD_QKV:
+                    self.run_load_qkv_role(
+                        sQ_SD, sK_DS, sV_DS,
+                        tma_atom_q, tma_tensor_q,
+                        tma_atom_k, tma_tensor_k,
+                        tma_atom_v, tma_tensor_v,
+                        q_pipeline, k_pipeline, v_pipeline,
+                        num_blocks, work_desc.tok_offset,
+                        q_head_idx, k_head_idx, v_head_idx,
+                    )
+                elif ldst_warp_role == LoadStoreWarpRole.STORE_O:
+                    CollectiveStoreTma(self.BLK_Q, self.D).run(
+                        sO, tma_atom_o, tma_tensor_o, g_tensormaps,
+                        o_pipeline, num_blocks, work_desc, total_cp_chunks, self.o_stage,
+                        num_q_heads, num_v_heads,
+                    )
+                elif ldst_warp_role == LoadStoreWarpRole.LOAD_BETA:
+                    self.run_load_t_role(
+                        sT, tma_atom_t, tma_tensor_t, t_pipeline,
+                        num_blocks, t_block_start, o_head_idx,
+                    )
+                elif ldst_warp_role == LoadStoreWarpRole.LOAD_ALPHA:
+                    self.run_load_alpha_role(
+                        sAlpha, g_alpha, alpha_pipeline, scale, num_blocks, work_desc.tok_offset,
+                        work_desc.tok_offset + work_desc.seq_len, o_head_idx, num_sab_heads,
+                    )
+            else:
+                if warp_group_idx == WarpGroupRole.MATH_AUX:
+                    cute.arch.setmaxregister_decrease(aux_mma_registers)
+                    self.run_aux_math_role(
+                        sQ_SD, sK_SD, sQK, sT, sKK_opd, sAlpha,
+                        q_pipeline, k_pipeline, t_pipeline, qk_pipeline, kk_pipeline,
+                        alpha_pipeline, work_desc, scale, math_tidx, num_blocks,
+                    )
+                else:
+                    cute.arch.setmaxregister_increase(state_mma_registers)
+                    self.run_cp_state_math_role(
+                        sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd,
+                        sO, sAlpha,
+                        q_pipeline, k_pipeline, v_pipeline, o_pipeline,
+                        qk_pipeline, kk_pipeline, alpha_pipeline,
+                        g_state, g_init_state, work_desc,
+                        seq_idx, init_state_idx, load_init_state, store_state,
+                        scale, wg_idx, math_tidx, num_blocks,
+                        num_q_heads, num_v_heads, num_sab_heads, total_cp_chunks, num_seqs,
+                    )
+
+
+def cp_delta_rule_prefill_dsl_sm90(
+    o: torch.Tensor,
+    state: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    t: torch.Tensor,
+    init_state: torch.Tensor,
+    alpha: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.Tensor,
+    total_seqlen: int,
+    cp_chunk_len: int = 4096,
+    max_seqlen: int | None = None,
+    *,
+    _skip_check: bool = False,
+):
+    """Run CP main prefill with precomputed T and fixed-up chunk states.
+
+    Flat varlen input consumes flat Q/K/V/O/alpha tensors and varlen T/init
+    workspaces. `state` is the public per-sequence final state in native
+    `(DimV, DimK)` layout.
+    """
+    from cutlass.cute.runtime import from_dlpack
+    import cuda.bindings.driver as cuda_driver
+
+    if not _skip_check:
+        if q.ndim != 3:
+            raise RuntimeError(f"q must have shape (total_seqlen, num_q_heads, D), got {tuple(q.shape)}")
+        if k.ndim != 3 or v.ndim != 3 or o.ndim != 3:
+            raise RuntimeError(
+                "k, v, and o must have shape (total_seqlen, num_heads, D), "
+                f"got k={tuple(k.shape)}, v={tuple(v.shape)}, o={tuple(o.shape)}"
+            )
+        if k.shape[0] != q.shape[0] or v.shape[0] != q.shape[0] or o.shape[0] != q.shape[0]:
+            raise RuntimeError("q, k, v, and o must have the same total_seqlen")
+        if k.shape[2] != q.shape[2] or v.shape[2] != q.shape[2] or o.shape[2] != q.shape[2]:
+            raise RuntimeError("q, k, v, and o must have the same D")
+        if alpha.ndim != 2 or alpha.shape[0] != q.shape[0]:
+            raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
+        if total_seqlen != q.shape[0]:
+            raise RuntimeError(f"total_seqlen must match q.shape[0], got {total_seqlen} and {q.shape[0]}")
+        if max_seqlen is not None and max_seqlen <= 0:
+            raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
+        if cp_chunk_len % 64 != 0:
+            raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
+        if cu_seqlens.dtype != torch.int64:
+            raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+        if not cu_seqlens.is_contiguous():
+            raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+    _, num_q_heads, d = q.shape
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
+    total_cp_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
+    if not _skip_check:
+        if o.shape[1] != num_sab_heads:
+            raise RuntimeError(f"o heads must equal max(q heads, v heads)={num_sab_heads}, got {o.shape[1]}")
+        if alpha.shape[1] != num_sab_heads:
+            raise RuntimeError(f"alpha heads must equal max(q heads, v heads)={num_sab_heads}, got {alpha.shape[1]}")
+        if not _FullyFusedDeltaRuleSm90.can_implement(num_q_heads, num_k_heads, num_v_heads, d, q.element_size()):
+            raise RuntimeError(
+                "CPDeltaRulePrefillSm90 only supports head counts where q/v heads are positive multiples "
+                f"of k heads, got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
+            )
+        if t.shape != (total_t_blocks, num_sab_heads, 64, 64):
+            raise RuntimeError(
+                "t must have shape "
+                f"{(total_t_blocks, num_sab_heads, 64, 64)}, got {tuple(t.shape)}"
+            )
+        expected_init_state_shape = (total_cp_chunks, num_sab_heads, d, d)
+        expected_state_shape = (num_seqs, num_sab_heads, d, d)
+        if init_state.shape != expected_init_state_shape or state.shape != expected_state_shape:
+            raise RuntimeError(
+                "init_state/state must have shapes "
+                f"{expected_init_state_shape} and {expected_state_shape}, "
+                f"got {tuple(init_state.shape)} and {tuple(state.shape)}"
+            )
+        if q.shape[-1] != 128:
+            raise RuntimeError(f"CPDeltaRulePrefillSm90 only supports D=128, got {q.shape[-1]}")
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            raise RuntimeError(f"CPDeltaRulePrefillSm90 only supports fp16/bf16 inputs, got {q.dtype}")
+        if k.dtype != q.dtype or v.dtype != q.dtype or o.dtype != q.dtype or t.dtype != q.dtype:
+            raise RuntimeError(
+                "q/k/v/o/t dtypes must match, "
+                f"got q={q.dtype}, k={k.dtype}, v={v.dtype}, o={o.dtype}, t={t.dtype}"
+            )
+        if alpha.dtype != torch.float32:
+            raise RuntimeError(f"alpha must have dtype torch.float32, got {alpha.dtype}")
+        for name, tensor in (
+            ("q", q), ("k", k), ("v", v), ("t", t), ("init_state", init_state), ("alpha", alpha), ("o", o), ("state", state)
+        ):
+            if not tensor.is_contiguous():
+                raise RuntimeError(f"{name} must be contiguous")
+
+    max_cp_chunks_per_seq = max_num_chunks_host(cu_seqlens, cp_chunk_len, max_seqlen)
+    if total_cp_chunks == 0:
+        return
+    q_tma = q.as_strided(
+        (total_seqlen, d, num_q_heads),
+        (num_q_heads * d, 1, d),
+    )
+    k_tma = k.as_strided(
+        (d, total_seqlen, num_k_heads),
+        (1, num_k_heads * d, d),
+    )
+    v_tma = v.as_strided(
+        (d, total_seqlen, num_v_heads),
+        (1, num_v_heads * d, d),
+    )
+    o_tma = o.as_strided(
+        (d, total_seqlen, num_sab_heads),
+        (1, num_sab_heads * d, d),
+    )
+    t_tma = t.as_strided(
+        (64, 64, num_sab_heads, total_t_blocks),
+        (
+            64,
+            1,
+            64 * 64,
+            num_sab_heads * 64 * 64,
+        ),
+    )
+
+    kernel_dtype = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+    }[q.dtype]
+
+    sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
+    tensormaps_t = torch.empty(sm_count * 128, dtype=torch.uint8, device=q.device)
+    stream_val = torch.cuda.current_stream().cuda_stream
+    stream = cuda_driver.CUstream(stream_val)
+
+    enable_tvm_ffi = True
+    if enable_tvm_ffi:
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
+
+    kernel = CPDeltaRulePrefillSm90(kernel_dtype)
+    kernel_args = (
+        from_dlpack(q_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
+        from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+        from_dlpack(v_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+        from_dlpack(t_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
+        from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
+        from_dlpack(alpha.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(init_state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic(),
+        from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
+        cutlass.Float32(scale),
+        cutlass.Int32(num_q_heads),
+        cutlass.Int32(num_k_heads),
+        cutlass.Int32(num_v_heads),
+        cutlass.Int32(num_sab_heads),
+        cutlass.Int32(cp_chunk_len),
+        cutlass.Int32(total_cp_chunks),
+        cutlass.Int32(max_cp_chunks_per_seq),
+        cutlass.Int32(num_seqs),
+        stream,
+    )
+    compiled = cached_compile(
+        kernel,
+        *kernel_args,
+        compile_options=(cute.GPUArch("sm_90a"),),
+    )
+    compiled(*kernel_args)
+
+
+def cp_delta_rule_dsl_sm90(
+    o: torch.Tensor,
+    state: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    alpha: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    scale: float,
+    *,
+    max_seqlen: int,
+    cp_chunk_len: int | None = None,
+    cp_chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
+):
+    """Run the CP SM90 delta-rule prefill pipeline on flat varlen tensors.
+
+    Q/K/V/alpha/beta/O/state follow the same public layout as the non-CP
+    prefill path. Internal T, M, N, and fixed-state tensors use the varlen
+    workspace layout.
+    """
+    total_seqlen = q.shape[0]
+    if cp_chunk_len is None:
+        num_heads = max(q.shape[1], v.shape[1])
+        num_sms = torch.cuda.get_device_properties(q.device).multi_processor_count
+        cp_chunk_len = choose_cp_chunk_len_host(
+            max_seqlen,
+            num_heads,
+            num_sms,
+            chunk_len_granularity=cp_chunk_len_granularity,
+        )
+    if q.ndim != 3:
+        raise RuntimeError(f"q must have shape (total_seqlen, num_q_heads, D), got {tuple(q.shape)}")
+    if k.ndim != 3 or v.ndim != 3 or o.ndim != 3:
+        raise RuntimeError(
+            "k, v, and o must have shape (total_seqlen, num_heads, D), "
+            f"got k={tuple(k.shape)}, v={tuple(v.shape)}, o={tuple(o.shape)}"
+        )
+    if k.shape[0] != q.shape[0] or v.shape[0] != q.shape[0] or o.shape[0] != q.shape[0]:
+        raise RuntimeError("q, k, v, and o must have the same total_seqlen")
+    if k.shape[2] != q.shape[2] or v.shape[2] != q.shape[2] or o.shape[2] != q.shape[2]:
+        raise RuntimeError("q, k, v, and o must have the same D")
+    if alpha.ndim != 2 or alpha.shape[0] != q.shape[0]:
+        raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
+    if beta.ndim != 2 or beta.shape[0] != q.shape[0]:
+        raise RuntimeError(f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}")
+    if max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
+    if cp_chunk_len % 64 != 0:
+        raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
+    if cu_seqlens.dtype != torch.int64:
+        raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+    if not cu_seqlens.is_contiguous():
+        raise RuntimeError("cu_seqlens must be contiguous")
+    num_seqs = cu_seqlens.shape[0] - 1
+    _, num_q_heads, d = q.shape
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    if o.shape[1] != num_sab_heads:
+        raise RuntimeError(f"o heads must equal max(q heads, v heads)={num_sab_heads}, got {o.shape[1]}")
+    if alpha.shape[1] != num_sab_heads:
+        raise RuntimeError(f"alpha heads must equal max(q heads, v heads)={num_sab_heads}, got {alpha.shape[1]}")
+    if beta.shape[1] != num_sab_heads:
+        raise RuntimeError(f"beta heads must equal max(q heads, v heads)={num_sab_heads}, got {beta.shape[1]}")
+    if not _FullyFusedDeltaRuleSm90.can_implement(num_q_heads, num_k_heads, num_v_heads, d, q.element_size()):
+        raise RuntimeError(
+            "CPDeltaRuleSm90 only supports head counts where q/v heads are positive multiples "
+            f"of k heads, got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
+        )
+    expected_state_shape = (num_seqs, num_sab_heads, d, d)
+    if state.shape != expected_state_shape:
+        raise RuntimeError(f"state must have shape {expected_state_shape}, got {tuple(state.shape)}")
+    if q.shape[-1] != 128:
+        raise RuntimeError(f"CPDeltaRuleSm90 only supports D=128, got {q.shape[-1]}")
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        raise RuntimeError(f"CPDeltaRuleSm90 only supports fp16/bf16 inputs, got {q.dtype}")
+    if k.dtype != q.dtype or v.dtype != q.dtype or o.dtype != q.dtype:
+        raise RuntimeError(
+            "q/k/v/o dtypes must match, "
+            f"got q={q.dtype}, k={k.dtype}, v={v.dtype}, o={o.dtype}"
+        )
+    if alpha.dtype != torch.float32 or beta.dtype != torch.float32:
+        raise RuntimeError(f"alpha/beta must have dtype torch.float32, got {alpha.dtype} and {beta.dtype}")
+    for name, tensor in (
+        ("q", q), ("k", k), ("v", v), ("alpha", alpha), ("beta", beta), ("o", o), ("state", state)
+    ):
+        if not tensor.is_contiguous():
+            raise RuntimeError(f"{name} must be contiguous")
+
+    t = cp_delta_rule_t_precompute_dsl_sm90(
+        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen, _skip_check=True)
+    local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
+        k, v, t, alpha, cu_seqlens, total_seqlen,
+        cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen, _skip_check=True)
+    fixed_state = cp_delta_rule_fixup_dsl_sm90(
+        local_transfer, local_state, cu_seqlens, total_seqlen,
+        cp_chunk_len=cp_chunk_len, _skip_check=True)
+
+    state.zero_()
+    cp_delta_rule_prefill_dsl_sm90(
+        o, state, q, k, v, t, fixed_state, alpha, scale,
+        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen, _skip_check=True,
+    )

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -2044,9 +2044,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         for i in cutlass.range_constexpr(cute.size(tKKrT)):
             s, t = tKKcMkk_cv[i]
             value = cutlass.Float32(0.0)
-            pred = True
+            pred = s >= t
             if cutlass.const_expr(is_final_block):
-                pred = s < B and t < B
+                pred = pred and s < B and t < B
             if pred:
                 gamma = cute.math.exp2(
                     cutlass.Float32(alpha_log[s]) - cutlass.Float32(alpha_log[t]),

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -15,6 +15,7 @@ from cutlass.cute.nvgpu import warp
 from cutlass.cute.nvgpu import warpgroup
 from cutlass.cute.typing import Shape
 
+from ...utils import get_device_sm_count, _get_cache_buf
 from .alpha import AlphaProcessor
 from .collective_inverse_hmma import CollectiveInverse
 from .collective_store_tma import CollectiveStoreTma
@@ -3862,8 +3863,8 @@ def cp_delta_rule_prefill_dsl_sm90(
         torch.bfloat16: cutlass.BFloat16,
     }[q.dtype]
 
-    sm_count = torch.cuda.get_device_properties(q.device).multi_processor_count
-    tensormaps_t = torch.empty(sm_count * 128, dtype=torch.uint8, device=q.device)
+    workspace_size = get_device_sm_count(q.device) * 128
+    tensormaps_t = _get_cache_buf("gdn_cp_prefill_tensormaps", workspace_size, q.device)
     stream_val = torch.cuda.current_stream().cuda_stream
     stream = cuda_driver.CUstream(stream_val)
 
@@ -3945,7 +3946,7 @@ def cp_delta_rule_dsl_sm90(
         raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
     if cp_chunk_len is None:
         num_heads = max(q.shape[1], v.shape[1])
-        num_sms = torch.cuda.get_device_properties(q.device).multi_processor_count
+        num_sms = get_device_sm_count(q.device)
         cp_chunk_len = choose_cp_chunk_len_host(
             max_seqlen,
             num_heads,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -1,19 +1,12 @@
-from dataclasses import dataclass
 from enum import IntEnum
 
 import torch
 import cutlass
 import cutlass.cute as cute
-from cutlass.cutlass_dsl import T
-from cutlass._mlir.dialects import llvm
-import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
 import cutlass.pipeline as pipeline
-from cutlass.cute import core as cute_core
-from cutlass.cute.atom import Trait, make_atom
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu import warp
 from cutlass.cute.nvgpu import warpgroup
-from cutlass.cute.typing import Shape
 
 from ...utils import get_device_sm_count, _get_cache_buf
 from .alpha import AlphaProcessor
@@ -22,6 +15,8 @@ from .collective_store_tma import CollectiveStoreTma
 from .custom_compile_cache import KeyedCompileMixin, cached_compile
 from .helpers import (
     SM90,
+    TF32,
+    WarpMmaTF32Op,
     load_tensor_as_c,
     load_tensor_as_a,
     round_down,
@@ -48,51 +43,6 @@ class NamedBarrier(IntEnum):
     MATH_WG0 = 4
     MATH_WG1 = 5
     MATH_SYNC = 6
-
-
-@dataclass(frozen=True)
-class WarpMmaTF32Op(warp.WarpMmaOp):
-    shape_mnk: Shape
-
-    def __post_init__(self) -> None:
-        if self.shape_mnk != (16, 8, 8):
-            raise ValueError(
-                f"WarpMmaTF32Op only supports (16, 8, 8), got {self.shape_mnk}"
-            )
-
-    def _make_trait(self, *, loc=None, ip=None, **kwargs):
-        shape_mnk = cute_core._pack_shape(self.shape_mnk, loc=loc, ip=ip)
-        ty = _cute_nvgpu_ir.MmaAtomSM80Type.get(
-            shape_mnk.type.attribute,
-            cutlass.TFloat32.mlir_type,
-            cutlass.TFloat32.mlir_type,
-            cutlass.Float32.mlir_type,
-        )
-        return WarpMmaTF32Trait(make_atom(ty, loc=loc, ip=ip))
-
-    def _verify_fragment_A(self, input, *, loc=None, ip=None):
-        return True
-
-    def _verify_fragment_B(self, input, *, loc=None, ip=None):
-        return True
-
-
-class WarpMmaTF32Trait(Trait):
-    pass
-
-
-@cute.jit
-def round_to_tf32_f32(value: cutlass.Float32) -> cutlass.Float32:
-    bits = llvm.inline_asm(
-        T.i32(),
-        [value.ir_value()],
-        "cvt.rz.tf32.f32 $0, $1;",
-        "=r,f",
-        has_side_effects=False,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-    )
-    return cutlass.Float32(llvm.bitcast(T.f32(), bits))
 
 
 class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
@@ -1905,46 +1855,6 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         return tensor_producer_state
 
     @cute.jit
-    def convert_fp32_to_tf32_residual(
-        self,
-        tensor: cute.Tensor,
-    ):
-        residual = cute.make_rmem_tensor_like(tensor, cutlass.Float32)
-        for i in cutlass.range_constexpr(cute.size(residual)):
-            value = tensor[i]
-            residual[i] = value - round_to_tf32_f32(value)
-        return cute.recast_tensor(residual, cutlass.TFloat32)
-
-    @cute.jit
-    def convert_tf32_c_to_kpermuted_a(
-        self,
-        tCrC: cute.Tensor,
-        tCrA: cute.Tensor,
-    ):
-        for i in cutlass.range(cute.size(tCrA), unroll_full=True):
-            tCrA[i] = tCrC[i]
-        for m in cutlass.range_constexpr(cute.size(tCrA, mode=[1])):
-            for k in cutlass.range_constexpr(cute.size(tCrA, mode=[2])):
-                tmp = tCrA[(1, 0), m, k]
-                tCrA[(1, 0), m, k] = tCrA[(0, 1), m, k]
-                tCrA[(0, 1), m, k] = tmp
-
-    @cute.jit
-    def load_tf32_kpermuted_b(
-        self,
-        tCrB: cute.Tensor,
-        sB_NK: cute.Tensor,
-        lane_idx: cutlass.Int32,
-    ):
-        sB_8x8 = cute.flat_divide(sB_NK, (8, 8))
-        n = lane_idx // 4
-        k = lane_idx - n * 4
-        for iter_n in cutlass.range_constexpr(cute.size(tCrB, mode=[1])):
-            for iter_k in cutlass.range_constexpr(cute.size(tCrB, mode=[2])):
-                tCrB[0, iter_n, iter_k] = sB_8x8[n, k * 2, iter_n, iter_k]
-                tCrB[1, iter_n, iter_k] = sB_8x8[n, k * 2 + 1, iter_n, iter_k]
-
-    @cute.jit
     def store_fixed_state(
         self,
         tiled_store_C,
@@ -2050,7 +1960,7 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             cute.autovec_copy(tSMgInitialState, tSMrState_cv)
 
         for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
-            self.convert_tf32_c_to_kpermuted_a(tSMrState, tSMrS)
+            TF32.convert_tf32_c_to_kpermuted_a(tSMrState, tSMrS)
             n_pipeline.consumer_wait(n_consumer_state)
             m_pipeline.consumer_wait(m_consumer_state)
             cute.arch.fence_view_async_shared()
@@ -2058,7 +1968,7 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
                 tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv
             )
 
-            self.load_tf32_kpermuted_b(
+            TF32.load_tf32_kpermuted_b(
                 tSMrM, sM_NK[None, None, m_consumer_state.index], lane_idx
             )
             for iter_k in cutlass.range_constexpr(self.k_tiles):
@@ -2070,11 +1980,11 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
                 )
                 cute.gemm(tiled_mma, tSMrState, tSMrS_h, tSMrM_h, tSMrState)
                 if cutlass.const_expr(self.use_3xtf32):
-                    tSMrM_l = self.convert_fp32_to_tf32_residual(
+                    tSMrM_l = TF32.convert_fp32_to_tf32_residual(
                         tSMrM[None, None, iter_k]
                     )
                     cute.gemm(tiled_mma, tSMrState, tSMrS_h, tSMrM_l, tSMrState)
-                    tSMrS_l = self.convert_fp32_to_tf32_residual(
+                    tSMrS_l = TF32.convert_fp32_to_tf32_residual(
                         tSMrS[None, None, iter_k]
                     )
                     tSMrM_h = cute.recast_tensor(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -19,7 +19,13 @@ from .alpha import AlphaProcessor
 from .collective_inverse_hmma import CollectiveInverse
 from .collective_store_tma import CollectiveStoreTma
 from .custom_compile_cache import KeyedCompileMixin, cached_compile
-from .helpers import SM90, load_tensor_as_c, load_tensor_as_a, round_down, select_tensor_10
+from .helpers import (
+    SM90,
+    load_tensor_as_c,
+    load_tensor_as_a,
+    round_down,
+    select_tensor_10,
+)
 from .varlen_helper import (
     CP_CHUNK_LEN_GRANULARITY,
     choose_cp_chunk_len_host,
@@ -50,7 +56,9 @@ class WarpMmaTF32Op(warp.WarpMmaOp):
 
     def __post_init__(self) -> None:
         if self.shape_mnk != (16, 8, 8):
-            raise ValueError(f"WarpMmaTF32Op only supports (16, 8, 8), got {self.shape_mnk}")
+            raise ValueError(
+                f"WarpMmaTF32Op only supports (16, 8, 8), got {self.shape_mnk}"
+            )
 
     def _make_trait(self, *, loc=None, ip=None, **kwargs):
         shape_mnk = cute_core._pack_shape(self.shape_mnk, loc=loc, ip=ip)
@@ -93,11 +101,11 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
     ):
-        self.dtype         = dtype
-        self.acc_dtype     = acc_dtype
+        self.dtype = dtype
+        self.acc_dtype = acc_dtype
         self.inverse_dtype = cutlass.Float16
-        self.BLK          = 64
-        self.D            = 128
+        self.BLK = 64
+        self.D = 128
         self.manual_cache_key("dtype", "acc_dtype", "inverse_dtype", "BLK", "D")
 
     @cute.jit
@@ -115,9 +123,7 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
             (0, tok_offset),
             tma_tensor_k[None, None, head_idx],
         )
-        gK = cute.zipped_divide(mK, (self.D, self.BLK))[
-            ((None, None), (0, 0))
-        ]
+        gK = cute.zipped_divide(mK, (self.D, self.BLK))[((None, None), (0, 0))]
         tKsK, tKgK = cpasync.tma_partition(
             tma_atom_k,
             0,
@@ -169,13 +175,14 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         tKKcMkk: cute.Tensor,
     ):
         stsm_atom = cute.make_copy_atom(
-            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype
+        )
         tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
-        thr_store   = tiled_store.get_slice(thread_idx)
-        tKKsKK      = thr_store.partition_D(sKK_inv)
-        tKKrKK_cv   = thr_store.retile(tKKrKK)
-        tKKcMkk_cv  = thr_store.retile(tKKcMkk)
-        tKKrIKK     = cute.make_fragment_like(tKKrKK_cv, self.inverse_dtype)
+        thr_store = tiled_store.get_slice(thread_idx)
+        tKKsKK = thr_store.partition_D(sKK_inv)
+        tKKrKK_cv = thr_store.retile(tKKrKK)
+        tKKcMkk_cv = thr_store.retile(tKKcMkk)
+        tKKrIKK = cute.make_fragment_like(tKKrKK_cv, self.inverse_dtype)
         for i in cutlass.range_constexpr(cute.size(tKKrKK_cv)):
             row, col = tKKcMkk_cv[i]
             value = cutlass.Float32(0.0)
@@ -210,23 +217,28 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         tidx: cutlass.Int32,
     ):
         ldsm_atom = cute.make_copy_atom(
-            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype)
+            warp.LdMatrix8x8x16bOp(transpose=False, num_matrices=4), self.inverse_dtype
+        )
         tiled_load = cute.make_tiled_copy_C(ldsm_atom, kk_tiled_mma)
-        thr_load   = tiled_load.get_slice(tidx)
-        tTsT       = thr_load.partition_S(sKK_inv)
-        tTrInv     = cute.make_rmem_tensor(kk_tiled_mma.partition_shape_C((self.BLK, self.BLK)), self.inverse_dtype)
-        tTrInv_cv  = thr_load.retile(tTrInv)
+        thr_load = tiled_load.get_slice(tidx)
+        tTsT = thr_load.partition_S(sKK_inv)
+        tTrInv = cute.make_rmem_tensor(
+            kk_tiled_mma.partition_shape_C((self.BLK, self.BLK)), self.inverse_dtype
+        )
+        tTrInv_cv = thr_load.retile(tTrInv)
         cute.copy(tiled_load, tTsT, tTrInv_cv)
 
-        store_atom  = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.dtype)
+        store_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.dtype)
         tiled_store = cute.make_tiled_copy_C(store_atom, kk_tiled_mma)
-        thr_store   = tiled_store.get_slice(tidx)
-        tTgT        = thr_store.partition_D(gT_CR)
-        cT_CR       = cute.make_identity_tensor((self.BLK, self.BLK))
-        tTcT        = thr_store.partition_D(cT_CR)
+        thr_store = tiled_store.get_slice(tidx)
+        tTgT = thr_store.partition_D(gT_CR)
+        cT_CR = cute.make_identity_tensor((self.BLK, self.BLK))
+        tTcT = thr_store.partition_D(cT_CR)
         tTrInv_store = thr_store.retile(tTrInv)
-        tTrT        = cute.make_rmem_tensor(kk_tiled_mma.partition_shape_C((self.BLK, self.BLK)), self.dtype)
-        tTrT_store  = thr_store.retile(tTrT)
+        tTrT = cute.make_rmem_tensor(
+            kk_tiled_mma.partition_shape_C((self.BLK, self.BLK)), self.dtype
+        )
+        tTrT_store = thr_store.retile(tTrT)
 
         for i in cutlass.range_constexpr(cute.size(tTrT_store)):
             col, row = tTcT[i]
@@ -255,10 +267,14 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
             warpgroup.SmemLayoutAtomKind.K_SW128,
             self.dtype,
         )
-        k_storage_layout_sd = cute.tile_to_shape(qkv_smem_layout_atom, (self.BLK, self.D), order=(0, 1))
+        k_storage_layout_sd = cute.tile_to_shape(
+            qkv_smem_layout_atom, (self.BLK, self.D), order=(0, 1)
+        )
         k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0])
         kk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
-        kk_layout = cute.tile_to_shape(kk_layout_atom, (self.BLK, self.BLK), order=(0, 1))
+        kk_layout = cute.tile_to_shape(
+            kk_layout_atom, (self.BLK, self.BLK), order=(0, 1)
+        )
         beta_layout = cute.make_layout(self.BLK)
 
         tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
@@ -274,14 +290,27 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         class SharedStorage:
             k_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
             beta_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
-            smem_k: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128]
-            smem_kk: cute.struct.Align[cute.struct.MemRange[self.inverse_dtype, cute.cosize(kk_layout)], 16]
-            smem_beta: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_layout)], 16]
+            smem_k: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128
+            ]
+            smem_kk: cute.struct.Align[
+                cute.struct.MemRange[self.inverse_dtype, cute.cosize(kk_layout)], 16
+            ]
+            smem_beta: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(beta_layout)], 16
+            ]
 
         self.shared_storage = SharedStorage
         self.kernel(
-            tma_atom_k, tma_tensor_k, g_beta, g_t, cu_seqlens,
-            num_k_heads, num_sab_heads, total_t_blocks, num_seqs,
+            tma_atom_k,
+            tma_tensor_k,
+            g_beta,
+            g_t,
+            cu_seqlens,
+            num_k_heads,
+            num_sab_heads,
+            total_t_blocks,
+            num_seqs,
         ).launch(
             grid=(num_sab_heads * max_t_blocks_per_seq, num_seqs, 1),
             block=(128, 1, 1),
@@ -315,12 +344,16 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
         num_blocks = chunks_for_len(seq_len, self.BLK)
         if block_idx_in_seq < num_blocks:
             tok_offset = seq_start + block_idx_in_seq * self.BLK
-            t_block_idx = varlen_chunk_idx(seq_idx, seq_start, block_idx_in_seq, self.BLK)
+            t_block_idx = varlen_chunk_idx(
+                seq_idx, seq_start, block_idx_in_seq, self.BLK
+            )
             valid_len = varlen_chunk_valid_len(seq_len, block_idx_in_seq, self.BLK)
             mT = cute.make_tensor(
                 g_t.iterator,
                 cute.make_ordered_layout(
-                    (self.BLK, self.BLK, num_sab_heads, total_t_blocks), order=(0, 1, 2, 3)),
+                    (self.BLK, self.BLK, num_sab_heads, total_t_blocks),
+                    order=(0, 1, 2, 3),
+                ),
             )
             gT = mT[None, None, sab_head_idx, t_block_idx]
 
@@ -328,15 +361,21 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
                 warpgroup.SmemLayoutAtomKind.K_SW128,
                 self.dtype,
             )
-            k_storage_layout_sd = cute.tile_to_shape(qkv_smem_layout_atom, (self.BLK, self.D), order=(0, 1))
+            k_storage_layout_sd = cute.tile_to_shape(
+                qkv_smem_layout_atom, (self.BLK, self.D), order=(0, 1)
+            )
             k_storage_layout_ds = cute.select(k_storage_layout_sd, [1, 0])
             kk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
-            kk_layout = cute.tile_to_shape(kk_layout_atom, (self.BLK, self.BLK), order=(0, 1))
+            kk_layout = cute.tile_to_shape(
+                kk_layout_atom, (self.BLK, self.BLK), order=(0, 1)
+            )
             beta_layout = cute.make_layout(self.BLK)
 
             allocator = cutlass.utils.SmemAllocator()
             storage = allocator.allocate(self.shared_storage)
-            sK_DS = storage.smem_k.get_tensor(k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner)
+            sK_DS = storage.smem_k.get_tensor(
+                k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner
+            )
             sK_SD = select_tensor_10(sK_DS)
             sKK_inv = storage.smem_kk.get_tensor(kk_layout)
             sBeta = storage.smem_beta.get_tensor(beta_layout)
@@ -344,7 +383,9 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
             load_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
             tma_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 4)
             vector_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
-            vector_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 128)
+            vector_consumer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, 128
+            )
             k_pipeline = pipeline.PipelineTmaAsync.create(
                 barrier_storage=storage.k_mbar_ptr.data_ptr(),
                 num_stages=1,
@@ -359,23 +400,43 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
                 producer_group=vector_producer_group,
                 consumer_group=vector_consumer_group,
             )
-            k_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
-            beta_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
-            k_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
-            beta_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+            k_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, 1
+            )
+            beta_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, 1
+            )
+            k_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, 1
+            )
+            beta_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, 1
+            )
             cute.arch.mbarrier_init_fence()
             cute.arch.sync_threads()
 
             if warp_idx == 1:
                 cpasync.prefetch_descriptor(tma_atom_k)
                 self.load_k_tile_tma(
-                    tma_atom_k, tma_tensor_k, sK_DS, k_pipeline, k_producer_state,
-                    tok_offset, k_head_idx,
+                    tma_atom_k,
+                    tma_tensor_k,
+                    sK_DS,
+                    k_pipeline,
+                    k_producer_state,
+                    tok_offset,
+                    k_head_idx,
                 )
             elif warp_idx == 2:
                 self.load_beta_tile(
-                    g_beta, sBeta, beta_pipeline, beta_producer_state,
-                    tok_offset, sab_head_idx, valid_len, num_sab_heads, tidx,
+                    g_beta,
+                    sBeta,
+                    beta_pipeline,
+                    beta_producer_state,
+                    tok_offset,
+                    sab_head_idx,
+                    valid_len,
+                    num_sab_heads,
+                    tidx,
                 )
 
             k_pipeline.consumer_wait(k_consumer_state)
@@ -384,12 +445,16 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
             cute.arch.sync_threads()
 
             kk_tiled_mma = cute.make_tiled_mma(
-                cute.make_mma_atom(warpgroup.MmaF16BF16Op(
-                    self.dtype, self.acc_dtype, (self.BLK, self.BLK, 16),
-                    warpgroup.OperandSource.SMEM,
-                    cute.nvgpu.OperandMajorMode.K,
-                    cute.nvgpu.OperandMajorMode.K,
-                )),
+                cute.make_mma_atom(
+                    warpgroup.MmaF16BF16Op(
+                        self.dtype,
+                        self.acc_dtype,
+                        (self.BLK, self.BLK, 16),
+                        warpgroup.OperandSource.SMEM,
+                        cute.nvgpu.OperandMajorMode.K,
+                        cute.nvgpu.OperandMajorMode.K,
+                    )
+                ),
                 cute.make_layout((1, 1, 1)),
             )
             kk_thr_mma = kk_tiled_mma.get_slice(tidx)
@@ -397,7 +462,9 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
             tKKsB = kk_thr_mma.partition_B(sK_SD)
             tKKrA = kk_thr_mma.make_fragment_A(tKKsA)
             tKKrB = kk_thr_mma.make_fragment_B(tKKsB)
-            tKKrKK = kk_thr_mma.make_fragment_C(kk_thr_mma.partition_shape_C((self.BLK, self.BLK)))
+            tKKrKK = kk_thr_mma.make_fragment_C(
+                kk_thr_mma.partition_shape_C((self.BLK, self.BLK))
+            )
             cMkk = cute.make_identity_tensor((self.BLK, self.BLK))
             tKKcMkk = kk_thr_mma.partition_C(cMkk)
 
@@ -413,7 +480,12 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
             CollectiveInverse().run(sKK_inv, NamedBarrier.MATH_SYNC)
             cute.arch.barrier(barrier_id=NamedBarrier.MATH_SYNC, number_of_threads=128)
             self.store_t_to_gmem(
-                sKK_inv, sBeta, gT, valid_len, kk_tiled_mma, tidx,
+                sKK_inv,
+                sBeta,
+                gT,
+                valid_len,
+                kk_tiled_mma,
+                tidx,
             )
             beta_pipeline.consumer_release(beta_consumer_state)
 
@@ -441,13 +513,21 @@ def cp_delta_rule_t_precompute_dsl_sm90(
 
     if not _skip_check:
         if k.ndim != 3:
-            raise RuntimeError(f"k must have shape (total_seqlen, num_k_heads, D), got {tuple(k.shape)}")
+            raise RuntimeError(
+                f"k must have shape (total_seqlen, num_k_heads, D), got {tuple(k.shape)}"
+            )
         if beta.ndim != 2 or beta.shape[0] != k.shape[0]:
-            raise RuntimeError(f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}")
+            raise RuntimeError(
+                f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}"
+            )
         if total_seqlen != k.shape[0]:
-            raise RuntimeError(f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}")
+            raise RuntimeError(
+                f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}"
+            )
         if cu_seqlens.dtype != torch.int64:
-            raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+            raise RuntimeError(
+                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+            )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
     num_seqs = cu_seqlens.shape[0] - 1
@@ -464,9 +544,13 @@ def cp_delta_rule_t_precompute_dsl_sm90(
                 f"got beta heads={num_sab_heads} and k heads={num_k_heads}"
             )
         if k.shape[-1] != 128:
-            raise RuntimeError(f"CPDeltaRuleTPrecomputeSm90 only supports D=128, got {k.shape[-1]}")
+            raise RuntimeError(
+                f"CPDeltaRuleTPrecomputeSm90 only supports D=128, got {k.shape[-1]}"
+            )
         if k.dtype not in (torch.float16, torch.bfloat16):
-            raise RuntimeError(f"CPDeltaRuleTPrecomputeSm90 only supports fp16/bf16 inputs, got {k.dtype}")
+            raise RuntimeError(
+                f"CPDeltaRuleTPrecomputeSm90 only supports fp16/bf16 inputs, got {k.dtype}"
+            )
         if beta.dtype != torch.float32:
             raise RuntimeError(f"beta must have dtype torch.float32, got {beta.dtype}")
         for name, tensor in (("k", k), ("beta", beta)):
@@ -474,7 +558,9 @@ def cp_delta_rule_t_precompute_dsl_sm90(
                 raise RuntimeError(f"{name} must be contiguous")
     total_t_blocks = workspace_num_chunks_host(cu_seqlens, 64, total_seqlen)
     max_t_blocks_per_seq = max_num_chunks_host(max_seqlen, 64)
-    t = torch.empty((total_t_blocks, num_sab_heads, 64, 64), dtype=k.dtype, device=k.device)
+    t = torch.empty(
+        (total_t_blocks, num_sab_heads, 64, 64), dtype=k.dtype, device=k.device
+    )
     if total_t_blocks == 0:
         return t
     k_tma = k.as_strided(
@@ -492,7 +578,9 @@ def cp_delta_rule_t_precompute_dsl_sm90(
 
     enable_tvm_ffi = True
     if enable_tvm_ffi:
-        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
 
     kernel = CPDeltaRuleTPrecomputeSm90(kernel_dtype)
     kernel_args = (
@@ -555,42 +643,49 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
     ):
-        self.dtype       = dtype
-        self.acc_dtype   = acc_dtype
-        self.BLK         = 64
-        self.D           = 128
-        self.k_stage     = 3
-        self.v_stage     = 2
-        self.t_stage     = 2
+        self.dtype = dtype
+        self.acc_dtype = acc_dtype
+        self.BLK = 64
+        self.D = 128
+        self.k_stage = 3
+        self.v_stage = 2
+        self.t_stage = 2
         self.alpha_stage = 4
         self.manual_cache_key(
-            "dtype", "acc_dtype", "BLK", "D",
-            "k_stage", "v_stage", "t_stage", "alpha_stage",
+            "dtype",
+            "acc_dtype",
+            "BLK",
+            "D",
+            "k_stage",
+            "v_stage",
+            "t_stage",
+            "alpha_stage",
         )
 
     @cute.jit
     def _math_order_init(self, wg_idx: cutlass.Int32):
         if cutlass.const_expr(wg_idx == self.WarpGroupRole.MATH1):
             cute.arch.barrier_arrive(
-                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256
+            )
 
     @cute.jit
     def _math_order_wait(self, wg_idx: cutlass.Int32):
         if cutlass.const_expr(wg_idx == self.WarpGroupRole.MATH0):
-            cute.arch.barrier(
-                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+            cute.arch.barrier(barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
         else:
-            cute.arch.barrier(
-                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+            cute.arch.barrier(barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
 
     @cute.jit
     def _math_order_notify(self, wg_idx: cutlass.Int32):
         if cutlass.const_expr(wg_idx == self.WarpGroupRole.MATH0):
             cute.arch.barrier_arrive(
-                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256)
+                barrier_id=NamedBarrier.MATH_WG1, number_of_threads=256
+            )
         else:
             cute.arch.barrier_arrive(
-                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256)
+                barrier_id=NamedBarrier.MATH_WG0, number_of_threads=256
+            )
 
     @cute.jit
     def store_acc_to_smem(
@@ -600,12 +695,14 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         tiled_mma,
         thread_idx: cutlass.Int32,
     ):
-        stsm_atom = cute.make_copy_atom(warp.StMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype)
+        stsm_atom = cute.make_copy_atom(
+            warp.StMatrix8x8x16bOp(transpose=True, num_matrices=4), self.dtype
+        )
         tiled_copy = cute.make_tiled_copy_C(stsm_atom, tiled_mma)
-        thr_copy   = tiled_copy.get_slice(thread_idx)
-        tCsC       = thr_copy.partition_D(sC)
+        thr_copy = tiled_copy.get_slice(thread_idx)
+        tCsC = thr_copy.partition_D(sC)
         tCsC_align = cute.make_tensor(tCsC.iterator.align(16), tCsC.layout)
-        tCrC_cvt   = cute.make_fragment_like(tCrC, self.dtype)
+        tCrC_cvt = cute.make_fragment_like(tCrC, self.dtype)
         for i in cutlass.range(cute.size(tCrC), unroll_full=True):
             tCrC_cvt[i] = self.dtype(tCrC[i])
         tCrC_cvt_cv = thr_copy.retile(tCrC_cvt)
@@ -619,10 +716,10 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         tiled_mma,
         thread_idx: cutlass.Int32,
     ):
-        copy_atom  = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
+        copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.acc_dtype)
         tiled_copy = cute.make_tiled_copy_C(copy_atom, tiled_mma)
-        thr_copy   = tiled_copy.get_slice(thread_idx)
-        tCgC    = thr_copy.partition_D(gC)
+        thr_copy = tiled_copy.get_slice(thread_idx)
+        tCgC = thr_copy.partition_D(gC)
         tCrC_cv = thr_copy.retile(tCrC)
         cute.autovec_copy(tCrC_cv, tCgC)
 
@@ -734,38 +831,50 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
     ):
         # ── Tiled MMAs ───────────────────────────────────────────────────────
         x_tiled_mma = cute.make_tiled_mma(
-            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
-                self.dtype, self.acc_dtype, (64, self.BLK, 16),
-                warpgroup.OperandSource.SMEM,
-                cute.nvgpu.OperandMajorMode.MN,
-                cute.nvgpu.OperandMajorMode.K,
-            )),
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (64, self.BLK, 16),
+                    warpgroup.OperandSource.SMEM,
+                    cute.nvgpu.OperandMajorMode.MN,
+                    cute.nvgpu.OperandMajorMode.K,
+                )
+            ),
             cute.make_layout((2, 1, 1)),
         )
         z_tiled_mma = cute.make_tiled_mma(
-            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
-                self.dtype, self.acc_dtype, (64, self.BLK, 16),
-                warpgroup.OperandSource.RMEM,
-                cute.nvgpu.OperandMajorMode.K,
-                cute.nvgpu.OperandMajorMode.K,
-            )),
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (64, self.BLK, 16),
+                    warpgroup.OperandSource.RMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.K,
+                )
+            ),
             cute.make_layout((2, 1, 1)),
         )
         y_tiled_mma = z_tiled_mma
         trans_tiled_mma = cute.make_tiled_mma(
-            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
-                self.dtype, self.acc_dtype, (64, self.D, 16),
-                warpgroup.OperandSource.RMEM,
-                cute.nvgpu.OperandMajorMode.K,
-                cute.nvgpu.OperandMajorMode.MN,
-            )),
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (64, self.D, 16),
+                    warpgroup.OperandSource.RMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.MN,
+                )
+            ),
             cute.make_layout((2, 1, 1)),
         )
         state_tiled_mma = trans_tiled_mma
 
-        x_thr_mma     = x_tiled_mma.get_slice(thread_idx)
-        z_thr_mma     = z_tiled_mma.get_slice(thread_idx)
-        y_thr_mma     = z_thr_mma
+        x_thr_mma = x_tiled_mma.get_slice(thread_idx)
+        z_thr_mma = z_tiled_mma.get_slice(thread_idx)
+        y_thr_mma = z_thr_mma
         trans_thr_mma = trans_tiled_mma.get_slice(thread_idx)
         state_thr_mma = trans_thr_mma
 
@@ -778,20 +887,20 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         alpha_pipeline.consumer_wait(alpha_consumer_state)
         cute.arch.fence_view_async_shared()
 
-        sK     = sK_DS[None, None, k_consumer_state.index]
-        sV     = sV_DS[None, None, v_consumer_state.index]
+        sK = sK_DS[None, None, k_consumer_state.index]
+        sV = sV_DS[None, None, v_consumer_state.index]
         sT_blk = sT[None, None, t_consumer_state.index]
         sAlpha_blk = sAlpha[None, None, alpha_consumer_state.index]
         sK_SD = select_tensor_10(sK)
 
-        block_coeff = cutlass.Float32(
-            sAlpha_blk[valid_len - 1, AlphaProcessor.CUMPROD]
-        )
+        block_coeff = cutlass.Float32(sAlpha_blk[valid_len - 1, AlphaProcessor.CUMPROD])
 
         # ── X = T_fused K, stored as Xt = X^T for state and transfer ────────
         tXrK = x_thr_mma.make_fragment_A(x_thr_mma.partition_A(sK))
         tXrT = x_thr_mma.make_fragment_B(x_thr_mma.partition_B(sT_blk))
-        tXrX = x_thr_mma.make_fragment_C(x_thr_mma.partition_shape_C((self.D, self.BLK)))
+        tXrX = x_thr_mma.make_fragment_C(
+            x_thr_mma.partition_shape_C((self.D, self.BLK))
+        )
         SM90.warpgroup_fence_operand(tXrX)
         cute.nvgpu.warpgroup.fence()
         self._math_order_wait(wg_idx)
@@ -806,13 +915,19 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
 
         # ── Transfer: Z = M K^T, M <- gamma_end (M + Z X) ───────────────────
         tZrK = z_thr_mma.make_fragment_B(z_thr_mma.partition_B(sK_SD))
-        if cutlass.const_expr(is_first_block):  # first iter transfer matrix is identity, skip MMA
+        if cutlass.const_expr(
+            is_first_block
+        ):  # first iter transfer matrix is identity, skip MMA
             self._math_order_wait(wg_idx)
-            tTRANSrZ = load_tensor_as_a(sK, trans_thr_mma, thread_idx, (self.D, self.BLK), self.dtype, False)
+            tTRANSrZ = load_tensor_as_a(
+                sK, trans_thr_mma, thread_idx, (self.D, self.BLK), self.dtype, False
+            )
             self._math_order_notify(wg_idx)
         else:
             tZrTrans = SM90.make_acc_into_op(tTransferT, z_tiled_mma, self.dtype)
-            tZrZ     = z_thr_mma.make_fragment_C(z_thr_mma.partition_shape_C((self.D, self.BLK)))
+            tZrZ = z_thr_mma.make_fragment_C(
+                z_thr_mma.partition_shape_C((self.D, self.BLK))
+            )
             SM90.warpgroup_fence_operand(tZrTrans)
             SM90.warpgroup_fence_operand(tZrZ)
             cute.nvgpu.warpgroup.fence()
@@ -835,9 +950,19 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         self.scale_acc_by_scalar(tTransferT, block_coeff)
 
         # ── State: Y = gamma_end S K^T - gamma_end V^T Gamma^-1, S <- gamma_end S + Y X
-        tYrY = y_thr_mma.make_fragment_C(y_thr_mma.partition_shape_C((self.D, self.BLK)))
+        tYrY = y_thr_mma.make_fragment_C(
+            y_thr_mma.partition_shape_C((self.D, self.BLK))
+        )
         tYcK = y_thr_mma.partition_C(cK)
-        tYrV = load_tensor_as_c(sV, y_tiled_mma, thread_idx, (self.D, self.BLK), self.dtype, False, self.acc_dtype)
+        tYrV = load_tensor_as_c(
+            sV,
+            y_tiled_mma,
+            thread_idx,
+            (self.D, self.BLK),
+            self.dtype,
+            False,
+            self.acc_dtype,
+        )
         for i in cutlass.range(cute.size(tYrY), unroll_full=True):
             _, token = tYcK[i]
             neg_end_rcp = sAlpha_blk[token, AlphaProcessor.CUMPROD_NEG_END_RCP]
@@ -880,7 +1005,12 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         t_consumer_state.advance()
         alpha_pipeline.consumer_release(alpha_consumer_state)
         alpha_consumer_state.advance()
-        return k_consumer_state, v_consumer_state, t_consumer_state, alpha_consumer_state
+        return (
+            k_consumer_state,
+            v_consumer_state,
+            t_consumer_state,
+            alpha_consumer_state,
+        )
 
     @cute.jit
     def run_load_tensor_role(
@@ -898,8 +1028,16 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
     ):
         for blk in cutlass.range(num_blocks, unroll=1):
             tensor_producer_state = self.load_tensor_block_tma(
-                tma_atom, tma_tensor, sTensor, tensor_pipeline, tensor_producer_state,
-                tok_offset, t_block_start, head_idx, blk, is_transfer,
+                tma_atom,
+                tma_tensor,
+                sTensor,
+                tensor_pipeline,
+                tensor_producer_state,
+                tok_offset,
+                t_block_start,
+                head_idx,
+                blk,
+                is_transfer,
             )
         return tensor_producer_state
 
@@ -921,12 +1059,21 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
             alpha_pipeline.producer_acquire(alpha_producer_state)
             cute.arch.fence_view_async_shared()
             self.load_alpha_block(
-                g_alpha, sAlpha,
-                tok_offset, head_idx, blk,
-                chunk_len, num_heads,
-                alpha_producer_state.index, tidx,
+                g_alpha,
+                sAlpha,
+                tok_offset,
+                head_idx,
+                blk,
+                chunk_len,
+                num_heads,
+                alpha_producer_state.index,
+                tidx,
             )
-            AlphaProcessor().run(sAlpha[None, None, alpha_producer_state.index], cutlass.Float32(1.0), True)
+            AlphaProcessor().run(
+                sAlpha[None, None, alpha_producer_state.index],
+                cutlass.Float32(1.0),
+                True,
+            )
             cute.arch.fence_view_async_shared()
             alpha_pipeline.producer_commit(alpha_producer_state)
             alpha_producer_state.advance()
@@ -960,18 +1107,24 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         tidx: cutlass.Int32,
     ):
         acc_mma = cute.make_tiled_mma(
-            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
-                self.dtype, self.acc_dtype, (64, self.D, 16),
-                warpgroup.OperandSource.RMEM,
-                cute.nvgpu.OperandMajorMode.K,
-                cute.nvgpu.OperandMajorMode.MN,
-            )),
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (64, self.D, 16),
+                    warpgroup.OperandSource.RMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.MN,
+                )
+            ),
             cute.make_layout((2, 1, 1)),
         )
         acc_thr = acc_mma.get_slice(tidx)
-        tTransferT = acc_thr.make_fragment_C(acc_thr.partition_shape_C((self.D, self.D)))
-        tStateT    = acc_thr.make_fragment_C(acc_thr.partition_shape_C((self.D, self.D)))
-        cTransfer  = cute.make_identity_tensor((self.D, self.D))
+        tTransferT = acc_thr.make_fragment_C(
+            acc_thr.partition_shape_C((self.D, self.D))
+        )
+        tStateT = acc_thr.make_fragment_C(acc_thr.partition_shape_C((self.D, self.D)))
+        cTransfer = cute.make_identity_tensor((self.D, self.D))
         tTransferC = acc_thr.partition_C(cTransfer)
         tStateT.fill(self.acc_dtype(0.0))
         for i in cutlass.range(cute.size(tTransferT), unroll_full=True):
@@ -991,13 +1144,25 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
             t_consumer_state,
             alpha_consumer_state,
         ) = self.compute_loop_body(
-            sV_DS, sK_DS, sT, sX_DS, sAlpha,
-            k_pipeline, k_consumer_state,
-            v_pipeline, v_consumer_state,
-            t_pipeline, t_consumer_state,
-            alpha_pipeline, alpha_consumer_state,
-            tTransferT, tStateT,
-            valid_len, tidx, wg_idx, True,
+            sV_DS,
+            sK_DS,
+            sT,
+            sX_DS,
+            sAlpha,
+            k_pipeline,
+            k_consumer_state,
+            v_pipeline,
+            v_consumer_state,
+            t_pipeline,
+            t_consumer_state,
+            alpha_pipeline,
+            alpha_consumer_state,
+            tTransferT,
+            tStateT,
+            valid_len,
+            tidx,
+            wg_idx,
+            True,
         )
 
         for blk in cutlass.range(1, num_blocks, 1, unroll=1):
@@ -1012,13 +1177,25 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
                 t_consumer_state,
                 alpha_consumer_state,
             ) = self.compute_loop_body(
-                sV_DS, sK_DS, sT, sX_DS, sAlpha,
-                k_pipeline, k_consumer_state,
-                v_pipeline, v_consumer_state,
-                t_pipeline, t_consumer_state,
-                alpha_pipeline, alpha_consumer_state,
-                tTransferT, tStateT,
-                valid_len, tidx, wg_idx, False,
+                sV_DS,
+                sK_DS,
+                sT,
+                sX_DS,
+                sAlpha,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                t_pipeline,
+                t_consumer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                tTransferT,
+                tStateT,
+                valid_len,
+                tidx,
+                wg_idx,
+                False,
             )
 
         out_layout = cute.make_layout(
@@ -1027,9 +1204,18 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         )
         mTransferT = cute.make_tensor(g_transfer_t.iterator, out_layout)
         mStateT = cute.make_tensor(g_state_t.iterator, out_layout)
-        self.store_acc_to_gmem(tTransferT, mTransferT[None, None, head_idx, chunk_idx], acc_mma, tidx)
-        self.store_acc_to_gmem(tStateT, mStateT[None, None, head_idx, chunk_idx], acc_mma, tidx)
-        return k_consumer_state, v_consumer_state, t_consumer_state, alpha_consumer_state
+        self.store_acc_to_gmem(
+            tTransferT, mTransferT[None, None, head_idx, chunk_idx], acc_mma, tidx
+        )
+        self.store_acc_to_gmem(
+            tStateT, mStateT[None, None, head_idx, chunk_idx], acc_mma, tidx
+        )
+        return (
+            k_consumer_state,
+            v_consumer_state,
+            t_consumer_state,
+            alpha_consumer_state,
+        )
 
     @cute.jit
     def __call__(
@@ -1102,21 +1288,44 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
             v_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.v_stage * 2]
             t_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.t_stage * 2]
             alpha_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_stage * 2]
-            smem_v: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(v_storage_layout_sd)], 128]
-            smem_k: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128]
-            smem_x: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(x_storage_layout_ds)], 128]
-            smem_t: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(t_storage_layout)], 16]
+            smem_v: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(v_storage_layout_sd)], 128
+            ]
+            smem_k: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128
+            ]
+            smem_x: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(x_storage_layout_ds)], 128
+            ]
+            smem_t: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(t_storage_layout)], 16
+            ]
             smem_alpha: cute.struct.Align[
-                cute.struct.MemRange[cutlass.Float32, self.BLK * AlphaProcessor.NUM_CHANNELS * self.alpha_stage], 16]
+                cute.struct.MemRange[
+                    cutlass.Float32,
+                    self.BLK * AlphaProcessor.NUM_CHANNELS * self.alpha_stage,
+                ],
+                16,
+            ]
 
         self.shared_storage = SharedStorage
         self.kernel(
             g_alpha,
-            tma_atom_k, tma_tensor_k,
-            tma_atom_v, tma_tensor_v,
-            tma_atom_t, tma_tensor_t,
-            g_transfer_t, g_state_t, g_cu_seqlens,
-            chunk_len, num_k_heads, num_v_heads, num_sab_heads, total_cp_chunks, num_seqs,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_t,
+            tma_tensor_t,
+            g_transfer_t,
+            g_state_t,
+            g_cu_seqlens,
+            chunk_len,
+            num_k_heads,
+            num_v_heads,
+            num_sab_heads,
+            total_cp_chunks,
+            num_seqs,
         ).launch(
             grid=(num_sab_heads * max_cp_chunks_per_seq, num_seqs, 1),
             block=(384, 1, 1),
@@ -1149,7 +1358,9 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         NUM_MMA_WARP_GROUPS = 2
         THREADS_PER_WARP_GROUP = 128
         MIN_BLOCKS_PER_MP = 1
-        MAX_THREADS_PER_BLOCK = (NUM_LOAD_WARP_GROUPS + NUM_MMA_WARP_GROUPS) * THREADS_PER_WARP_GROUP
+        MAX_THREADS_PER_BLOCK = (
+            NUM_LOAD_WARP_GROUPS + NUM_MMA_WARP_GROUPS
+        ) * THREADS_PER_WARP_GROUP
         load_registers, mma_registers = self.get_register_requirements(
             MAX_THREADS_PER_BLOCK,
             MIN_BLOCKS_PER_MP,
@@ -1178,7 +1389,8 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
         num_blocks = (valid_chunk_len + self.BLK - 1) // self.BLK
         t_blocks_per_cp_chunk = (chunk_len + self.BLK - 1) // self.BLK
         t_block_start = varlen_chunk_idx(
-            seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK)
+            seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK
+        )
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(
             warpgroup.SmemLayoutAtomKind.K_SW128,
@@ -1209,14 +1421,22 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
             order=(0, 1, 2),
         )
 
-        alpha_layout = cute.make_layout((self.BLK, AlphaProcessor.NUM_CHANNELS, self.alpha_stage))
+        alpha_layout = cute.make_layout(
+            (self.BLK, AlphaProcessor.NUM_CHANNELS, self.alpha_stage)
+        )
 
         allocator = cutlass.utils.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
-        sV_DS = storage.smem_v.get_tensor(v_storage_layout_ds.outer, swizzle=v_storage_layout_ds.inner)
-        sK_DS = storage.smem_k.get_tensor(k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner)
+        sV_DS = storage.smem_v.get_tensor(
+            v_storage_layout_ds.outer, swizzle=v_storage_layout_ds.inner
+        )
+        sK_DS = storage.smem_k.get_tensor(
+            k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner
+        )
         sX_DS = storage.smem_x.get_tensor(x_storage_layout_ds)
-        sT = storage.smem_t.get_tensor(t_storage_layout.outer, swizzle=t_storage_layout.inner)
+        sT = storage.smem_t.get_tensor(
+            t_storage_layout.outer, swizzle=t_storage_layout.inner
+        )
         sAlpha = storage.smem_alpha.get_tensor(alpha_layout)
 
         ldst_warp_role = cute.arch.make_warp_uniform(warp_idx % 4)
@@ -1261,14 +1481,30 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
             producer_group=alpha_producer_group,
             consumer_group=alpha_consumer_group,
         )
-        k_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.k_stage)
-        v_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.v_stage)
-        t_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.t_stage)
-        alpha_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.alpha_stage)
-        k_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.k_stage)
-        v_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.v_stage)
-        t_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.t_stage)
-        alpha_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.alpha_stage)
+        k_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.k_stage
+        )
+        v_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.v_stage
+        )
+        t_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.t_stage
+        )
+        alpha_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.alpha_stage
+        )
+        k_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.k_stage
+        )
+        v_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.v_stage
+        )
+        t_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.t_stage
+        )
+        alpha_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.alpha_stage
+        )
         cute.arch.mbarrier_init_fence()
         if warp_group_idx == self.WarpGroupRole.MATH1:
             self._math_order_init(self.WarpGroupRole.MATH1)
@@ -1279,23 +1515,55 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
                 cute.arch.setmaxregister_decrease(load_registers)
                 if ldst_warp_role == self.LoadWarpRole.LOAD_K:
                     k_producer_state = self.run_load_tensor_role(
-                        tma_atom_k, tma_tensor_k, sK_DS, k_pipeline,
-                        k_producer_state, tok_offset, t_block_start, k_head_idx, num_blocks, False,
+                        tma_atom_k,
+                        tma_tensor_k,
+                        sK_DS,
+                        k_pipeline,
+                        k_producer_state,
+                        tok_offset,
+                        t_block_start,
+                        k_head_idx,
+                        num_blocks,
+                        False,
                     )
                 elif ldst_warp_role == self.LoadWarpRole.LOAD_V:
                     v_producer_state = self.run_load_tensor_role(
-                        tma_atom_v, tma_tensor_v, sV_DS, v_pipeline,
-                        v_producer_state, tok_offset, t_block_start, v_head_idx, num_blocks, False,
+                        tma_atom_v,
+                        tma_tensor_v,
+                        sV_DS,
+                        v_pipeline,
+                        v_producer_state,
+                        tok_offset,
+                        t_block_start,
+                        v_head_idx,
+                        num_blocks,
+                        False,
                     )
                 elif ldst_warp_role == self.LoadWarpRole.LOAD_T:
                     t_producer_state = self.run_load_tensor_role(
-                        tma_atom_t, tma_tensor_t, sT, t_pipeline,
-                        t_producer_state, tok_offset, t_block_start, sab_head_idx, num_blocks, True,
+                        tma_atom_t,
+                        tma_tensor_t,
+                        sT,
+                        t_pipeline,
+                        t_producer_state,
+                        tok_offset,
+                        t_block_start,
+                        sab_head_idx,
+                        num_blocks,
+                        True,
                     )
                 else:
                     alpha_producer_state = self.run_load_alpha_role(
-                        g_alpha, sAlpha, alpha_pipeline, alpha_producer_state,
-                        tok_offset, sab_head_idx, valid_chunk_len, num_blocks, num_sab_heads, local_tidx,
+                        g_alpha,
+                        sAlpha,
+                        alpha_pipeline,
+                        alpha_producer_state,
+                        tok_offset,
+                        sab_head_idx,
+                        valid_chunk_len,
+                        num_blocks,
+                        num_sab_heads,
+                        local_tidx,
                     )
             elif warp_group_idx == self.WarpGroupRole.MATH0:
                 cute.arch.setmaxregister_increase(mma_registers)
@@ -1306,15 +1574,29 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
                     t_consumer_state,
                     alpha_consumer_state,
                 ) = self.run_math_role(
-                    sV_DS, sK_DS, sT, sX_DS, sAlpha,
-                    k_pipeline, k_consumer_state,
-                    v_pipeline, v_consumer_state,
-                    t_pipeline, t_consumer_state,
-                    alpha_pipeline, alpha_consumer_state,
-                    g_transfer_t, g_state_t,
-                    cp_chunk_idx, sab_head_idx,
-                    valid_chunk_len, num_blocks, num_sab_heads, total_cp_chunks,
-                    self.WarpGroupRole.MATH0, math_tidx,
+                    sV_DS,
+                    sK_DS,
+                    sT,
+                    sX_DS,
+                    sAlpha,
+                    k_pipeline,
+                    k_consumer_state,
+                    v_pipeline,
+                    v_consumer_state,
+                    t_pipeline,
+                    t_consumer_state,
+                    alpha_pipeline,
+                    alpha_consumer_state,
+                    g_transfer_t,
+                    g_state_t,
+                    cp_chunk_idx,
+                    sab_head_idx,
+                    valid_chunk_len,
+                    num_blocks,
+                    num_sab_heads,
+                    total_cp_chunks,
+                    self.WarpGroupRole.MATH0,
+                    math_tidx,
                 )
             else:
                 cute.arch.setmaxregister_increase(mma_registers)
@@ -1325,15 +1607,29 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
                     t_consumer_state,
                     alpha_consumer_state,
                 ) = self.run_math_role(
-                    sV_DS, sK_DS, sT, sX_DS, sAlpha,
-                    k_pipeline, k_consumer_state,
-                    v_pipeline, v_consumer_state,
-                    t_pipeline, t_consumer_state,
-                    alpha_pipeline, alpha_consumer_state,
-                    g_transfer_t, g_state_t,
-                    cp_chunk_idx, sab_head_idx,
-                    valid_chunk_len, num_blocks, num_sab_heads, total_cp_chunks,
-                    self.WarpGroupRole.MATH1, math_tidx,
+                    sV_DS,
+                    sK_DS,
+                    sT,
+                    sX_DS,
+                    sAlpha,
+                    k_pipeline,
+                    k_consumer_state,
+                    v_pipeline,
+                    v_consumer_state,
+                    t_pipeline,
+                    t_consumer_state,
+                    alpha_pipeline,
+                    alpha_consumer_state,
+                    g_transfer_t,
+                    g_state_t,
+                    cp_chunk_idx,
+                    sab_head_idx,
+                    valid_chunk_len,
+                    num_blocks,
+                    num_sab_heads,
+                    total_cp_chunks,
+                    self.WarpGroupRole.MATH1,
+                    math_tidx,
                 )
 
 
@@ -1363,17 +1659,29 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
 
     if not _skip_check:
         if k.ndim != 3:
-            raise RuntimeError(f"k must have shape (total_seqlen, num_k_heads, D), got {tuple(k.shape)}")
+            raise RuntimeError(
+                f"k must have shape (total_seqlen, num_k_heads, D), got {tuple(k.shape)}"
+            )
         if v.ndim != 3 or v.shape[0] != k.shape[0] or v.shape[2] != k.shape[2]:
-            raise RuntimeError(f"v must have shape (total_seqlen, num_v_heads, D), got {tuple(v.shape)}")
+            raise RuntimeError(
+                f"v must have shape (total_seqlen, num_v_heads, D), got {tuple(v.shape)}"
+            )
         if alpha.ndim != 2 or alpha.shape[0] != k.shape[0]:
-            raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
+            raise RuntimeError(
+                f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}"
+            )
         if total_seqlen != k.shape[0]:
-            raise RuntimeError(f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}")
+            raise RuntimeError(
+                f"total_seqlen must match k.shape[0], got {total_seqlen} and {k.shape[0]}"
+            )
         if cp_chunk_len % 64 != 0:
-            raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
+            raise RuntimeError(
+                f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}"
+            )
         if cu_seqlens.dtype != torch.int64:
-            raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+            raise RuntimeError(
+                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+            )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
     num_seqs = cu_seqlens.shape[0] - 1
@@ -1404,11 +1712,17 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
     total_cp_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
     if not _skip_check:
         if k.shape[-1] != 128:
-            raise RuntimeError(f"CPDeltaRuleMNPrecomputeSm90 only supports D=128, got {k.shape[-1]}")
+            raise RuntimeError(
+                f"CPDeltaRuleMNPrecomputeSm90 only supports D=128, got {k.shape[-1]}"
+            )
         if k.dtype not in (torch.float16, torch.bfloat16):
-            raise RuntimeError(f"CPDeltaRuleMNPrecomputeSm90 only supports fp16/bf16 inputs, got {k.dtype}")
+            raise RuntimeError(
+                f"CPDeltaRuleMNPrecomputeSm90 only supports fp16/bf16 inputs, got {k.dtype}"
+            )
         if t.dtype != k.dtype:
-            raise RuntimeError(f"t dtype must match k dtype, got {t.dtype} and {k.dtype}")
+            raise RuntimeError(
+                f"t dtype must match k dtype, got {t.dtype} and {k.dtype}"
+            )
         for name, tensor in (("k", k), ("v", v), ("t", t), ("alpha", alpha)):
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
@@ -1431,8 +1745,12 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
         ),
     )
     workspace_ctor = torch.empty if num_seqs == 1 else torch.zeros
-    transfer_t = workspace_ctor((total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device)
-    state_t = workspace_ctor((total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device)
+    transfer_t = workspace_ctor(
+        (total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device
+    )
+    state_t = workspace_ctor(
+        (total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device
+    )
     if total_cp_chunks == 0:
         return transfer_t, state_t
 
@@ -1446,7 +1764,9 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
 
     enable_tvm_ffi = True
     if enable_tvm_ffi:
-        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
 
     kernel = CPDeltaRuleMNPrecomputeSm90(kernel_dtype)
     kernel_args = (
@@ -1490,10 +1810,13 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         min_blocks_per_multiprocessor: int,
     ) -> int:
         reg_alloc_granularity = 8
-        registers_per_thread = round_down(
-            64 * 1024 // min_blocks_per_multiprocessor,
-            max_threads_per_block * reg_alloc_granularity,
-        ) // max_threads_per_block
+        registers_per_thread = (
+            round_down(
+                64 * 1024 // min_blocks_per_multiprocessor,
+                max_threads_per_block * reg_alloc_granularity,
+            )
+            // max_threads_per_block
+        )
         return min(248, registers_per_thread)
 
     def __init__(self, needs_initial_state: bool = False):
@@ -1516,10 +1839,21 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         )
         self.use_3xtf32 = False
         self.manual_cache_key(
-            "needs_initial_state", "D", "rows_per_cta", "row_ctas",
-            "threads_per_cta", "num_warps", "m_stage", "n_stage",
-            "num_col_tiles", "num_row_tiles", "num_tiles", "k_tiles",
-            "min_blocks_per_mp", "registers_per_thread", "use_3xtf32",
+            "needs_initial_state",
+            "D",
+            "rows_per_cta",
+            "row_ctas",
+            "threads_per_cta",
+            "num_warps",
+            "m_stage",
+            "n_stage",
+            "num_col_tiles",
+            "num_row_tiles",
+            "num_tiles",
+            "k_tiles",
+            "min_blocks_per_mp",
+            "registers_per_thread",
+            "use_3xtf32",
         )
 
     @cute.jit
@@ -1548,9 +1882,9 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
                 ((None, None), (0, 0))
             ]
         else:
-            gTensor = cute.zipped_divide(tma_tensor[None, None, head_idx, chunk_idx], (self.D, self.D))[
-                ((None, None), (0, 0))
-            ]
+            gTensor = cute.zipped_divide(
+                tma_tensor[None, None, head_idx, chunk_idx], (self.D, self.D)
+            )[((None, None), (0, 0))]
 
         tTsT, tTgT = cpasync.tma_partition(
             tma_atom,
@@ -1646,18 +1980,26 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
     ):
         warp_idx = math_tidx // 32
         lane_idx = math_tidx - warp_idx * 32
-        tiled_mma  = cute.make_tiled_mma(WarpMmaTF32Op((16, 8, 8)))
-        copy_atom  = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32)
-        store_atom = cute.make_copy_atom(cute.nvgpu.CopyR2GOp(), cutlass.Float32, num_bits_per_copy=64)
-        tiled_copy_C  = cute.make_tiled_copy_C(copy_atom, tiled_mma)
+        tiled_mma = cute.make_tiled_mma(WarpMmaTF32Op((16, 8, 8)))
+        copy_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32)
+        store_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyR2GOp(), cutlass.Float32, num_bits_per_copy=64
+        )
+        tiled_copy_C = cute.make_tiled_copy_C(copy_atom, tiled_mma)
         tiled_store_C = cute.make_tiled_copy_C(store_atom, tiled_mma)
-        thr_copy_C  = tiled_copy_C.get_slice(lane_idx)  # for N, local state
+        thr_copy_C = tiled_copy_C.get_slice(lane_idx)  # for N, local state
         thr_store_C = tiled_store_C.get_slice(lane_idx)
 
-        tSMrS = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, self.D)), cutlass.Float32)
-        tSMrM = cute.make_rmem_tensor(tiled_mma.partition_shape_B((self.D, self.D)), cutlass.Float32)
+        tSMrS = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_C((16, self.D)), cutlass.Float32
+        )
+        tSMrM = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_B((self.D, self.D)), cutlass.Float32
+        )
         sM_NK = select_tensor_10(sM)
-        tSMrState = cute.make_rmem_tensor(tiled_mma.partition_shape_C((16, self.D)), cutlass.Float32)
+        tSMrState = cute.make_rmem_tensor(
+            tiled_mma.partition_shape_C((16, self.D)), cutlass.Float32
+        )
         tSMrState_cv = thr_copy_C.retile(tSMrState)
         tSMrState_store = thr_store_C.retile(tSMrState)
 
@@ -1690,12 +2032,16 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             # init tSMrState from N
             n_pipeline.consumer_wait(n_consumer_state)
             cute.arch.fence_view_async_shared()
-            cute.autovec_copy(tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv)
+            cute.autovec_copy(
+                tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv
+            )
             n_pipeline.consumer_release(n_consumer_state)
             n_consumer_state.advance()
             # and
 
-            self.store_fixed_state(tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start)
+            self.store_fixed_state(
+                tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start
+            )
         else:
             # do normal recurrence for the first chunk
             start = cutlass.Int32(0)
@@ -1708,18 +2054,32 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             n_pipeline.consumer_wait(n_consumer_state)
             m_pipeline.consumer_wait(m_consumer_state)
             cute.arch.fence_view_async_shared()
-            cute.autovec_copy(tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv)
+            cute.autovec_copy(
+                tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv
+            )
 
-            self.load_tf32_kpermuted_b(tSMrM, sM_NK[None, None, m_consumer_state.index], lane_idx)
+            self.load_tf32_kpermuted_b(
+                tSMrM, sM_NK[None, None, m_consumer_state.index], lane_idx
+            )
             for iter_k in cutlass.range_constexpr(self.k_tiles):
-                tSMrS_h = cute.recast_tensor(tSMrS[None, None, iter_k], cutlass.TFloat32)
-                tSMrM_h = cute.recast_tensor(tSMrM[None, None, iter_k], cutlass.TFloat32)
+                tSMrS_h = cute.recast_tensor(
+                    tSMrS[None, None, iter_k], cutlass.TFloat32
+                )
+                tSMrM_h = cute.recast_tensor(
+                    tSMrM[None, None, iter_k], cutlass.TFloat32
+                )
                 cute.gemm(tiled_mma, tSMrState, tSMrS_h, tSMrM_h, tSMrState)
                 if cutlass.const_expr(self.use_3xtf32):
-                    tSMrM_l = self.convert_fp32_to_tf32_residual(tSMrM[None, None, iter_k])
+                    tSMrM_l = self.convert_fp32_to_tf32_residual(
+                        tSMrM[None, None, iter_k]
+                    )
                     cute.gemm(tiled_mma, tSMrState, tSMrS_h, tSMrM_l, tSMrState)
-                    tSMrS_l = self.convert_fp32_to_tf32_residual(tSMrS[None, None, iter_k])
-                    tSMrM_h = cute.recast_tensor(tSMrM[None, None, iter_k], cutlass.TFloat32)
+                    tSMrS_l = self.convert_fp32_to_tf32_residual(
+                        tSMrS[None, None, iter_k]
+                    )
+                    tSMrM_h = cute.recast_tensor(
+                        tSMrM[None, None, iter_k], cutlass.TFloat32
+                    )
                     cute.gemm(tiled_mma, tSMrState, tSMrS_l, tSMrM_h, tSMrState)
 
             n_pipeline.consumer_release(n_consumer_state)
@@ -1727,7 +2087,9 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             m_pipeline.consumer_release(m_consumer_state)
             m_consumer_state.advance()
 
-            self.store_fixed_state(tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start + chunk_idx)
+            self.store_fixed_state(
+                tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start + chunk_idx
+            )
 
         return m_consumer_state, n_consumer_state
 
@@ -1749,16 +2111,26 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             warpgroup.SmemLayoutAtomKind.K_INTER,
             cutlass.Float32,
         )
-        transfer_layout = cute.tile_to_shape(smem_layout_atom, (self.D, self.D, self.m_stage), order=(0, 1, 2))
-        state_layout = cute.tile_to_shape(smem_layout_atom, (self.rows_per_cta, self.D, self.n_stage), order=(0, 1, 2))
+        transfer_layout = cute.tile_to_shape(
+            smem_layout_atom, (self.D, self.D, self.m_stage), order=(0, 1, 2)
+        )
+        state_layout = cute.tile_to_shape(
+            smem_layout_atom, (self.rows_per_cta, self.D, self.n_stage), order=(0, 1, 2)
+        )
         transfer_tma_layout = cute.slice_(transfer_layout, (None, None, 0))
         state_tma_layout = cute.slice_(state_layout, (None, None, 0))
         tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
         tma_atom_m, tma_tensor_m = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_transfer_t, transfer_tma_layout, (self.D, self.D),
+            tma_load_op,
+            g_transfer_t,
+            transfer_tma_layout,
+            (self.D, self.D),
         )
         tma_atom_n, tma_tensor_n = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_local_state_t, state_tma_layout, (self.rows_per_cta, self.D),
+            tma_load_op,
+            g_local_state_t,
+            state_tma_layout,
+            (self.rows_per_cta, self.D),
         )
         self.tma_load_m_bytes = cute.size(transfer_tma_layout) * 4
         self.tma_load_n_bytes = cute.size(state_tma_layout) * 4
@@ -1767,17 +2139,26 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         class SharedStorage:
             m_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.m_stage * 2]
             n_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.n_stage * 2]
-            smem_m: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, cute.cosize(transfer_layout)], 128]
-            smem_n: cute.struct.Align[cute.struct.MemRange[cutlass.Float32, cute.cosize(state_layout)], 128]
+            smem_m: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(transfer_layout)], 128
+            ]
+            smem_n: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(state_layout)], 128
+            ]
 
         self.shared_storage = SharedStorage
         self.kernel(
-            tma_atom_m, tma_tensor_m,
-            tma_atom_n, tma_tensor_n,
+            tma_atom_m,
+            tma_tensor_m,
+            tma_atom_n,
+            tma_tensor_n,
             g_initial_state_t,
             g_fixed_state_t,
             g_cu_seqlens,
-            chunk_len, total_cp_chunks, num_seqs, num_heads,
+            chunk_len,
+            total_cp_chunks,
+            num_seqs,
+            num_heads,
         ).launch(
             grid=(num_seqs * num_heads * self.row_ctas, 1, 1),
             block=(self.threads_per_cta, 1, 1),
@@ -1820,15 +2201,21 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             warpgroup.SmemLayoutAtomKind.K_INTER,
             cutlass.Float32,
         )
-        transfer_layout = cute.tile_to_shape(smem_layout_atom, (self.D, self.D, self.m_stage), order=(0, 1, 2))
-        state_layout = cute.tile_to_shape(smem_layout_atom, (self.rows_per_cta, self.D, self.n_stage), order=(0, 1, 2))
+        transfer_layout = cute.tile_to_shape(
+            smem_layout_atom, (self.D, self.D, self.m_stage), order=(0, 1, 2)
+        )
+        state_layout = cute.tile_to_shape(
+            smem_layout_atom, (self.rows_per_cta, self.D, self.n_stage), order=(0, 1, 2)
+        )
         out_layout = cute.make_layout(
             (self.D, self.D, num_heads, total_cp_chunks),
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
         allocator = cutlass.utils.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
-        sM = storage.smem_m.get_tensor(transfer_layout.outer, swizzle=transfer_layout.inner)
+        sM = storage.smem_m.get_tensor(
+            transfer_layout.outer, swizzle=transfer_layout.inner
+        )
         sN = storage.smem_n.get_tensor(state_layout.outer, swizzle=state_layout.inner)
         gFixedState = cute.make_tensor(g_fixed_state_t.iterator.align(128), out_layout)
         fixed_state_layout = cute.make_layout(
@@ -1836,7 +2223,9 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
         if cutlass.const_expr(self.needs_initial_state):
-            gInitialState = cute.make_tensor(g_initial_state_t.iterator, fixed_state_layout)
+            gInitialState = cute.make_tensor(
+                g_initial_state_t.iterator, fixed_state_layout
+            )
         else:
             gInitialState = gFixedState
 
@@ -1865,10 +2254,18 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             tx_count=self.tma_load_n_bytes,
             cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
         )
-        m_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.m_stage)
-        n_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.n_stage)
-        m_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.m_stage)
-        n_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.n_stage)
+        m_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.m_stage
+        )
+        n_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.n_stage
+        )
+        m_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.m_stage
+        )
+        n_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.n_stage
+        )
         cute.arch.mbarrier_init_fence()
         cute.arch.sync_threads()
 
@@ -1878,31 +2275,65 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
                 if cutlass.const_expr(self.needs_initial_state):
                     for chunk_idx in cutlass.range(0, num_chunks, 1, unroll=1):
                         m_producer_state = self.load_fixup_tma(
-                            tma_atom_m, tma_tensor_m, sM, m_pipeline, m_producer_state,
-                            chunk_start, chunk_idx, head_idx, row_cta_idx, False,
+                            tma_atom_m,
+                            tma_tensor_m,
+                            sM,
+                            m_pipeline,
+                            m_producer_state,
+                            chunk_start,
+                            chunk_idx,
+                            head_idx,
+                            row_cta_idx,
+                            False,
                         )
                 else:
                     for chunk_idx in cutlass.range(1, num_chunks, 1, unroll=1):
                         m_producer_state = self.load_fixup_tma(
-                            tma_atom_m, tma_tensor_m, sM, m_pipeline, m_producer_state,
-                            chunk_start, chunk_idx, head_idx, row_cta_idx, False,
+                            tma_atom_m,
+                            tma_tensor_m,
+                            sM,
+                            m_pipeline,
+                            m_producer_state,
+                            chunk_start,
+                            chunk_idx,
+                            head_idx,
+                            row_cta_idx,
+                            False,
                         )
             elif ldst_warp_role == self.LoadWarpRole.LOAD_N and num_chunks > 0:
                 for chunk_idx in cutlass.range(0, num_chunks, 1, unroll=1):
                     n_producer_state = self.load_fixup_tma(
-                        tma_atom_n, tma_tensor_n, sN, n_pipeline, n_producer_state,
-                        chunk_start, chunk_idx, head_idx, row_cta_idx, True,
+                        tma_atom_n,
+                        tma_tensor_n,
+                        sN,
+                        n_pipeline,
+                        n_producer_state,
+                        chunk_start,
+                        chunk_idx,
+                        head_idx,
+                        row_cta_idx,
+                        True,
                     )
         else:
             cute.arch.setmaxregister_increase(self.registers_per_thread)
             if num_chunks > 0:
                 math_tidx = local_tidx
                 self.run_fixup_loop(
-                    sM, sN,
-                    m_pipeline, m_consumer_state,
-                    n_pipeline, n_consumer_state,
-                    gFixedState, gInitialState, num_chunks, total_cp_chunks,
-                    chunk_start, seq_idx, head_idx, row_cta_idx, math_tidx,
+                    sM,
+                    sN,
+                    m_pipeline,
+                    m_consumer_state,
+                    n_pipeline,
+                    n_consumer_state,
+                    gFixedState,
+                    gInitialState,
+                    num_chunks,
+                    total_cp_chunks,
+                    chunk_start,
+                    seq_idx,
+                    head_idx,
+                    row_cta_idx,
+                    math_tidx,
                 )
 
 
@@ -1937,22 +2368,33 @@ def cp_delta_rule_fixup_dsl_sm90(
                 f"got {tuple(local_state.shape)} and {tuple(local_transfer.shape)}"
             )
         if local_transfer.shape[-2:] != (128, 128):
-            raise RuntimeError(f"CPDeltaRuleFixupSm90 only supports D=128, got {tuple(local_transfer.shape[-2:])}")
+            raise RuntimeError(
+                f"CPDeltaRuleFixupSm90 only supports D=128, got {tuple(local_transfer.shape[-2:])}"
+            )
         if local_transfer.dtype != torch.float32 or local_state.dtype != torch.float32:
             raise RuntimeError(
                 "CPDeltaRuleFixupSm90 only supports float32 inputs, "
                 f"got {local_transfer.dtype} and {local_state.dtype}"
             )
         if initial_state is not None:
-            if initial_state.shape != (cu_seqlens.shape[0] - 1, local_transfer.shape[1], 128, 128):
+            if initial_state.shape != (
+                cu_seqlens.shape[0] - 1,
+                local_transfer.shape[1],
+                128,
+                128,
+            ):
                 raise RuntimeError(
                     "initial_state must have shape "
                     f"{(cu_seqlens.shape[0] - 1, local_transfer.shape[1], 128, 128)}, got {tuple(initial_state.shape)}"
                 )
             if initial_state.dtype != torch.float32:
-                raise RuntimeError(f"initial_state must have dtype torch.float32, got {initial_state.dtype}")
+                raise RuntimeError(
+                    f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
+                )
         for name, tensor in (
-            ("local_transfer", local_transfer), ("local_state", local_state), ("initial_state", initial_state)
+            ("local_transfer", local_transfer),
+            ("local_state", local_state),
+            ("initial_state", initial_state),
         ):
             if tensor is None:
                 continue
@@ -1963,8 +2405,12 @@ def cp_delta_rule_fixup_dsl_sm90(
         if cp_chunk_len <= 0:
             raise RuntimeError(f"cp_chunk_len must be positive, got {cp_chunk_len}")
         if cu_seqlens.dtype != torch.int64:
-            raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
-        expected_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
+            raise RuntimeError(
+                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+            )
+        expected_chunks = workspace_num_chunks_host(
+            cu_seqlens, cp_chunk_len, total_seqlen
+        )
         if expected_chunks != total_cp_chunks:
             raise RuntimeError(
                 "local_transfer/local_state first dim must equal "
@@ -1974,7 +2420,11 @@ def cp_delta_rule_fixup_dsl_sm90(
             raise RuntimeError("cu_seqlens must be contiguous")
     num_seqs = cu_seqlens.shape[0] - 1
 
-    fixed_state = torch.empty_like(local_state) if num_seqs == 1 else torch.zeros_like(local_state)
+    fixed_state = (
+        torch.empty_like(local_state)
+        if num_seqs == 1
+        else torch.zeros_like(local_state)
+    )
     if total_cp_chunks == 0:
         return fixed_state
 
@@ -1992,17 +2442,24 @@ def cp_delta_rule_fixup_dsl_sm90(
 
     enable_tvm_ffi = True
     if enable_tvm_ffi:
-        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
 
     needs_initial_state = initial_state is not None
     initial_state_cute = (
         from_dlpack(initial_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
-        if needs_initial_state else None
+        if needs_initial_state
+        else None
     )
     kernel = CPDeltaRuleFixupSm90(needs_initial_state)
     kernel_args = (
-        from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(leading_dim=1),
-        from_dlpack(local_state_tma, assumed_align=128).mark_layout_dynamic(leading_dim=1),
+        from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(
+            leading_dim=1
+        ),
+        from_dlpack(local_state_tma, assumed_align=128).mark_layout_dynamic(
+            leading_dim=1
+        ),
         initial_state_cute,
         from_dlpack(fixed_state.reshape(-1), assumed_align=128).mark_layout_dynamic(),
         from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
@@ -2032,11 +2489,25 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         self.needs_initial_state = needs_initial_state
         self.t_stage = 2
         self.manual_cache_key(
-            "needs_alpha", "needs_beta", "needs_init_state", "needs_checkpointing",
-            "needs_initial_state", "dtype", "acc_dtype", "inverse_dtype",
-            "BLK_Q", "BLK_KV", "D",
-            "q_stage", "k_stage", "v_stage", "o_stage",
-            "qk_stage", "kk_stage", "alpha_beta_stage", "t_stage",
+            "needs_alpha",
+            "needs_beta",
+            "needs_init_state",
+            "needs_checkpointing",
+            "needs_initial_state",
+            "dtype",
+            "acc_dtype",
+            "inverse_dtype",
+            "BLK_Q",
+            "BLK_KV",
+            "D",
+            "q_stage",
+            "k_stage",
+            "v_stage",
+            "o_stage",
+            "qk_stage",
+            "kk_stage",
+            "alpha_beta_stage",
+            "t_stage",
         )
 
     @cute.jit
@@ -2053,9 +2524,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
     ):
         sT_stage = sT[None, None, t_producer_state.index]
         mT = tma_tensor_t[None, None, head_idx, t_block_start + blk]
-        gT = cute.zipped_divide(mT, (self.BLK_KV, self.BLK_KV))[
-            ((None, None), (0, 0))
-        ]
+        gT = cute.zipped_divide(mT, (self.BLK_KV, self.BLK_KV))[((None, None), (0, 0))]
         tTsT, tTgT = cpasync.tma_partition(
             tma_atom_t,
             0,
@@ -2065,7 +2534,9 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         )
         t_pipeline.producer_acquire(t_producer_state)
         cute.copy(
-            tma_atom_t, tTgT, tTsT,
+            tma_atom_t,
+            tTgT,
+            tTsT,
             tma_bar_ptr=t_pipeline.producer_get_barrier(t_producer_state),
         )
         t_pipeline.producer_commit(t_producer_state)
@@ -2084,11 +2555,18 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         head_idx: cutlass.Int32,
     ):
         t_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.t_stage)
+            pipeline.PipelineUserType.Producer, self.t_stage
+        )
         for blk in cutlass.range(num_blocks, unroll=1):
             t_producer_state = self.load_t_tma(
-                sT, tma_atom_t, tma_tensor_t, t_pipeline,
-                t_producer_state, blk, t_block_start, head_idx,
+                sT,
+                tma_atom_t,
+                tma_tensor_t,
+                t_pipeline,
+                t_producer_state,
+                blk,
+                t_block_start,
+                head_idx,
             )
 
     @cute.jit
@@ -2120,12 +2598,13 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             tQKrQK[i] = tQKrQK[i] * alpha * scale if pred else cutlass.Float32(0.0)
 
         stsm_atom = cute.make_copy_atom(
-            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype)
+            warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype
+        )
         tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
-        thr_store   = tiled_store.get_slice(aux_tidx)
-        tKKsKK      = thr_store.partition_D(sKK_opd)
-        tKKcMkk_cv  = thr_store.retile(tKKcMkk)
-        tKKrT       = cute.make_fragment_like(tKKsKK, self.dtype)
+        thr_store = tiled_store.get_slice(aux_tidx)
+        tKKsKK = thr_store.partition_D(sKK_opd)
+        tKKcMkk_cv = thr_store.retile(tKKcMkk)
+        tKKrT = cute.make_fragment_like(tKKsKK, self.dtype)
 
         for i in cutlass.range_constexpr(cute.size(tKKrT)):
             s, t = tKKcMkk_cv[i]
@@ -2180,7 +2659,10 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         k_pipeline.consumer_wait(k_consumer_state)
         q_pipeline.consumer_wait(q_consumer_state)
         tQKrQK = qk_tiled_mma.get_slice(aux_tidx).make_fragment_C(
-            qk_tiled_mma.get_slice(aux_tidx).partition_shape_C((self.BLK_Q, self.BLK_KV)))
+            qk_tiled_mma.get_slice(aux_tidx).partition_shape_C(
+                (self.BLK_Q, self.BLK_KV)
+            )
+        )
         cute.nvgpu.warpgroup.fence()
         SM90.wgmma_gemm_zero_acc(
             qk_tiled_mma,
@@ -2201,12 +2683,18 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
 
         kk_pipeline.producer_acquire(kk_producer_state)
         self.cp_qk_and_t_epi(
-            tQKrQK, tQKcMqk,
+            tQKrQK,
+            tQKcMqk,
             sT[None, None, t_consumer_state.index],
             sKK_opd[None, None, kk_producer_state.index],
-            sAlpha, alpha_consumer_state.index,
-            is_final_block, B, scale,
-            kk_tiled_mma, tKKcMkk, aux_tidx,
+            sAlpha,
+            alpha_consumer_state.index,
+            is_final_block,
+            B,
+            scale,
+            kk_tiled_mma,
+            tKKcMkk,
+            aux_tidx,
         )
         cute.arch.fence_view_async_shared()
         kk_pipeline.producer_commit(kk_producer_state)
@@ -2259,21 +2747,29 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         aux_tidx = math_tidx % 128
 
         qk_tiled_mma = cute.make_tiled_mma(
-            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
-                self.dtype, self.acc_dtype, (self.BLK_Q, self.BLK_KV, 16),
-                warpgroup.OperandSource.SMEM,
-                cute.nvgpu.OperandMajorMode.K,
-                cute.nvgpu.OperandMajorMode.K,
-            )),
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (self.BLK_Q, self.BLK_KV, 16),
+                    warpgroup.OperandSource.SMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.K,
+                )
+            ),
             cute.make_layout((1, 1, 1)),
         )
         kk_tiled_mma = cute.make_tiled_mma(
-            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
-                self.dtype, self.acc_dtype, (self.BLK_KV, self.BLK_KV, 16),
-                warpgroup.OperandSource.SMEM,
-                cute.nvgpu.OperandMajorMode.K,
-                cute.nvgpu.OperandMajorMode.K,
-            )),
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (self.BLK_KV, self.BLK_KV, 16),
+                    warpgroup.OperandSource.SMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.K,
+                )
+            ),
             cute.make_layout((1, 1, 1)),
         )
 
@@ -2290,17 +2786,23 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         tKKcMkk = kk_thr_mma.partition_C(cMqk)
 
         q_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.q_stage)
+            pipeline.PipelineUserType.Consumer, self.q_stage
+        )
         k_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.k_stage)
+            pipeline.PipelineUserType.Consumer, self.k_stage
+        )
         t_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.t_stage)
+            pipeline.PipelineUserType.Consumer, self.t_stage
+        )
         qk_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.qk_stage)
+            pipeline.PipelineUserType.Producer, self.qk_stage
+        )
         kk_producer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Producer, self.kk_stage)
+            pipeline.PipelineUserType.Producer, self.kk_stage
+        )
         alpha_consumer_state = pipeline.make_pipeline_state(
-            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage
+        )
 
         for blk in cutlass.range(num_blocks - 1, unroll=1):
             (
@@ -2311,30 +2813,64 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                 kk_producer_state,
                 alpha_consumer_state,
             ) = self.run_aux_loop_body(
-                sQK, sT, sKK_opd, sAlpha,
-                q_pipeline, q_consumer_state,
-                k_pipeline, k_consumer_state,
-                t_pipeline, t_consumer_state,
-                qk_pipeline, qk_producer_state,
-                kk_pipeline, kk_producer_state,
-                alpha_pipeline, alpha_consumer_state,
-                work_desc, scale, blk, False,
-                qk_tiled_mma, kk_tiled_mma,
-                tQKrQ, tQKrK, tQKcMqk, tKKcMkk, aux_tidx,
+                sQK,
+                sT,
+                sKK_opd,
+                sAlpha,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                t_pipeline,
+                t_consumer_state,
+                qk_pipeline,
+                qk_producer_state,
+                kk_pipeline,
+                kk_producer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                work_desc,
+                scale,
+                blk,
+                False,
+                qk_tiled_mma,
+                kk_tiled_mma,
+                tQKrQ,
+                tQKrK,
+                tQKcMqk,
+                tKKcMkk,
+                aux_tidx,
             )
 
         last_blk = num_blocks - 1
         self.run_aux_loop_body(
-            sQK, sT, sKK_opd, sAlpha,
-            q_pipeline, q_consumer_state,
-            k_pipeline, k_consumer_state,
-            t_pipeline, t_consumer_state,
-            qk_pipeline, qk_producer_state,
-            kk_pipeline, kk_producer_state,
-            alpha_pipeline, alpha_consumer_state,
-            work_desc, scale, last_blk, True,
-            qk_tiled_mma, kk_tiled_mma,
-            tQKrQ, tQKrK, tQKcMqk, tKKcMkk, aux_tidx,
+            sQK,
+            sT,
+            sKK_opd,
+            sAlpha,
+            q_pipeline,
+            q_consumer_state,
+            k_pipeline,
+            k_consumer_state,
+            t_pipeline,
+            t_consumer_state,
+            qk_pipeline,
+            qk_producer_state,
+            kk_pipeline,
+            kk_producer_state,
+            alpha_pipeline,
+            alpha_consumer_state,
+            work_desc,
+            scale,
+            last_blk,
+            True,
+            qk_tiled_mma,
+            kk_tiled_mma,
+            tQKrQ,
+            tQKrK,
+            tQKcMqk,
+            tKKcMkk,
+            aux_tidx,
         )
 
     @cute.jit
@@ -2376,35 +2912,59 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         num_seqs: cutlass.Int32,
     ):
         self._math_order_init(wg_idx)
-        q_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.q_stage)
-        k_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.k_stage)
-        v_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.v_stage)
-        o_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.o_stage)
-        qk_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.qk_stage)
-        kk_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.kk_stage)
-        alpha_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.alpha_beta_stage)
+        q_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.q_stage
+        )
+        k_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.k_stage
+        )
+        v_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.v_stage
+        )
+        o_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, self.o_stage
+        )
+        qk_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.qk_stage
+        )
+        kk_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.kk_stage
+        )
+        alpha_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.alpha_beta_stage
+        )
 
         kv_tiled_mma = cute.make_tiled_mma(
-            cute.make_mma_atom(warpgroup.MmaF16BF16Op(
-                self.dtype, self.acc_dtype, (64, self.D, 16),
-                warpgroup.OperandSource.RMEM,
-                cute.nvgpu.OperandMajorMode.K,
-                cute.nvgpu.OperandMajorMode.MN,
-            )),
+            cute.make_mma_atom(
+                warpgroup.MmaF16BF16Op(
+                    self.dtype,
+                    self.acc_dtype,
+                    (64, self.D, 16),
+                    warpgroup.OperandSource.RMEM,
+                    cute.nvgpu.OperandMajorMode.K,
+                    cute.nvgpu.OperandMajorMode.MN,
+                )
+            ),
             cute.make_layout((2, 1, 1)),
         )
         kv_thr_mma = kv_tiled_mma.get_slice(math_tidx)
-        tKVrKV = kv_thr_mma.make_fragment_C(kv_thr_mma.partition_shape_C((self.D, self.D)))
+        tKVrKV = kv_thr_mma.make_fragment_C(
+            kv_thr_mma.partition_shape_C((self.D, self.D))
+        )
         tKVrKV.fill(self.acc_dtype(0.0))
 
-        state_layout = cute.make_ordered_layout((self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3))
+        state_layout = cute.make_ordered_layout(
+            (self.D, self.D, num_sab_heads, num_seqs), order=(0, 1, 2, 3)
+        )
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
         gStateKV = mState[None, None, o_head_idx, public_seq_idx]
         if cutlass.const_expr(self.needs_initial_state):
             mInitialState = cute.make_tensor(g_initial_state.iterator, state_layout)
             gInitialKV = mInitialState[None, None, o_head_idx, public_seq_idx]
-        fixed_state_layout = cute.make_ordered_layout((self.D, self.D, num_sab_heads, num_chunks), order=(0, 1, 2, 3))
+        fixed_state_layout = cute.make_ordered_layout(
+            (self.D, self.D, num_sab_heads, num_chunks), order=(0, 1, 2, 3)
+        )
         mFixedState = cute.make_tensor(g_fixed_state.iterator, fixed_state_layout)
         gFixedKV = mFixedState[None, None, o_head_idx, fixed_state_idx]
         if cutlass.const_expr(self.needs_initial_state):
@@ -2425,17 +2985,36 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             kk_consumer_state,
             alpha_consumer_state,
         ) = self.compute_loop_body(
-            sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha,
+            sQ_SD,
+            sK_SD,
+            sK_DS,
+            sV_DS,
+            sQK,
+            sKK_inv,
+            sKK_opd,
+            sO,
+            sAlpha,
             kv_tiled_mma,
-            q_pipeline, q_consumer_state,
-            k_pipeline, k_consumer_state,
-            v_pipeline, v_consumer_state,
-            o_pipeline, o_producer_state,
-            qk_pipeline, qk_consumer_state,
-            kk_pipeline, kk_consumer_state,
-            alpha_pipeline, alpha_consumer_state,
-            False, True, first_B,
-            tKVrKV, scale, wg_idx,
+            q_pipeline,
+            q_consumer_state,
+            k_pipeline,
+            k_consumer_state,
+            v_pipeline,
+            v_consumer_state,
+            o_pipeline,
+            o_producer_state,
+            qk_pipeline,
+            qk_consumer_state,
+            kk_pipeline,
+            kk_consumer_state,
+            alpha_pipeline,
+            alpha_consumer_state,
+            False,
+            True,
+            first_B,
+            tKVrKV,
+            scale,
+            wg_idx,
         )
 
         for blk in cutlass.range(1, num_blocks - 1, 1, unroll=1):
@@ -2448,17 +3027,36 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                 kk_consumer_state,
                 alpha_consumer_state,
             ) = self.compute_loop_body(
-                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha,
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
                 kv_tiled_mma,
-                q_pipeline, q_consumer_state,
-                k_pipeline, k_consumer_state,
-                v_pipeline, v_consumer_state,
-                o_pipeline, o_producer_state,
-                qk_pipeline, qk_consumer_state,
-                kk_pipeline, kk_consumer_state,
-                alpha_pipeline, alpha_consumer_state,
-                False, False, self.BLK_KV,
-                tKVrKV, scale, wg_idx,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                qk_pipeline,
+                qk_consumer_state,
+                kk_pipeline,
+                kk_consumer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                False,
+                False,
+                self.BLK_KV,
+                tKVrKV,
+                scale,
+                wg_idx,
             )
 
         if num_blocks != 1:
@@ -2473,17 +3071,36 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                 kk_consumer_state,
                 alpha_consumer_state,
             ) = self.compute_loop_body(
-                sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd, sO, sAlpha,
+                sQ_SD,
+                sK_SD,
+                sK_DS,
+                sV_DS,
+                sQK,
+                sKK_inv,
+                sKK_opd,
+                sO,
+                sAlpha,
                 kv_tiled_mma,
-                q_pipeline, q_consumer_state,
-                k_pipeline, k_consumer_state,
-                v_pipeline, v_consumer_state,
-                o_pipeline, o_producer_state,
-                qk_pipeline, qk_consumer_state,
-                kk_pipeline, kk_consumer_state,
-                alpha_pipeline, alpha_consumer_state,
-                False, True, last_B,
-                tKVrKV, scale, wg_idx,
+                q_pipeline,
+                q_consumer_state,
+                k_pipeline,
+                k_consumer_state,
+                v_pipeline,
+                v_consumer_state,
+                o_pipeline,
+                o_producer_state,
+                qk_pipeline,
+                qk_consumer_state,
+                kk_pipeline,
+                kk_consumer_state,
+                alpha_pipeline,
+                alpha_consumer_state,
+                False,
+                True,
+                last_B,
+                tKVrKV,
+                scale,
+                wg_idx,
             )
         if store_state:
             self.kv_store(tKVrKV, gStateKV, kv_tiled_mma, math_tidx)
@@ -2559,22 +3176,28 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
 
         qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
         t_storage_layout = cute.tile_to_shape(
-            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.t_stage), order=(0, 1, 2))
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.t_stage), order=(0, 1, 2)
+        )
         t_smem_layout = cute.slice_(t_storage_layout, (None, None, 0))
 
         tma_load_op = cpasync.CopyBulkTensorTileG2SOp()
         tma_atom_q, tma_tensor_q = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_q, q_smem_layout, (self.BLK_Q, self.D))
+            tma_load_op, g_q, q_smem_layout, (self.BLK_Q, self.D)
+        )
         tma_atom_k, tma_tensor_k = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_k, k_smem_layout, (self.D, self.BLK_KV))
+            tma_load_op, g_k, k_smem_layout, (self.D, self.BLK_KV)
+        )
         tma_atom_v, tma_tensor_v = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_v, v_smem_layout, (self.D, self.BLK_KV))
+            tma_load_op, g_v, v_smem_layout, (self.D, self.BLK_KV)
+        )
         tma_atom_t, tma_tensor_t = cpasync.make_tiled_tma_atom(
-            tma_load_op, g_t, t_smem_layout, (self.BLK_KV, self.BLK_KV))
+            tma_load_op, g_t, t_smem_layout, (self.BLK_KV, self.BLK_KV)
+        )
 
         tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
         tma_atom_o, tma_tensor_o = cpasync.make_tiled_tma_atom(
-            tma_store_op, g_o, o_smem_layout, (self.D, self.BLK_Q))
+            tma_store_op, g_o, o_smem_layout, (self.D, self.BLK_Q)
+        )
 
         dtype_bytes = self.dtype.width // 8
         self.tma_load_q_bytes = cute.size(q_smem_layout) * dtype_bytes
@@ -2583,11 +3206,14 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         self.tma_load_t_bytes = cute.size(t_smem_layout) * dtype_bytes
 
         qk_storage_layout = cute.tile_to_shape(
-            qk_layout_atom, (self.BLK_Q, self.BLK_KV, self.qk_stage), order=(0, 1, 2))
+            qk_layout_atom, (self.BLK_Q, self.BLK_KV, self.qk_stage), order=(0, 1, 2)
+        )
         kk_storage_layout = cute.tile_to_shape(
-            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.kk_stage), order=(0, 1, 2))
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.kk_stage), order=(0, 1, 2)
+        )
         alpha_storage_layout = cute.make_layout(
-            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage)
+        )
 
         @cute.struct
         class SharedStorage:
@@ -2598,28 +3224,64 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             o_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.o_stage * 2]
             qk_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.qk_stage * 2]
             kk_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.kk_stage * 2]
-            alpha_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.alpha_beta_stage * 2]
+            alpha_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.alpha_beta_stage * 2
+            ]
 
-            smem_q: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(q_storage_layout)], 128]
-            smem_k: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128]
-            smem_v: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(v_storage_layout_sd)], 128]
-            smem_t: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(t_storage_layout)], 16]
-            smem_qk: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(qk_storage_layout)], 16]
-            smem_kk: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(kk_storage_layout)], 16]
-            smem_o: cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(o_storage_layout)], 128]
+            smem_q: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(q_storage_layout)], 128
+            ]
+            smem_k: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(k_storage_layout_sd)], 128
+            ]
+            smem_v: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(v_storage_layout_sd)], 128
+            ]
+            smem_t: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(t_storage_layout)], 16
+            ]
+            smem_qk: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(qk_storage_layout)], 16
+            ]
+            smem_kk: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(kk_storage_layout)], 16
+            ]
+            smem_o: cute.struct.Align[
+                cute.struct.MemRange[self.dtype, cute.cosize(o_storage_layout)], 128
+            ]
             smem_alpha: cute.struct.Align[
-                cute.struct.MemRange[cutlass.Float32, cute.cosize(alpha_storage_layout)], 16]
+                cute.struct.MemRange[
+                    cutlass.Float32, cute.cosize(alpha_storage_layout)
+                ],
+                16,
+            ]
 
         self.shared_storage = SharedStorage
         self.kernel(
             g_alpha,
-            tma_atom_q, tma_tensor_q,
-            tma_atom_k, tma_tensor_k,
-            tma_atom_v, tma_tensor_v,
-            tma_atom_t, tma_tensor_t,
-            tma_atom_o, tma_tensor_o,
-            g_state, g_fixed_state, g_initial_state, g_tensormaps, g_cu_seqlens,
-            scale, num_q_heads, num_k_heads, num_v_heads, num_sab_heads, chunk_len, total_cp_chunks, num_seqs,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_t,
+            tma_tensor_t,
+            tma_atom_o,
+            tma_tensor_o,
+            g_state,
+            g_fixed_state,
+            g_initial_state,
+            g_tensormaps,
+            g_cu_seqlens,
+            scale,
+            num_q_heads,
+            num_k_heads,
+            num_v_heads,
+            num_sab_heads,
+            chunk_len,
+            total_cp_chunks,
+            num_seqs,
         ).launch(
             grid=(num_sab_heads * max_cp_chunks_per_seq, num_seqs, 1),
             block=(512, 1, 1),
@@ -2663,9 +3325,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         WARPS_PER_WARP_GROUP = 4
         MIN_BLOCKS_PER_MP = 1
         MAX_THREADS_PER_BLOCK = (
-            NUM_LOAD_WARP_GROUPS
-            + NUM_STATE_MMA_WARP_GROUPS
-            + NUM_AUX_MMA_WARP_GROUPS
+            NUM_LOAD_WARP_GROUPS + NUM_STATE_MMA_WARP_GROUPS + NUM_AUX_MMA_WARP_GROUPS
         ) * THREADS_PER_WARP_GROUP
         (
             load_registers,
@@ -2680,10 +3340,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
 
         tidx, _, _ = cute.arch.thread_idx()
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        warp_group_idx = cute.arch.make_warp_uniform(
-            tidx // THREADS_PER_WARP_GROUP)
-        ldst_warp_role = cute.arch.make_warp_uniform(
-            warp_idx % WARPS_PER_WARP_GROUP)
+        warp_group_idx = cute.arch.make_warp_uniform(tidx // THREADS_PER_WARP_GROUP)
+        ldst_warp_role = cute.arch.make_warp_uniform(warp_idx % WARPS_PER_WARP_GROUP)
 
         bx, seq_idx, _ = cute.arch.block_idx()
         o_head_idx = bx % num_sab_heads
@@ -2703,7 +3361,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         num_blocks = (valid_chunk_len + self.BLK_KV - 1) // self.BLK_KV
         t_blocks_per_cp_chunk = (chunk_len + self.BLK_KV - 1) // self.BLK_KV
         t_block_start = varlen_chunk_idx(
-            seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK_KV)
+            seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK_KV
+        )
         work_desc = WorkDesc(
             seq_idx=cp_chunk_idx,
             private_q_head_idx=q_head_idx,
@@ -2728,7 +3387,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             cpasync.prefetch_descriptor(tma_atom_t)
 
         math_tidx = tidx - THREADS_PER_WARP_GROUP
-        wg_idx    = math_tidx // THREADS_PER_WARP_GROUP
+        wg_idx = math_tidx // THREADS_PER_WARP_GROUP
 
         allocator = cutlass.utils.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
@@ -2772,11 +3431,14 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
 
         qk_layout_atom = cute.make_layout((8, 8), stride=(8, 1))
         qk_layout = cute.tile_to_shape(
-            qk_layout_atom, (self.BLK_Q, self.BLK_KV, self.qk_stage), order=(0, 1, 2))
+            qk_layout_atom, (self.BLK_Q, self.BLK_KV, self.qk_stage), order=(0, 1, 2)
+        )
         kk_layout = cute.tile_to_shape(
-            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.kk_stage), order=(0, 1, 2))
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.kk_stage), order=(0, 1, 2)
+        )
         t_layout = cute.tile_to_shape(
-            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.t_stage), order=(0, 1, 2))
+            qk_layout_atom, (self.BLK_KV, self.BLK_KV, self.t_stage), order=(0, 1, 2)
+        )
         sQK = storage.smem_qk.get_tensor(qk_layout)
         sKK_opd = storage.smem_kk.get_tensor(kk_layout)
         sKK_inv = sKK_opd
@@ -2793,13 +3455,15 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         )
         sO = storage.smem_o.get_tensor(o_layout.outer, swizzle=o_layout.inner)
         alpha_layout = cute.make_layout(
-            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage))
+            (self.BLK_Q, AlphaProcessor.NUM_CHANNELS, self.alpha_beta_stage)
+        )
         sAlpha = storage.smem_alpha.get_tensor(alpha_layout)
 
         load_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
         qk_load_consumer_group = pipeline.CooperativeGroup(
             pipeline.Agent.Thread,
-            (NUM_STATE_MMA_WARP_GROUPS + NUM_AUX_MMA_WARP_GROUPS) * WARPS_PER_WARP_GROUP,
+            (NUM_STATE_MMA_WARP_GROUPS + NUM_AUX_MMA_WARP_GROUPS)
+            * WARPS_PER_WARP_GROUP,
         )
         v_consumer_group = pipeline.CooperativeGroup(
             pipeline.Agent.Thread,
@@ -2895,49 +3559,118 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                 cute.arch.setmaxregister_decrease(load_registers)
                 if ldst_warp_role == LoadStoreWarpRole.LOAD_QKV:
                     self.run_load_qkv_role(
-                        sQ_SD, sK_DS, sV_DS,
-                        tma_atom_q, tma_tensor_q,
-                        tma_atom_k, tma_tensor_k,
-                        tma_atom_v, tma_tensor_v,
-                        q_pipeline, k_pipeline, v_pipeline,
-                        num_blocks, work_desc.tok_offset,
-                        q_head_idx, k_head_idx, v_head_idx,
+                        sQ_SD,
+                        sK_DS,
+                        sV_DS,
+                        tma_atom_q,
+                        tma_tensor_q,
+                        tma_atom_k,
+                        tma_tensor_k,
+                        tma_atom_v,
+                        tma_tensor_v,
+                        q_pipeline,
+                        k_pipeline,
+                        v_pipeline,
+                        num_blocks,
+                        work_desc.tok_offset,
+                        q_head_idx,
+                        k_head_idx,
+                        v_head_idx,
                     )
                 elif ldst_warp_role == LoadStoreWarpRole.STORE_O:
                     CollectiveStoreTma(self.BLK_Q, self.D).run(
-                        sO, tma_atom_o, tma_tensor_o, g_tensormaps,
-                        o_pipeline, num_blocks, work_desc, total_cp_chunks, self.o_stage,
-                        num_q_heads, num_v_heads,
+                        sO,
+                        tma_atom_o,
+                        tma_tensor_o,
+                        g_tensormaps,
+                        o_pipeline,
+                        num_blocks,
+                        work_desc,
+                        total_cp_chunks,
+                        self.o_stage,
+                        num_q_heads,
+                        num_v_heads,
                     )
                 elif ldst_warp_role == LoadStoreWarpRole.LOAD_BETA:
                     self.run_load_t_role(
-                        sT, tma_atom_t, tma_tensor_t, t_pipeline,
-                        num_blocks, t_block_start, o_head_idx,
+                        sT,
+                        tma_atom_t,
+                        tma_tensor_t,
+                        t_pipeline,
+                        num_blocks,
+                        t_block_start,
+                        o_head_idx,
                     )
                 elif ldst_warp_role == LoadStoreWarpRole.LOAD_ALPHA:
                     self.run_load_alpha_role(
-                        sAlpha, g_alpha, alpha_pipeline, scale, num_blocks, work_desc.tok_offset,
-                        work_desc.tok_offset + work_desc.seq_len, o_head_idx, num_sab_heads,
+                        sAlpha,
+                        g_alpha,
+                        alpha_pipeline,
+                        scale,
+                        num_blocks,
+                        work_desc.tok_offset,
+                        work_desc.tok_offset + work_desc.seq_len,
+                        o_head_idx,
+                        num_sab_heads,
                     )
             else:
                 if warp_group_idx == WarpGroupRole.MATH_AUX:
                     cute.arch.setmaxregister_decrease(aux_mma_registers)
                     self.run_aux_math_role(
-                        sQ_SD, sK_SD, sQK, sT, sKK_opd, sAlpha,
-                        q_pipeline, k_pipeline, t_pipeline, qk_pipeline, kk_pipeline,
-                        alpha_pipeline, work_desc, scale, math_tidx, num_blocks,
+                        sQ_SD,
+                        sK_SD,
+                        sQK,
+                        sT,
+                        sKK_opd,
+                        sAlpha,
+                        q_pipeline,
+                        k_pipeline,
+                        t_pipeline,
+                        qk_pipeline,
+                        kk_pipeline,
+                        alpha_pipeline,
+                        work_desc,
+                        scale,
+                        math_tidx,
+                        num_blocks,
                     )
                 else:
                     cute.arch.setmaxregister_increase(state_mma_registers)
                     self.run_cp_state_math_role(
-                        sQ_SD, sK_SD, sK_DS, sV_DS, sQK, sKK_inv, sKK_opd,
-                        sO, sAlpha,
-                        q_pipeline, k_pipeline, v_pipeline, o_pipeline,
-                        qk_pipeline, kk_pipeline, alpha_pipeline,
-                        g_state, g_fixed_state, g_initial_state, work_desc,
-                        seq_idx, fixed_state_idx, load_fixed_state, load_initial_state, store_state,
-                        scale, wg_idx, math_tidx, num_blocks,
-                        num_q_heads, num_v_heads, num_sab_heads, total_cp_chunks, num_seqs,
+                        sQ_SD,
+                        sK_SD,
+                        sK_DS,
+                        sV_DS,
+                        sQK,
+                        sKK_inv,
+                        sKK_opd,
+                        sO,
+                        sAlpha,
+                        q_pipeline,
+                        k_pipeline,
+                        v_pipeline,
+                        o_pipeline,
+                        qk_pipeline,
+                        kk_pipeline,
+                        alpha_pipeline,
+                        g_state,
+                        g_fixed_state,
+                        g_initial_state,
+                        work_desc,
+                        seq_idx,
+                        fixed_state_idx,
+                        load_fixed_state,
+                        load_initial_state,
+                        store_state,
+                        scale,
+                        wg_idx,
+                        math_tidx,
+                        num_blocks,
+                        num_q_heads,
+                        num_v_heads,
+                        num_sab_heads,
+                        total_cp_chunks,
+                        num_seqs,
                     )
 
 
@@ -2970,24 +3703,42 @@ def cp_delta_rule_prefill_dsl_sm90(
 
     if not _skip_check:
         if q.ndim != 3:
-            raise RuntimeError(f"q must have shape (total_seqlen, num_q_heads, D), got {tuple(q.shape)}")
+            raise RuntimeError(
+                f"q must have shape (total_seqlen, num_q_heads, D), got {tuple(q.shape)}"
+            )
         if k.ndim != 3 or v.ndim != 3 or o.ndim != 3:
             raise RuntimeError(
                 "k, v, and o must have shape (total_seqlen, num_heads, D), "
                 f"got k={tuple(k.shape)}, v={tuple(v.shape)}, o={tuple(o.shape)}"
             )
-        if k.shape[0] != q.shape[0] or v.shape[0] != q.shape[0] or o.shape[0] != q.shape[0]:
+        if (
+            k.shape[0] != q.shape[0]
+            or v.shape[0] != q.shape[0]
+            or o.shape[0] != q.shape[0]
+        ):
             raise RuntimeError("q, k, v, and o must have the same total_seqlen")
-        if k.shape[2] != q.shape[2] or v.shape[2] != q.shape[2] or o.shape[2] != q.shape[2]:
+        if (
+            k.shape[2] != q.shape[2]
+            or v.shape[2] != q.shape[2]
+            or o.shape[2] != q.shape[2]
+        ):
             raise RuntimeError("q, k, v, and o must have the same D")
         if alpha.ndim != 2 or alpha.shape[0] != q.shape[0]:
-            raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
+            raise RuntimeError(
+                f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}"
+            )
         if total_seqlen != q.shape[0]:
-            raise RuntimeError(f"total_seqlen must match q.shape[0], got {total_seqlen} and {q.shape[0]}")
+            raise RuntimeError(
+                f"total_seqlen must match q.shape[0], got {total_seqlen} and {q.shape[0]}"
+            )
         if cp_chunk_len % 64 != 0:
-            raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
+            raise RuntimeError(
+                f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}"
+            )
         if cu_seqlens.dtype != torch.int64:
-            raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+            raise RuntimeError(
+                f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+            )
         if not cu_seqlens.is_contiguous():
             raise RuntimeError("cu_seqlens must be contiguous")
     num_seqs = cu_seqlens.shape[0] - 1
@@ -3003,10 +3754,16 @@ def cp_delta_rule_prefill_dsl_sm90(
     total_cp_chunks = workspace_num_chunks_host(cu_seqlens, cp_chunk_len, total_seqlen)
     if not _skip_check:
         if o.shape[1] != num_sab_heads:
-            raise RuntimeError(f"o heads must equal max(q heads, v heads)={num_sab_heads}, got {o.shape[1]}")
+            raise RuntimeError(
+                f"o heads must equal max(q heads, v heads)={num_sab_heads}, got {o.shape[1]}"
+            )
         if alpha.shape[1] != num_sab_heads:
-            raise RuntimeError(f"alpha heads must equal max(q heads, v heads)={num_sab_heads}, got {alpha.shape[1]}")
-        if not _FullyFusedDeltaRuleSm90.can_implement(num_q_heads, num_k_heads, num_v_heads, d, q.element_size()):
+            raise RuntimeError(
+                f"alpha heads must equal max(q heads, v heads)={num_sab_heads}, got {alpha.shape[1]}"
+            )
+        if not _FullyFusedDeltaRuleSm90.can_implement(
+            num_q_heads, num_k_heads, num_v_heads, d, q.element_size()
+        ):
             raise RuntimeError(
                 "CPDeltaRulePrefillSm90 only supports head counts where q/v heads are positive multiples "
                 f"of k heads, got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
@@ -3018,30 +3775,55 @@ def cp_delta_rule_prefill_dsl_sm90(
             )
         expected_fixed_state_shape = (total_cp_chunks, num_sab_heads, d, d)
         expected_state_shape = (num_seqs, num_sab_heads, d, d)
-        if fixed_state.shape != expected_fixed_state_shape or state.shape != expected_state_shape:
+        if (
+            fixed_state.shape != expected_fixed_state_shape
+            or state.shape != expected_state_shape
+        ):
             raise RuntimeError(
                 "fixed_state/state must have shapes "
                 f"{expected_fixed_state_shape} and {expected_state_shape}, "
                 f"got {tuple(fixed_state.shape)} and {tuple(state.shape)}"
             )
         if initial_state is not None and initial_state.shape != expected_state_shape:
-            raise RuntimeError(f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}")
+            raise RuntimeError(
+                f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+            )
         if q.shape[-1] != 128:
-            raise RuntimeError(f"CPDeltaRulePrefillSm90 only supports D=128, got {q.shape[-1]}")
+            raise RuntimeError(
+                f"CPDeltaRulePrefillSm90 only supports D=128, got {q.shape[-1]}"
+            )
         if q.dtype not in (torch.float16, torch.bfloat16):
-            raise RuntimeError(f"CPDeltaRulePrefillSm90 only supports fp16/bf16 inputs, got {q.dtype}")
-        if k.dtype != q.dtype or v.dtype != q.dtype or o.dtype != q.dtype or t.dtype != q.dtype:
+            raise RuntimeError(
+                f"CPDeltaRulePrefillSm90 only supports fp16/bf16 inputs, got {q.dtype}"
+            )
+        if (
+            k.dtype != q.dtype
+            or v.dtype != q.dtype
+            or o.dtype != q.dtype
+            or t.dtype != q.dtype
+        ):
             raise RuntimeError(
                 "q/k/v/o/t dtypes must match, "
                 f"got q={q.dtype}, k={k.dtype}, v={v.dtype}, o={o.dtype}, t={t.dtype}"
             )
         if alpha.dtype != torch.float32:
-            raise RuntimeError(f"alpha must have dtype torch.float32, got {alpha.dtype}")
+            raise RuntimeError(
+                f"alpha must have dtype torch.float32, got {alpha.dtype}"
+            )
         if initial_state is not None and initial_state.dtype != torch.float32:
-            raise RuntimeError(f"initial_state must have dtype torch.float32, got {initial_state.dtype}")
+            raise RuntimeError(
+                f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
+            )
         for name, tensor in (
-            ("q", q), ("k", k), ("v", v), ("t", t), ("fixed_state", fixed_state), ("initial_state", initial_state),
-            ("alpha", alpha), ("o", o), ("state", state)
+            ("q", q),
+            ("k", k),
+            ("v", v),
+            ("t", t),
+            ("fixed_state", fixed_state),
+            ("initial_state", initial_state),
+            ("alpha", alpha),
+            ("o", o),
+            ("state", state),
         ):
             if tensor is None:
                 continue
@@ -3088,14 +3870,19 @@ def cp_delta_rule_prefill_dsl_sm90(
 
     enable_tvm_ffi = True
     if enable_tvm_ffi:
-        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
+        from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(
+            *args, **{**kwargs, "enable_tvm_ffi": True}
+        )
 
     needs_initial_state = initial_state is not None
     initial_state_cute = (
         from_dlpack(initial_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
-        if needs_initial_state else None
+        if needs_initial_state
+        else None
     )
-    kernel = CPDeltaRulePrefillSm90(kernel_dtype, needs_initial_state=needs_initial_state)
+    kernel = CPDeltaRulePrefillSm90(
+        kernel_dtype, needs_initial_state=needs_initial_state
+    )
     kernel_args = (
         from_dlpack(q_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
         from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
@@ -3167,7 +3954,9 @@ def cp_delta_rule_dsl_sm90(
             chunk_len_granularity=cp_chunk_len_granularity,
         )
     if q.ndim != 3:
-        raise RuntimeError(f"q must have shape (total_seqlen, num_q_heads, D), got {tuple(q.shape)}")
+        raise RuntimeError(
+            f"q must have shape (total_seqlen, num_q_heads, D), got {tuple(q.shape)}"
+        )
     if k.ndim != 3 or v.ndim != 3 or o.ndim != 3:
         raise RuntimeError(
             "k, v, and o must have shape (total_seqlen, num_heads, D), "
@@ -3178,13 +3967,19 @@ def cp_delta_rule_dsl_sm90(
     if k.shape[2] != q.shape[2] or v.shape[2] != q.shape[2] or o.shape[2] != q.shape[2]:
         raise RuntimeError("q, k, v, and o must have the same D")
     if alpha.ndim != 2 or alpha.shape[0] != q.shape[0]:
-        raise RuntimeError(f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}")
+        raise RuntimeError(
+            f"alpha must have shape (total_seqlen, num_sab_heads), got {tuple(alpha.shape)}"
+        )
     if beta.ndim != 2 or beta.shape[0] != q.shape[0]:
-        raise RuntimeError(f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}")
+        raise RuntimeError(
+            f"beta must have shape (total_seqlen, num_sab_heads), got {tuple(beta.shape)}"
+        )
     if cp_chunk_len % 64 != 0:
         raise RuntimeError(f"cp_chunk_len must be a multiple of 64, got {cp_chunk_len}")
     if cu_seqlens.dtype != torch.int64:
-        raise RuntimeError(f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}")
+        raise RuntimeError(
+            f"cu_seqlens must have dtype torch.int64, got {cu_seqlens.dtype}"
+        )
     if not cu_seqlens.is_contiguous():
         raise RuntimeError("cu_seqlens must be contiguous")
     _, num_q_heads, d = q.shape
@@ -3192,37 +3987,61 @@ def cp_delta_rule_dsl_sm90(
     num_v_heads = v.shape[1]
     num_sab_heads = max(num_q_heads, num_v_heads)
     if o.shape[1] != num_sab_heads:
-        raise RuntimeError(f"o heads must equal max(q heads, v heads)={num_sab_heads}, got {o.shape[1]}")
+        raise RuntimeError(
+            f"o heads must equal max(q heads, v heads)={num_sab_heads}, got {o.shape[1]}"
+        )
     if alpha.shape[1] != num_sab_heads:
-        raise RuntimeError(f"alpha heads must equal max(q heads, v heads)={num_sab_heads}, got {alpha.shape[1]}")
+        raise RuntimeError(
+            f"alpha heads must equal max(q heads, v heads)={num_sab_heads}, got {alpha.shape[1]}"
+        )
     if beta.shape[1] != num_sab_heads:
-        raise RuntimeError(f"beta heads must equal max(q heads, v heads)={num_sab_heads}, got {beta.shape[1]}")
-    if not _FullyFusedDeltaRuleSm90.can_implement(num_q_heads, num_k_heads, num_v_heads, d, q.element_size()):
+        raise RuntimeError(
+            f"beta heads must equal max(q heads, v heads)={num_sab_heads}, got {beta.shape[1]}"
+        )
+    if not _FullyFusedDeltaRuleSm90.can_implement(
+        num_q_heads, num_k_heads, num_v_heads, d, q.element_size()
+    ):
         raise RuntimeError(
             "CPDeltaRuleSm90 only supports head counts where q/v heads are positive multiples "
             f"of k heads, got q={num_q_heads}, k={num_k_heads}, v={num_v_heads}"
         )
     expected_state_shape = (num_seqs, num_sab_heads, d, d)
     if state.shape != expected_state_shape:
-        raise RuntimeError(f"state must have shape {expected_state_shape}, got {tuple(state.shape)}")
+        raise RuntimeError(
+            f"state must have shape {expected_state_shape}, got {tuple(state.shape)}"
+        )
     if initial_state is not None and initial_state.shape != expected_state_shape:
-        raise RuntimeError(f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}")
+        raise RuntimeError(
+            f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}"
+        )
     if q.shape[-1] != 128:
         raise RuntimeError(f"CPDeltaRuleSm90 only supports D=128, got {q.shape[-1]}")
     if q.dtype not in (torch.float16, torch.bfloat16):
-        raise RuntimeError(f"CPDeltaRuleSm90 only supports fp16/bf16 inputs, got {q.dtype}")
+        raise RuntimeError(
+            f"CPDeltaRuleSm90 only supports fp16/bf16 inputs, got {q.dtype}"
+        )
     if k.dtype != q.dtype or v.dtype != q.dtype or o.dtype != q.dtype:
         raise RuntimeError(
             "q/k/v/o dtypes must match, "
             f"got q={q.dtype}, k={k.dtype}, v={v.dtype}, o={o.dtype}"
         )
     if alpha.dtype != torch.float32 or beta.dtype != torch.float32:
-        raise RuntimeError(f"alpha/beta must have dtype torch.float32, got {alpha.dtype} and {beta.dtype}")
+        raise RuntimeError(
+            f"alpha/beta must have dtype torch.float32, got {alpha.dtype} and {beta.dtype}"
+        )
     if initial_state is not None and initial_state.dtype != torch.float32:
-        raise RuntimeError(f"initial_state must have dtype torch.float32, got {initial_state.dtype}")
+        raise RuntimeError(
+            f"initial_state must have dtype torch.float32, got {initial_state.dtype}"
+        )
     for name, tensor in (
-        ("q", q), ("k", k), ("v", v), ("alpha", alpha), ("beta", beta), ("o", o), ("state", state),
-        ("initial_state", initial_state)
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("alpha", alpha),
+        ("beta", beta),
+        ("o", o),
+        ("state", state),
+        ("initial_state", initial_state),
     ):
         if tensor is None:
             continue
@@ -3230,18 +4049,45 @@ def cp_delta_rule_dsl_sm90(
             raise RuntimeError(f"{name} must be contiguous")
 
     t = cp_delta_rule_t_precompute_dsl_sm90(
-        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen, _skip_check=True)
+        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen, _skip_check=True
+    )
     local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen,
-        cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen, _skip_check=True)
+        k,
+        v,
+        t,
+        alpha,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
+        _skip_check=True,
+    )
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
-        local_transfer, local_state, cu_seqlens, total_seqlen,
-        cp_chunk_len=cp_chunk_len, initial_state=initial_state, _skip_check=True)
+        local_transfer,
+        local_state,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        initial_state=initial_state,
+        _skip_check=True,
+    )
 
     if num_seqs != 1:
         state.zero_()
     cp_delta_rule_prefill_dsl_sm90(
-        o, state, q, k, v, t, fixed_state, alpha, scale,
-        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen,
-        initial_state=initial_state, _skip_check=True,
+        o,
+        state,
+        q,
+        k,
+        v,
+        t,
+        fixed_state,
+        alpha,
+        scale,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
+        initial_state=initial_state,
+        _skip_check=True,
     )

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -1488,7 +1488,8 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         ) // max_threads_per_block
         return min(248, registers_per_thread)
 
-    def __init__(self):
+    def __init__(self, needs_initial_state: bool = False):
+        self.needs_initial_state = needs_initial_state
         self.D = 128
         self.rows_per_cta = 64
         self.row_ctas = 2
@@ -1620,9 +1621,11 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         n_pipeline,
         n_consumer_state,
         gFixedState: cute.Tensor,
+        gInitialState: cute.Tensor,
         num_chunks: cutlass.Int32,
         total_cp_chunks: cutlass.Int32,
         chunk_start: cutlass.Int32,
+        seq_idx: cutlass.Int32,
         head_idx: cutlass.Int32,
         row_cta_idx: cutlass.Int32,
         math_tidx: cutlass.Int32,
@@ -1652,19 +1655,41 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
             (16, self.D, total_cp_chunks),
             (global_row_base // 16, 0, 0),
         )
+        if cutlass.const_expr(self.needs_initial_state):
+            gInitialState_warp = cute.local_tile(
+                gInitialState[None, None, head_idx, seq_idx],
+                (16, self.D),
+                (global_row_base // 16, 0),
+            )
         tSMsN = thr_copy_C.partition_S(sN_warp)
         tSMgFixedState = thr_store_C.partition_D(gFixedState_warp)
+        if cutlass.const_expr(self.needs_initial_state):
+            tSMgInitialState = thr_copy_C.partition_S(gInitialState_warp)
 
-        # NOTE: assume initial state is always zero, S_c1 = S_init @ M + N,
-        # then the state after fixup for the first chunk is N automatically.
-        n_pipeline.consumer_wait(n_consumer_state)
-        cute.arch.fence_view_async_shared()
-        cute.autovec_copy(tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv)
-        n_pipeline.consumer_release(n_consumer_state)
-        n_consumer_state.advance()
-        self.store_fixed_state(tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start)
+        start = cutlass.Int32(0)
+        if cutlass.const_expr(not self.needs_initial_state):
+            # NOTE: assume initial state is always zero, S_c1 = S_init @ M + N,
+            # then the state after fixup for the first chunk is N automatically.
 
-        for chunk_idx in cutlass.range(1, num_chunks, 1, unroll=1):
+            # skip the first recurrence
+            start = cutlass.Int32(1)
+            # init tSMrState from N
+            n_pipeline.consumer_wait(n_consumer_state)
+            cute.arch.fence_view_async_shared()
+            cute.autovec_copy(tSMsN[None, None, None, n_consumer_state.index], tSMrState_cv)
+            n_pipeline.consumer_release(n_consumer_state)
+            n_consumer_state.advance()
+            # and
+
+            self.store_fixed_state(tiled_store_C, tSMrState_store, tSMgFixedState, chunk_start)
+        else:
+            # do normal recurrence for the first chunk
+            start = cutlass.Int32(0)
+
+            # init tSMrState from initial_state
+            cute.autovec_copy(tSMgInitialState, tSMrState_cv)
+
+        for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
             self.convert_tf32_c_to_kpermuted_a(tSMrState, tSMrS)
             n_pipeline.consumer_wait(n_consumer_state)
             m_pipeline.consumer_wait(m_consumer_state)
@@ -1697,6 +1722,7 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         self,
         g_transfer_t: cute.Tensor,
         g_local_state_t: cute.Tensor,
+        g_initial_state_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
@@ -1734,6 +1760,7 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         self.kernel(
             tma_atom_m, tma_tensor_m,
             tma_atom_n, tma_tensor_n,
+            g_initial_state_t,
             g_fixed_state_t,
             g_cu_seqlens,
             chunk_len, total_cp_chunks, num_seqs, num_heads,
@@ -1752,6 +1779,7 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         tma_tensor_m: cute.Tensor,
         tma_atom_n: cute.CopyAtom,
         tma_tensor_n: cute.Tensor,
+        g_initial_state_t: cute.Tensor,
         g_fixed_state_t: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         chunk_len: cutlass.Int32,
@@ -1789,6 +1817,14 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         sM = storage.smem_m.get_tensor(transfer_layout.outer, swizzle=transfer_layout.inner)
         sN = storage.smem_n.get_tensor(state_layout.outer, swizzle=state_layout.inner)
         gFixedState = cute.make_tensor(g_fixed_state_t.iterator.align(128), out_layout)
+        fixed_state_layout = cute.make_layout(
+            (self.D, self.D, num_heads, num_seqs),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        if cutlass.const_expr(self.needs_initial_state):
+            gInitialState = cute.make_tensor(g_initial_state_t.iterator, fixed_state_layout)
+        else:
+            gInitialState = gFixedState
 
         ldst_warp_role = cute.arch.make_warp_uniform(warp_idx % 4)
         if warp_group_idx == self.WarpGroupRole.LOAD:
@@ -1825,11 +1861,18 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
         if warp_group_idx == self.WarpGroupRole.LOAD:
             cute.arch.setmaxregister_decrease(40)
             if ldst_warp_role == self.LoadWarpRole.LOAD_M and num_chunks > 0:
-                for chunk_idx in cutlass.range(1, num_chunks, 1, unroll=1):
-                    m_producer_state = self.load_fixup_tma(
-                        tma_atom_m, tma_tensor_m, sM, m_pipeline, m_producer_state,
-                        chunk_start, chunk_idx, head_idx, row_cta_idx, False,
-                    )
+                if cutlass.const_expr(self.needs_initial_state):
+                    for chunk_idx in cutlass.range(0, num_chunks, 1, unroll=1):
+                        m_producer_state = self.load_fixup_tma(
+                            tma_atom_m, tma_tensor_m, sM, m_pipeline, m_producer_state,
+                            chunk_start, chunk_idx, head_idx, row_cta_idx, False,
+                        )
+                else:
+                    for chunk_idx in cutlass.range(1, num_chunks, 1, unroll=1):
+                        m_producer_state = self.load_fixup_tma(
+                            tma_atom_m, tma_tensor_m, sM, m_pipeline, m_producer_state,
+                            chunk_start, chunk_idx, head_idx, row_cta_idx, False,
+                        )
             elif ldst_warp_role == self.LoadWarpRole.LOAD_N and num_chunks > 0:
                 for chunk_idx in cutlass.range(0, num_chunks, 1, unroll=1):
                     n_producer_state = self.load_fixup_tma(
@@ -1844,7 +1887,8 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
                     sM, sN,
                     m_pipeline, m_consumer_state,
                     n_pipeline, n_consumer_state,
-                    gFixedState, num_chunks, total_cp_chunks, chunk_start, head_idx, row_cta_idx, math_tidx,
+                    gFixedState, gInitialState, num_chunks, total_cp_chunks,
+                    chunk_start, seq_idx, head_idx, row_cta_idx, math_tidx,
                 )
 
 
@@ -1854,6 +1898,7 @@ def cp_delta_rule_fixup_dsl_sm90(
     cu_seqlens: torch.Tensor,
     total_seqlen: int,
     cp_chunk_len: int = 4096,
+    initial_state: torch.Tensor | None = None,
     *,
     _skip_check: bool = False,
 ):
@@ -1884,7 +1929,19 @@ def cp_delta_rule_fixup_dsl_sm90(
                 "CPDeltaRuleFixupSm90 only supports float32 inputs, "
                 f"got {local_transfer.dtype} and {local_state.dtype}"
             )
-        for name, tensor in (("local_transfer", local_transfer), ("local_state", local_state)):
+        if initial_state is not None:
+            if initial_state.shape != (cu_seqlens.shape[0] - 1, local_transfer.shape[1], 128, 128):
+                raise RuntimeError(
+                    "initial_state must have shape "
+                    f"{(cu_seqlens.shape[0] - 1, local_transfer.shape[1], 128, 128)}, got {tuple(initial_state.shape)}"
+                )
+            if initial_state.dtype != torch.float32:
+                raise RuntimeError(f"initial_state must have dtype torch.float32, got {initial_state.dtype}")
+        for name, tensor in (
+            ("local_transfer", local_transfer), ("local_state", local_state), ("initial_state", initial_state)
+        ):
+            if tensor is None:
+                continue
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
     total_cp_chunks, num_heads, _, _ = local_transfer.shape
@@ -1923,10 +1980,16 @@ def cp_delta_rule_fixup_dsl_sm90(
     if enable_tvm_ffi:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
 
-    kernel = CPDeltaRuleFixupSm90()
+    needs_initial_state = initial_state is not None
+    initial_state_cute = (
+        from_dlpack(initial_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
+        if needs_initial_state else None
+    )
+    kernel = CPDeltaRuleFixupSm90(needs_initial_state)
     kernel_args = (
         from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(leading_dim=1),
         from_dlpack(local_state_tma, assumed_align=128).mark_layout_dynamic(leading_dim=1),
+        initial_state_cute,
         from_dlpack(fixed_state.reshape(-1), assumed_align=128).mark_layout_dynamic(),
         from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
         cutlass.Int32(cp_chunk_len),
@@ -1949,8 +2012,10 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         self,
         dtype: type[cutlass.Numeric] = cutlass.Float16,
         acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        needs_initial_state: bool = False,
     ):
         super().__init__(True, False, True, False, dtype, acc_dtype)
+        self.needs_initial_state = needs_initial_state
         self.t_stage = 2
 
     @cute.jit
@@ -2271,11 +2336,13 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         kk_pipeline,
         alpha_pipeline,
         g_state: cute.Tensor,
-        g_init_state: cute.Tensor,
+        g_fixed_state: cute.Tensor,
+        g_initial_state: cute.Tensor,
         work_desc: WorkDesc,
         public_seq_idx: cutlass.Int32,
-        init_state_idx: cutlass.Int32,
-        load_init_state,
+        fixed_state_idx: cutlass.Int32,
+        load_fixed_state,
+        load_initial_state,
         store_state,
         scale: cutlass.Float32,
         wg_idx: cutlass.Int32,
@@ -2313,11 +2380,17 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         o_head_idx = work_desc.o_head_idx(num_q_heads, num_v_heads)
         mState = cute.make_tensor(g_state.iterator, state_layout)
         gStateKV = mState[None, None, o_head_idx, public_seq_idx]
-        init_state_layout = cute.make_ordered_layout((self.D, self.D, num_sab_heads, num_chunks), order=(0, 1, 2, 3))
-        mInitState = cute.make_tensor(g_init_state.iterator, init_state_layout)
-        gInitKV = mInitState[None, None, o_head_idx, init_state_idx]
-        if load_init_state:
-            self.kv_load(tKVrKV, gInitKV, kv_tiled_mma, math_tidx)
+        if cutlass.const_expr(self.needs_initial_state):
+            mInitialState = cute.make_tensor(g_initial_state.iterator, state_layout)
+            gInitialKV = mInitialState[None, None, o_head_idx, public_seq_idx]
+        fixed_state_layout = cute.make_ordered_layout((self.D, self.D, num_sab_heads, num_chunks), order=(0, 1, 2, 3))
+        mFixedState = cute.make_tensor(g_fixed_state.iterator, fixed_state_layout)
+        gFixedKV = mFixedState[None, None, o_head_idx, fixed_state_idx]
+        if cutlass.const_expr(self.needs_initial_state):
+            if load_initial_state:
+                self.kv_load(tKVrKV, gInitialKV, kv_tiled_mma, math_tidx)
+        if load_fixed_state:
+            self.kv_load(tKVrKV, gFixedKV, kv_tiled_mma, math_tidx)
 
         first_B = work_desc.seq_len
         if first_B > self.BLK_KV:
@@ -2404,7 +2477,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         g_o: cute.Tensor,
         g_alpha: cute.Tensor,
         g_state: cute.Tensor,
-        g_init_state: cute.Tensor,
+        g_fixed_state: cute.Tensor,
+        g_initial_state: cute.Tensor,
         g_tensormaps: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         scale: cutlass.Float32,
@@ -2523,7 +2597,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             tma_atom_v, tma_tensor_v,
             tma_atom_t, tma_tensor_t,
             tma_atom_o, tma_tensor_o,
-            g_state, g_init_state, g_tensormaps, g_cu_seqlens,
+            g_state, g_fixed_state, g_initial_state, g_tensormaps, g_cu_seqlens,
             scale, num_q_heads, num_k_heads, num_v_heads, num_sab_heads, chunk_len, total_cp_chunks, num_seqs,
         ).launch(
             grid=(num_sab_heads * max_cp_chunks_per_seq, num_seqs, 1),
@@ -2548,7 +2622,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         tma_atom_o: cute.CopyAtom,
         tma_tensor_o: cute.Tensor,
         g_state: cute.Tensor,
-        g_init_state: cute.Tensor,
+        g_fixed_state: cute.Tensor,
+        g_initial_state: cute.Tensor,
         g_tensormaps: cute.Tensor,
         g_cu_seqlens: cute.Tensor,
         scale: cutlass.Float32,
@@ -2616,10 +2691,11 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             seq_len=valid_chunk_len,
             tile_idx=0,
         )
-        load_init_state = chunk_idx_in_seq != 0
-        init_state_idx = cp_chunk_idx
-        if load_init_state:
-            init_state_idx = cp_chunk_idx - 1
+        load_fixed_state = chunk_idx_in_seq != 0
+        load_initial_state = chunk_idx_in_seq == 0
+        fixed_state_idx = cp_chunk_idx
+        if load_fixed_state:
+            fixed_state_idx = cp_chunk_idx - 1
         store_state = chunk_idx_in_seq == num_cp_chunks - 1
 
         if warp_idx == LoadStoreWarpRole.LOAD_QKV:
@@ -2837,8 +2913,8 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                         sO, sAlpha,
                         q_pipeline, k_pipeline, v_pipeline, o_pipeline,
                         qk_pipeline, kk_pipeline, alpha_pipeline,
-                        g_state, g_init_state, work_desc,
-                        seq_idx, init_state_idx, load_init_state, store_state,
+                        g_state, g_fixed_state, g_initial_state, work_desc,
+                        seq_idx, fixed_state_idx, load_fixed_state, load_initial_state, store_state,
                         scale, wg_idx, math_tidx, num_blocks,
                         num_q_heads, num_v_heads, num_sab_heads, total_cp_chunks, num_seqs,
                     )
@@ -2851,19 +2927,20 @@ def cp_delta_rule_prefill_dsl_sm90(
     k: torch.Tensor,
     v: torch.Tensor,
     t: torch.Tensor,
-    init_state: torch.Tensor,
+    fixed_state: torch.Tensor,
     alpha: torch.Tensor,
     scale: float,
     cu_seqlens: torch.Tensor,
     total_seqlen: int,
     cp_chunk_len: int = 4096,
     max_seqlen: int | None = None,
+    initial_state: torch.Tensor | None = None,
     *,
     _skip_check: bool = False,
 ):
     """Run CP main prefill with precomputed T and fixed-up chunk states.
 
-    Flat varlen input consumes flat Q/K/V/O/alpha tensors and varlen T/init
+    Flat varlen input consumes flat Q/K/V/O/alpha tensors and varlen T/fixed-state
     workspaces. `state` is the public per-sequence final state in native
     `(DimV, DimK)` layout.
     """
@@ -2916,14 +2993,16 @@ def cp_delta_rule_prefill_dsl_sm90(
                 "t must have shape "
                 f"{(total_t_blocks, num_sab_heads, 64, 64)}, got {tuple(t.shape)}"
             )
-        expected_init_state_shape = (total_cp_chunks, num_sab_heads, d, d)
+        expected_fixed_state_shape = (total_cp_chunks, num_sab_heads, d, d)
         expected_state_shape = (num_seqs, num_sab_heads, d, d)
-        if init_state.shape != expected_init_state_shape or state.shape != expected_state_shape:
+        if fixed_state.shape != expected_fixed_state_shape or state.shape != expected_state_shape:
             raise RuntimeError(
-                "init_state/state must have shapes "
-                f"{expected_init_state_shape} and {expected_state_shape}, "
-                f"got {tuple(init_state.shape)} and {tuple(state.shape)}"
+                "fixed_state/state must have shapes "
+                f"{expected_fixed_state_shape} and {expected_state_shape}, "
+                f"got {tuple(fixed_state.shape)} and {tuple(state.shape)}"
             )
+        if initial_state is not None and initial_state.shape != expected_state_shape:
+            raise RuntimeError(f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}")
         if q.shape[-1] != 128:
             raise RuntimeError(f"CPDeltaRulePrefillSm90 only supports D=128, got {q.shape[-1]}")
         if q.dtype not in (torch.float16, torch.bfloat16):
@@ -2935,9 +3014,14 @@ def cp_delta_rule_prefill_dsl_sm90(
             )
         if alpha.dtype != torch.float32:
             raise RuntimeError(f"alpha must have dtype torch.float32, got {alpha.dtype}")
+        if initial_state is not None and initial_state.dtype != torch.float32:
+            raise RuntimeError(f"initial_state must have dtype torch.float32, got {initial_state.dtype}")
         for name, tensor in (
-            ("q", q), ("k", k), ("v", v), ("t", t), ("init_state", init_state), ("alpha", alpha), ("o", o), ("state", state)
+            ("q", q), ("k", k), ("v", v), ("t", t), ("fixed_state", fixed_state), ("initial_state", initial_state),
+            ("alpha", alpha), ("o", o), ("state", state)
         ):
+            if tensor is None:
+                continue
             if not tensor.is_contiguous():
                 raise RuntimeError(f"{name} must be contiguous")
 
@@ -2984,7 +3068,12 @@ def cp_delta_rule_prefill_dsl_sm90(
     if enable_tvm_ffi:
         from_dlpack = lambda *args, **kwargs: cute.runtime.from_dlpack(*args, **{**kwargs, "enable_tvm_ffi": True})
 
-    kernel = CPDeltaRulePrefillSm90(kernel_dtype)
+    needs_initial_state = initial_state is not None
+    initial_state_cute = (
+        from_dlpack(initial_state.reshape(-1), assumed_align=16).mark_layout_dynamic()
+        if needs_initial_state else None
+    )
+    kernel = CPDeltaRulePrefillSm90(kernel_dtype, needs_initial_state=needs_initial_state)
     kernel_args = (
         from_dlpack(q_tma, assumed_align=16).mark_layout_dynamic(leading_dim=1),
         from_dlpack(k_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
@@ -2993,7 +3082,8 @@ def cp_delta_rule_prefill_dsl_sm90(
         from_dlpack(o_tma, assumed_align=16).mark_layout_dynamic(leading_dim=0),
         from_dlpack(alpha.reshape(-1), assumed_align=16).mark_layout_dynamic(),
         from_dlpack(state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
-        from_dlpack(init_state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+        from_dlpack(fixed_state.reshape(-1), assumed_align=16).mark_layout_dynamic(),
+        initial_state_cute,
         from_dlpack(tensormaps_t, assumed_align=128).mark_layout_dynamic(),
         from_dlpack(cu_seqlens, assumed_align=8).mark_layout_dynamic(),
         cutlass.Float32(scale),
@@ -3026,6 +3116,7 @@ def cp_delta_rule_dsl_sm90(
     cu_seqlens: torch.Tensor,
     scale: float,
     *,
+    initial_state: torch.Tensor | None = None,
     max_seqlen: int,
     cp_chunk_len: int | None = None,
     cp_chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
@@ -3088,6 +3179,8 @@ def cp_delta_rule_dsl_sm90(
     expected_state_shape = (num_seqs, num_sab_heads, d, d)
     if state.shape != expected_state_shape:
         raise RuntimeError(f"state must have shape {expected_state_shape}, got {tuple(state.shape)}")
+    if initial_state is not None and initial_state.shape != expected_state_shape:
+        raise RuntimeError(f"initial_state must have shape {expected_state_shape}, got {tuple(initial_state.shape)}")
     if q.shape[-1] != 128:
         raise RuntimeError(f"CPDeltaRuleSm90 only supports D=128, got {q.shape[-1]}")
     if q.dtype not in (torch.float16, torch.bfloat16):
@@ -3099,9 +3192,14 @@ def cp_delta_rule_dsl_sm90(
         )
     if alpha.dtype != torch.float32 or beta.dtype != torch.float32:
         raise RuntimeError(f"alpha/beta must have dtype torch.float32, got {alpha.dtype} and {beta.dtype}")
+    if initial_state is not None and initial_state.dtype != torch.float32:
+        raise RuntimeError(f"initial_state must have dtype torch.float32, got {initial_state.dtype}")
     for name, tensor in (
-        ("q", q), ("k", k), ("v", v), ("alpha", alpha), ("beta", beta), ("o", o), ("state", state)
+        ("q", q), ("k", k), ("v", v), ("alpha", alpha), ("beta", beta), ("o", o), ("state", state),
+        ("initial_state", initial_state)
     ):
+        if tensor is None:
+            continue
         if not tensor.is_contiguous():
             raise RuntimeError(f"{name} must be contiguous")
 
@@ -3112,10 +3210,11 @@ def cp_delta_rule_dsl_sm90(
         cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen, _skip_check=True)
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
         local_transfer, local_state, cu_seqlens, total_seqlen,
-        cp_chunk_len=cp_chunk_len, _skip_check=True)
+        cp_chunk_len=cp_chunk_len, initial_state=initial_state, _skip_check=True)
 
     state.zero_()
     cp_delta_rule_prefill_dsl_sm90(
         o, state, q, k, v, t, fixed_state, alpha, scale,
-        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen, _skip_check=True,
+        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen,
+        initial_state=initial_state, _skip_check=True,
     )

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -39,7 +39,6 @@ from .delta_rule_sm90 import (
     _FullyFusedDeltaRuleSm90,
     WarpGroupRole,
     LoadStoreWarpRole,
-    MathWarpGroupRole,
 )
 from .schedule import WorkDesc
 
@@ -3017,7 +3016,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
             wg_idx,
         )
 
-        for blk in cutlass.range(1, num_blocks - 1, 1, unroll=1):
+        for _ in cutlass.range(1, num_blocks - 1, 1, unroll=1):
             (
                 q_consumer_state,
                 k_consumer_state,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -131,6 +131,12 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         self.v_stage = 1
         self.o_stage = 1
         self.alpha_beta_stage = 2
+        self.manual_cache_key(
+            "needs_alpha", "needs_beta", "needs_init_state", "needs_checkpointing",
+            "dtype", "acc_dtype", "inverse_dtype",
+            "BLK_Q", "BLK_KV", "D",
+            "q_stage", "k_stage", "v_stage", "o_stage", "alpha_beta_stage",
+        )
 
     def get_next_work(
         self,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -132,10 +132,21 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         self.o_stage = 1
         self.alpha_beta_stage = 2
         self.manual_cache_key(
-            "needs_alpha", "needs_beta", "needs_init_state", "needs_checkpointing",
-            "dtype", "acc_dtype", "inverse_dtype",
-            "BLK_Q", "BLK_KV", "D",
-            "q_stage", "k_stage", "v_stage", "o_stage", "alpha_beta_stage",
+            "needs_alpha",
+            "needs_beta",
+            "needs_init_state",
+            "needs_checkpointing",
+            "dtype",
+            "acc_dtype",
+            "inverse_dtype",
+            "BLK_Q",
+            "BLK_KV",
+            "D",
+            "q_stage",
+            "k_stage",
+            "v_stage",
+            "o_stage",
+            "alpha_beta_stage",
         )
 
     def get_next_work(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -144,11 +144,23 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         self.kk_stage = 2
         self.alpha_beta_stage = 5
         self.manual_cache_key(
-            "needs_alpha", "needs_beta", "needs_init_state", "needs_checkpointing",
-            "dtype", "acc_dtype", "inverse_dtype",
-            "BLK_Q", "BLK_KV", "D",
-            "q_stage", "k_stage", "v_stage", "o_stage",
-            "qk_stage", "kk_stage", "alpha_beta_stage",
+            "needs_alpha",
+            "needs_beta",
+            "needs_init_state",
+            "needs_checkpointing",
+            "dtype",
+            "acc_dtype",
+            "inverse_dtype",
+            "BLK_Q",
+            "BLK_KV",
+            "D",
+            "q_stage",
+            "k_stage",
+            "v_stage",
+            "o_stage",
+            "qk_stage",
+            "kk_stage",
+            "alpha_beta_stage",
         )
 
     def get_next_work(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -143,6 +143,13 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         self.qk_stage = 2
         self.kk_stage = 2
         self.alpha_beta_stage = 5
+        self.manual_cache_key(
+            "needs_alpha", "needs_beta", "needs_init_state", "needs_checkpointing",
+            "dtype", "acc_dtype", "inverse_dtype",
+            "BLK_Q", "BLK_KV", "D",
+            "q_stage", "k_stage", "v_stage", "o_stage",
+            "qk_stage", "kk_stage", "alpha_beta_stage",
+        )
 
     def get_next_work(
         self,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -2384,7 +2384,7 @@ def delta_rule_prefill_dsl_sm90(
     total_checkpoints = state_checkpoints.shape[0] if needs_checkpointing else 1
 
     workspace_size = get_device_sm_count(q.device) * 128
-    tensormaps_t = _get_cache_buf("gdn_cp_prefill_tensormaps", workspace_size, q.device)
+    tensormaps_t = _get_cache_buf("gdn_prefill_tensormaps", workspace_size, q.device)
 
     stream_val = torch.cuda.current_stream().cuda_stream
     stream = cuda_driver.CUstream(stream_val)

--- a/flashinfer/gdn_kernels/delta_rule_dsl/helpers.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/helpers.py
@@ -1,12 +1,100 @@
+from dataclasses import dataclass
+
 import cutlass
 import cutlass.cute as cute
+import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
+from cutlass.cute import core as cute_core
+from cutlass.cute.atom import Trait, make_atom
 from cutlass.cute.nvgpu import warp, warpgroup
+from cutlass.cute.typing import Shape
 from cutlass.cutlass_dsl import T
 from cutlass._mlir.dialects import llvm
 
 
 def round_down(a: int, b: int) -> int:
     return (a // b) * b
+
+
+@dataclass(frozen=True)
+class WarpMmaTF32Op(warp.WarpMmaOp):
+    shape_mnk: Shape
+
+    def __post_init__(self) -> None:
+        if self.shape_mnk != (16, 8, 8):
+            raise ValueError(
+                f"WarpMmaTF32Op only supports (16, 8, 8), got {self.shape_mnk}"
+            )
+
+    def _make_trait(self, *, loc=None, ip=None, **kwargs):
+        shape_mnk = cute_core._pack_shape(self.shape_mnk, loc=loc, ip=ip)
+        ty = _cute_nvgpu_ir.MmaAtomSM80Type.get(
+            shape_mnk.type.attribute,
+            cutlass.TFloat32.mlir_type,
+            cutlass.TFloat32.mlir_type,
+            cutlass.Float32.mlir_type,
+        )
+        return WarpMmaTF32Trait(make_atom(ty, loc=loc, ip=ip))
+
+    def _verify_fragment_A(self, input, *, loc=None, ip=None):
+        return True
+
+    def _verify_fragment_B(self, input, *, loc=None, ip=None):
+        return True
+
+
+class WarpMmaTF32Trait(Trait):
+    pass
+
+
+class TF32:
+    @staticmethod
+    @cute.jit
+    def round_to_tf32_f32(value: cutlass.Float32) -> cutlass.Float32:
+        bits = llvm.inline_asm(
+            T.i32(),
+            [value.ir_value()],
+            "cvt.rz.tf32.f32 $0, $1;",
+            "=r,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+        return cutlass.Float32(llvm.bitcast(T.f32(), bits))
+
+    @staticmethod
+    @cute.jit
+    def convert_fp32_to_tf32_residual(tensor: cute.Tensor):
+        residual = cute.make_rmem_tensor_like(tensor, cutlass.Float32)
+        for i in cutlass.range_constexpr(cute.size(residual)):
+            value = tensor[i]
+            residual[i] = value - TF32.round_to_tf32_f32(value)
+        return cute.recast_tensor(residual, cutlass.TFloat32)
+
+    @staticmethod
+    @cute.jit
+    def convert_tf32_c_to_kpermuted_a(tCrC: cute.Tensor, tCrA: cute.Tensor):
+        for i in cutlass.range(cute.size(tCrA), unroll_full=True):
+            tCrA[i] = tCrC[i]
+        for m in cutlass.range_constexpr(cute.size(tCrA, mode=[1])):
+            for k in cutlass.range_constexpr(cute.size(tCrA, mode=[2])):
+                tmp = tCrA[(1, 0), m, k]
+                tCrA[(1, 0), m, k] = tCrA[(0, 1), m, k]
+                tCrA[(0, 1), m, k] = tmp
+
+    @staticmethod
+    @cute.jit
+    def load_tf32_kpermuted_b(
+        tCrB: cute.Tensor,
+        sB_NK: cute.Tensor,
+        lane_idx: cutlass.Int32,
+    ):
+        sB_8x8 = cute.flat_divide(sB_NK, (8, 8))
+        n = lane_idx // 4
+        k = lane_idx - n * 4
+        for iter_n in cutlass.range_constexpr(cute.size(tCrB, mode=[1])):
+            for iter_k in cutlass.range_constexpr(cute.size(tCrB, mode=[2])):
+                tCrB[0, iter_n, iter_k] = sB_8x8[n, k * 2, iter_n, iter_k]
+                tCrB[1, iter_n, iter_k] = sB_8x8[n, k * 2 + 1, iter_n, iter_k]
 
 
 @cute.jit

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -1,0 +1,130 @@
+import torch
+import cutlass
+import cutlass.cute as cute
+
+
+CP_CHUNK_LEN_GRANULARITY = 512
+
+
+def chunk_bound_host(num_items: int, total: int, chunk_size: int) -> int:
+    if chunk_size <= 0:
+        raise RuntimeError(f"chunk_size must be positive, got {chunk_size}")
+    m = min(num_items, total)
+    return m + (total - m) // chunk_size
+
+
+def exact_num_chunks_host(cu_seqlens: torch.Tensor, chunk_size: int) -> int:
+    if cu_seqlens.ndim != 1:
+        raise RuntimeError(f"cu_seqlens must be 1D, got {tuple(cu_seqlens.shape)}")
+    if cu_seqlens.numel() <= 1:
+        return 0
+    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunks = torch.div(lengths + chunk_size - 1, chunk_size, rounding_mode="floor")
+    return int(chunks.sum().item())
+
+
+def workspace_num_chunks_host(cu_seqlens: torch.Tensor, chunk_size: int, total_seqlen: int | None = None) -> int:
+    if cu_seqlens.ndim != 1:
+        raise RuntimeError(f"cu_seqlens must be 1D, got {tuple(cu_seqlens.shape)}")
+    num_seqs = cu_seqlens.numel() - 1
+    total = int(cu_seqlens[-1].item()) if total_seqlen is None else total_seqlen
+    return chunk_bound_host(num_seqs, total, chunk_size)
+
+
+def max_num_chunks_host(cu_seqlens: torch.Tensor, chunk_size: int, max_seqlen: int | None = None) -> int:
+    if cu_seqlens.ndim != 1:
+        raise RuntimeError(f"cu_seqlens must be 1D, got {tuple(cu_seqlens.shape)}")
+    if max_seqlen is None:
+        if cu_seqlens.numel() <= 1:
+            return 0
+        lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+        max_seqlen = int(lengths.max().item())
+    return (max_seqlen + chunk_size - 1) // chunk_size
+
+
+def choose_cp_chunk_len_host(
+    max_seqlen: int,
+    num_heads: int,
+    num_sms: int,
+    chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
+) -> int:
+    """Choose a CP chunk length that keeps MN precompute in one CTA wave.
+
+    The TTFT path is usually one long sequence. For that case, MN precompute
+    launches `ceil_div(max_seqlen, chunk_len) * num_heads` CTAs. Pick the
+    smallest granularity-aligned chunk length whose CTA count does not exceed
+    the SM count, preserving as much CP parallelism as possible within one wave.
+    """
+    if max_seqlen <= 0:
+        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
+    if num_heads <= 0:
+        raise RuntimeError(f"num_heads must be positive, got {num_heads}")
+    if num_sms <= 0:
+        raise RuntimeError(f"num_sms must be positive, got {num_sms}")
+    if chunk_len_granularity <= 0:
+        raise RuntimeError(f"chunk_len_granularity must be positive, got {chunk_len_granularity}")
+    if chunk_len_granularity % 64 != 0:
+        raise RuntimeError(
+            f"chunk_len_granularity must be a multiple of 64, got {chunk_len_granularity}"
+        )
+
+    target_chunks = max(1, num_sms // num_heads)
+    min_chunk_len = (max_seqlen + target_chunks - 1) // target_chunks
+    return ((min_chunk_len + chunk_len_granularity - 1) // chunk_len_granularity) * chunk_len_granularity
+
+
+@cute.jit
+def chunk_bound(seq_idx: cutlass.Int32, total: cutlass.Int32, chunk_size: cutlass.Int32) -> cutlass.Int32:
+    m = seq_idx
+    if total < m:
+        m = total
+    return m + (total - m) // chunk_size
+
+
+@cute.jit
+def chunks_for_len(seq_len: cutlass.Int32, chunk_size: cutlass.Int32) -> cutlass.Int32:
+    return (seq_len + chunk_size - cutlass.Int32(1)) // chunk_size
+
+
+@cute.jit
+def logical_chunk_to_work_desc(
+    cu_seqlens: cute.Tensor,
+    logical_chunk_idx: cutlass.Int32,
+    chunk_size: cutlass.Int32,
+    num_seqs: cutlass.Int32,
+):
+    seq_idx = cutlass.Int32(0)
+    chunk_idx_in_seq = logical_chunk_idx
+    running = cutlass.Int32(0)
+    for candidate_seq in cutlass.range(num_seqs, unroll=1):
+        seq_start = cutlass.Int32(cu_seqlens[candidate_seq])
+        seq_end = cutlass.Int32(cu_seqlens[candidate_seq + cutlass.Int32(1)])
+        seq_chunks = chunks_for_len(seq_end - seq_start, chunk_size)
+        next_running = running + seq_chunks
+        if logical_chunk_idx >= running and logical_chunk_idx < next_running:
+            seq_idx = candidate_seq
+            chunk_idx_in_seq = logical_chunk_idx - running
+        running = next_running
+    return seq_idx, chunk_idx_in_seq
+
+
+@cute.jit
+def varlen_chunk_idx(
+    seq_idx: cutlass.Int32,
+    tok_idx_start: cutlass.Int32,
+    chunk_idx_in_seq: cutlass.Int32,
+    chunk_size: cutlass.Int32,
+) -> cutlass.Int32:
+    return chunk_bound(seq_idx, tok_idx_start, chunk_size) + chunk_idx_in_seq
+
+
+@cute.jit
+def varlen_chunk_valid_len(
+    seq_len: cutlass.Int32,
+    chunk_idx_in_seq: cutlass.Int32,
+    chunk_size: cutlass.Int32,
+) -> cutlass.Int32:
+    remaining = seq_len - chunk_idx_in_seq * chunk_size
+    if remaining > chunk_size:
+        remaining = chunk_size
+    return remaining

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -13,32 +13,14 @@ def chunk_bound_host(num_items: int, total: int, chunk_size: int) -> int:
     return m + (total - m) // chunk_size
 
 
-def exact_num_chunks_host(cu_seqlens: torch.Tensor, chunk_size: int) -> int:
-    if cu_seqlens.ndim != 1:
-        raise RuntimeError(f"cu_seqlens must be 1D, got {tuple(cu_seqlens.shape)}")
-    if cu_seqlens.numel() <= 1:
-        return 0
-    lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-    chunks = torch.div(lengths + chunk_size - 1, chunk_size, rounding_mode="floor")
-    return int(chunks.sum().item())
-
-
-def workspace_num_chunks_host(cu_seqlens: torch.Tensor, chunk_size: int, total_seqlen: int | None = None) -> int:
+def workspace_num_chunks_host(cu_seqlens: torch.Tensor, chunk_size: int, total_seqlen: int) -> int:
     if cu_seqlens.ndim != 1:
         raise RuntimeError(f"cu_seqlens must be 1D, got {tuple(cu_seqlens.shape)}")
     num_seqs = cu_seqlens.numel() - 1
-    total = int(cu_seqlens[-1].item()) if total_seqlen is None else total_seqlen
-    return chunk_bound_host(num_seqs, total, chunk_size)
+    return chunk_bound_host(num_seqs, total_seqlen, chunk_size)
 
 
-def max_num_chunks_host(cu_seqlens: torch.Tensor, chunk_size: int, max_seqlen: int | None = None) -> int:
-    if cu_seqlens.ndim != 1:
-        raise RuntimeError(f"cu_seqlens must be 1D, got {tuple(cu_seqlens.shape)}")
-    if max_seqlen is None:
-        if cu_seqlens.numel() <= 1:
-            return 0
-        lengths = cu_seqlens[1:] - cu_seqlens[:-1]
-        max_seqlen = int(lengths.max().item())
+def max_num_chunks_host(max_seqlen: int, chunk_size: int) -> int:
     return (max_seqlen + chunk_size - 1) // chunk_size
 
 

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -13,7 +13,9 @@ def chunk_bound_host(num_items: int, total: int, chunk_size: int) -> int:
     return m + (total - m) // chunk_size
 
 
-def workspace_num_chunks_host(cu_seqlens: torch.Tensor, chunk_size: int, total_seqlen: int) -> int:
+def workspace_num_chunks_host(
+    cu_seqlens: torch.Tensor, chunk_size: int, total_seqlen: int
+) -> int:
     if cu_seqlens.ndim != 1:
         raise RuntimeError(f"cu_seqlens must be 1D, got {tuple(cu_seqlens.shape)}")
     num_seqs = cu_seqlens.numel() - 1
@@ -44,7 +46,9 @@ def choose_cp_chunk_len_host(
     if num_sms <= 0:
         raise RuntimeError(f"num_sms must be positive, got {num_sms}")
     if chunk_len_granularity <= 0:
-        raise RuntimeError(f"chunk_len_granularity must be positive, got {chunk_len_granularity}")
+        raise RuntimeError(
+            f"chunk_len_granularity must be positive, got {chunk_len_granularity}"
+        )
     if chunk_len_granularity % 64 != 0:
         raise RuntimeError(
             f"chunk_len_granularity must be a multiple of 64, got {chunk_len_granularity}"
@@ -52,11 +56,15 @@ def choose_cp_chunk_len_host(
 
     target_chunks = max(1, num_sms // num_heads)
     min_chunk_len = (max_seqlen + target_chunks - 1) // target_chunks
-    return ((min_chunk_len + chunk_len_granularity - 1) // chunk_len_granularity) * chunk_len_granularity
+    return (
+        (min_chunk_len + chunk_len_granularity - 1) // chunk_len_granularity
+    ) * chunk_len_granularity
 
 
 @cute.jit
-def chunk_bound(seq_idx: cutlass.Int32, total: cutlass.Int32, chunk_size: cutlass.Int32) -> cutlass.Int32:
+def chunk_bound(
+    seq_idx: cutlass.Int32, total: cutlass.Int32, chunk_size: cutlass.Int32
+) -> cutlass.Int32:
     m = seq_idx
     if total < m:
         m = total

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -50,8 +50,6 @@ def _cp_delta_rule_rejection_reason(
         return "CP delta rule is currently implemented only for SM90"
     if cp_delta_rule_dsl_sm90 is None:
         return "CP delta rule SM90 DSL kernel is unavailable"
-    if initial_state is not None:
-        return "CP delta rule does not support initial_state yet"
     if checkpoint_every_n_tokens > 0 or state_checkpoints is not None or checkpoint_cu_starts is not None:
         return "CP delta rule does not support state checkpointing yet"
     if q.shape[-1] != 128:
@@ -66,7 +64,9 @@ def _cp_delta_rule_rejection_reason(
                 return f"CP delta rule requires {name} to be float32"
             if not tensor.is_contiguous():
                 return f"CP delta rule requires {name} to be contiguous"
-    for name, tensor in (("q", q), ("k", k), ("v", v), ("output", output)):
+    for name, tensor in (("q", q), ("k", k), ("v", v), ("output", output), ("initial_state", initial_state)):
+        if tensor is None:
+            continue
         if not tensor.is_contiguous():
             return f"CP delta rule requires {name} to be contiguous"
     return None
@@ -327,6 +327,7 @@ def chunk_gated_delta_rule(
                 _beta,
                 cu_seqlens.to(torch.int64),
                 _scale,
+                initial_state=initial_state,
                 max_seqlen=total_seq_len,
             )
             if output_final_state:

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 
 import math
-from typing import Optional, Union, Tuple
+import warnings
+from typing import Literal, Optional, Union, Tuple
 import torch
 
 from .api_logging import flashinfer_api
@@ -27,7 +28,48 @@ from .gdn_kernels import (
     chunk_gated_delta_rule_sm90,
     chunk_gated_delta_rule_sm100,
     chunk_gated_delta_rule_sm120,
+    cp_delta_rule_dsl_sm90,
 )
+
+
+def _cp_delta_rule_rejection_reason(
+    *,
+    arch_major: int,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: Optional[torch.Tensor],
+    beta: Optional[torch.Tensor],
+    output: torch.Tensor,
+    initial_state: Optional[torch.Tensor],
+    checkpoint_every_n_tokens: int,
+    state_checkpoints: Optional[torch.Tensor],
+    checkpoint_cu_starts: Optional[torch.Tensor],
+) -> Optional[str]:
+    if arch_major != 9:
+        return "CP delta rule is currently implemented only for SM90"
+    if cp_delta_rule_dsl_sm90 is None:
+        return "CP delta rule SM90 DSL kernel is unavailable"
+    if initial_state is not None:
+        return "CP delta rule does not support initial_state yet"
+    if checkpoint_every_n_tokens > 0 or state_checkpoints is not None or checkpoint_cu_starts is not None:
+        return "CP delta rule does not support state checkpointing yet"
+    if q.shape[-1] != 128:
+        return f"CP delta rule only supports head_size=128, got {q.shape[-1]}"
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        return f"CP delta rule only supports fp16/bf16 inputs, got {q.dtype}"
+    if k.dtype != q.dtype or v.dtype != q.dtype or output.dtype != q.dtype:
+        return "CP delta rule requires q/k/v/output dtypes to match"
+    for name, tensor in (("g", g), ("beta", beta)):
+        if tensor is not None:
+            if tensor.dtype != torch.float32:
+                return f"CP delta rule requires {name} to be float32"
+            if not tensor.is_contiguous():
+                return f"CP delta rule requires {name} to be contiguous"
+    for name, tensor in (("q", q), ("k", k), ("v", v), ("output", output)):
+        if not tensor.is_contiguous():
+            return f"CP delta rule requires {name} to be contiguous"
+    return None
 
 
 @flashinfer_api(trace=gdn_prefill_trace)
@@ -47,6 +89,7 @@ def chunk_gated_delta_rule(
     state_checkpoints: Optional[torch.Tensor] = None,
     checkpoint_cu_starts: Optional[torch.Tensor] = None,
     checkpoint_every_n_tokens: int = 0,
+    use_cp: Literal["auto"] | bool = "auto",
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Chunked Gated Delta Rule (GDN) attention for prefill.
 
@@ -113,6 +156,12 @@ def chunk_gated_delta_rule(
     checkpoint_every_n_tokens : int
         Store intermediate state every N tokens.  Must be a multiple of the
         chunk size (64).  ``0`` disables checkpointing (default).
+    use_cp : Literal["auto"] | bool, optional:
+        Whether to use the SM90 context-parallel DSL implementation when
+        low-parallelism heuristics match. ``"auto"`` enables conservative
+        routing, ``True`` requires CP support, and ``False`` disables CP.
+        Default: ``"auto"``.
+
 
     Returns
     -------
@@ -132,6 +181,8 @@ def chunk_gated_delta_rule(
       ``nvidia-cutlass-dsl[cu13]>=4.4.2`` (``pip install
       flashinfer-python[cu13]``).
     """
+    if use_cp not in ("auto", True, False):
+        raise ValueError(f'use_cp must be "auto", True, or False, got {use_cp!r}')
     if checkpoint_every_n_tokens < 0:
         raise ValueError(
             f"checkpoint_every_n_tokens must be non-negative, "
@@ -218,6 +269,69 @@ def chunk_gated_delta_rule(
 
     _cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
     _arch_major = get_compute_capability(device)[0]
+    cp_heuristic_matches = (
+        _arch_major == 9
+        and num_seqs * num_sab_heads < max(1, torch.cuda.get_device_properties(device).multi_processor_count // 2)
+    )
+    if use_cp is True or (use_cp == "auto" and cp_heuristic_matches):
+        cp_rejection_reason = _cp_delta_rule_rejection_reason(
+            arch_major=_arch_major,
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            output=output,
+            initial_state=initial_state,
+            checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+            state_checkpoints=state_checkpoints,
+            checkpoint_cu_starts=checkpoint_cu_starts,
+        )
+        if cp_rejection_reason is not None:
+            if use_cp is True:
+                raise ValueError(cp_rejection_reason)
+            warnings.warn(
+                f"CP delta rule heuristic matched but CP dispatch is unavailable: {cp_rejection_reason}; "
+                "falling back to non-CP delta rule.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        else:
+            if output_state is None:
+                output_state = torch.empty(
+                    (num_seqs, num_sab_heads, head_size, head_size),
+                    dtype=torch.float32,
+                    device=device,
+                )
+            _g = (
+                g
+                if g is not None
+                else torch.ones(
+                    total_seq_len, num_sab_heads, dtype=torch.float32, device=device
+                )
+            )
+            _beta = (
+                beta
+                if beta is not None
+                else torch.ones(
+                    total_seq_len, num_sab_heads, dtype=torch.float32, device=device
+                )
+            )
+            cp_delta_rule_dsl_sm90(
+                output,
+                output_state,
+                q,
+                k,
+                v,
+                _g,
+                _beta,
+                cu_seqlens.to(torch.int64),
+                _scale,
+                max_seqlen=total_seq_len,
+            )
+            if output_final_state:
+                return output, output_state
+            return output
     if _arch_major == 10:
         if _cuda_major < 13:
             raise NotImplementedError(

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -50,7 +50,11 @@ def _cp_delta_rule_rejection_reason(
         return "CP delta rule is currently implemented only for SM90"
     if cp_delta_rule_dsl_sm90 is None:
         return "CP delta rule SM90 DSL kernel is unavailable"
-    if checkpoint_every_n_tokens > 0 or state_checkpoints is not None or checkpoint_cu_starts is not None:
+    if (
+        checkpoint_every_n_tokens > 0
+        or state_checkpoints is not None
+        or checkpoint_cu_starts is not None
+    ):
         return "CP delta rule does not support state checkpointing yet"
     if q.shape[-1] != 128:
         return f"CP delta rule only supports head_size=128, got {q.shape[-1]}"
@@ -64,7 +68,13 @@ def _cp_delta_rule_rejection_reason(
                 return f"CP delta rule requires {name} to be float32"
             if not tensor.is_contiguous():
                 return f"CP delta rule requires {name} to be contiguous"
-    for name, tensor in (("q", q), ("k", k), ("v", v), ("output", output), ("initial_state", initial_state)):
+    for name, tensor in (
+        ("q", q),
+        ("k", k),
+        ("v", v),
+        ("output", output),
+        ("initial_state", initial_state),
+    ):
         if tensor is None:
             continue
         if not tensor.is_contiguous():
@@ -269,9 +279,8 @@ def chunk_gated_delta_rule(
 
     _cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
     _arch_major = get_compute_capability(device)[0]
-    cp_heuristic_matches = (
-        _arch_major == 9
-        and num_seqs * num_sab_heads < max(1, torch.cuda.get_device_properties(device).multi_processor_count // 2)
+    cp_heuristic_matches = _arch_major == 9 and num_seqs * num_sab_heads < max(
+        1, torch.cuda.get_device_properties(device).multi_processor_count // 2
     )
     if use_cp is True or (use_cp == "auto" and cp_heuristic_matches):
         cp_rejection_reason = _cp_delta_rule_rejection_reason(

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -21,9 +21,7 @@ import torch
 
 from .api_logging import flashinfer_api
 from .trace.templates.gdn import gdn_prefill_trace
-from .utils import (
-    get_compute_capability,
-)
+from .utils import get_compute_capability, get_device_sm_count
 from .gdn_kernels import (
     chunk_gated_delta_rule_sm90,
     chunk_gated_delta_rule_sm100,
@@ -277,10 +275,11 @@ def chunk_gated_delta_rule(
     device = q.device
     _scale = scale if scale is not None and scale != 0.0 else 1.0 / math.sqrt(head_size)
 
+    _sm_count = get_device_sm_count(device)
     _cuda_major = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else 0
     _arch_major = get_compute_capability(device)[0]
     cp_heuristic_matches = _arch_major == 9 and num_seqs * num_sab_heads < max(
-        1, torch.cuda.get_device_properties(device).multi_processor_count // 2
+        1, _sm_count // 2
     )
     if use_cp is True or (use_cp == "auto" and cp_heuristic_matches):
         cp_rejection_reason = _cp_delta_rule_rejection_reason(

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -346,9 +346,13 @@ def _expand_delta_rule_heads(
     num_sab_heads = max(num_q_heads, num_v_heads)
 
     if alpha is None:
-        alpha = torch.ones(total_seqlen, num_sab_heads, dtype=torch.float32, device=q.device)
+        alpha = torch.ones(
+            total_seqlen, num_sab_heads, dtype=torch.float32, device=q.device
+        )
     if beta is None:
-        beta = torch.ones(total_seqlen, num_sab_heads, dtype=torch.float32, device=q.device)
+        beta = torch.ones(
+            total_seqlen, num_sab_heads, dtype=torch.float32, device=q.device
+        )
 
     if num_q_heads > num_v_heads:  # GQA
         k = k.repeat_interleave(num_q_heads // num_k_heads, dim=1)
@@ -362,10 +366,10 @@ def _expand_delta_rule_heads(
 
 @torch.inference_mode
 def cp_delta_rule_pre(
-    k: torch.Tensor,      # [chunk_len, num_heads, head_size]
-    v: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    k: torch.Tensor,  # [chunk_len, num_heads, head_size]
+    v: torch.Tensor,  # [chunk_len, num_heads, head_size]
     alpha: torch.Tensor,  # [chunk_len, num_heads]
-    beta: torch.Tensor,   # [chunk_len, num_heads]
+    beta: torch.Tensor,  # [chunk_len, num_heads]
     *,
     kv_dtype: torch.dtype = torch.float32,
 ):
@@ -377,9 +381,13 @@ def cp_delta_rule_pre(
     assert k.size(0) == v.size(0) == alpha.size(0) == beta.size(0)
     num_heads = k.size(1)
     head_size = k.size(2)
-    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(num_heads, head_size, head_size)
+    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(
+        num_heads, head_size, head_size
+    )
     transfer_HKK = eye_HKK.clone()
-    state_HKV = torch.zeros((num_heads, head_size, head_size), dtype=kv_dtype, device=k.device)
+    state_HKV = torch.zeros(
+        (num_heads, head_size, head_size), dtype=kv_dtype, device=k.device
+    )
 
     for token_idx in range(k.size(0)):
         k_HK = k[token_idx].to(kv_dtype)
@@ -400,10 +408,10 @@ def cp_delta_rule_pre(
 
 @torch.inference_mode
 def blockwise_cp_delta_rule_pre(
-    k: torch.Tensor,      # [chunk_len, num_heads, head_size]
-    v: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    k: torch.Tensor,  # [chunk_len, num_heads, head_size]
+    v: torch.Tensor,  # [chunk_len, num_heads, head_size]
     alpha: torch.Tensor,  # [chunk_len, num_heads]
-    beta: torch.Tensor,   # [chunk_len, num_heads]
+    beta: torch.Tensor,  # [chunk_len, num_heads]
     *,
     block_size: int = 64,
     kv_dtype: torch.dtype = torch.float32,
@@ -420,9 +428,13 @@ def blockwise_cp_delta_rule_pre(
     chunk_len = k.size(0)
     num_heads = k.size(1)
     head_size = k.size(2)
-    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(num_heads, head_size, head_size)
+    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(
+        num_heads, head_size, head_size
+    )
     transfer_HKK = eye_HKK.clone()
-    state_HKV = torch.zeros((num_heads, head_size, head_size), dtype=kv_dtype, device=k.device)
+    state_HKV = torch.zeros(
+        (num_heads, head_size, head_size), dtype=kv_dtype, device=k.device
+    )
 
     for blk_offset in range(0, chunk_len, block_size):
         valid_len = min(block_size, chunk_len - blk_offset)
@@ -432,10 +444,18 @@ def blockwise_cp_delta_rule_pre(
             alpha_SH = alpha[blk_offset : blk_offset + block_size]
             beta_SH = beta[blk_offset : blk_offset + block_size]
         else:
-            k_SHK = torch.zeros((block_size, num_heads, head_size), dtype=k.dtype, device=k.device)
-            v_SHV = torch.zeros((block_size, num_heads, head_size), dtype=v.dtype, device=v.device)
-            alpha_SH = torch.ones((block_size, num_heads), dtype=alpha.dtype, device=alpha.device)
-            beta_SH = torch.zeros((block_size, num_heads), dtype=beta.dtype, device=beta.device)
+            k_SHK = torch.zeros(
+                (block_size, num_heads, head_size), dtype=k.dtype, device=k.device
+            )
+            v_SHV = torch.zeros(
+                (block_size, num_heads, head_size), dtype=v.dtype, device=v.device
+            )
+            alpha_SH = torch.ones(
+                (block_size, num_heads), dtype=alpha.dtype, device=alpha.device
+            )
+            beta_SH = torch.zeros(
+                (block_size, num_heads), dtype=beta.dtype, device=beta.device
+            )
             k_SHK[:valid_len] = k[blk_offset:]
             v_SHV[:valid_len] = v[blk_offset:]
             alpha_SH[:valid_len] = alpha[blk_offset:]
@@ -475,8 +495,8 @@ def blockwise_cp_delta_rule_pre(
 
 @torch.inference_mode
 def precompute_blockwise_cp_delta_rule_t(
-    k: torch.Tensor,      # [chunk_len, num_heads, head_size]
-    beta: torch.Tensor,   # [chunk_len, num_heads]
+    k: torch.Tensor,  # [chunk_len, num_heads, head_size]
+    beta: torch.Tensor,  # [chunk_len, num_heads]
     *,
     block_size: int = 64,
     kv_dtype: torch.dtype = torch.float32,
@@ -498,7 +518,9 @@ def precompute_blockwise_cp_delta_rule_t(
     num_heads = k.size(1)
     head_size = k.size(2)
     num_blocks = (chunk_len + block_size - 1) // block_size
-    t_HSS = torch.empty((num_blocks, num_heads, block_size, block_size), dtype=t_dtype, device=k.device)
+    t_HSS = torch.empty(
+        (num_blocks, num_heads, block_size, block_size), dtype=t_dtype, device=k.device
+    )
 
     for blk_idx, blk_offset in enumerate(range(0, chunk_len, block_size)):
         valid_len = min(block_size, chunk_len - blk_offset)
@@ -506,8 +528,12 @@ def precompute_blockwise_cp_delta_rule_t(
             k_SHK = k[blk_offset : blk_offset + block_size]
             beta_SH = beta[blk_offset : blk_offset + block_size]
         else:
-            k_SHK = torch.zeros((block_size, num_heads, head_size), dtype=k.dtype, device=k.device)
-            beta_SH = torch.zeros((block_size, num_heads), dtype=beta.dtype, device=beta.device)
+            k_SHK = torch.zeros(
+                (block_size, num_heads, head_size), dtype=k.dtype, device=k.device
+            )
+            beta_SH = torch.zeros(
+                (block_size, num_heads), dtype=beta.dtype, device=beta.device
+            )
             k_SHK[:valid_len] = k[blk_offset:]
             beta_SH[:valid_len] = beta[blk_offset:]
 
@@ -515,7 +541,8 @@ def precompute_blockwise_cp_delta_rule_t(
         k_HSK = k_SHK.transpose(0, 1)
 
         IKK = identity_add_strict_lower_diagonal(
-            beta_HS1.to(kv_dtype) * matmul(k_HSK.to(kv_dtype), k_HSK.to(kv_dtype).transpose(-2, -1))
+            beta_HS1.to(kv_dtype)
+            * matmul(k_HSK.to(kv_dtype), k_HSK.to(kv_dtype).transpose(-2, -1))
         )
         t_clean_HSS = torch.inverse(IKK) * beta_HS1.transpose(1, 2).to(kv_dtype)
         t_HSS[blk_idx] = (-t_clean_HSS.transpose(-2, -1)).to(t_dtype)
@@ -525,10 +552,10 @@ def precompute_blockwise_cp_delta_rule_t(
 
 @torch.inference_mode
 def blockwise_cp_delta_rule_pre_transposed(
-    k: torch.Tensor,      # [chunk_len, num_heads, head_size]
-    v: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    k: torch.Tensor,  # [chunk_len, num_heads, head_size]
+    v: torch.Tensor,  # [chunk_len, num_heads, head_size]
     alpha: torch.Tensor,  # [chunk_len, num_heads]
-    t: torch.Tensor,      # [num_blocks, num_heads, block_size, block_size], signed gamma-sandwiched
+    t: torch.Tensor,  # [num_blocks, num_heads, block_size, block_size], signed gamma-sandwiched
     *,
     block_size: int = 64,
     kv_dtype: torch.dtype = torch.float32,
@@ -549,9 +576,13 @@ def blockwise_cp_delta_rule_pre_transposed(
     num_blocks = (chunk_len + block_size - 1) // block_size
     assert t.shape == (num_blocks, num_heads, block_size, block_size)
 
-    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(num_heads, head_size, head_size)
+    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(
+        num_heads, head_size, head_size
+    )
     transfer_t_HKK = eye_HKK.clone()
-    state_t_HKV = torch.zeros((num_heads, head_size, head_size), dtype=kv_dtype, device=k.device)
+    state_t_HKV = torch.zeros(
+        (num_heads, head_size, head_size), dtype=kv_dtype, device=k.device
+    )
 
     for blk_idx, blk_offset in enumerate(range(0, chunk_len, block_size)):
         valid_len = min(block_size, chunk_len - blk_offset)
@@ -560,9 +591,15 @@ def blockwise_cp_delta_rule_pre_transposed(
             v_SHV = v[blk_offset : blk_offset + block_size]
             alpha_SH = alpha[blk_offset : blk_offset + block_size]
         else:
-            k_SHK = torch.zeros((block_size, num_heads, head_size), dtype=k.dtype, device=k.device)
-            v_SHV = torch.zeros((block_size, num_heads, head_size), dtype=v.dtype, device=v.device)
-            alpha_SH = torch.ones((block_size, num_heads), dtype=alpha.dtype, device=alpha.device)
+            k_SHK = torch.zeros(
+                (block_size, num_heads, head_size), dtype=k.dtype, device=k.device
+            )
+            v_SHV = torch.zeros(
+                (block_size, num_heads, head_size), dtype=v.dtype, device=v.device
+            )
+            alpha_SH = torch.ones(
+                (block_size, num_heads), dtype=alpha.dtype, device=alpha.device
+            )
             k_SHK[:valid_len] = k[blk_offset:]
             v_SHV[:valid_len] = v[blk_offset:]
             alpha_SH[:valid_len] = alpha[blk_offset:]
@@ -581,7 +618,9 @@ def blockwise_cp_delta_rule_pre_transposed(
         kt_HDS = k_HSD.transpose(-2, -1)
 
         block_state_t_HKV = -block_gamma_H11 * matmul(matmul(v_inv_HDS, t_HSS), k_HSD)
-        block_transfer_t_HKK = block_gamma_H11 * eye_HKK + block_gamma_H11 * matmul(matmul(kt_HDS, t_HSS), k_HSD)
+        block_transfer_t_HKK = block_gamma_H11 * eye_HKK + block_gamma_H11 * matmul(
+            matmul(kt_HDS, t_HSS), k_HSD
+        )
 
         state_t_HKV = matmul(state_t_HKV, block_transfer_t_HKK) + block_state_t_HKV
         transfer_t_HKK = matmul(transfer_t_HKK, block_transfer_t_HKK)
@@ -592,7 +631,7 @@ def blockwise_cp_delta_rule_pre_transposed(
 @torch.inference_mode
 def compose_delta_rule_chunk_range(
     local_transfers: torch.Tensor,  # [num_chunks, num_heads, head_size, head_size]
-    local_states: torch.Tensor,     # [num_chunks, num_heads, head_size, head_size]
+    local_states: torch.Tensor,  # [num_chunks, num_heads, head_size, head_size]
     start_chunk: int = 0,
     end_chunk: int | None = None,
 ):
@@ -606,7 +645,11 @@ def compose_delta_rule_chunk_range(
 
     num_heads = local_transfers.size(1)
     head_size = local_transfers.size(2)
-    transfer_HKK = torch.eye(head_size, dtype=local_transfers.dtype, device=local_transfers.device).expand(num_heads, head_size, head_size).clone()
+    transfer_HKK = (
+        torch.eye(head_size, dtype=local_transfers.dtype, device=local_transfers.device)
+        .expand(num_heads, head_size, head_size)
+        .clone()
+    )
     state_HKV = torch.zeros(
         (local_states.size(1), local_states.size(2), local_states.size(3)),
         dtype=local_states.dtype,
@@ -635,7 +678,9 @@ def cp_delta_rule_fixup(
     fixed_states_by_seq = []
     final_states = []
 
-    for local_transfers, local_states in zip(local_transfers_by_seq, local_states_by_seq):
+    for local_transfers, local_states in zip(
+        local_transfers_by_seq, local_states_by_seq
+    ):
         assert local_transfers.size(0) == local_states.size(0)
         seq_fixed_states = []
         if local_transfers.size(0) == 0:
@@ -645,7 +690,10 @@ def cp_delta_rule_fixup(
 
         state_HKV = torch.zeros_like(local_states[0])
         for chunk_idx in range(local_transfers.size(0)):
-            state_HKV = torch.bmm(local_transfers[chunk_idx], state_HKV) + local_states[chunk_idx]
+            state_HKV = (
+                torch.bmm(local_transfers[chunk_idx], state_HKV)
+                + local_states[chunk_idx]
+            )
             seq_fixed_states.append(state_HKV)
 
         fixed_states = torch.stack(seq_fixed_states)
@@ -672,18 +720,33 @@ def cp_delta_rule_fixup_transposed(
     fixed_states_by_seq = []
     final_states = []
 
-    for seq_idx, (local_transfers, local_states) in enumerate(zip(local_transfers_by_seq, local_states_by_seq)):
+    for seq_idx, (local_transfers, local_states) in enumerate(
+        zip(local_transfers_by_seq, local_states_by_seq)
+    ):
         assert local_transfers.size(0) == local_states.size(0)
         seq_fixed_states = []
-        initial_state = initial_states_by_seq[seq_idx] if initial_states_by_seq is not None else None
+        initial_state = (
+            initial_states_by_seq[seq_idx]
+            if initial_states_by_seq is not None
+            else None
+        )
         if local_transfers.size(0) == 0:
             fixed_states_by_seq.append(local_states)
-            final_states.append(local_states if initial_state is None else initial_state)
+            final_states.append(
+                local_states if initial_state is None else initial_state
+            )
             continue
 
-        state_HKV = torch.zeros_like(local_states[0]) if initial_state is None else initial_state.clone()
+        state_HKV = (
+            torch.zeros_like(local_states[0])
+            if initial_state is None
+            else initial_state.clone()
+        )
         for chunk_idx in range(local_transfers.size(0)):
-            state_HKV = torch.bmm(state_HKV, local_transfers[chunk_idx]) + local_states[chunk_idx]
+            state_HKV = (
+                torch.bmm(state_HKV, local_transfers[chunk_idx])
+                + local_states[chunk_idx]
+            )
             seq_fixed_states.append(state_HKV)
 
         fixed_states = torch.stack(seq_fixed_states)
@@ -701,7 +764,7 @@ def context_parallel_delta_rule_states(
     seq_lens: list[int],  # sequence length for each sequence
     *,
     alpha: torch.Tensor | None = None,  # [total_seq_len, num_qo_heads]
-    beta: torch.Tensor | None = None,   # [total_seq_len, num_qo_heads]
+    beta: torch.Tensor | None = None,  # [total_seq_len, num_qo_heads]
     chunk_size: int = 256,
     pre_block_size: int = 64,
     kv_dtype: torch.dtype = torch.float32,
@@ -748,14 +811,20 @@ def context_parallel_delta_rule_states(
         local_transfers_by_seq.append(torch.stack(seq_local_transfers))
         local_states_by_seq.append(torch.stack(seq_local_states))
 
-    final_states, fixed_states_by_seq = cp_delta_rule_fixup(local_transfers_by_seq, local_states_by_seq)
+    final_states, fixed_states_by_seq = cp_delta_rule_fixup(
+        local_transfers_by_seq, local_states_by_seq
+    )
 
     if not return_debug:
         return final_states, fixed_states_by_seq
 
     debug = {
-        "local_transfers": torch.stack(local_transfers) if local_transfers else final_states.new_empty(0),
-        "local_states": torch.stack(local_states) if local_states else final_states.new_empty(0),
+        "local_transfers": torch.stack(local_transfers)
+        if local_transfers
+        else final_states.new_empty(0),
+        "local_states": torch.stack(local_states)
+        if local_states
+        else final_states.new_empty(0),
         "local_transfers_by_seq": local_transfers_by_seq,
         "local_states_by_seq": local_states_by_seq,
         "fixed_states_by_seq": fixed_states_by_seq,

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -659,6 +659,7 @@ def cp_delta_rule_fixup(
 def cp_delta_rule_fixup_transposed(
     local_transfers_by_seq: list[torch.Tensor],
     local_states_by_seq: list[torch.Tensor],
+    initial_states_by_seq: list[torch.Tensor] | None = None,
 ):
     """Fix CP chunk artifacts in CPDeltaRuleFixupSm90 workspace orientation.
 
@@ -666,18 +667,21 @@ def cp_delta_rule_fixup_transposed(
     workspace layout and applies `S_i = S_{i-1} @ M_i + N_i`.
     """
     assert len(local_transfers_by_seq) == len(local_states_by_seq)
+    if initial_states_by_seq is not None:
+        assert len(initial_states_by_seq) == len(local_transfers_by_seq)
     fixed_states_by_seq = []
     final_states = []
 
-    for local_transfers, local_states in zip(local_transfers_by_seq, local_states_by_seq):
+    for seq_idx, (local_transfers, local_states) in enumerate(zip(local_transfers_by_seq, local_states_by_seq)):
         assert local_transfers.size(0) == local_states.size(0)
         seq_fixed_states = []
+        initial_state = initial_states_by_seq[seq_idx] if initial_states_by_seq is not None else None
         if local_transfers.size(0) == 0:
             fixed_states_by_seq.append(local_states)
-            final_states.append(local_states)
+            final_states.append(local_states if initial_state is None else initial_state)
             continue
 
-        state_HKV = torch.zeros_like(local_states[0])
+        state_HKV = torch.zeros_like(local_states[0]) if initial_state is None else initial_state.clone()
         for chunk_idx in range(local_transfers.size(0)):
             state_HKV = torch.bmm(state_HKV, local_transfers[chunk_idx]) + local_states[chunk_idx]
             seq_fixed_states.append(state_HKV)

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -332,6 +332,433 @@ def delta_rule(
     return torch.stack(o), torch.stack(kv)
 
 
+def _expand_delta_rule_heads(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    alpha: torch.Tensor | None,
+    beta: torch.Tensor | None,
+):
+    total_seqlen = q.size(0)
+    num_q_heads = q.size(1)
+    num_k_heads = k.size(1)
+    num_v_heads = v.size(1)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    if alpha is None:
+        alpha = torch.ones(total_seqlen, num_sab_heads, dtype=torch.float32, device=q.device)
+    if beta is None:
+        beta = torch.ones(total_seqlen, num_sab_heads, dtype=torch.float32, device=q.device)
+
+    if num_q_heads > num_v_heads:  # GQA
+        k = k.repeat_interleave(num_q_heads // num_k_heads, dim=1)
+        v = v.repeat_interleave(num_q_heads // num_v_heads, dim=1)
+    else:  # GVA
+        q = q.repeat_interleave(num_v_heads // num_q_heads, dim=1)
+        k = k.repeat_interleave(num_v_heads // num_k_heads, dim=1)
+
+    return q, k, v, alpha, beta
+
+
+@torch.inference_mode
+def cp_delta_rule_pre(
+    k: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    v: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    alpha: torch.Tensor,  # [chunk_len, num_heads]
+    beta: torch.Tensor,   # [chunk_len, num_heads]
+    *,
+    kv_dtype: torch.dtype = torch.float32,
+):
+    """CP chunk core: compute only this chunk's affine transfer.
+
+    The returned `(M, B)` satisfies `S_out = M @ S_in + B` for this chunk.
+    This function intentionally receives no data outside the CP chunk.
+    """
+    assert k.size(0) == v.size(0) == alpha.size(0) == beta.size(0)
+    num_heads = k.size(1)
+    head_size = k.size(2)
+    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(num_heads, head_size, head_size)
+    transfer_HKK = eye_HKK.clone()
+    state_HKV = torch.zeros((num_heads, head_size, head_size), dtype=kv_dtype, device=k.device)
+
+    for token_idx in range(k.size(0)):
+        k_HK = k[token_idx].to(kv_dtype)
+        v_HV = v[token_idx].to(kv_dtype)
+        alpha_H11 = alpha[token_idx].to(kv_dtype).reshape(num_heads, 1, 1)
+        beta_H11 = beta[token_idx].to(kv_dtype).reshape(num_heads, 1, 1)
+
+        kk_HKK = torch.einsum("hk,hl->hkl", k_HK, k_HK)
+        kv_HKV = torch.einsum("hk,hv->hkv", k_HK, v_HV)
+        token_transfer_HKK = alpha_H11 * (eye_HKK - beta_H11 * kk_HKK)
+        token_update_HKV = beta_H11 * kv_HKV
+
+        transfer_HKK = torch.bmm(token_transfer_HKK, transfer_HKK)
+        state_HKV = torch.bmm(token_transfer_HKK, state_HKV) + token_update_HKV
+
+    return transfer_HKK, state_HKV
+
+
+@torch.inference_mode
+def blockwise_cp_delta_rule_pre(
+    k: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    v: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    alpha: torch.Tensor,  # [chunk_len, num_heads]
+    beta: torch.Tensor,   # [chunk_len, num_heads]
+    *,
+    block_size: int = 64,
+    kv_dtype: torch.dtype = torch.float32,
+):
+    """CP preprocessing using matrix-form delta-rule blocks.
+
+    Tokens inside each `block_size` block are processed with the same matrix
+    formulation as `blockwise_delta_rule`; recurrence is only across blocks.
+    Returns `(M, B)` such that `S_out = M @ S_in + B` for the whole CP chunk.
+    """
+    assert block_size > 0
+    assert k.size(0) == v.size(0) == alpha.size(0) == beta.size(0)
+
+    chunk_len = k.size(0)
+    num_heads = k.size(1)
+    head_size = k.size(2)
+    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(num_heads, head_size, head_size)
+    transfer_HKK = eye_HKK.clone()
+    state_HKV = torch.zeros((num_heads, head_size, head_size), dtype=kv_dtype, device=k.device)
+
+    for blk_offset in range(0, chunk_len, block_size):
+        valid_len = min(block_size, chunk_len - blk_offset)
+        if valid_len == block_size:
+            k_SHK = k[blk_offset : blk_offset + block_size]
+            v_SHV = v[blk_offset : blk_offset + block_size]
+            alpha_SH = alpha[blk_offset : blk_offset + block_size]
+            beta_SH = beta[blk_offset : blk_offset + block_size]
+        else:
+            k_SHK = torch.zeros((block_size, num_heads, head_size), dtype=k.dtype, device=k.device)
+            v_SHV = torch.zeros((block_size, num_heads, head_size), dtype=v.dtype, device=v.device)
+            alpha_SH = torch.ones((block_size, num_heads), dtype=alpha.dtype, device=alpha.device)
+            beta_SH = torch.zeros((block_size, num_heads), dtype=beta.dtype, device=beta.device)
+            k_SHK[:valid_len] = k[blk_offset:]
+            v_SHV[:valid_len] = v[blk_offset:]
+            alpha_SH[:valid_len] = alpha[blk_offset:]
+            beta_SH[:valid_len] = beta[blk_offset:]
+
+        alpha_HS = alpha_SH.transpose(0, 1)
+        beta_HS1 = beta_SH.transpose(0, 1).unsqueeze(2)
+        Gamma_HSS, gamma_HS1 = to_logspace_Gamma_and_gamma(alpha_HS)
+        block_gamma_H11 = gamma_HS1[:, [valid_len - 1], :]
+
+        k_HSK = k_SHK.transpose(0, 1)
+        v_HSV = v_SHV.transpose(0, 1)
+
+        IKK = identity_add_strict_lower_diagonal(
+            beta_HS1 * torch.exp(Gamma_HSS) * matmul(k_HSK, k_HSK.transpose(-2, -1))
+        )
+        T = torch.inverse(IKK) * beta_HS1.transpose(1, 2)
+        T = T.to(k.dtype)
+        u_HSV = matmul(T, v_HSV)
+        w_HSK = matmul(T, torch.exp(gamma_HS1) * k_HSK)
+
+        k_decay_HSK = torch.exp(block_gamma_H11 - gamma_HS1) * k_HSK
+        block_transfer_HKK = torch.exp(block_gamma_H11) * eye_HKK - matmul(
+            k_decay_HSK.transpose(-2, -1).to(kv_dtype),
+            w_HSK.to(kv_dtype),
+        )
+        block_state_HKV = matmul(
+            k_decay_HSK.transpose(-2, -1).to(kv_dtype),
+            u_HSV.to(kv_dtype),
+        )
+
+        transfer_HKK = torch.bmm(block_transfer_HKK, transfer_HKK)
+        state_HKV = torch.bmm(block_transfer_HKK, state_HKV) + block_state_HKV
+
+    return transfer_HKK, state_HKV
+
+
+@torch.inference_mode
+def precompute_blockwise_cp_delta_rule_t(
+    k: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    beta: torch.Tensor,   # [chunk_len, num_heads]
+    *,
+    block_size: int = 64,
+    kv_dtype: torch.dtype = torch.float32,
+    t_dtype: torch.dtype | None = None,
+):
+    """Precompute the signed, beta-folded triangular solve matrix.
+
+    Returns `T := -(T_clean beta)^T` with shape
+    `[num_blocks, num_heads, block_size, block_size]`, in the orientation used
+    directly by the CP preprocess WGMMA. Tail blocks are padded with `K = 0`,
+    and `beta = 0`, so the returned tail tile is projected as `P T P`.
+    """
+    assert block_size > 0
+    assert k.size(0) == beta.size(0)
+    if t_dtype is None:
+        t_dtype = k.dtype
+
+    chunk_len = k.size(0)
+    num_heads = k.size(1)
+    head_size = k.size(2)
+    num_blocks = (chunk_len + block_size - 1) // block_size
+    t_HSS = torch.empty((num_blocks, num_heads, block_size, block_size), dtype=t_dtype, device=k.device)
+
+    for blk_idx, blk_offset in enumerate(range(0, chunk_len, block_size)):
+        valid_len = min(block_size, chunk_len - blk_offset)
+        if valid_len == block_size:
+            k_SHK = k[blk_offset : blk_offset + block_size]
+            beta_SH = beta[blk_offset : blk_offset + block_size]
+        else:
+            k_SHK = torch.zeros((block_size, num_heads, head_size), dtype=k.dtype, device=k.device)
+            beta_SH = torch.zeros((block_size, num_heads), dtype=beta.dtype, device=beta.device)
+            k_SHK[:valid_len] = k[blk_offset:]
+            beta_SH[:valid_len] = beta[blk_offset:]
+
+        beta_HS1 = beta_SH.transpose(0, 1).unsqueeze(2)
+        k_HSK = k_SHK.transpose(0, 1)
+
+        IKK = identity_add_strict_lower_diagonal(
+            beta_HS1.to(kv_dtype) * matmul(k_HSK.to(kv_dtype), k_HSK.to(kv_dtype).transpose(-2, -1))
+        )
+        t_clean_HSS = torch.inverse(IKK) * beta_HS1.transpose(1, 2).to(kv_dtype)
+        t_HSS[blk_idx] = (-t_clean_HSS.transpose(-2, -1)).to(t_dtype)
+
+    return t_HSS
+
+
+@torch.inference_mode
+def blockwise_cp_delta_rule_pre_transposed(
+    k: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    v: torch.Tensor,      # [chunk_len, num_heads, head_size]
+    alpha: torch.Tensor,  # [chunk_len, num_heads]
+    t: torch.Tensor,      # [num_blocks, num_heads, block_size, block_size], signed gamma-sandwiched
+    *,
+    block_size: int = 64,
+    kv_dtype: torch.dtype = torch.float32,
+):
+    """CP preprocessing in the same orientation as `CPDeltaRuleMNPrecomputeSm90`.
+
+    This path consumes raw `K`, raw `V`, `alpha`, and externally precomputed
+    signed gamma-sandwiched `T`. It keeps the running transfer/state transposed internally:
+    `Mt_next = Mt @ M_block_t` and `Bt_next = Bt @ M_block_t + B_block_t`.
+    The returned tensors use the normal `(M, B)` orientation.
+    """
+    assert block_size > 0
+    assert k.size(0) == v.size(0) == alpha.size(0)
+
+    chunk_len = k.size(0)
+    num_heads = k.size(1)
+    head_size = k.size(2)
+    num_blocks = (chunk_len + block_size - 1) // block_size
+    assert t.shape == (num_blocks, num_heads, block_size, block_size)
+
+    eye_HKK = torch.eye(head_size, dtype=kv_dtype, device=k.device).expand(num_heads, head_size, head_size)
+    transfer_t_HKK = eye_HKK.clone()
+    state_t_HKV = torch.zeros((num_heads, head_size, head_size), dtype=kv_dtype, device=k.device)
+
+    for blk_idx, blk_offset in enumerate(range(0, chunk_len, block_size)):
+        valid_len = min(block_size, chunk_len - blk_offset)
+        if valid_len == block_size:
+            k_SHK = k[blk_offset : blk_offset + block_size]
+            v_SHV = v[blk_offset : blk_offset + block_size]
+            alpha_SH = alpha[blk_offset : blk_offset + block_size]
+        else:
+            k_SHK = torch.zeros((block_size, num_heads, head_size), dtype=k.dtype, device=k.device)
+            v_SHV = torch.zeros((block_size, num_heads, head_size), dtype=v.dtype, device=v.device)
+            alpha_SH = torch.ones((block_size, num_heads), dtype=alpha.dtype, device=alpha.device)
+            k_SHK[:valid_len] = k[blk_offset:]
+            v_SHV[:valid_len] = v[blk_offset:]
+            alpha_SH[:valid_len] = alpha[blk_offset:]
+
+        alpha_HS = alpha_SH.transpose(0, 1)
+        _, gamma_HS1 = to_logspace_Gamma_and_gamma(alpha_HS)
+        gamma_HS1 = torch.exp(gamma_HS1).to(kv_dtype)
+        inv_gamma_H1S = torch.reciprocal(gamma_HS1.transpose(1, 2))
+        block_gamma_H11 = gamma_HS1[:, [valid_len - 1], :]
+
+        k_HSK = k_SHK.transpose(0, 1)
+        v_HSV = v_SHV.transpose(0, 1)
+        k_HSD = k_HSK.to(kv_dtype)
+        t_HSS = t[blk_idx].to(kv_dtype)
+        v_inv_HDS = v_HSV.transpose(-2, -1).to(kv_dtype) * inv_gamma_H1S
+        kt_HDS = k_HSD.transpose(-2, -1)
+
+        block_state_t_HKV = -block_gamma_H11 * matmul(matmul(v_inv_HDS, t_HSS), k_HSD)
+        block_transfer_t_HKK = block_gamma_H11 * eye_HKK + block_gamma_H11 * matmul(matmul(kt_HDS, t_HSS), k_HSD)
+
+        state_t_HKV = matmul(state_t_HKV, block_transfer_t_HKK) + block_state_t_HKV
+        transfer_t_HKK = matmul(transfer_t_HKK, block_transfer_t_HKK)
+
+    return transfer_t_HKK.transpose(-2, -1), state_t_HKV.transpose(-2, -1)
+
+
+@torch.inference_mode
+def compose_delta_rule_chunk_range(
+    local_transfers: torch.Tensor,  # [num_chunks, num_heads, head_size, head_size]
+    local_states: torch.Tensor,     # [num_chunks, num_heads, head_size, head_size]
+    start_chunk: int = 0,
+    end_chunk: int | None = None,
+):
+    """Compose chunk-local affine maps over `[start_chunk, end_chunk)`.
+
+    Returns `(M, B)` such that `S_end = M @ S_start + B`.
+    """
+    if end_chunk is None:
+        end_chunk = local_transfers.size(0)
+    assert 0 <= start_chunk <= end_chunk <= local_transfers.size(0)
+
+    num_heads = local_transfers.size(1)
+    head_size = local_transfers.size(2)
+    transfer_HKK = torch.eye(head_size, dtype=local_transfers.dtype, device=local_transfers.device).expand(num_heads, head_size, head_size).clone()
+    state_HKV = torch.zeros(
+        (local_states.size(1), local_states.size(2), local_states.size(3)),
+        dtype=local_states.dtype,
+        device=local_states.device,
+    )
+
+    for chunk_idx in range(start_chunk, end_chunk):
+        chunk_transfer_HKK = local_transfers[chunk_idx]
+        chunk_state_HKV = local_states[chunk_idx]
+        transfer_HKK = torch.bmm(chunk_transfer_HKK, transfer_HKK)
+        state_HKV = torch.bmm(chunk_transfer_HKK, state_HKV) + chunk_state_HKV
+
+    return transfer_HKK, state_HKV
+
+
+@torch.inference_mode
+def cp_delta_rule_fixup(
+    local_transfers_by_seq: list[torch.Tensor],
+    local_states_by_seq: list[torch.Tensor],
+):
+    """Fix CP chunk artifacts into global chunk-boundary states.
+
+    This stage consumes only outputs from `blockwise_cp_delta_rule_pre`.
+    """
+    assert len(local_transfers_by_seq) == len(local_states_by_seq)
+    fixed_states_by_seq = []
+    final_states = []
+
+    for local_transfers, local_states in zip(local_transfers_by_seq, local_states_by_seq):
+        assert local_transfers.size(0) == local_states.size(0)
+        seq_fixed_states = []
+        if local_transfers.size(0) == 0:
+            fixed_states_by_seq.append(local_states)
+            final_states.append(local_states)
+            continue
+
+        state_HKV = torch.zeros_like(local_states[0])
+        for chunk_idx in range(local_transfers.size(0)):
+            state_HKV = torch.bmm(local_transfers[chunk_idx], state_HKV) + local_states[chunk_idx]
+            seq_fixed_states.append(state_HKV)
+
+        fixed_states = torch.stack(seq_fixed_states)
+        fixed_states_by_seq.append(fixed_states)
+        final_states.append(state_HKV)
+
+    return torch.stack(final_states), fixed_states_by_seq
+
+
+@torch.inference_mode
+def cp_delta_rule_fixup_transposed(
+    local_transfers_by_seq: list[torch.Tensor],
+    local_states_by_seq: list[torch.Tensor],
+):
+    """Fix CP chunk artifacts in CPDeltaRuleFixupSm90 workspace orientation.
+
+    `CPDeltaRuleFixupSm90` consumes transfer/state tensors in transposed
+    workspace layout and applies `S_i = S_{i-1} @ M_i + N_i`.
+    """
+    assert len(local_transfers_by_seq) == len(local_states_by_seq)
+    fixed_states_by_seq = []
+    final_states = []
+
+    for local_transfers, local_states in zip(local_transfers_by_seq, local_states_by_seq):
+        assert local_transfers.size(0) == local_states.size(0)
+        seq_fixed_states = []
+        if local_transfers.size(0) == 0:
+            fixed_states_by_seq.append(local_states)
+            final_states.append(local_states)
+            continue
+
+        state_HKV = torch.zeros_like(local_states[0])
+        for chunk_idx in range(local_transfers.size(0)):
+            state_HKV = torch.bmm(state_HKV, local_transfers[chunk_idx]) + local_states[chunk_idx]
+            seq_fixed_states.append(state_HKV)
+
+        fixed_states = torch.stack(seq_fixed_states)
+        fixed_states_by_seq.append(fixed_states)
+        final_states.append(state_HKV)
+
+    return torch.stack(final_states), fixed_states_by_seq
+
+
+@torch.inference_mode
+def context_parallel_delta_rule_states(
+    q: torch.Tensor,  # [total_seq_len, num_qo_heads, head_size]
+    k: torch.Tensor,  # [total_seq_len, num_kv_heads, head_size]
+    v: torch.Tensor,  # [total_seq_len, num_kv_heads, head_size]
+    seq_lens: list[int],  # sequence length for each sequence
+    *,
+    alpha: torch.Tensor | None = None,  # [total_seq_len, num_qo_heads]
+    beta: torch.Tensor | None = None,   # [total_seq_len, num_qo_heads]
+    chunk_size: int = 256,
+    pre_block_size: int = 64,
+    kv_dtype: torch.dtype = torch.float32,
+    return_debug: bool = False,
+):
+    """Torch reference for context-parallel delta-rule chunk-state fixup.
+
+    Each chunk independently computes an affine transfer `S_out = M S_in + B`.
+    The fixup pass applies those chunk transfers to recover true global
+    chunk-boundary states. The final fixed state should match `delta_rule`.
+    """
+    assert chunk_size > 0
+    assert pre_block_size > 0
+
+    q, k, v, alpha, beta = _expand_delta_rule_heads(q, k, v, alpha, beta)
+    del q  # State fixup only needs K/V and gates.
+
+    local_transfers = []
+    local_states = []
+    local_transfers_by_seq = []
+    local_states_by_seq = []
+
+    seq_offset = exclusive_cumsum(seq_lens)
+    for seq_idx, seq_start in enumerate(seq_offset[:-1]):
+        seq_end = seq_offset[seq_idx + 1]
+        seq_local_transfers = []
+        seq_local_states = []
+
+        for chunk_start in range(seq_start, seq_end, chunk_size):
+            chunk_end = min(seq_end, chunk_start + chunk_size)
+            transfer_HKK, local_state_HKV = blockwise_cp_delta_rule_pre(
+                k[chunk_start:chunk_end],
+                v[chunk_start:chunk_end],
+                alpha[chunk_start:chunk_end],
+                beta[chunk_start:chunk_end],
+                block_size=pre_block_size,
+                kv_dtype=kv_dtype,
+            )
+            seq_local_transfers.append(transfer_HKK)
+            seq_local_states.append(local_state_HKV)
+            local_transfers.append(transfer_HKK)
+            local_states.append(local_state_HKV)
+
+        local_transfers_by_seq.append(torch.stack(seq_local_transfers))
+        local_states_by_seq.append(torch.stack(seq_local_states))
+
+    final_states, fixed_states_by_seq = cp_delta_rule_fixup(local_transfers_by_seq, local_states_by_seq)
+
+    if not return_debug:
+        return final_states, fixed_states_by_seq
+
+    debug = {
+        "local_transfers": torch.stack(local_transfers) if local_transfers else final_states.new_empty(0),
+        "local_states": torch.stack(local_states) if local_states else final_states.new_empty(0),
+        "local_transfers_by_seq": local_transfers_by_seq,
+        "local_states_by_seq": local_states_by_seq,
+        "fixed_states_by_seq": fixed_states_by_seq,
+    }
+    return final_states, debug
+
+
 def identity_add_strict_lower_diagonal(m: torch.Tensor):
     SIZE = m.size(-1)
     assert m.size(-2) == SIZE

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -678,7 +678,7 @@ def cp_delta_rule_fixup(
     fixed_states_by_seq = []
     final_states = []
 
-    for local_transfers, local_states in zip(
+    for local_transfers, local_states in zip(  # noqa: B905
         local_transfers_by_seq, local_states_by_seq
     ):
         assert local_transfers.size(0) == local_states.size(0)
@@ -721,7 +721,7 @@ def cp_delta_rule_fixup_transposed(
     final_states = []
 
     for seq_idx, (local_transfers, local_states) in enumerate(
-        zip(local_transfers_by_seq, local_states_by_seq)
+        zip(local_transfers_by_seq, local_states_by_seq)  # noqa: B905
     ):
         assert local_transfers.size(0) == local_states.size(0)
         seq_fixed_states = []

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -67,10 +67,12 @@ def _make_gates(total_seqlen, num_heads, baseline, device):
 
 
 @torch.inference_mode()
-def _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chunk_len, scale, initial_state=None):
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+def _run_cp_kernel_chain(
+    q, k, v, alpha, beta, cu_seqlens, total_seqlen, max_seqlen, cp_chunk_len, scale, initial_state=None,
+):
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
     local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
         local_transfer, local_state, cu_seqlens, total_seqlen,
         cp_chunk_len=cp_chunk_len, initial_state=initial_state)
@@ -86,7 +88,7 @@ def _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chun
     )
     cp_delta_rule_prefill_dsl_sm90(
         our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
-        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, initial_state=initial_state)
+        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen, initial_state=initial_state)
     return our_o, our_state
 
 
@@ -125,6 +127,7 @@ def test_cp_delta_rule_t_precompute(
     num_heads = 1
     head_size = 128
     total_seqlen = sum(seq_lens)
+    max_seqlen = max(seq_lens)
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
 
     with torch.device(device):
@@ -132,10 +135,10 @@ def test_cp_delta_rule_t_precompute(
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
 
-    our_t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    our_t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
     torch.cuda.synchronize()
 
-    assert our_t.shape == (workspace_num_chunks_host(cu_seqlens.cpu(), 64), num_heads, 64, 64)
+    assert our_t.shape == (workspace_num_chunks_host(cu_seqlens.cpu(), 64, total_seqlen), num_heads, 64, 64)
     for seq_idx, seq_len in enumerate(seq_lens):
         seq_start = int(cu_seqlens[seq_idx].item())
         seq_end = int(cu_seqlens[seq_idx + 1].item())
@@ -162,6 +165,7 @@ def test_cp_delta_rule_t_precompute_varlen_tail_is_projected(
     head_size = 128
     seq_lens = [96]
     total_seqlen = sum(seq_lens)
+    max_seqlen = max(seq_lens)
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
 
     with torch.device(device):
@@ -169,7 +173,7 @@ def test_cp_delta_rule_t_precompute_varlen_tail_is_projected(
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     beta = _make_gates(total_seqlen, num_heads, 0.99, device)
 
-    got = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    got = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
     torch.cuda.synchronize()
 
     tail = got[1, 0]
@@ -201,6 +205,7 @@ def test_cp_delta_rule_mn_precompute(
     head_size = 128
     block_size = 64
     total_seqlen = sum(seq_lens)
+    max_seqlen = max(seq_lens)
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
 
     with torch.device(device):
@@ -210,13 +215,13 @@ def test_cp_delta_rule_mn_precompute(
     alpha = _make_gates(total_seqlen, num_heads, gate_baseline, device)
     beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
 
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
     our_transfer, our_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
     torch.cuda.synchronize()
 
     assert our_transfer.shape == (
-        workspace_num_chunks_host(cu_seqlens.cpu(), cp_chunk_len),
+        workspace_num_chunks_host(cu_seqlens.cpu(), cp_chunk_len, total_seqlen),
         num_heads,
         head_size,
         head_size,
@@ -276,7 +281,7 @@ def test_cp_delta_rule_fixup(
     head_size = 128
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
     total_seqlen = sum(seq_lens)
-    total_cp_chunks = workspace_num_chunks_host(cu_seqlens.cpu(), cp_chunk_len)
+    total_cp_chunks = workspace_num_chunks_host(cu_seqlens.cpu(), cp_chunk_len, total_seqlen)
 
     local_transfer = torch.randn(
         total_cp_chunks, num_heads, head_size, head_size, dtype=torch.float32, device=device,
@@ -360,6 +365,7 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
     cp_chunk_len = chunk_len
     seq_lens = [chunk_len, chunk_len]
     total_seqlen = sum(seq_lens)
+    max_seqlen = max(seq_lens)
     cu_values = [0]
     for seq_len in seq_lens:
         cu_values.append(cu_values[-1] + seq_len)
@@ -374,9 +380,9 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
     alpha = _make_gates(total_seqlen, num_heads, gate_baseline, device)
     beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
 
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
     local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
         local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
 
@@ -402,6 +408,7 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
         cu_seqlens,
         total_seqlen,
         cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
     )
     torch.cuda.synchronize()
 
@@ -431,6 +438,7 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
     cp_chunk_len = 64
     seq_lens = [96, 64]
     total_seqlen = sum(seq_lens)
+    max_seqlen = max(seq_lens)
     cu_values = [0]
     for seq_len in seq_lens:
         cu_values.append(cu_values[-1] + seq_len)
@@ -446,9 +454,9 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
     alpha = _make_gates(total_seqlen, num_sab_heads, 0.99, device)
     beta = _make_gates(total_seqlen, num_sab_heads, 0.99, device)
 
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
     local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
         local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
 
@@ -456,7 +464,7 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
     our_state = torch.empty(len(seq_lens), num_sab_heads, head_size, head_size, dtype=torch.float32, device=device)
     cp_delta_rule_prefill_dsl_sm90(
         our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
-        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
     torch.cuda.synchronize()
 
     ref_o = torch.empty_like(our_o)
@@ -495,6 +503,7 @@ def test_cp_delta_rule_kernel_chain_long_small_bh_matches_non_cp_prefill(
     device = torch.device("cuda")
     head_size = 128
     total_seqlen = sum(seq_lens)
+    max_seqlen = max(seq_lens)
     num_sab_heads = max(num_q_heads, num_v_heads)
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
     scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
@@ -507,7 +516,8 @@ def test_cp_delta_rule_kernel_chain_long_small_bh_matches_non_cp_prefill(
     alpha = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
     beta = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
 
-    our_o, our_state = _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chunk_len, scale)
+    our_o, our_state = _run_cp_kernel_chain(
+        q, k, v, alpha, beta, cu_seqlens, total_seqlen, max_seqlen, cp_chunk_len, scale)
     torch.cuda.synchronize()
     ref_o, ref_state = _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale)
     torch.cuda.synchronize()

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+# ruff: noqa: B008
+
 import os
 import random
 import math
@@ -23,6 +25,7 @@ import torch
 
 from .reference_delta_rule import exclusive_cumsum
 from . import reference_delta_rule as reference
+from flashinfer.utils import is_sm90a_supported
 from flashinfer.gdn_kernels.delta_rule_dsl.delta_rule_cp_sm90 import (
     cp_delta_rule_dsl_sm90,
     cp_delta_rule_fixup_dsl_sm90,
@@ -41,12 +44,11 @@ FIXUP_TF32_ATOL = 2e-3
 FIXUP_TF32_RTOL = 2e-3
 
 
-def _skip_without_cp_kernel_device():
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA is required")
-    major, _ = torch.cuda.get_device_capability()
-    if major < 9:
-        pytest.skip("SM90+ GPU is required")
+def _skip_if_cp_unsupported():
+    """Skip test if context parallelism is unsupported."""
+    device = torch.device("cuda")
+    if not is_sm90a_supported(device):
+        pytest.skip("CP GDN prefill requires SM90")
 
 
 def _seed_all(seed):
@@ -182,7 +184,7 @@ def test_cp_delta_rule_t_precompute(
     gate_baseline,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     dtype = getattr(torch, dtype)
@@ -210,7 +212,7 @@ def test_cp_delta_rule_t_precompute(
         64,
         64,
     )
-    for seq_idx, seq_len in enumerate(seq_lens):
+    for seq_idx, _ in enumerate(seq_lens):
         seq_start = int(cu_seqlens[seq_idx].item())
         seq_end = int(cu_seqlens[seq_idx + 1].item())
         t_start = chunk_bound_host(seq_idx, seq_start, 64)
@@ -231,7 +233,7 @@ def test_cp_delta_rule_t_precompute_varlen_tail_is_projected(
     qkv_factory,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     dtype = torch.bfloat16
@@ -280,7 +282,7 @@ def test_cp_delta_rule_mn_precompute(
     gate_baseline,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     dtype = getattr(torch, dtype)
@@ -379,7 +381,7 @@ def test_cp_delta_rule_fixup(
     use_initial_state,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     head_size = 128
@@ -463,7 +465,7 @@ def test_cp_delta_rule_fixup(
         ref_states_by_seq,
         ref_initial_states_by_seq if use_initial_state else None,
     )
-    for seq_idx, seq_fixed in zip(ref_seq_indices, ref_by_seq):
+    for seq_idx, seq_fixed in zip(ref_seq_indices, ref_by_seq):  # noqa: B905
         seq_start = int(cu_seqlens[seq_idx].item())
         chunk_start = chunk_bound_host(seq_idx, seq_start, cp_chunk_len)
         for chunk_idx in range(seq_fixed.shape[0]):
@@ -492,7 +494,7 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
     gate_baseline,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     dtype = getattr(torch, dtype)
@@ -602,7 +604,7 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
     num_v_heads,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     dtype = torch.bfloat16
@@ -718,7 +720,7 @@ def test_cp_delta_rule_kernel_chain_long_small_bh_matches_non_cp_prefill(
     scale,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     head_size = 128
@@ -758,7 +760,7 @@ def test_cp_delta_rule_e2e_with_initial_state(
     seq_lens,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     head_size = 128
@@ -831,7 +833,7 @@ def test_cp_delta_rule_e2e(
     gate_baseline,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     head_size = 128
@@ -925,7 +927,7 @@ def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
     seq_lens,
     seed=int(os.environ.get("SEED", "0")),
 ):
-    _skip_without_cp_kernel_device()
+    _skip_if_cp_unsupported()
     _seed_all(seed)
     device = torch.device("cuda")
     dtype = getattr(torch, dtype)

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -451,62 +451,6 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
 
 
 @torch.inference_mode()
-def test_cp_delta_rule_prefill_gva_random_alpha_kernel_chain(
-    qkv_factory,
-    seed = int(os.environ.get("SEED", "0")),
-):
-    _skip_without_cp_kernel_device()
-    _seed_all(seed)
-    device = torch.device("cuda")
-    dtype = torch.float16
-    head_size = 128
-    seq_lens = [256, 256]
-    total_seqlen = sum(seq_lens)
-    cu_seqlens = _make_cu_seqlens(seq_lens, device)
-    num_q_heads, num_k_heads, num_v_heads = 16, 16, 32
-    num_sab_heads = max(num_q_heads, num_v_heads)
-    cp_chunk_len = 4096
-    scale = 1.0
-
-    with torch.device(device):
-        q, k, v = qkv_factory(seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype)
-    q = q.contiguous()
-    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
-    v = v.contiguous()
-    alpha = torch.rand(total_seqlen, num_sab_heads, dtype=torch.float32, device=device).contiguous()
-    beta = torch.ones_like(alpha)
-
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
-    local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
-    fixed_state = cp_delta_rule_fixup_dsl_sm90(
-        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
-    torch.cuda.synchronize()
-
-    assert torch.isfinite(t[:8]).all()
-    assert torch.isfinite(local_transfer).all()
-    assert torch.isfinite(local_state).all()
-    assert torch.isfinite(fixed_state).all()
-
-    our_o = torch.empty(total_seqlen, num_sab_heads, head_size, dtype=dtype, device=device)
-    our_state = torch.empty(len(seq_lens), num_sab_heads, head_size, head_size, dtype=torch.float32, device=device)
-    our_o.fill_(float("nan"))
-    our_state.fill_(float("nan"))
-    cp_delta_rule_prefill_dsl_sm90(
-        our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
-        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
-    torch.cuda.synchronize()
-
-    assert torch.isfinite(our_o).all()
-    assert torch.isfinite(our_state).all()
-
-    ref_o, ref_state = _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale)
-    torch.cuda.synchronize()
-    torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
-    torch.testing.assert_close(our_state, ref_state, atol=4e-2, rtol=4e-2)
-
-
-@torch.inference_mode()
 @pytest.mark.parametrize(
     "dtype, seq_lens, cp_chunk_len, num_q_heads, num_k_heads, num_v_heads, gate_baseline, scale",
     [

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -30,7 +30,10 @@ from flashinfer.gdn_kernels.delta_rule_dsl.delta_rule_cp_sm90 import (
     cp_delta_rule_prefill_dsl_sm90,
     cp_delta_rule_t_precompute_dsl_sm90,
 )
-from flashinfer.gdn_kernels.delta_rule_dsl.varlen_helper import chunk_bound_host, workspace_num_chunks_host
+from flashinfer.gdn_kernels.delta_rule_dsl.varlen_helper import (
+    chunk_bound_host,
+    workspace_num_chunks_host,
+)
 from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 
@@ -62,22 +65,52 @@ def _make_cu_seqlens(seq_lens, device):
 def _make_gates(total_seqlen, num_heads, baseline, device):
     return (
         baseline
-        + (1.0 - baseline) * torch.rand(total_seqlen, num_heads, dtype=torch.float32, device=device)
+        + (1.0 - baseline)
+        * torch.rand(total_seqlen, num_heads, dtype=torch.float32, device=device)
     ).contiguous()
 
 
 @torch.inference_mode()
 def _run_cp_kernel_chain(
-    q, k, v, alpha, beta, cu_seqlens, total_seqlen, max_seqlen, cp_chunk_len, scale, initial_state=None,
+    q,
+    k,
+    v,
+    alpha,
+    beta,
+    cu_seqlens,
+    total_seqlen,
+    max_seqlen,
+    cp_chunk_len,
+    scale,
+    initial_state=None,
 ):
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
+    t = cp_delta_rule_t_precompute_dsl_sm90(
+        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen
+    )
     local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
+        k,
+        v,
+        t,
+        alpha,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
+    )
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
-        local_transfer, local_state, cu_seqlens, total_seqlen,
-        cp_chunk_len=cp_chunk_len, initial_state=initial_state)
+        local_transfer,
+        local_state,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        initial_state=initial_state,
+    )
 
-    our_o = torch.empty((total_seqlen, max(q.shape[1], v.shape[1]), q.shape[2]), dtype=q.dtype, device=q.device)
+    our_o = torch.empty(
+        (total_seqlen, max(q.shape[1], v.shape[1]), q.shape[2]),
+        dtype=q.dtype,
+        device=q.device,
+    )
     our_state = torch.empty(
         cu_seqlens.numel() - 1,
         max(q.shape[1], v.shape[1]),
@@ -87,14 +120,31 @@ def _run_cp_kernel_chain(
         device=q.device,
     )
     cp_delta_rule_prefill_dsl_sm90(
-        our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
-        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen, initial_state=initial_state)
+        our_o,
+        our_state,
+        q,
+        k,
+        v,
+        t,
+        fixed_state,
+        alpha,
+        scale,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
+        initial_state=initial_state,
+    )
     return our_o, our_state
 
 
 @torch.inference_mode()
 def _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale, initial_state=None):
-    ref_o = torch.empty((q.shape[0], max(q.shape[1], v.shape[1]), q.shape[2]), dtype=q.dtype, device=q.device)
+    ref_o = torch.empty(
+        (q.shape[0], max(q.shape[1], v.shape[1]), q.shape[2]),
+        dtype=q.dtype,
+        device=q.device,
+    )
     ref_state = torch.empty(
         cu_seqlens.numel() - 1,
         max(q.shape[1], v.shape[1]),
@@ -104,8 +154,20 @@ def _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale, initial_state=N
         device=q.device,
     )
     chunk_gated_delta_rule(
-        q, k, v, alpha, beta, scale, initial_state, True, cu_seqlens, True,
-        output=ref_o, output_state=ref_state, use_cp=False)
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        scale,
+        initial_state,
+        True,
+        cu_seqlens,
+        True,
+        output=ref_o,
+        output_state=ref_state,
+        use_cp=False,
+    )
     return ref_o, ref_state
 
 
@@ -118,7 +180,7 @@ def test_cp_delta_rule_t_precompute(
     dtype,
     seq_lens,
     gate_baseline,
-    seed = int(os.environ.get("SEED", "0")),
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -131,14 +193,23 @@ def test_cp_delta_rule_t_precompute(
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
 
     with torch.device(device):
-        _, k, _ = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+        _, k, _ = qkv_factory(
+            seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype
+        )
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
 
-    our_t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
+    our_t = cp_delta_rule_t_precompute_dsl_sm90(
+        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen
+    )
     torch.cuda.synchronize()
 
-    assert our_t.shape == (workspace_num_chunks_host(cu_seqlens.cpu(), 64, total_seqlen), num_heads, 64, 64)
+    assert our_t.shape == (
+        workspace_num_chunks_host(cu_seqlens.cpu(), 64, total_seqlen),
+        num_heads,
+        64,
+        64,
+    )
     for seq_idx, seq_len in enumerate(seq_lens):
         seq_start = int(cu_seqlens[seq_idx].item())
         seq_end = int(cu_seqlens[seq_idx + 1].item())
@@ -150,12 +221,15 @@ def test_cp_delta_rule_t_precompute(
             kv_dtype=torch.float32,
             t_dtype=dtype,
         )
-        torch.testing.assert_close(our_t[t_start : t_start + ref_t.shape[0]], ref_t, atol=5e-3, rtol=5e-3)
+        torch.testing.assert_close(
+            our_t[t_start : t_start + ref_t.shape[0]], ref_t, atol=5e-3, rtol=5e-3
+        )
 
 
 @torch.inference_mode()
 def test_cp_delta_rule_t_precompute_varlen_tail_is_projected(
-    qkv_factory, seed = int(os.environ.get("SEED", "0")),
+    qkv_factory,
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -169,16 +243,24 @@ def test_cp_delta_rule_t_precompute_varlen_tail_is_projected(
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
 
     with torch.device(device):
-        _, k, _ = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+        _, k, _ = qkv_factory(
+            seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype
+        )
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     beta = _make_gates(total_seqlen, num_heads, 0.99, device)
 
-    got = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
+    got = cp_delta_rule_t_precompute_dsl_sm90(
+        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen
+    )
     torch.cuda.synchronize()
 
     tail = got[1, 0]
-    torch.testing.assert_close(tail[32:], torch.zeros_like(tail[32:]), atol=0.0, rtol=0.0)
-    torch.testing.assert_close(tail[:, 32:], torch.zeros_like(tail[:, 32:]), atol=0.0, rtol=0.0)
+    torch.testing.assert_close(
+        tail[32:], torch.zeros_like(tail[32:]), atol=0.0, rtol=0.0
+    )
+    torch.testing.assert_close(
+        tail[:, 32:], torch.zeros_like(tail[:, 32:]), atol=0.0, rtol=0.0
+    )
 
 
 @torch.inference_mode()
@@ -196,7 +278,7 @@ def test_cp_delta_rule_mn_precompute(
     cp_chunk_len,
     num_heads,
     gate_baseline,
-    seed = int(os.environ.get("SEED", "0")),
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -209,15 +291,27 @@ def test_cp_delta_rule_mn_precompute(
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
 
     with torch.device(device):
-        _, k, v = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+        _, k, v = qkv_factory(
+            seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype
+        )
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     v = v.contiguous()
     alpha = _make_gates(total_seqlen, num_heads, gate_baseline, device)
     beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
 
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
+    t = cp_delta_rule_t_precompute_dsl_sm90(
+        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen
+    )
     our_transfer, our_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
+        k,
+        v,
+        t,
+        alpha,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
+    )
     torch.cuda.synchronize()
 
     assert our_transfer.shape == (
@@ -255,25 +349,35 @@ def test_cp_delta_rule_mn_precompute(
             else:
                 atol = 1e-3
                 rtol = 5e-4
-            torch.testing.assert_close(our_transfer[slot].transpose(-1, -2), ref_transfer, atol=atol, rtol=rtol)
-            torch.testing.assert_close(our_state[slot].transpose(-1, -2), ref_state, atol=atol, rtol=rtol)
+            torch.testing.assert_close(
+                our_transfer[slot].transpose(-1, -2), ref_transfer, atol=atol, rtol=rtol
+            )
+            torch.testing.assert_close(
+                our_state[slot].transpose(-1, -2), ref_state, atol=atol, rtol=rtol
+            )
 
     for slot in range(our_transfer.shape[0]):
         if slot not in valid_cp_slots:
-            torch.testing.assert_close(our_transfer[slot], torch.zeros_like(our_transfer[slot]))
-            torch.testing.assert_close(our_state[slot], torch.zeros_like(our_state[slot]))
+            torch.testing.assert_close(
+                our_transfer[slot], torch.zeros_like(our_transfer[slot])
+            )
+            torch.testing.assert_close(
+                our_state[slot], torch.zeros_like(our_state[slot])
+            )
 
 
 @torch.inference_mode()
 @pytest.mark.parametrize("use_initial_state", [False, True])
 @pytest.mark.parametrize("num_heads", [1, 3])
-@pytest.mark.parametrize("seq_lens, cp_chunk_len", [([96, 0, 300], 128), ([1], 1), ([2], 1), ([5], 1)])
+@pytest.mark.parametrize(
+    "seq_lens, cp_chunk_len", [([96, 0, 300], 128), ([1], 1), ([2], 1), ([5], 1)]
+)
 def test_cp_delta_rule_fixup(
     seq_lens,
     cp_chunk_len,
     num_heads,
     use_initial_state,
-    seed = int(os.environ.get("SEED", "0")),
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -281,21 +385,47 @@ def test_cp_delta_rule_fixup(
     head_size = 128
     cu_seqlens = _make_cu_seqlens(seq_lens, device)
     total_seqlen = sum(seq_lens)
-    total_cp_chunks = workspace_num_chunks_host(cu_seqlens.cpu(), cp_chunk_len, total_seqlen)
+    total_cp_chunks = workspace_num_chunks_host(
+        cu_seqlens.cpu(), cp_chunk_len, total_seqlen
+    )
 
-    local_transfer = torch.randn(
-        total_cp_chunks, num_heads, head_size, head_size, dtype=torch.float32, device=device,
-    ) * 0.02
-    local_state = torch.randn(
-        total_cp_chunks, num_heads, head_size, head_size, dtype=torch.float32, device=device,
-    ) * 0.1
+    local_transfer = (
+        torch.randn(
+            total_cp_chunks,
+            num_heads,
+            head_size,
+            head_size,
+            dtype=torch.float32,
+            device=device,
+        )
+        * 0.02
+    )
+    local_state = (
+        torch.randn(
+            total_cp_chunks,
+            num_heads,
+            head_size,
+            head_size,
+            dtype=torch.float32,
+            device=device,
+        )
+        * 0.1
+    )
     diag = torch.arange(head_size, device=device)
     local_transfer[:, :, diag, diag] += 0.9
     initial_state = None
     if use_initial_state:
-        initial_state = torch.randn(
-            len(seq_lens), num_heads, head_size, head_size, dtype=torch.float32, device=device,
-        ) * 0.03
+        initial_state = (
+            torch.randn(
+                len(seq_lens),
+                num_heads,
+                head_size,
+                head_size,
+                dtype=torch.float32,
+                device=device,
+            )
+            * 0.03
+        )
 
     our_fixed_state = cp_delta_rule_fixup_dsl_sm90(
         local_transfer.contiguous(),
@@ -346,7 +476,9 @@ def test_cp_delta_rule_fixup(
 
     for slot in range(total_cp_chunks):
         if slot not in valid_slots:
-            torch.testing.assert_close(our_fixed_state[slot], torch.zeros_like(our_fixed_state[slot]))
+            torch.testing.assert_close(
+                our_fixed_state[slot], torch.zeros_like(our_fixed_state[slot])
+            )
 
 
 @torch.inference_mode()
@@ -354,7 +486,11 @@ def test_cp_delta_rule_fixup(
 @pytest.mark.parametrize("chunk_len", [64, 128])
 @pytest.mark.parametrize("gate_baseline", [0.9, 0.9995])
 def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
-    qkv_factory, dtype, chunk_len, gate_baseline, seed = int(os.environ.get("SEED", "0")),
+    qkv_factory,
+    dtype,
+    chunk_len,
+    gate_baseline,
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -373,18 +509,31 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
     scale = 1.0
 
     with torch.device(device):
-        q, k, v = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+        q, k, v = qkv_factory(
+            seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype
+        )
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     q = q.contiguous()
     v = v.contiguous()
     alpha = _make_gates(total_seqlen, num_heads, gate_baseline, device)
     beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
 
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
+    t = cp_delta_rule_t_precompute_dsl_sm90(
+        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen
+    )
     local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
+        k,
+        v,
+        t,
+        alpha,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
+    )
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
-        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len
+    )
 
     our_o = torch.empty_like(q)
     our_state = torch.empty(
@@ -413,8 +562,29 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
     torch.cuda.synchronize()
 
     ref_o = torch.empty_like(q)
-    ref_state = torch.empty(len(seq_lens), num_heads, head_size, head_size, dtype=torch.float32, device=device)
-    chunk_gated_delta_rule(q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, output=ref_o, output_state=ref_state, use_cp=False)
+    ref_state = torch.empty(
+        len(seq_lens),
+        num_heads,
+        head_size,
+        head_size,
+        dtype=torch.float32,
+        device=device,
+    )
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        scale,
+        None,
+        True,
+        cu_seqlens,
+        True,
+        output=ref_o,
+        output_state=ref_state,
+        use_cp=False,
+    )
     torch.cuda.synchronize()
 
     torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
@@ -422,13 +592,15 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
 
 
 @torch.inference_mode()
-@pytest.mark.parametrize("num_q_heads, num_k_heads, num_v_heads", [(4, 1, 1), (1, 1, 4)])
+@pytest.mark.parametrize(
+    "num_q_heads, num_k_heads, num_v_heads", [(4, 1, 1), (1, 1, 4)]
+)
 def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
     qkv_factory,
     num_q_heads,
     num_k_heads,
     num_v_heads,
-    seed = int(os.environ.get("SEED", "0")),
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -447,29 +619,77 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
     scale = 1.0
 
     with torch.device(device):
-        q, k, v = qkv_factory(seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype)
+        q, k, v = qkv_factory(
+            seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype
+        )
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     q = q.contiguous()
     v = v.contiguous()
     alpha = _make_gates(total_seqlen, num_sab_heads, 0.99, device)
     beta = _make_gates(total_seqlen, num_sab_heads, 0.99, device)
 
-    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen)
+    t = cp_delta_rule_t_precompute_dsl_sm90(
+        k, beta, cu_seqlens, total_seqlen, max_seqlen=max_seqlen
+    )
     local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
-        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
+        k,
+        v,
+        t,
+        alpha,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
+    )
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
-        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len
+    )
 
-    our_o = torch.empty(total_seqlen, num_sab_heads, head_size, dtype=dtype, device=device)
-    our_state = torch.empty(len(seq_lens), num_sab_heads, head_size, head_size, dtype=torch.float32, device=device)
+    our_o = torch.empty(
+        total_seqlen, num_sab_heads, head_size, dtype=dtype, device=device
+    )
+    our_state = torch.empty(
+        len(seq_lens),
+        num_sab_heads,
+        head_size,
+        head_size,
+        dtype=torch.float32,
+        device=device,
+    )
     cp_delta_rule_prefill_dsl_sm90(
-        our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
-        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, max_seqlen=max_seqlen)
+        our_o,
+        our_state,
+        q,
+        k,
+        v,
+        t,
+        fixed_state,
+        alpha,
+        scale,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+        max_seqlen=max_seqlen,
+    )
     torch.cuda.synchronize()
 
     ref_o = torch.empty_like(our_o)
     ref_state = torch.empty_like(our_state)
-    chunk_gated_delta_rule(q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, output=ref_o, output_state=ref_state, use_cp=False)
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        scale,
+        None,
+        True,
+        cu_seqlens,
+        True,
+        output=ref_o,
+        output_state=ref_state,
+        use_cp=False,
+    )
     torch.cuda.synchronize()
 
     torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
@@ -496,7 +716,7 @@ def test_cp_delta_rule_kernel_chain_long_small_bh_matches_non_cp_prefill(
     num_v_heads,
     gate_baseline,
     scale,
-    seed = int(os.environ.get("SEED", "0")),
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -509,7 +729,9 @@ def test_cp_delta_rule_kernel_chain_long_small_bh_matches_non_cp_prefill(
     scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
 
     with torch.device(device):
-        q, k, v = qkv_factory(seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype)
+        q, k, v = qkv_factory(
+            seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype
+        )
     q = q.contiguous()
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     v = v.contiguous()
@@ -517,7 +739,8 @@ def test_cp_delta_rule_kernel_chain_long_small_bh_matches_non_cp_prefill(
     beta = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
 
     our_o, our_state = _run_cp_kernel_chain(
-        q, k, v, alpha, beta, cu_seqlens, total_seqlen, max_seqlen, cp_chunk_len, scale)
+        q, k, v, alpha, beta, cu_seqlens, total_seqlen, max_seqlen, cp_chunk_len, scale
+    )
     torch.cuda.synchronize()
     ref_o, ref_state = _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale)
     torch.cuda.synchronize()
@@ -533,7 +756,7 @@ def test_cp_delta_rule_e2e_with_initial_state(
     qkv_factory,
     dtype,
     seq_lens,
-    seed = int(os.environ.get("SEED", "0")),
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -546,17 +769,29 @@ def test_cp_delta_rule_e2e_with_initial_state(
     num_heads = 1
 
     with torch.device(device):
-        q, k, v = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+        q, k, v = qkv_factory(
+            seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype
+        )
     q = q.contiguous()
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     v = v.contiguous()
     alpha = _make_gates(total_seqlen, num_heads, 0.99, device)
     beta = _make_gates(total_seqlen, num_heads, 0.99, device)
-    initial_state = torch.randn(
-        len(seq_lens), num_heads, head_size, head_size, dtype=torch.float32, device=device,
-    ) * 0.02
+    initial_state = (
+        torch.randn(
+            len(seq_lens),
+            num_heads,
+            head_size,
+            head_size,
+            dtype=torch.float32,
+            device=device,
+        )
+        * 0.02
+    )
 
-    our_o = torch.empty([total_seqlen, num_heads, head_size], dtype=q.dtype, device=q.device)
+    our_o = torch.empty(
+        [total_seqlen, num_heads, head_size], dtype=q.dtype, device=q.device
+    )
     our_state = torch.empty_like(initial_state)
     cp_delta_rule_dsl_sm90(
         our_o,
@@ -574,7 +809,9 @@ def test_cp_delta_rule_e2e_with_initial_state(
     )
     torch.cuda.synchronize()
 
-    ref_o, ref_state = _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale, initial_state=initial_state)
+    ref_o, ref_state = _run_non_cp_prefill(
+        q, k, v, alpha, beta, cu_seqlens, scale, initial_state=initial_state
+    )
     torch.cuda.synchronize()
 
     torch.testing.assert_close(our_o, ref_o, atol=5e-2, rtol=5e-2)
@@ -582,7 +819,7 @@ def test_cp_delta_rule_e2e_with_initial_state(
 
 
 @pytest.mark.parametrize("gate_baseline", [0.9995, 0.99])
-@pytest.mark.parametrize("num_heads", [(1,1,1), (2,2,8), (4,1,1), (16,16,64)])
+@pytest.mark.parametrize("num_heads", [(1, 1, 1), (2, 2, 8), (4, 1, 1), (16, 16, 64)])
 @pytest.mark.parametrize("seq_lens", [[192, 64], [2048], [1025], [9999, 65530]])
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
 @torch.inference_mode()
@@ -592,7 +829,7 @@ def test_cp_delta_rule_e2e(
     seq_lens,
     num_heads,
     gate_baseline,
-    seed = int(os.environ.get("SEED", "0")),
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -608,15 +845,26 @@ def test_cp_delta_rule_e2e(
     num_sab_heads = max(num_heads)
 
     with torch.device(device):
-        q, k, v = qkv_factory(seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype)
+        q, k, v = qkv_factory(
+            seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype
+        )
     q = q.contiguous()
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     v = v.contiguous()
     alpha = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
     beta = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
 
-    our_o = torch.empty([total_seqlen, num_o_heads, head_size], dtype=q.dtype, device=q.device)
-    our_state = torch.empty(len(seq_lens), num_sab_heads, head_size, head_size, dtype=torch.float32, device=device)
+    our_o = torch.empty(
+        [total_seqlen, num_o_heads, head_size], dtype=q.dtype, device=q.device
+    )
+    our_state = torch.empty(
+        len(seq_lens),
+        num_sab_heads,
+        head_size,
+        head_size,
+        dtype=torch.float32,
+        device=device,
+    )
     our_o.fill_(float("nan"))
     our_state.fill_(float("nan"))
     cp_delta_rule_dsl_sm90(
@@ -635,7 +883,21 @@ def test_cp_delta_rule_e2e(
 
     ref_o = torch.empty_like(our_o)
     ref_state = torch.empty_like(our_state)
-    chunk_gated_delta_rule(q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, output=ref_o, output_state=ref_state, use_cp=False)
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        scale,
+        None,
+        True,
+        cu_seqlens,
+        True,
+        output=ref_o,
+        output_state=ref_state,
+        use_cp=False,
+    )
     torch.cuda.synchronize()
 
     if dtype == torch.bfloat16:
@@ -661,7 +923,7 @@ def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
     qkv_factory,
     dtype,
     seq_lens,
-    seed = int(os.environ.get("SEED", "0")),
+    seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
     _seed_all(seed)
@@ -674,7 +936,9 @@ def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
     scale = 1.0
 
     with torch.device(device):
-        q, k, v = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+        q, k, v = qkv_factory(
+            seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype
+        )
     q = q.contiguous()
     k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
     v = v.contiguous()
@@ -682,9 +946,11 @@ def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
     beta = _make_gates(total_seqlen, num_heads, 0.99, device)
 
     our_o, our_state = chunk_gated_delta_rule(
-        q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, use_cp=True)
+        q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, use_cp=True
+    )
     ref_o, ref_state = chunk_gated_delta_rule(
-        q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, use_cp=False)
+        q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, use_cp=False
+    )
     torch.cuda.synchronize()
 
     torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -1,0 +1,608 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import random
+import math
+
+import pytest
+import torch
+
+from .reference_delta_rule import exclusive_cumsum
+from . import reference_delta_rule as reference
+from flashinfer.gdn_kernels.delta_rule_dsl.delta_rule_cp_sm90 import (
+    cp_delta_rule_dsl_sm90,
+    cp_delta_rule_fixup_dsl_sm90,
+    cp_delta_rule_mn_precompute_dsl_sm90,
+    cp_delta_rule_prefill_dsl_sm90,
+    cp_delta_rule_t_precompute_dsl_sm90,
+)
+from flashinfer.gdn_kernels.delta_rule_dsl.varlen_helper import chunk_bound_host, workspace_num_chunks_host
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
+
+
+FIXUP_TF32_ATOL = 2e-3
+FIXUP_TF32_RTOL = 2e-3
+
+
+def _skip_without_cp_kernel_device():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, _ = torch.cuda.get_device_capability()
+    if major < 9:
+        pytest.skip("SM90+ GPU is required")
+
+
+def _seed_all(seed):
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+
+def _make_cu_seqlens(seq_lens, device):
+    return torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int64, device=device)
+
+
+def _make_gates(total_seqlen, num_heads, baseline, device):
+    return (
+        baseline
+        + (1.0 - baseline) * torch.rand(total_seqlen, num_heads, dtype=torch.float32, device=device)
+    ).contiguous()
+
+
+@torch.inference_mode()
+def _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chunk_len, scale):
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    fixed_state = cp_delta_rule_fixup_dsl_sm90(
+        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+
+    our_o = torch.empty((total_seqlen, max(q.shape[1], v.shape[1]), q.shape[2]), dtype=q.dtype, device=q.device)
+    our_state = torch.empty(
+        cu_seqlens.numel() - 1,
+        max(q.shape[1], v.shape[1]),
+        q.shape[2],
+        q.shape[2],
+        dtype=torch.float32,
+        device=q.device,
+    )
+    cp_delta_rule_prefill_dsl_sm90(
+        our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
+        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    return our_o, our_state
+
+
+@torch.inference_mode()
+def _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale):
+    ref_o = torch.empty((q.shape[0], max(q.shape[1], v.shape[1]), q.shape[2]), dtype=q.dtype, device=q.device)
+    ref_state = torch.empty(
+        cu_seqlens.numel() - 1,
+        max(q.shape[1], v.shape[1]),
+        q.shape[2],
+        q.shape[2],
+        dtype=torch.float32,
+        device=q.device,
+    )
+    chunk_gated_delta_rule(q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, output=ref_o, output_state=ref_state, use_cp=False)
+    return ref_o, ref_state
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("seq_lens", [[128], [192, 64], [2048], [1025], [9999, 6553]])
+@pytest.mark.parametrize("gate_baseline", [1.0, 0.9, 0.9995])
+def test_cp_delta_rule_t_precompute(
+    qkv_factory,
+    dtype,
+    seq_lens,
+    gate_baseline,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+    num_heads = 1
+    head_size = 128
+    total_seqlen = sum(seq_lens)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+
+    with torch.device(device):
+        _, k, _ = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
+
+    our_t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    torch.cuda.synchronize()
+
+    assert our_t.shape == (workspace_num_chunks_host(cu_seqlens.cpu(), 64), num_heads, 64, 64)
+    for seq_idx, seq_len in enumerate(seq_lens):
+        seq_start = int(cu_seqlens[seq_idx].item())
+        seq_end = int(cu_seqlens[seq_idx + 1].item())
+        t_start = chunk_bound_host(seq_idx, seq_start, 64)
+        ref_t = reference.precompute_blockwise_cp_delta_rule_t(
+            k[seq_start:seq_end],
+            beta[seq_start:seq_end],
+            block_size=64,
+            kv_dtype=torch.float32,
+            t_dtype=dtype,
+        )
+        torch.testing.assert_close(our_t[t_start : t_start + ref_t.shape[0]], ref_t, atol=5e-3, rtol=5e-3)
+
+
+@torch.inference_mode()
+def test_cp_delta_rule_t_precompute_varlen_tail_is_projected(
+    qkv_factory, seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_heads = 1
+    head_size = 128
+    seq_lens = [96]
+    total_seqlen = sum(seq_lens)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+
+    with torch.device(device):
+        _, k, _ = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    beta = _make_gates(total_seqlen, num_heads, 0.99, device)
+
+    got = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    torch.cuda.synchronize()
+
+    tail = got[1, 0]
+    torch.testing.assert_close(tail[32:], torch.zeros_like(tail[32:]), atol=0.0, rtol=0.0)
+    torch.testing.assert_close(tail[:, 32:], torch.zeros_like(tail[:, 32:]), atol=0.0, rtol=0.0)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("num_heads", [1, 2])
+@pytest.mark.parametrize("gate_baseline", [0.9, 0.99, 0.9995])
+@pytest.mark.parametrize(
+    "seq_lens, cp_chunk_len",
+    [([64, 192], 64), ([128, 200], 128), ([1024, 3000], 1024), ([96, 64, 192], 128)],
+)
+def test_cp_delta_rule_mn_precompute(
+    qkv_factory,
+    dtype,
+    seq_lens,
+    cp_chunk_len,
+    num_heads,
+    gate_baseline,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+    head_size = 128
+    block_size = 64
+    total_seqlen = sum(seq_lens)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+
+    with torch.device(device):
+        _, k, v = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(total_seqlen, num_heads, gate_baseline, device)
+    beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
+
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    our_transfer, our_state = cp_delta_rule_mn_precompute_dsl_sm90(
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    torch.cuda.synchronize()
+
+    assert our_transfer.shape == (
+        workspace_num_chunks_host(cu_seqlens.cpu(), cp_chunk_len),
+        num_heads,
+        head_size,
+        head_size,
+    )
+    assert our_state.shape == our_transfer.shape
+
+    valid_cp_slots = set()
+    for seq_idx, seq_len in enumerate(seq_lens):
+        seq_start = int(cu_seqlens[seq_idx].item())
+        cp_start = chunk_bound_host(seq_idx, seq_start, cp_chunk_len)
+        t_start = chunk_bound_host(seq_idx, seq_start, block_size)
+        num_cp_chunks = (seq_len + cp_chunk_len - 1) // cp_chunk_len
+        for chunk_idx in range(num_cp_chunks):
+            chunk_offset = chunk_idx * cp_chunk_len
+            chunk_end = min(seq_len, chunk_offset + cp_chunk_len)
+            num_t_blocks = (chunk_end - chunk_offset + block_size - 1) // block_size
+            t_block_offset = chunk_idx * (cp_chunk_len // block_size)
+            slot = cp_start + chunk_idx
+            valid_cp_slots.add(slot)
+            ref_transfer, ref_state = reference.blockwise_cp_delta_rule_pre_transposed(
+                k[seq_start + chunk_offset : seq_start + chunk_end],
+                v[seq_start + chunk_offset : seq_start + chunk_end],
+                alpha[seq_start + chunk_offset : seq_start + chunk_end],
+                t[t_start + t_block_offset : t_start + t_block_offset + num_t_blocks],
+                block_size=block_size,
+                kv_dtype=torch.float32,
+            )
+            if dtype == torch.bfloat16:
+                atol = 5e-3
+                rtol = 2e-3
+            else:
+                atol = 1e-3
+                rtol = 5e-4
+            torch.testing.assert_close(our_transfer[slot].transpose(-1, -2), ref_transfer, atol=atol, rtol=rtol)
+            torch.testing.assert_close(our_state[slot].transpose(-1, -2), ref_state, atol=atol, rtol=rtol)
+
+    for slot in range(our_transfer.shape[0]):
+        if slot not in valid_cp_slots:
+            torch.testing.assert_close(our_transfer[slot], torch.zeros_like(our_transfer[slot]))
+            torch.testing.assert_close(our_state[slot], torch.zeros_like(our_state[slot]))
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("num_heads", [1, 3])
+@pytest.mark.parametrize("seq_lens, cp_chunk_len", [([96, 0, 300], 128), ([1], 1), ([2], 1), ([5], 1)])
+def test_cp_delta_rule_fixup(
+    seq_lens,
+    cp_chunk_len,
+    num_heads,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    head_size = 128
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+    total_seqlen = sum(seq_lens)
+    total_cp_chunks = workspace_num_chunks_host(cu_seqlens.cpu(), cp_chunk_len)
+
+    local_transfer = torch.randn(
+        total_cp_chunks, num_heads, head_size, head_size, dtype=torch.float32, device=device,
+    ) * 0.02
+    local_state = torch.randn(
+        total_cp_chunks, num_heads, head_size, head_size, dtype=torch.float32, device=device,
+    ) * 0.1
+    diag = torch.arange(head_size, device=device)
+    local_transfer[:, :, diag, diag] += 0.9
+
+    our_fixed_state = cp_delta_rule_fixup_dsl_sm90(
+        local_transfer.contiguous(),
+        local_state.contiguous(),
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+    )
+    torch.cuda.synchronize()
+
+    valid_slots = set()
+    ref_transfers_by_seq = []
+    ref_states_by_seq = []
+    ref_seq_indices = []
+    for seq_idx, seq_len in enumerate(seq_lens):
+        seq_start = int(cu_seqlens[seq_idx].item())
+        chunk_start = chunk_bound_host(seq_idx, seq_start, cp_chunk_len)
+        num_chunks = (seq_len + cp_chunk_len - 1) // cp_chunk_len
+        seq_slots = []
+        for chunk_idx in range(num_chunks):
+            slot = chunk_start + chunk_idx
+            seq_slots.append(slot)
+            valid_slots.add(slot)
+        if seq_slots:
+            ref_transfers_by_seq.append(local_transfer[seq_slots])
+            ref_states_by_seq.append(local_state[seq_slots])
+            ref_seq_indices.append(seq_idx)
+
+    _, ref_by_seq = reference.cp_delta_rule_fixup_transposed(ref_transfers_by_seq, ref_states_by_seq)
+    for seq_idx, seq_fixed in zip(ref_seq_indices, ref_by_seq):
+        seq_start = int(cu_seqlens[seq_idx].item())
+        chunk_start = chunk_bound_host(seq_idx, seq_start, cp_chunk_len)
+        for chunk_idx in range(seq_fixed.shape[0]):
+            torch.testing.assert_close(
+                our_fixed_state[chunk_start + chunk_idx],
+                seq_fixed[chunk_idx],
+                atol=FIXUP_TF32_ATOL,
+                rtol=FIXUP_TF32_RTOL,
+            )
+
+    for slot in range(total_cp_chunks):
+        if slot not in valid_slots:
+            torch.testing.assert_close(our_fixed_state[slot], torch.zeros_like(our_fixed_state[slot]))
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("chunk_len", [64, 128])
+@pytest.mark.parametrize("gate_baseline", [0.9, 0.9995])
+def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill(
+    qkv_factory, dtype, chunk_len, gate_baseline, seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+    num_heads = 1
+    head_size = 128
+    cp_chunk_len = chunk_len
+    seq_lens = [chunk_len, chunk_len]
+    total_seqlen = sum(seq_lens)
+    cu_values = [0]
+    for seq_len in seq_lens:
+        cu_values.append(cu_values[-1] + seq_len)
+    cu_seqlens = torch.tensor(cu_values, dtype=torch.int64, device=device)
+    scale = 1.0
+
+    with torch.device(device):
+        q, k, v = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    q = q.contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(total_seqlen, num_heads, gate_baseline, device)
+    beta = _make_gates(total_seqlen, num_heads, gate_baseline, device)
+
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    fixed_state = cp_delta_rule_fixup_dsl_sm90(
+        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+
+    our_o = torch.empty_like(q)
+    our_state = torch.empty(
+        len(seq_lens),
+        num_heads,
+        head_size,
+        head_size,
+        dtype=torch.float32,
+        device=device,
+    )
+    cp_delta_rule_prefill_dsl_sm90(
+        our_o,
+        our_state,
+        q,
+        k,
+        v,
+        t,
+        fixed_state,
+        alpha,
+        scale,
+        cu_seqlens,
+        total_seqlen,
+        cp_chunk_len=cp_chunk_len,
+    )
+    torch.cuda.synchronize()
+
+    ref_o = torch.empty_like(q)
+    ref_state = torch.empty(len(seq_lens), num_heads, head_size, head_size, dtype=torch.float32, device=device)
+    chunk_gated_delta_rule(q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, output=ref_o, output_state=ref_state, use_cp=False)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
+    torch.testing.assert_close(our_state, ref_state, atol=4e-2, rtol=4e-2)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("num_q_heads, num_k_heads, num_v_heads", [(4, 1, 1), (1, 1, 4)])
+def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
+    qkv_factory,
+    num_q_heads,
+    num_k_heads,
+    num_v_heads,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    head_size = 128
+    cp_chunk_len = 64
+    seq_lens = [96, 64]
+    total_seqlen = sum(seq_lens)
+    cu_values = [0]
+    for seq_len in seq_lens:
+        cu_values.append(cu_values[-1] + seq_len)
+    cu_seqlens = torch.tensor(cu_values, dtype=torch.int64, device=device)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    scale = 1.0
+
+    with torch.device(device):
+        q, k, v = qkv_factory(seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype)
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    q = q.contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(total_seqlen, num_sab_heads, 0.99, device)
+    beta = _make_gates(total_seqlen, num_sab_heads, 0.99, device)
+
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    fixed_state = cp_delta_rule_fixup_dsl_sm90(
+        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+
+    our_o = torch.empty(total_seqlen, num_sab_heads, head_size, dtype=dtype, device=device)
+    our_state = torch.empty(len(seq_lens), num_sab_heads, head_size, head_size, dtype=torch.float32, device=device)
+    cp_delta_rule_prefill_dsl_sm90(
+        our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
+        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    torch.cuda.synchronize()
+
+    ref_o = torch.empty_like(our_o)
+    ref_state = torch.empty_like(our_state)
+    chunk_gated_delta_rule(q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, output=ref_o, output_state=ref_state, use_cp=False)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
+    torch.testing.assert_close(our_state, ref_state, atol=4e-2, rtol=4e-2)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize(
+    "dtype, seq_lens, cp_chunk_len, num_q_heads, num_k_heads, num_v_heads, gate_baseline, scale",
+    [
+        (torch.bfloat16, [2048], 1024, 1, 1, 1, 0.99, 1.0),
+        (torch.bfloat16, [4096], 2048, 2, 1, 1, 0.9995, 1.0),
+        (torch.float16, [2049], 1024, 1, 1, 1, 0.99, "auto"),
+        (torch.bfloat16, [1536, 257], 1024, 1, 1, 2, 0.99, 1.0),
+    ],
+)
+def test_cp_delta_rule_kernel_chain_long_small_bh_matches_non_cp_prefill(
+    qkv_factory,
+    dtype,
+    seq_lens,
+    cp_chunk_len,
+    num_q_heads,
+    num_k_heads,
+    num_v_heads,
+    gate_baseline,
+    scale,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    head_size = 128
+    total_seqlen = sum(seq_lens)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+    scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
+
+    with torch.device(device):
+        q, k, v = qkv_factory(seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype)
+    q = q.contiguous()
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
+    beta = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
+
+    our_o, our_state = _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chunk_len, scale)
+    torch.cuda.synchronize()
+    ref_o, ref_state = _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(our_o, ref_o, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(our_state, ref_state, atol=5e-2, rtol=5e-2)
+
+
+@pytest.mark.parametrize("gate_baseline", [0.9995, 0.99])
+@pytest.mark.parametrize("num_heads", [(1,1,1), (2,2,8), (4,1,1), (16,16,64)])
+@pytest.mark.parametrize("seq_lens", [[192, 64], [2048], [1025], [9999, 65530]])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@torch.inference_mode()
+def test_cp_delta_rule_e2e(
+    qkv_factory,
+    dtype,
+    seq_lens,
+    num_heads,
+    gate_baseline,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    head_size = 128
+    total_seqlen = sum(seq_lens)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+    scale = 1.0
+    dtype = getattr(torch, dtype)
+
+    num_q_heads, num_k_heads, num_v_heads = num_heads
+    num_o_heads = max(num_q_heads, num_v_heads)
+    num_sab_heads = max(num_heads)
+
+    with torch.device(device):
+        q, k, v = qkv_factory(seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype)
+    q = q.contiguous()
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
+    beta = _make_gates(total_seqlen, num_sab_heads, gate_baseline, device)
+
+    our_o = torch.empty([total_seqlen, num_o_heads, head_size], dtype=q.dtype, device=q.device)
+    our_state = torch.empty(len(seq_lens), num_sab_heads, head_size, head_size, dtype=torch.float32, device=device)
+    our_o.fill_(float("nan"))
+    our_state.fill_(float("nan"))
+    cp_delta_rule_dsl_sm90(
+        our_o,
+        our_state,
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        cu_seqlens,
+        scale,
+        max_seqlen=max(seq_lens),
+    )
+    torch.cuda.synchronize()
+
+    ref_o = torch.empty_like(our_o)
+    ref_state = torch.empty_like(our_state)
+    chunk_gated_delta_rule(q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, output=ref_o, output_state=ref_state, use_cp=False)
+    torch.cuda.synchronize()
+
+    if dtype == torch.bfloat16:
+        ref_o = ref_o.to(dtype)
+        atol_o = 2e-2
+        rtol_o = 2e-2
+        atol_state = 5e-3
+        rtol_state = 5e-3
+    else:
+        atol_o = 5e-3
+        rtol_o = 5e-3
+        atol_state = 1e-3
+        rtol_state = 1e-3
+
+    torch.testing.assert_close(our_o, ref_o, atol=atol_o, rtol=rtol_o)
+    torch.testing.assert_close(our_state, ref_state, atol=atol_state, rtol=rtol_state)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("seq_lens", [[128], [256, 64]])
+def test_cp_delta_rule_public_wrapper_matches_non_cp_prefill(
+    qkv_factory,
+    dtype,
+    seq_lens,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    dtype = getattr(torch, dtype)
+    head_size = 128
+    num_heads = 1
+    total_seqlen = sum(seq_lens)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+    scale = 1.0
+
+    with torch.device(device):
+        q, k, v = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+    q = q.contiguous()
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(total_seqlen, num_heads, 0.99, device)
+    beta = _make_gates(total_seqlen, num_heads, 0.99, device)
+
+    our_o, our_state = chunk_gated_delta_rule(
+        q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, use_cp=True)
+    ref_o, ref_state = chunk_gated_delta_rule(
+        q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, use_cp=False)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
+    torch.testing.assert_close(our_state, ref_state, atol=4e-2, rtol=4e-2)

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -451,6 +451,62 @@ def test_cp_delta_rule_prefill_varlen_matches_non_cp_prefill_unequal_heads(
 
 
 @torch.inference_mode()
+def test_cp_delta_rule_prefill_gva_random_alpha_kernel_chain(
+    qkv_factory,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    dtype = torch.float16
+    head_size = 128
+    seq_lens = [256, 256]
+    total_seqlen = sum(seq_lens)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+    num_q_heads, num_k_heads, num_v_heads = 16, 16, 32
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    cp_chunk_len = 4096
+    scale = 1.0
+
+    with torch.device(device):
+        q, k, v = qkv_factory(seq_lens, num_q_heads, num_k_heads, num_v_heads, head_size, dtype=dtype)
+    q = q.contiguous()
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    v = v.contiguous()
+    alpha = torch.rand(total_seqlen, num_sab_heads, dtype=torch.float32, device=device).contiguous()
+    beta = torch.ones_like(alpha)
+
+    t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
+    local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
+        k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    fixed_state = cp_delta_rule_fixup_dsl_sm90(
+        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(t[:8]).all()
+    assert torch.isfinite(local_transfer).all()
+    assert torch.isfinite(local_state).all()
+    assert torch.isfinite(fixed_state).all()
+
+    our_o = torch.empty(total_seqlen, num_sab_heads, head_size, dtype=dtype, device=device)
+    our_state = torch.empty(len(seq_lens), num_sab_heads, head_size, head_size, dtype=torch.float32, device=device)
+    our_o.fill_(float("nan"))
+    our_state.fill_(float("nan"))
+    cp_delta_rule_prefill_dsl_sm90(
+        our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
+        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(our_o).all()
+    assert torch.isfinite(our_state).all()
+
+    ref_o, ref_state = _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(our_o, ref_o, atol=4e-2, rtol=4e-2)
+    torch.testing.assert_close(our_state, ref_state, atol=4e-2, rtol=4e-2)
+
+
+@torch.inference_mode()
 @pytest.mark.parametrize(
     "dtype, seq_lens, cp_chunk_len, num_q_heads, num_k_heads, num_v_heads, gate_baseline, scale",
     [

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -67,12 +67,13 @@ def _make_gates(total_seqlen, num_heads, baseline, device):
 
 
 @torch.inference_mode()
-def _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chunk_len, scale):
+def _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chunk_len, scale, initial_state=None):
     t = cp_delta_rule_t_precompute_dsl_sm90(k, beta, cu_seqlens, total_seqlen)
     local_transfer, local_state = cp_delta_rule_mn_precompute_dsl_sm90(
         k, v, t, alpha, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
     fixed_state = cp_delta_rule_fixup_dsl_sm90(
-        local_transfer, local_state, cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        local_transfer, local_state, cu_seqlens, total_seqlen,
+        cp_chunk_len=cp_chunk_len, initial_state=initial_state)
 
     our_o = torch.empty((total_seqlen, max(q.shape[1], v.shape[1]), q.shape[2]), dtype=q.dtype, device=q.device)
     our_state = torch.empty(
@@ -85,12 +86,12 @@ def _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chun
     )
     cp_delta_rule_prefill_dsl_sm90(
         our_o, our_state, q, k, v, t, fixed_state, alpha, scale,
-        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len)
+        cu_seqlens, total_seqlen, cp_chunk_len=cp_chunk_len, initial_state=initial_state)
     return our_o, our_state
 
 
 @torch.inference_mode()
-def _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale):
+def _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale, initial_state=None):
     ref_o = torch.empty((q.shape[0], max(q.shape[1], v.shape[1]), q.shape[2]), dtype=q.dtype, device=q.device)
     ref_state = torch.empty(
         cu_seqlens.numel() - 1,
@@ -100,7 +101,9 @@ def _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale):
         dtype=torch.float32,
         device=q.device,
     )
-    chunk_gated_delta_rule(q, k, v, alpha, beta, scale, None, True, cu_seqlens, True, output=ref_o, output_state=ref_state, use_cp=False)
+    chunk_gated_delta_rule(
+        q, k, v, alpha, beta, scale, initial_state, True, cu_seqlens, True,
+        output=ref_o, output_state=ref_state, use_cp=False)
     return ref_o, ref_state
 
 
@@ -257,12 +260,14 @@ def test_cp_delta_rule_mn_precompute(
 
 
 @torch.inference_mode()
+@pytest.mark.parametrize("use_initial_state", [False, True])
 @pytest.mark.parametrize("num_heads", [1, 3])
 @pytest.mark.parametrize("seq_lens, cp_chunk_len", [([96, 0, 300], 128), ([1], 1), ([2], 1), ([5], 1)])
 def test_cp_delta_rule_fixup(
     seq_lens,
     cp_chunk_len,
     num_heads,
+    use_initial_state,
     seed = int(os.environ.get("SEED", "0")),
 ):
     _skip_without_cp_kernel_device()
@@ -281,6 +286,11 @@ def test_cp_delta_rule_fixup(
     ) * 0.1
     diag = torch.arange(head_size, device=device)
     local_transfer[:, :, diag, diag] += 0.9
+    initial_state = None
+    if use_initial_state:
+        initial_state = torch.randn(
+            len(seq_lens), num_heads, head_size, head_size, dtype=torch.float32, device=device,
+        ) * 0.03
 
     our_fixed_state = cp_delta_rule_fixup_dsl_sm90(
         local_transfer.contiguous(),
@@ -288,12 +298,14 @@ def test_cp_delta_rule_fixup(
         cu_seqlens,
         total_seqlen,
         cp_chunk_len=cp_chunk_len,
+        initial_state=initial_state,
     )
     torch.cuda.synchronize()
 
     valid_slots = set()
     ref_transfers_by_seq = []
     ref_states_by_seq = []
+    ref_initial_states_by_seq = []
     ref_seq_indices = []
     for seq_idx, seq_len in enumerate(seq_lens):
         seq_start = int(cu_seqlens[seq_idx].item())
@@ -307,9 +319,15 @@ def test_cp_delta_rule_fixup(
         if seq_slots:
             ref_transfers_by_seq.append(local_transfer[seq_slots])
             ref_states_by_seq.append(local_state[seq_slots])
+            if use_initial_state:
+                ref_initial_states_by_seq.append(initial_state[seq_idx])
             ref_seq_indices.append(seq_idx)
 
-    _, ref_by_seq = reference.cp_delta_rule_fixup_transposed(ref_transfers_by_seq, ref_states_by_seq)
+    _, ref_by_seq = reference.cp_delta_rule_fixup_transposed(
+        ref_transfers_by_seq,
+        ref_states_by_seq,
+        ref_initial_states_by_seq if use_initial_state else None,
+    )
     for seq_idx, seq_fixed in zip(ref_seq_indices, ref_by_seq):
         seq_start = int(cu_seqlens[seq_idx].item())
         chunk_start = chunk_bound_host(seq_idx, seq_start, cp_chunk_len)
@@ -492,6 +510,61 @@ def test_cp_delta_rule_kernel_chain_long_small_bh_matches_non_cp_prefill(
     our_o, our_state = _run_cp_kernel_chain(q, k, v, alpha, beta, cu_seqlens, total_seqlen, cp_chunk_len, scale)
     torch.cuda.synchronize()
     ref_o, ref_state = _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(our_o, ref_o, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(our_state, ref_state, atol=5e-2, rtol=5e-2)
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+@pytest.mark.parametrize("seq_lens", [[192, 64], [1025]])
+def test_cp_delta_rule_e2e_with_initial_state(
+    qkv_factory,
+    dtype,
+    seq_lens,
+    seed = int(os.environ.get("SEED", "0")),
+):
+    _skip_without_cp_kernel_device()
+    _seed_all(seed)
+    device = torch.device("cuda")
+    head_size = 128
+    total_seqlen = sum(seq_lens)
+    cu_seqlens = _make_cu_seqlens(seq_lens, device)
+    scale = 1.0
+    dtype = getattr(torch, dtype)
+    num_heads = 1
+
+    with torch.device(device):
+        q, k, v = qkv_factory(seq_lens, num_heads, num_heads, num_heads, head_size, dtype=dtype)
+    q = q.contiguous()
+    k = torch.nn.functional.normalize(k.float(), p=2.0, dim=-1).to(dtype).contiguous()
+    v = v.contiguous()
+    alpha = _make_gates(total_seqlen, num_heads, 0.99, device)
+    beta = _make_gates(total_seqlen, num_heads, 0.99, device)
+    initial_state = torch.randn(
+        len(seq_lens), num_heads, head_size, head_size, dtype=torch.float32, device=device,
+    ) * 0.02
+
+    our_o = torch.empty([total_seqlen, num_heads, head_size], dtype=q.dtype, device=q.device)
+    our_state = torch.empty_like(initial_state)
+    cp_delta_rule_dsl_sm90(
+        our_o,
+        our_state,
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        cu_seqlens,
+        scale,
+        initial_state=initial_state,
+        max_seqlen=max(seq_lens),
+        cp_chunk_len=128,
+    )
+    torch.cuda.synchronize()
+
+    ref_o, ref_state = _run_non_cp_prefill(q, k, v, alpha, beta, cu_seqlens, scale, initial_state=initial_state)
     torch.cuda.synchronize()
 
     torch.testing.assert_close(our_o, ref_o, atol=5e-2, rtol=5e-2)

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -70,6 +70,7 @@ def _test_prefill_kernel(
     scale: float,
     alpha: bool,
     beta: bool,
+    use_cp: bool,
     seed: int | None = None,
 ):
     _skip_if_unsupported()
@@ -124,6 +125,7 @@ def _test_prefill_kernel(
         True,
         output=our_o,
         output_state=our_state,
+        use_cp=use_cp,
     )
 
     torch.cuda.synchronize()
@@ -163,6 +165,7 @@ def _test_prefill_kernel(
 @pytest.mark.parametrize("beta", [False, True])
 @pytest.mark.parametrize("alpha", [False, True])
 @pytest.mark.parametrize("scale", [1.0, "auto"])
+@pytest.mark.parametrize("use_cp", [False, True])
 @pytest.mark.parametrize("head_size", [128])
 @pytest.mark.parametrize(
     "num_q_heads, num_k_heads, num_v_heads",
@@ -192,6 +195,7 @@ def test_prefill_kernel_basic(
     scale: float | str,
     alpha: bool,
     beta: bool,
+    use_cp: bool,
     seed: int = int(os.environ.get("SEED", "0")),
 ):
     scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
@@ -207,6 +211,7 @@ def test_prefill_kernel_basic(
         scale,
         alpha,
         beta,
+        use_cp,
         seed,
     )
 
@@ -214,6 +219,7 @@ def test_prefill_kernel_basic(
 @pytest.mark.parametrize("beta", [False, True])
 @pytest.mark.parametrize("alpha", [False, True])
 @pytest.mark.parametrize("scale", [1.0, "auto"])
+@pytest.mark.parametrize("use_cp", [False, True])
 @pytest.mark.parametrize("head_size", [128])
 @pytest.mark.parametrize(
     "num_q_heads, num_k_heads, num_v_heads",
@@ -246,6 +252,7 @@ def test_prefill_kernel_nonfull(
     scale: float | str,
     alpha: bool,
     beta: bool,
+    use_cp: bool,
     seed: int = int(os.environ.get("SEED", "0")),
 ):
     scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
@@ -261,6 +268,7 @@ def test_prefill_kernel_nonfull(
         scale,
         alpha,
         beta,
+        use_cp,
         seed,
     )
 
@@ -422,6 +430,7 @@ def _test_chunked_prefill(
         True,
         output=our_o1,
         output_state=our_state1,
+        use_cp=False,
     )
     chunk_gated_delta_rule(
         q2,
@@ -436,6 +445,7 @@ def _test_chunked_prefill(
         True,
         output=our_o2,
         output_state=our_state2,
+        use_cp=False,
     )
     our_state = our_state2
 
@@ -628,6 +638,7 @@ def _test_checkpoint(
         state_checkpoints=state_checkpoints,
         checkpoint_cu_starts=checkpoint_cu_starts,
         checkpoint_every_n_tokens=checkpoint_every_n_tokens,
+        use_cp=False,
     )
     torch.cuda.synchronize()
 
@@ -671,6 +682,7 @@ def _test_checkpoint(
                 True,
                 output=prefix_o,
                 output_state=prefix_state,
+                use_cp=False,
             )
             torch.cuda.synchronize()
 
@@ -771,6 +783,7 @@ def test_checkpoint_noop(qkv_factory):
         True,
         output=o1,
         output_state=s1,
+        use_cp=False,
     )
 
     # Run with checkpoint_every_n_tokens=0 (disabled)
@@ -790,6 +803,7 @@ def test_checkpoint_noop(qkv_factory):
         output=o2,
         output_state=s2,
         checkpoint_every_n_tokens=0,
+        use_cp=False,
     )
 
     torch.cuda.synchronize()
@@ -947,6 +961,7 @@ def _test_prefill_kernel_bf16_state(
         True,
         output=our_o,
         output_state=our_state,
+        use_cp=False,
     )
 
     torch.cuda.synchronize()

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -48,6 +48,13 @@ def _skip_if_unsupported():
         pytest.skip("GDN prefill requires SM90, SM100, or SM120")
 
 
+def _skip_if_cp_unsupported():
+    """Skip test if context parallelism is unsupported."""
+    device = torch.device("cuda")
+    if not is_sm90a_supported(device):
+        pytest.skip("CP GDN prefill requires SM90")
+
+
 def _skip_if_not_sm100():
     """Skip test if not SM100 (Blackwell) with CUDA 13+."""
     device = torch.device("cuda")
@@ -74,6 +81,8 @@ def _test_prefill_kernel(
     seed: int | None = None,
 ):
     _skip_if_unsupported()
+    if use_cp:
+        _skip_if_cp_unsupported()
     if not alpha and not beta:
         pytest.skip(
             "large diff due to output value amplitude explosion along token dimension"

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -282,9 +282,11 @@ def test_prefill_kernel_nonfull(
     )
 
 
+@pytest.mark.parametrize("use_cp", [False, True])
 @pytest.mark.parametrize(
     "num_q_heads,num_k_heads,num_v_heads", [(1, 1, 1), (16, 16, 64)]
 )
+@pytest.mark.parametrize("seq_len", [256, 255])
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
 def test_prefill_kernel_zero_length_sequence(
     qkv_factory,
@@ -292,17 +294,20 @@ def test_prefill_kernel_zero_length_sequence(
     num_q_heads: int,
     num_k_heads: int,
     num_v_heads: int,
-    head_size: int = 128,
-    seq_len: int = 64,
+    seq_len: int,
+    use_cp: bool,
     scale: float = 0.1,
     seed: int = int(os.environ.get("SEED", "0")),
 ):
     _skip_if_unsupported()
+    if use_cp:
+        _skip_if_cp_unsupported()
 
     random.seed(seed)
     torch.random.manual_seed(seed)
     torch.cuda.manual_seed(seed)
 
+    head_size = 128
     num_o_heads = max(num_q_heads, num_v_heads)
     num_sab_heads = max(num_q_heads, num_v_heads)
     dtype = getattr(torch, dtype)
@@ -347,6 +352,7 @@ def test_prefill_kernel_zero_length_sequence(
         cu_seq_lens_with_empty,
         True,
         output=our_o,
+        use_cp=use_cp,
     )
     torch.cuda.synchronize()
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

- [x] depends on #3477
- [x] depends on #3478
- [x] depends on #3479
- [x] depends on #3480

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

- [x] #3491

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

```

GPU: NVIDIA H100 80GB HBM3 [Hopper (SM90)]
Models: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128

Heads            Seqlens           h_qk  h_v        FI Hopper (SM90)   TFLOPS  FLA/Triton   Speedup
---------------------------------------------------------------------------------------------------
397B/122B TP8    1x65536              2    8                  0.507ms    67.7      1.966ms     3.88x +
397B/122B TP8    1x32768              2    8                  0.306ms    56.2      0.995ms     3.25x +
397B/122B TP8    1x16384              2    8                  0.208ms    41.3      0.504ms     2.42x +
397B/122B TP8    1x8192               2    8                  0.159ms    27.1      0.259ms     1.63x +
397B/122B TP8    1x4096               2    8                  0.111ms    19.4      0.142ms     1.28x +
397B/122B TP8    1x2048               2    8                  0.089ms    12.1      0.086ms     0.97x -
397B/122B TP8    6144+2048            2    8                  0.155ms    27.6      0.220ms     1.42x +
397B/122B TP8    4096+4096            2    8                  0.139ms    30.9      0.183ms     1.32x +
397B/122B TP8    2048+6144            2    8                  0.155ms    27.7      0.222ms     1.43x +
397B/122B TP8    1024+7168            2    8                  0.164ms    26.2      0.241ms     1.47x +
397B/122B TP8    2048x4               2    8                  0.133ms    32.2      0.148ms     1.11x +
397B/122B TP8    1024x8               2    8                  0.154ms    27.9      0.154ms     1.00x +
397B/122B TP8    8192x8               2    8                  0.525ms    65.4      1.081ms     2.06x +
397B/122B TP8    8192x16              2    8                  0.394ms   174.3      2.146ms     5.44x +
397B/122B TP8    8192x32              2    8                  0.836ms   164.4      4.262ms     5.10x +

397B/122B TP4    1x65536              4   16                  0.878ms    78.3      2.771ms     3.16x +
397B/122B TP4    1x32768              4   16                  0.468ms    73.4      1.389ms     2.97x +
397B/122B TP4    1x16384              4   16                  0.275ms    62.5      0.698ms     2.54x +
397B/122B TP4    1x8192               4   16                  0.176ms    48.8      0.356ms     2.02x +
397B/122B TP4    1x4096               4   16                  0.126ms    34.2      0.183ms     1.46x +
397B/122B TP4    1x2048               4   16                  0.095ms    22.6      0.106ms     1.11x +
397B/122B TP4    6144+2048            4   16                  0.183ms    47.0      0.318ms     1.74x +
397B/122B TP4    4096+4096            4   16                  0.176ms    48.8      0.282ms     1.60x +
397B/122B TP4    2048+6144            4   16                  0.184ms    46.7      0.320ms     1.74x +
397B/122B TP4    1024+7168            4   16                  0.187ms    45.9      0.339ms     1.81x +
397B/122B TP4    2048x4               4   16                  0.182ms    47.3      0.287ms     1.58x +
397B/122B TP4    1024x8               4   16                  0.058ms   148.1      0.299ms     5.15x +
397B/122B TP4    8192x8               4   16                  0.372ms   184.9      2.195ms     5.91x +
397B/122B TP4    8192x16              4   16                  0.826ms   166.5      4.390ms     5.32x +
397B/122B TP4    8192x32              4   16                  1.652ms   166.4      8.772ms     5.31x +

397B/122B TP2    1x65536              8   32                  1.713ms    80.2      4.424ms     2.58x +
397B/122B TP2    1x32768              8   32                  0.889ms    77.3      2.210ms     2.49x +
397B/122B TP2    1x16384              8   32                  0.456ms    75.3      1.089ms     2.39x +
397B/122B TP2    1x8192               8   32                  0.259ms    66.3      0.552ms     2.13x +
397B/122B TP2    1x4096               8   32                  0.162ms    53.1      0.286ms     1.77x +
397B/122B TP2    1x2048               8   32                  0.112ms    38.4      0.151ms     1.35x +
397B/122B TP2    6144+2048            8   32                  0.278ms    61.7      0.557ms     2.00x +
397B/122B TP2    4096+4096            8   32                  0.277ms    62.1      0.557ms     2.02x +
397B/122B TP2    2048+6144            8   32                  0.281ms    61.2      0.558ms     1.99x +
397B/122B TP2    1024+7168            8   32                  0.298ms    57.6      0.560ms     1.88x +
397B/122B TP2    2048x4               8   32                  0.104ms   166.0      0.569ms     5.50x +
397B/122B TP2    1024x8               8   32                  0.113ms   152.6      0.590ms     5.24x +
397B/122B TP2    8192x8               8   32                  0.846ms   162.5      4.483ms     5.30x +
397B/122B TP2    8192x16              8   32                  1.645ms   167.1      8.970ms     5.45x +
397B/122B TP2    8192x32              8   32                  3.268ms   168.2     18.213ms     5.57x +

397B/122B TP1    1x65536             16   64                  3.357ms    81.9      8.642ms     2.57x +
397B/122B TP1    1x32768             16   64                  1.706ms    80.6      4.288ms     2.51x +
397B/122B TP1    1x16384             16   64                  0.861ms    79.8      2.100ms     2.44x +
397B/122B TP1    1x8192              16   64                  0.453ms    75.9      1.047ms     2.31x +
397B/122B TP1    1x4096              16   64                  0.253ms    67.8      0.534ms     2.11x +
397B/122B TP1    1x2048              16   64                  0.156ms    55.1      0.278ms     1.79x +
397B/122B TP1    6144+2048           16   64                  0.280ms   122.6      1.050ms     3.74x +
397B/122B TP1    4096+4096           16   64                  0.193ms   178.1      1.052ms     5.45x +
397B/122B TP1    2048+6144           16   64                  0.282ms   121.8      1.058ms     3.75x +
397B/122B TP1    1024+7168           16   64                  0.324ms   106.2      1.060ms     3.28x +
397B/122B TP1    2048x4              16   64                  0.201ms   170.8      1.064ms     5.29x +
397B/122B TP1    1024x8              16   64                  0.218ms   157.8      1.088ms     4.99x +
397B/122B TP1    8192x8              16   64                  1.643ms   167.3      8.699ms     5.30x +
397B/122B TP1    8192x16             16   64                  3.280ms   167.6     17.504ms     5.34x +
397B/122B TP1    8192x32             16   64                  7.054ms   155.9     35.950ms     5.10x +

35B/9B/4B TP1    1x65536             16   32                  1.750ms    78.5      4.429ms     2.53x +
35B/9B/4B TP1    1x32768             16   32                  0.905ms    75.9      2.214ms     2.45x +
35B/9B/4B TP1    1x16384             16   32                  0.464ms    74.0      1.086ms     2.34x +
35B/9B/4B TP1    1x8192              16   32                  0.264ms    65.0      0.551ms     2.09x +
35B/9B/4B TP1    1x4096              16   32                  0.165ms    52.0      0.285ms     1.73x +
35B/9B/4B TP1    1x2048              16   32                  0.115ms    37.3      0.151ms     1.31x +
35B/9B/4B TP1    6144+2048           16   32                  0.285ms    60.3      0.558ms     1.96x +
35B/9B/4B TP1    4096+4096           16   32                  0.280ms    61.4      0.558ms     1.99x +
35B/9B/4B TP1    2048+6144           16   32                  0.286ms    60.2      0.558ms     1.96x +
35B/9B/4B TP1    1024+7168           16   32                  0.302ms    56.8      0.558ms     1.85x +
35B/9B/4B TP1    2048x4              16   32                  0.104ms   164.4      0.570ms     5.45x +
35B/9B/4B TP1    1024x8              16   32                  0.114ms   150.2      0.590ms     5.16x +
35B/9B/4B TP1    8192x8              16   32                  0.843ms   163.1      4.485ms     5.32x +
35B/9B/4B TP1    8192x16             16   32                  1.689ms   162.8      8.981ms     5.32x +
35B/9B/4B TP1    8192x32             16   32                  3.309ms   166.1     18.190ms     5.50x +

27B TP1          1x65536             16   48                  3.003ms    68.7      6.561ms     2.18x +
27B TP1          1x32768             16   48                  1.527ms    67.5      3.302ms     2.16x +
27B TP1          1x16384             16   48                  0.792ms    65.0      1.614ms     2.04x +
27B TP1          1x8192              16   48                  0.425ms    60.7      0.804ms     1.89x +
27B TP1          1x4096              16   48                  0.240ms    53.8      0.415ms     1.73x +
27B TP1          1x2048              16   48                  0.147ms    44.0      0.227ms     1.55x +
27B TP1          6144+2048           16   48                  0.278ms    92.9      0.819ms     2.95x +
27B TP1          4096+4096           16   48                  0.189ms   136.1      0.844ms     4.46x +
27B TP1          2048+6144           16   48                  0.277ms    93.0      0.831ms     3.00x +
27B TP1          1024+7168           16   48                  0.322ms    80.1      0.824ms     2.56x +
27B TP1          2048x4              16   48                  0.198ms   130.3      0.823ms     4.16x +
27B TP1          1024x8              16   48                  0.167ms   154.6      0.837ms     5.02x +
27B TP1          8192x8              16   48                  1.261ms   163.5      6.632ms     5.26x +
27B TP1          8192x16             16   48                  2.469ms   167.0     13.304ms     5.39x +
27B TP1          8192x32             16   48                  4.920ms   167.6     26.974ms     5.48x +

2B/0.8B TP1      1x65536             16   16                  0.945ms    72.7      2.781ms     2.94x +
2B/0.8B TP1      1x32768             16   16                  0.502ms    68.5      1.394ms     2.78x +
2B/0.8B TP1      1x16384             16   16                  0.292ms    58.8      0.696ms     2.38x +
2B/0.8B TP1      1x8192              16   16                  0.189ms    45.5      0.354ms     1.88x +
2B/0.8B TP1      1x4096              16   16                  0.134ms    32.1      0.183ms     1.37x +
2B/0.8B TP1      1x2048              16   16                  0.098ms    22.0      0.106ms     1.09x +
2B/0.8B TP1      6144+2048           16   16                  0.200ms    43.1      0.318ms     1.60x +
2B/0.8B TP1      4096+4096           16   16                  0.193ms    44.5      0.282ms     1.46x +
2B/0.8B TP1      2048+6144           16   16                  0.200ms    43.0      0.319ms     1.60x +
2B/0.8B TP1      1024+7168           16   16                  0.204ms    42.2      0.337ms     1.65x +
2B/0.8B TP1      2048x4              16   16                  0.196ms    43.8      0.288ms     1.47x +
2B/0.8B TP1      1024x8              16   16                  0.061ms   140.0      0.299ms     4.87x +
2B/0.8B TP1      8192x8              16   16                  0.420ms   163.5      2.195ms     5.22x +
2B/0.8B TP1      8192x16             16   16                  0.891ms   154.2      4.395ms     4.93x +
2B/0.8B TP1      8192x32             16   16                  1.743ms   157.7      8.768ms     5.03x +

Sym h32          1x65536             32   32                  1.858ms    74.0      4.430ms     2.38x +
Sym h32          1x32768             32   32                  0.963ms    71.3      2.208ms     2.29x +
Sym h32          1x16384             32   32                  0.499ms    68.9      1.089ms     2.18x +
Sym h32          1x8192              32   32                  0.285ms    60.3      0.550ms     1.93x +
Sym h32          1x4096              32   32                  0.178ms    48.4      0.286ms     1.61x +
Sym h32          1x2048              32   32                  0.121ms    35.5      0.151ms     1.25x +
Sym h32          6144+2048           32   32                  0.306ms    56.1      0.556ms     1.82x +
Sym h32          4096+4096           32   32                  0.303ms    56.7      0.557ms     1.84x +
Sym h32          2048+6144           32   32                  0.308ms    55.7      0.559ms     1.81x +
Sym h32          1024+7168           32   32                  0.320ms    53.7      0.561ms     1.75x +
Sym h32          2048x4              32   32                  0.108ms   159.7      0.571ms     5.31x +
Sym h32          1024x8              32   32                  0.120ms   143.5      0.590ms     4.93x +
Sym h32          8192x8              32   32                  0.897ms   153.2      4.477ms     4.99x +
Sym h32          8192x16             32   32                  1.716ms   160.2      8.980ms     5.23x +
Sym h32          8192x32             32   32                  3.448ms   159.5     18.169ms     5.27x +
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Context-parallel execution mode for delta-rule prefill operations on SM90A GPUs, configurable via runtime parameter
  * Variable-length sequence support for context-parallel delta-rule operations

* **Improvements**
  * Enhanced kernel compilation cache mechanism with improved reliability and deterministic caching behavior across runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->