### PR TITLE
fix(sm120-moe): derive M tile count from atom layout

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -338,8 +338,8 @@ class MoEDynamicKernel:
             self.acc_dtype,
             self.sf_dtype,
         )
-        atom_layout = cute.make_layout((2, 2, 1))
         atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -339,6 +339,7 @@ class MoEDynamicKernel:
             self.sf_dtype,
         )
         atom_layout = cute.make_layout((2, 2, 1))
+        atom_shape = (2, 2, 1)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -351,9 +352,16 @@ class MoEDynamicKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
-        self.num_k_blocks = self.tile_shape_mnk[2] // 64
+        # Derive atom loop bounds from the tile shape and the warp atom layout,
+        # like the dense kernel. atom_layout=(2,2,1) => 2 M-warps, 2 N-warps.
+        # The previous hardcoded (16*4) was copied from the dense kernel's
+        # (4,2,1) layout and gave num_m_tiles=2 instead of 4, so the GEMM filled
+        # only M-tiles {0,1} and left rows 64..127 (the 2nd 64-row warp quadrant)
+        # at fill(0.0). num_n_tiles was accidentally correct (atom_shape[1]=2).
+        mma_m, mma_n, mma_k = 16, 8, 64
+        self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.tile_shape_mnk[2] // mma_k
 
         sfa_smem = sm120_make_smem_layout_sfa(
             self.tiled_mma,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -352,12 +352,8 @@ class MoEDynamicKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        # Derive atom loop bounds from the tile shape and the warp atom layout,
-        # like the dense kernel. atom_layout=(2,2,1) => 2 M-warps, 2 N-warps.
-        # The previous hardcoded (16*4) was copied from the dense kernel's
-        # (4,2,1) layout and gave num_m_tiles=2 instead of 4, so the GEMM filled
-        # only M-tiles {0,1} and left rows 64..127 (the 2nd 64-row warp quadrant)
-        # at fill(0.0). num_n_tiles was accidentally correct (atom_shape[1]=2).
+        # Derive loop bounds from atom_shape (like the dense kernel). The old
+        # hardcoded (16*4) assumed dense's (4,2,1); this kernel is (2,2,1).
         mma_m, mma_n, mma_k = 16, 8, 64
         self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -537,12 +537,8 @@ class MoEMicroKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        # Derive atom loop bounds from the tile shape and the warp atom layout,
-        # like the dense kernel. atom_layout=(2,2,1) => 2 M-warps, 2 N-warps.
-        # The previous hardcoded (16*4) was copied from the dense kernel's
-        # (4,2,1) layout and gave num_m_tiles=2 instead of 4, so the GEMM filled
-        # only M-tiles {0,1} and left rows 64..127 (the 2nd 64-row warp quadrant)
-        # at fill(0.0). num_n_tiles was accidentally correct (atom_shape[1]=2).
+        # Derive loop bounds from atom_shape (like the dense kernel). The old
+        # hardcoded (16*4) assumed dense's (4,2,1); this kernel is (2,2,1).
         mma_m, mma_n, mma_k = 16, 8, 64
         self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -523,8 +523,8 @@ class MoEMicroKernel:
             self.acc_dtype,
             self.sf_dtype,
         )
-        atom_layout = cute.make_layout((2, 2, 1))
         atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -524,6 +524,7 @@ class MoEMicroKernel:
             self.sf_dtype,
         )
         atom_layout = cute.make_layout((2, 2, 1))
+        atom_shape = (2, 2, 1)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -536,9 +537,16 @@ class MoEMicroKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
-        self.num_k_blocks = self.tile_shape_mnk[2] // 64
+        # Derive atom loop bounds from the tile shape and the warp atom layout,
+        # like the dense kernel. atom_layout=(2,2,1) => 2 M-warps, 2 N-warps.
+        # The previous hardcoded (16*4) was copied from the dense kernel's
+        # (4,2,1) layout and gave num_m_tiles=2 instead of 4, so the GEMM filled
+        # only M-tiles {0,1} and left rows 64..127 (the 2nd 64-row warp quadrant)
+        # at fill(0.0). num_n_tiles was accidentally correct (atom_shape[1]=2).
+        mma_m, mma_n, mma_k = 16, 8, 64
+        self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.tile_shape_mnk[2] // mma_k
 
         sfa_smem = sm120_make_smem_layout_sfa(
             self.tiled_mma,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -494,6 +494,7 @@ class MoEStaticKernel:
             self.sf_dtype,
         )
         atom_layout = cute.make_layout((2, 2, 1))
+        atom_shape = (2, 2, 1)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -506,9 +507,18 @@ class MoEStaticKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
-        self.num_k_blocks = self.tile_shape_mnk[2] // 64
+        # Derive atom loop bounds from the tile shape and the (M,N,K) warp atom
+        # layout, exactly like the dense kernel. MMA atom = m16 n8 k64; with
+        # atom_layout=(2,2,1) the warp group spans m32 n16 k64. The previous
+        # hardcoded (16*4)/(8*2) was copied from the dense kernel's (4,2,1)
+        # layout and gave num_m_tiles=2 (4-warp-M) instead of 4 (this kernel's
+        # 2-warp-M) -- the GEMM loop then filled only M-tiles {0,1}, leaving the
+        # second 64-row warp quadrant (rows 64..127) at fill(0.0). num_n_tiles
+        # was accidentally correct because both layouts share atom_shape[1]=2.
+        mma_m, mma_n, mma_k = 16, 8, 64
+        self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.tile_shape_mnk[2] // mma_k
 
         sfa_smem = sm120_make_smem_layout_sfa(
             self.tiled_mma,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -493,8 +493,8 @@ class MoEStaticKernel:
             self.acc_dtype,
             self.sf_dtype,
         )
-        atom_layout = cute.make_layout((2, 2, 1))
         atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -507,14 +507,8 @@ class MoEStaticKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        # Derive atom loop bounds from the tile shape and the (M,N,K) warp atom
-        # layout, exactly like the dense kernel. MMA atom = m16 n8 k64; with
-        # atom_layout=(2,2,1) the warp group spans m32 n16 k64. The previous
-        # hardcoded (16*4)/(8*2) was copied from the dense kernel's (4,2,1)
-        # layout and gave num_m_tiles=2 (4-warp-M) instead of 4 (this kernel's
-        # 2-warp-M) -- the GEMM loop then filled only M-tiles {0,1}, leaving the
-        # second 64-row warp quadrant (rows 64..127) at fill(0.0). num_n_tiles
-        # was accidentally correct because both layouts share atom_shape[1]=2.
+        # Derive loop bounds from atom_shape (like the dense kernel). The old
+        # hardcoded (16*4) assumed dense's (4,2,1); this kernel is (2,2,1).
         mma_m, mma_n, mma_k = 16, 8, 64
         self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -1121,6 +1121,126 @@ class TestB12xFunctional:
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
 
+    @pytest.mark.parametrize("rows_per_expert", [128, 256, 512])
+    @pytest.mark.parametrize("activation", ["silu", "relu2"])
+    def test_skewed_routing_fills_second_m_quadrant(
+        self, rows_per_expert: int, activation: str
+    ):
+        """Regression for num_m_tiles dropping the 2nd 64-row M warp quadrant.
+
+        The static MoE kernels derive their M-tile loop bound from the warp atom
+        layout. A prior hardcoded divisor assumed the dense kernel's 4-M-warp
+        layout, so the GEMM mainloop only filled M-tiles {0,1} (rows 0..63) and
+        left rows 64..127 of every >64-row expert tile at fill(0.0) -- exact-zero
+        output. Random routing over many experts never puts >64 rows on a single
+        expert, so this only surfaces under skewed routing.
+
+        Here every token is forced (top_k=1) onto expert 0, so that one expert's
+        GEMM has `rows_per_expert` (>= 128) rows and must populate the second
+        64-row quadrant. Row counts stay within the static-backend range so the
+        affected kernels are exercised directly. With the bug, ~half the rows are
+        zero and accuracy collapses; with the fix it sits at the FP4 floor.
+        """
+        from flashinfer import b12x_fused_moe
+
+        num_tokens = rows_per_expert
+        hidden_size, intermediate_size = 256, 512
+        num_experts, top_k = 256, 1
+
+        if activation == "relu2":
+            tensors = create_relu2_moe_tensors(
+                num_tokens=num_tokens,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_experts=num_experts,
+                num_local_experts=num_experts,
+                top_k=top_k,
+                seed=2024,
+            )
+        else:
+            tensors = create_moe_tensors(
+                num_tokens=num_tokens,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_experts=num_experts,
+                num_local_experts=num_experts,
+                top_k=top_k,
+                seed=2024,
+            )
+
+        # Force ALL tokens onto a single expert -> one expert gets num_tokens
+        # (>= 128) rows, spanning both 64-row M warp quadrants.
+        target_expert = 0
+        tensors["token_selected_experts"] = torch.full(
+            (num_tokens, top_k), target_expert, dtype=torch.int32, device="cuda"
+        )
+        tensors["token_final_scales"] = torch.ones(
+            (num_tokens, top_k), dtype=torch.float32, device="cuda"
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation=activation,
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        # The bug zeroed rows 64..127 of each 128-row tile; assert no all-zero
+        # rows beyond the first quadrant (decisive, independent of tolerance).
+        upper = result[64:]
+        assert not (upper == 0).all(dim=-1).any(), (
+            f"rows>=64 contain all-zero output ({activation}, "
+            f"rows_per_expert={rows_per_expert}) -- 2nd M quadrant dropped"
+        )
+
+        if activation == "relu2":
+            ref_output = compute_reference_moe_relu2(
+                hidden_states=tensors["x_bf16"].float().cuda(),
+                fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+                fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                num_tokens=num_tokens,
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                fc2_input_scale=tensors["fc2_input_scale"],
+            )
+        else:
+            ref_output = compute_reference_moe_fp4(
+                hidden_states=tensors["x_bf16"].float().cuda(),
+                gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+                gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                num_tokens=num_tokens,
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                fc2_input_scale=tensors["fc2_input_scale"],
+            )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Skewed routing {activation} rows_per_expert={rows_per_expert}: "
+            f"only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+        )
+
     def test_activation_precision_api_validation(self):
         """W4A4 requires fc2_input_scale; W4A16 tolerates it."""
         from flashinfer import b12x_fused_moe


### PR DESCRIPTION
## Description

The static / micro / dynamic SM120 MoE kernels hardcoded

```python
num_m_tiles = tile_shape_mnk[0] // (16 * 4)
```

copied from the dense kernel, whose `atom_layout=(4,2,1)` has 4M-warps. These
MoE kernels use `atom_layout=(2,2,1)` (2M-warps), so the divisor must be
`(16 * 2)` → `num_m_tiles = 4, not 2`. With `2`, the GEMM mainloop filled only
M-tiles `{0,1}`; tiles `{2,3}` (rows 64..127) stayed at `fill(0.0)`, giving
**exact-zero output** for the second 64-row warp quadrant. The fix derives the
bound from `atom_shape`

## How it was found

I was trying to get DeepSeek-V4-flash on SM120 (a 4× RTX PRO 6000 Max-Q box) to a reasonable state through FlashInfer. NVFP4 worked, but MXFP4 MoE did not. The two paths share these kernels and only differ in the block-scale format, so I thought it was the MXFP4 scale layout, but a single-expert test showed rows 64..127 coming back zero. 

## Impact

Any static-family MoE call with **>64 routed rows/expert** and a 128-wide
`tile_m` silently zeroed rows 64..127. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).
- [x] Skewed routing (one expert gets 128/256/768 rows): rows 64:128 nonzero vs a BF16/dequant reference.

## Reviewer Notes

small fix, one-linish change across the three kernels. This is supposed to be the first a set of stacked PRs to get MXFP4×MXFP4 fused MoE in place for SM120.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized kernel tiling logic for Blackwell SM120/SM121 by parameterizing MMA atom layout so tiling math is consistent across kernel variants.

* **Bug Fixes**
  * Prevents a skewed-routing case that could leave rows in a second processing quadrant all zeros, improving correctness for certain routing patterns.

* **Tests**
  * Added a regression test validating skewed routing fills the second quadrant and maintains numerical accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->