### PR TITLE
feat(moe_bgmv): direct decode fast-path for shrink (1.3-3.8x vs sliced kernel)

### DIFF
--- a/csrc/bgmv_moe/moe_bgmv_impl.cuh
+++ b/csrc/bgmv_moe/moe_bgmv_impl.cuh
@@ -258,6 +258,78 @@ __global__ void moe_bgmv_shrink_sliced_kernel(
 }
 
 // ============================================================
+// MoE BGMV Shrink Direct Kernel (decode fast-path)
+//
+// One CTA per (pair, rank, slice): block of NTHREADS strides the full feat_in
+// contraction with 128-bit vectorized loads (vec_t), then a warp+block reduction
+// writes the single output element. Fuses the contraction with scale+cast and
+// uses no shared-memory staging / async pipeline.
+//
+// Rationale: in the decode regime (num_pairs small), the pipelined sliced kernel
+// launches only ceil(num_pairs/PPB)*ceil(feat_out/RANK_TILE) blocks -> a few SMs
+// active, launch-starved. Mapping one block per output element raises resident
+// blocks ~feat_out-fold and removes the smem-staging overhead, which dominates
+// when there is no inter-pair reuse to amortize it. Dtype/accumulation preserved
+// (fp32 accumulate, out_T cast). Prefill keeps the pipelined kernel unchanged.
+// ============================================================
+template <int feat_in, int feat_out, int NTHREADS, size_t vec_size, typename in_T, typename out_T,
+          typename W_T>
+__global__ void moe_bgmv_shrink_direct_kernel(
+    out_T* __restrict__ Y, const in_T* __restrict__ X, W_T** __restrict__ w_ptr,
+    const int64_t* __restrict__ sorted_token_ids, const int64_t* __restrict__ expert_ids,
+    const int64_t* __restrict__ lora_indices, int64_t num_pairs, int64_t num_experts,
+    int64_t num_tokens, int64_t lora_stride, float scale) {
+  const int slice_id = blockIdx.z;
+  const int pair = blockIdx.x;
+  const int r = blockIdx.y;  // rank index in [0, feat_out)
+  const int tid = threadIdx.x;
+
+  const int64_t token_idx = sorted_token_ids[pair];
+  bool valid = (token_idx >= 0 && token_idx < num_tokens);
+  int64_t lid = -1, eid = 0;
+  if (valid) {
+    lid = lora_indices[token_idx];
+    valid = (lid >= 0);
+    if (valid) eid = expert_ids[pair];
+  }
+  if (!valid) return;  // leave the (pre-zeroed / accumulated) output element untouched
+
+  const W_T* Wrow = w_ptr[slice_id * num_experts + eid] + lid * lora_stride + (int64_t)r * feat_in;
+  const in_T* Xrow = X + token_idx * (int64_t)feat_in;
+
+  constexpr int NVEC = feat_in / vec_size;
+  float acc = 0.f;
+  vec_t<in_T, vec_size> xv;
+  vec_t<W_T, vec_size> wv;
+  for (int i = tid; i < NVEC; i += NTHREADS) {
+    xv.load(Xrow + i * vec_size);
+    wv.load(Wrow + i * vec_size);
+#pragma unroll
+    for (int j = 0; j < (int)vec_size; ++j) acc += float(xv[j]) * float(wv[j]);
+  }
+  // scalar tail — only emitted when feat_in is not a multiple of vec_size. All compiled
+  // `wide` values are multiples of 8 (== vec_size), so this is dropped at compile time and
+  // the hot loop above is purely 128-bit vectorized (verified in SASS / ncu sectors-per-req).
+  if constexpr (feat_in % vec_size != 0) {
+    for (int i = NVEC * vec_size + tid; i < feat_in; i += NTHREADS)
+      acc += float(Xrow[i]) * float(Wrow[i]);
+  }
+
+#pragma unroll
+  for (int off = 16; off > 0; off >>= 1) acc += __shfl_down_sync(0xffffffffu, acc, off);
+  __shared__ float warp_sum[NTHREADS / 32];
+  if ((tid & 31) == 0) warp_sum[tid >> 5] = acc;
+  __syncthreads();
+  if (tid == 0) {
+    float s = 0.f;
+#pragma unroll
+    for (int i = 0; i < NTHREADS / 32; ++i) s += warp_sum[i];
+    Y[slice_id * num_pairs * feat_out + (int64_t)pair * feat_out + r] +=
+        static_cast<out_T>(s * scale);
+  }
+}
+
+// ============================================================
 // MoE BGMV Expand Sliced Kernel
 // ============================================================
 template <int feat_in, int feat_out, size_t vec_size, int tx, int ty, int tz, typename in_T,
@@ -324,6 +396,20 @@ void moe_bgmv_shrink_sliced(out_T* __restrict__ Y, const in_T* __restrict__ X,
   cudaDeviceGetAttribute(&sm_major, cudaDevAttrComputeCapabilityMajor, dev);
   const bool extended = (sm_major >= 9);
   const bool decode = (num_pairs <= MoeShrinkKernelConfig::decode_threshold);
+
+  // Decode fast-path: one block per (pair, rank, slice) with vectorized contraction.
+  // All compiled `wide` (feat_in) values are multiples of 8, so 128-bit loads apply.
+  if (decode) {
+    constexpr int FUSED_NT = 128;
+    constexpr size_t FUSED_VEC = 8;
+    if constexpr (feat_in % FUSED_VEC == 0) {
+      dim3 gfused((int)num_pairs, feat_out, (int)num_slices);
+      moe_bgmv_shrink_direct_kernel<feat_in, feat_out, FUSED_NT, FUSED_VEC, in_T, out_T, W_T>
+          <<<gfused, FUSED_NT, 0, stream>>>(Y, X, w_ptr, sorted_token_ids, expert_ids, lora_indices,
+                                            num_pairs, num_experts, num_tokens, lora_stride, scale);
+      return;
+    }
+  }
 
   const int ppb = (extended && decode) ? MoeShrinkKernelConfig::pairs_per_block_decode
                                        : MoeShrinkKernelConfig::pairs_per_block_prefill;

--- a/csrc/bgmv_moe/moe_bgmv_impl.cuh
+++ b/csrc/bgmv_moe/moe_bgmv_impl.cuh
@@ -399,7 +399,10 @@ void moe_bgmv_shrink_sliced(out_T* __restrict__ Y, const in_T* __restrict__ X,
 
   // Decode fast-path: one block per (pair, rank, slice) with vectorized contraction.
   // All compiled `wide` (feat_in) values are multiples of 8, so 128-bit loads apply.
-  if (decode) {
+  // Gated on `extended` (sm_90+): the fast-path is only measured/tuned on Hopper+, and the
+  // baseline decode tuning is likewise gated on `extended`. On sm_80 and below we keep the
+  // proven pipelined sliced kernel rather than silently rerouting an unbenchmarked path.
+  if (extended && decode) {
     constexpr int FUSED_NT = 128;
     constexpr size_t FUSED_VEC = 8;
     if constexpr (feat_in % FUSED_VEC == 0) {

--- a/tests/moe/test_bgmv_moe.py
+++ b/tests/moe/test_bgmv_moe.py
@@ -310,6 +310,68 @@ class TestBgmvMoeShrink:
             f"rank={rank}, experts={num_experts}, dtype={dtype}",
         )
 
+    @pytest.mark.parametrize("num_tokens", [1, 4, 32])
+    @pytest.mark.parametrize("hidden_size", [768, 2048])
+    @pytest.mark.parametrize("rank", [16, 32])
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_shrink_correctness_multislice(self, num_tokens, hidden_size, rank, dtype):
+        """num_slices=2 (gate_up packing). Exercises the kernel's blockIdx.z / grid-z
+        slice path, which the num_slices=1 tests above do not cover. num_pairs in {2, 8}
+        hit the decode path; 64 hits the prefill path."""
+        from flashinfer.fused_moe.bgmv_moe import bgmv_moe_shrink, fill_w_ptr
+
+        top_k = 2
+        num_loras = 4
+        num_slices = 2
+        num_experts = 64
+
+        data = generate_test_data(
+            num_tokens,
+            hidden_size,
+            rank,
+            num_experts,
+            top_k,
+            num_loras,
+            num_slices,
+            dtype,
+        )
+
+        ref_out = reference_moe_bgmv_shrink(
+            data["x"],
+            data["lora_a_weights"],
+            data["sorted_token_ids"],
+            data["expert_ids"],
+            data["lora_indices"],
+        )
+
+        num_pairs = data["num_pairs"]
+        w_ptr = torch.zeros(num_slices, num_experts, dtype=torch.int64, device="cuda")
+        lora_stride = 0
+        for s_idx in range(num_slices):
+            lora_stride = fill_w_ptr(
+                w_ptr, data["lora_a_weights"][s_idx], num_experts, s_idx
+            )
+
+        cuda_out = torch.zeros(num_slices, num_pairs, rank, dtype=dtype, device="cuda")
+        bgmv_moe_shrink(
+            cuda_out,
+            data["x"],
+            w_ptr,
+            data["sorted_token_ids"],
+            data["expert_ids"],
+            data["lora_indices"],
+            lora_stride,
+        )
+
+        torch.testing.assert_close(
+            cuda_out.float(),
+            ref_out.float(),
+            atol=1e-2,
+            rtol=1e-2,
+            msg=f"Multi-slice shrink mismatch: tokens={num_tokens}, "
+            f"hidden={hidden_size}, rank={rank}, slices={num_slices}, dtype={dtype}",
+        )
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 class TestBgmvMoeExpand:


### PR DESCRIPTION
## 📌 Description

Adds a fused decode fast-path to `moe_bgmv_shrink_sliced`. In the decode path
(`num_pairs <= decode_threshold`, i.e. small batch), the existing cp.async-pipelined
sliced kernel is launch-starved: its grid is only
`ceil(num_pairs/PPB) × ceil(feat_out/RANK_TILE) × num_slices` blocks, so just a handful
of SMs are active, and the shared-memory staging / async-pipeline overhead is pure cost
because there is no inter-pair reuse to amortize it at small batch.

The new `moe_bgmv_shrink_fused_kernel` maps **one CTA per (pair, rank, slice)** output
element. Each block strides the full `feat_in` contraction with 128-bit vectorized loads
(`vec_t`), reduces with a warp shuffle + small block reduction, and fuses the
`scale + cast` into the single accumulating write. This raises resident blocks ~`feat_out`-fold
and removes the staging overhead.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks


- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).


## 🧪 Tests


- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validated via FlashInfer's own `tests/moe/test_bgmv_moe.py` (JIT recompile of the edited source):

```
tests/moe/test_bgmv_moe.py ............ 147 passed
```

- `TestBgmvMoeShrink` 48/48, `TestBgmvMoeEndToEnd` + edge cases 27/27, full suite 147/147.
- Batch sizes give `num_pairs ∈ {2, 8, 64}`, exercising both the fused path (≤32) and the
  pipelined path (64).
- **Added `test_shrink_correctness_multislice`** (`num_slices=2`, gate_up packing, bf16+fp16)
  to cover the kernel's `blockIdx.z` slice path, which the existing `num_slices=1` tests do
  not exercise — 24/24 pass, `max_diff = 0`.
- `compute-sanitizer` clean on the fused kernel: **memcheck 0 errors, racecheck 0 hazards,
  synccheck 0 errors** (decode / multi-slice / `lora_id=-1` skip / out-of-bounds-token branches).


## Reviewer Notes

**What the speedup compares.** All numbers are **this PR's `moe_bgmv_shrink_fused_kernel`
vs. the existing `moe_bgmv_shrink_sliced_kernel` decode instantiation** (the current
upstream baseline: `RANK_TILE=8, PAIRS_PER_BLOCK=4, NUM_STAGES=3` — the cp.async-pipelined
kernel selected today when `num_pairs <= decode_threshold`). Both kernels were compiled from
the same tree and run through the same `bgmv_moe_shrink` API on the same H200 (SM90), at the
same shape (`feat_in=3072, feat_out=32, bf16, num_pairs=8`), timed back-to-back. So this is a
like-for-like replacement of one decode kernel by another.

**SASS comparison insights** (control codes decoded with the SM90 layout — `hi64[44:41]`
stall, `[48:46]` write-barrier, `[57:52]` wait mask; same disassembled `.cuda.o`):

| | baseline `..._sliced_kernel` (decode) | this PR `..._fused_kernel` |
|---|---|---|
| static instructions | 4008 | **184** (21.8× fewer) |
| total static stall cycles | 11 798 | 410 |
| `LDGSTS` async-copy ops | 12 | **0** |
| smem staging (`STS.128`/`LDS.128`) | present (pipeline round-trip) | **none** |


### Benchmarking results on H200

Kernel-level evidence at `feat_in=3072, feat_out=32, bf16`, decode (`num_pairs=8`), on the
production build path (`bgmv_moe_bf16_bf16_bf16`), H200 SM90 — i.e. NOT the Python/API
dispatch floor:

| metric | baseline (pipelined) | this PR (direct) |  |
|---|---|---|---|
| **kernel duration** (ncu `gpu__time_duration`) | **34.5 µs** | **5.95 µs** | **≈5.8× faster kernel** |
| blocks launched | 8 | 256 | 32× parallelism |
| occupancy limit (smem) | **1 block/SM** | 28 blocks/SM | staging cap removed |
| SM throughput | 0.87 % | 5.12 % | |
| `LDGSTS` async-copy ops (SASS) | 12 | **0** | |
| static instructions (SASS) | 4008 | **184** | 21.8× fewer |

The mechanism is structural (launch starvation + cp.async-staging removal) and reproducible
under ncu, not a fragile micro-optimization. The prefill kernel's SASS is byte-for-byte
identical before/after this change.

### Performance ( `bgmv_moe_shrink` API, H200 SM90)

CUDA-event timed, 30 warmup + 200 iters × 5 reps, median; baseline vs this PR, same GPU:

| hidden | rank | tokens | baseline µs | this PR µs | speedup |
|-------:|-----:|-------:|------------:|-----------:|--------:|
|   768  |  16  |   4    |    21.4     |    16.0    | **1.34×** |
|  2048  |  16  |  16    |    30.5     |    15.9    | **1.92×** |
|  3072  |  32  |   4    |    38.4     |    16.0    | **2.40×** |
|  4096  |  32  |  16    |    46.3     |    16.9    | **2.73×** |
|  5888  |  32  |   4    |    61.6     |    16.0    | **3.84×** |

Win grows with hidden size. Prefill control (tokens=256, gated → pipelined kernel): within
noise, no regression. (The ~16 µs API floor is Python dispatch; the kernel speedup is larger,
as the ncu numbers above show.)

> The core CUDA optimization techniques in this patch were discovered by IFCO, an autonomous
> CUDA optimization agent built by AWS; the kernel was then re-derived against the production `w_ptr` table
> interface.


| hot-path global load | mixed | single rolled **`LDG.E.128`** (0x800-B grid stride) |
| scalar `LDG.E.U16` fallback | — | **0** (`if constexpr`-compiled away) |

- The baseline spends most of its instruction stream staging `X`/`W` tiles into shared
  memory via `LDGSTS` and reading them back (`LDS.128`) to feed the pipeline. At decode there
  is no inter-pair reuse to amortize that round-trip, so it is pure latency. The fused kernel
  reads global memory straight into registers with 128-bit `LDG.E.128` and reduces with
  `SHFL` — eliminating all `LDGSTS`/`STS`/`LDS` and 21.8× of the static instructions.
- The disassembly confirms the contraction is **fully 128-bit vectorized** (one `LDG.E.128`
  loop, no scalar `LDG.E.U16` path), and ncu reports 9.78 sectors/request — consistent with
  128-bit loads, not a scalar bf16 contraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an optimized decode fast-path for MoE BGMV shrink computations to speed up execution using vectorized operations and an early-exit dispatch when supported.

* **Tests**
  * Added a new PyTest case to validate shrink correctness for multi-slice runs (`num_slices=2`) by comparing CUDA results against the existing reference implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->