### PR TITLE
Fix smem race in `FilteredTopK` overflow refinement

### DIFF
--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -2769,6 +2769,7 @@ __global__ void __launch_bounds__(FILTERED_TOPK_BLOCK_THREADS)
           threshold_bytes[round] = static_cast<uint8_t>(threshold);
           topk_remain -= static_cast<uint32_t>(s_histogram[threshold + 1]);
 
+          __syncthreads();
           if (topk_remain == 0) {
             stop_round = round;
             break;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
The `FilteredTopK` overflow refinement path has an smem race (flagged by `racecheck`).

In the overflow refinement loop, each round reuses `s_histogram` ([code](https://github.com/flashinfer-ai/flashinfer/blob/a28703432faab15fda7edd71b6c80be0206df973/include/flashinfer/topk.cuh#L2733)):
- near the end of round `r`, threads read `s_histogram` to update `topk_remain`:
  ```cpp
  topk_remain -= static_cast<uint32_t>(s_histogram[threshold + 1]);
  ```
- at the start of round `r + 1`, threads clear `s_histogram`:
  ```cpp
  if (tx < RADIX + 1) s_histogram[tx] = 0;
  ```

This PR fixes by adding a `__synchtreads()` after the `topk_remain` decrement before the loop can either break or continue to the next round.

---

<details>

<summary> Repro Script </summary>

```bash
compute-sanitizer --tool racecheck --target-processes all uv run python repro_flashinfer_topk_race.py
```

```
#!/usr/bin/env python3
"""Minimal FlashInfer radix top-k racecheck repro.

This script intentionally uses a tie-heavy input so FlashInfer's filtered top-k
kernel enters the shared-memory overflow refinement path.

Example:
    python repro_flashinfer_topk_race.py

Run under NVIDIA Compute Sanitizer:
    compute-sanitizer --tool racecheck --target-processes all \
        python repro_flashinfer_topk_race.py

Affected FlashInfer versions report shared-memory hazards in the radix top-k
kernel. The script does not use any project-specific wrappers.
"""

from __future__ import annotations

import argparse
import sys
from importlib import metadata

import torch

DTYPES = {
    "float32": torch.float32,
    "float16": torch.float16,
    "bfloat16": torch.bfloat16,
}


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser()
    parser.add_argument("--rows", type=int, default=512)
    parser.add_argument("--vocab", type=int, default=131072)
    parser.add_argument("--k", type=int, default=128)
    parser.add_argument("--dtype", choices=sorted(DTYPES), default="float32")
    parser.add_argument("--iters", type=int, default=1)
    parser.add_argument("--deterministic", action="store_true", default=True)
    parser.add_argument("--nondeterministic", dest="deterministic", action="store_false")
    parser.add_argument("--sorted", action="store_true")
    return parser.parse_args()


def main() -> int:
    args = parse_args()
    if not torch.cuda.is_available():
        print("CUDA is required for this repro.", file=sys.stderr)
        return 1

    import flashinfer
    from flashinfer.topk import can_implement_filtered_topk, get_topk_module

    device = torch.device("cuda")
    dtype = DTYPES[args.dtype]

    try:
        flashinfer_version = metadata.version("flashinfer")
    except metadata.PackageNotFoundError:
        flashinfer_version = getattr(flashinfer, "__version__", "unknown")

    print(f"torch={torch.__version__}")
    print(f"flashinfer={flashinfer_version} ({flashinfer.__file__})")
    print(f"cuda_device={torch.cuda.get_device_name(device)}")
    print(f"can_implement_filtered_topk={can_implement_filtered_topk()}")
    print(
        "case="
        f"rows={args.rows}, vocab={args.vocab}, k={args.k}, dtype={args.dtype}, "
        f"sorted={args.sorted}, deterministic={args.deterministic}"
    )

    # All zeros force all logits into the same radix bucket. For vocab=128K and
    # k=128 this enters the overflow refinement loop that reuses s_histogram.
    # The default 512 rows give racecheck enough CTAs to report the hazard
    # reliably on affected versions.
    logits = torch.zeros((args.rows, args.vocab), dtype=dtype, device=device)

    topk_module = get_topk_module()
    row_states_buffer = torch.zeros(1024 * 1024, dtype=torch.uint8, device=device)
    output_values = torch.empty((args.rows, args.k), dtype=dtype, device=device)

    indices = None
    for _ in range(args.iters):
        indices = topk_module.radix_topk(
            logits,
            args.k,
            args.sorted,
            args.deterministic,
            row_states_buffer,
            output_values,
        )
        torch.cuda.synchronize()

    assert indices is not None
    assert output_values.shape == (args.rows, args.k)
    assert indices.shape == (args.rows, args.k)
    assert indices.dtype == torch.int32
    assert bool(torch.all(output_values == 0).item())
    assert bool(torch.all((indices >= 0) & (indices < args.vocab)).item())

    print("completed")
    return 0


if __name__ == "__main__":
    raise SystemExit(main())
```

</details>

<details>

<summary> Example Output </summary>

```
========= COMPUTE-SANITIZER
========= Variable environment CUDA_COREDUMP_FILE is not supported by compute-sanitizer, clearing it before target process launch.
========= Variable environment CUDA_COREDUMP_GENERATION_FLAGS is not supported by compute-sanitizer, clearing it before target process launch.
========= Variable environment CUDA_ENABLE_COREDUMP_ON_EXCEPTION is not supported by compute-sanitizer, clearing it before target process launch.
torch=2.11.0+cu130
flashinfer=0.6.8.post1 (/tmp/.../lib/python3.12/site-packages/flashinfer/__init__.py)
cuda_device=NVIDIA GB300
can_implement_filtered_topk=True
case=rows=512, vocab=131072, k=128, dtype=float32, sorted=False, deterministic=True
========= Error: Race reported between Read access at void flashinfer::sampling::FilteredTopKUnifiedKernel<float, int, (int)4, (bool)1, (flashinfer::sampling::FilteredTopKMode)0>(const T1 *, T2 *, T1 *, const T2 *, long, const T2 *, const T2 *, unsigned int, unsigned int, unsigned int)+0x111e0
=========     and Write access at void flashinfer::sampling::FilteredTopKUnifiedKernel<float, int, (int)4, (bool)1, (flashinfer::sampling::FilteredTopKMode)0>(const T1 *, T2 *, T1 *, const T2 *, long, const T2 *, const T2 *, unsigned int, unsigned int, unsigned int)+0x11230 [3852 hazards]
========= 
========= Error: Race reported between Read access at void flashinfer::sampling::FilteredTopKUnifiedKernel<float, int, (int)4, (bool)1, (flashinfer::sampling::FilteredTopKMode)0>(const T1 *, T2 *, T1 *, const T2 *, long, const T2 *, const T2 *, unsigned int, unsigned int, unsigned int)+0x137a0
=========     and Write access at void flashinfer::sampling::FilteredTopKUnifiedKernel<float, int, (int)4, (bool)1, (flashinfer::sampling::FilteredTopKMode)0>(const T1 *, T2 *, T1 *, const T2 *, long, const T2 *, const T2 *, unsigned int, unsigned int, unsigned int)+0x137f0 [3596 hazards]
========= 
========= Error: Race reported between Read access at void flashinfer::sampling::FilteredTopKUnifiedKernel<float, int, (int)4, (bool)1, (flashinfer::sampling::FilteredTopKMode)0>(const T1 *, T2 *, T1 *, const T2 *, long, const T2 *, const T2 *, unsigned int, unsigned int, unsigned int)+0x16160
=========     and Write access at void flashinfer::sampling::FilteredTopKUnifiedKernel<float, int, (int)4, (bool)1, (flashinfer::sampling::FilteredTopKMode)0>(const T1 *, T2 *, T1 *, const T2 *, long, const T2 *, const T2 *, unsigned int, unsigned int, unsigned int)+0x161a0 [3560 hazards]
========= 
completed
========= RACECHECK SUMMARY: 3 hazards displayed (3 errors, 0 warnings)
```

</details>


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved reliability of top-k filtering operations by resolving a synchronization issue in the multi-round fallback path to ensure accurate results across all computational scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->