### PR TITLE
perf(mamba): set minBlocksPerSM in simple-MTP SSU launch_bounds

### DIFF
--- a/include/flashinfer/mamba/kernel_selective_state_update_mtp_simple.cuh
+++ b/include/flashinfer/mamba/kernel_selective_state_update_mtp_simple.cuh
@@ -570,7 +570,7 @@ __device__ __forceinline__ void update_state_simple(SramT& sram, int lane, int w
 template <typename input_t, typename weight_t, typename matrixA_t, typename state_t,
           typename stateIndex_t, typename state_scale_t, int NTOKENS, int DIM, int DSTATE,
           int HEADS_PER_GROUP, int PHILOX_ROUNDS, int NUM_WARPS, int CTAS_PER_HEAD>
-__global__ void __launch_bounds__(NUM_WARPS * 32)
+__global__ void __launch_bounds__(NUM_WARPS * 32, 12)
     selective_state_update_kernel_simple_mtp(SelectiveStateMTPParams params) {
   constexpr int DSTATE_PAD = padDstate<input_t>(DSTATE);
   constexpr int DIM_PER_CTA = DIM / CTAS_PER_HEAD;

--- a/tests/mamba/test_selective_state_update_mtp.py
+++ b/tests/mamba/test_selective_state_update_mtp.py
@@ -1476,3 +1476,62 @@ class TestSelectiveStateUpdateMTPStochasticRoundingWithIntermediateStates(
                 )
 
             assert states_match, f"Intermediate state at step {t} mismatch"
+
+
+@pytest.mark.parametrize("batch", [4, 64, 256])
+@pytest.mark.parametrize("state_dtype", [torch.bfloat16, torch.float16])
+def test_simple_mtp_launch_bounds_regression(batch, state_dtype):
+    """simple-MTP SSU (launch_bounds occupancy fix) matches the Triton reference."""
+    nheads, dim, dstate, ngroups, cache_steps = 64, 64, 128, 8, 6
+    inputs = create_test_inputs(
+        batch,
+        nheads,
+        dim,
+        dstate,
+        ngroups,
+        input_dtype=torch.bfloat16,
+        weight_dtype=torch.float32,
+        matrixA_dtype=torch.float32,
+        state_dtype=state_dtype,
+        generate_z=False,
+        cache_steps=cache_steps,
+        seed=0,
+    )
+
+    state_ref = clone_preserving_strides(inputs["state_cache"])
+    y_ref = selective_state_update_triton(
+        state_ref,
+        inputs["x"],
+        inputs["dt"],
+        inputs["A"],
+        inputs["B"],
+        inputs["C"],
+        D=inputs["D"],
+        dt_bias=inputs["dt_bias"],
+        dt_softplus=True,
+        state_batch_indices=inputs["slot_idx"],
+        pad_slot_id=-1,
+    )
+
+    y_test = flashinfer.mamba.selective_state_update(
+        inputs["state_cache"],
+        inputs["x"],
+        inputs["dt"],
+        inputs["A"],
+        inputs["B"],
+        inputs["C"],
+        D=inputs["D"],
+        dt_bias=inputs["dt_bias"],
+        dt_softplus=True,
+        state_batch_indices=inputs["slot_idx"],
+        pad_slot_id=-1,
+        algorithm="simple",
+    )
+
+    atol, rtol = 1e-3, 1e-2
+    torch.testing.assert_close(y_test, y_ref, atol=atol, rtol=rtol)
+    # in-place state update must also match the reference for the touched slots
+    slot = inputs["slot_idx"]
+    torch.testing.assert_close(
+        inputs["state_cache"][slot], state_ref[slot], atol=atol, rtol=rtol
+    )


### PR DESCRIPTION
## 📌 Description

`selective_state_update_kernel_simple_mtp`
(`include/flashinfer/mamba/kernel_selective_state_update_mtp_simple.cuh`) declared
`__launch_bounds__(NUM_WARPS * 32)` with **no `minBlocksPerSM`** argument — unlike its
horizontal/vertical MTP siblings, which set `, 6` and `, 2`. Without it, nvcc used **69
registers/thread** on H200/SM90, capping achieved occupancy at ~42% (≈7 blocks/SM). The kernel is
**SM-bound** at decode shapes, so the low occupancy left it unable to hide its memory-latency stalls.

This PR adds `minBlocksPerSM = 12`:

```cuda
-__global__ void __launch_bounds__(NUM_WARPS * 32)
+__global__ void __launch_bounds__(NUM_WARPS * 32, 12)
     selective_state_update_kernel_simple_mtp(SelectiveStateMTPParams params) {
```

which directs nvcc to fit ≥12 blocks/SM, capping registers at 40/thread.

**This also resolves a latent host/device occupancy mismatch.** The launcher in
`invoke_selective_state_update_mtp.cuh` already sizes the `CTAS_PER_HEAD` grid assuming the kernel
reaches **10 blocks/SM** (`constexpr int kBlocksPerSM = 10;`, with the comment "128 threads and 48
regs/thread"). But the kernel compiled at 69 regs → ≈7 blocks/SM, so it could never hit the occupancy
the host budgets for. `minBlocksPerSM=12` (≥ that documented 10) makes the kernel honor the launcher's
existing assumption; 12 was also the fastest in a {8, 10, 12, 16} sweep at every batch size.

**Benchmark** (H200, CUDA 12.8, bf16 state, Mamba2/Nemotron-H decode: nheads=64, dim=64, dstate=128,
MTP cache_steps=6; 200 iters after warmup, variance <0.1%):

| batch | baseline | this PR | speedup |
|-------|----------|---------|---------|
| 1     | 14.51 µs | 14.71 µs | 0.99x (neutral; latency-bound) |
| 4     | 21.90 µs | 17.10 µs | **1.28x** |
| 16    | 58.27 µs | 48.62 µs | **1.20x** |
| 64    | 176.7 µs | 162.9 µs | **1.08x** |
| 256   | 651.2 µs | 588.1 µs | **1.11x** |

**ncu before → after (B=256, kernel-only):** registers 69 → 40, achieved occupancy 42.6% → 72.1%,
SM throughput 76.8% → 90.3%, short-scoreboard stall 25.0% → 17.9%.

This is a **launch-configuration change only** (register cap / occupancy) — no arithmetic is touched,
so the output and the in-place state update are **bit-identical** to baseline (verified max_abs = 0.0).

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Added `test_simple_mtp_launch_bounds_regression` to `tests/mamba/test_selective_state_update_mtp.py`:
pins the production decode shape (nheads=64, dim=64, dstate=128, MTP=6) across batch 4/64/256 and
bf16/fp16 state, checking both output and the in-place state update against the Triton reference.
Run locally on H200 (CUDA 12.8): **6 passed**. The existing `TestSelectiveStateUpdateMTP` (simple
algorithm) also exercises this kernel.

## Reviewer Notes

`__launch_bounds__` is on the kernel template, so the register cap applies to every
`DIM`/`DSTATE`/`CTAS_PER_HEAD` instantiation. I benchmarked the production Mamba2/Nemotron shape
(dim=64, dstate=128) and tested bf16/fp16 across batch 4/64/256; the full `DSTATE` matrix is covered
by the existing mamba tests.