### PR TITLE
[feat] Add gated tanh-GELU (GeluTanh) activation to CUTLASS fused MoE (GEMMA 4)

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -2122,7 +2122,7 @@ void doGatedActivation(ActivationOutputType* output, GemmOutputType const* gemm_
              : activation_type == ActivationType::Geglu
                  ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType,
                                             GLUAdaptor<cutlass::epilogue::thread::GELU>>
-             : activation_type == ActivationType::GeluTanh
+             : activation_type == ActivationType::GegluTanh
                  ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType,
                                             GLUAdaptor<cutlass::epilogue::thread::GELU_taylor>>
              : activation_type == ActivationType::SwigluBias
@@ -2369,7 +2369,7 @@ void doActivation(T* output, GemmOutputType const* gemm_result, float const* fp8
           &doActivationKernel<
               T, GemmOutputType, ScaleBiasType, GLUAdaptor<cutlass::epilogue::thread::GELU_taylor>,
               decltype(block_scaling_type)::value, decltype(disableFP4QuantFastMathTag)::value,
-              decltype(nvfp4_4over6_config_tag)>,  // GeluTanh
+              decltype(nvfp4_4over6_config_tag)>,  // GegluTanh
           &doActivationKernel<T, GemmOutputType, ScaleBiasType,
                               IdentityAdaptor<cutlass::epilogue::thread::Identity>,
                               decltype(block_scaling_type)::value,

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -2122,6 +2122,9 @@ void doGatedActivation(ActivationOutputType* output, GemmOutputType const* gemm_
              : activation_type == ActivationType::Geglu
                  ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType,
                                             GLUAdaptor<cutlass::epilogue::thread::GELU>>
+             : activation_type == ActivationType::GeluTanh
+                 ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType,
+                                            GLUAdaptor<cutlass::epilogue::thread::GELU_taylor>>
              : activation_type == ActivationType::SwigluBias
                  ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType, SwigluBiasAdaptor>
              : activation_type == ActivationType::SwigluStep
@@ -2363,6 +2366,10 @@ void doActivation(T* output, GemmOutputType const* gemm_result, float const* fp8
                               decltype(block_scaling_type)::value,
                               decltype(disableFP4QuantFastMathTag)::value,
                               decltype(nvfp4_4over6_config_tag)>,  // SwigluStep
+          &doActivationKernel<
+              T, GemmOutputType, ScaleBiasType, GLUAdaptor<cutlass::epilogue::thread::GELU_taylor>,
+              decltype(block_scaling_type)::value, decltype(disableFP4QuantFastMathTag)::value,
+              decltype(nvfp4_4over6_config_tag)>,  // GeluTanh
           &doActivationKernel<T, GemmOutputType, ScaleBiasType,
                               IdentityAdaptor<cutlass::epilogue::thread::Identity>,
                               decltype(block_scaling_type)::value,

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/common.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/common.h
@@ -28,6 +28,7 @@ enum class ActivationType {
   SwigluBias,
   Relu2,
   SwigluStep,
+  GeluTanh,
   Identity,
   InvalidType
 };

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/common.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/common.h
@@ -28,7 +28,7 @@ enum class ActivationType {
   SwigluBias,
   Relu2,
   SwigluStep,
-  GeluTanh,
+  GegluTanh,
   Identity,
   InvalidType
 };

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
@@ -237,7 +237,8 @@ struct TmaWarpSpecializedGroupedGemmInput {
 constexpr bool isGatedActivation(ActivationType activation_type) {
   return activation_type == ActivationType::Swiglu || activation_type == ActivationType::Geglu ||
          activation_type == ActivationType::SwigluBias ||
-         activation_type == ActivationType::SwigluStep;
+         activation_type == ActivationType::SwigluStep ||
+         activation_type == ActivationType::GeluTanh;
 }
 
 template <typename T,                          /*The type used for activations/scales/compute*/

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h
@@ -238,7 +238,7 @@ constexpr bool isGatedActivation(ActivationType activation_type) {
   return activation_type == ActivationType::Swiglu || activation_type == ActivationType::Geglu ||
          activation_type == ActivationType::SwigluBias ||
          activation_type == ActivationType::SwigluStep ||
-         activation_type == ActivationType::GeluTanh;
+         activation_type == ActivationType::GegluTanh;
 }
 
 template <typename T,                          /*The type used for activations/scales/compute*/

--- a/flashinfer/tllm_enums.py
+++ b/flashinfer/tllm_enums.py
@@ -44,7 +44,7 @@ class ActivationType(IntEnum):
     SwigluBias = 5
     Relu2 = 6
     SwigluStep = 7
-    GeluTanh = 8
+    GegluTanh = 8
     Identity = 9
     InvalidType = 10
 

--- a/flashinfer/tllm_enums.py
+++ b/flashinfer/tllm_enums.py
@@ -44,8 +44,9 @@ class ActivationType(IntEnum):
     SwigluBias = 5
     Relu2 = 6
     SwigluStep = 7
-    Identity = 8
-    InvalidType = 9
+    GeluTanh = 8
+    Identity = 9
+    InvalidType = 10
 
     # Eval-safe repr — see ``RoutingMethodType.__repr__``.
     def __repr__(self) -> str:

--- a/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/include/flashinfer/trtllm/fused_moe/runner.h
@@ -166,8 +166,9 @@ enum class ActivationType : int64_t {
   SwigluBias = 5,
   Relu2 = 6,
   SwigluStep = 7,
-  Identity = 8,
-  InvalidType = 9,  // Must be last
+  GeluTanh = 8,
+  Identity = 9,
+  InvalidType = 10,  // Must be last
 };
 
 inline std::string serializeActivationType(ActivationType activationType) {
@@ -190,6 +191,8 @@ inline std::string serializeActivationType(ActivationType activationType) {
       return "Identity";
     case ActivationType::SwigluStep:
       return "SwigluStep";
+    case ActivationType::GeluTanh:
+      return "GeluTanh";
     default:
       return "InvalidActivationType";  // TODO throw error
   };
@@ -198,7 +201,7 @@ inline std::string serializeActivationType(ActivationType activationType) {
 inline bool isGatedActivation(ActivationType activationType) {
   return activationType == ActivationType::Swiglu || activationType == ActivationType::Geglu ||
          activationType == ActivationType::SwigluBias ||
-         activationType == ActivationType::SwigluStep;
+         activationType == ActivationType::SwigluStep || activationType == ActivationType::GeluTanh;
 }
 
 }  // namespace MoE

--- a/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/include/flashinfer/trtllm/fused_moe/runner.h
@@ -166,7 +166,7 @@ enum class ActivationType : int64_t {
   SwigluBias = 5,
   Relu2 = 6,
   SwigluStep = 7,
-  GeluTanh = 8,
+  GegluTanh = 8,
   Identity = 9,
   InvalidType = 10,  // Must be last
 };
@@ -191,8 +191,8 @@ inline std::string serializeActivationType(ActivationType activationType) {
       return "Identity";
     case ActivationType::SwigluStep:
       return "SwigluStep";
-    case ActivationType::GeluTanh:
-      return "GeluTanh";
+    case ActivationType::GegluTanh:
+      return "GegluTanh";
     default:
       return "InvalidActivationType";  // TODO throw error
   };
@@ -201,7 +201,8 @@ inline std::string serializeActivationType(ActivationType activationType) {
 inline bool isGatedActivation(ActivationType activationType) {
   return activationType == ActivationType::Swiglu || activationType == ActivationType::Geglu ||
          activationType == ActivationType::SwigluBias ||
-         activationType == ActivationType::SwigluStep || activationType == ActivationType::GeluTanh;
+         activationType == ActivationType::SwigluStep ||
+         activationType == ActivationType::GegluTanh;
 }
 
 }  // namespace MoE

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -445,6 +445,93 @@ def test_moe(
     torch.testing.assert_close(ref_output, flash_output[0], rtol=1e-2, atol=1e-2)
 
 
+def compute_with_experts_gelu_tanh(
+    num_experts,
+    x,
+    w31_weight,
+    w2_weight,
+    selected_experts,
+    routing_weights,
+):
+    """Reference for gated tanh-GELU MoE.
+
+    Mirrors ``compute_with_experts`` (the SwiGLU reference) exactly, including
+    the gated weight split convention: ``w31`` is split along dim 0 into
+    ``(w3, w1)`` where ``w3`` is the first half and ``w1`` is the second half.
+    The gate branch (``w1``) is activated and multiplied by the linear branch
+    (``w3``). The only difference vs SwiGLU is the activation:
+    ``F.gelu(gate, approximate="tanh")`` instead of ``F.silu(gate)``.
+    """
+    results = torch.zeros_like(x)
+    for expert_id in range(num_experts):
+        mask = selected_experts == expert_id
+        if not mask.sum():
+            continue
+        batch_idx, nth_expert = torch.where(mask)
+        w31_expert = w31_weight[expert_id]  # [2 * intermediate_size, hidden_size]
+        w2_expert = w2_weight[expert_id]  # [hidden_size, intermediate_size]
+
+        # Same split as compute_with_experts: w3 = first half, w1 = second half.
+        w3_expert, w1_expert = torch.chunk(w31_expert, 2, dim=0)
+
+        expert_inputs = x[batch_idx]
+        gate = expert_inputs @ w1_expert.t()
+        linear = expert_inputs @ w3_expert.t()
+        inter = F.gelu(gate, approximate="tanh") * linear
+        output = inter @ w2_expert.t()
+        results[batch_idx] += routing_weights[batch_idx, nth_expert, None] * output
+    return results.view_as(x)
+
+
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("num_experts", NUM_EXPERTS)
+@pytest.mark.parametrize("top_k", TOP_K_VALUES)
+@pytest.mark.parametrize("intermediate_size", INTERMEDIATE_SIZES)
+def test_moe_gelu_tanh(batch_size, hidden_size, num_experts, top_k, intermediate_size):
+    """Gated tanh-GELU activation (ActivationType.GeluTanh) on the bf16 CUTLASS
+    MoE path. Same shapes / weight-split convention as the SwiGLU ``test_moe``,
+    but activation = GELU_tanh(gate) * linear, compared against a torch
+    ``F.gelu(..., approximate="tanh")`` gated reference.
+    """
+    # Skip invalid configurations
+    if top_k > num_experts:
+        pytest.skip(
+            f"top_k ({top_k}) cannot be greater than num_experts ({num_experts})"
+        )
+
+    torch.manual_seed(42)
+    dtype = torch.bfloat16
+    x = torch.randn(batch_size, hidden_size, dtype=dtype).cuda() / 5
+    router_logits = torch.randn(batch_size, num_experts, dtype=torch.float32).cuda()
+    w31_weight = (
+        torch.randn(num_experts, 2 * intermediate_size, hidden_size, dtype=dtype).cuda()
+        / 5
+    )
+    w2_weight = (
+        torch.randn(num_experts, hidden_size, intermediate_size, dtype=dtype).cuda() / 5
+    )
+
+    routing_weights, selected_experts = compute_routing(router_logits, top_k)
+    ref_output = compute_with_experts_gelu_tanh(
+        num_experts, x, w31_weight, w2_weight, selected_experts, routing_weights
+    )
+    flash_output = torch.empty_like(ref_output)
+    flash_output = fused_moe.cutlass_fused_moe(
+        x,
+        selected_experts.to(torch.int),
+        routing_weights,
+        w31_weight,
+        w2_weight,
+        flash_output.dtype,
+        output=flash_output,
+        quant_scales=None,
+        activation_type=ActivationType.GeluTanh,
+    )
+
+    torch.testing.assert_close(ref_output, flash_output[0], rtol=1e-2, atol=1e-2)
+
+
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
 @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
 @pytest.mark.parametrize("num_experts", NUM_EXPERTS)

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -489,7 +489,7 @@ def compute_with_experts_gelu_tanh(
 @pytest.mark.parametrize("top_k", TOP_K_VALUES)
 @pytest.mark.parametrize("intermediate_size", INTERMEDIATE_SIZES)
 def test_moe_gelu_tanh(batch_size, hidden_size, num_experts, top_k, intermediate_size):
-    """Gated tanh-GELU activation (ActivationType.GeluTanh) on the bf16 CUTLASS
+    """Gated tanh-GELU activation (ActivationType.GegluTanh) on the bf16 CUTLASS
     MoE path. Same shapes / weight-split convention as the SwiGLU ``test_moe``,
     but activation = GELU_tanh(gate) * linear, compared against a torch
     ``F.gelu(..., approximate="tanh")`` gated reference.
@@ -526,7 +526,7 @@ def test_moe_gelu_tanh(batch_size, hidden_size, num_experts, top_k, intermediate
         flash_output.dtype,
         output=flash_output,
         quant_scales=None,
-        activation_type=ActivationType.GeluTanh,
+        activation_type=ActivationType.GegluTanh,
     )
 
     torch.testing.assert_close(ref_output, flash_output[0], rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
Add ActivationType::GeluTanh (gated, GLUAdaptor<cutlass::epilogue::thread::GELU_taylor>) so gemma-style gated gelu_pytorch_tanh MoE can run on the FlashInfer CUTLASS backend. Reuses CUTLASS's existing GELU_taylor (tanh-approx) functor; the activation is a standalone kernel (not a GEMM epilogue), so the change is small and append-safe.

- enum: common.h, runner.h (+serialize +isGatedActivation), moe_gemm_kernels.h
- dispatch: doGatedActivation ternary + index-keyed fn_list in cutlass_fused_moe_kernels.cuh -> GLUAdaptor<GELU_taylor>
- python: flashinfer/tllm_enums.py
- test: test_moe_gelu_tanh + gated F.gelu(approximate="tanh") reference

Validated on H200 (bf16, SM90): test_moe_gelu_tanh passes at rtol/atol 1e-2, alongside the existing SwiGLU test_moe (non-breaking).

<!-- .github/pull_request_template.md -->

## 📌 Description


# TEP4 (TP4 + EP4, 4x H200) — same sweep

VLLM, ISL=1600 / OSL=600, conc 1->256, bf16, 4x H200 (TP4 EP4)
- Triton -> `Using TRITON Unquantized MoE backend` 
- FI     -> `--moe-backend flashinfer_cutlass` -> `Using FlashInfer CUTLASS Unquantized MoE backend` (GeluTanh)

| conc | Tri OTPS | Tri OTPS/u | Tri TTFT(ms) | Tri ITL(ms) | FI OTPS | FI OTPS/u | FI TTFT(ms) | FI ITL(ms) | FI vs Tri OTPS |
|-----:|---------:|-----------:|-------------:|------------:|--------:|----------:|------------:|-----------:|---------------:|
| 1    | 237.4    | 237.4      | 45.1         | 4.14        | 234.0   | 234.0     | 41.6        | 4.21       | -1.4%          |
| 2    | 433.7    | 216.8      | 104.8        | 4.45        | 454.5   | 227.2     | 50.9        | 4.32       | +4.8%          |
| 4    | 797.9    | 199.5      | 147.1        | 4.77        | 824.5   | 206.1     | 76.9        | 4.73       | +3.3%          |
| 8    | 1455.4   | 181.9      | 118.9        | 5.31        | 1471.2  | 183.9     | 113.6       | 5.26       | +1.1%          |
| 16   | 2496.2   | 156.0      | 178.7        | 6.12        | 2488.0  | 155.5     | 177.7       | 6.14       | -0.3%          |
| 32   | 4046.2   | 126.4      | 276.6        | 7.46        | 4127.8  | 129.0     | 291.3       | 7.27       | +2.0%          |
| 64   | 6127.6   | 95.7       | 404.1        | 9.79        | 6324.9  | 98.8      | 364.1       | 9.56       | +3.2%          |
| 128  | 8965.2   | 70.0       | 434.1        | 13.57       | 9007.4  | 70.4      | 434.3       | 13.50      | +0.5%          |
| 256  | 11263.6  | 44.0       | 696.5        | 21.56       | 11258.5 | 44.0      | 726.4       | 21.53      | -0.0%          |

OTPS = total tok/s across 4 GPUs (OTPS/gpu = OTPS/4); OTPS/u = per-user.


## Accuracy gsm8k (exact_match, ±0.0137)

| TP | max_seq_len | MoE backend                    | flexible-extract | strict-match |
|----|-------------|--------------------------------|------------------|--------------|
| 4  | 8192        | TRITON (default)               | 0.4367           | 0.4276       |
| 4  | 8192        | FlashInfer CUTLASS (GeluTanh)  | 0.4564           | 0.4450       |
| 1  | 8192        | TRITON (default)               | 0.4412           | 0.4291       |
| 1  | 8192        | FlashInfer CUTLASS (GeluTanh)  | 0.4428           | 0.4382       |
| 1  | 32768       | TRITON (default)               | 0.4466           | 0.4412       |
| 1  | 32768       | FlashInfer CUTLASS (GeluTanh)  | 0.4519           | 0.4382       |

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GeluTanh activation for Mixture-of-Experts models — selectable at runtime and treated as a gated activation.

* **Tests**
  * Added a bf16 reference implementation and parameterized tests to validate GeluTanh behavior and numerical correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->