### PR TITLE
feat: delta rule work with zero length sequence

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -1235,49 +1235,25 @@ class GatedDeltaNetChunkedKernel:
                 seqlen_b = cu_seqlens[batch_idx + 1] - batch_start
                 num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
                 checkpoint_offset = 0
-                if cutlass.const_expr(self.enable_checkpoints):
-                    checkpoint_offset = cu_checkpoints[batch_idx]
-                if cutlass.const_expr(self.use_initial_state):
-                    kv_acc_producer = self._load_initial_state(
-                        tidx,
-                        mS_init,
-                        head_idx,
-                        batch_idx,
-                        tmem_ptr,
-                        tiled_mma_kv,
-                        kv_acc_producer,
-                    )
                 sV_pisl = self._transform_to_position_independent_layout(
                     sV, v_smem_layout_staged.inner
                 )
                 sO_pisl = self._transform_to_position_independent_layout(
                     sO, o_smem_layout_staged.inner
                 )
-                (
-                    load_v_consumer,
-                    load_gate_consumer,
-                    shared_acc_consumer,
-                    kv_acc_consumer,
-                    q_state_acc_consumer,
-                    group_order_consumer,
-                    kv_acc_producer,
-                    state_inp_ready_producer,
-                    shared_inp_ready_producer,
-                    o_store_producer,
-                    checkpoint_idx,
-                ) = self.compute_group_1(
-                    tidx,
-                    tmem_ptr,
-                    scale,
-                    (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
-                    (
-                        sV_pisl,
-                        sCumsumlog,
-                        sCumprod,
-                        sBeta,
-                        sO_pisl,
-                    ),
-                    (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
+                if num_chunks_b > 0:
+                    if cutlass.const_expr(self.enable_checkpoints):
+                        checkpoint_offset = cu_checkpoints[batch_idx]
+                    if cutlass.const_expr(self.use_initial_state):
+                        kv_acc_producer = self._load_initial_state(
+                            tidx,
+                            mS_init,
+                            head_idx,
+                            batch_idx,
+                            tmem_ptr,
+                            tiled_mma_kv,
+                            kv_acc_producer,
+                        )
                     (
                         load_v_consumer,
                         load_gate_consumer,
@@ -1289,9 +1265,34 @@ class GatedDeltaNetChunkedKernel:
                         state_inp_ready_producer,
                         shared_inp_ready_producer,
                         o_store_producer,
-                    ),
-                    (True, 0, head_idx),
-                )
+                        checkpoint_idx,
+                    ) = self.compute_group_1(
+                        tidx,
+                        tmem_ptr,
+                        scale,
+                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                        (
+                            sV_pisl,
+                            sCumsumlog,
+                            sCumprod,
+                            sBeta,
+                            sO_pisl,
+                        ),
+                        (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
+                        (
+                            load_v_consumer,
+                            load_gate_consumer,
+                            shared_acc_consumer,
+                            kv_acc_consumer,
+                            q_state_acc_consumer,
+                            group_order_consumer,
+                            kv_acc_producer,
+                            state_inp_ready_producer,
+                            shared_inp_ready_producer,
+                            o_store_producer,
+                        ),
+                        (True, 0, head_idx),
+                    )
                 for chunk_idx in cutlass.range(1, num_chunks_b):
                     chunk_offset = batch_start + chunk_idx * self.b_t
                     (
@@ -1333,25 +1334,26 @@ class GatedDeltaNetChunkedKernel:
                         ),
                         (False, chunk_idx, head_idx),
                     )
-                if cutlass.const_expr(
-                    self.store_final_state or self.enable_checkpoints
-                ):
-                    kv_acc_consumer = self._store_final_state(
-                        tidx,
-                        mS_out,
-                        head_idx,
-                        batch_idx,
-                        tmem_ptr,
-                        tiled_mma_kv,
-                        kv_acc_consumer,
-                        seqlen_b,
-                        mS_checkpoints,
-                        checkpoint_offset,
-                        checkpoint_every_n_tokens,
-                    )
-                else:
-                    kv_acc_handle = kv_acc_consumer.wait_and_advance()
-                    kv_acc_handle.release()
+                if num_chunks_b > 0:
+                    if cutlass.const_expr(
+                        self.store_final_state or self.enable_checkpoints
+                    ):
+                        kv_acc_consumer = self._store_final_state(
+                            tidx,
+                            mS_out,
+                            head_idx,
+                            batch_idx,
+                            tmem_ptr,
+                            tiled_mma_kv,
+                            kv_acc_consumer,
+                            seqlen_b,
+                            mS_checkpoints,
+                            checkpoint_offset,
+                            checkpoint_every_n_tokens,
+                        )
+                    else:
+                        kv_acc_handle = kv_acc_consumer.wait_and_advance()
+                        kv_acc_handle.release()
 
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
@@ -1382,27 +1384,7 @@ class GatedDeltaNetChunkedKernel:
                 num_chunks_b = cute.ceil_div(seqlen_b, self.b_t)
                 # First chunk: no previous state (S_prev = 0), skip GEMMs 3/4.
                 chunk_offset = batch_start
-                (
-                    shared_acc_producer,
-                    q_state_acc_producer,
-                    kv_acc_producer,
-                    load_k_consumer,
-                    load_q_consumer,
-                    load_v_consumer,
-                    a_inv_ready_consumer,
-                    qk_ready_consumer,
-                    state_inp_ready_consumer,
-                    shared_inp_ready_consumer,
-                ) = self.mma_warp(
-                    tmem_ptr,
-                    (
-                        tiled_mma_qk,
-                        tiled_mma_qs,
-                        tiled_mma_qkv,
-                        tiled_mma_qkv_ss,
-                        tiled_mma_kv,
-                    ),
-                    (sQ, sK, sK_trans, sV, sAinv, sQk),
+                if num_chunks_b > 0:
                     (
                         shared_acc_producer,
                         q_state_acc_producer,
@@ -1414,10 +1396,30 @@ class GatedDeltaNetChunkedKernel:
                         qk_ready_consumer,
                         state_inp_ready_consumer,
                         shared_inp_ready_consumer,
-                    ),
-                    (True,),
-                )
-
+                    ) = self.mma_warp(
+                        tmem_ptr,
+                        (
+                            tiled_mma_qk,
+                            tiled_mma_qs,
+                            tiled_mma_qkv,
+                            tiled_mma_qkv_ss,
+                            tiled_mma_kv,
+                        ),
+                        (sQ, sK, sK_trans, sV, sAinv, sQk),
+                        (
+                            shared_acc_producer,
+                            q_state_acc_producer,
+                            kv_acc_producer,
+                            load_k_consumer,
+                            load_q_consumer,
+                            load_v_consumer,
+                            a_inv_ready_consumer,
+                            qk_ready_consumer,
+                            state_inp_ready_consumer,
+                            shared_inp_ready_consumer,
+                        ),
+                        (True,),
+                    )
                 # Main loop: chunks 1..num_chunks_b-1 with previous state.
                 for chunk_idx in cutlass.range(1, num_chunks_b):  # noqa: B007
                     (
@@ -1515,14 +1517,15 @@ class GatedDeltaNetChunkedKernel:
                         stride=(mV.stride[0], mV.stride[1], mV.stride[2]),
                     ),
                 )
-                # Update K/Q/V descriptors
-                tensormap_manager.update_tensormap(
-                    (bounded_q, bounded_k, bounded_v),
-                    (tma_q.atom, tma_k.atom, tma_v.atom),
-                    (tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr),
-                    self.tma_qkv_warp_id,
-                    (None, None, None),
-                )
+                if num_chunks_b > 0:
+                    # Update K/Q/V descriptors
+                    tensormap_manager.update_tensormap(
+                        (bounded_q, bounded_k, bounded_v),
+                        (tma_q.atom, tma_k.atom, tma_v.atom),
+                        (tensormap_q_ptr, tensormap_k_ptr, tensormap_v_ptr),
+                        self.tma_qkv_warp_id,
+                        (None, None, None),
+                    )
 
                 for chunk_idx in cutlass.range(num_chunks_b):
                     chunk_offset = batch_start + chunk_idx * self.b_t
@@ -1574,19 +1577,20 @@ class GatedDeltaNetChunkedKernel:
                         (load_gate_producer, load_beta_producer),
                         (chunk_offset, head_idx, False, batch_end),
                     )
-                # Last tile: is_last_tile=True, valid_tokens derived inside
-                load_gate_producer, load_beta_producer = self.load_gate_beta_warp(
-                    tidx,
-                    (mGate, mBeta),
-                    (sCumsumlog, sCumprod, sBeta),
-                    (load_gate_producer, load_beta_producer),
-                    (
-                        batch_start + (num_chunks_b - 1) * self.b_t,
-                        head_idx,
-                        True,
-                        batch_end,
-                    ),
-                )
+                if num_chunks_b > 0:
+                    # Last tile: is_last_tile=True, valid_tokens derived inside
+                    load_gate_producer, load_beta_producer = self.load_gate_beta_warp(
+                        tidx,
+                        (mGate, mBeta),
+                        (sCumsumlog, sCumprod, sBeta),
+                        (load_gate_producer, load_beta_producer),
+                        (
+                            batch_start + (num_chunks_b - 1) * self.b_t,
+                            head_idx,
+                            True,
+                            batch_end,
+                        ),
+                    )
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
             load_gate_producer.tail()
@@ -1624,15 +1628,16 @@ class GatedDeltaNetChunkedKernel:
                     ),
                 )
 
-                # Update O descriptor independently
-                tensormap_manager.update_tensormap(
-                    (bounded_o,),
-                    (tma_o.atom,),
-                    (tensormap_o_ptr,),
-                    self.epilogue_warp_id,
-                    (None,),
-                )
-                tensormap_manager.fence_tensormap_update(tensormap_o_ptr)
+                if num_chunks_b > 0:
+                    # Update O descriptor independently
+                    tensormap_manager.update_tensormap(
+                        (bounded_o,),
+                        (tma_o.atom,),
+                        (tensormap_o_ptr,),
+                        self.epilogue_warp_id,
+                        (None,),
+                    )
+                    tensormap_manager.fence_tensormap_update(tensormap_o_ptr)
 
                 for chunk_idx in cutlass.range(num_chunks_b):
                     chunk_offset = batch_start + chunk_idx * self.b_t

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -259,6 +259,77 @@ def test_prefill_kernel_nonfull(
     )
 
 
+@pytest.mark.parametrize(
+    "num_q_heads,num_k_heads,num_v_heads", [(1, 1, 1), (16, 16, 64)]
+)
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_prefill_kernel_zero_length_sequence(
+    qkv_factory,
+    dtype: str,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_size: int = 128,
+    seq_len: int = 64,
+    scale: float = 0.1,
+    seed: int = int(os.environ.get("SEED", "0")),
+):
+    _skip_if_unsupported()
+
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    num_o_heads = max(num_q_heads, num_v_heads)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    dtype = getattr(torch, dtype)
+    device = torch.device("cuda")
+
+    with device:
+        q, k, v = qkv_factory(
+            [seq_len], num_q_heads, num_k_heads, num_v_heads, head_size, dtype
+        )
+        k = torch.nn.functional.normalize(k, p=2.0, dim=-1)
+        alpha = torch.rand(seq_len, num_sab_heads)
+        beta = torch.rand(seq_len, num_sab_heads)
+        cu_seq_lens = torch.tensor([0, seq_len], dtype=torch.int64)
+        cu_seq_lens_with_empty = torch.tensor([0, seq_len, seq_len], dtype=torch.int64)
+
+    ref_o = torch.empty(
+        [seq_len, num_o_heads, head_size], dtype=q.dtype, device=q.device
+    )
+    our_o = torch.empty_like(ref_o)
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        scale,
+        None,
+        False,
+        cu_seq_lens,
+        True,
+        output=ref_o,
+    )
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        scale,
+        None,
+        False,
+        cu_seq_lens_with_empty,
+        True,
+        output=our_o,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(our_o, ref_o, atol=2e-2, rtol=2e-2)
+
+
 def _test_chunked_prefill(
     qkv_factory,
     dtype: str,


### PR DESCRIPTION
## 📌 Description

Avoid current sm100 gdn to deadlock on inputs with sequence length as 0 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

This is a very edge case we have ever met in production environment from customers for softmax attention.

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed kernel handling of empty or zero-length sequences to prevent undefined behavior and ensure correct state management.

* **Tests**
  * Added test coverage for zero-length sequence scenarios in the Gated Delta Net kernel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->