### PR TITLE
feat(sm120): MXFP4 dense GEMM + fused MoE

### DIFF
--- a/flashinfer/cute_dsl/fp4_common.py
+++ b/flashinfer/cute_dsl/fp4_common.py
@@ -2436,3 +2436,119 @@ def relu2_quantize_block_fp4(
     activated = relu2_16(x)
     block_max = max_abs_16(activated)
     return quantize_block_fp4(activated, block_max, global_scale_val)
+
+
+# =============================================================================
+# MXFP4 activation quantizers: 32-element blocks, E8M0 power-of-two
+# block scale, self-scaling (no global scale). Mirror the NVFP4 16-block helpers
+# above; 32 elems -> 16 bytes -> two uint64, and return the E8M0 scale byte.
+# =============================================================================
+
+
+@cute.jit
+def quantize_and_pack_32(
+    y_f32: cute.Tensor, inv_scale: Float32
+) -> Tuple[Uint64, Uint64]:
+    """Quantize 32 float32 values to FP4 and pack into two uint64 (lo, hi)."""
+    q = cute.make_rmem_tensor((32,), Float32)
+    for i in cutlass.range_constexpr(32):
+        q[i] = y_f32[i] * inv_scale
+
+    # 32 FP4 = 16 bytes = two uint64. Each uint64 holds 16 FP4 (two cvt_e2m1x8).
+    lo_a = cvt_e2m1x8_f32(q[0], q[1], q[2], q[3], q[4], q[5], q[6], q[7])
+    lo_b = cvt_e2m1x8_f32(q[8], q[9], q[10], q[11], q[12], q[13], q[14], q[15])
+    hi_a = cvt_e2m1x8_f32(q[16], q[17], q[18], q[19], q[20], q[21], q[22], q[23])
+    hi_b = cvt_e2m1x8_f32(q[24], q[25], q[26], q[27], q[28], q[29], q[30], q[31])
+    packed_lo = (Uint64(lo_b) << Uint64(32)) | Uint64(lo_a)
+    packed_hi = (Uint64(hi_b) << Uint64(32)) | Uint64(hi_a)
+    return packed_lo, packed_hi
+
+
+@cute.jit
+def quantize_block_mxf4(
+    values: cute.Tensor,
+    max_abs: Float32,
+) -> Tuple[Uint64, Uint64, Uint8]:
+    """Quantize 32 float32 values to packed FP4 (2x uint64) + E8M0 scale byte.
+
+    Self-scaling: block scale is ``2^ceil(log2(max_abs/6))`` as a UE8M0 byte
+    (no global scale). Returns ``(packed_lo, packed_hi, scale_byte)``.
+    """
+    packed_lo = Uint64(0)
+    packed_hi = Uint64(0)
+    scale_byte = Uint8(0)
+    if max_abs > Float32(0.0):
+        # /6 so the block max maps to <= FLOAT4_E2M1_MAX, not overflow.
+        ue8m0 = cvt_f32_to_ue8m0(max_abs / Float32(FLOAT4_E2M1_MAX))
+        scale_byte = Uint8(ue8m0 & Uint32(0xFF))
+        inv_scale = ue8m0_to_output_scale(ue8m0)  # 2^(127 - ue8m0) = 1/scale
+        packed_lo, packed_hi = quantize_and_pack_32(values, inv_scale)
+    return packed_lo, packed_hi, scale_byte
+
+
+@cute.jit
+def quantize_block_mxf4_fast(
+    values: cute.Tensor,
+    max_abs: Float32,
+) -> Tuple[Uint64, Uint64, Uint8]:
+    """Alias of quantize_block_mxf4 (the E8M0 path is already single-pass).
+
+    Kept for call-site symmetry with the NVFP4 quantize_block_fp4_fast.
+    """
+    return quantize_block_mxf4(values, max_abs)
+
+
+@cute.jit
+def max_abs_32(values: cute.Tensor) -> Float32:
+    """Compute the maximum absolute value of 32 float32 values."""
+    result = fabs_f32(values[0])
+    for i in cutlass.range_constexpr(1, 32):
+        result = fmax_f32(result, fabs_f32(values[i]))
+    return result
+
+
+@cute.jit
+def silu_mul_32(
+    gate: cute.Tensor,
+    up: cute.Tensor,
+) -> cute.Tensor:
+    """Fused SiLU(gate) * up for 32 float32 element pairs."""
+    out = cute.make_rmem_tensor((32,), Float32)
+    for i in cutlass.range_constexpr(32):
+        g = gate[i]
+        sigmoid_g = cute.arch.rcp_approx(
+            Float32(1.0) + cute.math.exp(-g, fastmath=False)
+        )
+        out[i] = g * sigmoid_g * up[i]
+    return out
+
+
+@cute.jit
+def silu_mul_quantize_block_mxf4(
+    gate: cute.Tensor,
+    up: cute.Tensor,
+) -> Tuple[Uint64, Uint64, Uint8]:
+    """Fused SiLU(gate)*up + MXFP4 quantize for 32 element pairs (no global scale)."""
+    activated = silu_mul_32(gate, up)
+    block_max = max_abs_32(activated)
+    return quantize_block_mxf4(activated, block_max)
+
+
+@cute.jit
+def relu2_32(x: cute.Tensor) -> cute.Tensor:
+    """Compute ReLU²(x) = max(0, x)² for 32 float32 values."""
+    out = cute.make_rmem_tensor((32,), Float32)
+    for i in cutlass.range_constexpr(32):
+        v = fmax_f32(x[i], Float32(0.0))
+        out[i] = v * v
+    return out
+
+
+@cute.jit
+def relu2_quantize_block_mxf4(
+    x: cute.Tensor,
+) -> Tuple[Uint64, Uint64, Uint8]:
+    """Fused ReLU² + MXFP4 quantize for 32 float32 values (no global scale)."""
+    activated = relu2_32(x)
+    block_max = max_abs_32(activated)
+    return quantize_block_mxf4(activated, block_max)

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/__init__.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/__init__.py
@@ -12,6 +12,7 @@ from .moe_dispatch import (
     launch_sm120_static_moe,
     launch_sm120_dynamic_moe,
     launch_sm120_moe,
+    sm120_moe_supported_quant_modes,
     _get_weight_views,
 )
 
@@ -27,4 +28,5 @@ __all__ = [
     "launch_sm120_static_moe",
     "launch_sm120_dynamic_moe",
     "launch_sm120_moe",
+    "sm120_moe_supported_quant_modes",
 ]

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -131,6 +131,28 @@ def _normalize_activation_precision(activation_precision: str) -> str:
         ) from exc
 
 
+# Public quant-mode aliases accepted by launch_sm120_moe (value = dispatch mode).
+_SM120_MOE_QUANT_MODE_ALIASES = {
+    "fp4": "nvfp4",
+    "nvfp4": "nvfp4",
+    "w4a4": "nvfp4",
+    "mxfp4": "mxfp4",
+    "bf16": "w4a16",
+    "w4a16": "w4a16",
+}
+
+
+def sm120_moe_supported_quant_modes() -> frozenset[str]:
+    """Quant-mode names accepted by ``launch_sm120_moe`` in this build.
+
+    Stable capability probe for callers (e.g. SGLang) that need to detect
+    whether the installed FlashInfer supports a given SM120 MoE quant mode
+    before selecting it. Includes both canonical names and aliases, e.g.
+    ``"mxfp4"``, ``"nvfp4"``/``"w4a4"``/``"fp4"``, ``"w4a16"``/``"bf16"``.
+    """
+    return frozenset(_SM120_MOE_QUANT_MODE_ALIASES)
+
+
 def _normalize_quant_mode(
     quant_mode: str | None = None,
     activation_precision: str | None = None,
@@ -145,19 +167,24 @@ def _normalize_quant_mode(
         return "w4a16" if activation_precision == "bf16" else "nvfp4"
 
     normalized = str(quant_mode).lower()
-    aliases = {
-        "fp4": "nvfp4",
-        "nvfp4": "nvfp4",
-        "w4a4": "nvfp4",
-        "bf16": "w4a16",
-        "w4a16": "w4a16",
-    }
     try:
-        return aliases[normalized]
+        return _SM120_MOE_QUANT_MODE_ALIASES[normalized]
     except KeyError as exc:
         raise ValueError(
-            f"quant_mode must be 'nvfp4'/'w4a4' or 'w4a16' (got {quant_mode!r})."
+            f"quant_mode must be 'nvfp4'/'w4a4', 'mxfp4', or 'w4a16' "
+            f"(got {quant_mode!r})."
         ) from exc
+
+
+def _sf_params_for_quant_mode(quant_mode: str):
+    """(sf_vec_size, sf_dtype, block_size) for an FP4 dispatch mode.
+
+    NVFP4: 16-element E4M3 block scales.  MXFP4: 32-element E8M0 block scales.
+    """
+    mode = _normalize_quant_mode(quant_mode)
+    if mode == "mxfp4":
+        return 32, cutlass.Float8E8M0FNU, 32
+    return 16, cutlass.Float8E4M3FN, _NVFP4_BLOCK_SIZE
 
 
 def _activation_precision_from_quant_mode(quant_mode: str) -> str:
@@ -293,6 +320,7 @@ def allocate_sm120_static_workspace(
     num_topk: int,
     device: torch.device,
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ) -> Sm120StaticMoEWorkspace:
     """Allocate workspace buffers for the SM120 static MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -302,8 +330,9 @@ def allocate_sm120_static_workspace(
             "use allocate_sm120_moe_workspace(..., quant_mode='w4a16') for W4A16."
         )
 
+    sf_vec_size, _sf_dt, _sf_block = _sf_params_for_quant_mode(quant_mode)
     rows_pad_k = _align_up(max_rows, 128)
-    cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    cols_pad_k = _align_up(k // sf_vec_size, 4)
     packed_input = torch.empty(
         state_E, max_rows, k // 2, dtype=torch.uint8, device=device
     )
@@ -337,7 +366,7 @@ def allocate_sm120_static_workspace(
     )
 
     # Finalize views
-    sf_dtype = cutlass.Float8E4M3FN
+    sf_dtype = _sf_dt
     workspace.packed_a_view = workspace.packed_input.permute(1, 2, 0).view(
         torch.float4_e2m1fn_x2
     )
@@ -384,6 +413,7 @@ def _get_weight_views(
     n: int,
     k: int,
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ) -> _WeightViews:
     """Create permuted weight views for the static kernel.
 
@@ -391,6 +421,7 @@ def _get_weight_views(
     via a single TMA descriptor.
     """
     activation_precision = _normalize_activation_precision(activation_precision)
+    sf_vec_size, _sf_dt, _sf_block = _sf_params_for_quant_mode(quant_mode)
     tile_n = _level_tile_n(activation_precision)
     # The kernel splits w13 into gate/up halves by tile index. This only works
     # when the boundary between halves lands on a tile-aligned column.
@@ -402,6 +433,7 @@ def _get_weight_views(
 
     key = (
         activation_precision,
+        sf_vec_size,
         w1_fp4.data_ptr(),
         w1_blockscale.data_ptr(),
         w1_alphas.data_ptr(),
@@ -424,19 +456,21 @@ def _get_weight_views(
     # We need the ORIGINAL physical storage, not .contiguous() of the view
     # (which would write in permuted logical order).
     # convert_sf_from_mma_layout reverses the permutation back to 2D swizzled.
-    sf_dtype = cutlass.Float8E4M3FN
+    sf_dtype = _sf_dt
     w1_rows = w1_fp4.shape[1]  # 2*n for gated, n for non-gated
     w13_sf_contiguous = convert_sf_from_mma_layout(
         w1_blockscale,
         m=w1_rows,
         k=k,
         num_groups=w1_fp4.shape[0],  # num_local_experts
+        sf_vec_size=sf_vec_size,
     ).contiguous()
     down_sf_contiguous = convert_sf_from_mma_layout(
         w2_blockscale,
         m=k,
         k=n,
         num_groups=w2_fp4.shape[0],
+        sf_vec_size=sf_vec_size,
     ).contiguous()
 
     views = _WeightViews(
@@ -489,6 +523,7 @@ def _get_static_kernel(
     mac_override: int | None = None,
     activation: str = "silu",
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ):
     """Compile (or retrieve cached) the SM120 static MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -496,7 +531,7 @@ def _get_static_kernel(
         raise ValueError(
             "internal routing error: quant_mode='w4a16' reached the NVFP4 static compiler"
         )
-    sf_vec_size = 16
+    sf_vec_size, sf_dtype, _sf_block = _sf_params_for_quant_mode(quant_mode)
     sm_count = get_num_sm(torch.device("cuda"))
     mac = (
         mac_override
@@ -513,6 +548,7 @@ def _get_static_kernel(
     cache_key = (
         "static",
         activation_precision,
+        sf_vec_size,
         state_E,
         weight_E,
         m,
@@ -533,7 +569,6 @@ def _get_static_kernel(
 
     ab_dtype = cutlass.Float4E2M1FN
     weight_dtype = cutlass.Float4E2M1FN
-    sf_dtype = cutlass.Float8E4M3FN
     a_dtype = cutlass.BFloat16
     alpha_dtype = cutlass.Float32
 
@@ -551,7 +586,7 @@ def _get_static_kernel(
     w1_rows = (2 if is_gated else 1) * n  # 2*n for gated, n for non-gated
 
     rows_pad_k = _align_up(max_rows, 128)
-    cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    cols_pad_k = _align_up(k // sf_vec_size, 4)
 
     # Build fake tensors for compilation
     a_input_fake = cute.runtime.make_fake_compact_tensor(
@@ -729,9 +764,10 @@ def _get_micro_kernel(
     single_token: bool = False,
     mac_override: int | None = None,
     activation: str = "silu",
+    quant_mode: str = "nvfp4",
 ):
     """Compile (or retrieve cached) the SM120 micro MoE kernel."""
-    sf_vec_size = 16
+    sf_vec_size, _micro_sf_dtype, _sf_block = _sf_params_for_quant_mode(quant_mode)
     sm_count = get_num_sm(torch.device("cuda"))
     mac = (
         mac_override
@@ -745,6 +781,7 @@ def _get_micro_kernel(
 
     cache_key = (
         "micro",
+        sf_vec_size,
         state_E,
         weight_E,
         m,
@@ -767,7 +804,7 @@ def _get_micro_kernel(
         return cached
 
     ab_dtype = cutlass.Float4E2M1FN
-    sf_dtype = cutlass.Float8E4M3FN
+    sf_dtype = _micro_sf_dtype
     a_dtype = cutlass.BFloat16
     alpha_dtype = cutlass.Float32
 
@@ -787,7 +824,7 @@ def _get_micro_kernel(
     w1_rows = (2 if is_gated else 1) * n
 
     rows_pad_k = _align_up(max_rows, 128)
-    cols_pad_k = _align_up(k // _NVFP4_BLOCK_SIZE, 4)
+    cols_pad_k = _align_up(k // sf_vec_size, 4)
 
     # Build fake tensors for compilation (identical to static kernel)
     a_input_fake = cute.runtime.make_fake_compact_tensor(
@@ -974,6 +1011,7 @@ def launch_sm120_static_moe(
     fast_math: bool = True,
     activation: str = "silu",
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ) -> torch.Tensor:
     """Launch the SM120 static or micro MoE kernel.
 
@@ -1007,6 +1045,10 @@ def launch_sm120_static_moe(
     if top_k > 1:
         micro_cutover = _MICRO_COMPACT_CUTOVER_PAIRS_MULTI_TOPK
     use_micro = activation_precision == "fp4" and routed_rows <= micro_cutover
+
+    # MXFP4 is fully supported on the micro and plain-static paths (the kernels
+    # carry the 32-element E8M0 quant). No mxfp4-specific dispatch gating is
+    # needed here — backend selection below is quant-mode agnostic.
 
     sm_count = get_num_sm(torch.device("cuda"))
     base_mac = min(get_max_active_clusters(1), sm_count)
@@ -1083,6 +1125,7 @@ def launch_sm120_static_moe(
             single_token=num_tokens == 1,
             mac_override=micro_mac,
             activation=activation,
+            quant_mode=quant_mode,
         )
     else:
         compiled, mac = _get_static_kernel(
@@ -1099,11 +1142,12 @@ def launch_sm120_static_moe(
             mac_override=static_mac,
             activation=activation,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
         launch_ids = flat_ids
 
-    # Pointer arguments must be passed as raw ints (data_ptr()) at runtime.
-    runtime_args: Tuple[Any, ...] = (
+    # Build runtime args (tensor-based; per-m static and micro paths)
+    runtime_args = (
         a,
         launch_ids,
         flat_weights,
@@ -1150,6 +1194,9 @@ def select_sm120_moe_backend(
     mode = _normalize_quant_mode(quant_mode, activation_precision)
     if mode == "w4a16":
         return "w4a16"
+    # MXFP4: static for small routed sets, dynamic above the cutover (the
+    # kernels carry the 32-element E8M0 quant). The cutover uses the "fp4"
+    # ladder since the routing/tiling geometry is identical.
     routed_rows = num_tokens * num_topk
     if routed_rows <= _get_static_compact_cutover_pairs("fp4"):
         return "static"
@@ -1499,6 +1546,7 @@ def _get_dynamic_kernel(
     activation: str = "silu",
     activation_precision: str = "fp4",
     share_input_across_experts: bool = False,
+    quant_mode: str = "nvfp4",
 ):
     """Compile (or retrieve cached) the SM120 dynamic MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -1509,7 +1557,7 @@ def _get_dynamic_kernel(
     share_input_across_experts = bool(
         share_input_across_experts and activation_precision == "fp4"
     )
-    sf_vec_size = 16
+    sf_vec_size, sf_dtype, _sf_block = _sf_params_for_quant_mode(quant_mode)
     sm_count = get_num_sm(torch.device("cuda"))
     mac = min(get_max_active_clusters(1), sm_count)
     mma_tiler_mn = (
@@ -1520,6 +1568,7 @@ def _get_dynamic_kernel(
     cache_key = (
         "dynamic",
         activation_precision,
+        sf_vec_size,
         E,
         k,
         n,
@@ -1541,7 +1590,6 @@ def _get_dynamic_kernel(
 
     scratch_dtype = cutlass.Float4E2M1FN
     weight_dtype = cutlass.Float4E2M1FN
-    sf_dtype = cutlass.Float8E4M3FN
     a_dtype = cutlass.BFloat16
     alpha_dtype = cutlass.Float32
 
@@ -1746,6 +1794,7 @@ def launch_sm120_dynamic_moe(
     fast_math: bool = True,
     activation: str = "silu",
     activation_precision: str = "fp4",
+    quant_mode: str = "nvfp4",
 ) -> torch.Tensor:
     """Launch the SM120 dynamic MoE kernel."""
     activation_precision = _normalize_activation_precision(activation_precision)
@@ -1774,6 +1823,7 @@ def launch_sm120_dynamic_moe(
         activation=activation,
         activation_precision=activation_precision,
         share_input_across_experts=input_gs_is_shared,
+        quant_mode=quant_mode,
     )
 
     # Dynamic kernel: runtime-shaped args are DataPointer (pass data_ptr()),
@@ -2286,6 +2336,7 @@ def allocate_sm120_moe_workspace(
             num_topk=num_topk,
             device=device,
             activation_precision=activation_precision,
+            quant_mode=mode,
         )
     raise ValueError(f"unsupported SM120 MoE backend {backend!r}")
 
@@ -2447,6 +2498,7 @@ def launch_sm120_moe(
             n=n,
             k=k,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
     )
 
@@ -2479,6 +2531,7 @@ def launch_sm120_moe(
             num_tokens=num_tokens,
             num_topk=top_k,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
         # The dynamic kernel indexes row_counts/expert_write_rows directly with
         # topk_ids but those buffers are sized with num_local_experts. Unless
@@ -2519,6 +2572,7 @@ def launch_sm120_moe(
             fast_math=fast_math,
             activation=activation,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
     else:
         return launch_sm120_static_moe(
@@ -2539,4 +2593,5 @@ def launch_sm120_moe(
             fast_math=fast_math,
             activation=activation,
             activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -84,6 +84,7 @@ from flashinfer.cute_dsl.fp4_common import (
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
+    quantize_block_mxf4,
     get_ptr_as_int64,
     st_global_f32,
     st_global_i32,
@@ -288,7 +289,13 @@ class MoEDynamicKernel:
         self.activation = activation
         self.is_gated = activation == "silu"
         self.share_input_across_experts = share_input_across_experts
-        tile_k = sf_vec_size * 8
+        # MXF4 (sf_vec_size==32) keeps tile_k=128 (4 SF blocks of 32, 2 MMA-K
+        # blocks of 64), NOT 32*8=256, to preserve the FC1-epilogue-N ==
+        # FC2-K-tile == 128 coupling the fused two-GEMM kernel relies on.
+        if sf_vec_size == 32:
+            tile_k = 128
+        else:
+            tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.cluster_shape_mnk = (1, 1, 1)
         self.cluster_shape_mn = (1, 1)
@@ -333,11 +340,20 @@ class MoEDynamicKernel:
 
         self._hidden_size = hidden_size
 
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
+        # sf_vec_size==32 selects the MXF4 atom (E8M0 32-block scales);
+        # else the NVF4 atom (E4M3 16-block). Same MMA shape (16,8,64).
+        if self.sf_vec_size == 32:
+            mma_op = cute.nvgpu.warp.MmaMXF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         atom_shape = (2, 2, 1)
         atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
@@ -939,7 +955,8 @@ class MoEDynamicKernel:
         scatter_base = scatter_output.iterator.toint()
         row_counts = launch_params.row_counts
         num_experts = Int32(row_counts.shape[0])
-        sf_blocks_per_row = cols // Int32(16)
+        # MXF4 (sf_vec_size==32) uses 32-element scale blocks; NVF4 uses 16.
+        sf_blocks_per_row = cols // Int32(self.sf_vec_size)
         output_bytes_per_row = cols // Int32(2)
         cols_u32 = cols // Int32(2)
         scatter_output_u32 = cute.recast_tensor(scatter_output, cutlass.Uint32)
@@ -947,7 +964,9 @@ class MoEDynamicKernel:
         num_topk = total_pairs // num_tokens
         flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
-        num_k_tiles = (cols + Int32(63)) // Int32(64)
+        # num_k_tiles = cols / (blk_sf * sf_vec_size) = cols/64 (NVF4) or /128 (MXF4)
+        _sf_k_tile = Int32(4 * self.sf_vec_size)
+        num_k_tiles = (cols + _sf_k_tile - Int32(1)) // _sf_k_tile
         route_gate_tile_cnt = launch_params.gate_tile_cnt
         task_slice_chunk = Int32(_TASK_SLICE_CHUNK)
         full_tile_publish_enabled = Int32(0)
@@ -1147,111 +1166,229 @@ class MoEDynamicKernel:
                                     * Int32(4)
                                 )
 
-                            sf_idx = lane_id
-                            while sf_idx < sf_blocks_per_row:
-                                block_start = sf_idx * Int32(16)
-                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                                block_max = cutlass.Float32(0.0)
-                                for elem_idx in cutlass.range_constexpr(16):
-                                    value = cutlass.Float32(
-                                        a_input[
-                                            token_idx, block_start + Int32(elem_idx)
-                                        ]
+                            if cutlass.const_expr(self.sf_vec_size == 32):
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(32)
+                                    values = cute.make_rmem_tensor(
+                                        (32,), cutlass.Float32
                                     )
-                                    values[elem_idx] = value
-                                    block_max = fmax_f32(block_max, fabs_f32(value))
-                                packed64 = Uint64(0)
-                                scale_byte = Uint8(0)
-                                if self.fast_math:
-                                    packed64, scale_byte = quantize_block_fp4_fast(
-                                        values, block_max, gs_value
-                                    )
-                                else:
-                                    packed64, scale_byte = quantize_block_fp4(
-                                        values, block_max, gs_value
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(32):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed_lo, packed_hi, scale_byte = (
+                                        quantize_block_mxf4(values, block_max)
                                     )
 
-                                k_tile_idx = sf_idx // Int32(4)
-                                scale_k_base = k_tile_idx * Int32(32 * 4 * 4) + (
-                                    sf_idx % Int32(4)
-                                )
-                                for cache_slot in cutlass.range_constexpr(8):
-                                    output_offset = route_output_base[
-                                        cache_slot
-                                    ] + sf_idx * Int32(8)
-                                    st_global_u64(
-                                        get_ptr_as_int64(
-                                            packed_a_storage, output_offset
-                                        ),
-                                        packed64,
-                                    )
-                                    scale_storage[
-                                        route_scale_base[cache_slot] + scale_k_base
-                                    ] = scale_byte
-                                sf_idx += Int32(32)
-                        else:
-                            sf_idx = lane_id
-                            while sf_idx < sf_blocks_per_row:
-                                block_start = sf_idx * Int32(16)
-                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                                block_max = cutlass.Float32(0.0)
-                                for elem_idx in cutlass.range_constexpr(16):
-                                    value = cutlass.Float32(
-                                        a_input[
-                                            token_idx, block_start + Int32(elem_idx)
-                                        ]
-                                    )
-                                    values[elem_idx] = value
-                                    block_max = fmax_f32(block_max, fabs_f32(value))
-                                packed64 = Uint64(0)
-                                scale_byte = Uint8(0)
-                                if self.fast_math:
-                                    packed64, scale_byte = quantize_block_fp4_fast(
-                                        values, block_max, gs_value
-                                    )
-                                else:
-                                    packed64, scale_byte = quantize_block_fp4(
-                                        values, block_max, gs_value
-                                    )
-
-                                topk_slot = Int32(0)
-                                while topk_slot < num_topk:
-                                    slot = route_slot_base + topk_slot
-                                    phys_row = _ld_shared_i32(
-                                        route_phys_rows_addr + slot * Int32(4)
-                                    )
-                                    phys_tile = phys_row // Int32(
-                                        self.tile_shape_mnk[0]
-                                    )
-                                    tile_row = phys_row - phys_tile * Int32(
-                                        self.tile_shape_mnk[0]
-                                    )
-                                    output_offset = (
-                                        phys_row * output_bytes_per_row
-                                        + sf_idx * Int32(8)
-                                    )
-                                    st_global_u64(
-                                        get_ptr_as_int64(
-                                            packed_a_storage, output_offset
-                                        ),
-                                        packed64,
-                                    )
                                     k_tile_idx = sf_idx // Int32(4)
-                                    outer_m_idx = tile_row % Int32(32)
-                                    inner_m_idx = (tile_row % Int32(32 * 4)) // Int32(
-                                        32
+                                    scale_k_base = k_tile_idx * Int32(32 * 4 * 4) + (
+                                        sf_idx % Int32(4)
                                     )
-                                    inner_k_idx = sf_idx % Int32(4)
-                                    scale_offset = (
-                                        phys_tile * num_k_tiles * Int32(32 * 4 * 4)
-                                        + k_tile_idx * Int32(32 * 4 * 4)
-                                        + outer_m_idx * Int32(4 * 4)
-                                        + inner_m_idx * Int32(4)
-                                        + inner_k_idx
+                                    for cache_slot in cutlass.range_constexpr(8):
+                                        # 32 FP4 = 16 bytes = two uint64 (sf_idx*16).
+                                        output_offset = route_output_base[
+                                            cache_slot
+                                        ] + sf_idx * Int32(16)
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage, output_offset
+                                            ),
+                                            packed_lo,
+                                        )
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage,
+                                                output_offset + Int32(8),
+                                            ),
+                                            packed_hi,
+                                        )
+                                        scale_storage[
+                                            route_scale_base[cache_slot] + scale_k_base
+                                        ] = scale_byte
+                                    sf_idx += Int32(32)
+                            else:
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(16)
+                                    values = cute.make_rmem_tensor(
+                                        (16,), cutlass.Float32
                                     )
-                                    scale_storage[scale_offset] = scale_byte
-                                    topk_slot += Int32(1)
-                                sf_idx += Int32(32)
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(16):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed64 = Uint64(0)
+                                    scale_byte = Uint8(0)
+                                    if self.fast_math:
+                                        packed64, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed64, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
+
+                                    k_tile_idx = sf_idx // Int32(4)
+                                    scale_k_base = k_tile_idx * Int32(32 * 4 * 4) + (
+                                        sf_idx % Int32(4)
+                                    )
+                                    for cache_slot in cutlass.range_constexpr(8):
+                                        output_offset = route_output_base[
+                                            cache_slot
+                                        ] + sf_idx * Int32(8)
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage, output_offset
+                                            ),
+                                            packed64,
+                                        )
+                                        scale_storage[
+                                            route_scale_base[cache_slot] + scale_k_base
+                                        ] = scale_byte
+                                    sf_idx += Int32(32)
+                        else:
+                            if cutlass.const_expr(self.sf_vec_size == 32):
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(32)
+                                    values = cute.make_rmem_tensor(
+                                        (32,), cutlass.Float32
+                                    )
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(32):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed_lo, packed_hi, scale_byte = (
+                                        quantize_block_mxf4(values, block_max)
+                                    )
+
+                                    topk_slot = Int32(0)
+                                    while topk_slot < num_topk:
+                                        slot = route_slot_base + topk_slot
+                                        phys_row = _ld_shared_i32(
+                                            route_phys_rows_addr + slot * Int32(4)
+                                        )
+                                        phys_tile = phys_row // Int32(
+                                            self.tile_shape_mnk[0]
+                                        )
+                                        tile_row = phys_row - phys_tile * Int32(
+                                            self.tile_shape_mnk[0]
+                                        )
+                                        # 32 FP4 = 16 bytes = two uint64 (sf_idx*16).
+                                        output_offset = (
+                                            phys_row * output_bytes_per_row
+                                            + sf_idx * Int32(16)
+                                        )
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage, output_offset
+                                            ),
+                                            packed_lo,
+                                        )
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage,
+                                                output_offset + Int32(8),
+                                            ),
+                                            packed_hi,
+                                        )
+                                        k_tile_idx = sf_idx // Int32(4)
+                                        outer_m_idx = tile_row % Int32(32)
+                                        inner_m_idx = (
+                                            tile_row % Int32(32 * 4)
+                                        ) // Int32(32)
+                                        inner_k_idx = sf_idx % Int32(4)
+                                        scale_offset = (
+                                            phys_tile * num_k_tiles * Int32(32 * 4 * 4)
+                                            + k_tile_idx * Int32(32 * 4 * 4)
+                                            + outer_m_idx * Int32(4 * 4)
+                                            + inner_m_idx * Int32(4)
+                                            + inner_k_idx
+                                        )
+                                        scale_storage[scale_offset] = scale_byte
+                                        topk_slot += Int32(1)
+                                    sf_idx += Int32(32)
+                            else:
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(16)
+                                    values = cute.make_rmem_tensor(
+                                        (16,), cutlass.Float32
+                                    )
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(16):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed64 = Uint64(0)
+                                    scale_byte = Uint8(0)
+                                    if self.fast_math:
+                                        packed64, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed64, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
+
+                                    topk_slot = Int32(0)
+                                    while topk_slot < num_topk:
+                                        slot = route_slot_base + topk_slot
+                                        phys_row = _ld_shared_i32(
+                                            route_phys_rows_addr + slot * Int32(4)
+                                        )
+                                        phys_tile = phys_row // Int32(
+                                            self.tile_shape_mnk[0]
+                                        )
+                                        tile_row = phys_row - phys_tile * Int32(
+                                            self.tile_shape_mnk[0]
+                                        )
+                                        output_offset = (
+                                            phys_row * output_bytes_per_row
+                                            + sf_idx * Int32(8)
+                                        )
+                                        st_global_u64(
+                                            get_ptr_as_int64(
+                                                packed_a_storage, output_offset
+                                            ),
+                                            packed64,
+                                        )
+                                        k_tile_idx = sf_idx // Int32(4)
+                                        outer_m_idx = tile_row % Int32(32)
+                                        inner_m_idx = (
+                                            tile_row % Int32(32 * 4)
+                                        ) // Int32(32)
+                                        inner_k_idx = sf_idx % Int32(4)
+                                        scale_offset = (
+                                            phys_tile * num_k_tiles * Int32(32 * 4 * 4)
+                                            + k_tile_idx * Int32(32 * 4 * 4)
+                                            + outer_m_idx * Int32(4 * 4)
+                                            + inner_m_idx * Int32(4)
+                                            + inner_k_idx
+                                        )
+                                        scale_storage[scale_offset] = scale_byte
+                                        topk_slot += Int32(1)
+                                    sf_idx += Int32(32)
 
                         if full_tile_publish_enabled > Int32(0):
                             cute.arch.sync_warp()
@@ -1337,52 +1474,108 @@ class MoEDynamicKernel:
                                     gs_value = rcp_approx_ftz(gs_value)
                                 else:
                                     gs_value = cutlass.Float32(1.0) / gs_value
-                            sf_idx = lane_id
-                            while sf_idx < sf_blocks_per_row:
-                                block_start = sf_idx * Int32(16)
-                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                                block_max = cutlass.Float32(0.0)
-                                for elem_idx in cutlass.range_constexpr(16):
-                                    value = cutlass.Float32(
-                                        a_input[
-                                            token_idx, block_start + Int32(elem_idx)
-                                        ]
+                            if cutlass.const_expr(self.sf_vec_size == 32):
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(32)
+                                    values = cute.make_rmem_tensor(
+                                        (32,), cutlass.Float32
                                     )
-                                    values[elem_idx] = value
-                                    block_max = fmax_f32(block_max, fabs_f32(value))
-                                packed64 = Uint64(0)
-                                scale_byte = Uint8(0)
-                                if self.fast_math:
-                                    packed64, scale_byte = quantize_block_fp4_fast(
-                                        values, block_max, gs_value
-                                    )
-                                else:
-                                    packed64, scale_byte = quantize_block_fp4(
-                                        values, block_max, gs_value
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(32):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed_lo, packed_hi, scale_byte = (
+                                        quantize_block_mxf4(values, block_max)
                                     )
 
-                                output_offset = (
-                                    phys_tile * Int32(self.tile_shape_mnk[0])
-                                    + row % Int32(self.tile_shape_mnk[0])
-                                ) * output_bytes_per_row + sf_idx * Int32(8)
-                                st_global_u64(
-                                    get_ptr_as_int64(packed_a_storage, output_offset),
-                                    packed64,
-                                )
+                                    # 32 FP4 = 16 bytes = two uint64 (sf_idx*16).
+                                    output_offset = (
+                                        phys_tile * Int32(self.tile_shape_mnk[0])
+                                        + row % Int32(self.tile_shape_mnk[0])
+                                    ) * output_bytes_per_row + sf_idx * Int32(16)
+                                    st_global_u64(
+                                        get_ptr_as_int64(
+                                            packed_a_storage, output_offset
+                                        ),
+                                        packed_lo,
+                                    )
+                                    st_global_u64(
+                                        get_ptr_as_int64(
+                                            packed_a_storage, output_offset + Int32(8)
+                                        ),
+                                        packed_hi,
+                                    )
 
-                                k_tile_idx = sf_idx // Int32(4)
-                                outer_m_idx = row % Int32(32)
-                                inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
-                                inner_k_idx = sf_idx % Int32(4)
-                                scale_offset = (
-                                    phys_tile * num_k_tiles * Int32(32 * 4 * 4)
-                                    + k_tile_idx * Int32(32 * 4 * 4)
-                                    + outer_m_idx * Int32(4 * 4)
-                                    + inner_m_idx * Int32(4)
-                                    + inner_k_idx
-                                )
-                                scale_storage[scale_offset] = scale_byte
-                                sf_idx += Int32(32)
+                                    k_tile_idx = sf_idx // Int32(4)
+                                    outer_m_idx = row % Int32(32)
+                                    inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
+                                    inner_k_idx = sf_idx % Int32(4)
+                                    scale_offset = (
+                                        phys_tile * num_k_tiles * Int32(32 * 4 * 4)
+                                        + k_tile_idx * Int32(32 * 4 * 4)
+                                        + outer_m_idx * Int32(4 * 4)
+                                        + inner_m_idx * Int32(4)
+                                        + inner_k_idx
+                                    )
+                                    scale_storage[scale_offset] = scale_byte
+                                    sf_idx += Int32(32)
+                            else:
+                                sf_idx = lane_id
+                                while sf_idx < sf_blocks_per_row:
+                                    block_start = sf_idx * Int32(16)
+                                    values = cute.make_rmem_tensor(
+                                        (16,), cutlass.Float32
+                                    )
+                                    block_max = cutlass.Float32(0.0)
+                                    for elem_idx in cutlass.range_constexpr(16):
+                                        value = cutlass.Float32(
+                                            a_input[
+                                                token_idx, block_start + Int32(elem_idx)
+                                            ]
+                                        )
+                                        values[elem_idx] = value
+                                        block_max = fmax_f32(block_max, fabs_f32(value))
+                                    packed64 = Uint64(0)
+                                    scale_byte = Uint8(0)
+                                    if self.fast_math:
+                                        packed64, scale_byte = quantize_block_fp4_fast(
+                                            values, block_max, gs_value
+                                        )
+                                    else:
+                                        packed64, scale_byte = quantize_block_fp4(
+                                            values, block_max, gs_value
+                                        )
+
+                                    output_offset = (
+                                        phys_tile * Int32(self.tile_shape_mnk[0])
+                                        + row % Int32(self.tile_shape_mnk[0])
+                                    ) * output_bytes_per_row + sf_idx * Int32(8)
+                                    st_global_u64(
+                                        get_ptr_as_int64(
+                                            packed_a_storage, output_offset
+                                        ),
+                                        packed64,
+                                    )
+
+                                    k_tile_idx = sf_idx // Int32(4)
+                                    outer_m_idx = row % Int32(32)
+                                    inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
+                                    inner_k_idx = sf_idx % Int32(4)
+                                    scale_offset = (
+                                        phys_tile * num_k_tiles * Int32(32 * 4 * 4)
+                                        + k_tile_idx * Int32(32 * 4 * 4)
+                                        + outer_m_idx * Int32(4 * 4)
+                                        + inner_m_idx * Int32(4)
+                                        + inner_k_idx
+                                    )
+                                    scale_storage[scale_offset] = scale_byte
+                                    sf_idx += Int32(32)
 
                             if full_tile_publish_enabled > Int32(0):
                                 cute.arch.sync_warp()
@@ -2160,15 +2353,21 @@ class MoEDynamicKernel:
                     # Activation + quant into sA
                     sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                     packed_cols = Int32(self.tile_shape_mnk[2] // 2)
-                    sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
-                    gs_value = global_scale[task_expert_idx].to(cutlass.Float32)
-                    if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
-                        0.0
-                    ):
-                        if self.fast_math:
-                            gs_value = rcp_approx_ftz(gs_value)
-                        else:
-                            gs_value = cutlass.Float32(1.0) / gs_value
+                    # MXF4 (sf_vec_size==32) uses 32-element scale blocks + self-
+                    # scaling E8M0 (no global scale); NVF4 uses 16 + global scale.
+                    sf_blocks_per_row = Int32(
+                        self.tile_shape_mnk[2] // self.sf_vec_size
+                    )
+                    if cutlass.const_expr(self.sf_vec_size != 32):
+                        gs_value = global_scale[task_expert_idx].to(cutlass.Float32)
+                        if (
+                            self.input_scales_are_reciprocal
+                            and gs_value != cutlass.Float32(0.0)
+                        ):
+                            if self.fast_math:
+                                gs_value = rcp_approx_ftz(gs_value)
+                            else:
+                                gs_value = cutlass.Float32(1.0) / gs_value
 
                     for epi_m in cutlass.range_constexpr(epi_rest_m):
                         epi_m_valid = valid_rows - Int32(epi_m) * Int32(
@@ -2230,43 +2429,96 @@ class MoEDynamicKernel:
                             local_row = quant_idx // sf_blocks_per_row
                             row = rows_offset + local_row
                             sf_block = quant_idx - local_row * sf_blocks_per_row
-                            block_start = sf_block * Int32(16)
 
-                            values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                            block_max = cutlass.Float32(0.0)
-                            for elem_idx in cutlass.range_constexpr(16):
-                                value = cutlass.Float32(
-                                    sC[
-                                        local_row,
-                                        block_start + elem_idx,
-                                        silu_epi_buffer,
-                                    ]
-                                )
-                                values[elem_idx] = value
-                                block_max = fmax_f32(block_max, fabs_f32(value))
+                            if cutlass.const_expr(self.sf_vec_size == 32):
+                                block_start = sf_block * Int32(32)
+                                values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                                block_max = cutlass.Float32(0.0)
+                                for elem_idx in cutlass.range_constexpr(32):
+                                    value = cutlass.Float32(
+                                        sC[
+                                            local_row,
+                                            block_start + elem_idx,
+                                            silu_epi_buffer,
+                                        ]
+                                    )
+                                    values[elem_idx] = value
+                                    block_max = fmax_f32(block_max, fabs_f32(value))
 
-                            packed64 = Uint64(0)
-                            scale_byte = Uint8(0)
-                            if self.fast_math:
-                                packed64, scale_byte = quantize_block_fp4_fast(
-                                    values, block_max, gs_value
+                                packed_lo, packed_hi, scale_byte = quantize_block_mxf4(
+                                    values, block_max
                                 )
+                                # 32 FP4 = 16 bytes (two uint64). tile_k=128 ->
+                                # A SMEM atom K_SW64, byte-swizzle identical to
+                                # NVF4: packed_cols=tile_k/2=64, XOR mask 0x3.
+                                packed_base = sf_block << Int32(4)
+                                dst_pcol = row & Int32(63)
+                                xor_bits = (
+                                    (dst_pcol >> Int32(1)) & Int32(0x3)
+                                ) << Int32(4)
+                                row_high = row >> Int32(6)
+                                for byte_idx in cutlass.range_constexpr(8):
+                                    src_pcol = packed_base + Int32(byte_idx)
+                                    dst_row = (
+                                        (src_pcol ^ xor_bits) << Int32(1)
+                                    ) + row_high
+                                    dst_flat = dst_row * packed_cols + dst_pcol
+                                    sA_u8[dst_flat] = Uint8(
+                                        (packed_lo >> Uint64(byte_idx * 8))
+                                        & Uint64(0xFF)
+                                    )
+                                for byte_idx in cutlass.range_constexpr(8):
+                                    src_pcol = packed_base + Int32(8) + Int32(byte_idx)
+                                    dst_row = (
+                                        (src_pcol ^ xor_bits) << Int32(1)
+                                    ) + row_high
+                                    dst_flat = dst_row * packed_cols + dst_pcol
+                                    sA_u8[dst_flat] = Uint8(
+                                        (packed_hi >> Uint64(byte_idx * 8))
+                                        & Uint64(0xFF)
+                                    )
                             else:
-                                packed64, scale_byte = quantize_block_fp4(
-                                    values, block_max, gs_value
-                                )
-                            packed_base = sf_block << Int32(3)
-                            dst_pcol = row & Int32(63)
-                            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
-                            row_high = row >> Int32(6)
-                            for byte_idx in cutlass.range_constexpr(8):
-                                src_pcol = packed_base + Int32(byte_idx)
-                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
-                                dst_flat = dst_row * packed_cols + dst_pcol
-                                byte_val = Uint8(
-                                    (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
-                                )
-                                sA_u8[dst_flat] = byte_val
+                                block_start = sf_block * Int32(16)
+                                values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                                block_max = cutlass.Float32(0.0)
+                                for elem_idx in cutlass.range_constexpr(16):
+                                    value = cutlass.Float32(
+                                        sC[
+                                            local_row,
+                                            block_start + elem_idx,
+                                            silu_epi_buffer,
+                                        ]
+                                    )
+                                    values[elem_idx] = value
+                                    block_max = fmax_f32(block_max, fabs_f32(value))
+
+                                packed64 = Uint64(0)
+                                scale_byte = Uint8(0)
+                                if self.fast_math:
+                                    packed64, scale_byte = quantize_block_fp4_fast(
+                                        values, block_max, gs_value
+                                    )
+                                else:
+                                    packed64, scale_byte = quantize_block_fp4(
+                                        values, block_max, gs_value
+                                    )
+                                packed_base = sf_block << Int32(3)
+                                dst_pcol = row & Int32(63)
+                                xor_bits = (
+                                    (dst_pcol >> Int32(1)) & Int32(0x3)
+                                ) << Int32(4)
+                                row_high = row >> Int32(6)
+                                for byte_idx in cutlass.range_constexpr(8):
+                                    src_pcol = packed_base + Int32(byte_idx)
+                                    dst_row = (
+                                        (src_pcol ^ xor_bits) << Int32(1)
+                                    ) + row_high
+                                    dst_flat = dst_row * packed_cols + dst_pcol
+                                    byte_val = Uint8(
+                                        (packed64 >> Uint64(byte_idx * 8))
+                                        & Uint64(0xFF)
+                                    )
+                                    sA_u8[dst_flat] = byte_val
 
                             outer_m_idx = row % Int32(32)
                             inner_m_idx = row // Int32(32)

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -338,8 +338,8 @@ class MoEDynamicKernel:
             self.acc_dtype,
             self.sf_dtype,
         )
-        atom_layout = cute.make_layout((2, 2, 1))
         atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -339,6 +339,7 @@ class MoEDynamicKernel:
             self.sf_dtype,
         )
         atom_layout = cute.make_layout((2, 2, 1))
+        atom_shape = (2, 2, 1)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -351,9 +352,16 @@ class MoEDynamicKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
-        self.num_k_blocks = self.tile_shape_mnk[2] // 64
+        # Derive atom loop bounds from the tile shape and the warp atom layout,
+        # like the dense kernel. atom_layout=(2,2,1) => 2 M-warps, 2 N-warps.
+        # The previous hardcoded (16*4) was copied from the dense kernel's
+        # (4,2,1) layout and gave num_m_tiles=2 instead of 4, so the GEMM filled
+        # only M-tiles {0,1} and left rows 64..127 (the 2nd 64-row warp quadrant)
+        # at fill(0.0). num_n_tiles was accidentally correct (atom_shape[1]=2).
+        mma_m, mma_n, mma_k = 16, 8, 64
+        self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.tile_shape_mnk[2] // mma_k
 
         sfa_smem = sm120_make_smem_layout_sfa(
             self.tiled_mma,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -352,12 +352,8 @@ class MoEDynamicKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        # Derive atom loop bounds from the tile shape and the warp atom layout,
-        # like the dense kernel. atom_layout=(2,2,1) => 2 M-warps, 2 N-warps.
-        # The previous hardcoded (16*4) was copied from the dense kernel's
-        # (4,2,1) layout and gave num_m_tiles=2 instead of 4, so the GEMM filled
-        # only M-tiles {0,1} and left rows 64..127 (the 2nd 64-row warp quadrant)
-        # at fill(0.0). num_n_tiles was accidentally correct (atom_shape[1]=2).
+        # Derive loop bounds from atom_shape (like the dense kernel). The old
+        # hardcoded (16*4) assumed dense's (4,2,1); this kernel is (2,2,1).
         mma_m, mma_n, mma_k = 16, 8, 64
         self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -537,12 +537,8 @@ class MoEMicroKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        # Derive atom loop bounds from the tile shape and the warp atom layout,
-        # like the dense kernel. atom_layout=(2,2,1) => 2 M-warps, 2 N-warps.
-        # The previous hardcoded (16*4) was copied from the dense kernel's
-        # (4,2,1) layout and gave num_m_tiles=2 instead of 4, so the GEMM filled
-        # only M-tiles {0,1} and left rows 64..127 (the 2nd 64-row warp quadrant)
-        # at fill(0.0). num_n_tiles was accidentally correct (atom_shape[1]=2).
+        # Derive loop bounds from atom_shape (like the dense kernel). The old
+        # hardcoded (16*4) assumed dense's (4,2,1); this kernel is (2,2,1).
         mma_m, mma_n, mma_k = 16, 8, 64
         self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -523,8 +523,8 @@ class MoEMicroKernel:
             self.acc_dtype,
             self.sf_dtype,
         )
-        atom_layout = cute.make_layout((2, 2, 1))
         atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -524,6 +524,7 @@ class MoEMicroKernel:
             self.sf_dtype,
         )
         atom_layout = cute.make_layout((2, 2, 1))
+        atom_shape = (2, 2, 1)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -536,9 +537,16 @@ class MoEMicroKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
-        self.num_k_blocks = self.tile_shape_mnk[2] // 64
+        # Derive atom loop bounds from the tile shape and the warp atom layout,
+        # like the dense kernel. atom_layout=(2,2,1) => 2 M-warps, 2 N-warps.
+        # The previous hardcoded (16*4) was copied from the dense kernel's
+        # (4,2,1) layout and gave num_m_tiles=2 instead of 4, so the GEMM filled
+        # only M-tiles {0,1} and left rows 64..127 (the 2nd 64-row warp quadrant)
+        # at fill(0.0). num_n_tiles was accidentally correct (atom_shape[1]=2).
+        mma_m, mma_n, mma_k = 16, 8, 64
+        self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.tile_shape_mnk[2] // mma_k
 
         sfa_smem = sm120_make_smem_layout_sfa(
             self.tiled_mma,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -114,6 +114,7 @@ from flashinfer.cute_dsl.fp4_common import (
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
+    quantize_block_mxf4,
     get_ptr_as_int64,
     st_global_f32,
     st_global_i32,
@@ -386,7 +387,14 @@ class MoEMicroKernel:
         self.share_input_across_experts = share_input_across_experts
         self.share_expert_scales = share_expert_scales
         self.single_token = single_token
-        tile_k = sf_vec_size * 8
+        # MXF4 (sf_vec_size==32) keeps tile_k=128 (4 SF blocks of 32, 2 MMA-K
+        # blocks of 64), NOT 32*8=256, to preserve the FC1-epilogue-N ==
+        # FC2-K-tile == 128 coupling the fused two-GEMM kernel relies on
+        # (sC is sized by epi_tile=mma_tiler_mn, 128 wide regardless of vec).
+        if sf_vec_size == 32:
+            tile_k = 128
+        else:
+            tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
         self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
@@ -518,11 +526,20 @@ class MoEMicroKernel:
 
         self._hidden_size = hidden_size
 
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
+        # sf_vec_size==32 selects the MXF4 atom (E8M0 32-block scales);
+        # else the NVF4 atom (E4M3 16-block). Same MMA shape (16,8,64).
+        if self.sf_vec_size == 32:
+            mma_op = cute.nvgpu.warp.MmaMXF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         atom_shape = (2, 2, 1)
         atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
@@ -995,7 +1012,8 @@ class MoEMicroKernel:
         num_tokens = Int32(a_input.shape[0])
         cols = Int32(a_input.shape[1])
         num_experts = Int32(row_counts.shape[0])
-        sf_blocks_per_row = cols // Int32(16)
+        # MXF4 (sf_vec_size==32) uses 32-element scale blocks; NVF4 uses 16.
+        sf_blocks_per_row = cols // Int32(self.sf_vec_size)
         output_bytes_per_row = cols // Int32(2)
         max_rows = Int32(token_map.shape[1])
         total_pairs = Int32(topk_ids.shape[0])
@@ -1003,7 +1021,9 @@ class MoEMicroKernel:
         expert_scale_stride = Int32(scale_storage.shape[0]) // num_experts
         flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
-        num_k_tiles = (cols + Int32(63)) // Int32(64)
+        # num_k_tiles = cols / (blk_sf * sf_vec_size) = cols/64 (NVF4) or /128 (MXF4)
+        _sf_k_tile = Int32(4 * self.sf_vec_size)
+        num_k_tiles = (cols + _sf_k_tile - Int32(1)) // _sf_k_tile
 
         # Phase 0: cooperative init — set row_counts and zero scatter_output.
         # The Triton compact pre-pass has already populated
@@ -1094,65 +1114,117 @@ class MoEMicroKernel:
                     packed_local_expert_id = Int32(0)
                     packed_row = Int32(0)
             if should_quantize > Int32(0):
-                scale_idx = (
-                    Int32(0)
-                    if cutlass.const_expr(self.share_expert_scales)
-                    else quant_expert_id
-                )
-                gs_value = input_global_scale[scale_idx].to(cutlass.Float32)
-                if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
-                    0.0
-                ):
-                    if self.fast_math:
-                        gs_value = rcp_approx_ftz(gs_value)
-                    else:
-                        gs_value = cutlass.Float32(1.0) / gs_value
-                sf_idx = Int32(tidx)
-                while sf_idx < sf_blocks_per_row:
-                    block_start = sf_idx * Int32(16)
-                    values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                    block_max = cutlass.Float32(0.0)
-                    for elem_idx in cutlass.range_constexpr(16):
-                        value = cutlass.Float32(
-                            a_input[token_idx, block_start + Int32(elem_idx)]
-                        )
-                        values[elem_idx] = value
-                        block_max = fmax_f32(block_max, fabs_f32(value))
-                    packed64 = Uint64(0)
-                    scale_byte = Uint8(0)
-                    if self.fast_math:
-                        packed64, scale_byte = quantize_block_fp4_fast(
-                            values, block_max, gs_value
-                        )
-                    else:
-                        packed64, scale_byte = quantize_block_fp4(
-                            values, block_max, gs_value
+                # MXF4 (sf_vec_size==32): 32-element blocks + self-scaling E8M0
+                # (no global scale). NVF4: 16-element blocks + per-expert global
+                # scale. The packed_row / scale-storage swizzle is identical.
+                if cutlass.const_expr(self.sf_vec_size == 32):
+                    sf_idx = Int32(tidx)
+                    while sf_idx < sf_blocks_per_row:
+                        block_start = sf_idx * Int32(32)
+                        values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                        block_max = cutlass.Float32(0.0)
+                        for elem_idx in cutlass.range_constexpr(32):
+                            value = cutlass.Float32(
+                                a_input[token_idx, block_start + Int32(elem_idx)]
+                            )
+                            values[elem_idx] = value
+                            block_max = fmax_f32(block_max, fabs_f32(value))
+                        packed_lo, packed_hi, scale_byte = quantize_block_mxf4(
+                            values, block_max
                         )
 
-                    output_offset = (
-                        packed_local_expert_id * max_rows * output_bytes_per_row
-                        + packed_row * output_bytes_per_row
-                        + sf_idx * Int32(8)
-                    )
-                    st_global_u64(
-                        get_ptr_as_int64(packed_a_storage, output_offset), packed64
-                    )
+                        # 32 FP4 = 16 bytes = two uint64 (sf_idx * 16).
+                        output_offset = (
+                            packed_local_expert_id * max_rows * output_bytes_per_row
+                            + packed_row * output_bytes_per_row
+                            + sf_idx * Int32(16)
+                        )
+                        st_global_u64(
+                            get_ptr_as_int64(packed_a_storage, output_offset),
+                            packed_lo,
+                        )
+                        st_global_u64(
+                            get_ptr_as_int64(
+                                packed_a_storage, output_offset + Int32(8)
+                            ),
+                            packed_hi,
+                        )
 
-                    m_tile_idx = packed_row // Int32(32 * 4)
-                    k_tile_idx = sf_idx // Int32(4)
-                    outer_m_idx = packed_row % Int32(32)
-                    inner_m_idx = (packed_row % Int32(32 * 4)) // Int32(32)
-                    inner_k_idx = sf_idx % Int32(4)
-                    scale_offset = (
-                        packed_local_expert_id * expert_scale_stride
-                        + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
-                        + k_tile_idx * Int32(32 * 4 * 4)
-                        + outer_m_idx * Int32(4 * 4)
-                        + inner_m_idx * Int32(4)
-                        + inner_k_idx
+                        m_tile_idx = packed_row // Int32(32 * 4)
+                        k_tile_idx = sf_idx // Int32(4)
+                        outer_m_idx = packed_row % Int32(32)
+                        inner_m_idx = (packed_row % Int32(32 * 4)) // Int32(32)
+                        inner_k_idx = sf_idx % Int32(4)
+                        scale_offset = (
+                            packed_local_expert_id * expert_scale_stride
+                            + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
+                            + k_tile_idx * Int32(32 * 4 * 4)
+                            + outer_m_idx * Int32(4 * 4)
+                            + inner_m_idx * Int32(4)
+                            + inner_k_idx
+                        )
+                        scale_storage[scale_offset] = scale_byte
+                        sf_idx += Int32(self.threads_per_cta)
+                else:
+                    scale_idx = (
+                        Int32(0)
+                        if cutlass.const_expr(self.share_expert_scales)
+                        else quant_expert_id
                     )
-                    scale_storage[scale_offset] = scale_byte
-                    sf_idx += Int32(self.threads_per_cta)
+                    gs_value = input_global_scale[scale_idx].to(cutlass.Float32)
+                    if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
+                        0.0
+                    ):
+                        if self.fast_math:
+                            gs_value = rcp_approx_ftz(gs_value)
+                        else:
+                            gs_value = cutlass.Float32(1.0) / gs_value
+                    sf_idx = Int32(tidx)
+                    while sf_idx < sf_blocks_per_row:
+                        block_start = sf_idx * Int32(16)
+                        values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                        block_max = cutlass.Float32(0.0)
+                        for elem_idx in cutlass.range_constexpr(16):
+                            value = cutlass.Float32(
+                                a_input[token_idx, block_start + Int32(elem_idx)]
+                            )
+                            values[elem_idx] = value
+                            block_max = fmax_f32(block_max, fabs_f32(value))
+                        packed64 = Uint64(0)
+                        scale_byte = Uint8(0)
+                        if self.fast_math:
+                            packed64, scale_byte = quantize_block_fp4_fast(
+                                values, block_max, gs_value
+                            )
+                        else:
+                            packed64, scale_byte = quantize_block_fp4(
+                                values, block_max, gs_value
+                            )
+
+                        output_offset = (
+                            packed_local_expert_id * max_rows * output_bytes_per_row
+                            + packed_row * output_bytes_per_row
+                            + sf_idx * Int32(8)
+                        )
+                        st_global_u64(
+                            get_ptr_as_int64(packed_a_storage, output_offset), packed64
+                        )
+
+                        m_tile_idx = packed_row // Int32(32 * 4)
+                        k_tile_idx = sf_idx // Int32(4)
+                        outer_m_idx = packed_row % Int32(32)
+                        inner_m_idx = (packed_row % Int32(32 * 4)) // Int32(32)
+                        inner_k_idx = sf_idx % Int32(4)
+                        scale_offset = (
+                            packed_local_expert_id * expert_scale_stride
+                            + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
+                            + k_tile_idx * Int32(32 * 4 * 4)
+                            + outer_m_idx * Int32(4 * 4)
+                            + inner_m_idx * Int32(4)
+                            + inner_k_idx
+                        )
+                        scale_storage[scale_offset] = scale_byte
+                        sf_idx += Int32(self.threads_per_cta)
 
             if cutlass.const_expr(not self.single_token):
                 cute.arch.sync_threads()
@@ -1832,20 +1904,23 @@ class MoEMicroKernel:
                 # Activation + quant into sA
                 sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                 packed_cols = Int32(self.tile_shape_mnk[2] // 2)
-                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
-                scale_idx = (
-                    Int32(0)
-                    if cutlass.const_expr(self.share_expert_scales)
-                    else weight_expert_idx
-                )
-                gs_value = global_scale[scale_idx].to(cutlass.Float32)
-                if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
-                    0.0
-                ):
-                    if self.fast_math:
-                        gs_value = rcp_approx_ftz(gs_value)
-                    else:
-                        gs_value = cutlass.Float32(1.0) / gs_value
+                # MXF4 (sf_vec_size==32) uses 32-element scale blocks + self-
+                # scaling E8M0 (no global scale); NVF4 uses 16 + global scale.
+                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // self.sf_vec_size)
+                if cutlass.const_expr(self.sf_vec_size != 32):
+                    scale_idx = (
+                        Int32(0)
+                        if cutlass.const_expr(self.share_expert_scales)
+                        else weight_expert_idx
+                    )
+                    gs_value = global_scale[scale_idx].to(cutlass.Float32)
+                    if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
+                        0.0
+                    ):
+                        if self.fast_math:
+                            gs_value = rcp_approx_ftz(gs_value)
+                        else:
+                            gs_value = cutlass.Float32(1.0) / gs_value
 
                 for epi_m in cutlass.range_constexpr(epi_rest_m):
                     epi_m_valid = (
@@ -1907,39 +1982,84 @@ class MoEMicroKernel:
                         local_row = quant_idx // sf_blocks_per_row
                         row = sa_row_base + rows_offset + local_row
                         sf_block = quant_idx - local_row * sf_blocks_per_row
-                        block_start = sf_block * Int32(16)
 
-                        values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                        block_max = cutlass.Float32(0.0)
-                        for elem_idx in cutlass.range_constexpr(16):
-                            value = cutlass.Float32(
-                                sC[local_row, block_start + elem_idx, silu_epi_buffer]
-                            )
-                            values[elem_idx] = value
-                            block_max = fmax_f32(block_max, fabs_f32(value))
+                        if cutlass.const_expr(self.sf_vec_size == 32):
+                            block_start = sf_block * Int32(32)
+                            values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                            block_max = cutlass.Float32(0.0)
+                            for elem_idx in cutlass.range_constexpr(32):
+                                value = cutlass.Float32(
+                                    sC[
+                                        local_row,
+                                        block_start + elem_idx,
+                                        silu_epi_buffer,
+                                    ]
+                                )
+                                values[elem_idx] = value
+                                block_max = fmax_f32(block_max, fabs_f32(value))
 
-                        packed64 = Uint64(0)
-                        scale_byte = Uint8(0)
-                        if self.fast_math:
-                            packed64, scale_byte = quantize_block_fp4_fast(
-                                values, block_max, gs_value
+                            packed_lo, packed_hi, scale_byte = quantize_block_mxf4(
+                                values, block_max
                             )
+                            # 32 FP4 = 16 bytes (two uint64). With tile_k=128 the
+                            # A SMEM atom is K_SW64 (same as NVF4), so the byte-
+                            # swizzle is identical: packed_cols=tile_k/2=64, XOR
+                            # mask 0x3 (4 blocks x 16 bytes = 64 = tile_k/2).
+                            packed_base = sf_block << Int32(4)
+                            dst_pcol = row & Int32(63)
+                            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+                            row_high = row >> Int32(6)
+                            for byte_idx in cutlass.range_constexpr(8):
+                                src_pcol = packed_base + Int32(byte_idx)
+                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                                dst_flat = dst_row * packed_cols + dst_pcol
+                                sA_u8[dst_flat] = Uint8(
+                                    (packed_lo >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
+                            for byte_idx in cutlass.range_constexpr(8):
+                                src_pcol = packed_base + Int32(8) + Int32(byte_idx)
+                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                                dst_flat = dst_row * packed_cols + dst_pcol
+                                sA_u8[dst_flat] = Uint8(
+                                    (packed_hi >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
                         else:
-                            packed64, scale_byte = quantize_block_fp4(
-                                values, block_max, gs_value
-                            )
-                        packed_base = sf_block << Int32(3)
-                        dst_pcol = row & Int32(63)
-                        xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
-                        row_high = row >> Int32(6)
-                        for byte_idx in cutlass.range_constexpr(8):
-                            src_pcol = packed_base + Int32(byte_idx)
-                            dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
-                            dst_flat = dst_row * packed_cols + dst_pcol
-                            byte_val = Uint8(
-                                (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
-                            )
-                            sA_u8[dst_flat] = byte_val
+                            block_start = sf_block * Int32(16)
+                            values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                            block_max = cutlass.Float32(0.0)
+                            for elem_idx in cutlass.range_constexpr(16):
+                                value = cutlass.Float32(
+                                    sC[
+                                        local_row,
+                                        block_start + elem_idx,
+                                        silu_epi_buffer,
+                                    ]
+                                )
+                                values[elem_idx] = value
+                                block_max = fmax_f32(block_max, fabs_f32(value))
+
+                            packed64 = Uint64(0)
+                            scale_byte = Uint8(0)
+                            if self.fast_math:
+                                packed64, scale_byte = quantize_block_fp4_fast(
+                                    values, block_max, gs_value
+                                )
+                            else:
+                                packed64, scale_byte = quantize_block_fp4(
+                                    values, block_max, gs_value
+                                )
+                            packed_base = sf_block << Int32(3)
+                            dst_pcol = row & Int32(63)
+                            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+                            row_high = row >> Int32(6)
+                            for byte_idx in cutlass.range_constexpr(8):
+                                src_pcol = packed_base + Int32(byte_idx)
+                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                                dst_flat = dst_row * packed_cols + dst_pcol
+                                byte_val = Uint8(
+                                    (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
+                                sA_u8[dst_flat] = byte_val
 
                         outer_m_idx = row % Int32(32)
                         inner_m_idx = row // Int32(32)

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -494,6 +494,7 @@ class MoEStaticKernel:
             self.sf_dtype,
         )
         atom_layout = cute.make_layout((2, 2, 1))
+        atom_shape = (2, 2, 1)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -506,9 +507,18 @@ class MoEStaticKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
-        self.num_k_blocks = self.tile_shape_mnk[2] // 64
+        # Derive atom loop bounds from the tile shape and the (M,N,K) warp atom
+        # layout, exactly like the dense kernel. MMA atom = m16 n8 k64; with
+        # atom_layout=(2,2,1) the warp group spans m32 n16 k64. The previous
+        # hardcoded (16*4)/(8*2) was copied from the dense kernel's (4,2,1)
+        # layout and gave num_m_tiles=2 (4-warp-M) instead of 4 (this kernel's
+        # 2-warp-M) -- the GEMM loop then filled only M-tiles {0,1}, leaving the
+        # second 64-row warp quadrant (rows 64..127) at fill(0.0). num_n_tiles
+        # was accidentally correct because both layouts share atom_shape[1]=2.
+        mma_m, mma_n, mma_k = 16, 8, 64
+        self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.tile_shape_mnk[2] // mma_k
 
         sfa_smem = sm120_make_smem_layout_sfa(
             self.tiled_mma,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -112,6 +112,7 @@ from flashinfer.cute_dsl.fp4_common import (
     rcp_approx_ftz,
     quantize_block_fp4,
     quantize_block_fp4_fast,
+    quantize_block_mxf4,
     get_ptr_as_int64,
     st_global_f32,
     st_global_i32,
@@ -356,7 +357,16 @@ class MoEStaticKernel:
         self.fast_math = fast_math
         self.activation = activation
         self.is_gated = activation == "silu"
-        tile_k = sf_vec_size * 8
+        # The GEMM K-tile must hold a whole number of SF blocks and MMA-K
+        # blocks. NVF4 uses tile_k = 16*8 = 128. MXF4 (sf_vec_size=32) keeps
+        # tile_k = 128 (= 4 SF blocks of 32, 2 MMA-K blocks of 64) rather than
+        # 32*8 = 256: this preserves the FC1-epilogue-N == FC2-K-tile == 128
+        # coupling the fused two-GEMM kernel relies on (sC is sized by
+        # epi_tile = mma_tiler_mn, which is 128 wide regardless of sf_vec_size).
+        if sf_vec_size == 32:
+            tile_k = 128
+        else:
+            tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
         self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
@@ -488,11 +498,20 @@ class MoEStaticKernel:
 
         self._hidden_size = hidden_size
 
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
+        # sf_vec_size==32 selects the MXF4 atom (E8M0 32-block scales);
+        # else the NVF4 atom (E4M3 16-block). Same MMA shape (16,8,64).
+        if self.sf_vec_size == 32:
+            mma_op = cute.nvgpu.warp.MmaMXF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         atom_shape = (2, 2, 1)
         atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
@@ -965,7 +984,8 @@ class MoEStaticKernel:
         num_tokens = Int32(a_input.shape[0])
         cols = Int32(a_input.shape[1])
         num_experts = Int32(row_counts.shape[0])
-        sf_blocks_per_row = cols // Int32(16)
+        # MXF4 (sf_vec_size==32) uses 32-element scale blocks; NVF4 uses 16.
+        sf_blocks_per_row = cols // Int32(self.sf_vec_size)
         output_bytes_per_row = cols // Int32(2)
         max_rows = Int32(token_map.shape[1])
         total_pairs = Int32(topk_ids.shape[0])
@@ -974,7 +994,9 @@ class MoEStaticKernel:
         num_global_experts = Int32(global_to_local_expert.shape[0])
         flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
-        num_k_tiles = (cols + Int32(63)) // Int32(64)
+        # num_k_tiles = cols / (blk_sf * sf_vec_size) = cols/64 (NVF4) or /128 (MXF4)
+        _sf_k_tile = Int32(4 * self.sf_vec_size)
+        num_k_tiles = (cols + _sf_k_tile - Int32(1)) // _sf_k_tile
 
         # Phase 0: cooperative init — zero row_counts and scatter_output
         i = flat_tid
@@ -1050,59 +1072,109 @@ class MoEStaticKernel:
             row = _ld_shared_i32(ctrl_base_addr + Int32(4))
 
             # Distribute quantization across ALL CTA threads, not just leader.
-            # Each FP4 block (16 elements) is independent — perfect parallelism.
-            gs_value = input_global_scale[expert_id].to(cutlass.Float32)
-            if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(0.0):
-                if self.fast_math:
-                    gs_value = rcp_approx_ftz(gs_value)
-                else:
-                    gs_value = cutlass.Float32(1.0) / gs_value
-            sf_idx = Int32(tidx)
-            while sf_idx < sf_blocks_per_row:
-                block_start = sf_idx * Int32(16)
-                values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                block_max = cutlass.Float32(0.0)
-                for elem_idx in cutlass.range_constexpr(16):
-                    value = cutlass.Float32(
-                        a_input[token_idx, block_start + Int32(elem_idx)]
-                    )
-                    values[elem_idx] = value
-                    block_max = fmax_f32(block_max, fabs_f32(value))
-                packed64 = Uint64(0)
-                scale_byte = Uint8(0)
-                if self.fast_math:
-                    packed64, scale_byte = quantize_block_fp4_fast(
-                        values, block_max, gs_value
-                    )
-                else:
-                    packed64, scale_byte = quantize_block_fp4(
-                        values, block_max, gs_value
+            # Each FP4 block is independent — perfect parallelism. NVF4 uses
+            # 16-element blocks + per-expert global scale; MXF4 uses 32-element
+            # blocks + self-scaling E8M0 (no global scale).
+            if cutlass.const_expr(self.sf_vec_size == 32):
+                sf_idx = Int32(tidx)
+                while sf_idx < sf_blocks_per_row:
+                    block_start = sf_idx * Int32(32)
+                    values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                    block_max = cutlass.Float32(0.0)
+                    for elem_idx in cutlass.range_constexpr(32):
+                        value = cutlass.Float32(
+                            a_input[token_idx, block_start + Int32(elem_idx)]
+                        )
+                        values[elem_idx] = value
+                        block_max = fmax_f32(block_max, fabs_f32(value))
+                    packed_lo, packed_hi, scale_byte = quantize_block_mxf4(
+                        values, block_max
                     )
 
-                output_offset = (
-                    local_expert_id * max_rows * output_bytes_per_row
-                    + row * output_bytes_per_row
-                    + sf_idx * Int32(8)
-                )
-                st_global_u64(
-                    get_ptr_as_int64(packed_a_storage, output_offset), packed64
-                )
+                    # 32 FP4 = 16 bytes = two uint64 (sf_idx * 16).
+                    output_offset = (
+                        local_expert_id * max_rows * output_bytes_per_row
+                        + row * output_bytes_per_row
+                        + sf_idx * Int32(16)
+                    )
+                    st_global_u64(
+                        get_ptr_as_int64(packed_a_storage, output_offset), packed_lo
+                    )
+                    st_global_u64(
+                        get_ptr_as_int64(packed_a_storage, output_offset + Int32(8)),
+                        packed_hi,
+                    )
 
-                m_tile_idx = row // Int32(32 * 4)
-                k_tile_idx = sf_idx // Int32(4)
-                outer_m_idx = row % Int32(32)
-                inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
-                inner_k_idx = sf_idx % Int32(4)
-                scale_offset = (
-                    local_expert_id * expert_scale_stride
-                    + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
-                    + k_tile_idx * Int32(32 * 4 * 4)
-                    + outer_m_idx * Int32(4 * 4)
-                    + inner_m_idx * Int32(4)
-                    + inner_k_idx
-                )
-                scale_storage[scale_offset] = scale_byte
-                sf_idx += Int32(self.threads_per_cta)
+                    m_tile_idx = row // Int32(32 * 4)
+                    k_tile_idx = sf_idx // Int32(4)
+                    outer_m_idx = row % Int32(32)
+                    inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
+                    inner_k_idx = sf_idx % Int32(4)
+                    scale_offset = (
+                        local_expert_id * expert_scale_stride
+                        + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
+                        + k_tile_idx * Int32(32 * 4 * 4)
+                        + outer_m_idx * Int32(4 * 4)
+                        + inner_m_idx * Int32(4)
+                        + inner_k_idx
+                    )
+                    scale_storage[scale_offset] = scale_byte
+                    sf_idx += Int32(self.threads_per_cta)
+            else:
+                gs_value = input_global_scale[expert_id].to(cutlass.Float32)
+                if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
+                    0.0
+                ):
+                    if self.fast_math:
+                        gs_value = rcp_approx_ftz(gs_value)
+                    else:
+                        gs_value = cutlass.Float32(1.0) / gs_value
+                sf_idx = Int32(tidx)
+                while sf_idx < sf_blocks_per_row:
+                    block_start = sf_idx * Int32(16)
+                    values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                    block_max = cutlass.Float32(0.0)
+                    for elem_idx in cutlass.range_constexpr(16):
+                        value = cutlass.Float32(
+                            a_input[token_idx, block_start + Int32(elem_idx)]
+                        )
+                        values[elem_idx] = value
+                        block_max = fmax_f32(block_max, fabs_f32(value))
+                    packed64 = Uint64(0)
+                    scale_byte = Uint8(0)
+                    if self.fast_math:
+                        packed64, scale_byte = quantize_block_fp4_fast(
+                            values, block_max, gs_value
+                        )
+                    else:
+                        packed64, scale_byte = quantize_block_fp4(
+                            values, block_max, gs_value
+                        )
+
+                    output_offset = (
+                        local_expert_id * max_rows * output_bytes_per_row
+                        + row * output_bytes_per_row
+                        + sf_idx * Int32(8)
+                    )
+                    st_global_u64(
+                        get_ptr_as_int64(packed_a_storage, output_offset), packed64
+                    )
+
+                    m_tile_idx = row // Int32(32 * 4)
+                    k_tile_idx = sf_idx // Int32(4)
+                    outer_m_idx = row % Int32(32)
+                    inner_m_idx = (row % Int32(32 * 4)) // Int32(32)
+                    inner_k_idx = sf_idx % Int32(4)
+                    scale_offset = (
+                        local_expert_id * expert_scale_stride
+                        + m_tile_idx * num_k_tiles * Int32(32 * 4 * 4)
+                        + k_tile_idx * Int32(32 * 4 * 4)
+                        + outer_m_idx * Int32(4 * 4)
+                        + inner_m_idx * Int32(4)
+                        + inner_k_idx
+                    )
+                    scale_storage[scale_offset] = scale_byte
+                    sf_idx += Int32(self.threads_per_cta)
 
             cute.arch.sync_threads()
             pair_idx += Int32(gdim_z)
@@ -1754,15 +1826,18 @@ class MoEStaticKernel:
                 # Activation + quant into sA
                 sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
                 packed_cols = Int32(self.tile_shape_mnk[2] // 2)
-                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // 16)
-                gs_value = global_scale[weight_expert_idx].to(cutlass.Float32)
-                if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
-                    0.0
-                ):
-                    if self.fast_math:
-                        gs_value = rcp_approx_ftz(gs_value)
-                    else:
-                        gs_value = cutlass.Float32(1.0) / gs_value
+                # MXF4 (sf_vec_size==32) uses 32-element scale blocks + self-
+                # scaling E8M0 (no global scale); NVF4 uses 16 + global scale.
+                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // self.sf_vec_size)
+                if cutlass.const_expr(self.sf_vec_size != 32):
+                    gs_value = global_scale[weight_expert_idx].to(cutlass.Float32)
+                    if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
+                        0.0
+                    ):
+                        if self.fast_math:
+                            gs_value = rcp_approx_ftz(gs_value)
+                        else:
+                            gs_value = cutlass.Float32(1.0) / gs_value
 
                 for epi_m in cutlass.range_constexpr(epi_rest_m):
                     epi_m_valid = (
@@ -1824,39 +1899,85 @@ class MoEStaticKernel:
                         local_row = quant_idx // sf_blocks_per_row
                         row = sa_row_base + rows_offset + local_row
                         sf_block = quant_idx - local_row * sf_blocks_per_row
-                        block_start = sf_block * Int32(16)
 
-                        values = cute.make_rmem_tensor((16,), cutlass.Float32)
-                        block_max = cutlass.Float32(0.0)
-                        for elem_idx in cutlass.range_constexpr(16):
-                            value = cutlass.Float32(
-                                sC[local_row, block_start + elem_idx, silu_epi_buffer]
-                            )
-                            values[elem_idx] = value
-                            block_max = fmax_f32(block_max, fabs_f32(value))
+                        if cutlass.const_expr(self.sf_vec_size == 32):
+                            block_start = sf_block * Int32(32)
+                            values = cute.make_rmem_tensor((32,), cutlass.Float32)
+                            block_max = cutlass.Float32(0.0)
+                            for elem_idx in cutlass.range_constexpr(32):
+                                value = cutlass.Float32(
+                                    sC[
+                                        local_row,
+                                        block_start + elem_idx,
+                                        silu_epi_buffer,
+                                    ]
+                                )
+                                values[elem_idx] = value
+                                block_max = fmax_f32(block_max, fabs_f32(value))
 
-                        packed64 = Uint64(0)
-                        scale_byte = Uint8(0)
-                        if self.fast_math:
-                            packed64, scale_byte = quantize_block_fp4_fast(
-                                values, block_max, gs_value
+                            packed_lo, packed_hi, scale_byte = quantize_block_mxf4(
+                                values, block_max
                             )
+                            # 32 FP4 = 16 bytes (two uint64). With tile_k=128 the
+                            # A SMEM atom is K_SW64 (same as NVF4), so the byte-
+                            # swizzle is identical to NVF4: packed_cols=tile_k/2=64,
+                            # XOR mask 0x3. src_pcol stays in 0..63 (4 blocks x 16
+                            # bytes = 64 = tile_k/2), matching NVF4's 8 blocks x 8.
+                            packed_base = sf_block << Int32(4)
+                            dst_pcol = row & Int32(63)
+                            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+                            row_high = row >> Int32(6)
+                            for byte_idx in cutlass.range_constexpr(8):
+                                src_pcol = packed_base + Int32(byte_idx)
+                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                                dst_flat = dst_row * packed_cols + dst_pcol
+                                sA_u8[dst_flat] = Uint8(
+                                    (packed_lo >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
+                            for byte_idx in cutlass.range_constexpr(8):
+                                src_pcol = packed_base + Int32(8) + Int32(byte_idx)
+                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                                dst_flat = dst_row * packed_cols + dst_pcol
+                                sA_u8[dst_flat] = Uint8(
+                                    (packed_hi >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
                         else:
-                            packed64, scale_byte = quantize_block_fp4(
-                                values, block_max, gs_value
-                            )
-                        packed_base = sf_block << Int32(3)
-                        dst_pcol = row & Int32(63)
-                        xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
-                        row_high = row >> Int32(6)
-                        for byte_idx in cutlass.range_constexpr(8):
-                            src_pcol = packed_base + Int32(byte_idx)
-                            dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
-                            dst_flat = dst_row * packed_cols + dst_pcol
-                            byte_val = Uint8(
-                                (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
-                            )
-                            sA_u8[dst_flat] = byte_val
+                            block_start = sf_block * Int32(16)
+                            values = cute.make_rmem_tensor((16,), cutlass.Float32)
+                            block_max = cutlass.Float32(0.0)
+                            for elem_idx in cutlass.range_constexpr(16):
+                                value = cutlass.Float32(
+                                    sC[
+                                        local_row,
+                                        block_start + elem_idx,
+                                        silu_epi_buffer,
+                                    ]
+                                )
+                                values[elem_idx] = value
+                                block_max = fmax_f32(block_max, fabs_f32(value))
+
+                            packed64 = Uint64(0)
+                            scale_byte = Uint8(0)
+                            if self.fast_math:
+                                packed64, scale_byte = quantize_block_fp4_fast(
+                                    values, block_max, gs_value
+                                )
+                            else:
+                                packed64, scale_byte = quantize_block_fp4(
+                                    values, block_max, gs_value
+                                )
+                            packed_base = sf_block << Int32(3)
+                            dst_pcol = row & Int32(63)
+                            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+                            row_high = row >> Int32(6)
+                            for byte_idx in cutlass.range_constexpr(8):
+                                src_pcol = packed_base + Int32(byte_idx)
+                                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                                dst_flat = dst_row * packed_cols + dst_pcol
+                                byte_val = Uint8(
+                                    (packed64 >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                                )
+                                sA_u8[dst_flat] = byte_val
 
                         outer_m_idx = row % Int32(32)
                         inner_m_idx = row // Int32(32)

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -493,8 +493,8 @@ class MoEStaticKernel:
             self.acc_dtype,
             self.sf_dtype,
         )
-        atom_layout = cute.make_layout((2, 2, 1))
         atom_shape = (2, 2, 1)
+        atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -507,14 +507,8 @@ class MoEStaticKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        # Derive atom loop bounds from the tile shape and the (M,N,K) warp atom
-        # layout, exactly like the dense kernel. MMA atom = m16 n8 k64; with
-        # atom_layout=(2,2,1) the warp group spans m32 n16 k64. The previous
-        # hardcoded (16*4)/(8*2) was copied from the dense kernel's (4,2,1)
-        # layout and gave num_m_tiles=2 (4-warp-M) instead of 4 (this kernel's
-        # 2-warp-M) -- the GEMM loop then filled only M-tiles {0,1}, leaving the
-        # second 64-row warp quadrant (rows 64..127) at fill(0.0). num_n_tiles
-        # was accidentally correct because both layouts share atom_shape[1]=2.
+        # Derive loop bounds from atom_shape (like the dense kernel). The old
+        # hardcoded (16*4) assumed dense's (4,2,1); this kernel is (2,2,1).
         mma_m, mma_n, mma_k = 16, 8, 64
         self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
         self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5483,7 +5483,8 @@ def _b12x_gemm_fp4_requirement(
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
 ):
-    # b12x backend requires CUDA 13+, 128x4 scale factor layout, and NVFP4 only.
+    # b12x backend requires CUDA 13+ and the 128x4 scale factor layout.
+    # Supports NVFP4 (sf_vec_size=16/E4M3) and MXFP4 (sf_vec_size=32/E8M0).
     if get_cuda_version().major < 13:
         raise ValueError(
             "b12x FP4 GEMM requires CUDA 13 or later. "
@@ -5491,8 +5492,6 @@ def _b12x_gemm_fp4_requirement(
         )
     if use_8x4_sf_layout:
         raise ValueError("b12x FP4 GEMM only supports 128x4 scale factor layout.")
-    if not use_nvfp4:
-        raise ValueError("b12x FP4 GEMM only supports NVFP4 (sf_vec_size=16).")
     _check_cute_dsl_availability()
     return True
 
@@ -5840,9 +5839,10 @@ def _b12x_gemm_fp4_runner(
             n = b.shape[1]
             real_k = k_packed * 2
 
-            sf_vec_size = 16
+            # NVFP4 -> sf_vec_size=16/E4M3; MXFP4 -> sf_vec_size=32/E8M0.
+            sf_vec_size = 16 if use_nvfp4 else 32
             ab_dtype = cutlass.Float4E2M1FN
-            sf_dtype = cutlass.Float8E4M3FN
+            sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
             batch_size = 1
 
             valid_tactics = []
@@ -5889,8 +5889,9 @@ def _b12x_gemm_fp4_runner(
             n = b.shape[1]
             real_k = k_packed * 2
 
-            sf_vec_size = 16
-            sf_dtype = cutlass.Float8E4M3FN
+            # NVFP4 -> sf_vec_size=16/E4M3; MXFP4 -> sf_vec_size=32/E8M0.
+            sf_vec_size = 16 if use_nvfp4 else 32
+            sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
             batch_size = 1
 
             if tactic is None or tactic == -1:

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -141,11 +141,20 @@ class DenseGemmKernel:
         self.mma_register_requirement = 232
 
     def _setup_attributes(self):
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
+        # sf_vec_size==32 -> MXF4 atom (E8M0 32-block); else NVF4 (E4M3 16-block).
+        # Both share MMA shape (16,8,64); only sf_vec_size/sf_type differ.
+        if self.sf_vec_size == 32:
+            mma_op = cute.nvgpu.warp.MmaMXF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
         atom_shape = (4, 2, 1)
         atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
@@ -390,6 +399,12 @@ class DenseGemmKernel:
         thr_vmk = (thr_vmnk[0], (thr_vmnk[1], thr_vmnk[3]))
         partitioned_sfa = thr_tensor[thr_vmk, (None, None)]
         partitioned_sfa = cute.group_modes(cute.flatten(partitioned_sfa), 0, 2)
+        # sf_vec_size=32 (MXF4, mma_nsf=2) leaves a rank-4 fragment; collapse the
+        # trailing K-modes to rank-3 (mode[2] == num_k_blocks). No-op for NVF4.
+        if cute.rank(partitioned_sfa) > 3:
+            partitioned_sfa = cute.group_modes(
+                partitioned_sfa, 2, cute.rank(partitioned_sfa)
+            )
         return cute.make_fragment_like(partitioned_sfa)
 
     def _partition_fragment_SFB(
@@ -405,6 +420,12 @@ class DenseGemmKernel:
         partitioned_sfb = thr_tensor[thr_vnk, (None, None)]
         partitioned_sfb = cute.group_modes(cute.flatten(partitioned_sfb), 0, 2)
         partitioned_sfb = cute.group_modes(partitioned_sfb, 1, 3)
+        # See _partition_fragment_SFA: collapse extra trailing K-modes for
+        # sf_vec_size=32 so the fragment is rank-3 (mode[2] == num_k_blocks).
+        if cute.rank(partitioned_sfb) > 3:
+            partitioned_sfb = cute.group_modes(
+                partitioned_sfb, 2, cute.rank(partitioned_sfb)
+            )
         return cute.make_fragment_like(partitioned_sfb)
 
     def _thrfrg_SFA(self, sfa_tensor, tiled_mma: cute.TiledMma):
@@ -1429,14 +1450,17 @@ class DenseGemmKernel:
         # scale-factor blocks.
         if mma_tiler_mn[0] % 64 != 0 or mma_tiler_mn[1] % 64 != 0:
             return False
-        # The current target only supports FP4 (MmaMXF4NVF4Op)
+        # The current target only supports FP4 (MmaMXF4NVF4Op / MmaMXF4Op)
         if ab_dtype != cutlass.Float4E2M1FN:
             return False
-        # SM120 warp-level MmaMXF4NVF4Op only supports sf_vec_size=16
-        # (CUTLASS DSL hardcodes sf_vec_size=16 in the MMA atom constructor)
-        if sf_vec_size != 16:
-            return False
-        if sf_dtype != cutlass.Float8E4M3FN:
+        # Two valid block-scaled FP4 configs: (16, E4M3) NVF4 / (32, E8M0) MXF4.
+        if sf_vec_size == 16:
+            if sf_dtype != cutlass.Float8E4M3FN:
+                return False
+        elif sf_vec_size == 32:
+            if sf_dtype != cutlass.Float8E8M0FNU:
+                return False
+        else:
             return False
         # Only 16-bit output types supported for now
         if c_dtype not in (cutlass.Float16, cutlass.BFloat16):

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -39,14 +39,14 @@ def _test_mm_fp4(
             pytest.skip("b12x backend only supports 128x4 SF layout")
         if compute_capability[0] != 12:
             pytest.skip("b12x backend only supports SM120/SM121 GPUs.")
-        if not use_nvfp4:
-            pytest.skip("b12x backend only supports NVFP4 (sf_vec_size=16).")
         if torch.version.cuda and int(torch.version.cuda.split(".")[0]) < 13:
             pytest.skip("b12x backend requires CUDA 13+.")
     if not use_128x4_sf_layout and backend != "trtllm":
         pytest.skip("Skipping test for non-trtllm fp4 with use_128x4_sf_layout=False")
-    if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl"]:
-        pytest.skip("mx_fp4 is only supported for cudnn, cute-dsl, and auto backends")
+    if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl", "b12x"]:
+        pytest.skip(
+            "mx_fp4 is only supported for cudnn, cute-dsl, b12x, and auto backends"
+        )
 
     input = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
     mat2 = torch.randn([n, k], device="cuda", dtype=torch.bfloat16)

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -1121,6 +1121,126 @@ class TestB12xFunctional:
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
 
+    @pytest.mark.parametrize("rows_per_expert", [128, 256, 512])
+    @pytest.mark.parametrize("activation", ["silu", "relu2"])
+    def test_skewed_routing_fills_second_m_quadrant(
+        self, rows_per_expert: int, activation: str
+    ):
+        """Regression for num_m_tiles dropping the 2nd 64-row M warp quadrant.
+
+        The static MoE kernels derive their M-tile loop bound from the warp atom
+        layout. A prior hardcoded divisor assumed the dense kernel's 4-M-warp
+        layout, so the GEMM mainloop only filled M-tiles {0,1} (rows 0..63) and
+        left rows 64..127 of every >64-row expert tile at fill(0.0) -- exact-zero
+        output. Random routing over many experts never puts >64 rows on a single
+        expert, so this only surfaces under skewed routing.
+
+        Here every token is forced (top_k=1) onto expert 0, so that one expert's
+        GEMM has `rows_per_expert` (>= 128) rows and must populate the second
+        64-row quadrant. Row counts stay within the static-backend range so the
+        affected kernels are exercised directly. With the bug, ~half the rows are
+        zero and accuracy collapses; with the fix it sits at the FP4 floor.
+        """
+        from flashinfer import b12x_fused_moe
+
+        num_tokens = rows_per_expert
+        hidden_size, intermediate_size = 256, 512
+        num_experts, top_k = 256, 1
+
+        if activation == "relu2":
+            tensors = create_relu2_moe_tensors(
+                num_tokens=num_tokens,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_experts=num_experts,
+                num_local_experts=num_experts,
+                top_k=top_k,
+                seed=2024,
+            )
+        else:
+            tensors = create_moe_tensors(
+                num_tokens=num_tokens,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                num_experts=num_experts,
+                num_local_experts=num_experts,
+                top_k=top_k,
+                seed=2024,
+            )
+
+        # Force ALL tokens onto a single expert -> one expert gets num_tokens
+        # (>= 128) rows, spanning both 64-row M warp quadrants.
+        target_expert = 0
+        tensors["token_selected_experts"] = torch.full(
+            (num_tokens, top_k), target_expert, dtype=torch.int32, device="cuda"
+        )
+        tensors["token_final_scales"] = torch.ones(
+            (num_tokens, top_k), dtype=torch.float32, device="cuda"
+        )
+
+        result = b12x_fused_moe(
+            x=tensors["x_bf16"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation=activation,
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        # The bug zeroed rows 64..127 of each 128-row tile; assert no all-zero
+        # rows beyond the first quadrant (decisive, independent of tolerance).
+        upper = result[64:]
+        assert not (upper == 0).all(dim=-1).any(), (
+            f"rows>=64 contain all-zero output ({activation}, "
+            f"rows_per_expert={rows_per_expert}) -- 2nd M quadrant dropped"
+        )
+
+        if activation == "relu2":
+            ref_output = compute_reference_moe_relu2(
+                hidden_states=tensors["x_bf16"].float().cuda(),
+                fc1_weights=tensors["w1_weight_bf16"].float().cuda(),
+                fc2_weights=tensors["w2_weight_bf16"].float().cuda(),
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                num_tokens=num_tokens,
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                fc2_input_scale=tensors["fc2_input_scale"],
+            )
+        else:
+            ref_output = compute_reference_moe_fp4(
+                hidden_states=tensors["x_bf16"].float().cuda(),
+                gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+                gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                num_tokens=num_tokens,
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                fc2_input_scale=tensors["fc2_input_scale"],
+            )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Skewed routing {activation} rows_per_expert={rows_per_expert}: "
+            f"only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+        )
+
     def test_activation_precision_api_validation(self):
         """W4A4 requires fc2_input_scale; W4A16 tolerates it."""
         from flashinfer import b12x_fused_moe


### PR DESCRIPTION
> Supposed to be stacked on #3533 (num_m_tiles fix). WIP Draft for now. 

## Description

Adds a native **MXFP4 × MXFP4 (W4A4)** path for SM120, so dsv4 that ship MXFP4 weights can run as-is.

Two parts:

- **MXFP4 dense b12x GEMM**: adds E8M0/32 block scales to the SM120 FP4 GEMM alongside the existing NVFP4 path: pick `MmaMXF4Op` when `sf_vec_size == 32`, plus the E8M0/32 quant helpers (`fp4_common.py`). Reachable through the public `mm_fp4(backend="b12x")`
- **Native MXFP4 fused MoE**: a new `quant_mode="mxfp4"`: native E2M1 weights × E8M0 32-block scales, with MXFP4 **activations** self-scaled in E8M0. A fused SwiGLU `MmaMXF4Op` kernel across the micro / static / dynamic kernels, threaded through `moe_dispatch.py`. Static + micro are CUDA-graph safe

Reference E2E setup per [DEPLOY-MXFP4-W4A4-DEEPSEEK-V4-FLASH-SM120.md](https://github.com/ambientlight/rtx-pro-6000-bench/blob/main/docs/DEPLOY-MXFP4-W4A4-DEEPSEEK-V4-FLASH-SM120.md) (assembled via hillclimbing with 4.8 opus max against [OxSero/deepseek-v4-flash-sm120 fork](https://github.com/ambientlight/deepseek-v4-flash-sm120))

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).
- [x] Dense MXFP4: `test_mm_fp4` b12x parametrization now covers `mxfp4` /
      `mxfp4_alpha` (cos > 0.97 vs BF16 ref across m/n/k) — validated on RTX PRO 6000.
- [x] Skewed-routing MoE regression (from #3533) now also exercises the MXFP4 path
      (silu + relu2, >64 rows/expert) — validated on RTX PRO 6000.

<!-- .github/pull_request_template.md -->

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` (`pip install pre-commit`).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

## Reviewer Notes

All MXFP4 behavior is gated on `quant_mode=="mxfp4"` / `sf_vec_size==32`
