### PR TITLE
fix(mamba): SSDCombined TMA partition for B operand when dstate != chunk_size

### DIFF
--- a/flashinfer/mamba/ssd_kernel.py
+++ b/flashinfer/mamba/ssd_kernel.py
@@ -2718,6 +2718,7 @@ class SSDKernel:
             cluster_layout_vmnk,
             mma_tile_coord_v,
             block_in_cluster_coord_vmnk,
+            tile=self.tile_shape_mnk_intra2[1:],  # NK = (D, L)
         )
 
         # ((ATOM_V, REST_V), INPUT_STAGE)
@@ -2972,8 +2973,7 @@ class SSDKernel:
             cluster_layout_vmnk,
             mma_tile_coord_v,
             block_in_cluster_coord_vmnk,
-            # B is the intra1 B operand (L, N), not the intra2 default (D, L).
-            tile=self.tile_shape_mnk_intra1[1:],
+            tile=self.tile_shape_mnk_intra1[1:],  # NK = (L, N)
         )
 
         # ((ATOM_V, REST_V), INPUT_STAGE)
@@ -3636,18 +3636,13 @@ class SSDKernel:
         cluster_layout_vmnk,
         mma_tile_coord_v,
         block_in_cluster_coord_vmnk,
-        tile=None,
+        tile,
     ):
-        # `tile` overrides the default intra2 NK tile (D, L) for callers that
-        # partition a B/C SSM operand of shape (L, N) instead of an X operand of
-        # shape (D, L); when dstate != chunk_size the two tiles disagree and the
-        # default would mis-size the TMA K-mode against the smem allocation.
-        tile_shape = self.tile_shape_mnk_intra2[1:] if tile is None else tile
         # Local_tile partition global tensors
         # (D, L, 1, 1, C, EH, B)
         gX = cute.local_tile(
             tma_tensor_x,
-            tile_shape,
+            tile,
             (None, None, None, None, None),
         )
         # Partition global tensor with regard to TiledMMA

--- a/flashinfer/mamba/ssd_kernel.py
+++ b/flashinfer/mamba/ssd_kernel.py
@@ -2972,6 +2972,8 @@ class SSDKernel:
             cluster_layout_vmnk,
             mma_tile_coord_v,
             block_in_cluster_coord_vmnk,
+            # B is the intra1 B operand (L, N), not the intra2 default (D, L).
+            tile=self.tile_shape_mnk_intra1[1:],
         )
 
         # ((ATOM_V, REST_V), INPUT_STAGE)
@@ -3634,12 +3636,18 @@ class SSDKernel:
         cluster_layout_vmnk,
         mma_tile_coord_v,
         block_in_cluster_coord_vmnk,
+        tile=None,
     ):
+        # `tile` overrides the default intra2 NK tile (D, L) for callers that
+        # partition a B/C SSM operand of shape (L, N) instead of an X operand of
+        # shape (D, L); when dstate != chunk_size the two tiles disagree and the
+        # default would mis-size the TMA K-mode against the smem allocation.
+        tile_shape = self.tile_shape_mnk_intra2[1:] if tile is None else tile
         # Local_tile partition global tensors
         # (D, L, 1, 1, C, EH, B)
         gX = cute.local_tile(
             tma_tensor_x,
-            self.tile_shape_mnk_intra2[1:],  # mnk = (L, D, L)
+            tile_shape,
             (None, None, None, None, None),
         )
         # Partition global tensor with regard to TiledMMA

--- a/tests/mamba/test_chunk_scan_combined.py
+++ b/tests/mamba/test_chunk_scan_combined.py
@@ -172,9 +172,7 @@ class TestChunkScanCombined:
     def headdim(self, request):
         return request.param
 
-    @pytest.fixture(
-        params=[128]
-    )  # Must match kernel's N (CUTLASS kernel is hardcoded for N=128)
+    @pytest.fixture(params=[128, 64])
     def dstate(self, request):
         return request.param
 
@@ -865,7 +863,7 @@ class TestChunkScanCombinedVarlen:
     def headdim(self, request):
         return request.param
 
-    @pytest.fixture(params=[128])
+    @pytest.fixture(params=[128, 64])
     def dstate(self, request):
         return request.param
 
@@ -1358,7 +1356,7 @@ class TestChunkScanCombinedWithZ:
     def headdim(self, request):
         return request.param
 
-    @pytest.fixture(params=[128])
+    @pytest.fixture(params=[128, 64])
     def dstate(self, request):
         return request.param
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The shared helper `tma_partition_for_mma_b_operand` hard-coded the intra2 NK tile (D, L) for the local_tile partition, and used it to load both:
X = inputs = (D, L) = (head_dim, chunk_size)
B = SSM input projection = (L, N) = (chunk_size, dstate)
The Nemotron-H reference config (chunk_size == dstate == 128) hid the bug because the two tiles coincide.

Add a tile argument to `tma_partition_for_mma_b_operand` and pass the correct tile from each call site.

Parametrize `dstate` with {128, 64} in `TestChunkScanCombined`, `TestChunkScanCombinedVarlen`, and `TestChunkScanCombinedWithZ` so the regression is exercised against the Triton reference end-to-end across batch/varlen/with-Z paths.

## 🔍 Related Issues

Closes #3397

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSD kernel tensor partitioning so memory loads align with expected B/C operand layouts, reducing layout-related compute errors.

* **Tests**
  * Expanded test coverage for chunk-scan combined operations by adding an additional head-dimension configuration (64), now testing both 64 and 128.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->