### PR TITLE
fix XQA NVFP4 head dim

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3041,15 +3041,18 @@ def xqa_batch_decode_with_kv_cache(
 
     # Extract shape parameters based on layout
     if kv_layout == "NHD":
-        # NHD: [num_pages, page_size, num_kv_heads, head_dim]
+        # NHD: [num_pages, page_size, num_kv_heads, head_dim] for ordinary KV cache
+        # or [num_pages, page_size, num_kv_heads, head_dim// 2] for NVFP4 KV cache with packed head dim
         page_size = k_cache.shape[1]
         num_kv_heads = k_cache.shape[2]
-        head_dim = k_cache.shape[3]
     else:  # HND
-        # HND: [num_pages, num_kv_heads, page_size, head_dim]
+        # HND: [num_pages, num_kv_heads, page_size, head_dim] for ordinary KV cache
+        # or [num_pages, num_kv_heads, page_size, head_dim// 2] for NVFP4 KV cache with packed head dim
         num_kv_heads = k_cache.shape[1]
         page_size = k_cache.shape[2]
-        head_dim = k_cache.shape[3]
+
+    # query shape: [num_tokens, num_heads, head_dim]
+    head_dim = query.shape[-1]
 
     workspace_u8 = workspace_buffer.view(torch.uint8)
     semaphore = workspace_u8[: 8 * 1024 * 1024]  # reserve 8MB for semaphore

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -162,8 +162,8 @@ def create_kv_cache(
             dim=1,
         )
     elif kv_dtype == "nvfp4":
-        k_cache, k_scale, k_global_scale = to_nvfp4(k_cache / 4.0)
-        v_cache, v_scale, v_global_scale = to_nvfp4(v_cache / 4.0)
+        k_cache, k_scale, k_global_scale = to_nvfp4(k_cache)
+        v_cache, v_scale, v_global_scale = to_nvfp4(v_cache)
         k_cache_dq = nvfp4_to_float(k_cache, k_scale, k_global_scale)
         v_cache_dq = nvfp4_to_float(v_cache, v_scale, v_global_scale)
         ref_kv_cache = torch.stack(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

When kv cache is using NVFP4 format, the kv_cache.shape[-1] is not headdim but headdim//2.
Therefore, we choose to use query.shape[-1] as headdim instead.
## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dimension calculation used during batch decoding with packed key/value cache formats so query head size is derived from the query tensor, improving decoding accuracy across cache layouts.
  * Fixed NVFP4 quantization handling for key/value caches to remove an incorrect extra scaling step, improving numerical fidelity for NVFP4-backed caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->