### PR TITLE
Use an environment variable to control the number of reserved SMs for overlapping in TRT-LLM fused MoE

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -97,12 +97,14 @@ void runPostTopKPipeline(DataType const& data, void* stream) {
                             (data.mPtrPermutedIdxSize != nullptr) &&
                             (data.mPtrExpertCounts != nullptr);
     bool useCoop = false;
+    CoopLaunchSMCounts coopLaunchSMCounts{0, 0};
     int numBlocksCoop = 0;
 
     if (canUseCoop) {
       // Number of blocks we can use in the cooperative kernel
       static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
-      numBlocksCoop = getCoopLaunchBlockCount(smCount);
+      coopLaunchSMCounts = getCoopLaunchSMCounts(smCount);
+      numBlocksCoop = coopLaunchSMCounts.moeSms;
       // Maximum number of tokens supported by the kernel using a cooperative launch.
       // The number of blocks must be:
       //   >= ⌈(numTokens * topK) / (MaxExpandedIdxPerThread * NumThreads)⌉
@@ -114,6 +116,7 @@ void runPostTopKPipeline(DataType const& data, void* stream) {
     if (useCoop) {
       // Coop path: cooperative launch fuses histogram + offsets (more efficient).
       // The coop kernel atomicAdds to mPtrExpertCounts, so we must zero it first.
+      logCoopLaunchSMCounts(coopLaunchSMCounts);
       routingCustom::launchInitExpertCounts(customData, numThreadsHist, stream);
       routingCustom::launchCoopKernel(customData, numBlocksCoop, numThreadsHist, stream);
     } else {

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -102,8 +102,7 @@ void runPostTopKPipeline(DataType const& data, void* stream) {
     if (canUseCoop) {
       // Number of blocks we can use in the cooperative kernel
       static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
-      // WAR: Reserve 8 SMs for overlapping kernels.
-      numBlocksCoop = smCount - kReservedSMsForOverlapping;
+      numBlocksCoop = getCoopLaunchBlockCount(smCount);
       // Maximum number of tokens supported by the kernel using a cooperative launch.
       // The number of blocks must be:
       //   >= ⌈(numTokens * topK) / (MaxExpandedIdxPerThread * NumThreads)⌉

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -1316,16 +1316,19 @@ void run(Data const& data, void* stream) {
     bool const canUseCoop =
         (smMajor >= 9) && (data.mNumExperts <= 1024) && (data.mPtrPermutedIdxSize != nullptr);
     bool useCoop = false;
+    CoopLaunchSMCounts coopLaunchSMCounts{0, 0};
     int numBlocksCoop = 0;
 
     if (canUseCoop) {
       static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
-      numBlocksCoop = getCoopLaunchBlockCount(smCount);
+      coopLaunchSMCounts = getCoopLaunchSMCounts(smCount);
+      numBlocksCoop = coopLaunchSMCounts.moeSms;
       int const maxTokensCoop = (numBlocksCoop * numThreadsHist * 64) / data.mTopK;
       useCoop = (data.mNumTokens <= maxTokensCoop);
     }
 
     if (useCoop) {
+      logCoopLaunchSMCounts(coopLaunchSMCounts);
       launchInitExpertCounts(mutableData, numThreadsHist, stream);
       launchCoopKernel(mutableData, numBlocksCoop, numThreadsHist, stream);
     } else {

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -1320,7 +1320,7 @@ void run(Data const& data, void* stream) {
 
     if (canUseCoop) {
       static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
-      numBlocksCoop = smCount - kReservedSMsForOverlapping;
+      numBlocksCoop = getCoopLaunchBlockCount(smCount);
       int const maxTokensCoop = (numBlocksCoop * numThreadsHist * 64) / data.mTopK;
       useCoop = (data.mNumTokens <= maxTokensCoop);
     }

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
@@ -544,27 +544,31 @@ void run(Data& data, void* stream) {
       data.mPtrExpertCounts = nullptr;
     }
 
-    static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
-    int const numBlocksCoop = smCount - 8;
-    int const maxTokensCoop = (numBlocksCoop * numThreadsHist * 64) / data.mTopK;
-
     if (useSingleCluster) {
       launchClusterKernel(data, numThreadsHist, stream);
-    } else if (data.mNumTokens <= maxTokensCoop) {
-      launchCoopKernel(data, numBlocksCoop, numThreadsHist, stream);
     } else {
-      const int32_t expandedIdxSize = data.mNumTokens * data.mTopK;
-      const int32_t histogramEltsPerBlock = 8 * numThreadsHist;
-      const int32_t offsetEltsPerBlock = NumEltsPerOffsetTilePerThread * numThreadsHist;
-      const int32_t maxNumBlocks = 1024;
+      static int const smCount = tensorrt_llm::common::getMultiProcessorCount();
+      CoopLaunchSMCounts const coopLaunchSMCounts = getCoopLaunchSMCounts(smCount);
+      int const numBlocksCoop = coopLaunchSMCounts.moeSms;
+      int const maxTokensCoop = (numBlocksCoop * numThreadsHist * 64) / data.mTopK;
 
-      int const numBlocksHistogram = std::min(
-          (expandedIdxSize + histogramEltsPerBlock - 1) / histogramEltsPerBlock, maxNumBlocks);
-      int const numBlocksOffsets =
-          std::min((expandedIdxSize + offsetEltsPerBlock - 1) / offsetEltsPerBlock, maxNumBlocks);
+      if (data.mNumTokens <= maxTokensCoop) {
+        logCoopLaunchSMCounts(coopLaunchSMCounts);
+        launchCoopKernel(data, numBlocksCoop, numThreadsHist, stream);
+      } else {
+        const int32_t expandedIdxSize = data.mNumTokens * data.mTopK;
+        const int32_t histogramEltsPerBlock = 8 * numThreadsHist;
+        const int32_t offsetEltsPerBlock = NumEltsPerOffsetTilePerThread * numThreadsHist;
+        const int32_t maxNumBlocks = 1024;
 
-      launchHistogramKernel(data, numBlocksHistogram, numThreadsHist, stream);
-      launchOffsetsKernel(data, numBlocksOffsets, numThreadsHist, stream);
+        int const numBlocksHistogram = std::min(
+            (expandedIdxSize + histogramEltsPerBlock - 1) / histogramEltsPerBlock, maxNumBlocks);
+        int const numBlocksOffsets =
+            std::min((expandedIdxSize + offsetEltsPerBlock - 1) / offsetEltsPerBlock, maxNumBlocks);
+
+        launchHistogramKernel(data, numBlocksHistogram, numThreadsHist, stream);
+        launchOffsetsKernel(data, numBlocksOffsets, numThreadsHist, stream);
+      }
     }
   }
 }

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
@@ -19,6 +19,7 @@
 #include <cooperative_groups/reduce.h>
 #include <cutlass/arch/arch.h>
 
+#include <cstdlib>
 #include <cub/cub.cuh>
 #include <cute/arch/cluster_sm90.hpp>
 #include <type_traits>
@@ -42,8 +43,40 @@ static constexpr int WarpSize = 32;
 static constexpr int NumBlocksPerCluster = 8;
 // Performance tuning knob.
 static constexpr int NumEltsPerOffsetTilePerThread = 8;
-// Number of SMs to reserve for overlapping kernels when using cooperative launch.
-static constexpr int kReservedSMsForOverlapping = 8;
+// Default number of SMs to leave available for overlapping kernels when using cooperative launch.
+static constexpr int kDefaultReservedSMsForOverlapping = 8;
+static constexpr char kReservedSMsForOverlappingEnv[] =
+    "FLASHINFER_TRTLLM_MOE_OVERLAP_RESERVED_SMS";
+
+struct ReservedSMsForOverlappingConfig {
+  long reservedSms;
+  bool isSet;
+};
+
+inline ReservedSMsForOverlappingConfig getReservedSMsForOverlappingConfig() {
+  static ReservedSMsForOverlappingConfig const config = [] {
+    char const* env = std::getenv(kReservedSMsForOverlappingEnv);
+    if (env == nullptr) {
+      return ReservedSMsForOverlappingConfig{kDefaultReservedSMsForOverlapping, false};
+    }
+    char* end = nullptr;
+    long const value = std::strtol(env, &end, 10);
+    FLASHINFER_CHECK(end != env && *end == '\0', kReservedSMsForOverlappingEnv,
+                     " must be an integer, got ", env);
+    return ReservedSMsForOverlappingConfig{value, true};
+  }();
+  return config;
+}
+
+inline int getCoopLaunchBlockCount(int smCount) {
+  ReservedSMsForOverlappingConfig const config = getReservedSMsForOverlappingConfig();
+  if (config.isSet) {
+    FLASHINFER_CHECK(config.reservedSms >= 0 && config.reservedSms < smCount,
+                     kReservedSMsForOverlappingEnv, " must satisfy 0 <= value < SM count (",
+                     smCount, "), got ", config.reservedSms);
+  }
+  return smCount - static_cast<int>(config.reservedSms);
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
@@ -19,6 +19,7 @@
 #include <cooperative_groups/reduce.h>
 #include <cutlass/arch/arch.h>
 #include <flashinfer/exception.h>
+#include <flashinfer/logging.h>
 
 #include <cstdlib>
 #include <cub/cub.cuh>
@@ -57,6 +58,11 @@ struct ReservedSMsForOverlappingConfig {
   bool isSet;
 };
 
+struct CoopLaunchSMCounts {
+  int moeSms;
+  int reservedSms;
+};
+
 // Return the reserved-SM configuration for TRT-LLM fused MoE overlap.
 // The value is read from FLASHINFER_TRTLLM_MOE_OVERLAP_RESERVED_SMS once per
 // process. When the variable is not set, the default reserved-SM count is used
@@ -76,15 +82,27 @@ inline ReservedSMsForOverlappingConfig getReservedSMsForOverlappingConfig() {
   return config;
 }
 
-// Return the number of cooperative-launch blocks available after reserving SMs.
+// Return the cooperative-launch SM allocation after reserving SMs.
 // Validate the effective reserved-SM count against the runtime SM count before
-// subtraction so the result is always positive.
-inline int getCoopLaunchBlockCount(int smCount) {
+// subtraction so the number of SMs used by MoE is always positive.
+inline CoopLaunchSMCounts getCoopLaunchSMCounts(int smCount) {
   ReservedSMsForOverlappingConfig const config = getReservedSMsForOverlappingConfig();
   char const* source = config.isSet ? kReservedSMsForOverlappingEnv : "default reserved SM count";
   FLASHINFER_CHECK(config.reservedSms >= 0 && config.reservedSms < smCount, source,
                    " must satisfy 0 <= value < SM count (", smCount, "), got ", config.reservedSms);
-  return smCount - static_cast<int>(config.reservedSms);
+  int const reservedSms = static_cast<int>(config.reservedSms);
+  return CoopLaunchSMCounts{smCount - reservedSms, reservedSms};
+}
+
+inline void logCoopLaunchSMCounts(CoopLaunchSMCounts const& counts) {
+  static bool logged = false;
+  if (!logged) {
+    logged = true;
+    FLASHINFER_LOG_INFO(
+        "TRT-LLM fused MoE cooperative launch SM allocation: {} SMs used for MoE, {} SMs "
+        "reserved for overlapping kernels (total SMs: {})",
+        counts.moeSms, counts.reservedSms, counts.moeSms + counts.reservedSms);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh
@@ -18,6 +18,7 @@
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
 #include <cutlass/arch/arch.h>
+#include <flashinfer/exception.h>
 
 #include <cstdlib>
 #include <cub/cub.cuh>
@@ -48,11 +49,18 @@ static constexpr int kDefaultReservedSMsForOverlapping = 8;
 static constexpr char kReservedSMsForOverlappingEnv[] =
     "FLASHINFER_TRTLLM_MOE_OVERLAP_RESERVED_SMS";
 
+// Parsed reserved-SM value and whether it came from the environment.
 struct ReservedSMsForOverlappingConfig {
+  // Number of SMs to reserve for overlapping kernels.
   long reservedSms;
+  // True when reservedSms was read from FLASHINFER_TRTLLM_MOE_OVERLAP_RESERVED_SMS.
   bool isSet;
 };
 
+// Return the reserved-SM configuration for TRT-LLM fused MoE overlap.
+// The value is read from FLASHINFER_TRTLLM_MOE_OVERLAP_RESERVED_SMS once per
+// process. When the variable is not set, the default reserved-SM count is used
+// and isSet is false so error messages can identify the source of the value.
 inline ReservedSMsForOverlappingConfig getReservedSMsForOverlappingConfig() {
   static ReservedSMsForOverlappingConfig const config = [] {
     char const* env = std::getenv(kReservedSMsForOverlappingEnv);
@@ -68,13 +76,14 @@ inline ReservedSMsForOverlappingConfig getReservedSMsForOverlappingConfig() {
   return config;
 }
 
+// Return the number of cooperative-launch blocks available after reserving SMs.
+// Validate the effective reserved-SM count against the runtime SM count before
+// subtraction so the result is always positive.
 inline int getCoopLaunchBlockCount(int smCount) {
   ReservedSMsForOverlappingConfig const config = getReservedSMsForOverlappingConfig();
-  if (config.isSet) {
-    FLASHINFER_CHECK(config.reservedSms >= 0 && config.reservedSms < smCount,
-                     kReservedSMsForOverlappingEnv, " must satisfy 0 <= value < SM count (",
-                     smCount, "), got ", config.reservedSms);
-  }
+  char const* source = config.isSet ? kReservedSMsForOverlappingEnv : "default reserved SM count";
+  FLASHINFER_CHECK(config.reservedSms >= 0 && config.reservedSms < smCount, source,
+                   " must satisfy 0 <= value < SM count (", smCount, "), got ", config.reservedSms);
   return smCount - static_cast<int>(config.reservedSms);
 }
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The current code hardcodes the number of reserved SMs for overlapping in TRT-LLM fused MoE to be 8. Because sometimes better overlapping can be achieved by using other numbers of reserved SMs for overlapping, this PR modifies the code to use an environment variable `FLASHINFER_TRTLLM_MOE_OVERLAP_RESERVED_SMS` to control the number of reserved SMs. If this environment variable is not set, the current value 8 is used.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Cooperative-kernel resource management now uses a validated, configurable allocation instead of a fixed constant, improving GPU utilization and flexibility; the chosen allocation is logged when the cooperative path is used.
* **New Features**
  * Added an environment variable to adjust reserved GPU resources at runtime and enable tuning without code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->