### PR TITLE
test: correct XQA NVFP4 skip reason to SM120/SM121  

### DIFF
--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -581,7 +581,7 @@ def test_xqa_batch_decode(
 
 @pytest.mark.skipif(
     get_compute_capability(torch.device(device="cuda"))[0] not in [12],
-    reason="XQA with NVFP4 KV is only supported on SM120 GPUs",
+    reason="XQA with NVFP4 KV is only supported on SM120/SM121 GPUs",
 )
 @pytest.mark.parametrize(
     "batch_size,q_len_per_req,page_size,num_kv_heads,head_grp_size",


### PR DESCRIPTION
The skipif predicate on test_xqa_batch_decode_nvfp4_kv covers all SM12x GPUs, but the reason string only mentioned SM120. This updates the wording to match.
Verified on SM121 (DGX Spark, GB10): the test now executes (instead of skipping on non-SM12x hardware) and all 6 parametrize variants pass.
Follows #3170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GPU support configuration for batch decode tests to include SM121 GPU architecture alongside SM120.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->