### PR TITLE
Support smaller DSv4 sparse MLA head counts

### DIFF
--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -348,8 +348,8 @@ def _check_dsv4_sparse_mla_inputs(
         )
     if head_dim != 512:
         raise ValueError(f"Expected query head dim 512, got {head_dim}")
-    if num_heads not in (64, 128):
-        raise ValueError(f"Expected 64 or 128 query heads, got {num_heads}")
+    if num_heads not in (8, 16, 32, 64, 128):
+        raise ValueError(f"Expected 8, 16, 32, 64, or 128 query heads, got {num_heads}")
 
     if (
         sparse_indices is None

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -256,6 +256,60 @@ def gen_testcase() -> tuple[RawTestParamForDecode, ...]:
                         sparse_case="swa128+topk128x",
                     )
 
+    # Smaller head counts use the sparse MLA small-head kernel selection path.
+    swa_seq_len, c4_seq_len, c128_seq_len = DECODE_SEQ_LEN_CASES[0]
+    c128_topk = _round_up(c128_seq_len + (DECODE_BATCH_SIZE - 1) * C128_PAGE_SIZE, 4)
+    for h_q in (8, 16, 32):
+        for dtype in (torch.bfloat16, torch.float8_e4m3fn):
+            for kv_layout in ("HND", "NHD"):
+                add_case(
+                    b=DECODE_BATCH_SIZE,
+                    h_q=h_q,
+                    s_q=DECODE_Q_LEN,
+                    h_kv=1,
+                    s_kv=swa_seq_len,
+                    is_varlen=True,
+                    topk=DSV4_SWA_TOPK,
+                    block_size=SWA_PAGE_SIZE,
+                    dtype=dtype,
+                    kv_layout=kv_layout,
+                    sparse_case="swa128",
+                )
+                add_case(
+                    b=DECODE_BATCH_SIZE,
+                    h_q=h_q,
+                    s_q=DECODE_Q_LEN,
+                    h_kv=1,
+                    s_kv=swa_seq_len,
+                    is_varlen=True,
+                    topk=DSV4_SWA_TOPK,
+                    extra_s_k=c4_seq_len,
+                    extra_topk=h_q * 8,
+                    block_size=SWA_PAGE_SIZE,
+                    extra_block_size=C4_PAGE_SIZE,
+                    have_extra_topk_length=True,
+                    dtype=dtype,
+                    kv_layout=kv_layout,
+                    sparse_case="swa128+topk4x",
+                )
+                add_case(
+                    b=DECODE_BATCH_SIZE,
+                    h_q=h_q,
+                    s_q=DECODE_Q_LEN,
+                    h_kv=1,
+                    s_kv=swa_seq_len,
+                    is_varlen=True,
+                    topk=DSV4_SWA_TOPK,
+                    extra_s_k=c128_seq_len,
+                    extra_topk=c128_topk,
+                    block_size=SWA_PAGE_SIZE,
+                    extra_block_size=C128_PAGE_SIZE,
+                    have_extra_topk_length=True,
+                    dtype=dtype,
+                    kv_layout=kv_layout,
+                    sparse_case="swa128+topk128x",
+                )
+
     # Guard seq_lens-driven SWA masking. With q_len == kv_len == 128, early
     # query tokens have fewer than 128 valid SWA entries, so the kernel must use
     # real seq_lens instead of treating every SWA tile as full.


### PR DESCRIPTION
## Summary
- allow DeepSeek V4 sparse MLA validation for 8/16/32 heads in addition to 64/128
- add targeted BF16/FP8 sparse MLA coverage for 8, 16, and 32 heads

## Tests
- `python -m ruff check flashinfer/mla/_core.py tests/attention/test_trtllm_gen_sparse_mla_dsv4.py`
- `FLASHINFER_DISABLE_VERSION_CHECK=1 python -m pytest --collect-only tests/attention/test_trtllm_gen_sparse_mla_dsv4.py -q`
- `FLASHINFER_DISABLE_VERSION_CHECK=1 python -m pytest tests/attention/test_trtllm_gen_sparse_mla_dsv4.py -k 'h8 or h16 or h32' -vv`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded DeepSeek V4 sparse MLA support to head counts: 8, 16, 32, 64, and 128.

* **Bug Fixes**
  * Updated input validation to accept the expanded set of supported head counts.

* **Tests**
  * Added test coverage for sparse MLA decode scenarios with smaller head counts, multiple data types, and both KV layout variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->