### PR TITLE
Validate custom-mask length in prefill plan

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1409,6 +1409,38 @@ def _compute_page_mask_indptr(
     return mask_indptr
 
 
+def _compute_packed_mask_length(mask_indptr: torch.Tensor) -> int:
+    segment_lens = mask_indptr[1:] - mask_indptr[:-1]
+    return int(torch.sum((segment_lens + 7) // 8).item())
+
+
+def _check_custom_mask_length(
+    custom_mask: Optional[torch.Tensor],
+    packed_custom_mask: Optional[torch.Tensor],
+    mask_indptr: torch.Tensor,
+) -> None:
+    if packed_custom_mask is not None:
+        expected_packed_len = _compute_packed_mask_length(mask_indptr)
+        actual_packed_len = packed_custom_mask.numel()
+        if actual_packed_len != expected_packed_len:
+            raise ValueError(
+                "The packed_custom_mask length should match the derived packed "
+                "custom-mask span, expected {}, got {}.".format(
+                    expected_packed_len, actual_packed_len
+                )
+            )
+        return
+
+    if custom_mask is not None:
+        expected_mask_len = int(mask_indptr[-1].item())
+        actual_mask_len = custom_mask.numel()
+        if actual_mask_len != expected_mask_len:
+            raise ValueError(
+                "The custom_mask length should match the derived custom-mask span, "
+                "expected {}, got {}.".format(expected_mask_len, actual_mask_len)
+            )
+
+
 class BatchPrefillWithPagedKVCacheWrapper:
     r"""Wrapper class for prefill/append attention with paged kv-cache for batch of
     requests.
@@ -1892,6 +1924,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 paged_kv_last_page_len,
                 page_size,
             )
+            _check_custom_mask_length(custom_mask, packed_custom_mask, mask_indptr)
         if packed_custom_mask is None and custom_mask is not None:
             # create packed custom mask from custom mask
             packed_custom_mask, mask_indptr = segment_packbits(
@@ -2972,6 +3005,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             )
         if custom_mask is not None or packed_custom_mask is not None:
             mask_indptr = _compute_mask_indptr(qo_indptr, kv_indptr)
+            _check_custom_mask_length(custom_mask, packed_custom_mask, mask_indptr)
         if packed_custom_mask is None and custom_mask is not None:
             # create packed custom mask from custom mask
             packed_custom_mask, mask_indptr = segment_packbits(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1410,6 +1410,7 @@ def _compute_page_mask_indptr(
 
 
 def _compute_packed_mask_length(mask_indptr: torch.Tensor) -> int:
+    """Return the number of bytes required for a segmented packed custom mask."""
     segment_lens = mask_indptr[1:] - mask_indptr[:-1]
     return int(torch.sum((segment_lens + 7) // 8).item())
 
@@ -1419,6 +1420,7 @@ def _check_custom_mask_length(
     packed_custom_mask: Optional[torch.Tensor],
     mask_indptr: torch.Tensor,
 ) -> None:
+    """Validate custom-mask storage length against derived per-request spans."""
     if packed_custom_mask is not None:
         expected_packed_len = _compute_packed_mask_length(mask_indptr)
         actual_packed_len = packed_custom_mask.numel()
@@ -2571,6 +2573,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
 def _compute_mask_indptr(
     qo_indptr: torch.Tensor, kv_indptr: torch.Tensor
 ) -> torch.Tensor:
+    """Return flattened custom-mask offsets for ragged qo and kv batches."""
     if len(qo_indptr) != len(kv_indptr):
         raise ValueError("The length of qo_indptr and kv_indptr should be the same.")
     mask_indptr = torch.empty_like(qo_indptr)

--- a/tests/attention/test_custom_mask_contract.py
+++ b/tests/attention/test_custom_mask_contract.py
@@ -1,0 +1,61 @@
+import unittest
+
+import torch
+
+from flashinfer.prefill import (
+    _check_custom_mask_length,
+    _compute_mask_indptr,
+    _compute_page_mask_indptr,
+    _compute_packed_mask_length,
+)
+
+
+class TestCustomMaskContract(unittest.TestCase):
+    def testPagedCustomMaskLengthMatchesDerivedSpan(self):
+        qo_indptr = torch.tensor([0, 2, 5], dtype=torch.int32)
+        paged_kv_indptr = torch.tensor([0, 1, 3], dtype=torch.int32)
+        paged_kv_last_page_len = torch.tensor([4, 2], dtype=torch.int32)
+
+        mask_indptr = _compute_page_mask_indptr(
+            qo_indptr,
+            paged_kv_indptr,
+            paged_kv_last_page_len,
+            page_size=4,
+        )
+
+        self.assertEqual([0, 8, 26], mask_indptr.tolist())
+        _check_custom_mask_length(torch.ones(26, dtype=torch.bool), None, mask_indptr)
+
+        with self.assertRaisesRegex(ValueError, "custom_mask length"):
+            _check_custom_mask_length(
+                torch.ones(25, dtype=torch.bool), None, mask_indptr
+            )
+
+    def testPagedPackedCustomMaskLengthMatchesSegmentPackedSpan(self):
+        mask_indptr = torch.tensor([0, 8, 26], dtype=torch.int32)
+
+        self.assertEqual(4, _compute_packed_mask_length(mask_indptr))
+        _check_custom_mask_length(None, torch.ones(4, dtype=torch.uint8), mask_indptr)
+
+        with self.assertRaisesRegex(ValueError, "packed_custom_mask length"):
+            _check_custom_mask_length(
+                None, torch.ones(3, dtype=torch.uint8), mask_indptr
+            )
+
+    def testRaggedCustomMaskLengthMatchesDerivedSpan(self):
+        qo_indptr = torch.tensor([0, 2, 5], dtype=torch.int32)
+        kv_indptr = torch.tensor([0, 4, 10], dtype=torch.int32)
+
+        mask_indptr = _compute_mask_indptr(qo_indptr, kv_indptr)
+
+        self.assertEqual([0, 8, 26], mask_indptr.tolist())
+        _check_custom_mask_length(torch.ones(26, dtype=torch.bool), None, mask_indptr)
+
+        with self.assertRaisesRegex(ValueError, "custom_mask length"):
+            _check_custom_mask_length(
+                torch.ones(27, dtype=torch.bool), None, mask_indptr
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 Description

This PR adds a small `plan()`-time validation for prefill `custom_mask` and
`packed_custom_mask` inputs.

For raw `custom_mask`, the wrapper now checks that the number of mask elements
matches the derived logical mask span from `mask_indptr`.

For `packed_custom_mask`, the wrapper now checks that the byte count matches the
sum of per-request packed mask spans.

The check is applied in both:

- `BatchPrefillWithPagedKVCacheWrapper.plan`
- `BatchPrefillWithRaggedKVCacheWrapper.plan`

The prefill wrappers already derive `mask_indptr` from request metadata before
the mask is cached and passed to the compiled attention path. If a caller
provides a raw or packed custom mask whose length does not match that derived
span, the mismatch can be reported earlier and more clearly at `plan()` time.

This is a wrapper-level input validation improvement. It does not replace the
CUDA `LogitsMask` guard for kernel-internal `qo_idx` / `kv_idx` coordinates.

## 🔍 Related Issues

Related to https://github.com/flashinfer-ai/flashinfer/issues/1005 and
https://github.com/flashinfer-ai/flashinfer/pull/1008.

This PR does not replace the kernel-side fix from #1008. It adds an earlier
Python wrapper validation for inconsistent custom-mask lengths.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New unit tests:

```bash
conda run -n torch-opcheck python -m unittest tests.attention.test_custom_mask_contract
```

Observed result:

```text
Ran 3 tests in 0.004s
OK
```

Selected existing custom-mask runtime tests:

```bash
conda run -n torch-opcheck pytest -q \
  'tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_with_paged_kv_cache_custom_mask[True-True-0.0-NONE-NHD-128-4-4-1-37-54-12]' \
  'tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_with_ragged_kv_cache_custom_mask[True-0.0-NONE-128-4-4-37-54-12]'
```

Observed result:

```text
2 passed in 42.72s
```

Environment notes:

```bash
git submodule update --init --recursive
python -m pip install pytest
python -m pip install --no-build-isolation -e . -v
python -m pip install pre-commit
pre-commit install
pre-commit run --all-files
```

Observed pre-commit result after applying `ruff format` changes:

```text
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
fix requirements.txt.....................................................Passed
trim trailing whitespace.................................................Passed
Tabs remover.............................................................Passed
CRLF end-lines remover...................................................Passed
clang-format.............................................................Passed
mypy.....................................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
```

## Reviewer Notes

This PR is intentionally narrow. It validates mask length consistency at the
Python wrapper boundary and does not claim to validate all custom-mask semantic
properties.

The related upstream fix #1008 added a CUDA-side guard in
`include/flashinfer/attention/variants.cuh`: when `qo_idx >= qo_len` or
`kv_idx >= kv_len`, the logits mask returns false instead of computing
`custom_mask_ptr[offset / 8]`. This PR is complementary and checks the wrapper
input length before the packed mask reaches that kernel path.

The patch adds:

```python
def _compute_packed_mask_length(mask_indptr: torch.Tensor) -> int:
    segment_lens = mask_indptr[1:] - mask_indptr[:-1]
    return int(torch.sum((segment_lens + 7) // 8).item())


def _check_custom_mask_length(
    custom_mask: Optional[torch.Tensor],
    packed_custom_mask: Optional[torch.Tensor],
    mask_indptr: torch.Tensor,
) -> None:
    ...
```

and calls `_check_custom_mask_length(...)` after `mask_indptr` is derived.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tightened validation of custom attention masks (boolean and packed) during prefill so mismatched lengths are detected early with clear error messages.

* **Tests**
  * Added unit tests covering mask-length contracts across paged and ragged KV cache layouts to ensure correct acceptance/rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->