### PR TITLE
fix: handle negative draft_token_ids in ChainSpeculativeSampling

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -1882,7 +1882,7 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
   uint32_t pos = num_speculative_tokens;
   for (uint32_t i = 0; i < num_speculative_tokens; ++i) {
     IdType draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
-    if (draft_id < 0) {
+    if (static_cast<int32_t>(draft_id) < 0) {
       pos = i;
       break;
     }
@@ -1900,8 +1900,8 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
   uint32_t emitted_token_num = pos;
   uint32_t accepted_token_num = pos;
   for (uint32_t i = pos; i < num_speculative_tokens; ++i) {
-    int draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
-    if (draft_id < 0) {
+    IdType draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
+    if (static_cast<int32_t>(draft_id) < 0) {
       break;
     }
     float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -1882,11 +1882,14 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
   uint32_t pos = num_speculative_tokens;
   for (uint32_t i = 0; i < num_speculative_tokens; ++i) {
     IdType draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
+    if (draft_id < 0) {
+      pos = i;
+      break;
+    }
     float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
           p = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
     float u = curand_uniform(&curand_state);
     if (u * p < q) {
-      // accept the draft models output
       output_token_ids[row_idx * (num_speculative_tokens + 1) + i] = draft_id;
     } else {
       pos = i;
@@ -1898,6 +1901,9 @@ __global__ void ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token
   uint32_t accepted_token_num = pos;
   for (uint32_t i = pos; i < num_speculative_tokens; ++i) {
     int draft_id = draft_token_ids[row_idx * num_speculative_tokens + i];
+    if (draft_id < 0) {
+      break;
+    }
     float q = target_probs[(row_idx * (num_speculative_tokens + 1) + i) * d + draft_id],
           p = draft_probs[(row_idx * num_speculative_tokens + i) * d + draft_id];
     float u = curand_uniform(&curand_state);

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -834,6 +834,56 @@ def test_chain_speculative_sampling(
         assert torch.all(emitted_num + 1 == (output_token_ids != -1).sum(dim=1))
 
 
+def test_chain_speculative_sampling_negative_draft_ids():
+    """Regression test for https://github.com/flashinfer-ai/flashinfer/issues/879
+
+    When draft_token_ids contains -1 sentinel values (early-stopped draft),
+    the kernel must treat them as rejections instead of using -1 as an array index.
+    """
+    token_ids = torch.tensor([[1, 0, 1, -1, -1]], device="cuda:0", dtype=torch.int32)
+    draft_probs = torch.tensor(
+        [
+            [
+                [0.5883, 0.4117, 0.0000, 0.0000],
+                [1.0000, 0.0000, 0.0000, 0.0000],
+                [0.3803, 0.5435, 0.0762, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000],
+            ]
+        ],
+        device="cuda:0",
+    )
+    verify_probs = torch.tensor(
+        [
+            [
+                [0.4555, 0.5445, 0.0000, 0.0000],
+                [1.0000, 0.0000, 0.0000, 0.0000],
+                [0.5783, 0.2831, 0.0000, 0.1386],
+                [0.2346, 0.6850, 0.0804, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 0.0000, 0.0000],
+            ]
+        ],
+        device="cuda:0",
+    )
+
+    num_valid_drafts = 3
+    for _ in range(50):
+        accepted_num = torch.zeros(1, dtype=torch.int32, device="cuda:0")
+        emitted_num = torch.zeros(1, dtype=torch.int32, device="cuda:0")
+        output_token_ids, accepted_num, emitted_num = (
+            flashinfer.sampling.chain_speculative_sampling(
+                draft_probs, token_ids, verify_probs, accepted_num, emitted_num
+            )
+        )
+        assert emitted_num.item() <= num_valid_drafts, (
+            f"emitted_token_num ({emitted_num.item()}) exceeded the number of "
+            f"valid draft tokens ({num_valid_drafts})"
+        )
+        assert accepted_num.item() <= num_valid_drafts
+        assert torch.all(output_token_ids[0, num_valid_drafts + 1 :] == -1)
+
+
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 0.7, 1])


### PR DESCRIPTION
## Summary

Fixes #879.

`ChainSpeculativeSampling` kernel used `draft_token_ids[i]` directly as an array index into `draft_probs` and `target_probs` without validating the value. When the draft model produces fewer tokens than `num_speculate_tokens`, the remaining positions are filled with `-1` sentinel values. Using `-1` as an index causes **out-of-bounds memory access**, reading garbage values that happen to satisfy the acceptance condition (`u * 0 < garbage_q`), leading to:

- Invalid `-1` tokens being "accepted" as draft output
- `output_emitted_token_num` exceeding the number of valid draft tokens
- Nondeterministic incorrect results

## Changes

- **`include/flashinfer/sampling.cuh`**: Add `draft_id < 0` guard in both the contiguous-acceptance loop (line ~1884) and the post-rejection counting loop (line ~1900). Negative IDs are treated as immediate rejections.
- **`tests/utils/test_sampling.py`**: Add regression test using the exact reproduction case from #879, verifying that `emitted_token_num` never exceeds the count of valid (non-negative) draft tokens.

## Test plan

- [ ] Existing `test_chain_speculative_sampling` tests pass (no behavioral change for valid inputs)
- [ ] New `test_chain_speculative_sampling_negative_draft_ids` verifies the fix over 50 trials with the exact inputs from the bug report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed speculative sampling so early-terminated draft tokens with sentinel values no longer cause incorrect outputs or indexing errors.
* **Tests**
  * Added a regression test to ensure sampling correctly handles trailing sentinel draft tokens and does not emit or accept tokens beyond valid drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->