### PR TITLE
fix(quantization): `nvfp4_quantize(backend='cuda')` silently corrupts scale factors when global_scale is not float32

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.cpp
+++ b/csrc/nv_internal/tensorrt_llm/thop/fp4Quantize.cpp
@@ -43,7 +43,7 @@ void fp4_quantize(TensorView self, Optional<TensorView> const& globalScale, Tens
     TVM_FFI_ICHECK_EQ(sfVecSize, 32) << "sfVecSize can only be 32, when sfUseUE8M0 is true";
   } else {
     TVM_FFI_ICHECK(globalScale.has_value()) << "globalScale is required when sfUseUE8M0 is false";
-    // CHECK_INPUT_AND_TYPE(globalScale.value(), torch::kFloat32);
+    CHECK_INPUT_AND_TYPE(globalScale.value(), (DLDataType{kDLFloat, 32, 1}));
     TVM_FFI_ICHECK_EQ(sfVecSize, 16) << "sfVecSize can only be 16, when sfUseUE8M0 is false";
   }
 

--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -859,6 +859,10 @@ def fp4_quantize(
     assert input.shape[-1] % sf_vec_size == 0
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
+    # Kernel reads global_scale as float32; normalize so a bf16/fp16 scale isn't
+    # misread byte-wise into corrupt scale factors (issue #3398). No-op if float32.
+    if global_scale is not None and global_scale.dtype != torch.float32:
+        global_scale = global_scale.to(torch.float32)
     # get input device sm version
     major, minor = get_compute_capability(input.device)
     x_q, sf = get_fp4_quantization_module(f"{major}{minor}").fp4_quantize_sm100(

--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -838,6 +838,12 @@ def fp4_quantize(
     if sf_vec_size != 16 and sf_vec_size != 32:
         raise NotImplementedError("sf_vec_size can only be 16 or 32")
 
+    # The quantize kernel reads global_scale as float32 on input's device. Normalize
+    # so a bf16/fp16 or off-device scale isn't misread byte-wise / cross-device-read
+    # into corrupt scale factors. This is a no-op when already float32 on input.device.
+    if global_scale is not None:
+        global_scale = global_scale.to(device=input.device, dtype=torch.float32)
+
     if backend == "cute-dsl":
         return _fp4_quantize_cute_dsl(
             input,
@@ -859,10 +865,6 @@ def fp4_quantize(
     assert input.shape[-1] % sf_vec_size == 0
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    # Kernel reads global_scale as float32; normalize so a bf16/fp16 scale isn't
-    # misread byte-wise into corrupt scale factors (issue #3398). No-op if float32.
-    if global_scale is not None and global_scale.dtype != torch.float32:
-        global_scale = global_scale.to(torch.float32)
     # get input device sm version
     major, minor = get_compute_capability(input.device)
     x_q, sf = get_fp4_quantization_module(f"{major}{minor}").fp4_quantize_sm100(

--- a/tests/utils/test_fp4_quantize.py
+++ b/tests/utils/test_fp4_quantize.py
@@ -1503,5 +1503,61 @@ def test_silu_and_mul_scaled_nvfp4_experts_quantize(
         torch.testing.assert_close(scale_ref[: mask[i]], scale_ans[: mask[i]])
 
 
+@pytest.mark.parametrize("m", [128, 256, 384, 512, 1024, 1152, 2048])
+@pytest.mark.parametrize("scale_dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_nvfp4_quantize_global_scale_dtype_regression(m: int, scale_dtype: torch.dtype):
+    """Regression for issue #3398.
+
+    The CUDA nvfp4 quantize kernel reads `global_scale` as float32. A bf16/fp16
+    global scale (e.g. ``(448*6) / x.abs().max()`` inherits x's bf16 dtype) used to
+    be misread byte-wise, silently producing all-zero scale factors for a range of
+    M (e.g. 384..1024 at K=2048) and under-scaled values elsewhere. The Python
+    wrapper now normalizes the global scale to float32, so every dtype must produce
+    valid, correctly-scaled scale factors.
+
+    Guards against cosine-only checks: we assert (a) scale factors are NOT all-zero
+    and (b) the dequant magnitude matches the input (catches the under-scaling that
+    a cosine-only test misses).
+    """
+    device = torch.device("cuda")
+    if not _is_fp4_supported(device):
+        pytest.skip("Nvfp4 requires compute capability >= 10 and CUDA >= 12.8")
+    torch.manual_seed(0)
+    k = 2048
+    x = torch.randn(m, k, device=device, dtype=torch.bfloat16) * 5
+    # global scale deliberately built in `scale_dtype` (bf16 reproduces the bug)
+    global_scale = ((448.0 * 6.0) / x.abs().max()).to(scale_dtype)
+
+    fp4, sf = nvfp4_quantize(
+        x,
+        global_scale,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+        backend="cuda",
+    )
+    sf_u8 = sf.view(torch.uint8).reshape(-1)
+    assert (sf_u8 != 0).any(), (
+        f"All scale-factor bytes are zero for m={m}, scale_dtype={scale_dtype} "
+        "(issue #3398: global scale misread)."
+    )
+
+    # Round-trip and check magnitude (not just direction).
+    deq = e2m1_and_ufp8sf_scale_to_float(
+        fp4.cpu(),
+        sf_u8.cpu(),
+        (1.0 / global_scale.float()).reshape(1).cpu(),
+        sf_vec_size=16,
+        ufp8_type=1,
+        is_sf_swizzled_layout=True,
+    ).to(device)
+    xf = x.float()
+    mask = xf.abs() > 0.5
+    ratio = (deq[mask].abs() / xf[mask].abs()).median().item()
+    assert 0.5 < ratio < 2.0, (
+        f"Dequant magnitude off (median |deq/x|={ratio:.3f}) for m={m}, "
+        f"scale_dtype={scale_dtype} -- global scale not applied correctly."
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

### Summary
Fixes #3398. `flashinfer.mm_fp4` / `nvfp4_quantize` (cuda backend) silently produced **all-zero or magnitude-wrong outputs** for certain batch sizes M when global scales are not provided as bfloat16. The root cause in the issue is that the CUDA quantize kernel reads the global scale as `float32`, but callers commonly pass a **bfloat16** global scale — e.g. `(448 * 6) / x.abs().max()` inherits `x`'s bf16  dtype. The kernel then misreads it byte-wise, and a dtype guard that would have caught this was commented out.

The PR fixes the issue by converting non-fp32 global scale factors to fp32 and adding checks. Also adds unit tests.


## 🔍 Related Issues

<!-- Link any related issues here -->

#3398

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FP4 quantization now validates and normalizes the global scale so kernels always receive a float32 scale on the correct device, preventing mis-scaling or all-zero outputs when scale is bfloat16/float16 or on a different device.

* **Tests**
  * Added a regression test covering global-scale handling across bfloat16, float16, and float32.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->