### PR TITLE
Robust boolean env-var parsing: add str2bool, fix FLAG=0 footguns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,6 +464,30 @@ export FLASHINFER_CUDA_ARCH_LIST="8.0 9.0a"  # Target architectures
 export FLASHINFER_WORKSPACE_BASE="/scratch"   # Custom cache directory
 ```
 
+### Parsing Boolean Environment Variables
+
+When reading a boolean env var in Python, **use `str2bool`, not bare truthiness**:
+
+```python
+from flashinfer.utils import str2bool          # public re-export
+# or: from flashinfer.jit.env import str2bool   # canonical home (cycle-free, low-level)
+
+if str2bool(os.environ.get("FLASHINFER_SOMETHING")):   # default False
+    ...
+enabled = str2bool(os.environ.get("FLASHINFER_FOO"), default=True)
+```
+
+`str2bool` accepts `1/true/yes/on` → `True`, `0/false/no/off`/`""` → `False` (case-insensitive),
+`None` → `default`, and raises `ValueError` on anything else (so typos surface).
+
+**Do NOT** write `if os.getenv("FLAG"):` — that treats *any* non-empty value, including
+`FLAG=0` and `FLAG=false`, as `True`. Also avoid ad-hoc `== "1"` / `!= "0"` / `not in ("0","")`
+checks; they're inconsistent with each other (`== "1"` rejects `FLAG=true`, `!= "0"` accepts it).
+
+In C++ there is no shared helper (the `nv_internal/` TRT-LLM env code is vendored). When adding a
+FlashInfer-owned C++ boolean env read, parse it explicitly (e.g. compare against `"1"`/`"0"`) rather
+than `getenv(...) != nullptr`, which has the same `=0`-is-true footgun.
+
 ## Development Workflow
 
 ### Typical Development Loop

--- a/flashinfer/api_logging.py
+++ b/flashinfer/api_logging.py
@@ -30,6 +30,8 @@ import contextlib
 import importlib
 import torch
 
+from .jit.env import str2bool
+
 
 # Helper function to substitute %i with process ID in file paths
 def _substitute_process_id(path: str) -> str:
@@ -61,7 +63,7 @@ _DUMP_INCLUDE_PATTERNS = [p.strip() for p in _DUMP_INCLUDE.split(",") if p.strip
 _DUMP_EXCLUDE_PATTERNS = [p.strip() for p in _DUMP_EXCLUDE.split(",") if p.strip()]
 
 # SafeTensors format option (default: use torch.save which preserves stride/contiguity)
-_DUMP_SAFETENSORS = os.environ.get("FLASHINFER_DUMP_SAFETENSORS", "0") == "1"
+_DUMP_SAFETENSORS = str2bool(os.environ.get("FLASHINFER_DUMP_SAFETENSORS"))
 
 _CUDA_GRAPH_CAPTURE_STACK: List[int] = []
 

--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -22,6 +22,7 @@ import torch
 from flashinfer.tllm_utils import delay_kernel
 
 from .jit.core import logger
+from .jit.env import str2bool
 from .version import __version__ as _flashinfer_version
 
 # This version should be updated whenever the nvfp4_cutlass backend is changed,
@@ -1014,7 +1015,7 @@ class AutoTuner:
 
                 # 3. Bundled package configs (legacy .py files)
                 if (
-                    os.environ.get("FLASHINFER_AUTOTUNER_LOAD_FROM_FILE", "0") == "1"
+                    str2bool(os.environ.get("FLASHINFER_AUTOTUNER_LOAD_FROM_FILE"))
                     and not self.is_tuning_mode
                 ):
                     output = load_from_file(cache_key)

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -22,6 +22,7 @@ from flashinfer.cute_dsl.utils import (
     get_num_sm,
     make_ptr,
 )
+from flashinfer.jit.env import str2bool
 from .moe_dynamic_kernel import MoEDynamicKernel
 from .moe_micro_kernel import MoEMicroKernel
 from .moe_static_kernel import MoEStaticKernel
@@ -47,8 +48,8 @@ _LEVEL_TILE_N = 128
 _DYNAMIC_SLICE_CHUNK = 1
 SF_VEC_SIZE = 16
 _FORCE_MOE_W4A16_ENV = "FLASHINFER_B12X_FORCE_MOE_W4A16"
-_MICRO_SHARE_INPUT_ACROSS_EXPERTS = (
-    os.environ.get("FLASHINFER_B12X_MICRO_SHARE_INPUT", "1") != "0"
+_MICRO_SHARE_INPUT_ACROSS_EXPERTS = str2bool(
+    os.environ.get("FLASHINFER_B12X_MICRO_SHARE_INPUT"), default=True
 )
 
 # Micro kernel cutover thresholds (routed pairs)
@@ -111,7 +112,7 @@ def _first_env(*names: str) -> str | None:
 
 def _normalize_activation_precision(activation_precision: str) -> str:
     """Normalize public activation-precision names to internal modes."""
-    if os.environ.get(_FORCE_MOE_W4A16_ENV, "0") == "1":
+    if str2bool(os.environ.get(_FORCE_MOE_W4A16_ENV)):
         return "bf16"
 
     normalized = str(activation_precision).lower()
@@ -136,7 +137,7 @@ def _normalize_quant_mode(
     activation_precision: str | None = None,
 ) -> str:
     """Normalize public quantization names to the dispatch mode."""
-    if os.environ.get(_FORCE_MOE_W4A16_ENV, "0") == "1":
+    if str2bool(os.environ.get(_FORCE_MOE_W4A16_ENV)):
         return "w4a16"
     if quant_mode is None:
         activation_precision = _normalize_activation_precision(

--- a/flashinfer/jit/attention/fmha_v2/fmha_library.py
+++ b/flashinfer/jit/attention/fmha_v2/fmha_library.py
@@ -1132,11 +1132,13 @@ const bool  use_tiled            = launch_params.use_granular_tiling;
 
 // "1" -> on, "0"/unset -> off. Mirrors the 1/0 fast path of
 // flashinfer.jit.env.str2bool; parsed inline here since this is a standalone
-// generated translation unit.
+// generated translation unit. The `[1] == 0` checks the null terminator (i.e.
+// the value is exactly "1"); integer 0 is used instead of '\0' to avoid a
+// backslash escape inside this Python string template.
 static const char* fmha_v2_verbose_env = std::getenv("FLASHINFER_FMHA_V2_VERBOSE");
 static const bool fmha_v2_verbose =
     (fmha_v2_verbose_env != nullptr && fmha_v2_verbose_env[0] == '1' &&
-     fmha_v2_verbose_env[1] == '\\0');
+     fmha_v2_verbose_env[1] == 0);
 
 {calls_v2_str}
 else {{

--- a/flashinfer/jit/attention/fmha_v2/fmha_library.py
+++ b/flashinfer/jit/attention/fmha_v2/fmha_library.py
@@ -1130,7 +1130,13 @@ const int  attention_input_layout            = static_cast<int>(launch_params.at
 // tiled variant uses ldgsts
 const bool  use_tiled            = launch_params.use_granular_tiling;
 
-static const bool fmha_v2_verbose = (std::getenv("FLASHINFER_FMHA_V2_VERBOSE") != nullptr);
+// "1" -> on, "0"/unset -> off. Mirrors flashinfer::str2bool (1/0 fast path, in
+// include/flashinfer/utils.cuh) and flashinfer.jit.env.str2bool; inlined here
+// to avoid pulling utils.cuh into this generated translation unit.
+static const char* fmha_v2_verbose_env = std::getenv("FLASHINFER_FMHA_V2_VERBOSE");
+static const bool fmha_v2_verbose =
+    (fmha_v2_verbose_env != nullptr && fmha_v2_verbose_env[0] == '1' &&
+     fmha_v2_verbose_env[1] == '\\0');
 
 {calls_v2_str}
 else {{

--- a/flashinfer/jit/attention/fmha_v2/fmha_library.py
+++ b/flashinfer/jit/attention/fmha_v2/fmha_library.py
@@ -1130,9 +1130,9 @@ const int  attention_input_layout            = static_cast<int>(launch_params.at
 // tiled variant uses ldgsts
 const bool  use_tiled            = launch_params.use_granular_tiling;
 
-// "1" -> on, "0"/unset -> off. Mirrors flashinfer::str2bool (1/0 fast path, in
-// include/flashinfer/utils.cuh) and flashinfer.jit.env.str2bool; inlined here
-// to avoid pulling utils.cuh into this generated translation unit.
+// "1" -> on, "0"/unset -> off. Mirrors the 1/0 fast path of
+// flashinfer.jit.env.str2bool; parsed inline here since this is a standalone
+// generated translation unit.
 static const char* fmha_v2_verbose_env = std::getenv("FLASHINFER_FMHA_V2_VERBOSE");
 static const bool fmha_v2_verbose =
     (fmha_v2_verbose_env != nullptr && fmha_v2_verbose_env[0] == '1' &&

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -287,7 +287,7 @@ class JitSpec:
         return self.ninja_path.exists()
 
     def build(self, verbose: bool, need_lock: bool = True) -> None:
-        if os.environ.get("FLASHINFER_DISABLE_JIT"):
+        if jit_env.str2bool(os.environ.get("FLASHINFER_DISABLE_JIT")):
             raise MissingJITCacheError(
                 "JIT compilation is disabled via FLASHINFER_DISABLE_JIT environment variable, "
                 "but the required module is not found in the JIT cache. "
@@ -312,7 +312,7 @@ class JitSpec:
         # where another process is building the library and removes the .so file.
         with FileLock(self.lock_path, thread_local=False):
             so_path = self.jit_library_path
-            verbose = os.environ.get("FLASHINFER_JIT_VERBOSE", "0") == "1"
+            verbose = jit_env.str2bool(os.environ.get("FLASHINFER_JIT_VERBOSE"))
             self.build(verbose, need_lock=False)
             result = self.load(so_path)
 
@@ -411,10 +411,12 @@ def gen_jit_spec(
     needs_device_linking: bool = False,
 ) -> JitSpec:
     check_cuda_arch()
-    # Use FLASHINFER_JIT_DEBUG if set, otherwise use FLASHINFER_JIT_VERBOSE (for backward compatibility)
-    debug_env = os.environ.get("FLASHINFER_JIT_DEBUG")
-    verbose_env = os.environ.get("FLASHINFER_JIT_VERBOSE", "0")
-    debug = (debug_env if debug_env is not None else verbose_env) == "1"
+    # Use FLASHINFER_JIT_DEBUG if set, otherwise fall back to FLASHINFER_JIT_VERBOSE
+    # (for backward compatibility).
+    debug = jit_env.str2bool(
+        os.environ.get("FLASHINFER_JIT_DEBUG"),
+        default=jit_env.str2bool(os.environ.get("FLASHINFER_JIT_VERBOSE")),
+    )
 
     # Only add default C++ standard if not specified in extra flags
     cflags_has_std = extra_cflags is not None and any(
@@ -456,7 +458,7 @@ def gen_jit_spec(
         cflags += ["-DNDEBUG", "-O3"]
 
     # useful for ncu source correlation
-    if os.environ.get("FLASHINFER_JIT_LINEINFO", "0") == "1":
+    if jit_env.str2bool(os.environ.get("FLASHINFER_JIT_LINEINFO")):
         cuda_cflags += ["-lineinfo"]
 
     if extra_cflags is not None:

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -28,7 +28,7 @@ import uuid
 import filelock
 
 from .core import logger
-from .env import FLASHINFER_CUBIN_DIR
+from .env import FLASHINFER_CUBIN_DIR, str2bool
 
 # This is the storage path for the cubins, it can be replaced
 # with a local path for testing.
@@ -189,7 +189,7 @@ def load_cubin(cubin_path: str, sha256: str) -> bytes:
     try:
         with open(cubin_path, mode="rb") as f:
             cubin = f.read()
-            if os.getenv("FLASHINFER_CUBIN_CHECKSUM_DISABLED"):
+            if str2bool(os.getenv("FLASHINFER_CUBIN_CHECKSUM_DISABLED")):
                 return cubin
             m = hashlib.sha256()
             m.update(cubin)
@@ -218,7 +218,7 @@ def get_artifact(file_name: str, sha256: str, session=None) -> bytes:
     if data:
         return data
 
-    if os.getenv("FLASHINFER_NO_DOWNLOAD"):
+    if str2bool(os.getenv("FLASHINFER_NO_DOWNLOAD")):
         raise RuntimeError(
             f"Artifact not found locally: {file_name} "
             f"(looked at {local_path}). "

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -20,8 +20,37 @@ limitations under the License.
 
 import os
 import pathlib
+from typing import Optional
 from ..compilation_context import CompilationContext
 from ..version import __version__ as flashinfer_version
+
+# Recognized spellings for boolean strings (case-insensitive).
+_TRUE_STRINGS = frozenset({"1", "true", "yes", "on", "y", "t"})
+_FALSE_STRINGS = frozenset({"0", "false", "no", "off", "n", "f", ""})
+
+
+def str2bool(value: Optional[str], default: bool = False) -> bool:
+    """Parse a boolean from a string (e.g. an environment variable value).
+
+    Accepts common spellings case-insensitively: ``1/true/yes/on`` -> True,
+    ``0/false/no/off`` (and empty string) -> False. ``None`` -> ``default``.
+
+    Avoids the footgun of ``if os.getenv("FLAG"):``, which treats *any*
+    non-empty value -- including ``FLAG=0`` or ``FLAG=false`` -- as True. An
+    unrecognized value raises ``ValueError`` so typos surface loudly instead of
+    silently flipping behavior.
+    """
+    if value is None:
+        return default
+    val = value.strip().lower()
+    if val in _TRUE_STRINGS:
+        return True
+    if val in _FALSE_STRINGS:
+        return False
+    raise ValueError(
+        f"Cannot interpret {value!r} as a boolean. "
+        f"Expected one of 1/0, true/false, yes/no, on/off."
+    )
 
 
 def has_flashinfer_jit_cache() -> bool:
@@ -72,7 +101,7 @@ def _get_cubin_dir():
         # NOTE(yiyang): skip version check for editable/source installs where
         # flashinfer_version falls back to "0.0.0+unknown" (no _build_meta.py).
         if (
-            not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
+            not str2bool(os.getenv("FLASHINFER_DISABLE_VERSION_CHECK"))
             and flashinfer_version != "0.0.0+unknown"
             and flashinfer_version != flashinfer_cubin_version
         ):
@@ -112,7 +141,7 @@ def _get_aot_dir():
         # contains the CUDA version suffix: e.g. 0.3.1+cu129.
         # Allow bypassing version check with environment variable
         if (
-            not os.getenv("FLASHINFER_DISABLE_VERSION_CHECK")
+            not str2bool(os.getenv("FLASHINFER_DISABLE_VERSION_CHECK"))
             and flashinfer_version != "0.0.0+unknown"
             and not flashinfer_jit_cache_version.startswith(flashinfer_version)
         ):

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -30,6 +30,7 @@ from ..trace.templates.attention import (
     xqa_batch_decode_mla_trace,
 )
 from ..jit import gen_batch_mla_module, gen_trtllm_gen_fmha_module, setup_cubin_loader
+from ..jit.env import str2bool
 from ..jit.mla import gen_mla_module
 from ..utils import (
     MaskMode,
@@ -261,7 +262,7 @@ def _normalize_dsv4_topk_lens(
 
 
 def _validate_dsv4_sync_checks() -> bool:
-    return os.environ.get("FLASHINFER_VALIDATE_INPUTS", "0") not in ("0", "")
+    return str2bool(os.environ.get("FLASHINFER_VALIDATE_INPUTS"))
 
 
 def _check_dsv4_sparse_mla_inputs(

--- a/flashinfer/norm/__init__.py
+++ b/flashinfer/norm/__init__.py
@@ -48,6 +48,7 @@ from ..utils import (
     get_compute_capability,
     register_custom_op,
     register_fake_op,
+    str2bool,
     supported_compute_capability,
 )
 
@@ -56,7 +57,7 @@ from ..jit.norm import gen_norm_module
 
 # Use CUDA JIT implementation instead of CuTe DSL (for debugging/fallback)
 # Also fallback to CUDA JIT if nvidia-cutlass-dsl is not installed
-_USE_CUDA_NORM = os.environ.get("FLASHINFER_USE_CUDA_NORM", "0") == "1"
+_USE_CUDA_NORM = str2bool(os.environ.get("FLASHINFER_USE_CUDA_NORM"))
 
 if not _USE_CUDA_NORM:
     try:

--- a/flashinfer/trace/template.py
+++ b/flashinfer/trace/template.py
@@ -51,6 +51,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 
+from ..jit.env import str2bool
+
 # These are read lazily at each call so that the caller can set them after
 # importing flashinfer (e.g. in scripts run with ``python -m``).
 
@@ -62,7 +64,7 @@ def _get_trace_dump_dir() -> Optional[str]:
 
 def _is_trace_dump_enabled() -> bool:
     """Return True if auto-dump is currently enabled via FLASHINFER_TRACE_DUMP."""
-    return os.environ.get("FLASHINFER_TRACE_DUMP", "0") not in ("0", "")
+    return str2bool(os.environ.get("FLASHINFER_TRACE_DUMP"))
 
 
 # Keep these module-level names for backwards compatibility with any code that

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -540,6 +540,7 @@ def has_cuda_cudart() -> bool:
 from .jit.env import (
     has_flashinfer_jit_cache as has_flashinfer_jit_cache,
     has_flashinfer_cubin as has_flashinfer_cubin,
+    str2bool as str2bool,
 )
 
 

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -22,9 +22,7 @@
 #include <cuda_runtime.h>
 
 #include <atomic>
-#include <cctype>
 #include <cstdint>
-#include <cstring>
 #include <iostream>
 #include <type_traits>
 #include <vector>
@@ -331,40 +329,6 @@
   }
 
 namespace flashinfer {
-
-// Parse a boolean from an environment-variable-style C string.
-//
-// Keep in sync with the Python implementation flashinfer.jit.env.str2bool
-// (flashinfer/jit/env.py): "1"/"true"/"yes"/"on" -> true,
-// "0"/"false"/"no"/"off"/"" -> false (all case-insensitive). A null pointer
-// (i.e. unset env var) returns `default_value`.
-//
-// Unlike the Python version, which raises on an unrecognized value, this host
-// helper falls back to `default_value` -- it is meant for hot/early-init paths
-// where throwing is undesirable. The single-character "1"/"0" fast path covers
-// the overwhelmingly common case without allocating.
-inline bool str2bool(char const* value, bool default_value = false) {
-  if (value == nullptr) return default_value;
-  // Fast path: exactly "1" or "0".
-  if (value[0] != '\0' && value[1] == '\0') {
-    if (value[0] == '1') return true;
-    if (value[0] == '0') return false;
-  }
-  char buf[8];
-  size_t len = std::strlen(value);
-  if (len < sizeof(buf)) {
-    for (size_t i = 0; i < len; ++i) buf[i] = static_cast<char>(std::tolower(value[i]));
-    buf[len] = '\0';
-    if (!std::strcmp(buf, "1") || !std::strcmp(buf, "true") || !std::strcmp(buf, "yes") ||
-        !std::strcmp(buf, "on") || !std::strcmp(buf, "y") || !std::strcmp(buf, "t"))
-      return true;
-    if (!std::strcmp(buf, "0") || !std::strcmp(buf, "false") || !std::strcmp(buf, "no") ||
-        !std::strcmp(buf, "off") || !std::strcmp(buf, "n") || !std::strcmp(buf, "f") ||
-        buf[0] == '\0')
-      return false;
-  }
-  return default_value;
-}
 
 template <typename T1, typename T2>
 __forceinline__ __device__ __host__ constexpr T1 ceil_div(const T1 x, const T2 y) noexcept {

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -22,7 +22,9 @@
 #include <cuda_runtime.h>
 
 #include <atomic>
+#include <cctype>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <type_traits>
 #include <vector>
@@ -329,6 +331,40 @@
   }
 
 namespace flashinfer {
+
+// Parse a boolean from an environment-variable-style C string.
+//
+// Keep in sync with the Python implementation flashinfer.jit.env.str2bool
+// (flashinfer/jit/env.py): "1"/"true"/"yes"/"on" -> true,
+// "0"/"false"/"no"/"off"/"" -> false (all case-insensitive). A null pointer
+// (i.e. unset env var) returns `default_value`.
+//
+// Unlike the Python version, which raises on an unrecognized value, this host
+// helper falls back to `default_value` -- it is meant for hot/early-init paths
+// where throwing is undesirable. The single-character "1"/"0" fast path covers
+// the overwhelmingly common case without allocating.
+inline bool str2bool(char const* value, bool default_value = false) {
+  if (value == nullptr) return default_value;
+  // Fast path: exactly "1" or "0".
+  if (value[0] != '\0' && value[1] == '\0') {
+    if (value[0] == '1') return true;
+    if (value[0] == '0') return false;
+  }
+  char buf[8];
+  size_t len = std::strlen(value);
+  if (len < sizeof(buf)) {
+    for (size_t i = 0; i < len; ++i) buf[i] = static_cast<char>(std::tolower(value[i]));
+    buf[len] = '\0';
+    if (!std::strcmp(buf, "1") || !std::strcmp(buf, "true") || !std::strcmp(buf, "yes") ||
+        !std::strcmp(buf, "on") || !std::strcmp(buf, "y") || !std::strcmp(buf, "t"))
+      return true;
+    if (!std::strcmp(buf, "0") || !std::strcmp(buf, "false") || !std::strcmp(buf, "no") ||
+        !std::strcmp(buf, "off") || !std::strcmp(buf, "n") || !std::strcmp(buf, "f") ||
+        buf[0] == '\0')
+      return false;
+  }
+  return default_value;
+}
 
 template <typename T1, typename T2>
 __forceinline__ __device__ __host__ constexpr T1 ceil_div(const T1 x, const T2 y) noexcept {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,11 @@ exclude = ["flashinfer-jit-cache*", "flashinfer-cubin*"]
 
 [tool.mypy]
 files = ["flashinfer"]
+# Match the project's minimum supported Python (requires-python = ">=3.10").
+# Without this, mypy defaults to the running interpreter's version and flags
+# legitimate 3.10+ syntax used throughout the codebase (PEP 604 `X | Y` unions,
+# dataclass slots=/kw_only=, zip(strict=...)).
+python_version = "3.10"
 ignore_missing_imports = true
 show_column_numbers = true
 show_error_context = true


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Several FlashInfer boolean environment variables were parsed as if os.getenv("FLAG"):, which treats any non-empty value as True — including FLAG=0 and FLAG=false. So FLASHINFER_CUBIN_CHECKSUM_DISABLED=0 disabled checksums, the opposite of what a user would expect.

This PR introduces a single canonical parser and routes the boolean env reads through it, fixing the genuine footguns and unifying several inconsistent idioms (== "1", != "0", not in ("0","")) that disagreed with each other on values like FLAG=true.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Changes

New helper — flashinfer/jit/env.py::str2bool(value, default=False)
- Case-insensitive: 1/true/yes/on → True, 0/false/no/off/"" → False, None → default, unrecognized → ValueError (so typos surface loudly).
- Decoupled from os.getenv (takes a string), re-exported from flashinfer.utils (from flashinfer.utils import str2bool), following the existing jit.env→utils re-export pattern.

Genuine =0 footguns fixed (these previously inverted on FLAG=0):
- FLASHINFER_CUBIN_CHECKSUM_DISABLED, FLASHINFER_NO_DOWNLOAD (jit/cubin_loader.py)
- FLASHINFER_DISABLE_JIT (jit/core.py)
- FLASHINFER_DISABLE_VERSION_CHECK (jit/env.py)

Inconsistent-but-safe idioms unified (defaults preserved):
JIT_VERBOSE / JIT_DEBUG (keeps the VERBOSE fallback) / JIT_LINEINFO, AUTOTUNER_LOAD_FROM_FILE, DUMP_SAFETENSORS, USE_CUDA_NORM, B12X_MICRO_SHARE_INPUT (default True), B12X_FORCE_MOE_W4A16, TRACE_DUMP, VALIDATE_INPUTS.

C++ footgun fixed — FLASHINFER_FMHA_V2_VERBOSE (generated in jit/attention/fmha_v2/fmha_library.py) was a getenv(...) != nullptr presence check, so =0 turned verbose on. Now parses "1" inline in the generated TU (mirrors the Python helper's 1/0 fast path; inlined to avoid pulling a heavy header into the generated translation unit).

mypy — pinned python_version = "3.10" in [tool.mypy] to match requires-python = ">=3.10". Without it mypy defaulted to an older target and rejected legitimate 3.10 syntax used across the repo (X | Y unions, dataclass(slots=/kw_only=), zip(strict=)).

Out of scope (intentionally not touched)

- Vendored csrc/nv_internal/ getEnvXxx() parsers — left untouched to keep TRT-LLM OSS syncs clean.
- tests/ and benchmarks/ env reads.
- routing_custom.cu's FLASHINFER_ROUTING_FORCE_BLOCK_PER_TOKEN — it's tri-state (auto/on/off), already parsed correctly, not a boolean.

Behavior notes

- FLAG=0 / FLAG=false now correctly read as off everywhere.
- A side effect of unifying the != "0" / not in ("0","") sites: values that were truthy by accident (e.g. FLAG=garbage) now raise ValueError instead of silently enabling. This is intentional — it surfaces typos.
- Per-site defaults are preserved (e.g. B12X_MICRO_SHARE_INPUT still defaults on).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Env vars now accept flexible boolean formats (e.g., "true"/"false", "yes"/"no", "1"/"0") across the project.

* **Bug Fixes**
  * Fixed misinterpretation of values like "0" or "false" so they reliably disable features.
  * Invalid boolean values now raise explicit errors instead of silently behaving as truthy.

* **Documentation**
  * Added guidance on parsing boolean environment variables and explicit error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->