### PR TITLE
fix: use routedScalingFactor to initialize mRouteScale

### DIFF
--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -115,7 +115,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mPostprocessType = moe::dev::routing::RoutingPostprocessType::ScaledSumNormalize;
     routingData.mPtrRoutingBias = routingBias;
     routingData.mDtypeBias = dtypeBias;
-    routingData.mRouteScale = 1.0f;
+    routingData.mRouteScale = routedScalingFactor;
     routingData.mSumEpsilon = 1e-20f;
 
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -2005,11 +2005,11 @@ def routing_reference_sigmoid_renorm(
 
 
 def routing_reference_minimax2(
-    expert_logits, routing_bias, top_k, num_experts, padding
+    expert_logits, routing_bias, top_k, num_experts, padding, routed_scaling_factor
 ):
     """Sigmoid + Bias -> TopK -> ScaledSumNormalize routing reference (MiniMax2).
     Bias affects expert selection but NOT the final weights.
-    Weights = sigmoid(logit) / (sum_of_selected_sigmoid + 1e-20).
+    Weights = sigmoid(logit) / (sum_of_selected_sigmoid + 1e-20) * routed_scaling_factor.
     """
     sigmoid_scores = torch.sigmoid(expert_logits.float())
     selection_scores = sigmoid_scores.clone()
@@ -2020,6 +2020,8 @@ def routing_reference_minimax2(
     # Weights use un-biased sigmoid scores
     raw_weights = torch.gather(sigmoid_scores, -1, topk_idx)
     raw_weights = raw_weights / (raw_weights.sum(dim=-1, keepdim=True) + 1e-20)
+    if routed_scaling_factor is not None:
+        raw_weights = raw_weights * routed_scaling_factor
     raw_weights = raw_weights.to(expert_logits.dtype)
 
     scores = torch.zeros_like(sigmoid_scores, dtype=expert_logits.dtype)
@@ -2933,7 +2935,7 @@ def run_moe_test(
         )
     elif routing_method_type == RoutingMethodType.MiniMax2:
         permute_info, scores = routing_reference_minimax2(
-            expert_logits, routing_bias, top_k, num_experts, padding
+            expert_logits, routing_bias, top_k, num_experts, padding, routed_scaling
         )
     elif routing_method_type == RoutingMethodType.Sigmoid:
         permute_info, scores = routing_reference_sigmoid_renorm(
@@ -3219,7 +3221,29 @@ def run_moe_test(
                 "compatible_intermediate_size": [384, 768, 1024],
                 "enable_autotune": False,
             },
-            id="MiniMax2_256e_top6",
+            id="MiniMax2_256e_top6_no_scale",
+        ),
+        pytest.param(
+            {
+                "num_experts": 256,
+                "top_k": 6,
+                "padding": 8,
+                "n_groups": None,
+                "top_k_groups": None,
+                "routed_scaling": 3.0,
+                "has_routing_bias": True,
+                "routing_method_type": RoutingMethodType.MiniMax2,
+                "compatible_moe_impls": [
+                    FP8PerTensorMoe,
+                    FP8BlockScaleMoe,
+                    FP4Moe,
+                    BF16Moe,
+                    MxInt4BlockScaleMoe,
+                ],
+                "compatible_intermediate_size": [384, 768, 1024],
+                "enable_autotune": False,
+            },
+            id="MiniMax2_256e_top6_scale3",
         ),
     ],
 )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Use `routedScalingFactor` to initialize `mRouteScale` instead of hard-coding `1.0`.

If the passed-in `routedScalingFactor` is not used, the accuracy of models with `moe_router_scaling_factor` non-1.0 will be affected, such as Step-3.7.

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the MiniMax2 routing implementation to properly utilize the provided routed scaling factor parameter instead of relying on a hardcoded default value in calculations.

* **Tests**
  * Enhanced test coverage for the MiniMax2 routing method by adding new test cases that validate routed scaling factor functionality with various parameter configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->