### PR TITLE
[draft] add tileN = 8,16 to SM120 blockscale GEMM.

### DIFF
--- a/csrc/fp4_gemm_cutlass_sm120.jinja
+++ b/csrc/fp4_gemm_cutlass_sm120.jinja
@@ -19,9 +19,12 @@
 
 namespace flashinfer {
 namespace gemm {
-// SM120/121 only supports 1x1x1 cluster shape
+// SM120/121 only supports 1x1x1 cluster shape.
+// Emit both the DP and StreamK scheduler launchers for each tile.
 INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 1, 1, 1, _1SM, true)
 INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 1, 1, 1, _1SM, false)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER_STREAMK({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 1, 1, 1, _1SM, true)
+INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER_STREAMK({{ type }}, {{ cta_m }}, {{ cta_n }}, {{ cta_k }}, 1, 1, 1, _1SM, false)
 
 }  // namespace gemm
 }  // namespace flashinfer

--- a/csrc/group_gemm_mxfp4_groupwise_sm120.cu
+++ b/csrc/group_gemm_mxfp4_groupwise_sm120.cu
@@ -40,6 +40,12 @@ using namespace flashinfer;
     } else if (tile_n == 32) {                     \
       constexpr int TILE_N = 32;                   \
       return __VA_ARGS__();                        \
+    } else if (tile_n == 16) {                     \
+      constexpr int TILE_N = 16;                   \
+      return __VA_ARGS__();                        \
+    } else if (tile_n == 8) {                      \
+      constexpr int TILE_N = 8;                    \
+      return __VA_ARGS__();                        \
     }                                              \
     TVM_FFI_ICHECK(false) << "Unsupported TILE N"; \
     return false;                                  \

--- a/csrc/group_gemm_mxfp4_groupwise_sm120_kernel_inst.jinja
+++ b/csrc/group_gemm_mxfp4_groupwise_sm120_kernel_inst.jinja
@@ -22,11 +22,14 @@ namespace flashinfer {
 namespace group_gemm {
 
 {% for tile_m in [128] %}
-{% for tile_n in [32, 64, 128] %}
+{% for tile_n in [8, 16, 32, 64, 128] %}
 {% for tile_k in [128] %}
 {% for swap_ab in ["true", "false"] %}
 {% for dtype_sfa in ["cutlass::float_ue8m0_t"] %}
 {% for dtype_sfb in ["cutlass::float_ue8m0_t"] %}
+{# tile_n=8 is a single MMA N-atom and is only valid for the decode orientation
+   (swap_ab=true, Out^T = Weight^T Act^T); the swap_ab=false kernel cannot initialize. #}
+{% if not (tile_n == 8 and swap_ab == "false") %}
 
 
 INSTANTIATE_GROUP_GEMM_MXFP4_GROUPWISE_SM120(
@@ -46,6 +49,7 @@ INSTANTIATE_GROUP_GEMM_MXFP4_GROUPWISE_SM120(
     {{ dtype_d  | replace("cutlass::", "")}}
 )
 
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/csrc/group_gemm_nvfp4_groupwise_sm120.cu
+++ b/csrc/group_gemm_nvfp4_groupwise_sm120.cu
@@ -40,6 +40,12 @@ using namespace flashinfer;
     } else if (tile_n == 32) {                     \
       constexpr int TILE_N = 32;                   \
       return __VA_ARGS__();                        \
+    } else if (tile_n == 16) {                     \
+      constexpr int TILE_N = 16;                   \
+      return __VA_ARGS__();                        \
+    } else if (tile_n == 8) {                      \
+      constexpr int TILE_N = 8;                    \
+      return __VA_ARGS__();                        \
     }                                              \
     TVM_FFI_ICHECK(false) << "Unsupported TILE N"; \
     return false;                                  \

--- a/csrc/group_gemm_nvfp4_groupwise_sm120_kernel_inst.jinja
+++ b/csrc/group_gemm_nvfp4_groupwise_sm120_kernel_inst.jinja
@@ -22,11 +22,14 @@ namespace flashinfer {
 namespace group_gemm {
 
 {% for tile_m in [128] %}
-{% for tile_n in [32, 64, 128] %}
+{% for tile_n in [8, 16, 32, 64, 128] %}
 {% for tile_k in [128, 256] %}
 {% for swap_ab in ["true", "false"] %}
 {% for dtype_sfa in ["cutlass::float_ue4m3_t"] %}
 {% for dtype_sfb in ["cutlass::float_ue4m3_t"] %}
+{# tile_n=8 is a single MMA N-atom and is only valid for the decode orientation
+   (swap_ab=true, Out^T = Weight^T Act^T); the swap_ab=false kernel cannot initialize. #}
+{% if not (tile_n == 8 and swap_ab == "false") %}
 
 
 INSTANTIATE_GROUP_GEMM_NVFP4_GROUPWISE_SM120(
@@ -46,6 +49,7 @@ INSTANTIATE_GROUP_GEMM_NVFP4_GROUPWISE_SM120(
     {{ dtype_d  | replace("cutlass::", "")}}
 )
 
+{% endif %}
 {% endfor %}
 {% endfor %}
 {% endfor %}

--- a/csrc/nv_internal/tensorrt_llm/cutlass_extensions/include/cutlass_extensions/gemm_configs.h
+++ b/csrc/nv_internal/tensorrt_llm/cutlass_extensions/include/cutlass_extensions/gemm_configs.h
@@ -165,6 +165,10 @@ enum class CutlassTileConfigSM120 : int {
   // Signals that we should run heuristics do choose a config
   ChooseWithHeuristic = 1,
 
+  CtaShape128x8x128B = shape_tuple_to_enum(128, 8, 128),
+  CtaShape128x8x64B = shape_tuple_to_enum(128, 8, 64),
+  CtaShape128x16x128B = shape_tuple_to_enum(128, 16, 128),
+  CtaShape128x16x64B = shape_tuple_to_enum(128, 16, 64),
   CtaShape128x32x128B = shape_tuple_to_enum(128, 32, 128),
   CtaShape128x32x64B = shape_tuple_to_enum(128, 32, 64),
   CtaShape128x64x128B = shape_tuple_to_enum(128, 64, 128),

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/cutlass_heuristic.cpp
@@ -604,6 +604,8 @@ std::vector<CutlassGemmConfig> get_candidate_configs_sm120(
         CutlassGemmConfig{CutlassTileConfigSM120::CtaShape128x32x128B, MainloopScheduleType::AUTO,
                           EpilogueScheduleType::AUTO, ClusterShape::ClusterShape_1x1x1},
         CutlassGemmConfig{CutlassTileConfigSM120::CtaShape128x64x128B, MainloopScheduleType::AUTO,
+                          EpilogueScheduleType::AUTO, ClusterShape::ClusterShape_1x1x1},
+        CutlassGemmConfig{CutlassTileConfigSM120::CtaShape128x16x128B, MainloopScheduleType::AUTO,
                           EpilogueScheduleType::AUTO, ClusterShape::ClusterShape_1x1x1}};
   } else {
     return {
@@ -627,6 +629,7 @@ std::vector<CutlassGemmConfig> get_candidate_configs_sm120(
       CutlassTileConfigSM120::CtaShape128x128x256B, CutlassTileConfigSM120::CtaShape256x128x128B,
       CutlassTileConfigSM120::CtaShape128x32x128B,  CutlassTileConfigSM120::CtaShape128x32x64B,
       CutlassTileConfigSM120::CtaShape128x64x128B,  CutlassTileConfigSM120::CtaShape128x64x64B,
+      CutlassTileConfigSM120::CtaShape128x16x128B,  CutlassTileConfigSM120::CtaShape128x16x64B,
   };
   std::vector<CutlassGemmConfig> result;
   for (auto tile : all_tiles) {

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch_tma_ws.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_gemm_template_dispatch_tma_ws.h
@@ -312,6 +312,8 @@ constexpr bool are_tile_shapes_supported_sm120() {
          (TileM == 128 && TileN == 64 && TileK == 256) ||
          (TileM == 128 && TileN == 32 && TileK == 128) ||
          (TileM == 128 && TileN == 32 && TileK == 256) ||
+         (TileM == 128 && TileN == 16 && TileK == 128) ||
+         (TileM == 128 && TileN == 16 && TileK == 256) ||
          (TileM == 128 && TileN == 256 && TileK == 128) ||
          (TileM == 256 && TileN == 128 && TileK == 128);
 }
@@ -499,6 +501,8 @@ void dispatchMoeGemmSelectTileShapeTmaWarpSpecialized(
       if constexpr (kernels::cutlass_kernels::isValidSM120MOESpecialisation<
                         T, WeightType, EpilogueTag, FUSION>()) {
         switch (gemm_config.tile_config_sm120) {
+          SHAPE_CASE(120, 128, 16, 64)
+          SHAPE_CASE(120, 128, 16, 128)
           SHAPE_CASE(120, 128, 32, 64)
           SHAPE_CASE(120, 128, 32, 128)
           SHAPE_CASE(120, 128, 64, 64)

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6913,8 +6913,13 @@ def _check_group_gemm_mxfp8_mxfp4_nt_groupwise_problem_size(
             raise ValueError(f"mma_sm must be 1, but got {mma_sm}")
         if tile_m not in [128]:
             raise ValueError(f"tile_m must be 128, but got {tile_m}")
-        if tile_n not in [32, 64, 128]:
-            raise ValueError(f"tile_n must be 32, 64, or 128, but got {tile_n}")
+        if tile_n not in [8, 16, 32, 64, 128]:
+            raise ValueError(f"tile_n must be 8, 16, 32, 64, or 128, but got {tile_n}")
+        if tile_n == 8 and not swap_ab:
+            raise ValueError(
+                "tile_n=8 on SM120/121 is only supported with swap_ab=True "
+                "(the decode orientation Out^T = Weight^T Act^T)."
+            )
         if tile_k not in [128]:
             raise ValueError(f"tile_k must be 128, but got {tile_k}")
     else:
@@ -7023,8 +7028,8 @@ def group_gemm_mxfp8_mxfp4_nt_groupwise(
         The tile size for the M dimension, must be 128.
 
     tile_n: int
-        The tile size for the N dimension, must be 32, 64, 128, 192, or 256.
-        Only 32, 64, 128 is supported on SM120/121.
+        The tile size for the N dimension, must be 8, 16, 32, 64, 128, 192, or 256.
+        Only 8, 16, 32, 64, 128 is supported on SM120/121.
         Only 64, 128, 192, 256 is supported on SM100, SM103, and SM110.
 
     tile_k: int
@@ -7149,12 +7154,17 @@ def _check_group_gemm_nvfp4_nt_groupwise_problem_size(
         )
     if tile_m not in [128]:
         raise ValueError(f"tile_m must be 128, but got {tile_m}")
-    if tile_n not in [32, 64, 128]:
-        raise ValueError(f"tile_n must be one of 32, 64, 128, but got {tile_n}")
+    if tile_n not in [8, 16, 32, 64, 128]:
+        raise ValueError(f"tile_n must be one of 8, 16, 32, 64, 128, but got {tile_n}")
     if tile_k not in [128, 256]:
         raise ValueError(f"tile_k must be either 128 or 256, but got {tile_k}")
     if swap_ab not in [True, False]:
         raise ValueError(f"swap_ab must be a boolean value, but got {swap_ab}")
+    if tile_n == 8 and not swap_ab:
+        raise ValueError(
+            "tile_n=8 on SM120/121 is only supported with swap_ab=True "
+            "(the decode orientation Out^T = Weight^T Act^T)."
+        )
 
     # Determine out_dtype if not specified
     if out is None:
@@ -7276,7 +7286,7 @@ def group_gemm_nvfp4_nt_groupwise(
         The tile size for the M dimension, must be 128.
 
     tile_n: int
-        The tile size for the N dimension, must be 32, 64, or 128.
+        The tile size for the N dimension, must be 8, 16, 32, 64, or 128.
 
     tile_k: int
         The tile size for the K dimension, must be 128 or 256.

--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -211,6 +211,10 @@ def gen_gemm_sm120_module_cutlass_fp4() -> JitSpec:
         dtype_list = ["__nv_bfloat16", "half"]
         # SM120/121 tile configurations with implied 1x1x1 cluster shape
         cta_m_n_k_list = [
+            (128, 8, 128),
+            (128, 8, 256),
+            (128, 16, 128),
+            (128, 16, 256),
             (128, 32, 128),
             (128, 32, 256),
             (128, 64, 128),
@@ -415,6 +419,7 @@ def gen_gemm_sm120_module_cutlass_mxfp8() -> JitSpec:
         # SM120 tile configs matching CutlassTileConfigSM120 enum entries.
         # ClusterShape is always 1x1x1 for SM120 (no programmatic multicast).
         cta_m_n_k_list = [
+            (128, 16, 128),
             (128, 32, 128),
             (128, 64, 128),
             (128, 128, 128),

--- a/flashinfer/jit/gemm/cutlass/generate_kernels.py
+++ b/flashinfer/jit/gemm/cutlass/generate_kernels.py
@@ -760,6 +760,8 @@ def generate_sm120_grouped_gemm_operations(is_arch_enabled):
     quant_ops = [TrtLlm_QuantOp.none]
     epi_tags = [TrtLlm_EpilogueTag.epilogue_op_default]
     cta_shapes_mnk = [
+        [128, 16, 128],
+        [128, 16, 256],
         [128, 32, 128],
         [128, 32, 256],
         [128, 64, 128],
@@ -813,7 +815,12 @@ def generate_sm120_grouped_gemm_operations(is_arch_enabled):
 
         # Minimal filter: for mixed FP8xFP4 on SM120/SM121, only emit 128xNx128
         if act_type == DataType.e4m3 and weight_type == e2m1:
-            if cta_shape_mnk not in ([128, 32, 128], [128, 64, 128], [128, 128, 128]):
+            if cta_shape_mnk not in (
+                [128, 16, 128],
+                [128, 32, 128],
+                [128, 64, 128],
+                [128, 128, 128],
+            ):
                 continue
 
         otypes = [act_type]

--- a/include/flashinfer/gemm/cutlass_gemm_configs.h
+++ b/include/flashinfer/gemm/cutlass_gemm_configs.h
@@ -147,6 +147,10 @@ enum class CutlassTileConfigSM120 {
   // Signals that we should run heuristics do choose a config
   ChooseWithHeuristic,
 
+  CtaShape128x8x128B,
+  CtaShape128x8x64B,
+  CtaShape128x16x128B,
+  CtaShape128x16x64B,
   CtaShape128x32x128B,
   CtaShape128x32x64B,
   CtaShape128x64x128B,

--- a/include/flashinfer/gemm/fp4_gemm_cutlass_template_sm120.h
+++ b/include/flashinfer/gemm/fp4_gemm_cutlass_template_sm120.h
@@ -119,6 +119,14 @@ size_t dispatchNVFP4xNVFP4GemmCTAShapeSm120(T* D, void const* A, void const* B,
                                             cudaStream_t stream, int* occupancy = nullptr) {
   // Dispatch based on tile config and scheduler type
   switch (gemmConfig.tile_config_sm120) {
+    case CutlassTileConfigSM120::CtaShape128x8x64B:
+      DISPATCH_WITH_SCHEDULER(128, 8, 128);
+    case CutlassTileConfigSM120::CtaShape128x8x128B:
+      DISPATCH_WITH_SCHEDULER(128, 8, 256);
+    case CutlassTileConfigSM120::CtaShape128x16x64B:
+      DISPATCH_WITH_SCHEDULER(128, 16, 128);
+    case CutlassTileConfigSM120::CtaShape128x16x128B:
+      DISPATCH_WITH_SCHEDULER(128, 16, 256);
     case CutlassTileConfigSM120::CtaShape128x32x64B:
       DISPATCH_WITH_SCHEDULER(128, 32, 128);
     case CutlassTileConfigSM120::CtaShape128x32x128B:
@@ -189,6 +197,8 @@ std::vector<CutlassGemmConfig> CutlassFp4GemmRunner<T, fp4GemmType>::getConfigs(
 
   // All supported tile configurations for SM120
   std::vector<CutlassTileConfigSM120> tilesSm120 = {
+      CutlassTileConfigSM120::CtaShape128x8x64B,   CutlassTileConfigSM120::CtaShape128x8x128B,
+      CutlassTileConfigSM120::CtaShape128x16x64B,  CutlassTileConfigSM120::CtaShape128x16x128B,
       CutlassTileConfigSM120::CtaShape128x32x64B,  CutlassTileConfigSM120::CtaShape128x32x128B,
       CutlassTileConfigSM120::CtaShape128x64x64B,  CutlassTileConfigSM120::CtaShape128x64x128B,
       CutlassTileConfigSM120::CtaShape128x128x64B, CutlassTileConfigSM120::CtaShape128x128x128B,

--- a/include/flashinfer/gemm/fp4_gemm_template_sm120.h
+++ b/include/flashinfer/gemm/fp4_gemm_template_sm120.h
@@ -279,14 +279,11 @@ inline size_t runFp4GemmImpl(void* D, void const* A, void const* B, void const* 
     using Gemm = GemmDefault; /* Default alias for compatibility */                                                  \
   };                                                                                                                 \
                                                                                                                      \
-  /* Type aliases for DP and StreamK schedulers */                                                                   \
+  /* DP-scheduler type alias.  The _StreamK alias + launcher are defined by the separate          \
+     INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER_STREAMK macro. */                                         \
   using Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##SWAP_AB_ =                                                     \
       DeviceGemmFp4GemmSm120_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_##SWAP_AB_:: \
           GemmDefault;                                                                                               \
-                                                                                                                     \
-  using Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##SWAP_AB_##_StreamK =                                           \
-      DeviceGemmFp4GemmSm120_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_##SWAP_AB_:: \
-          GemmStreamK;                                                                                               \
                                                                                                                      \
   /* DP scheduler launcher - uses common helper functions */                                                         \
   template <>                                                                                                        \
@@ -304,9 +301,17 @@ inline size_t runFp4GemmImpl(void* D, void const* A, void const* B, void const* 
       return runFp4GemmImpl<Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,                       \
                                              batch_count, workspace, workspaceBytes, stream, "");                    \
     }                                                                                                                \
-  }                                                                                                                  \
+  }
+
+// StreamK scheduler launcher - separate macro.  MUST be invoked after
+// INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER(..., SWAP_AB_), which defines the
+// DeviceGemmFp4GemmSm120_... struct this macro takes ::GemmStreamK from.
+#define INSTANTIATE_FP4_GEMM_KERNEL_LAUNCHER_STREAMK(T, CTA_M_, CTA_N_, CTA_K_, CGA_M_, CGA_N_,                       \
+                                                     CGA_K_, XSM_, SWAP_AB_)                                          \
+  using Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##SWAP_AB_##_StreamK =                                           \
+      DeviceGemmFp4GemmSm120_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_##SWAP_AB_:: \
+          GemmStreamK;                                                                                               \
                                                                                                                      \
-  /* StreamK scheduler launcher - uses common helper functions */                                                    \
   template <>                                                                                                        \
   size_t genericFp4GemmKernelLauncherStreamK<                                                                        \
       T, cute::Int<CTA_M_>, cute::Int<CTA_N_>, cute::Int<CTA_K_>, cute::Int<CGA_M_>,                                 \

--- a/include/flashinfer/gemm/mxfp8_gemm_cutlass_template_sm120.h
+++ b/include/flashinfer/gemm/mxfp8_gemm_cutlass_template_sm120.h
@@ -50,6 +50,11 @@ size_t dispatchMXFP8xMXFP8GemmCTAShapeSm120(T* D, void const* A, void const* B,
                                             const size_t workspaceBytes, cudaStream_t stream,
                                             int* occupancy = nullptr) {
   switch (gemmConfig.tile_config_sm120) {
+    case CutlassTileConfigSM120::CtaShape128x16x128B:
+      return genericMxfp8GemmKernelLauncherSm120<T, cute::Int<128>, cute::Int<16>, cute::Int<128>,
+                                                 SwapAB>(D, A, B, input_sf, weight_sf, m, n, k,
+                                                         batch_count, gemmConfig, workspace,
+                                                         workspaceBytes, stream, occupancy);
     case CutlassTileConfigSM120::CtaShape128x32x128B:
       return genericMxfp8GemmKernelLauncherSm120<T, cute::Int<128>, cute::Int<32>, cute::Int<128>,
                                                  SwapAB>(D, A, B, input_sf, weight_sf, m, n, k,
@@ -135,9 +140,9 @@ class CutlassMxfp8GemmRunnerSm120 : public virtual CutlassMxfp8GemmRunnerInterfa
   std::vector<CutlassGemmConfig> getConfigs() const override {
     // SM120 MXFP8 tile configs.  No cluster shape variants (always 1x1x1).
     static const std::vector<CutlassTileConfigSM120> tiles = {
-        CutlassTileConfigSM120::CtaShape128x32x128B,  CutlassTileConfigSM120::CtaShape128x64x128B,
-        CutlassTileConfigSM120::CtaShape128x128x128B, CutlassTileConfigSM120::CtaShape256x128x128B,
-        CutlassTileConfigSM120::CtaShape128x256x128B,
+        CutlassTileConfigSM120::CtaShape128x16x128B,  CutlassTileConfigSM120::CtaShape128x32x128B,
+        CutlassTileConfigSM120::CtaShape128x64x128B,  CutlassTileConfigSM120::CtaShape128x128x128B,
+        CutlassTileConfigSM120::CtaShape256x128x128B, CutlassTileConfigSM120::CtaShape128x256x128B,
     };
     std::vector<CutlassGemmConfig> configs;
     configs.reserve(tiles.size());

--- a/tests/gemm/test_group_gemm_fp4.py
+++ b/tests/gemm/test_group_gemm_fp4.py
@@ -134,7 +134,7 @@ def test_group_gemm_nvfp4(
     out_ref = gemm_nvfp4_nt_groupwise_ref(a_float, b_float, out_dtype)
 
     for swap_ab in [True, False]:
-        for tile_n in [32, 64, 128]:
+        for tile_n in [16, 32, 64, 128]:
             for tile_k in [128, 256]:
                 out = group_gemm_nvfp4_nt_groupwise(
                     a_fp4,

--- a/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
+++ b/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
@@ -331,7 +331,7 @@ def test_mxfp8_mxfp4_groupwise_group_gemm(
     if compute_capability[0] == 12:
         mma_sm_list = [1]
         tile_m_list = [128]
-        tile_n_list = [32, 64, 128]
+        tile_n_list = [16, 32, 64, 128]
         tile_k_list = [128]
         swap_ab_list = [True, False]
     else:

--- a/tests/gemm/test_mm_mxfp8_sm120.py
+++ b/tests/gemm/test_mm_mxfp8_sm120.py
@@ -72,9 +72,10 @@ def test_mm_mxfp8_sm120_tactic_num():
 
     module = gen_gemm_sm120_module_cutlass_mxfp8().build_and_load()
     num_tactics = module.mxfp8_gemm_tactic_num()
-    # SM120 has 5 tile configs (128x32x128, 128x64x128, 128x128x128, 256x128x128, 128x256x128)
-    # and each config can swap AB to compute Output^T = Weight^T Activations^T
-    assert num_tactics == 10, f"Expected 10 tactics, got {num_tactics}"
+    # SM120 has 6 tile configs (128x16x128, 128x32x128, 128x64x128, 128x128x128,
+    # 256x128x128, 128x256x128) and each config can swap AB to compute
+    # Output^T = Weight^T Activations^T
+    assert num_tactics == 12, f"Expected 12 tactics, got {num_tactics}"
 
 
 def test_mm_mxfp8_sm120_auto_tactic():


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Note: it's intentionally not added for grouped GEMM to reduce complexity, since there is nearly no speedup (1-2%).
<img width="1300" height="1170" alt="image" src="https://github.com/user-attachments/assets/adf9fe6c-d77a-4a58-a3d3-89c2fec7b8a3" />


<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

https://github.com/NVIDIA/cutlass/pull/3292
<!-- Link any related issues here -->

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
