### PR TITLE
FMHAv2 on SM120 for head_dim 256/512 + sliding-window masks

### DIFF
--- a/csrc/fmha_v2/templates/fa_kernel.jinja
+++ b/csrc/fmha_v2/templates/fa_kernel.jinja
@@ -157,6 +157,26 @@ using Kernel_traits_nl_causal = fmha::{{ kernel_traits }}<
 static_assert(Kernel_traits_nl_causal::CTAS_PER_HEAD == 1, "");
 static_assert(Kernel_traits_nl_causal::MASK_VERSION == 3, "");
 
+{% if sliding_or_chunked_causal_mask == "1" %}
+// MASK_VERSION 4 = sliding-or-chunked causal. Shared by the non-tiled (_nl) and
+// non-reload tiled (_nl_tiled else-branch) launchers; without it both route
+// SLIDING_OR_CHUNKED_CAUSAL to the maskless (dense) kernel.
+using Kernel_traits_nl_sliding_or_chunked = fmha::{{ kernel_traits }}<
+    fmha::{{ instruction_traits }},
+    {{ kv_loop_step }},
+    {{ head_size }},
+    {{ head_size_v }},
+    {{ noloop_step }},
+    1,
+    {{ warps_m }} * {{ warps_n }},
+    {{ ctas_per_head }},
+    {{ kernel_flags }} | 0x200 /* no_loop flag */,
+    /*sliding-or-chunked-causal mask*/ 4>;
+
+static_assert(Kernel_traits_nl_sliding_or_chunked::CTAS_PER_HEAD == 1, "");
+static_assert(Kernel_traits_nl_sliding_or_chunked::MASK_VERSION == 4, "");
+{% endif %}
+
 extern "C"
 __global__
 void {{ kernel_name }}_nl({{ params_type }} params){
@@ -177,6 +197,18 @@ void {{ causal_kernel_name }}_nl({{ params_type }} params){
 {% endif %}
 }
 
+{% if sliding_or_chunked_causal_mask == "1" %}
+extern "C"
+__global__
+void {{ sliding_or_chunked_causal_kernel_name }}_nl({{ params_type }} params){
+{% if kernel_variant == "flash_attention" %}
+  fused_multihead_attention::device_flash_attention_nl<Kernel_traits_nl_sliding_or_chunked>(params);
+{% else %}
+  fused_multihead_attention::device_1xN_nl<Kernel_traits_nl_sliding_or_chunked>(params);
+{% endif %}
+}
+{% endif %}
+
 void {{ launcher_name }}_nl(
     const {{ params_type }} &params,
     const Launch_params &launch_params,
@@ -193,6 +225,16 @@ void {{ launcher_name }}_nl(
                                             smem_size));
     }
     {{ causal_kernel_name }}_nl<<<grid, Kernel_traits_nl_causal::THREADS, Kernel_traits_nl_causal::BYTES_PER_SMEM, stream>>>(params);
+{% if sliding_or_chunked_causal_mask == "1" %}
+  } else if( launch_params.attention_mask_type == Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL ) {
+    constexpr int smem_size = Kernel_traits_nl_sliding_or_chunked::BYTES_PER_SMEM;
+    if( smem_size >= 48*1024 ) {
+        FMHA_CHECK_CUDA(cudaFuncSetAttribute({{ sliding_or_chunked_causal_kernel_name }}_nl,
+                                            cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                            smem_size));
+    }
+    {{ sliding_or_chunked_causal_kernel_name }}_nl<<<grid, Kernel_traits_nl_sliding_or_chunked::THREADS, Kernel_traits_nl_sliding_or_chunked::BYTES_PER_SMEM, stream>>>(params);
+{% endif %}
   } else {
     constexpr int smem_size = Kernel_traits_nl::BYTES_PER_SMEM;
     if( smem_size >= 48*1024 ) {
@@ -241,6 +283,26 @@ using Kernel_traits_nl_tiled_causal = fmha::{{ kernel_traits }}<
 static_assert(Kernel_traits_nl_tiled_causal::CTAS_PER_HEAD == 1, "");
 static_assert(Kernel_traits_nl_tiled_causal::MASK_VERSION == 3, "");
 
+{% if sliding_or_chunked_causal_mask == "1" %}
+// MASK_VERSION 4 = sliding-or-chunked causal (CAUSAL_MASK && SLIDING_WINDOW_ATTENTION).
+// Without this variant the tiled-noloop launcher routes SLIDING_OR_CHUNKED_CAUSAL
+// requests to the maskless (dense) kernel, silently producing bidirectional output.
+using Kernel_traits_nl_tiled_sliding_or_chunked = fmha::{{ kernel_traits }}<
+    fmha::{{ instruction_traits }},
+    {{ kv_loop_step }},
+    {{ head_size }},
+    {{ head_size_v }},
+    {{ noloop_step }},
+    {{ warps_m }},
+    {{ warps_n }},
+    {{ ctas_per_head }},
+    {{ kernel_flags }} | 0x200 /* no_loop flag */,
+    /*sliding-or-chunked-causal mask*/ 4>;
+
+static_assert(Kernel_traits_nl_tiled_sliding_or_chunked::CTAS_PER_HEAD == 1, "");
+static_assert(Kernel_traits_nl_tiled_sliding_or_chunked::MASK_VERSION == 4, "");
+{% endif %}
+
 {% else %} // !reload_q
 // Tiled (granular) variant: uses the same Kernel_traits_nl with USE_GRANULAR_TILING
 // in the flags for correct tile decomposition (CTA_O_TILE_K computed from K_PER_MMA
@@ -276,6 +338,18 @@ void {{ causal_kernel_name }}_nl_tiled({{ params_type }} params){
 {% endif %}
 }
 
+{% if kernel_variant == "flash_attention" and sliding_or_chunked_causal_mask == "1" %}
+extern "C"
+__global__
+void {{ sliding_or_chunked_causal_kernel_name }}_nl_tiled({{ params_type }} params){
+{% if reload_q %}
+  fused_multihead_attention::device_flash_attention_nl_tiled<Kernel_traits_nl_tiled_sliding_or_chunked>(params);
+{% else %}
+  fused_multihead_attention::device_flash_attention_nl<Kernel_traits_nl_sliding_or_chunked>(params);
+{% endif %}
+}
+{% endif %}
+
 void {{ launcher_name }}_nl_tiled(
     const {{ params_type }} &params,
     const Launch_params &launch_params,
@@ -283,7 +357,22 @@ void {{ launcher_name }}_nl_tiled(
 
   // Runtime loop_iters: flash attention supports variable sequence lengths.
   int loop_iters = ( params.s + {{ noloop_step }} - 1 )  / {{ noloop_step }};
-  dim3 grid(loop_iters, params.h, params.b); // better locality
+  // When the V/output head dim exceeds the per-CTA output tile (CTA_O_TILE_N, capped at
+  // 256 for granular tiling), the kernel splits the output feature dimension across
+  // ctas_per_o_row CTAs (kernel: q_loop = blockIdx.x / ctas_per_o_row,
+  // o_part = blockIdx.x % ctas_per_o_row). Each CTA recomputes BMM1+softmax and writes a
+  // disjoint slice of O (no cross-CTA reduction), so grid.x must include this factor.
+  // For head dims <= 256 this is 1, leaving existing kernels unchanged.
+{% if reload_q %}
+  constexpr int ctas_per_o_row =
+      ( (int)Kernel_traits_nl_tiled::Cta_tile_o::VALID_N + (int)Kernel_traits_nl_tiled::Cta_tile_o::N - 1 )
+      / (int)Kernel_traits_nl_tiled::Cta_tile_o::N;
+{% else %}
+  constexpr int ctas_per_o_row =
+      ( (int)Kernel_traits_nl::Cta_tile_o::VALID_N + (int)Kernel_traits_nl::Cta_tile_o::N - 1 )
+      / (int)Kernel_traits_nl::Cta_tile_o::N;
+{% endif %}
+  dim3 grid(loop_iters * ctas_per_o_row, params.h, params.b); // better locality
 {% if reload_q %}
   if( launch_params.attention_mask_type == Attention_mask_type::CAUSAL ) {
     constexpr int smem_size = Kernel_traits_nl_tiled_causal::BYTES_PER_SMEM;
@@ -293,6 +382,16 @@ void {{ launcher_name }}_nl_tiled(
                                             smem_size));
     }
     {{ causal_kernel_name }}_nl_tiled<<<grid, Kernel_traits_nl_tiled_causal::THREADS, Kernel_traits_nl_tiled_causal::BYTES_PER_SMEM, stream>>>(params);
+{% if sliding_or_chunked_causal_mask == "1" %}
+  } else if( launch_params.attention_mask_type == Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL ) {
+    constexpr int smem_size = Kernel_traits_nl_tiled_sliding_or_chunked::BYTES_PER_SMEM;
+    if( smem_size >= 48*1024 ) {
+        FMHA_CHECK_CUDA(cudaFuncSetAttribute({{ sliding_or_chunked_causal_kernel_name }}_nl_tiled,
+                                            cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                            smem_size));
+    }
+    {{ sliding_or_chunked_causal_kernel_name }}_nl_tiled<<<grid, Kernel_traits_nl_tiled_sliding_or_chunked::THREADS, Kernel_traits_nl_tiled_sliding_or_chunked::BYTES_PER_SMEM, stream>>>(params);
+{% endif %}
   } else {
     constexpr int smem_size = Kernel_traits_nl_tiled::BYTES_PER_SMEM;
     if( smem_size >= 48*1024 ) {
@@ -311,6 +410,16 @@ void {{ launcher_name }}_nl_tiled(
                                             smem_size));
     }
     {{ causal_kernel_name }}_nl_tiled<<<grid, Kernel_traits_nl_causal::THREADS, Kernel_traits_nl_causal::BYTES_PER_SMEM, stream>>>(params);
+{% if sliding_or_chunked_causal_mask == "1" %}
+  } else if( launch_params.attention_mask_type == Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL ) {
+    constexpr int smem_size = Kernel_traits_nl_sliding_or_chunked::BYTES_PER_SMEM;
+    if( smem_size >= 48*1024 ) {
+        FMHA_CHECK_CUDA(cudaFuncSetAttribute({{ sliding_or_chunked_causal_kernel_name }}_nl_tiled,
+                                            cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                            smem_size));
+    }
+    {{ sliding_or_chunked_causal_kernel_name }}_nl_tiled<<<grid, Kernel_traits_nl_sliding_or_chunked::THREADS, Kernel_traits_nl_sliding_or_chunked::BYTES_PER_SMEM, stream>>>(params);
+{% endif %}
   } else {
     constexpr int smem_size = Kernel_traits_nl::BYTES_PER_SMEM;
     if( smem_size >= 48*1024 ) {

--- a/csrc/fmha_v2_run.cu
+++ b/csrc/fmha_v2_run.cu
@@ -438,6 +438,19 @@ void fmha_v2_run(
   if (chunked_attention_size > 0) {
     assert((chunked_attention_size & (chunked_attention_size - 1)) == 0 &&
            "chunked_attention_size has to be a power of 2");
+    // Chunked-causal masking is only implemented by the warp-specialized (SM90)
+    // kernels (see fmha/warpspec/{epilogue,dma,compute}.h, which branch on
+    // log2_chunked_attention_size). The non-warp-specialized "tiled" kernels used
+    // on SM120 honor sliding_window_size only and ignore log2_chunked_attention_size,
+    // so reject chunked attention here rather than silently returning wrong results.
+    // Sliding-window causal IS supported on SM120 (via window_left).
+    if (sm == 120) {
+      throw std::invalid_argument(
+          "Chunked-causal attention (chunked_attention_size > 0) is not supported for "
+          "FMHAv2 on SM120 (Blackwell). The SM120 tiled kernels implement sliding-window "
+          "causal only. Use window_left for sliding-window masking, or run chunked "
+          "attention on SM90 (Hopper).");
+    }
     attention_mask_type = Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL;
   }
   size_t sliding_window_size = size_t(INT_MAX);

--- a/flashinfer/jit/attention/fmha_v2/fmha_library.py
+++ b/flashinfer/jit/attention/fmha_v2/fmha_library.py
@@ -109,8 +109,12 @@ def select_ldgsts(
             if head_size >= 256:
                 ldgsts_k = False
                 ldgsts_v = False
-            if head_size > 256:
-                ldgsts_q = False
+            # NOTE: head_size > 256 (e.g. 512) uses RELOAD_Q (D > CTA_P_TILE_K=64),
+            # but the tiled-noloop kernel still requires USE_LDGSTS to be true for at
+            # least one of Q/K/V (static_assert in
+            # fused_multihead_flash_attention_kernel_noloop_tiled.h). USE_LDGSTS_Q is
+            # orthogonal to RELOAD_Q (the latter only controls Q reload across D-tiles),
+            # so keep Q on cp.async to satisfy the kernel, mirroring the hd256 path.
             return (ldgsts_q, ldgsts_k, ldgsts_v)
         elif dtype == "e4m3":
             return (False, False, False)
@@ -343,6 +347,23 @@ def is_kernel_spec_valid(kspec: FMHAv2KernelSpec) -> bool:
         and kspec.flash_attention
         and kspec.input_layout != InputLayout.SEPARATE_Q_K_V
     )
+    # SM120 (Blackwell consumer) head_size 512 flash attention.
+    # Uses the dormant `head_size <= 512` arm in generate_kernel_spec
+    # (q_loop_step = kv_loop_step = 64, sm_mma=80, tiled noloop). Kept as a
+    # dedicated branch so the head_size<=256 cap in flash_valid stays intact
+    # for the other architectures (which have no 512 tiling validated).
+    flash_valid_sm120_hd512: bool = (
+        kspec.sm == 120
+        and kspec.dtype in ["fp16", "bf16"]
+        and kspec.head_size == 512
+        and kspec.head_size_v == 0
+        and kspec.sage_block_sizes is None
+        and kspec.version == 2
+        and not kspec.cross_mha
+        and kspec.flash_attention
+        and kspec.input_layout != InputLayout.SEPARATE_Q_K_V
+        and bool(kspec.tiled)
+    )
     # SM90 non-flash ldgsts support (fixed seq len)
     non_flash_valid: bool = (
         kspec.sm == 90
@@ -439,6 +460,7 @@ def is_kernel_spec_valid(kspec: FMHAv2KernelSpec) -> bool:
 
     return (
         flash_valid
+        or flash_valid_sm120_hd512
         or non_flash_valid
         or clip_valid
         or mla_valid_576_512
@@ -1268,7 +1290,7 @@ def generate_jit_sources(
         output_dtype_values,
     )
 
-    head_size_qk_sm120_values = [64, 128, 256]
+    head_size_qk_sm120_values = [64, 128, 256, 512]
     sm120_configs: itertools.product = itertools.product(
         [120] if include_sm120_kernels else [],
         dtype_values,  # fallback to avoid empty product

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4526,6 +4526,9 @@ def trtllm_fmha_v2_prefill(
     chunked_attention_size
         The chunked attention size. Defaults to ``0``, which means no chunked attention.
         Only effective when :attr:`mask_mode` is ``chunked``. Must be a power of 2.
+        Chunked-causal masking is implemented only by the warp-specialized SM90
+        (Hopper) kernels; it is **not supported on SM120 (Blackwell)**, where the
+        tiled kernels honor sliding-window causal (``window_left``) only.
     save_softmax_stats
         Whether to save the softmax statistics. Defaults to ``False``.
     skip_softmax_threshold_scale_factor
@@ -4630,6 +4633,19 @@ def trtllm_fmha_v2_prefill(
         raise ValueError(
             f"{feature} attention requires causal masking. "
             f"The underlying kernel only supports SLIDING_OR_CHUNKED_CAUSAL mode. "
+        )
+
+    # Chunked-causal masking is only implemented by the warp-specialized (SM90)
+    # kernels. The non-warp-specialized "tiled" kernels used on SM120 honor
+    # ``sliding_window_size`` only and silently ignore ``chunked_attention_size``,
+    # so reject chunked attention here rather than returning wrong results.
+    # Sliding-window causal (``window_left``) IS supported on SM120.
+    if uses_chunked and is_sm12x_supported(query.device):
+        raise ValueError(
+            "Chunked-causal attention (chunked_attention_size > 0) is not "
+            "supported for FMHAv2 on SM120 (Blackwell). The SM120 tiled kernels "
+            "implement sliding-window causal only. Use window_left for "
+            "sliding-window masking, or run chunked attention on SM90 (Hopper)."
         )
 
     # Determine output dtype

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4625,13 +4625,6 @@ def trtllm_fmha_v2_prefill(
     uses_chunked = chunked_attention_size is not None and chunked_attention_size > 0
     is_non_causal = mask_mode is not None and mask_mode.lower() == "padding"
 
-    if (uses_sliding_window or uses_chunked) and is_sm12x_supported(query.device):
-        feature = "Sliding window" if uses_sliding_window else "Chunked"
-        raise ValueError(
-            f"{feature} attention is not yet supported for FMHAv2 on SM120 (Blackwell). "
-            "Only CAUSAL masks are available. "
-        )
-
     if (uses_sliding_window or uses_chunked) and is_non_causal:
         feature = "Sliding window" if uses_sliding_window else "Chunked"
         raise ValueError(

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -919,6 +919,50 @@ def test_trtllm_fmha_v2_prefill_sm120_large_head_dim(
     )
 
 
+def test_trtllm_fmha_v2_prefill_sm120_chunked_rejected() -> None:
+    """Chunked-causal masking is not implemented by the SM120 tiled kernels.
+
+    The ``SLIDING_OR_CHUNKED_CAUSAL`` mask honors only the sliding-window branch
+    on SM120 -- the tiled noloop kernels ignore ``log2_chunked_attention_size``
+    (chunked is wired only in the warp-specialized SM90 path). A chunked request
+    must therefore be rejected rather than silently mis-served. Sliding-window
+    causal (``window_left``) remains supported.
+    """
+    from flashinfer.prefill import trtllm_fmha_v2_prefill
+
+    if not is_sm12x_supported(torch.device("cuda")):
+        pytest.skip("This test targets SM12x (Blackwell) FMHAv2.")
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_qo_heads, num_kv_heads, head_dim = 8, 2, 256
+    seq_len = 64
+
+    query = torch.randn(seq_len, num_qo_heads, head_dim, dtype=dtype, device=device)
+    kv = torch.randn(seq_len, 2, num_kv_heads, head_dim, dtype=dtype, device=device)
+    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    cu_seqlens = torch.tensor([0, seq_len], dtype=torch.int32, device=device)
+    workspace = torch.zeros(8 * 1024 * 1024, dtype=torch.uint8, device=device)
+
+    with pytest.raises(ValueError, match="[Cc]hunked"):
+        trtllm_fmha_v2_prefill(
+            (query, kv),
+            "CONTIGUOUS_Q_KV",
+            workspace_buffer=workspace,
+            seq_lens=seq_lens,
+            max_q_len=seq_len,
+            max_kv_len=seq_len,
+            bmm1_scale=1.0 / math.sqrt(head_dim),
+            bmm2_scale=1.0,
+            batch_size=1,
+            cum_seq_lens_q=cu_seqlens,
+            cum_seq_lens_kv=cu_seqlens,
+            out_dtype=dtype,
+            mask_mode="chunked",
+            chunked_attention_size=32,
+        )
+
+
 @pytest.mark.parametrize("batch_size", [1, 4])
 @pytest.mark.parametrize("max_seq_len", [16384])
 @pytest.mark.parametrize("num_qo_heads", [4, 32])

--- a/tests/attention/test_fmha_v2_prefill.py
+++ b/tests/attention/test_fmha_v2_prefill.py
@@ -499,8 +499,15 @@ def run_trtllm_fmha_v2_prefill_case(
         pytest.skip(
             "SEPARATE_Q_K_V requires SM90 warp-specialization, not available on SM12x"
         )
-    if is_sm12x and mask_mode is not None and mask_mode.upper() == "SLIDING_WINDOW":
-        pytest.skip("SLIDING_WINDOW mask not yet supported on SM12x (only causal)")
+    # head_dim 512 (full-attention layers) is only enabled/validated on SM12x,
+    # for fp16/bf16 and non-SEPARATE layouts.
+    if head_dim > 256:
+        if not is_sm12x:
+            pytest.skip("head_dim > 256 FMHAv2 is only supported on SM12x")
+        if dtype == torch.float8_e4m3fn:
+            pytest.skip("head_dim > 256 FMHAv2 does not support fp8")
+        if input_layout == "SEPARATE_Q_K_V":
+            pytest.skip("head_dim > 256 FMHAv2 does not support SEPARATE_Q_K_V")
     if input_layout == "SEPARATE_Q_K_V" and logits_soft_cap > 0:
         pytest.skip("Logits soft capping not supported for SEPARATE_Q_K_V layout")
     # save_softmax_stats only supported for CONTIGUOUS_Q_KV (normal attention)
@@ -840,6 +847,74 @@ def test_trtllm_fmha_v2_prefill(
         logits_soft_cap=logits_soft_cap,
         pos_encoding_mode=pos_encoding_mode,
         save_softmax_stats=save_softmax_stats,
+        skip_softmax_threshold_scale_factor=0.0,
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("max_seq_len", [1024])
+@pytest.mark.parametrize("num_qo_heads", [8])
+@pytest.mark.parametrize("num_kv_heads", [2])
+@pytest.mark.parametrize("head_dim", [256, 512])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    ("input_layout", "page_size"),
+    [
+        ("CONTIGUOUS_Q_KV", None),
+        ("Q_PAGED_KV_NHD", 32),
+        ("Q_PAGED_KV_NHD", 128),
+    ],
+)
+@pytest.mark.parametrize(
+    ("causal", "window_left", "mask_mode"),
+    [
+        (True, -1, "CAUSAL"),
+        (False, -1, "PADDING"),
+        (True, 127, "SLIDING_WINDOW"),
+        (True, 1024, "SLIDING_WINDOW"),
+    ],
+)
+def test_trtllm_fmha_v2_prefill_sm120_large_head_dim(
+    input_layout: str,
+    batch_size: int,
+    max_seq_len: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    page_size: Optional[int],
+    dtype: torch.dtype,
+    causal: bool,
+    window_left: int,
+    mask_mode: str,
+) -> None:
+    """SM120 (Blackwell) coverage for large head dims with mixed mask modes.
+
+    Exercises GQA at ``head_dim`` 256 and 512 with ``CAUSAL``, ``PADDING``
+    (bidirectional), and ``SLIDING_WINDOW`` (windowed causal) masks, over the
+    contiguous and paged-KV (NHD) layouts.
+
+    These cover the newly-enabled paths: hd512 on SM120 and the
+    SLIDING_OR_CHUNKED_CAUSAL tiled-noloop kernel variant (previously the tiled
+    launcher silently ran the maskless dense kernel for sliding requests).
+    """
+    if not is_sm12x_supported(torch.device("cuda")):
+        pytest.skip("This test targets SM12x (Blackwell) FMHAv2.")
+    run_trtllm_fmha_v2_prefill_case(
+        input_layout=input_layout,
+        batch_size=batch_size,
+        max_seq_len=max_seq_len,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        page_size=page_size,
+        dtype=dtype,
+        o_dtype=dtype,
+        causal=causal,
+        mask_mode=mask_mode,
+        window_left=window_left,
+        logits_soft_cap=0.0,
+        pos_encoding_mode=None,
+        save_softmax_stats=False,
         skip_softmax_threshold_scale_factor=0.0,
     )
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Summary

Extends the FMHAv2 (TRT-LLM v2 FMHA) prefill path so it can run on Blackwell
SM120 (e.g. RTX PRO 6000) with:

- `head_dim = 256` and `head_dim = 512` (previously `512` was not a valid SM120
  spec, and the `head_dim > 256` "reload-Q" path mis-launched the grid).
- Sliding-window / chunked-causal masking (`SLIDING_OR_CHUNKED_CAUSAL`,
  `MASK_VERSION == 4`), which was previously routed to the maskless dense kernel
  on the noloop launchers and was explicitly blocked in the Python API for
  SM12x.

These were validated against a torch reference for causal, padding, and
sliding-window masks at both head dims.

### Changes

- **`flashinfer/jit/attention/fmha_v2/fmha_library.py`**
  - Add `512` to the SM120 `head_size_qk` value set.
  - Add a `flash_valid_sm120_hd512` validity branch so `head_dim = 512` kernel
    specs are generated for SM120.
  - In `select_ldgsts`, keep `ldgsts_q = True` for `head_size > 256` on SM120
    (the `head_dim = 512` tiled kernel `static_assert`s on `USE_LDGSTS`).

- **`csrc/fmha_v2/templates/fa_kernel.jinja`**
  - `head_dim = 512` fix: multiply `grid.x` by `ctas_per_o_row` in the
    `_nl_tiled` launcher so all output channels are computed (previously only
    half the head dim was written).
  - Sliding-window fix: add `MASK_VERSION == 4`
    (`Kernel_traits_nl_tiled_sliding_or_chunked` and `Kernel_traits_nl_sliding_or_chunked`)
    traits + global kernels, and add `Attention_mask_type::SLIDING_OR_CHUNKED_CAUSAL`
    dispatch branches to both the reload-Q (`_nl_tiled`) and non-reload (`_nl`)
    noloop launchers. Without this, sliding requests silently ran the maskless
    dense kernel.

- **`flashinfer/prefill.py`**
  - Remove the guard that raised `ValueError` for sliding/chunked windows on
    SM12x, now that the kernel path supports it.

- **`tests/attention/test_fmha_v2_prefill.py`**
  - Remove the SM12x sliding-window skip and add `head_dim > 256` validity skips.
  - Add `test_trtllm_fmha_v2_prefill_sm120_large_head_dim`, covering
    `head_dim` ∈ {256, 512}, GQA, `CONTIGUOUS_Q_KV` / `Q_PAGED_KV_NHD` layouts,
    and `CAUSAL` / `PADDING` / `SLIDING_WINDOW` masks.

### Notes

- **Scope:** SM120 only. SM90 (Hopper) uses a separate warp-specialized kernel
  path; `head_dim = 256` likely works there already but `head_dim = 512` is not
  wired up.
- **Dtype:** BF16 / FP16. FP8 primitives exist in the kernel C++ but are not
  enabled/validated for these specs.
- AI-assisted change (Claude Opus 4.8 in Cursor).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sliding-or-chunked causal attention support in optimized kernels and expanded kernel variants for large head sizes.

* **Bug Fixes**
  * Enforced causal-only requirement for sliding/chunked modes; explicitly reject chunked-causal on SM120 to avoid incorrect runs.

* **Documentation**
  * Clarified platform and mask-mode limitations for chunked attention.

* **Tests**
  * Added SM120-focused tests covering large head dims (including 512).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->