### PR TITLE
feat: add BF16Q FP8KV transform-mode selection

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -135,8 +135,7 @@ void trtllm_paged_attention_launcher(
   TllmGenFmhaRunnerParams runner_params{};
   TVM_FFI_ICHECK(bf16q_fp8kv_transform_mode >= 0 && bf16q_fp8kv_transform_mode <= 2)
       << "bf16q_fp8kv_transform_mode must be 0, 1, or 2";
-  auto const transform_mode =
-      static_cast<Bf16QFp8KvTransformMode>(bf16q_fp8kv_transform_mode);
+  auto const transform_mode = static_cast<Bf16QFp8KvTransformMode>(bf16q_fp8kv_transform_mode);
   if (transform_mode != Bf16QFp8KvTransformMode::Full) {
     TVM_FFI_ICHECK(
         mode == TllmPagedAttentionMode::ForGen && q_data_type == Data_type::DATA_TYPE_BF16 &&

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -134,15 +134,15 @@ void trtllm_paged_attention_launcher(
       TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type, o_data_type);
   TllmGenFmhaRunnerParams runner_params{};
   TVM_FFI_ICHECK(bf16q_fp8kv_transform_mode >= 0 && bf16q_fp8kv_transform_mode <= 2)
-      << "trtllm_gen_bf16q_fp8kv_transform_mode must be 0, 1, or 2";
+      << "bf16q_fp8kv_transform_mode must be 0, 1, or 2";
   auto const transform_mode =
       static_cast<Bf16QFp8KvTransformMode>(bf16q_fp8kv_transform_mode);
   if (transform_mode != Bf16QFp8KvTransformMode::Full) {
     TVM_FFI_ICHECK(
         mode == TllmPagedAttentionMode::ForGen && q_data_type == Data_type::DATA_TYPE_BF16 &&
         kv_data_type == Data_type::DATA_TYPE_E4M3 && o_data_type == Data_type::DATA_TYPE_BF16)
-        << "trtllm_gen_bf16q_fp8kv_transform_mode is only supported for trtllm-gen BF16 "
-           "query, FP8 E4M3 KV, BF16 output decode";
+        << "bf16q_fp8kv_transform_mode is only supported for BF16 query, FP8 E4M3 KV, "
+           "BF16 output decode";
   }
   runner_params.mBf16QFp8KvTransformMode = transform_mode;
 

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -42,12 +42,6 @@ enum class TllmPagedAttentionMode {
   ForGen,
 };
 
-inline Bf16QFp8KvTransformMode parse_bf16q_fp8kv_transform_mode(int64_t mode) {
-  TVM_FFI_ICHECK(mode >= 0 && mode <= 2)
-      << "trtllm_gen_bf16q_fp8kv_transform_mode must be 0, 1, or 2";
-  return static_cast<Bf16QFp8KvTransformMode>(mode);
-}
-
 // Trailing pad we add to every softmax-stats workspace allocation. Two purposes:
 //   1. Defense in depth: any kernel that drifts past the documented
 //      [batchSize, mMaxNumCtasQ, numHeadsQ] write region writes into this pad
@@ -139,7 +133,10 @@ void trtllm_paged_attention_launcher(
   auto fmha_runner =
       TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type, o_data_type);
   TllmGenFmhaRunnerParams runner_params{};
-  auto const transform_mode = parse_bf16q_fp8kv_transform_mode(bf16q_fp8kv_transform_mode);
+  TVM_FFI_ICHECK(bf16q_fp8kv_transform_mode >= 0 && bf16q_fp8kv_transform_mode <= 2)
+      << "trtllm_gen_bf16q_fp8kv_transform_mode must be 0, 1, or 2";
+  auto const transform_mode =
+      static_cast<Bf16QFp8KvTransformMode>(bf16q_fp8kv_transform_mode);
   if (transform_mode != Bf16QFp8KvTransformMode::Full) {
     TVM_FFI_ICHECK(
         mode == TllmPagedAttentionMode::ForGen && q_data_type == Data_type::DATA_TYPE_BF16 &&

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -42,6 +42,12 @@ enum class TllmPagedAttentionMode {
   ForGen,
 };
 
+inline Bf16QFp8KvTransformMode parse_bf16q_fp8kv_transform_mode(int64_t mode) {
+  TVM_FFI_ICHECK(mode >= 0 && mode <= 2)
+      << "trtllm_gen_bf16q_fp8kv_transform_mode must be 0, 1, or 2";
+  return static_cast<Bf16QFp8KvTransformMode>(mode);
+}
+
 // Trailing pad we add to every softmax-stats workspace allocation. Two purposes:
 //   1. Defense in depth: any kernel that drifts past the documented
 //      [batchSize, mMaxNumCtasQ, numHeadsQ] write region writes into this pad
@@ -121,7 +127,7 @@ void trtllm_paged_attention_launcher(
     bool uses_shared_paged_kv_idx, bool enable_block_sparse_attention, int64_t sm_count,
     bool enable_pdl, int64_t workspace_size, int64_t k_sf_stride_heads, int64_t k_sf_stride_batch,
     int64_t v_sf_stride_heads, int64_t v_sf_stride_batch, bool is_causal, int64_t lse_stride_tokens,
-    int64_t lse_stride_heads, cudaStream_t stream) {
+    int64_t lse_stride_heads, int64_t bf16q_fp8kv_transform_mode, cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads must be a multiple of num_kv_heads, got num_kv_heads: " << num_kv_heads
@@ -133,6 +139,15 @@ void trtllm_paged_attention_launcher(
   auto fmha_runner =
       TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type, o_data_type);
   TllmGenFmhaRunnerParams runner_params{};
+  auto const transform_mode = parse_bf16q_fp8kv_transform_mode(bf16q_fp8kv_transform_mode);
+  if (transform_mode != Bf16QFp8KvTransformMode::Full) {
+    TVM_FFI_ICHECK(
+        mode == TllmPagedAttentionMode::ForGen && q_data_type == Data_type::DATA_TYPE_BF16 &&
+        kv_data_type == Data_type::DATA_TYPE_E4M3 && o_data_type == Data_type::DATA_TYPE_BF16)
+        << "trtllm_gen_bf16q_fp8kv_transform_mode is only supported for trtllm-gen BF16 "
+           "query, FP8 E4M3 KV, BF16 output decode";
+  }
+  runner_params.mBf16QFp8KvTransformMode = transform_mode;
 
   // Common params
   runner_params.qPtr = query;
@@ -341,7 +356,7 @@ void trtllm_paged_attention_decode(
     Optional<TensorView> value_block_scales, Optional<float> skip_softmax_threshold_scale_factor,
     Optional<bool> uses_shared_paged_kv_idx, Optional<TensorView> lse, int64_t lse_stride_tokens,
     int64_t lse_stride_heads, bool enable_block_sparse_attention,
-    Optional<TensorView> sparse_mla_top_k_lens) {
+    Optional<TensorView> sparse_mla_top_k_lens, int64_t bf16q_fp8kv_transform_mode) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
   TVM_FFI_ICHECK_EQ(key_cache.ndim(), value_cache.ndim());
@@ -512,7 +527,7 @@ void trtllm_paged_attention_decode(
       skip_softmax_threshold_scale_factor_value, skips_softmax, uses_shared_paged_kv_idx_value,
       enable_block_sparse_attention, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
       k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, /*is_causal=*/true,
-      lse_stride_tokens, lse_stride_heads, stream);
+      lse_stride_tokens, lse_stride_heads, bf16q_fp8kv_transform_mode, stream);
 }
 
 void trtllm_paged_attention_context(
@@ -652,7 +667,7 @@ void trtllm_paged_attention_context(
       skip_softmax_threshold_scale_factor_value, skips_softmax, uses_shared_paged_kv_idx_value,
       /*enable_block_sparse_attention=*/false, sm_count, enable_pdl, workspace_size,
       k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, is_causal,
-      lse_stride_tokens, lse_stride_heads, stream);
+      lse_stride_tokens, lse_stride_heads, /*bf16q_fp8kv_transform_mode=*/0, stream);
 }
 
 void trtllm_ragged_attention_launcher(
@@ -1004,7 +1019,7 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       enable_pdl, workspace_size,
       /*k_sf_stride_heads=*/0, /*k_sf_stride_batch=*/0, /*v_sf_stride_heads=*/0,
       /*v_sf_stride_batch=*/0, /*is_causal=*/true, /*lse_stride_tokens=*/0,
-      /*lse_stride_heads=*/0, stream);
+      /*lse_stride_heads=*/0, /*bf16q_fp8kv_transform_mode=*/0, stream);
 }
 
 namespace trtllm_cubin_loader {

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "a248cc9d9409244738f756f75b05a2e9d36b56c3/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "17dc05324d1d3c7c9d66ac85383f82371e0c8c0c/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "5988e15c0e6d006c6a64c0f6c6748b4d3150c1af/batched_gemm-3d40263-3e19f0a/"
     )
@@ -170,7 +170,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "edfbe15f5063367bbed5bde123d3b2c8e2bfd6565a17ade24c882d2b084f6484"
+        "fe5848d36929f65f588059301878880a65a27c4de0ad31de9ad752d5d29a0774"
     )
     TRTLLM_GEN_BMM: str = (
         "b19ed6c8b1d3fc13ced823bd65ee764d35a19080aea97e742c82ee73ce4c19b0"

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "158f6fa11ef139a098cfddcdddce73ca99d164ad/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "a248cc9d9409244738f756f75b05a2e9d36b56c3/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "5988e15c0e6d006c6a64c0f6c6748b4d3150c1af/batched_gemm-3d40263-3e19f0a/"
     )
@@ -170,7 +170,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "c2d9399b2537be785882354a4f9902ed6c03136c0ea341e201eac40c3923e1dc"
+        "edfbe15f5063367bbed5bde123d3b2c8e2bfd6565a17ade24c882d2b084f6484"
     )
     TRTLLM_GEN_BMM: str = (
         "b19ed6c8b1d3fc13ced823bd65ee764d35a19080aea97e742c82ee73ce4c19b0"

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "17dc05324d1d3c7c9d66ac85383f82371e0c8c0c/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "792869289f5e46f83b26f85e550c322e2ea8a9d7/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "5988e15c0e6d006c6a64c0f6c6748b4d3150c1af/batched_gemm-3d40263-3e19f0a/"
     )
@@ -170,7 +170,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "fe5848d36929f65f588059301878880a65a27c4de0ad31de9ad752d5d29a0774"
+        "1dd5c7f98372d60eb919d907ef2ba425653088629decf6db5a5a9e32c9e2e8d6"
     )
     TRTLLM_GEN_BMM: str = (
         "b19ed6c8b1d3fc13ced823bd65ee764d35a19080aea97e742c82ee73ce4c19b0"

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "792869289f5e46f83b26f85e550c322e2ea8a9d7/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "4f309dc0277a55fe4c4fbbf0c1df67299c94fa02/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "5988e15c0e6d006c6a64c0f6c6748b4d3150c1af/batched_gemm-3d40263-3e19f0a/"
     )
@@ -170,7 +170,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "1dd5c7f98372d60eb919d907ef2ba425653088629decf6db5a5a9e32c9e2e8d6"
+        "afa59462a134d4be15306a68ad1f2dfbd818b2affb4e9c9e50fd380b2e2f8391"
     )
     TRTLLM_GEN_BMM: str = (
         "b19ed6c8b1d3fc13ced823bd65ee764d35a19080aea97e742c82ee73ce4c19b0"

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -423,14 +423,14 @@ _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES = {
 }
 
 
-def _get_trtllm_gen_bf16q_fp8kv_transform_mode(
+def _get_bf16q_fp8kv_transform_mode(
     mode: Literal["k_only", "separate_kv"],
 ) -> int:
     try:
         return _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES[mode]
     except KeyError as err:
         raise ValueError(
-            "trtllm_gen_bf16q_fp8kv_transform_mode must be one of "
+            "bf16q_fp8kv_transform_mode must be one of "
             "'k_only' or 'separate_kv'"
         ) from err
 
@@ -3096,7 +3096,7 @@ def trtllm_batch_decode_with_kv_cache(
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     uses_shared_paged_kv_idx: bool = True,
-    trtllm_gen_bf16q_fp8kv_transform_mode: Optional[
+    bf16q_fp8kv_transform_mode: Optional[
         Literal["k_only", "separate_kv"]
     ] = None,
     lse: Optional[torch.Tensor] = None,
@@ -3245,7 +3245,7 @@ def trtllm_batch_decode_with_kv_cache(
         True (default) uses vLLM/FlashInfer layout with a 2D page table.
         False uses TRT-LLM layout with a 3D page table ``[batch_size, 2, max_num_pages_per_seq]``.
 
-    trtllm_gen_bf16q_fp8kv_transform_mode : Optional[Literal["k_only", "separate_kv"]] = None
+    bf16q_fp8kv_transform_mode : Optional[Literal["k_only", "separate_kv"]] = None
         Transform mode for BF16 query + FP8 E4M3 KV decode. ``None`` selects the
         default separate transformed-K/V cubins and is ignored by other paths.
         ``"k_only"`` selects the optimized K-only transform cubins, and
@@ -3372,24 +3372,24 @@ def trtllm_batch_decode_with_kv_cache(
         and v_cache.dtype == torch.float8_e4m3fn
         and out_dtype_for_transform_mode == torch.bfloat16
     )
-    if trtllm_gen_bf16q_fp8kv_transform_mode is None:
-        trtllm_gen_bf16q_fp8kv_transform_mode_value = (
+    if bf16q_fp8kv_transform_mode is None:
+        bf16q_fp8kv_transform_mode_value = (
             _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES["separate_kv"]
             if backend == "trtllm-gen" and uses_bf16q_fp8kv
             else 0
         )
     else:
-        trtllm_gen_bf16q_fp8kv_transform_mode_value = (
-            _get_trtllm_gen_bf16q_fp8kv_transform_mode(
-                trtllm_gen_bf16q_fp8kv_transform_mode
+        bf16q_fp8kv_transform_mode_value = (
+            _get_bf16q_fp8kv_transform_mode(
+                bf16q_fp8kv_transform_mode
             )
         )
     if (
         backend != "trtllm-gen"
-        and trtllm_gen_bf16q_fp8kv_transform_mode is not None
+        and bf16q_fp8kv_transform_mode is not None
     ):
         raise ValueError(
-            "trtllm_gen_bf16q_fp8kv_transform_mode is only supported by "
+            "bf16q_fp8kv_transform_mode is only supported by "
             "backend='trtllm-gen'"
         )
 
@@ -3618,7 +3618,7 @@ def trtllm_batch_decode_with_kv_cache(
             lse_stride_heads,
             enable_block_sparse_attention,
             None,  # sparse_mla_top_k_lens
-            trtllm_gen_bf16q_fp8kv_transform_mode_value,
+            bf16q_fp8kv_transform_mode_value,
         )
 
         result_out = (

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3095,12 +3095,12 @@ def trtllm_batch_decode_with_kv_cache(
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     uses_shared_paged_kv_idx: bool = True,
-    bf16q_fp8kv_transform_mode: Optional[Literal["k_only", "separate_kv"]] = None,
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
     bmm1_scale_log2: Optional[torch.Tensor] = None,
     multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
     enable_block_sparse_attention: bool = False,
+    bf16q_fp8kv_transform_mode: Optional[Literal["k_only", "separate_kv"]] = None,
 ) -> Union[
     torch.Tensor, FP4Tensor, Tuple[Union[torch.Tensor, FP4Tensor], torch.Tensor]
 ]:
@@ -3242,12 +3242,6 @@ def trtllm_batch_decode_with_kv_cache(
         True (default) uses vLLM/FlashInfer layout with a 2D page table.
         False uses TRT-LLM layout with a 3D page table ``[batch_size, 2, max_num_pages_per_seq]``.
 
-    bf16q_fp8kv_transform_mode : Optional[Literal["k_only", "separate_kv"]] = None
-        Transform mode for BF16 query + FP8 E4M3 KV decode. ``None`` selects the
-        default separate transformed-K/V cubins and is ignored by other paths.
-        ``"k_only"`` selects the optimized K-only transform cubins, and
-        ``"separate_kv"`` selects the separate transformed-K/V cubins.
-
     lse : Optional[torch.Tensor] = None
         Optional pre-allocated buffer for the Log-Sum-Exp (LSE) output, only supported
         by the ``trtllm-gen`` backend. Must have shape ``[num_tokens, num_qo_heads]``
@@ -3277,6 +3271,12 @@ def trtllm_batch_decode_with_kv_cache(
         (kv head, sequence) pairs (the dense maximum is a safe upper bound).
         Not compatible with sliding window (``window_left != -1``),
         ``skip_softmax_threshold_scale_factor``, or ``uses_shared_paged_kv_idx=False``.
+
+    bf16q_fp8kv_transform_mode : Optional[Literal["k_only", "separate_kv"]] = None
+        Transform mode for BF16 query + FP8 E4M3 KV decode. ``None`` selects the
+        default separate transformed-K/V cubins and is ignored by other paths.
+        ``"k_only"`` selects the optimized K-only transform cubins, and
+        ``"separate_kv"`` selects the separate transformed-K/V cubins.
 
     Returns
     -------

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -417,6 +417,25 @@ def get_trtllm_gen_fmha_module():
     return op
 
 
+_TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES = {
+    "full": 0,
+    "k_only": 1,
+    "separate_kv": 2,
+}
+
+
+def _get_trtllm_gen_bf16q_fp8kv_transform_mode(
+    mode: Literal["full", "k_only", "separate_kv"],
+) -> int:
+    try:
+        return _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES[mode]
+    except KeyError as err:
+        raise ValueError(
+            "trtllm_gen_bf16q_fp8kv_transform_mode must be one of "
+            "'full', 'k_only', or 'separate_kv'"
+        ) from err
+
+
 @flashinfer_api
 def single_decode_with_kv_cache_with_jit_module(
     jit_module: Any,
@@ -2878,6 +2897,7 @@ class TrtllmGenDecodeModule:
             lse_stride_heads,
             False,  # enable_block_sparse_attention
             None,  # sparse_mla_top_k_lens
+            0,  # trtllm_gen_bf16q_fp8kv_transform_mode
         )
         return out
 
@@ -3064,6 +3084,9 @@ def trtllm_batch_decode_with_kv_cache(
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     uses_shared_paged_kv_idx: bool = True,
+    trtllm_gen_bf16q_fp8kv_transform_mode: Literal[
+        "full", "k_only", "separate_kv"
+    ] = "full",
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
     bmm1_scale_log2: Optional[torch.Tensor] = None,
@@ -3210,6 +3233,12 @@ def trtllm_batch_decode_with_kv_cache(
         True (default) uses vLLM/FlashInfer layout with a 2D page table.
         False uses TRT-LLM layout with a 3D page table ``[batch_size, 2, max_num_pages_per_seq]``.
 
+    trtllm_gen_bf16q_fp8kv_transform_mode : Literal["full", "k_only", "separate_kv"] = "full"
+        Transform mode for BF16 query + FP8 E4M3 KV decode with the ``trtllm-gen``
+        backend. ``"full"`` preserves the legacy full K/V transform behavior,
+        ``"k_only"`` selects the optimized K-only transform cubins, and
+        ``"separate_kv"`` selects the separate transformed-K/V cubins.
+
     lse : Optional[torch.Tensor] = None
         Optional pre-allocated buffer for the Log-Sum-Exp (LSE) output, only supported
         by the ``trtllm-gen`` backend. Must have shape ``[num_tokens, num_qo_heads]``
@@ -3315,6 +3344,17 @@ def trtllm_batch_decode_with_kv_cache(
                 "block-sparse attention does not support "
                 "skip_softmax_threshold_scale_factor"
             )
+
+    trtllm_gen_bf16q_fp8kv_transform_mode_value = (
+        _get_trtllm_gen_bf16q_fp8kv_transform_mode(
+            trtllm_gen_bf16q_fp8kv_transform_mode
+        )
+    )
+    if backend != "trtllm-gen" and trtllm_gen_bf16q_fp8kv_transform_mode_value != 0:
+        raise ValueError(
+            "trtllm_gen_bf16q_fp8kv_transform_mode is only supported by "
+            "backend='trtllm-gen'"
+        )
 
     if backend == "xqa":
         # xqa backend doesn't support nvfp4 output
@@ -3541,6 +3581,7 @@ def trtllm_batch_decode_with_kv_cache(
             lse_stride_heads,
             enable_block_sparse_attention,
             None,  # sparse_mla_top_k_lens
+            trtllm_gen_bf16q_fp8kv_transform_mode_value,
         )
 
         result_out = (

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -418,21 +418,20 @@ def get_trtllm_gen_fmha_module():
 
 
 _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES = {
-    "full": 0,
     "k_only": 1,
     "separate_kv": 2,
 }
 
 
 def _get_trtllm_gen_bf16q_fp8kv_transform_mode(
-    mode: Literal["full", "k_only", "separate_kv"],
+    mode: Literal["k_only", "separate_kv"],
 ) -> int:
     try:
         return _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES[mode]
     except KeyError as err:
         raise ValueError(
             "trtllm_gen_bf16q_fp8kv_transform_mode must be one of "
-            "'full', 'k_only', or 'separate_kv'"
+            "'k_only' or 'separate_kv'"
         ) from err
 
 
@@ -2193,6 +2192,14 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 ]
 
                 if self._backend == "trtllm-gen":
+                    bf16q_fp8kv_transform_mode = (
+                        _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES["separate_kv"]
+                        if q.dtype == torch.bfloat16
+                        and k_cache.dtype == torch.float8_e4m3fn
+                        and v_cache.dtype == torch.float8_e4m3fn
+                        and out.dtype == torch.bfloat16
+                        else 0
+                    )
                     # decode.py's trtllm-gen paged_run (get_trtllm_gen_decode_module)
                     # has a different optional-param layout than prefill.py's paged_run
                     run_args += [
@@ -2208,6 +2215,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                         value_block_scales,
                         skip_softmax_threshold_scale_factor,
                         True,  # uses_shared_paged_kv_idx
+                        bf16q_fp8kv_transform_mode,
                     ]
                 else:
                     run_args += [
@@ -2838,6 +2846,7 @@ class TrtllmGenDecodeModule:
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
         lse: Optional[torch.Tensor] = None,
+        bf16q_fp8kv_transform_mode: int = 0,
     ) -> torch.Tensor:
         if out is None:
             out = torch.empty_like(query)
@@ -2897,7 +2906,7 @@ class TrtllmGenDecodeModule:
             lse_stride_heads,
             False,  # enable_block_sparse_attention
             None,  # sparse_mla_top_k_lens
-            0,  # trtllm_gen_bf16q_fp8kv_transform_mode
+            bf16q_fp8kv_transform_mode,
         )
         return out
 
@@ -2965,6 +2974,7 @@ def get_trtllm_gen_decode_module(*args):
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        bf16q_fp8kv_transform_mode: int = 0,
     ) -> None:
         assert paged_kv_cache is not None
         assert num_qo_heads is not None
@@ -2996,6 +3006,7 @@ def get_trtllm_gen_decode_module(*args):
             skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
             uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
             lse=maybe_lse,
+            bf16q_fp8kv_transform_mode=bf16q_fp8kv_transform_mode,
         )
 
     @register_fake_op(f"flashinfer::{uri}_paged_run")
@@ -3044,6 +3055,7 @@ def get_trtllm_gen_decode_module(*args):
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        bf16q_fp8kv_transform_mode: int = 0,
     ) -> None:
         pass
 
@@ -3084,9 +3096,9 @@ def trtllm_batch_decode_with_kv_cache(
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     uses_shared_paged_kv_idx: bool = True,
-    trtllm_gen_bf16q_fp8kv_transform_mode: Literal[
-        "full", "k_only", "separate_kv"
-    ] = "full",
+    trtllm_gen_bf16q_fp8kv_transform_mode: Optional[
+        Literal["k_only", "separate_kv"]
+    ] = None,
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
     bmm1_scale_log2: Optional[torch.Tensor] = None,
@@ -3233,11 +3245,12 @@ def trtllm_batch_decode_with_kv_cache(
         True (default) uses vLLM/FlashInfer layout with a 2D page table.
         False uses TRT-LLM layout with a 3D page table ``[batch_size, 2, max_num_pages_per_seq]``.
 
-    trtllm_gen_bf16q_fp8kv_transform_mode : Literal["full", "k_only", "separate_kv"] = "full"
+    trtllm_gen_bf16q_fp8kv_transform_mode : Optional[Literal["k_only", "separate_kv"]] = None
         Transform mode for BF16 query + FP8 E4M3 KV decode with the ``trtllm-gen``
-        backend. ``"full"`` preserves the legacy full K/V transform behavior,
-        ``"k_only"`` selects the optimized K-only transform cubins, and
-        ``"separate_kv"`` selects the separate transformed-K/V cubins.
+        backend. ``None`` selects the default separate transformed-K/V cubins for
+        BF16Q+FP8KV TRTLLM-GEN decode and is ignored by other paths. ``"k_only"``
+        selects the optimized K-only transform cubins, and ``"separate_kv"``
+        selects the separate transformed-K/V cubins.
 
     lse : Optional[torch.Tensor] = None
         Optional pre-allocated buffer for the Log-Sum-Exp (LSE) output, only supported
@@ -3345,12 +3358,37 @@ def trtllm_batch_decode_with_kv_cache(
                 "skip_softmax_threshold_scale_factor"
             )
 
-    trtllm_gen_bf16q_fp8kv_transform_mode_value = (
-        _get_trtllm_gen_bf16q_fp8kv_transform_mode(
-            trtllm_gen_bf16q_fp8kv_transform_mode
+    out_dtype_for_transform_mode = (
+        out_dtype
+        if isinstance(out_dtype, torch.dtype)
+        else (
+            out.dtype
+            if out is not None and isinstance(out, torch.Tensor)
+            else query.dtype
         )
     )
-    if backend != "trtllm-gen" and trtllm_gen_bf16q_fp8kv_transform_mode_value != 0:
+    uses_bf16q_fp8kv = (
+        query.dtype == torch.bfloat16
+        and k_cache.dtype == torch.float8_e4m3fn
+        and v_cache.dtype == torch.float8_e4m3fn
+        and out_dtype_for_transform_mode == torch.bfloat16
+    )
+    if trtllm_gen_bf16q_fp8kv_transform_mode is None:
+        trtllm_gen_bf16q_fp8kv_transform_mode_value = (
+            _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES["separate_kv"]
+            if backend == "trtllm-gen" and uses_bf16q_fp8kv
+            else 0
+        )
+    else:
+        trtllm_gen_bf16q_fp8kv_transform_mode_value = (
+            _get_trtllm_gen_bf16q_fp8kv_transform_mode(
+                trtllm_gen_bf16q_fp8kv_transform_mode
+            )
+        )
+    if (
+        backend != "trtllm-gen"
+        and trtllm_gen_bf16q_fp8kv_transform_mode is not None
+    ):
         raise ValueError(
             "trtllm_gen_bf16q_fp8kv_transform_mode is only supported by "
             "backend='trtllm-gen'"

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -430,8 +430,7 @@ def _get_bf16q_fp8kv_transform_mode(
         return _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES[mode]
     except KeyError as err:
         raise ValueError(
-            "bf16q_fp8kv_transform_mode must be one of "
-            "'k_only' or 'separate_kv'"
+            "bf16q_fp8kv_transform_mode must be one of 'k_only' or 'separate_kv'"
         ) from err
 
 
@@ -3096,9 +3095,7 @@ def trtllm_batch_decode_with_kv_cache(
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     uses_shared_paged_kv_idx: bool = True,
-    bf16q_fp8kv_transform_mode: Optional[
-        Literal["k_only", "separate_kv"]
-    ] = None,
+    bf16q_fp8kv_transform_mode: Optional[Literal["k_only", "separate_kv"]] = None,
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
     bmm1_scale_log2: Optional[torch.Tensor] = None,
@@ -3355,13 +3352,9 @@ def trtllm_batch_decode_with_kv_cache(
                 "block-sparse attention does not support "
                 "skip_softmax_threshold_scale_factor"
             )
-    if (
-        backend != "trtllm-gen"
-        and bf16q_fp8kv_transform_mode is not None
-    ):
+    if backend != "trtllm-gen" and bf16q_fp8kv_transform_mode is not None:
         raise ValueError(
-            "bf16q_fp8kv_transform_mode is only supported by "
-            "backend='trtllm-gen'"
+            "bf16q_fp8kv_transform_mode is only supported by backend='trtllm-gen'"
         )
 
     if backend == "xqa":

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3339,7 +3339,6 @@ def trtllm_batch_decode_with_kv_cache(
 
     if backend != "trtllm-gen" and bmm1_scale_log2 is not None:
         raise ValueError("bmm1_scale_log2 is only supported by the trtllm-gen backend")
-
     if enable_block_sparse_attention:
         if backend != "trtllm-gen":
             raise ValueError(
@@ -3356,34 +3355,6 @@ def trtllm_batch_decode_with_kv_cache(
                 "block-sparse attention does not support "
                 "skip_softmax_threshold_scale_factor"
             )
-
-    out_dtype_for_transform_mode = (
-        out_dtype
-        if isinstance(out_dtype, torch.dtype)
-        else (
-            out.dtype
-            if out is not None and isinstance(out, torch.Tensor)
-            else query.dtype
-        )
-    )
-    uses_bf16q_fp8kv = (
-        query.dtype == torch.bfloat16
-        and k_cache.dtype == torch.float8_e4m3fn
-        and v_cache.dtype == torch.float8_e4m3fn
-        and out_dtype_for_transform_mode == torch.bfloat16
-    )
-    if bf16q_fp8kv_transform_mode is None:
-        bf16q_fp8kv_transform_mode_value = (
-            _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES["separate_kv"]
-            if backend == "trtllm-gen" and uses_bf16q_fp8kv
-            else 0
-        )
-    else:
-        bf16q_fp8kv_transform_mode_value = (
-            _get_bf16q_fp8kv_transform_mode(
-                bf16q_fp8kv_transform_mode
-            )
-        )
     if (
         backend != "trtllm-gen"
         and bf16q_fp8kv_transform_mode is not None
@@ -3528,6 +3499,23 @@ def trtllm_batch_decode_with_kv_cache(
             check_shape_dtype_device(out, query.shape, out_dtype, query.device, "out")
         else:
             raise ValueError(f"Invalid out_dtype: {out_dtype}")
+
+        uses_bf16q_fp8kv = (
+            query.dtype == torch.bfloat16
+            and k_cache.dtype == torch.float8_e4m3fn
+            and v_cache.dtype == torch.float8_e4m3fn
+            and out_dtype == torch.bfloat16
+        )
+        if bf16q_fp8kv_transform_mode is None:
+            bf16q_fp8kv_transform_mode_value = (
+                _TRTLLM_GEN_BF16Q_FP8KV_TRANSFORM_MODES["separate_kv"]
+                if uses_bf16q_fp8kv
+                else 0
+            )
+        else:
+            bf16q_fp8kv_transform_mode_value = _get_bf16q_fp8kv_transform_mode(
+                bf16q_fp8kv_transform_mode
+            )
 
         bmm1_scale = _get_trtllm_gen_bmm1_scale_arg(
             bmm1_scale, bmm1_scale_log2, query.device

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3246,11 +3246,10 @@ def trtllm_batch_decode_with_kv_cache(
         False uses TRT-LLM layout with a 3D page table ``[batch_size, 2, max_num_pages_per_seq]``.
 
     trtllm_gen_bf16q_fp8kv_transform_mode : Optional[Literal["k_only", "separate_kv"]] = None
-        Transform mode for BF16 query + FP8 E4M3 KV decode with the ``trtllm-gen``
-        backend. ``None`` selects the default separate transformed-K/V cubins for
-        BF16Q+FP8KV TRTLLM-GEN decode and is ignored by other paths. ``"k_only"``
-        selects the optimized K-only transform cubins, and ``"separate_kv"``
-        selects the separate transformed-K/V cubins.
+        Transform mode for BF16 query + FP8 E4M3 KV decode. ``None`` selects the
+        default separate transformed-K/V cubins and is ignored by other paths.
+        ``"k_only"`` selects the optimized K-only transform cubins, and
+        ``"separate_kv"`` selects the separate transformed-K/V cubins.
 
     lse : Optional[torch.Tensor] = None
         Optional pre-allocated buffer for the Log-Sum-Exp (LSE) output, only supported

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -3291,6 +3291,7 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
             lse_stride_heads,
             False,  # enable_block_sparse_attention
             sparse_mla_top_k_lens,
+            0,  # bf16q_fp8kv_transform_mode
         )
         return out
 

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -4150,6 +4150,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
             0,  # lse_stride_heads
             False,  # enable_block_sparse_attention
             sparse_mla_top_k_lens,
+            0,  # bf16q_fp8kv_transform_mode
         )
         return out
 

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -587,8 +587,8 @@ class TllmGenFmhaKernel {
       int const maxNumCtasPerSeqKv =
           (maxAttentionWindow + 2 * kernelMeta.mStepKv - 1) / (2 * kernelMeta.mStepKv);
       int tunedMaxNumCtasPerSeqKv = maxNumCtasPerSeqKv;
-      // Mirror TRTLLM-GEN's BF16Q+FP8KV separate-transform cap so the runtime
-      // key selects CGA reduction when the autotuner would use the smaller split.
+      // Cap BF16Q+FP8KV separate-transform splits so the runtime key selects
+      // CGA reduction when the smaller split is expected.
       if (isBf16QFp8KvGeneration() &&
           selectKernelParams.mBf16QFp8KvTransformMode == Bf16QFp8KvTransformMode::SeparateKv &&
           isSwapsMmaAbForGenerationKernel(selectKernelParams.mKernelType) &&

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -197,25 +197,6 @@ class TllmGenFmhaKernel {
         if (mKernelMetaMap.find(hash) != mKernelMetaMap.end()) {
           // The kernelMeta of the existing kernel.
           auto const& existingKernelMeta = mKernelMeta[mKernelMetaMap.at(hash)];
-          // Some generation cubins are exported twice with the same metadata key. Different cubin
-          // names are equivalent Dense/Causal aliases; keep the first entry. Same-name duplicates
-          // collide on the published artifact path, so use the later metadata entry that matches
-          // the file left in the artifact manifest.
-          if (existingKernelMeta.mSM == kernelMeta.mSM) {
-            if (std::strcmp(existingKernelMeta.mFuncName, kernelMeta.mFuncName) == 0 &&
-                std::strcmp(existingKernelMeta.sha256, kernelMeta.sha256) != 0) {
-              mKernelMetaMap[hash] = i;
-              IKL_LOG_DEBUG(
-                  "Replacing duplicate tllmgen attention kernel metadata for shared cubin %s",
-                  kernelMeta.mFuncName);
-              continue;
-            }
-            IKL_LOG_DEBUG(
-                "Skipping duplicate tllmgen attention kernel %s for key already held by "
-                "%s",
-                kernelMeta.mFuncName, existingKernelMeta.mFuncName);
-            continue;
-          }
           // Allow conflicts only if they are family/specific versions of the same architecture.
           FLASHINFER_CHECK(isFamilySpecificSMPair(existingKernelMeta.mSM, kernelMeta.mSM),
                            "Hash conflicts exist between %s and %s.", existingKernelMeta.mFuncName,
@@ -262,7 +243,8 @@ class TllmGenFmhaKernel {
                          int multiCtasKvMode, int headDimPerCtaV, int headDimQk, int headDimV,
                          int tileSizeQ, int tileSizeKv, int numTokensPerPage,
                          bool dynamicNumTokensPerPage, bool reuseSmemKForV, bool uses2CtaMma,
-                         int sparseMlaType, bool skipsSoftmax, int bf16QFp8KvTransformMode) const {
+                         bool groupsTokensHeadsQ, int sparseMlaType, bool skipsSoftmax,
+                         int bf16QFp8KvTransformMode) const {
     FLASHINFER_CHECK((headDimPerCtaV >= 32) && (headDimQk >= 32) && (headDimV >= 32) &&
                          (headDimPerCtaV <= 1024) && (headDimQk <= 1024) && (headDimV <= 1024),
                      "Expect (32 <= headDim <= 1024), got headDimPerCtaV=%d, headDimQk=%d, "
@@ -298,6 +280,7 @@ class TllmGenFmhaKernel {
     // Bit 57 - 57: skipsSoftmax.
     // Bit 58 - 58: dynamicNumTokensPerPage.
     // Bit 59 - 60: BF16Q FP8KV transform mode (0=full, 1=K-only, 2=separate K/V).
+    // Bit 61 - 61: groupsTokensHeadsQ.
     uint64_t const numTokensPerPageLog2 =
         numTokensPerPage == 0 ? 0 : static_cast<uint64_t>(log2(numTokensPerPage));
     return (static_cast<uint64_t>(qkvLayout) << 0) | (static_cast<uint64_t>(maskType) << 4) |
@@ -313,7 +296,8 @@ class TllmGenFmhaKernel {
            (static_cast<uint64_t>(sparseMlaType) << 55) |
            (static_cast<uint64_t>(skipsSoftmax) << 57) |
            (static_cast<uint64_t>(dynamicNumTokensPerPage) << 58) |
-           (static_cast<uint64_t>(bf16QFp8KvTransformMode) << 59);
+           (static_cast<uint64_t>(bf16QFp8KvTransformMode) << 59) |
+           (static_cast<uint64_t>(groupsTokensHeadsQ) << 61);
   }
 
   inline bool isDynamicNumTokensPerPageKernel(KernelMeta const& kernelMeta) const {
@@ -327,7 +311,8 @@ class TllmGenFmhaKernel {
                   kernelMeta.mHeadDimPerCtaV, kernelMeta.mHeadDimQk, kernelMeta.mHeadDimV,
                   kernelMeta.mTileSizeQ, kernelMeta.mTileSizeKv, kernelMeta.mNumTokensPerPage,
                   isDynamicNumTokensPerPageKernel(kernelMeta), kernelMeta.mReuseSmemKForV,
-                  kernelMeta.m2CtaMma, kernelMeta.mSparseAttn, kernelMeta.mSkipsSoftmaxWhenPossible,
+                  kernelMeta.m2CtaMma, kernelMeta.mGroupsTokensHeadsQ, kernelMeta.mSparseAttn,
+                  kernelMeta.mSkipsSoftmaxWhenPossible,
                   getBf16QFp8KvTransformMode(kernelMeta.mEnablesBf16QFp8KvKOnlyTransform,
                                              kernelMeta.mSeparateTransformedKv));
   }
@@ -998,10 +983,12 @@ class TllmGenFmhaKernel {
     // Generic mixed precision kernels don't work with groupsTokensHeadsQ = true. BF16Q+FP8KV
     // transform paths present BF16 K to BMM1, so they can use the grouped-token cubins.
     if (!supportsGqaGroupingTokensHeadsQ(selectKernelParams)) {
+      selectKernelParams.mGroupsTokensHeadsQ = false;
       tileSizeQ = params.mNumHeadsQPerKv <= 8 ? 8 : 16;
       kernelType = FmhaKernelType::SwapsMmaAbForGeneration;
       return;
     }
+    selectKernelParams.mGroupsTokensHeadsQ = true;
 
     // The number of tokensQ and headsQ that can be grouped into one CTA.
     int numTokensHeadsQ = params.mNumHeadsQPerKv * params.mMaxSeqLenQ;
@@ -1100,6 +1087,7 @@ class TllmGenFmhaKernel {
         ", dynamicNumTokensPerPage=" + std::to_string(selectKernelParams.mDynamicNumTokensPerPage) +
         ", reuseSmemKForV=" + std::to_string(selectKernelParams.mReuseSmemKForV) +
         ", uses2CtaMma=" + std::to_string(selectKernelParams.mUses2CtaMma) +
+        ", groupsTokensHeadsQ=" + std::to_string(selectKernelParams.mGroupsTokensHeadsQ) +
         ", sparseMlaType=" + std::to_string(static_cast<int>(params.mSparseMlaType)) +
         ", skipsSoftmax=" + std::to_string(selectKernelParams.mSkipsSoftmaxWhenPossible) +
         ", bf16QFp8KvTransformMode=" +
@@ -1118,7 +1106,7 @@ class TllmGenFmhaKernel {
                selectKernelParams.mTileSizeQ, selectKernelParams.mTileSizeKv,
                selectKernelParams.mNumTokensPerPage, selectKernelParams.mDynamicNumTokensPerPage,
                selectKernelParams.mReuseSmemKForV, selectKernelParams.mUses2CtaMma,
-               static_cast<int>(params.mSparseMlaType),
+               selectKernelParams.mGroupsTokensHeadsQ, static_cast<int>(params.mSparseMlaType),
                selectKernelParams.mSkipsSoftmaxWhenPossible,
                static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode)),
         info);

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -586,9 +586,40 @@ class TllmGenFmhaKernel {
       // benefits of a shorter mainloop.
       int const maxNumCtasPerSeqKv =
           (maxAttentionWindow + 2 * kernelMeta.mStepKv - 1) / (2 * kernelMeta.mStepKv);
+      int tunedMaxNumCtasPerSeqKv = maxNumCtasPerSeqKv;
+      // Mirror TRTLLM-GEN's BF16Q+FP8KV separate-transform cap so the runtime
+      // key selects CGA reduction when the autotuner would use the smaller split.
+      if (isBf16QFp8KvGeneration() &&
+          selectKernelParams.mBf16QFp8KvTransformMode == Bf16QFp8KvTransformMode::SeparateKv &&
+          isSwapsMmaAbForGenerationKernel(selectKernelParams.mKernelType) &&
+          !isGmemReductionWithSeparateKernel(selectKernelParams.mMultiCtasKvMode) &&
+          params.mHeadDimV < 512) {
+        int const clusterDimX = selectKernelParams.mUses2CtaMma ? 2 : 1;
+        int const maxKvSplitsPerCgaCluster = 16 / clusterDimX;
+        if (maxNumCtasPerSeqKv <= numCtasForAllHeadsQ * maxKvSplitsPerCgaCluster) {
+          int const launchedClusters =
+              flashinfer::ceil_div(numCtasX, clusterDimX) * numCtasY * numCtasZ;
+          int const residentSplitBudget =
+              std::max(4, flashinfer::ceil_div(params.mMultiProcessorCount * 13 / 20,
+                                               launchedClusters));
+          int const targetMaxNumCtasPerSeqKv = std::min(
+              maxNumCtasPerSeqKv, std::min(maxKvSplitsPerCgaCluster, residentSplitBudget));
+          if (targetMaxNumCtasPerSeqKv > 1 &&
+              targetMaxNumCtasPerSeqKv < maxNumCtasPerSeqKv) {
+            int const targetTileSizePerCtaKv =
+                isSlidingOrChunkedCausalMask(selectKernelParams.mMaskType)
+                    ? flashinfer::ceil_div(params.mAttentionWindowSize,
+                                           targetMaxNumCtasPerSeqKv - 1)
+                    : flashinfer::ceil_div(maxAttentionWindow, targetMaxNumCtasPerSeqKv);
+            if (targetTileSizePerCtaKv <= 1024) {
+              tunedMaxNumCtasPerSeqKv = targetMaxNumCtasPerSeqKv;
+            }
+          }
+        }
+      }
       // Compute numCtasPerSeqKv.
       numCtasPerSeqKv = std::min(
-          maxNumCtasPerSeqKv,
+          tunedMaxNumCtasPerSeqKv,
           std::max(1, int32_t(params.mMultiProcessorCount / (numCtasX * numCtasY * numCtasZ))));
       // Update the numCtasX.
       numCtasX *= numCtasPerSeqKv;

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -197,6 +197,15 @@ class TllmGenFmhaKernel {
         if (mKernelMetaMap.find(hash) != mKernelMetaMap.end()) {
           // The kernelMeta of the existing kernel.
           auto const& existingKernelMeta = mKernelMeta[mKernelMetaMap.at(hash)];
+          // Some generation cubins are exported twice with equivalent Dense/Causal naming but the
+          // same metadata key. Runtime selection cannot distinguish them, so keep the first entry.
+          if (existingKernelMeta.mSM == kernelMeta.mSM) {
+            IKL_LOG_DEBUG(
+                "Skipping duplicate tllmgen attention kernel %s for key already held by "
+                "%s",
+                kernelMeta.mFuncName, existingKernelMeta.mFuncName);
+            continue;
+          }
           // Allow conflicts only if they are family/specific versions of the same architecture.
           FLASHINFER_CHECK(isFamilySpecificSMPair(existingKernelMeta.mSM, kernelMeta.mSM),
                            "Hash conflicts exist between %s and %s.", existingKernelMeta.mFuncName,
@@ -215,11 +224,24 @@ class TllmGenFmhaKernel {
 
   size_t getNumLoadedKernels() const { return mKernelMetaMap.size(); }
 
+  inline int getBf16QFp8KvTransformMode(bool enablesKOnlyTransform,
+                                        bool separateTransformedKv) const {
+    FLASHINFER_CHECK(!(enablesKOnlyTransform && separateTransformedKv),
+                     "BF16Q FP8KV transform mode cannot be both K-only and separate K/V.");
+    if (enablesKOnlyTransform) {
+      return static_cast<int>(Bf16QFp8KvTransformMode::KOnly);
+    }
+    if (separateTransformedKv) {
+      return static_cast<int>(Bf16QFp8KvTransformMode::SeparateKv);
+    }
+    return static_cast<int>(Bf16QFp8KvTransformMode::Full);
+  }
+
   inline uint64_t hashID(int qkvLayout, int maskType, int kernelType, int scheduler,
                          int multiCtasKvMode, int headDimPerCtaV, int headDimQk, int headDimV,
                          int tileSizeQ, int tileSizeKv, int numTokensPerPage,
                          bool dynamicNumTokensPerPage, bool reuseSmemKForV, bool uses2CtaMma,
-                         int sparseMlaType, bool skipsSoftmax) const {
+                         int sparseMlaType, bool skipsSoftmax, int bf16QFp8KvTransformMode) const {
     FLASHINFER_CHECK((headDimPerCtaV >= 32) && (headDimQk >= 32) && (headDimV >= 32) &&
                          (headDimPerCtaV <= 1024) && (headDimQk <= 1024) && (headDimV <= 1024),
                      "Expect (32 <= headDim <= 1024), got headDimPerCtaV=%d, headDimQk=%d, "
@@ -235,6 +257,8 @@ class TllmGenFmhaKernel {
     FLASHINFER_CHECK(tileSizeKv == 64 || tileSizeKv == 128, "The tileSizeKv must be 64 or 128.");
     FLASHINFER_CHECK(sparseMlaType >= 0 && sparseMlaType <= 3,
                      "The sparse MLA type must fit in 2 bits.");
+    FLASHINFER_CHECK(bf16QFp8KvTransformMode >= 0 && bf16QFp8KvTransformMode <= 2,
+                     "The BF16Q FP8KV transform mode must fit in 2 bits.");
     // Format of the hash key:
     // Bit 0  - 3 : qkvLayout.
     // Bit 4  - 7 : maskType.
@@ -252,6 +276,7 @@ class TllmGenFmhaKernel {
     // Bit 55 - 56: sparseMlaType (0=none, 1=static token sparse, 2=dynamic token sparse).
     // Bit 57 - 57: skipsSoftmax.
     // Bit 58 - 58: dynamicNumTokensPerPage.
+    // Bit 59 - 60: BF16Q FP8KV transform mode (0=full, 1=K-only, 2=separate K/V).
     uint64_t const numTokensPerPageLog2 =
         numTokensPerPage == 0 ? 0 : static_cast<uint64_t>(log2(numTokensPerPage));
     return (static_cast<uint64_t>(qkvLayout) << 0) | (static_cast<uint64_t>(maskType) << 4) |
@@ -266,7 +291,8 @@ class TllmGenFmhaKernel {
            (static_cast<uint64_t>(uses2CtaMma) << 54) |
            (static_cast<uint64_t>(sparseMlaType) << 55) |
            (static_cast<uint64_t>(skipsSoftmax) << 57) |
-           (static_cast<uint64_t>(dynamicNumTokensPerPage) << 58);
+           (static_cast<uint64_t>(dynamicNumTokensPerPage) << 58) |
+           (static_cast<uint64_t>(bf16QFp8KvTransformMode) << 59);
   }
 
   inline bool isDynamicNumTokensPerPageKernel(KernelMeta const& kernelMeta) const {
@@ -280,8 +306,9 @@ class TllmGenFmhaKernel {
                   kernelMeta.mHeadDimPerCtaV, kernelMeta.mHeadDimQk, kernelMeta.mHeadDimV,
                   kernelMeta.mTileSizeQ, kernelMeta.mTileSizeKv, kernelMeta.mNumTokensPerPage,
                   isDynamicNumTokensPerPageKernel(kernelMeta), kernelMeta.mReuseSmemKForV,
-                  kernelMeta.m2CtaMma, kernelMeta.mSparseAttn,
-                  kernelMeta.mSkipsSoftmaxWhenPossible);
+                  kernelMeta.m2CtaMma, kernelMeta.mSparseAttn, kernelMeta.mSkipsSoftmaxWhenPossible,
+                  getBf16QFp8KvTransformMode(kernelMeta.mEnablesBf16QFp8KvKOnlyTransform,
+                                             kernelMeta.mSeparateTransformedKv));
   }
 
   std::pair<bool, std::string> checkIfKernelExist(RunnerParams const& params) const {
@@ -1044,7 +1071,9 @@ class TllmGenFmhaKernel {
         ", reuseSmemKForV=" + std::to_string(selectKernelParams.mReuseSmemKForV) +
         ", uses2CtaMma=" + std::to_string(selectKernelParams.mUses2CtaMma) +
         ", sparseMlaType=" + std::to_string(static_cast<int>(params.mSparseMlaType)) +
-        ", skipsSoftmax=" + std::to_string(selectKernelParams.mSkipsSoftmaxWhenPossible);
+        ", skipsSoftmax=" + std::to_string(selectKernelParams.mSkipsSoftmaxWhenPossible) +
+        ", bf16QFp8KvTransformMode=" +
+        std::to_string(static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode));
     IKL_LOG_DEBUG(
         "Searching for kernel traits (%d available) in TllmGenFmhaKernel(%s, %s, %s, %s, %d) %s",
         getNumLoadedKernels(), toStr(mDtypeQ), toStr(mDtypeK), toStr(mDtypeV), toStr(mDtypeOut),
@@ -1060,7 +1089,8 @@ class TllmGenFmhaKernel {
                selectKernelParams.mNumTokensPerPage, selectKernelParams.mDynamicNumTokensPerPage,
                selectKernelParams.mReuseSmemKForV, selectKernelParams.mUses2CtaMma,
                static_cast<int>(params.mSparseMlaType),
-               selectKernelParams.mSkipsSoftmaxWhenPossible),
+               selectKernelParams.mSkipsSoftmaxWhenPossible,
+               static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode)),
         info);
   }
 

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -244,7 +244,7 @@ class TllmGenFmhaKernel {
                          int tileSizeQ, int tileSizeKv, int numTokensPerPage,
                          bool dynamicNumTokensPerPage, bool reuseSmemKForV, bool uses2CtaMma,
                          bool groupsTokensHeadsQ, int sparseMlaType, bool skipsSoftmax,
-                         int bf16QFp8KvTransformMode) const {
+                         int bf16QFp8KvTransformMode, bool uses2QSlidingWindowKernel) const {
     FLASHINFER_CHECK((headDimPerCtaV >= 32) && (headDimQk >= 32) && (headDimV >= 32) &&
                          (headDimPerCtaV <= 1024) && (headDimQk <= 1024) && (headDimV <= 1024),
                      "Expect (32 <= headDim <= 1024), got headDimPerCtaV=%d, headDimQk=%d, "
@@ -281,6 +281,7 @@ class TllmGenFmhaKernel {
     // Bit 58 - 58: dynamicNumTokensPerPage.
     // Bit 59 - 60: BF16Q FP8KV transform mode (0=full, 1=K-only, 2=separate K/V).
     // Bit 61 - 61: groupsTokensHeadsQ.
+    // Bit 62 - 62: uses2QSlidingWindowKernel (Keeps generation 2Qx1KV SlidingWindowCustom).
     uint64_t const numTokensPerPageLog2 =
         numTokensPerPage == 0 ? 0 : static_cast<uint64_t>(log2(numTokensPerPage));
     return (static_cast<uint64_t>(qkvLayout) << 0) | (static_cast<uint64_t>(maskType) << 4) |
@@ -297,7 +298,13 @@ class TllmGenFmhaKernel {
            (static_cast<uint64_t>(skipsSoftmax) << 57) |
            (static_cast<uint64_t>(dynamicNumTokensPerPage) << 58) |
            (static_cast<uint64_t>(bf16QFp8KvTransformMode) << 59) |
-           (static_cast<uint64_t>(groupsTokensHeadsQ) << 61);
+           (static_cast<uint64_t>(groupsTokensHeadsQ) << 61) |
+           (static_cast<uint64_t>(uses2QSlidingWindowKernel) << 62);
+  }
+
+  inline bool is2QSlidingWindowKernel(KernelMeta const& kernelMeta) const {
+    return kernelMeta.mKernelType == static_cast<int>(FmhaKernelType::KeepsMmaAbForGeneration) &&
+           kernelMeta.mGroupsTokensHeadsQ && kernelMeta.mStepQ == 2 * kernelMeta.mTileSizeQ;
   }
 
   inline bool isDynamicNumTokensPerPageKernel(KernelMeta const& kernelMeta) const {
@@ -314,7 +321,8 @@ class TllmGenFmhaKernel {
                   kernelMeta.m2CtaMma, kernelMeta.mGroupsTokensHeadsQ, kernelMeta.mSparseAttn,
                   kernelMeta.mSkipsSoftmaxWhenPossible,
                   getBf16QFp8KvTransformMode(kernelMeta.mEnablesBf16QFp8KvKOnlyTransform,
-                                             kernelMeta.mSeparateTransformedKv));
+                                             kernelMeta.mSeparateTransformedKv),
+                  is2QSlidingWindowKernel(kernelMeta));
   }
 
   std::pair<bool, std::string> checkIfKernelExist(RunnerParams const& params) const {
@@ -1137,7 +1145,8 @@ class TllmGenFmhaKernel {
                selectKernelParams.mReuseSmemKForV, selectKernelParams.mUses2CtaMma,
                selectKernelParams.mGroupsTokensHeadsQ, static_cast<int>(params.mSparseMlaType),
                selectKernelParams.mSkipsSoftmaxWhenPossible,
-               static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode)),
+               static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode),
+               /*uses2QSlidingWindowKernel=*/false),
         info);
   }
 

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -197,9 +197,19 @@ class TllmGenFmhaKernel {
         if (mKernelMetaMap.find(hash) != mKernelMetaMap.end()) {
           // The kernelMeta of the existing kernel.
           auto const& existingKernelMeta = mKernelMeta[mKernelMetaMap.at(hash)];
-          // Some generation cubins are exported twice with equivalent Dense/Causal naming but the
-          // same metadata key. Runtime selection cannot distinguish them, so keep the first entry.
+          // Some generation cubins are exported twice with the same metadata key. Different cubin
+          // names are equivalent Dense/Causal aliases; keep the first entry. Same-name duplicates
+          // collide on the published artifact path, so use the later metadata entry that matches
+          // the file left in the artifact manifest.
           if (existingKernelMeta.mSM == kernelMeta.mSM) {
+            if (std::strcmp(existingKernelMeta.mFuncName, kernelMeta.mFuncName) == 0 &&
+                std::strcmp(existingKernelMeta.sha256, kernelMeta.sha256) != 0) {
+              mKernelMetaMap[hash] = i;
+              IKL_LOG_DEBUG(
+                  "Replacing duplicate tllmgen attention kernel metadata for shared cubin %s",
+                  kernelMeta.mFuncName);
+              continue;
+            }
             IKL_LOG_DEBUG(
                 "Skipping duplicate tllmgen attention kernel %s for key already held by "
                 "%s",
@@ -235,6 +245,17 @@ class TllmGenFmhaKernel {
       return static_cast<int>(Bf16QFp8KvTransformMode::SeparateKv);
     }
     return static_cast<int>(Bf16QFp8KvTransformMode::Full);
+  }
+
+  inline bool isBf16QFp8KvGeneration() const {
+    return mDtypeQ == DATA_TYPE_BF16 && mDtypeK == DATA_TYPE_E4M3 && mDtypeV == DATA_TYPE_E4M3 &&
+           mDtypeOut == DATA_TYPE_BF16;
+  }
+
+  inline bool supportsGqaGroupingTokensHeadsQ(SelectKernelParams const& selectKernelParams) const {
+    return mDtypeQ == mDtypeK ||
+           (isBf16QFp8KvGeneration() &&
+            selectKernelParams.mBf16QFp8KvTransformMode != Bf16QFp8KvTransformMode::Full);
   }
 
   inline uint64_t hashID(int qkvLayout, int maskType, int kernelType, int scheduler,
@@ -855,6 +876,10 @@ class TllmGenFmhaKernel {
         {8, 1.0}     // Cost factor when tileSizeQ = 8
     };
 
+    bool const isBf16QFp8KvFullTransform =
+        isBf16QFp8KvGeneration() &&
+        selectKernelParams.mBf16QFp8KvTransformMode == Bf16QFp8KvTransformMode::SeparateKv;
+
     // Define the per-tile reduction cost model for different tileSizeQ choices.
     std::unordered_map<int, float> kernelReductionCost = {
         {128, 1.32},  // Reduction cost factor when tileSizeQ = 128
@@ -864,6 +889,9 @@ class TllmGenFmhaKernel {
         {8, 1.0}      // Reduction cost factor when tileSizeQ = 8
     };
 
+    // Full-transform kernels pay conversion work in the KV mainloop, so bias the model toward
+    // keeping enough KV parallelism without changing the reduction model.
+    float const kernelMainloopCostFactor = isBf16QFp8KvFullTransform ? 2.0f : 1.0f;
     // The reduction cost emulated as a sequence length factor.
     float const kernelReductionSeqLenFactor = 128.0f;
 
@@ -927,9 +955,10 @@ class TllmGenFmhaKernel {
           kernelMeta.mStepKv;
 
       // Compute the modeling kernel time = mainloop cost + reduction cost.
-      float modelingKernelTime = kernelMainloopCost.at(tileSizeQ) * seqLenPerCtaKv +
-                                 kernelReductionCost.at(tileSizeQ) * kernelReductionSeqLenFactor *
-                                     ctaLaunchParams.mMaxNumCtasKv;
+      float modelingKernelTime =
+          kernelMainloopCostFactor * kernelMainloopCost.at(tileSizeQ) * seqLenPerCtaKv +
+          kernelReductionCost.at(tileSizeQ) * kernelReductionSeqLenFactor *
+              ctaLaunchParams.mMaxNumCtasKv;
 
       // Compute the total number of CTAs.
       int32_t numCtas =
@@ -966,8 +995,9 @@ class TllmGenFmhaKernel {
     // The tile size for Q.
     int& tileSizeQ = selectKernelParams.mTileSizeQ;
 
-    // Mixed precision kernels don't work with groupsTokensHeadsQ = true for now.
-    if (mDtypeQ != mDtypeK || mDtypeQ != mDtypeV) {
+    // Generic mixed precision kernels don't work with groupsTokensHeadsQ = true. BF16Q+FP8KV
+    // transform paths present BF16 K to BMM1, so they can use the grouped-token cubins.
+    if (!supportsGqaGroupingTokensHeadsQ(selectKernelParams)) {
       tileSizeQ = params.mNumHeadsQPerKv <= 8 ? 8 : 16;
       kernelType = FmhaKernelType::SwapsMmaAbForGeneration;
       return;

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -599,13 +599,11 @@ class TllmGenFmhaKernel {
         if (maxNumCtasPerSeqKv <= numCtasForAllHeadsQ * maxKvSplitsPerCgaCluster) {
           int const launchedClusters =
               flashinfer::ceil_div(numCtasX, clusterDimX) * numCtasY * numCtasZ;
-          int const residentSplitBudget =
-              std::max(4, flashinfer::ceil_div(params.mMultiProcessorCount * 13 / 20,
-                                               launchedClusters));
-          int const targetMaxNumCtasPerSeqKv = std::min(
-              maxNumCtasPerSeqKv, std::min(maxKvSplitsPerCgaCluster, residentSplitBudget));
-          if (targetMaxNumCtasPerSeqKv > 1 &&
-              targetMaxNumCtasPerSeqKv < maxNumCtasPerSeqKv) {
+          int const residentSplitBudget = std::max(
+              4, flashinfer::ceil_div(params.mMultiProcessorCount * 13 / 20, launchedClusters));
+          int const targetMaxNumCtasPerSeqKv =
+              std::min(maxNumCtasPerSeqKv, std::min(maxKvSplitsPerCgaCluster, residentSplitBudget));
+          if (targetMaxNumCtasPerSeqKv > 1 && targetMaxNumCtasPerSeqKv < maxNumCtasPerSeqKv) {
             int const targetTileSizePerCtaKv =
                 isSlidingOrChunkedCausalMask(selectKernelParams.mMaskType)
                     ? flashinfer::ceil_div(params.mAttentionWindowSize,

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -426,6 +426,8 @@ struct TllmGenSelectKernelParams {
   int mTileSizeKv;
   // Use 2 CTA MMA or not.
   bool mUses2CtaMma;
+  // Whether the selected generation kernel groups tokensQ and headsQ into one CTA.
+  bool mGroupsTokensHeadsQ;
   // Transform mode for BF16 query + FP8 KV generation kernels.
   Bf16QFp8KvTransformMode mBf16QFp8KvTransformMode;
 
@@ -448,5 +450,6 @@ struct TllmGenSelectKernelParams {
         mTileSizeQ(128),
         mTileSizeKv(128),
         mUses2CtaMma(false),
+        mGroupsTokensHeadsQ(false),
         mBf16QFp8KvTransformMode(params.mBf16QFp8KvTransformMode) {};
 };

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -151,6 +151,12 @@ enum class TrtllmGenSparseMlaType {
   DynamicTokenSparse = 2,
 };
 
+enum class Bf16QFp8KvTransformMode {
+  Full = 0,
+  KOnly,
+  SeparateKv,
+};
+
 inline bool isSparseMla(TrtllmGenSparseMlaType sparseMlaType) {
   return sparseMlaType != TrtllmGenSparseMlaType::None;
 }
@@ -338,6 +344,8 @@ struct TllmGenFmhaRunnerParams {
   int mSparseMlaTopK;
   // Whether DSv4 sparse MLA should read tile 0 from slidingWindowKvPoolPtr.
   bool mHasSlidingWindowKvPool;
+  // Transform mode for BF16 query + FP8 KV generation kernels.
+  Bf16QFp8KvTransformMode mBf16QFp8KvTransformMode;
   // Whether the indices for K & V pages are shared as unified index.
   // true -> vLLM/FlashInfer; false -> TRT-LLM.
   bool mUsesSharedPagedKvIdx;
@@ -418,6 +426,8 @@ struct TllmGenSelectKernelParams {
   int mTileSizeKv;
   // Use 2 CTA MMA or not.
   bool mUses2CtaMma;
+  // Transform mode for BF16 query + FP8 KV generation kernels.
+  Bf16QFp8KvTransformMode mBf16QFp8KvTransformMode;
 
   // The constructor.
   TllmGenSelectKernelParams(TllmGenFmhaRunnerParams params)
@@ -437,5 +447,6 @@ struct TllmGenSelectKernelParams {
         mTileScheduler(params.mTileScheduler),
         mTileSizeQ(128),
         mTileSizeKv(128),
-        mUses2CtaMma(false) {};
+        mUses2CtaMma(false),
+        mBf16QFp8KvTransformMode(params.mBf16QFp8KvTransformMode) {};
 };

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -79,6 +79,12 @@ struct KernelParams {
   int64_t const* ptrCustomMaskOffsets;
   // The debug output matrix O
   float* ptrDebugO;
+  // DSv4 inverse-RoPE + FP8 quant fusion metadata and output scale tensor, only for epilogue
+  // fusion. Unused by FlashInfer but part of the kernel-side KernelParams ABI; the field order
+  // must stay in sync with the kernels or every later field is misread by the cubins.
+  float const* ptrDsv4InvRopeCosSinCache;
+  // Dsv4 output block-scaled tensor, only for epilogue fusion
+  float* ptrDsv4OScaleFp32;
   // The first sparseMask offsets in the Kv sequence dimension.
   int32_t const* ptrFirstSparseMaskOffsetsKv;
   // The counter for the multiCtasKv mode.
@@ -130,6 +136,9 @@ struct KernelParams {
   int32_t mBatchSize;
   // The chunked attention size in log2.
   int32_t mChunkedAttentionSizeLog2;
+  // Padded token dimension for the DSv4 fused FP32 scale layout. Unused by FlashInfer; kept for
+  // the KernelParams ABI (see the DSv4 pointer fields above).
+  int64_t mDsv4ScaleBufM;
   // The factor to add to the maximum value to increase the probability
   //   of skip correction during next iterations.
   float mInflateMax;
@@ -195,7 +204,7 @@ struct KernelParams {
   template <class FmhaOptions>
   static auto makeTmaShapeStrideQ(FmhaOptions const& options, bool groupsHeadsQ,
                                   bool groupsTokensHeadsQ, int32_t tileSizeQ,
-                                  int32_t numEltsInClampedHeadDimQ) {
+                                  int32_t tileSizePerCtaQ, int32_t numEltsInClampedHeadDimQ) {
     //
     // The Q has shape of [numTokens * numHeadsQPerKv, numHeadsKv * 1, headDim]
     // when grouping headsQ, otherwise it would be [numTokens, numHeadsQPerKv * numHeadsKv,
@@ -265,8 +274,10 @@ struct KernelParams {
     // The tile shape for TMA.
     auto tileShapes = std::vector<uint32_t>{static_cast<uint32_t>(numEltsInClampedHeadDimQ), 1, 1,
                                             static_cast<uint32_t>(tileSizeQ)};
-    // The number of tokensQ per CTA.
-    int32_t numTokensPerCtaQ{tileSizeQ};
+    // The number of tokensQ per CTA (the CTA covers all Q tile instances).
+    int32_t numTokensPerCtaQ{tileSizePerCtaQ};
+    // The number of tokensQ loaded by one Q tile instance (the TMA box covers one instance).
+    int32_t numTokensPerTileQ{tileSizeQ};
     // Re-compute the number of tokensQ per CTA if groupsHeadsQ is enabled.
     if (groupsHeadsQ) {
       if (groupsTokensHeadsQ) {
@@ -275,13 +286,15 @@ struct KernelParams {
         // tensor to [numTokensQ, numGroupedHeads, numHeads, headDimQ] and we might want to revisit
         // this in the future.
         numTokensPerCtaQ = static_cast<int32_t>(numTokensPerCtaQ / numGroupedHeads);
+        numTokensPerTileQ = static_cast<int32_t>(numTokensPerTileQ / numGroupedHeads);
       } else {
-        numGroupedHeads = tileSizeQ;
+        numGroupedHeads = tileSizePerCtaQ;
         numTokensPerCtaQ = 1;
+        numTokensPerTileQ = 1;
       }
       tileShapes = std::vector<uint32_t>{static_cast<uint32_t>(numEltsInClampedHeadDimQ),
                                          static_cast<uint32_t>(numGroupedHeads), 1,
-                                         static_cast<uint32_t>(numTokensPerCtaQ)};
+                                         static_cast<uint32_t>(numTokensPerTileQ)};
     }
 
     return std::make_tuple(shape, stride, tileShapes, numTokensPerCtaQ);
@@ -680,7 +693,7 @@ struct KernelParams {
     // Shape/stride for gmem tensor Q.
     auto [shapeQ, strideQ, tileShapeQ, numTokensPerCtaQ] =
         makeTmaShapeStrideQ(options, kernelMeta.mGroupsHeadsQ, kernelMeta.mGroupsTokensHeadsQ,
-                            kernelMeta.mTileSizeQ, numEltsInClampedHeadDimQ);
+                            kernelMeta.mTileSizeQ, kernelMeta.mStepQ, numEltsInClampedHeadDimQ);
     // Build tma descriptor for Q.
     params.tmaQ_ = buildNdTmaDescriptor(options, kernelMeta.mDataTypeQ, shapeQ, strideQ, tileShapeQ,
                                         const_cast<void*>(qPtr));

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1,3 +1,4 @@
+import inspect
 import math
 from typing import Union
 
@@ -1303,6 +1304,113 @@ def test_trtllm_batch_decode_bmm1_scale_log2(q_dtype, kv_dtype, o_dtype, device_
         device_scale=device_scale,
         uses_shared_paged_kv_idx=True,
         use_bmm1_scale_log2=True,
+    )
+
+
+def test_trtllm_gen_bf16q_fp8kv_transform_mode_kwarg_exists():
+    signature = inspect.signature(flashinfer.decode.trtllm_batch_decode_with_kv_cache)
+    assert "trtllm_gen_bf16q_fp8kv_transform_mode" in signature.parameters
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("full", 0),
+        ("k_only", 1),
+        ("separate_kv", 2),
+    ],
+)
+def test_trtllm_gen_bf16q_fp8kv_transform_mode_mapping(mode, expected):
+    assert (
+        flashinfer.decode._get_trtllm_gen_bf16q_fp8kv_transform_mode(mode) == expected
+    )
+
+
+def test_trtllm_gen_bf16q_fp8kv_transform_mode_rejects_invalid_value():
+    with pytest.raises(ValueError, match="trtllm_gen_bf16q_fp8kv_transform_mode"):
+        flashinfer.decode._get_trtllm_gen_bf16q_fp8kv_transform_mode("split_kv")
+
+
+def test_trtllm_gen_bf16q_fp8kv_transform_modes_run():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for trtllm-gen attention")
+    if get_compute_capability(torch.device("cuda"))[0] != 10:
+        pytest.skip("trtllm-gen backend requires SM100 or SM103 GPUs")
+
+    batch_size = 1
+    q_len = 1
+    num_kv_heads = 1
+    num_qo_heads = 8
+    head_dim = 64
+    page_size = 32
+    kv_len = 1024
+    num_pages = kv_len // page_size
+
+    torch.manual_seed(0)
+    query = (
+        torch.randn(
+            batch_size * q_len,
+            num_qo_heads,
+            head_dim,
+            device=GPU_DEVICE,
+            dtype=torch.bfloat16,
+        )
+        * 0.1
+    )
+    key_bf16 = (
+        torch.randn(
+            num_pages,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            device=GPU_DEVICE,
+            dtype=torch.bfloat16,
+        )
+        * 0.1
+    )
+    value_bf16 = (
+        torch.randn(
+            num_pages,
+            num_kv_heads,
+            page_size,
+            head_dim,
+            device=GPU_DEVICE,
+            dtype=torch.bfloat16,
+        )
+        * 0.1
+    )
+    key_fp8, key_scale = to_float8(key_bf16)
+    value_fp8, value_scale = to_float8(value_bf16)
+    kv_cache = torch.stack([key_fp8, value_fp8], dim=1).contiguous()
+    block_tables = torch.arange(
+        num_pages, device=GPU_DEVICE, dtype=torch.int32
+    ).reshape(batch_size, num_pages)
+    seq_lens = torch.full((batch_size,), kv_len, device=GPU_DEVICE, dtype=torch.int32)
+    workspace = torch.empty(workspace_size, dtype=torch.int8, device=GPU_DEVICE)
+
+    outputs = {}
+    for mode in ("full", "k_only", "separate_kv"):
+        outputs[mode] = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query,
+            kv_cache,
+            workspace,
+            block_tables,
+            seq_lens,
+            kv_len,
+            bmm1_scale=float(key_scale.item()) / math.sqrt(head_dim),
+            bmm2_scale=float(value_scale.item()),
+            backend="trtllm-gen",
+            q_len_per_req=q_len,
+            trtllm_gen_bf16q_fp8kv_transform_mode=mode,
+        )
+        torch.cuda.synchronize()
+        assert torch.isfinite(outputs[mode]).all()
+
+    torch.testing.assert_close(
+        outputs["k_only"].float(), outputs["full"].float(), rtol=5e-2, atol=5e-2
+    )
+    torch.testing.assert_close(
+        outputs["separate_kv"].float(), outputs["full"].float(), rtol=5e-2, atol=5e-2
     )
 
 

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1315,7 +1315,6 @@ def test_trtllm_gen_bf16q_fp8kv_transform_mode_kwarg_exists():
 @pytest.mark.parametrize(
     ("mode", "expected"),
     [
-        ("full", 0),
         ("k_only", 1),
         ("separate_kv", 2),
     ],
@@ -1329,6 +1328,8 @@ def test_trtllm_gen_bf16q_fp8kv_transform_mode_mapping(mode, expected):
 def test_trtllm_gen_bf16q_fp8kv_transform_mode_rejects_invalid_value():
     with pytest.raises(ValueError, match="trtllm_gen_bf16q_fp8kv_transform_mode"):
         flashinfer.decode._get_trtllm_gen_bf16q_fp8kv_transform_mode("split_kv")
+    with pytest.raises(ValueError, match="trtllm_gen_bf16q_fp8kv_transform_mode"):
+        flashinfer.decode._get_trtllm_gen_bf16q_fp8kv_transform_mode("full")
 
 
 def test_trtllm_gen_bf16q_fp8kv_transform_modes_run():
@@ -1389,7 +1390,56 @@ def test_trtllm_gen_bf16q_fp8kv_transform_modes_run():
     workspace = torch.empty(workspace_size, dtype=torch.int8, device=GPU_DEVICE)
 
     outputs = {}
-    for mode in ("full", "k_only", "separate_kv"):
+    outputs["default"] = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+        query,
+        kv_cache,
+        workspace,
+        block_tables,
+        seq_lens,
+        kv_len,
+        bmm1_scale=float(key_scale.item()) / math.sqrt(head_dim),
+        bmm2_scale=float(value_scale.item()),
+        backend="trtllm-gen",
+        q_len_per_req=q_len,
+    )
+    torch.cuda.synchronize()
+    assert torch.isfinite(outputs["default"]).all()
+
+    workspace.zero_()
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "HND", backend="trtllm-gen"
+    )
+    kv_indptr = torch.tensor([0, num_pages], device=GPU_DEVICE, dtype=torch.int32)
+    kv_indices = torch.arange(num_pages, device=GPU_DEVICE, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,), page_size, device=GPU_DEVICE, dtype=torch.int32
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=query.dtype,
+        kv_data_type=kv_cache.dtype,
+        o_data_type=torch.bfloat16,
+        q_len_per_req=q_len,
+    )
+    outputs["wrapper_default"] = wrapper.run(
+        query,
+        kv_cache,
+        q_len_per_req=q_len,
+        q_scale=1.0 / math.sqrt(head_dim),
+        k_scale=float(key_scale.item()),
+        v_scale=float(value_scale.item()),
+    )
+    torch.cuda.synchronize()
+    assert torch.isfinite(outputs["wrapper_default"]).all()
+
+    for mode in ("k_only", "separate_kv"):
+        workspace.zero_()
         outputs[mode] = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
             query,
             kv_cache,
@@ -1407,10 +1457,22 @@ def test_trtllm_gen_bf16q_fp8kv_transform_modes_run():
         assert torch.isfinite(outputs[mode]).all()
 
     torch.testing.assert_close(
-        outputs["k_only"].float(), outputs["full"].float(), rtol=5e-2, atol=5e-2
+        outputs["default"].float(),
+        outputs["separate_kv"].float(),
+        rtol=0,
+        atol=0,
     )
     torch.testing.assert_close(
-        outputs["separate_kv"].float(), outputs["full"].float(), rtol=5e-2, atol=5e-2
+        outputs["wrapper_default"].float(),
+        outputs["separate_kv"].float(),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+    torch.testing.assert_close(
+        outputs["k_only"].float(),
+        outputs["separate_kv"].float(),
+        rtol=5e-2,
+        atol=5e-2,
     )
 
 

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1320,9 +1320,7 @@ def test_bf16q_fp8kv_transform_mode_kwarg_exists():
     ],
 )
 def test_bf16q_fp8kv_transform_mode_mapping(mode, expected):
-    assert (
-        flashinfer.decode._get_bf16q_fp8kv_transform_mode(mode) == expected
-    )
+    assert flashinfer.decode._get_bf16q_fp8kv_transform_mode(mode) == expected
 
 
 def test_bf16q_fp8kv_transform_mode_rejects_invalid_value():

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1307,9 +1307,9 @@ def test_trtllm_batch_decode_bmm1_scale_log2(q_dtype, kv_dtype, o_dtype, device_
     )
 
 
-def test_trtllm_gen_bf16q_fp8kv_transform_mode_kwarg_exists():
+def test_bf16q_fp8kv_transform_mode_kwarg_exists():
     signature = inspect.signature(flashinfer.decode.trtllm_batch_decode_with_kv_cache)
-    assert "trtllm_gen_bf16q_fp8kv_transform_mode" in signature.parameters
+    assert "bf16q_fp8kv_transform_mode" in signature.parameters
 
 
 @pytest.mark.parametrize(
@@ -1319,24 +1319,24 @@ def test_trtllm_gen_bf16q_fp8kv_transform_mode_kwarg_exists():
         ("separate_kv", 2),
     ],
 )
-def test_trtllm_gen_bf16q_fp8kv_transform_mode_mapping(mode, expected):
+def test_bf16q_fp8kv_transform_mode_mapping(mode, expected):
     assert (
-        flashinfer.decode._get_trtllm_gen_bf16q_fp8kv_transform_mode(mode) == expected
+        flashinfer.decode._get_bf16q_fp8kv_transform_mode(mode) == expected
     )
 
 
-def test_trtllm_gen_bf16q_fp8kv_transform_mode_rejects_invalid_value():
-    with pytest.raises(ValueError, match="trtllm_gen_bf16q_fp8kv_transform_mode"):
-        flashinfer.decode._get_trtllm_gen_bf16q_fp8kv_transform_mode("split_kv")
-    with pytest.raises(ValueError, match="trtllm_gen_bf16q_fp8kv_transform_mode"):
-        flashinfer.decode._get_trtllm_gen_bf16q_fp8kv_transform_mode("full")
+def test_bf16q_fp8kv_transform_mode_rejects_invalid_value():
+    with pytest.raises(ValueError, match="bf16q_fp8kv_transform_mode"):
+        flashinfer.decode._get_bf16q_fp8kv_transform_mode("split_kv")
+    with pytest.raises(ValueError, match="bf16q_fp8kv_transform_mode"):
+        flashinfer.decode._get_bf16q_fp8kv_transform_mode("full")
 
 
-def test_trtllm_gen_bf16q_fp8kv_transform_modes_run():
+def test_bf16q_fp8kv_transform_modes_run():
     if not torch.cuda.is_available():
-        pytest.skip("CUDA is required for trtllm-gen attention")
+        pytest.skip("CUDA is required for this attention test")
     if get_compute_capability(torch.device("cuda"))[0] != 10:
-        pytest.skip("trtllm-gen backend requires SM100 or SM103 GPUs")
+        pytest.skip("This attention test requires SM100 or SM103 GPUs")
 
     batch_size = 1
     q_len = 1
@@ -1451,7 +1451,7 @@ def test_trtllm_gen_bf16q_fp8kv_transform_modes_run():
             bmm2_scale=float(value_scale.item()),
             backend="trtllm-gen",
             q_len_per_req=q_len,
-            trtllm_gen_bf16q_fp8kv_transform_mode=mode,
+            bf16q_fp8kv_transform_mode=mode,
         )
         torch.cuda.synchronize()
         assert torch.isfinite(outputs[mode]).all()

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1309,7 +1309,7 @@ def test_trtllm_batch_decode_bmm1_scale_log2(q_dtype, kv_dtype, o_dtype, device_
 
 def test_bf16q_fp8kv_transform_mode_kwarg_exists():
     signature = inspect.signature(flashinfer.decode.trtllm_batch_decode_with_kv_cache)
-    assert "bf16q_fp8kv_transform_mode" in signature.parameters
+    assert list(signature.parameters)[-1] == "bf16q_fp8kv_transform_mode"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds explicit transform-mode selection for BF16Q+FP8KV decode cubins.

Changes:
- Adds `bf16q_fp8kv_transform_mode` to batch decode.
- Defaults BF16Q+FP8KV decode to `separate_kv`.
- Supports explicit `k_only` and `separate_kv` modes.
- Caps BF16Q+FP8KV separate-transform splits so runtime selection lands on the expected CGA-reduction cubins.
- Adds tests for transform-mode mapping, invalid mode handling, and runtime execution.

Validation:
- Focused BF16Q+FP8KV transform-mode tests

Notes:
- `k_only` transforms K for BMM1 and consumes raw FP8 V for BMM2.
- `separate_kv` transforms K and V separately before the MMA pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `bf16q_fp8kv_transform_mode` to `trtllm-gen` batch decode (accepts `"k_only"` and `"separate_kv"`), including validation and a sensible default when omitted.
  * Updated decode/kernel behavior to correctly route BF16-query + FP8-KV “transform” variants.
* **Chores**
  * Updated the TRTLLM GEN FMHA cubin artifact path and checksum.
* **Tests**
  * Added tests for signature/kwarg presence, mode mapping, invalid-value rejection, and CUDA output comparisons across modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->