### PR TITLE
fix intermittent exit 141 (SIGPIPE) in test resource summary

### DIFF
--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -701,7 +701,8 @@ print_top_resource_rows() {
     fi
 
     echo "$title"
-    printf '%s\n' "$rows" | sort -t $'\t' -k"${sort_column},${sort_column}nr" | head -10 | \
+    # Top 10 via awk (not `| head`), which would SIGPIPE `sort` and fail under pipefail.
+    printf '%s\n' "$rows" | sort -t $'\t' -k"${sort_column},${sort_column}nr" | \
         awk -F '\t' '
             function format_duration(seconds) {
                 seconds += 0
@@ -726,7 +727,7 @@ print_top_resource_rows() {
                 }
                 return sprintf("%d MiB", mib)
             }
-            {
+            NR <= 10 {
                 suffix = ($6 == "partial") ? " (partial)" : ""
                 printf "  %2d. %s - duration %s, peak RSS %s, peak GPU %s, samples %s%s\n",
                     NR, $5, format_duration($1), format_mib($2), format_mib($3), $4, suffix
@@ -807,9 +808,9 @@ sample_tests() {
 
     # Sample every Nth test with random offset
     SAMPLED_NODE_IDS=$(echo "$all_node_ids" | awk "NR % $SAMPLE_RATE == $SAMPLE_OFFSET")
-    # Fallback: if no tests sampled (offset missed all tests), take the first test
+    # Fallback to first test if none sampled (param expansion avoids `| head` SIGPIPE).
     if [ -z "$SAMPLED_NODE_IDS" ] || [ "$(echo "$SAMPLED_NODE_IDS" | wc -l)" -eq 0 ]; then
-        SAMPLED_NODE_IDS=$(echo "$all_node_ids" | head -1)
+        SAMPLED_NODE_IDS="${all_node_ids%%$'\n'*}"
     fi
 }
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

## 📌 Description

Full unit test runs (e.g. H100) intermittently failed with exit code 141 **even when all tests passed**, right after printing the "TEST RUN RESOURCE SUMMARY" tables. (The failed workflow job: https://github.com/flashinfer-ai/flashinfer/actions/runs/26796385673/job/78993606387 ) 

root cause:  `print_top_resource_rows` in `scripts/test_utils.sh` used `sort | head -10 | awk`. `head` closes the pipe after 10 lines, sending SIGPIPE to `sort`. Under the script's `set -eo pipefail`, that SIGPIPE (141) becomes the exit code of the whole run. Whether it triggers depends on a buffering/scheduling race between `sort` finishing its writes and `head` closing — hence the intermittency (different summary tables died on different runs; some runs passed entirely).

Fix: Move the "top 10" limit into awk (`NR <= 10`) and drop `head`, so awk reads  `sort`'s full output to EOF — the pipe never closes early and SIGPIPE cannot  occur. Output is unchanged.


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of test utility scripts to prevent failures during execution in certain conditions.
  * Fixed test selection fallback behavior to gracefully handle edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->