### PR TITLE
perf(gemm): update mm_fp4 b12x SM120 NVFP4 dense GEMM kernel

### DIFF
--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -585,8 +585,10 @@ def sm120_make_smem_layout_sfb(
 
     assert sf_vec_size == 16 or sf_vec_size == 32, "sf_vec_size must be 16 or 32"
 
-    assert tile_shape_mnk[1] % (blk_mn // 2) == 0, (
-        "tile_shape_mnk[1] must be divisible by 64"
+    # Relaxed 64 -> 16 (upstream b12x commit 0daa6ab) to allow narrow-N FP4 tiles
+    # (64x32 / 64x16) used with swap_ab.
+    assert tile_shape_mnk[1] % (blk_mn // 8) == 0, (
+        "tile_shape_mnk[1] must be divisible by 16"
     )
 
     assert tile_shape_mnk[2] % sf_vec_size == 0, (

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -585,8 +585,6 @@ def sm120_make_smem_layout_sfb(
 
     assert sf_vec_size == 16 or sf_vec_size == 32, "sf_vec_size must be 16 or 32"
 
-    # Relaxed 64 -> 16 (upstream b12x commit 0daa6ab) to allow narrow-N FP4 tiles
-    # (64x32 / 64x16) used with swap_ab.
     assert tile_shape_mnk[1] % (blk_mn // 8) == 0, (
         "tile_shape_mnk[1] must be divisible by 16"
     )

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5809,8 +5809,6 @@ def _b12x_gemm_fp4_runner(
         )
 
     def _default_dense_plan(m, n, real_k, device):
-        # Shared by forward() and get_valid_tactics() so the tuner's candidate
-        # set always includes the default-path tile.
         return _select_default_dense_gemm_plan(
             m, n, real_k, get_device_sm_count(device), expected_m=m
         )
@@ -6019,15 +6017,9 @@ def _heuristic_func_mm_fp4(
     is_sm103 = major == 10 and minor == 3
     is_sm120 = major == 12 and minor == 0
 
-    # SM120 + CUDA 13: prefer b12x (warp-level MMA, underfill tile selection)
-    # TODO(sm121/DGX Spark): b12x is *supported* on SM121 (requirement is
-    # @supported_compute_capability([120, 121])) but `auto` only routes it at
-    # SM120 here, so on a Spark `backend="auto"` falls back to cutlass/cudnn and
-    # never picks b12x. To enable it, widen this to `major == 12` (covers 120+121).
-    # Gate the change on the Spark bench: only prefer b12x if it actually beats
-    # cutlass/cudnn on GB10. Also verify the kernel's hardcoded
-    # get_smem_capacity_in_bytes("sm_120") assumption holds on SM121 (run the
-    # e2e handoff's correctness section on the real Spark first).
+    # SM120 + CUDA 13: prefer b12x. SM121 (GB10) is intentionally excluded -- b12x
+    # is supported there as an explicit backend, but cutlass/cudnn are faster in
+    # most cases, so `auto` keeps using them.
     if is_sm120 and use_nvfp4 and cuda_major >= 13:
         return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4333,29 +4333,6 @@ _SM100_DEFAULT_MMA_TILER_MN = (128, 128)
 _SM100_DEFAULT_CLUSTER_SHAPE_MN = (1, 1)
 
 
-def _select_default_sm120_mma_tiler(m, n, sm_count):
-    """Select optimal SM120 tile shape based on problem size and SM count.
-
-    Uses narrower tiles (64x64, 64x128, 128x64) when the default 128x128
-    would leave SMs idle on small-M shapes.
-    """
-    coarse_tile = (128, 128)
-    coarse_tiles = ((m + coarse_tile[0] - 1) // coarse_tile[0]) * (
-        (n + coarse_tile[1] - 1) // coarse_tile[1]
-    )
-    if m <= 128 and coarse_tiles < max(1, sm_count // 2):
-        if n > 1536:
-            return (64, 128)
-        medium_tile = (128, 64)
-        medium_tiles = ((m + medium_tile[0] - 1) // medium_tile[0]) * (
-            (n + medium_tile[1] - 1) // medium_tile[1]
-        )
-        if medium_tiles < max(1, sm_count // 2):
-            return (64, 64)
-        return (128, 64)
-    return (128, 128)
-
-
 def _get_approximate_cta_nums(m, n, tile_mn, cluster_shape_mn):
     tile_m, tile_n = tile_mn
     cluster_m, cluster_n = cluster_shape_mn
@@ -5468,7 +5445,7 @@ def _cute_dsl_gemm_fp4_requirement(
 
 @supported_compute_capability([120, 121])
 def _b12x_gemm_fp4_requirement(
-    a: torch.Tensor,  # unused
+    a: torch.Tensor,
     b: torch.Tensor,  # unused
     a_descale: torch.Tensor,  # unused
     b_descale: torch.Tensor,  # unused
@@ -5493,6 +5470,17 @@ def _b12x_gemm_fp4_requirement(
         raise ValueError("b12x FP4 GEMM only supports 128x4 scale factor layout.")
     if not use_nvfp4:
         raise ValueError("b12x FP4 GEMM only supports NVFP4 (sf_vec_size=16).")
+    # The b12x NVFP4 kernel requires K % 128 == 0 (tile_k = sf_vec_size * 8); the
+    # default launch path skips can_implement, so enforce it here. Under "auto"
+    # this drops b12x for unsupported K (falls back to cutlass/cudnn); under
+    # explicit backend="b12x" it raises instead of silently dropping the K-tail.
+    # a is the packed FP4 operand of shape (M, K // 2), 2 FP4 values per uint8.
+    real_k = a.shape[1] * 2
+    if real_k % 128 != 0:
+        raise ValueError(
+            "b12x FP4 GEMM requires the contraction dim K to be a multiple of 128 "
+            f"(tile_k = sf_vec_size * 8). Got K={real_k}."
+        )
     _check_cute_dsl_availability()
     return True
 
@@ -5911,19 +5899,12 @@ def _b12x_gemm_fp4_runner(
                     get_device_sm_count(a.device),
                     expected_m=m,
                 )
-                # swap_ab (narrow-N) is not yet supported by this wrapper; when the
-                # plan would request it, fall back to the M-independent default tile.
-                plan_tile = (
-                    _select_default_sm120_mma_tiler(
-                        m, n, get_device_sm_count(a.device)
-                    )
-                    if plan.swap_ab
-                    else plan.mma_tiler_mn
-                )
+                # Honor the plan's swap_ab (narrow-N decode tiles, e.g. 64x32).
+                # b12x swap_ab is device-internal; see the launch + wrapper notes.
                 tactic = (
-                    plan_tile,
+                    plan.mma_tiler_mn,
                     (1, 1),
-                    False,
+                    plan.swap_ab,
                     False,
                     "sm120",
                     None,
@@ -5938,12 +5919,11 @@ def _b12x_gemm_fp4_runner(
                 use_tma_store,
             ) = tactic
 
-            kernel_m, kernel_n = m, n
             kernel_a, kernel_b = a, b.T
             kernel_a_sf, kernel_b_sf = a_descale, b_descale.T
 
-            sf_m = (kernel_m + 127) // 128
-            sf_n = (kernel_n + 127) // 128
+            sf_m = (m + 127) // 128
+            sf_n = (n + 127) // 128
             sf_k = (real_k // sf_vec_size + 3) // 4
 
             cache_key = (
@@ -5969,6 +5949,11 @@ def _b12x_gemm_fp4_runner(
                 swap_ab=swap_ab,
             )
 
+            # b12x swap_ab is device-internal (applied via the kernel ctor); the
+            # public C stays row-major (m, n). The shared harness's `swap_ab` instead
+            # selects the SM100 operand-swap FFI convention (C declared (n, m)), which
+            # b12x must not use -- so pass swap_ab=False (keeps c_fake (m, n) + plain
+            # `out`). cache_key still carries the real swap_ab (separate caching).
             compiled_gemm, _ = _compile_block_scaled_gemm(
                 _B12X_MM_FP4_KERNEL_CACHE,
                 cache_key,
@@ -5978,7 +5963,7 @@ def _b12x_gemm_fp4_runner(
                 c_cutlass_dtype=c_cutlass_dtype,
                 ab_assumed_align=32,
                 cluster_shape_mn=cluster_shape_mn,
-                swap_ab=swap_ab,
+                swap_ab=False,
                 sf_m=sf_m,
                 sf_n=sf_n,
                 sf_k=sf_k,
@@ -5987,8 +5972,7 @@ def _b12x_gemm_fp4_runner(
 
             alpha_for_launch = _prepare_alpha_for_launch(alpha_tensor, a.device)
 
-            # NOTE: swap_ab is always False here (narrow-N path disabled). When it is
-            # correctly supported, C must be passed as an (n, m) view of `out`.
+            # `out` is passed as-is (row-major (m, n)); see the swap_ab note above.
             compiled_gemm(
                 kernel_a,
                 kernel_b,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5810,6 +5810,15 @@ def _b12x_gemm_fp4_runner(
             f"Supported: torch.bfloat16, torch.float16."
         )
 
+    def _default_dense_plan(m, n, real_k, device):
+        # Single source of truth for the deterministic default tile / swap_ab pick.
+        # Used by BOTH forward()'s default path AND get_valid_tactics(), so the
+        # autotuner candidate set always contains the exact default-path tile --
+        # i.e. tuning is monotonic vs the static default (it can't pick worse).
+        return _select_default_dense_gemm_plan(
+            m, n, real_k, get_device_sm_count(device), expected_m=m
+        )
+
     class B12xFp4GemmRunner(TunableRunner):
         """TunableRunner for b12x block-scaled FP4 dense GEMM on SM120.
 
@@ -5835,18 +5844,9 @@ def _b12x_gemm_fp4_runner(
             batch_size = 1
 
             valid_tactics = []
-            # Autotuner candidate set (swap_ab-free). The M=1 decode tile (16x64) and
-            # other regime-optimal tiles are applied via the deterministic expected_m
-            # plan on the default path (see forward); adding extra tiles here only made
-            # the autotuner's per-shape pick noisier, so the set is kept minimal.
-            sm120_mma_tiler_candidates = [
-                (64, 64),
-                (64, 128),
-                (128, 64),
-                (128, 128),
-            ]
-            swap_ab = False
-            for mma_tiler_mn in sm120_mma_tiler_candidates:
+
+            def _add(mma_tiler_mn, swap_ab):
+                # upstream b12x can_implement is M-independent (no `m` arg)
                 if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
                     ab_dtype,
                     sf_dtype,
@@ -5854,7 +5854,6 @@ def _b12x_gemm_fp4_runner(
                     c_cutlass_dtype,
                     mma_tiler_mn,
                     (1, 1),
-                    # upstream b12x can_implement is M-independent (no `m` arg)
                     n,
                     real_k,
                     batch_size,
@@ -5863,11 +5862,26 @@ def _b12x_gemm_fp4_runner(
                     "n",
                     swap_ab=swap_ab,
                 ):
-                    continue
+                    return
                 for use_prefetch in (False, True):
-                    valid_tactics.append(
-                        (mma_tiler_mn, (1, 1), swap_ab, use_prefetch, "sm120", None)
-                    )
+                    tac = (mma_tiler_mn, (1, 1), swap_ab, use_prefetch, "sm120", None)
+                    if tac not in valid_tactics:
+                        valid_tactics.append(tac)
+
+            # Generic swap_ab-free candidate set the autotuner profiles. Kept minimal:
+            # a larger tile grid made the per-bucket pick noisier (overfits the bucket
+            # representative shape), so we only add a few balanced tiles here.
+            for mma_tiler_mn in [(64, 64), (64, 128), (128, 64), (128, 128)]:
+                _add(mma_tiler_mn, swap_ab=False)
+
+            # Also expose the deterministic plan's regime-optimal pick for this
+            # (bucketed) shape -- the same tile forward() uses on the default path,
+            # which may be a narrow-N swap_ab tile (e.g. (64,32) at m=1) absent from
+            # the generic set above. Including it keeps autotuning monotonic: the
+            # tuner can never select something worse than the static default, and it
+            # picks up swap_ab on SKUs where it actually wins.
+            plan = _default_dense_plan(m, n, real_k, a.device)
+            _add(plan.mma_tiler_mn, swap_ab=plan.swap_ab)
             return valid_tactics
 
         def forward(
@@ -5892,13 +5906,7 @@ def _b12x_gemm_fp4_runner(
                 # decode/prefill-optimal tile (via expected_m) and swap_ab for
                 # narrow-N, instead of the M-independent default tile. For a single
                 # call the actual m IS the representative regime, so expected_m=m.
-                plan = _select_default_dense_gemm_plan(
-                    m,
-                    n,
-                    real_k,
-                    get_device_sm_count(a.device),
-                    expected_m=m,
-                )
+                plan = _default_dense_plan(m, n, real_k, a.device)
                 # Honor the plan's swap_ab (narrow-N decode tiles, e.g. 64x32).
                 # b12x swap_ab is device-internal; see the launch + wrapper notes.
                 tactic = (
@@ -6027,6 +6035,14 @@ def _heuristic_func_mm_fp4(
     is_sm120 = major == 12 and minor == 0
 
     # SM120 + CUDA 13: prefer b12x (warp-level MMA, underfill tile selection)
+    # TODO(sm121/DGX Spark): b12x is *supported* on SM121 (requirement is
+    # @supported_compute_capability([120, 121])) but `auto` only routes it at
+    # SM120 here, so on a Spark `backend="auto"` falls back to cutlass/cudnn and
+    # never picks b12x. To enable it, widen this to `major == 12` (covers 120+121).
+    # Gate the change on the Spark bench: only prefer b12x if it actually beats
+    # cutlass/cudnn on GB10. Also verify the kernel's hardcoded
+    # get_smem_capacity_in_bytes("sm_120") assumption holds on SM121 (run the
+    # e2e handoff's correctness section on the real Spark first).
     if is_sm120 and use_nvfp4 and cuda_major >= 13:
         return [c for c in ("b12x", "cutlass", "cudnn") if c in suitable_backends]
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5909,7 +5909,6 @@ def _b12x_gemm_fp4_runner(
                     n,
                     real_k,
                     get_device_sm_count(a.device),
-                    is_mxfp8=False,
                     expected_m=m,
                 )
                 # swap_ab (narrow-N) is not yet supported by this wrapper; when the

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5809,6 +5809,7 @@ def _b12x_gemm_fp4_runner(
 
     from .kernels.dense_blockscaled_gemm_sm120_b12x import (
         Sm120B12xBlockScaledDenseGemmKernel,
+        _select_default_dense_gemm_plan,
     )
 
     cutlass_dtype_attr = _TORCH_TO_CUTLASS_DTYPE_ATTR.get(out_dtype)
@@ -5846,6 +5847,10 @@ def _b12x_gemm_fp4_runner(
             batch_size = 1
 
             valid_tactics = []
+            # Autotuner candidate set (swap_ab-free). The M=1 decode tile (16x64) and
+            # other regime-optimal tiles are applied via the deterministic expected_m
+            # plan on the default path (see forward); adding extra tiles here only made
+            # the autotuner's per-shape pick noisier, so the set is kept minimal.
             sm120_mma_tiler_candidates = [
                 (64, 64),
                 (64, 128),
@@ -5861,13 +5866,14 @@ def _b12x_gemm_fp4_runner(
                     c_cutlass_dtype,
                     mma_tiler_mn,
                     (1, 1),
-                    m,
+                    # upstream b12x can_implement is M-independent (no `m` arg)
                     n,
                     real_k,
                     batch_size,
                     "k",
                     "k",
                     "n",
+                    swap_ab=swap_ab,
                 ):
                     continue
                 for use_prefetch in (False, True):
@@ -5894,10 +5900,29 @@ def _b12x_gemm_fp4_runner(
             batch_size = 1
 
             if tactic is None or tactic == -1:
-                tactic = (
+                # Deterministic, regime-aware plan from upstream b12x: picks the
+                # decode/prefill-optimal tile (via expected_m) and swap_ab for
+                # narrow-N, instead of the M-independent default tile. For a single
+                # call the actual m IS the representative regime, so expected_m=m.
+                plan = _select_default_dense_gemm_plan(
+                    m,
+                    n,
+                    real_k,
+                    get_device_sm_count(a.device),
+                    is_mxfp8=False,
+                    expected_m=m,
+                )
+                # swap_ab (narrow-N) is not yet supported by this wrapper; when the
+                # plan would request it, fall back to the M-independent default tile.
+                plan_tile = (
                     _select_default_sm120_mma_tiler(
                         m, n, get_device_sm_count(a.device)
-                    ),
+                    )
+                    if plan.swap_ab
+                    else plan.mma_tiler_mn
+                )
+                tactic = (
+                    plan_tile,
                     (1, 1),
                     False,
                     False,
@@ -5914,7 +5939,6 @@ def _b12x_gemm_fp4_runner(
                 use_tma_store,
             ) = tactic
 
-            # b12x SM120 kernel does not support swap_ab
             kernel_m, kernel_n = m, n
             kernel_a, kernel_b = a, b.T
             kernel_a_sf, kernel_b_sf = a_descale, b_descale.T
@@ -5935,12 +5959,15 @@ def _b12x_gemm_fp4_runner(
                 out_dtype,
             )
 
+            # NOTE: upstream b12x ctor inserts mma_k/tile_k/single_work_tile_per_cta
+            # before use_prefetch, so pass these by keyword to avoid mis-binding.
             make_kernel = lambda: Sm120B12xBlockScaledDenseGemmKernel(
                 sf_vec_size,
                 mma_tiler_mn,
                 cluster_shape_mn,
-                use_prefetch,
-                enable_pdl,
+                use_prefetch=use_prefetch,
+                enable_pdl=enable_pdl,
+                swap_ab=swap_ab,
             )
 
             compiled_gemm, _ = _compile_block_scaled_gemm(
@@ -5961,6 +5988,8 @@ def _b12x_gemm_fp4_runner(
 
             alpha_for_launch = _prepare_alpha_for_launch(alpha_tensor, a.device)
 
+            # NOTE: swap_ab is always False here (narrow-N path disabled). When it is
+            # correctly supported, C must be passed as an (n, m) view of `out`.
             compiled_gemm(
                 kernel_a,
                 kernel_b,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5470,13 +5470,11 @@ def _b12x_gemm_fp4_requirement(
         raise ValueError("b12x FP4 GEMM only supports 128x4 scale factor layout.")
     if not use_nvfp4:
         raise ValueError("b12x FP4 GEMM only supports NVFP4 (sf_vec_size=16).")
-    # The b12x NVFP4 kernel requires K % 128 == 0 (tile_k = sf_vec_size * 8); the
-    # default launch path skips can_implement, so enforce it here. Under "auto"
-    # this drops b12x for unsupported K (falls back to cutlass/cudnn); under
-    # explicit backend="b12x" it raises instead of silently dropping the K-tail.
-    # a is the packed FP4 operand of shape (M, K // 2), 2 FP4 values per uint8.
+    # K must be a multiple of 128 (tile_k = sf_vec_size * 8); a is packed FP4 (M, K//2).
     real_k = a.shape[1] * 2
     if real_k % 128 != 0:
+        if backend != "b12x":
+            return False  # let "auto" fall back to cutlass/cudnn
         raise ValueError(
             "b12x FP4 GEMM requires the contraction dim K to be a multiple of 128 "
             f"(tile_k = sf_vec_size * 8). Got K={real_k}."
@@ -5811,10 +5809,8 @@ def _b12x_gemm_fp4_runner(
         )
 
     def _default_dense_plan(m, n, real_k, device):
-        # Single source of truth for the deterministic default tile / swap_ab pick.
-        # Used by BOTH forward()'s default path AND get_valid_tactics(), so the
-        # autotuner candidate set always contains the exact default-path tile --
-        # i.e. tuning is monotonic vs the static default (it can't pick worse).
+        # Shared by forward() and get_valid_tactics() so the tuner's candidate
+        # set always includes the default-path tile.
         return _select_default_dense_gemm_plan(
             m, n, real_k, get_device_sm_count(device), expected_m=m
         )
@@ -5846,7 +5842,7 @@ def _b12x_gemm_fp4_runner(
             valid_tactics = []
 
             def _add(mma_tiler_mn, swap_ab):
-                # upstream b12x can_implement is M-independent (no `m` arg)
+                # can_implement is M-independent (takes no `m`)
                 if not Sm120B12xBlockScaledDenseGemmKernel.can_implement(
                     ab_dtype,
                     sf_dtype,
@@ -5868,18 +5864,13 @@ def _b12x_gemm_fp4_runner(
                     if tac not in valid_tactics:
                         valid_tactics.append(tac)
 
-            # Generic swap_ab-free candidate set the autotuner profiles. Kept minimal:
-            # a larger tile grid made the per-bucket pick noisier (overfits the bucket
-            # representative shape), so we only add a few balanced tiles here.
+            # A few balanced swap_ab-free tiles for the tuner to profile (a larger
+            # grid overfit the bucket representative and made picks noisier).
             for mma_tiler_mn in [(64, 64), (64, 128), (128, 64), (128, 128)]:
                 _add(mma_tiler_mn, swap_ab=False)
 
-            # Also expose the deterministic plan's regime-optimal pick for this
-            # (bucketed) shape -- the same tile forward() uses on the default path,
-            # which may be a narrow-N swap_ab tile (e.g. (64,32) at m=1) absent from
-            # the generic set above. Including it keeps autotuning monotonic: the
-            # tuner can never select something worse than the static default, and it
-            # picks up swap_ab on SKUs where it actually wins.
+            # Also include the default-path tile (may be a narrow-N swap_ab tile
+            # absent from the set above) so the tuner can't pick worse than static.
             plan = _default_dense_plan(m, n, real_k, a.device)
             _add(plan.mma_tiler_mn, swap_ab=plan.swap_ab)
             return valid_tactics
@@ -5902,13 +5893,9 @@ def _b12x_gemm_fp4_runner(
             batch_size = 1
 
             if tactic is None or tactic == -1:
-                # Deterministic, regime-aware plan from upstream b12x: picks the
-                # decode/prefill-optimal tile (via expected_m) and swap_ab for
-                # narrow-N, instead of the M-independent default tile. For a single
-                # call the actual m IS the representative regime, so expected_m=m.
+                # Default path: the m-aware plan picks the tile (and swap_ab for
+                # narrow-N) for this shape; expected_m=m since m is the actual size.
                 plan = _default_dense_plan(m, n, real_k, a.device)
-                # Honor the plan's swap_ab (narrow-N decode tiles, e.g. 64x32).
-                # b12x swap_ab is device-internal; see the launch + wrapper notes.
                 tactic = (
                     plan.mma_tiler_mn,
                     (1, 1),
@@ -5946,8 +5933,8 @@ def _b12x_gemm_fp4_runner(
                 out_dtype,
             )
 
-            # NOTE: upstream b12x ctor inserts mma_k/tile_k/single_work_tile_per_cta
-            # before use_prefetch, so pass these by keyword to avoid mis-binding.
+            # ctor takes mma_k/tile_k/single_work_tile_per_cta before use_prefetch,
+            # so pass the later args by keyword to avoid mis-binding.
             make_kernel = lambda: Sm120B12xBlockScaledDenseGemmKernel(
                 sf_vec_size,
                 mma_tiler_mn,
@@ -5957,11 +5944,9 @@ def _b12x_gemm_fp4_runner(
                 swap_ab=swap_ab,
             )
 
-            # b12x swap_ab is device-internal (applied via the kernel ctor); the
-            # public C stays row-major (m, n). The shared harness's `swap_ab` instead
-            # selects the SM100 operand-swap FFI convention (C declared (n, m)), which
-            # b12x must not use -- so pass swap_ab=False (keeps c_fake (m, n) + plain
-            # `out`). cache_key still carries the real swap_ab (separate caching).
+            # swap_ab is device-internal (applied in the kernel ctor); public C
+            # stays row-major (m, n). Pass swap_ab=False to the harness so it keeps
+            # the (m, n) output convention, not the SM100 operand-swap one.
             compiled_gemm, _ = _compile_block_scaled_gemm(
                 _B12X_MM_FP4_KERNEL_CACHE,
                 cache_key,
@@ -5980,7 +5965,7 @@ def _b12x_gemm_fp4_runner(
 
             alpha_for_launch = _prepare_alpha_for_launch(alpha_tensor, a.device)
 
-            # `out` is passed as-is (row-major (m, n)); see the swap_ab note above.
+            # `out` passed as-is (row-major (m, n)).
             compiled_gemm(
                 kernel_a,
                 kernel_b,

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -30,7 +30,7 @@
 # and adapted for the current Blackwell GeForce target.
 
 from dataclasses import dataclass
-from typing import Callable, List, Literal, Optional, Tuple, Type
+from typing import Literal, Optional, Tuple
 
 import cuda.bindings.driver as cuda
 import cutlass
@@ -40,11 +40,8 @@ import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm120_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 import cutlass.utils.hopper_helpers as sm90_utils
-import functools
 import logging
 import os
-import time
-import torch
 from cutlass import Int32, Int64
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp.mma import Field as WarpField
@@ -53,12 +50,6 @@ from cutlass.utils.static_persistent_tile_scheduler import WorkTileInfo
 from cutlass._mlir.dialects import llvm
 
 from flashinfer.cute_dsl.utils import (
-    current_cuda_stream,
-    cutlass_to_torch_dtype,
-    get_cutlass_dtype,
-    get_max_active_clusters,
-    get_num_sm,
-    make_ptr,
     sm120_make_smem_layout_sfa,
     sm120_make_smem_layout_sfb,
 )
@@ -108,10 +99,11 @@ def scatter_add_bf16x2(addr: Int64, val0_f32, val1_f32, *, loc=None, ip=None):
         asm_dialect=llvm.AsmDialect.AD_ATT,
     )
 
+
 logger = logging.getLogger(__name__)
-_B12X_TIMING = os.getenv("B12X_TIMING", "0") == "1" or os.getenv(
-    "VLLM_B12X_TIMING", "0"
-) == "1"
+_B12X_TIMING = (
+    os.getenv("B12X_TIMING", "0") == "1" or os.getenv("VLLM_B12X_TIMING", "0") == "1"
+)
 _B12X_TIMING_THRESHOLD_MS = float(
     os.getenv(
         "B12X_TIMING_THRESHOLD_MS",
@@ -127,10 +119,6 @@ class _DenseGemmPlan:
     mma_tiler_mn: Tuple[int, int]
     load_path: Literal["tma", "cpasync"]
     swap_ab: bool
-
-
-
-
 
 
 # @dsl_user_op on PersistentTileSchedulerParams.__init__ can rename attributes
@@ -189,12 +177,6 @@ def _reshape_acc_to_mn(acc: cute.Tensor, transpose: bool = False) -> cute.Tensor
     return cute.make_tensor(
         acc.iterator, _convert_layout_acc_mn(acc.layout, transpose=transpose)
     )
-
-
-
-
-
-
 
 
 class DenseGemmKernel:
@@ -786,9 +768,7 @@ class DenseGemmKernel:
         )
         for rest_v in cutlass.range_constexpr(tPred.shape[0]):
             for rest_k in cutlass.range_constexpr(tPred.shape[2]):
-                tPred[rest_v, 0, rest_k] = (
-                    tCc[(0, rest_v), 0, rest_k][0] < row_limit
-                )
+                tPred[rest_v, 0, rest_k] = tCc[(0, rest_v), 0, rest_k][0] < row_limit
         return tPred
 
     @cute.jit
@@ -878,11 +858,15 @@ class DenseGemmKernel:
 
         # Prefetch TMA descriptors
         if warp_idx == 0:
-            if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_a):
+            if cutlass.const_expr(
+                self.load_path == "tma" and not self.use_m1_non_tma_a
+            ):
                 cpasync.prefetch_descriptor(tma_atom_a)
             if cutlass.const_expr(self.load_path == "tma"):
                 cpasync.prefetch_descriptor(tma_atom_b)
-            if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_sfa):
+            if cutlass.const_expr(
+                self.load_path == "tma" and not self.use_m1_non_tma_sfa
+            ):
                 cpasync.prefetch_descriptor(tma_atom_sfa)
             if cutlass.const_expr(self.load_path == "tma"):
                 cpasync.prefetch_descriptor(tma_atom_sfb)
@@ -899,10 +883,9 @@ class DenseGemmKernel:
         sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, 0))
         sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, 0))
         if cutlass.const_expr(self.use_m1_non_tma_sfa):
-            tma_copy_bytes = (
-                cute.size_in_bytes(self.b_dtype, b_smem_layout)
-                + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
-            )
+            tma_copy_bytes = cute.size_in_bytes(
+                self.b_dtype, b_smem_layout
+            ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
             if cutlass.const_expr(not self.use_m1_non_tma_a):
                 tma_copy_bytes += cute.size_in_bytes(self.a_dtype, a_smem_layout)
         else:
@@ -1132,15 +1115,23 @@ class DenseGemmKernel:
         tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
         tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
         if cutlass.const_expr(self.swap_ab):
-            tCrSFA_full = self._partition_fragment_SFA(sSFB[None, None, 0], thr_mma, tidx)
-            tCrSFB_full = self._partition_fragment_SFB(sSFA[None, None, 0], thr_mma, tidx)
+            tCrSFA_full = self._partition_fragment_SFA(
+                sSFB[None, None, 0], thr_mma, tidx
+            )
+            tCrSFB_full = self._partition_fragment_SFB(
+                sSFA[None, None, 0], thr_mma, tidx
+            )
             c_mma = cute.make_identity_tensor(
                 (self.tile_shape_mnk[1], self.tile_shape_mnk[0])
             )
             tCgC = thr_mma.partition_C(c_mma)
         else:
-            tCrSFA_full = self._partition_fragment_SFA(sSFA[None, None, 0], thr_mma, tidx)
-            tCrSFB_full = self._partition_fragment_SFB(sSFB[None, None, 0], thr_mma, tidx)
+            tCrSFA_full = self._partition_fragment_SFA(
+                sSFA[None, None, 0], thr_mma, tidx
+            )
+            tCrSFB_full = self._partition_fragment_SFB(
+                sSFB[None, None, 0], thr_mma, tidx
+            )
             tCgC = thr_mma.partition_C(gC_mnl)
         acc_shape = tCgC.shape[:3]
         accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
@@ -1266,8 +1257,8 @@ class DenseGemmKernel:
                             cute.slice_(self.tile_shape_mnk, (0, None, None)),
                             (sfb_tile_offset, 0, None),
                         )
-                        tCsSFA_tile_copy_view = (
-                            thr_copy_ldmatrix_SFA.partition_S(sSFB_tile)
+                        tCsSFA_tile_copy_view = thr_copy_ldmatrix_SFA.partition_S(
+                            sSFB_tile
                         )
                         tCrSFA_tile = self._partition_fragment_SFA(
                             sSFB_tile[None, None, 0], thr_mma, tidx
@@ -1285,8 +1276,8 @@ class DenseGemmKernel:
                             cute.slice_(self.tile_shape_mnk, (None, 0, None)),
                             (sfa_tile_offset, 0, None),
                         )
-                        tCsSFB_tile_copy_view = (
-                            thr_copy_ldmatrix_SFB.partition_S(sSFA_tile)
+                        tCsSFB_tile_copy_view = thr_copy_ldmatrix_SFB.partition_S(
+                            sSFA_tile
                         )
                         tCrSFB_tile = self._partition_fragment_SFB(
                             sSFA_tile[None, None, 0], thr_mma, tidx
@@ -1305,8 +1296,8 @@ class DenseGemmKernel:
                             cute.slice_(self.tile_shape_mnk, (None, 0, None)),
                             (sfa_tile_offset, 0, None),
                         )
-                        tCsSFA_tile_copy_view = (
-                            thr_copy_ldmatrix_SFA.partition_S(sSFA_tile)
+                        tCsSFA_tile_copy_view = thr_copy_ldmatrix_SFA.partition_S(
+                            sSFA_tile
                         )
                         tCrSFA_tile = self._partition_fragment_SFA(
                             sSFA_tile[None, None, 0], thr_mma, tidx
@@ -1324,8 +1315,8 @@ class DenseGemmKernel:
                             cute.slice_(self.tile_shape_mnk, (0, None, None)),
                             (sfb_tile_offset, 0, None),
                         )
-                        tCsSFB_tile_copy_view = (
-                            thr_copy_ldmatrix_SFB.partition_S(sSFB_tile)
+                        tCsSFB_tile_copy_view = thr_copy_ldmatrix_SFB.partition_S(
+                            sSFB_tile
                         )
                         tCrSFB_tile = self._partition_fragment_SFB(
                             sSFB_tile[None, None, 0], thr_mma, tidx
@@ -1386,7 +1377,7 @@ class DenseGemmKernel:
                     tCrSFB_copy_view_filtered[None, None, 0],
                 )
 
-                for k_tile in range(0, k_tile_iter_cnt - 1, 1, unroll=2):
+                for _k_tile in range(0, k_tile_iter_cnt - 1, 1, unroll=2):  # type: ignore[call-overload]
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                         k_block_next = (
                             0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
@@ -1448,8 +1439,12 @@ class DenseGemmKernel:
 
                         tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
                         tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
-                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
-                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(
+                            tCrSFA_tile_copy_view
+                        )
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(
+                            tCrSFB_tile_copy_view
+                        )
                         cute.copy(
                             smem_tiled_copy_SFA,
                             tCsSFA_p_filtered[None, None, k_block_next],
@@ -1484,8 +1479,12 @@ class DenseGemmKernel:
                         )
                         tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
                         tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
-                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
-                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(
+                            tCrSFA_tile_copy_view
+                        )
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(
+                            tCrSFB_tile_copy_view
+                        )
                         cute.copy(
                             smem_tiled_copy_SFA,
                             tCsSFA_p_filtered[None, None, k_block_next],
@@ -1525,7 +1524,9 @@ class DenseGemmKernel:
                         transpose=True,
                     )
                     for acc_m in cutlass.range_constexpr(cute.size(acc_mn.shape[0])):
-                        for acc_n in cutlass.range_constexpr(cute.size(acc_mn.shape[1])):
+                        for acc_n in cutlass.range_constexpr(
+                            cute.size(acc_mn.shape[1])
+                        ):
                             coord = coord_mn[acc_m, acc_n]
                             m_coord = (
                                 tile_coord_mnl[0] * Int32(self.tile_shape_mnk[0])
@@ -1535,10 +1536,9 @@ class DenseGemmKernel:
                                 tile_coord_mnl[1] * Int32(self.tile_shape_mnk[1])
                                 + coord[0]
                             )
-                            if (
-                                m_coord < Int32(directC_mnl.shape[0])
-                                and n_coord < Int32(directC_mnl.shape[1])
-                            ):
+                            if m_coord < Int32(
+                                directC_mnl.shape[0]
+                            ) and n_coord < Int32(directC_mnl.shape[1]):
                                 directC_mnl[
                                     (
                                         m_coord,
@@ -1569,7 +1569,8 @@ class DenseGemmKernel:
                         )
                     else:
                         copy_atom_r2s = cute.make_copy_atom(
-                            cute.nvgpu.CopyUniversalOp(), self.c_dtype,
+                            cute.nvgpu.CopyUniversalOp(),
+                            self.c_dtype,
                         )
 
                     if cutlass.const_expr(self.c_dtype.width == 16):
@@ -1603,7 +1604,9 @@ class DenseGemmKernel:
                     tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
 
                     sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
-                    tcgc_for_tma_partition = cute.zipped_divide(gC_mnl_slice, self.epi_tile)
+                    tcgc_for_tma_partition = cute.zipped_divide(
+                        gC_mnl_slice, self.epi_tile
+                    )
 
                     bSG_sD, bSG_gD = cpasync.tma_partition(
                         tma_atom_c,
@@ -1620,7 +1623,9 @@ class DenseGemmKernel:
                     mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rAcc, mode=[1])
                     mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rAcc, mode=[2])
                     has_multi_epi_store = cutlass.const_expr(
-                        not (self.epi_stage == 1 and epi_rest_m == 1 and epi_rest_n == 1)
+                        not (
+                            self.epi_stage == 1 and epi_rest_m == 1 and epi_rest_n == 1
+                        )
                     )
                     tma_store_producer_group = pipeline.CooperativeGroup(
                         pipeline.Agent.Thread,
@@ -1636,7 +1641,9 @@ class DenseGemmKernel:
                             MmaMPerEpiM = epi_tile_m // mma_tile_m
                             MmaNPerEpiN = epi_tile_n // mma_tile_n
                             for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
-                                for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                for mma_m_in_epi in cutlass.range_constexpr(
+                                    MmaMPerEpiM
+                                ):
                                     mma_n = (epi_n * MmaNPerEpiN) + mma_n_in_epi
                                     mma_m = (epi_m * MmaMPerEpiM) + mma_m_in_epi
                                     tRS_rD_slice = tRS_rD[
@@ -1646,7 +1653,9 @@ class DenseGemmKernel:
                                     for elem_idx in cutlass.range_constexpr(
                                         cute.size(tRS_rD_slice)
                                     ):
-                                        tRS_rD_slice[elem_idx] = tRS_rAcc_slice[elem_idx]
+                                        tRS_rD_slice[elem_idx] = tRS_rAcc_slice[
+                                            elem_idx
+                                        ]
 
                             gmem_coord = (epi_m, epi_n)
                             if cutlass.const_expr(self.split_k_slices > 1):
@@ -1690,7 +1699,8 @@ class DenseGemmKernel:
                                             )
                                             if (
                                                 m_coord0 < Int32(directC_mnl.shape[0])
-                                                and m_coord1 < Int32(directC_mnl.shape[0])
+                                                and m_coord1
+                                                < Int32(directC_mnl.shape[0])
                                                 and n_coord0
                                                 < Int32(directC_mnl.shape[1])
                                                 and n_coord1
@@ -1727,10 +1737,9 @@ class DenseGemmKernel:
                                                 * Int32(self.tile_shape_mnk[1])
                                                 + coord[1]
                                             )
-                                            if (
-                                                m_coord < Int32(directC_mnl.shape[0])
-                                                and n_coord < Int32(directC_mnl.shape[1])
-                                            ):
+                                            if m_coord < Int32(
+                                                directC_mnl.shape[0]
+                                            ) and n_coord < Int32(directC_mnl.shape[1]):
                                                 c_offset = cute.crd2idx(
                                                     (
                                                         m_coord,
@@ -1765,10 +1774,9 @@ class DenseGemmKernel:
                                                 * Int32(self.tile_shape_mnk[1])
                                                 + coord[1]
                                             )
-                                            if (
-                                                m_coord < Int32(directC_mnl.shape[0])
-                                                and n_coord < Int32(directC_mnl.shape[1])
-                                            ):
+                                            if m_coord < Int32(
+                                                directC_mnl.shape[0]
+                                            ) and n_coord < Int32(directC_mnl.shape[1]):
                                                 directC_mnl[
                                                     (m_coord, n_coord, split_idx)
                                                 ] = alpha_value * acc_mn[acc_m, acc_n]
@@ -1827,10 +1835,9 @@ class DenseGemmKernel:
                                             + Int32(epi_n * self.epi_tile[1])
                                             + n_local
                                         )
-                                        if (
-                                            n_local < Int32(self.epi_tile[1])
-                                            and n_coord < Int32(directC_mnl.shape[1])
-                                        ):
+                                        if n_local < Int32(
+                                            self.epi_tile[1]
+                                        ) and n_coord < Int32(directC_mnl.shape[1]):
                                             directC_mnl[
                                                 (
                                                     Int32(0),
@@ -1858,9 +1865,8 @@ class DenseGemmKernel:
                     else:
                         tile_sched.advance_to_next_work()
                         work_tile = tile_sched.get_current_work()
-                    if (
-                        has_multi_epi_store
-                        and cutlass.const_expr(self.split_k_slices == 1)
+                    if has_multi_epi_store and cutlass.const_expr(
+                        self.split_k_slices == 1
                     ):
                         tma_store_pipeline.producer_tail()
 
@@ -1869,20 +1875,24 @@ class DenseGemmKernel:
 
             while work_tile.is_valid_tile:
                 tile_coord_mnl = work_tile.tile_idx
-                if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_a):
-                    tAgA_mkl = tAgA[
-                        (None, tile_coord_mnl[0], None, tile_coord_mnl[2])
-                    ]
+                if cutlass.const_expr(
+                    self.load_path == "tma" and not self.use_m1_non_tma_a
+                ):
+                    tAgA_mkl = tAgA[(None, tile_coord_mnl[0], None, tile_coord_mnl[2])]
                 if cutlass.const_expr(self.load_path == "tma"):
                     tBgB_nkl = tBgB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
-                if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_sfa):
+                if cutlass.const_expr(
+                    self.load_path == "tma" and not self.use_m1_non_tma_sfa
+                ):
                     sfa_tile_coord_m = tile_coord_mnl[0] // self.sfa_tiles_per_block
                     tAgSFA_mkl = tAgSFA[
                         (None, sfa_tile_coord_m, None, tile_coord_mnl[2])
                     ]
                 if cutlass.const_expr(self.load_path == "tma"):
                     sfb_tile_coord_n = tile_coord_mnl[1] // self.sfb_tiles_per_block
-                    tBgSFB_nkl = tBgSFB[(None, sfb_tile_coord_n, None, tile_coord_mnl[2])]
+                    tBgSFB_nkl = tBgSFB[
+                        (None, sfb_tile_coord_n, None, tile_coord_mnl[2])
+                    ]
                 if cutlass.const_expr(self.load_path == "cpasync"):
                     cpasync_sfa_tile_coord_m = (
                         tile_coord_mnl[0] // self.sfa_tiles_per_block
@@ -1893,7 +1903,7 @@ class DenseGemmKernel:
 
                 mainloop_producer_state.reset_count()
 
-                for k_tile in range(0, k_tile_iter_cnt, 1, unroll=2):
+                for _k_tile in range(0, k_tile_iter_cnt, 1, unroll=2):  # type: ignore[call-overload]
                     mainloop_pipeline.producer_acquire(mainloop_producer_state)
 
                     k_tile_global = k_tile_start + mainloop_producer_state.count
@@ -2059,8 +2069,7 @@ class DenseGemmKernel:
                             k_local = lane + Int32(a_iter * self.num_threads_per_warp)
                             if k_local < Int32(self.tile_shape_mnk[2]):
                                 k_coord = (
-                                    k_tile_global
-                                    * Int32(self.tile_shape_mnk[2])
+                                    k_tile_global * Int32(self.tile_shape_mnk[2])
                                     + k_local
                                 )
                                 sA[
@@ -2093,24 +2102,19 @@ class DenseGemmKernel:
                         scale_groups_per_k_tile = (
                             self.tile_shape_mnk[2] // self.sf_vec_size
                         )
-                        sfa_slots = (
-                            self.sfa_tile_shape_mk[0] * scale_groups_per_k_tile
-                        )
+                        sfa_slots = self.sfa_tile_shape_mk[0] * scale_groups_per_k_tile
                         for sfa_iter in cutlass.range_constexpr(
                             (sfa_slots + self.num_threads_per_warp - 1)
                             // self.num_threads_per_warp
                         ):
-                            linear = lane + Int32(
-                                sfa_iter * self.num_threads_per_warp
-                            )
+                            linear = lane + Int32(sfa_iter * self.num_threads_per_warp)
                             m_local = linear // Int32(scale_groups_per_k_tile)
-                            scale_group = (
-                                linear - m_local * Int32(scale_groups_per_k_tile)
+                            scale_group = linear - m_local * Int32(
+                                scale_groups_per_k_tile
                             )
                             k_local_sfa = scale_group * Int32(self.sf_vec_size)
                             k_coord_sfa = (
-                                k_tile_global
-                                * Int32(self.tile_shape_mnk[2])
+                                k_tile_global * Int32(self.tile_shape_mnk[2])
                                 + k_local_sfa
                             )
                             if linear < Int32(sfa_slots):
@@ -2144,7 +2148,7 @@ class DenseGemmKernel:
                             tBsB_pipe,
                             tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
                                 mainloop_producer_state
-                        ),
+                            ),
                         )
                         cute.copy(
                             tma_atom_sfb,
@@ -2152,7 +2156,7 @@ class DenseGemmKernel:
                             tBsSFB_pipe,
                             tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
                                 mainloop_producer_state
-                        ),
+                            ),
                         )
                     if cutlass.const_expr(self.load_path == "cpasync"):
                         cute.arch.cp_async_commit_group()
@@ -2504,25 +2508,7 @@ class DenseGemmKernel:
         )
 
 
-
-
-
-
-
-
-
-
-
-
 _ALPHA_ONE_CACHE: dict = {}
-
-
-
-
-
-
-
-
 
 
 def _select_default_mma_tiler_mn(
@@ -2597,8 +2583,6 @@ def _select_default_dense_gemm_plan(
         load_path="tma",
         swap_ab=(tile[1] < 64),
     )
-
-
 
 
 # Alias for FlashInfer integration

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -310,24 +310,20 @@ class DenseGemmKernel:
         self.mma_register_requirement = 232
 
     def _setup_attributes(self):
-        if cutlass.const_expr(self.a_dtype == cutlass.Float8E4M3FN):
-            mma_op = cute.nvgpu.warp.MmaMXF8Op(
-                self.a_dtype,
-                self.acc_dtype,
-                self.sf_dtype,
-            )
-        else:
-            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-                self.a_dtype,
-                self.acc_dtype,
-                self.sf_dtype,
-            )
+        # FP4-only target (NVF4 sf_vec_size=16 / MXF4 sf_vec_size=32). The MXFP8
+        # warp-MMA path was dropped: FlashInfer only drives this kernel for FP4,
+        # and cute.nvgpu.warp.MmaMXF8Op is absent in the public cutlass-dsl build.
+        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+            self.a_dtype,
+            self.acc_dtype,
+            self.sf_dtype,
+        )
         atom_shape = self.atom_shape
         atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.mma_tile_shape_mnk,
             self.sf_vec_size,
-            cutlass.const_expr(self.a_dtype == cutlass.Float8E4M3FN),
+            False,  # is_mxfp8: FP4-only
         )
         self.tiled_mma = cute.make_tiled_mma(
             mma_op,
@@ -337,7 +333,7 @@ class DenseGemmKernel:
         # Bare atom for manual unroll workaround (avoids hasAuxTensor address space bug)
         self.mma_atom = cute.make_mma_atom(mma_op)
         # Compute atom loop bounds from tile shape and atom/layout shape
-        # MMA atom: m16n8k64 for FP4, m16n8k32 for MXFP8.
+        # MMA atom: m16n8k64 for FP4.
         mma_m, mma_n, mma_k = 16, 8, self.mma_k
         self.num_m_tiles = self.mma_tile_shape_mnk[0] // (mma_m * atom_shape[0])
         self.num_n_tiles = self.mma_tile_shape_mnk[1] // (mma_n * atom_shape[1])
@@ -2391,41 +2387,25 @@ class DenseGemmKernel:
             return False
         if load_path not in _DENSE_LOAD_PATHS:
             return False
+        # FP4-only target (NVF4/MXF4). The MXFP8 warp-MMA path was dropped.
+        if ab_dtype != cutlass.Float4E2M1FN:
+            return False
         if swap_ab:
             if l != 1:
                 return False
-            if not (
-                (ab_dtype == cutlass.Float4E2M1FN and sf_vec_size == 16)
-                or (ab_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32)
-            ):
+            if sf_vec_size != 16:
                 return False
-        if load_path == "cpasync" and (
-            ab_dtype != cutlass.Float4E2M1FN or sf_vec_size != 16 or l != 1
-        ):
+        if load_path == "cpasync" and (sf_vec_size != 16 or l != 1):
             return False
         # FP4 experiments allow narrow N tiles. The scale-factor smem paths
         # still allocate full 128-element SF blocks, but the live MMA tile may
         # consume only 16/32 columns.
-        mma_check_mn = (
-            (mma_tiler_mn[1], mma_tiler_mn[0]) if swap_ab else mma_tiler_mn
-        )
-        if ab_dtype == cutlass.Float8E4M3FN:
-            if mma_check_mn not in ((16, 64), (16, 128), (32, 64), (32, 128)):
-                if mma_check_mn[0] % 64 != 0 or mma_check_mn[1] % 64 != 0:
-                    return False
-        elif ab_dtype == cutlass.Float4E2M1FN:
-            if (
-                mma_tiler_mn[0] % 64 != 0
-                or mma_tiler_mn[1] % 16 != 0
-                or mma_tiler_mn[1] > 128
-                or (mma_tiler_mn[1] < 64 and not swap_ab)
-            ):
-                return False
-        else:
-            if mma_check_mn[0] % 64 != 0 or mma_check_mn[1] % 64 != 0:
-                return False
-        # The current target supports FP4 and MXFP8 warp MMA paths.
-        if ab_dtype not in (cutlass.Float4E2M1FN, cutlass.Float8E4M3FN):
+        if (
+            mma_tiler_mn[0] % 64 != 0
+            or mma_tiler_mn[1] % 16 != 0
+            or mma_tiler_mn[1] > 128
+            or (mma_tiler_mn[1] < 64 and not swap_ab)
+        ):
             return False
         # Current target MMA constraints:
         #   sf_vec_size=16 requires sf_dtype=Float8E4M3FN
@@ -2434,8 +2414,6 @@ class DenseGemmKernel:
             return False
         if sf_vec_size == 32 and sf_dtype != cutlass.Float8E8M0FNU:
             return False
-        if ab_dtype == cutlass.Float8E4M3FN and sf_vec_size != 32:
-            return False
         # Public output is 16-bit; split-K internally uses FP32 partial output.
         if c_dtype not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float32):
             return False
@@ -2443,7 +2421,7 @@ class DenseGemmKernel:
         if a_major != "k" or b_major != "k":
             return False
         # Alignment: K must be divisible by tile_k
-        tile_k = 128 if ab_dtype == cutlass.Float8E4M3FN else sf_vec_size * 8
+        tile_k = sf_vec_size * 8
         if k % tile_k != 0:
             return False
         return True
@@ -2556,73 +2534,12 @@ def _select_default_mma_tiler_mn(
     n: int,
     sm_count: int,
     *,
-    is_mxfp8: bool,
     expected_m: Optional[int] = None,
     k: Optional[int] = None,
 ) -> Tuple[int, int]:
+    # FP4-only tile selector. The MXFP8 regimes (16x64/16x128/32x128 decode
+    # tiles, narrow-N 64x64) were dropped along with the MXFP8 warp-MMA path.
     coarse_tile = (128, 128)
-    if is_mxfp8 and n > 1536:
-        # DeepGEMM-style regime hint. When a caller declares expected_m, pick the
-        # per-regime optimal tile and key the compile on it: ONE kernel per
-        # (N,K,expected_m), reused for every live M in that regime under frozen
-        # resolution (M-independent within the regime). Probe optima
-        # (benchmarks/probe_dense_fp8_tile_sweep.py): exact M=1 -> 16x64
-        # (flushed common-shape decode sweep); expected_m=2..8 -> 16x128
-        # (tiny-M decode; mirrors the no-hint m<=8 specialization so cudagraph
-        # decode batches <=8 -- where callers like vLLM set expected_m == live m
-        # -- get the decode tile instead of being lumped into the 32x128 bucket);
-        # <=128 (small batch) -> 32x128 (~25% faster than 64x128 at M=32..128);
-        # else -> 64x128 (the M-independent default, good to prefill).
-        if expected_m is not None:
-            if expected_m == 1:
-                return (16, 64)
-            if expected_m <= 8:
-                return (16, 128)
-            if expected_m <= 128:
-                return (32, 128)
-            return (64, 128)
-        # No regime hint: keep the true single-token decode specialization and
-        # use the decode-tuned tile for tiny standalone graph shapes. Broader
-        # live-M reuse still falls back to the M-independent prefill-safe tile.
-        if m == 1:
-            return (16, 64)
-        if m <= 8:
-            return (16, 128)
-        # Wide-N MXFP8: the 128x128 pin spans only ceil(N/128) column tiles, so
-        # at small/medium M it launches ~32-64 CTAs and runs flat (~80us, B-BW
-        # starved). It is in fact the WORST tile at every M (geomean ~121us over
-        # M=2..4096; see benchmarks/probe_dense_fp8_tile_sweep.py). 64x128 is the
-        # best M-INDEPENDENT tile: it beats 128x128 at every M (1.1x-2.4x; geomean
-        # ~69us) with byte-identical output. M-independence is required because
-        # dense serving warms one kernel per (N,K) and reuses it for all live M
-        # under frozen resolution (see test_block_fp8_linear_small_live_m_reuses_
-        # prefill_dense_kernel) -- an M-dependent tile forces an illegal recompile
-        # mid-serve. (Smaller 32x128/16x128 are faster at M<=128 but regress
-        # prefill M>=2k and would break that one-kernel-per-(N,K) reuse contract.)
-        return (64, 128)
-
-    if is_mxfp8:
-        # Narrow-N MXFP8 (n <= 1536; the n > 1536 case returned above). The
-        # (128,128) coarse tile spans only ceil(N/128) column tiles (<=12 at
-        # N<=1536), so at M>=512 it launches ~32-48 CTAs on a 188-SM part and
-        # runs CTA-starved -- 2x-3.5x slower than a CTA-multiplying tile
-        # (probe_dense_fp8_tile_sweep.py: N=1024 M=512 (128,128)=63.5us vs
-        # (64,64)=18.4us; N=1536 M=512 (128,128)=65.5us vs (64,128)=24.6us).
-        # Mirror the wide-N expected_m design where we have data. Exact M=1
-        # gets the flushed common-shape decode winner (16,64). Declared prefill
-        # (expected_m>128) -> (64,128): the best narrow-N tile at M>=512 for
-        # both N=1024 and N=1536 across M=512..8192 (probe sweep), recovering
-        # both the M~512 cliff and the large-M tail (N=1024 M=4096:
-        # (64,128)=80us vs (64,64)=105us vs (128,128)=125us). Other
-        # decode/small and the no-hint default use the M-independent (64,64)
-        # (max CTAs; best at M<=512), preserving the one-kernel-per-(N,K) reuse
-        # contract.
-        if expected_m == 1 or (expected_m is None and m == 1):
-            return (16, 64)
-        if expected_m is not None and expected_m > 128:
-            return (64, 128)
-        return (64, 64)
-
     plan_m = expected_m if expected_m is not None else m
     if plan_m == 1 and k is not None:
         # Flushed M=1 FP4 probe (benchmarks/probe_dense_fp4_tile_load_sweep.py)
@@ -2670,21 +2587,19 @@ def _select_default_dense_gemm_plan(
     k: int,
     sm_count: int,
     *,
-    is_mxfp8: bool,
     expected_m: Optional[int] = None,
 ) -> _DenseGemmPlan:
     tile = _select_default_mma_tiler_mn(
         m,
         n,
         sm_count,
-        is_mxfp8=is_mxfp8,
         expected_m=expected_m,
         k=k,
     )
     return _DenseGemmPlan(
         mma_tiler_mn=tile,
         load_path="tma",
-        swap_ab=(not is_mxfp8 and tile[1] < 64),
+        swap_ab=(tile[1] < 64),
     )
 
 

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -2470,16 +2470,12 @@ class DenseGemmKernel:
             b_ptr,
             layout=cute.make_ordered_layout((n, k, l), order=(1, 0, 2)),
         )
-        if cutlass.const_expr(swap_ab):
-            c_tensor = cute.make_tensor(
-                mC.iterator,
-                layout=cute.make_ordered_layout((m, n, l), order=(0, 1, 2)),
-            )
-        else:
-            c_tensor = cute.make_tensor(
-                mC.iterator,
-                layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
-            )
+        # C is always row-major (m, n): b12x swap_ab is device-internal (the
+        # epilogue writes logical [m, n]), so this `swap_ab` arg is unused here.
+        c_tensor = cute.make_tensor(
+            mC.iterator,
+            layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
+        )
         sfa_tensor = cute.make_tensor(
             a_sf_ptr,
             layout=cute.make_ordered_layout(

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -45,14 +45,13 @@ import logging
 import os
 import time
 import torch
-import triton
-import triton.language as tl
-from cutlass import Int32
+from cutlass import Int32, Int64
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp.mma import Field as WarpField
+from cutlass.cutlass_dsl import T, dsl_user_op
 from cutlass.utils.static_persistent_tile_scheduler import WorkTileInfo
+from cutlass._mlir.dialects import llvm
 
-from b12x.cute.compiler import KernelCompileSpec, compile as b12x_compile
 from flashinfer.cute_dsl.utils import (
     current_cuda_stream,
     cutlass_to_torch_dtype,
@@ -63,8 +62,51 @@ from flashinfer.cute_dsl.utils import (
     sm120_make_smem_layout_sfa,
     sm120_make_smem_layout_sfb,
 )
-from b12x.cute.fp4 import get_ptr_as_int64, scatter_add_bf16, scatter_add_bf16x2
-from b12x.cute.runtime_control import raise_if_kernel_resolution_frozen
+
+
+# Vendored from b12x.cute.fp4 (so this kernel does not depend on the external
+# b12x package). Used only by the kernel's opt-in split-K atomic-reduction path.
+@dsl_user_op
+def get_ptr_as_int64(tensor: cute.Tensor, offset, *, loc=None, ip=None) -> Int64:
+    """Get the memory address of tensor[offset] as Int64."""
+    elem_ptr = tensor.iterator + offset
+    ptr_int = llvm.ptrtoint(T.i64(), elem_ptr.llvm_ptr, loc=loc, ip=ip)
+    return Int64(ptr_int)
+
+
+@dsl_user_op
+def scatter_add_bf16(addr: Int64, val_f32, *, loc=None, ip=None):
+    """BF16 atomic reduction add to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            val_f32.ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b16 packed; cvt.rn.satfinite.bf16.f32 packed, $1; red.relaxed.gpu.global.add.noftz.bf16 [$0], packed; }",
+        "l,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def scatter_add_bf16x2(addr: Int64, val0_f32, val1_f32, *, loc=None, ip=None):
+    """BF16x2 atomic reduction add to global memory."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            val0_f32.ir_value(loc=loc, ip=ip),
+            val1_f32.ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b32 packed; cvt.rn.satfinite.bf16x2.f32 packed, $2, $1; red.relaxed.gpu.global.add.noftz.bf16x2 [$0], packed; }",
+        "l,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
 
 logger = logging.getLogger(__name__)
 _B12X_TIMING = os.getenv("B12X_TIMING", "0") == "1" or os.getenv(
@@ -87,35 +129,8 @@ class _DenseGemmPlan:
     swap_ab: bool
 
 
-@triton.jit
-def _reduce_split_k2_bf16_kernel(partials, out, total: tl.constexpr, BLOCK: tl.constexpr) -> None:
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    mask = offs < total
-    accum = tl.load(partials + offs, mask=mask).to(tl.float32)
-    accum += tl.load(partials + total + offs, mask=mask).to(tl.float32)
-    tl.store(out + offs, accum, mask=mask)
 
 
-def _reduce_split_k2_bf16(partials: torch.Tensor, out: torch.Tensor, *, m: int, n: int) -> None:
-    """Fused 2-way split-K FP32-partials reduction (exact); faster than torch.add.
-
-    Falls back to torch.add when the scratch/output layout is not the expected
-    [m, n, 2] / [m, n, 1] contiguous-row form.
-    """
-    total = int(m) * int(n)
-    if (
-        partials.shape == (m, n, 2)
-        and partials.stride() == (n, 1, total)
-        and out.shape == (m, n, 1)
-        and out.stride()[0] == n
-        and out.stride()[1] == 1
-    ):
-        block = 1024
-        grid = (triton.cdiv(total, block),)
-        _reduce_split_k2_bf16_kernel[grid](partials, out, total, BLOCK=block)
-    else:
-        torch.add(partials[:, :, 0], partials[:, :, 1], out=out[:, :, 0])
 
 
 # @dsl_user_op on PersistentTileSchedulerParams.__init__ can rename attributes
@@ -176,79 +191,10 @@ def _reshape_acc_to_mn(acc: cute.Tensor, transpose: bool = False) -> cute.Tensor
     )
 
 
-@dataclass(frozen=True)
-class _DenseGemmPolicy:
-    single_work_tile_per_cta: bool
-    direct_one_m_tile_scheduler: bool
-    use_m1_non_tma: bool
-    split_k_slices: int
-    split_k_atomic_bf16: bool
 
 
-def _max_active_clusters_for(
-    cluster_shape_mn: Tuple[int, int],
-    sm_count: int,
-) -> int:
-    cluster_size = cluster_shape_mn[0] * cluster_shape_mn[1]
-    # For the default single-cluster launch, occupancy is bounded only by
-    # the SM count. Avoid the CUTLASS hardware-info probe here because it
-    # can fail on some driver/runtime combinations with INVALID_HANDLE
-    # while providing no additional information for cluster_size == 1.
-    return (
-        sm_count
-        if cluster_size == 1
-        else min(get_max_active_clusters(cluster_size), sm_count)
-    )
 
 
-def _dense_gemm_policy_for(
-    *,
-    m: int,
-    n: int,
-    k: int,
-    l: int,
-    ab_dtype: Type[cutlass.Numeric],
-    c_dtype: Type[cutlass.Numeric],
-    mma_tiler_mn: Tuple[int, int],
-    cluster_shape_mn: Tuple[int, int],
-    sm_count: int,
-) -> _DenseGemmPolicy:
-    max_active_clusters = _max_active_clusters_for(cluster_shape_mn, sm_count)
-    tile_m, tile_n = mma_tiler_mn
-    one_work_tile_per_cta = (
-        ((m + tile_m - 1) // tile_m)
-        * ((n + tile_n - 1) // tile_n)
-        * l
-        <= max_active_clusters
-    )
-    single_work_tile_per_cta = (
-        one_work_tile_per_cta and m < 16 and m <= tile_m and l == 1
-    )
-    direct_one_m_tile_scheduler = (
-        one_work_tile_per_cta and m == 1 and m <= tile_m and l == 1
-    )
-    use_m1_non_tma = ab_dtype == cutlass.Float8E4M3FN and m == 1
-    split_k_slices = (
-        2
-        if (
-            single_work_tile_per_cta
-            and ab_dtype == cutlass.Float8E4M3FN
-            and c_dtype == cutlass.BFloat16
-            and m <= 8
-            and n >= 4096
-            and k >= 4096
-            and k % 256 == 0
-            and l == 1
-        )
-        else 1
-    )
-    return _DenseGemmPolicy(
-        single_work_tile_per_cta=single_work_tile_per_cta,
-        direct_one_m_tile_scheduler=direct_one_m_tile_scheduler,
-        use_m1_non_tma=use_m1_non_tma,
-        split_k_slices=split_k_slices,
-        split_k_atomic_bf16=_B12X_DENSE_SPLITK_TURBO,
-    )
 
 
 class DenseGemmKernel:
@@ -2584,690 +2530,25 @@ class DenseGemmKernel:
         )
 
 
-class _DenseGemmLaunch:
-    def __init__(
-        self,
-        n: int,
-        k: int,
-        l: int,
-        c_l: int,
-        a_major: str,
-        b_major: str,
-        c_major: str,
-        ab_dtype: torch.dtype,
-        sf_dtype: torch.dtype,
-        c_dtype: torch.dtype,
-        alpha_dtype: torch.dtype,
-        sf_vec_size: int,
-        mma_k: int,
-        tile_k: int,
-        mma_tiler_mn: Tuple[int, int],
-        cluster_shape_mn: Tuple[int, int],
-        policy: _DenseGemmPolicy,
-        sm_count: int,
-        sm_version: str,
-        load_path: str,
-        swap_ab: bool,
-    ):
-        self._n = n
-        self._k = k
-        self._l = l
-        self._c_l = c_l
-        self._a_major = a_major
-        self._b_major = b_major
-        self._c_major = c_major
-        self._ab_dtype = ab_dtype
-        self._sf_dtype = sf_dtype
-        self._c_dtype = c_dtype
-        self._alpha_dtype = alpha_dtype
-        self._sf_vec_size = sf_vec_size
-        self._mma_k = mma_k
-        self._tile_k = tile_k
-        self._mma_tiler_mn = mma_tiler_mn
-        self._cluster_shape_mn = cluster_shape_mn
-        self._policy = policy
-        self._load_path = load_path
-        self._swap_ab = swap_ab
-
-        if not DenseGemmKernel.can_implement(
-            ab_dtype,
-            sf_dtype,
-            sf_vec_size,
-            c_dtype,
-            mma_tiler_mn,
-            cluster_shape_mn,
-            n,
-            k,
-            l,
-            a_major,
-            b_major,
-            c_major,
-            load_path=load_path,
-            swap_ab=swap_ab,
-        ):
-            raise TypeError(
-                "dense_gemm launch is unsupported with "
-                f"{ab_dtype}, {sf_dtype}, {sf_vec_size}, {c_dtype}, "
-                f"{mma_tiler_mn}, {cluster_shape_mn}, {n}, {k}, {l}, "
-                f"{a_major}, {b_major}, {c_major}, "
-                f"load_path={load_path}, swap_ab={swap_ab}"
-            )
-
-        self._max_active_clusters = _max_active_clusters_for(
-            self._cluster_shape_mn, sm_count
-        )
-
-    @cute.jit
-    def __call__(
-        self,
-        a_ptr: cute.Pointer,
-        b_ptr: cute.Pointer,
-        sfa_ptr: cute.Pointer,
-        sfb_ptr: cute.Pointer,
-        c_ptr: cute.Pointer,
-        alpha_ptr: cute.Pointer,
-        m: cutlass.Int32,
-        current_stream: cuda.CUstream,
-    ):
-        a_tensor = cute.make_tensor(
-            a_ptr,
-            layout=cute.make_ordered_layout(
-                (m, self._k, self._l),
-                order=(0, 1, 2) if self._a_major == "m" else (1, 0, 2),
-            ),
-        )
-        b_tensor = cute.make_tensor(
-            b_ptr,
-            layout=cute.make_ordered_layout(
-                (self._n, self._k, self._l),
-                order=(0, 1, 2) if self._b_major == "n" else (1, 0, 2),
-            ),
-        )
-        c_tensor = cute.make_tensor(
-            c_ptr,
-            layout=cute.make_ordered_layout(
-                (m, self._n, self._c_l),
-                order=(0, 1, 2) if self._c_major == "m" else (1, 0, 2),
-            ),
-        )
-        alpha_tensor = cute.make_tensor(
-            alpha_ptr,
-            layout=cute.make_ordered_layout((1,), order=(0,)),
-        )
-        sfa_tensor = cute.make_tensor(sfa_ptr, layout=cute.make_layout((1,)))
-        sfb_tensor = cute.make_tensor(sfb_ptr, layout=cute.make_layout((1,)))
-        policy = self._policy
-        DenseGemmKernel(
-            sf_vec_size=self._sf_vec_size,
-            mma_tiler_mn=self._mma_tiler_mn,
-            cluster_shape_mn=self._cluster_shape_mn,
-            mma_k=self._mma_k,
-            tile_k=self._tile_k,
-            single_work_tile_per_cta=policy.single_work_tile_per_cta,
-            direct_one_m_tile_scheduler=policy.direct_one_m_tile_scheduler,
-            split_k_slices=policy.split_k_slices,
-            split_k_atomic_bf16=policy.split_k_atomic_bf16,
-            # M=1 FP8 benefits from normal TMA loads for A/SFA on the
-            # standalone tiny-M profile. Keep C on the direct epilogue path;
-            # the normal TMA store did not beat it in the DSV4F TP=2 GPU5 run.
-            use_m1_non_tma_a=False,
-            use_m1_non_tma_c=policy.use_m1_non_tma and not self._swap_ab,
-            use_m1_non_tma_sfa=False,
-            load_path=self._load_path,
-            swap_ab=self._swap_ab,
-        )(
-            a_tensor,
-            b_tensor,
-            sfa_tensor,
-            sfb_tensor,
-            c_tensor,
-            alpha_tensor,
-            self._max_active_clusters,
-            current_stream,
-        )
 
 
-@functools.cache
-def _get_compiled_dense_gemm(
-    n: int,
-    k: int,
-    l: int,
-    c_l: int,
-    a_major: str,
-    b_major: str,
-    c_major: str,
-    ab_dtype: Type[cutlass.Numeric],
-    sf_dtype: Type[cutlass.Numeric],
-    c_dtype: Type[cutlass.Numeric],
-    alpha_dtype: Type[cutlass.Numeric],
-    sf_vec_size: int,
-    mma_k: int,
-    tile_k: int,
-    mma_tiler_mn: Tuple[int, int],
-    cluster_shape_mn: Tuple[int, int],
-    policy: _DenseGemmPolicy,
-    sm_count: int,
-    sm_version: str,
-    load_path: str,
-    swap_ab: bool,
-) -> Callable:
-    def _make_runtime_pointers(
-        input_tensors: Optional[List[torch.Tensor]],
-    ) -> List[cute.Pointer]:
-        if input_tensors is None:
-            (
-                a_data_ptr,
-                b_data_ptr,
-                sfa_data_ptr,
-                sfb_data_ptr,
-                c_data_ptr,
-                alpha_data_ptr,
-            ) = [16 for _ in range(6)]
-        else:
-            (
-                a_tensor_gpu,
-                b_tensor_gpu,
-                sfa_tensor_gpu,
-                sfb_tensor_gpu,
-                c_tensor_gpu,
-                alpha_tensor_gpu,
-            ) = input_tensors
-            (
-                a_data_ptr,
-                b_data_ptr,
-                sfa_data_ptr,
-                sfb_data_ptr,
-                c_data_ptr,
-                alpha_data_ptr,
-            ) = (
-                a_tensor_gpu.data_ptr(),
-                b_tensor_gpu.data_ptr(),
-                sfa_tensor_gpu.data_ptr(),
-                sfb_tensor_gpu.data_ptr(),
-                c_tensor_gpu.data_ptr(),
-                alpha_tensor_gpu.data_ptr(),
-            )
-
-        return [
-            make_ptr(ab_dtype, a_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(ab_dtype, b_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(sf_dtype, sfa_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(sf_dtype, sfb_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(c_dtype, c_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(alpha_dtype, alpha_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
-        ]
-
-    launch = _DenseGemmLaunch(
-        n=n,
-        k=k,
-        l=l,
-        c_l=c_l,
-        a_major=a_major,
-        b_major=b_major,
-        c_major=c_major,
-        ab_dtype=ab_dtype,
-        sf_dtype=sf_dtype,
-        c_dtype=c_dtype,
-        alpha_dtype=alpha_dtype,
-        sf_vec_size=sf_vec_size,
-        mma_k=mma_k,
-        tile_k=tile_k,
-        mma_tiler_mn=mma_tiler_mn,
-        cluster_shape_mn=cluster_shape_mn,
-        policy=policy,
-        sm_count=sm_count,
-        sm_version=sm_version,
-        load_path=load_path,
-        swap_ab=swap_ab,
-    )
-    compile_key = (
-        n,
-        k,
-        l,
-        c_l,
-        ab_dtype,
-        sf_dtype,
-        c_dtype,
-        alpha_dtype,
-        sf_vec_size,
-        mma_k,
-        tile_k,
-        mma_tiler_mn,
-        cluster_shape_mn,
-        policy,
-        sm_count,
-        sm_version,
-        load_path,
-        swap_ab,
-    )
-    raise_if_kernel_resolution_frozen(
-        "cute.compile",
-        target=launch,
-        cache_key=compile_key,
-    )
-    compiled_kernel = b12x_compile(
-        launch,
-        *_make_runtime_pointers(None),
-        1,
-        current_cuda_stream(),
-        compile_spec=KernelCompileSpec.from_key("gemm.dense", 1, compile_key),
-    )
-
-    def tensor_api(
-        a_tensor_gpu: torch.Tensor,
-        b_tensor_gpu: torch.Tensor,
-        sfa_tensor_gpu: torch.Tensor,
-        sfb_tensor_gpu: torch.Tensor,
-        c_tensor_gpu: Optional[torch.Tensor] = None,
-        alpha_tensor_gpu: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        m = a_tensor_gpu.shape[0]
-        if c_tensor_gpu is None:
-            c_tensor_gpu = torch.empty(
-                (m, n, c_l),
-                dtype=cutlass_to_torch_dtype(c_dtype),
-                device=a_tensor_gpu.device,
-            )
-        if alpha_tensor_gpu is None:
-            alpha_tensor_gpu = _cached_alpha_one(a_tensor_gpu.device)
-
-        nonlocal compiled_kernel
-        compiled_kernel(
-            *_make_runtime_pointers(
-                [
-                    a_tensor_gpu,
-                    b_tensor_gpu,
-                    sfa_tensor_gpu,
-                    sfb_tensor_gpu,
-                    c_tensor_gpu,
-                    alpha_tensor_gpu,
-                ]
-            ),
-            m,
-            current_cuda_stream(),
-        )
-        return c_tensor_gpu
-
-    return tensor_api
 
 
-def _dense_gemm_launch_flat(
-    a_tensor_gpu: torch.Tensor,
-    b_tensor_gpu: torch.Tensor,
-    sfa_tensor_gpu: torch.Tensor,
-    sfb_tensor_gpu: torch.Tensor,
-    c_tensor_gpu: torch.Tensor,
-    alpha_tensor_gpu: torch.Tensor,
-    n: int,
-    k: int,
-    l: int,
-    c_l: int,
-    ab_dtype: str,
-    sf_dtype: str,
-    c_dtype: str,
-    alpha_dtype: str,
-    sf_vec_size: int,
-    mma_k: int,
-    tile_k: int,
-    mma_tile_m: int,
-    mma_tile_n: int,
-    cluster_shape_m: int,
-    cluster_shape_n: int,
-    sm_count: int,
-    single_work_tile_per_cta: bool,
-    direct_one_m_tile_scheduler: bool,
-    use_m1_non_tma: bool,
-    split_k_slices: int,
-    split_k_atomic_bf16: bool,
-    load_path: str,
-    swap_ab: bool,
-) -> None:
-    policy = _DenseGemmPolicy(
-        single_work_tile_per_cta=single_work_tile_per_cta,
-        direct_one_m_tile_scheduler=direct_one_m_tile_scheduler,
-        use_m1_non_tma=use_m1_non_tma,
-        split_k_slices=split_k_slices,
-        split_k_atomic_bf16=split_k_atomic_bf16,
-    )
-    compiled = _get_compiled_dense_gemm(
-        n=n,
-        k=k,
-        l=l,
-        c_l=c_l,
-        a_major="k",
-        b_major="k",
-        c_major="n",
-        ab_dtype=get_cutlass_dtype(ab_dtype),
-        sf_dtype=get_cutlass_dtype(sf_dtype),
-        c_dtype=get_cutlass_dtype(c_dtype),
-        alpha_dtype=get_cutlass_dtype(alpha_dtype),
-        sf_vec_size=sf_vec_size,
-        mma_k=mma_k,
-        tile_k=tile_k,
-        mma_tiler_mn=(mma_tile_m, mma_tile_n),
-        cluster_shape_mn=(cluster_shape_m, cluster_shape_n),
-        policy=policy,
-        sm_count=sm_count,
-        sm_version="sm_120",
-        load_path=load_path,
-        swap_ab=swap_ab,
-    )
-    compiled(
-        a_tensor_gpu=a_tensor_gpu,
-        b_tensor_gpu=b_tensor_gpu,
-        sfa_tensor_gpu=sfa_tensor_gpu,
-        sfb_tensor_gpu=sfb_tensor_gpu,
-        c_tensor_gpu=c_tensor_gpu,
-        alpha_tensor_gpu=alpha_tensor_gpu,
-    )
 
 
-@torch.library.custom_op(
-    "b12x::dense_gemm_launch",
-    mutates_args=("c_tensor_gpu",),
-)
-def _dense_gemm_launch_op(
-    a_tensor_gpu: torch.Tensor,
-    b_tensor_gpu: torch.Tensor,
-    sfa_tensor_gpu: torch.Tensor,
-    sfb_tensor_gpu: torch.Tensor,
-    c_tensor_gpu: torch.Tensor,
-    alpha_tensor_gpu: torch.Tensor,
-    n: int,
-    k: int,
-    l: int,
-    c_l: int,
-    ab_dtype: str,
-    sf_dtype: str,
-    c_dtype: str,
-    alpha_dtype: str,
-    sf_vec_size: int,
-    mma_k: int,
-    tile_k: int,
-    mma_tile_m: int,
-    mma_tile_n: int,
-    cluster_shape_m: int,
-    cluster_shape_n: int,
-    sm_count: int,
-    single_work_tile_per_cta: bool,
-    direct_one_m_tile_scheduler: bool,
-    use_m1_non_tma: bool,
-    split_k_slices: int,
-    split_k_atomic_bf16: bool,
-    load_path: str,
-    swap_ab: bool,
-) -> None:
-    _dense_gemm_launch_flat(
-        a_tensor_gpu,
-        b_tensor_gpu,
-        sfa_tensor_gpu,
-        sfb_tensor_gpu,
-        c_tensor_gpu,
-        alpha_tensor_gpu,
-        n,
-        k,
-        l,
-        c_l,
-        ab_dtype,
-        sf_dtype,
-        c_dtype,
-        alpha_dtype,
-        sf_vec_size,
-        mma_k,
-        tile_k,
-        mma_tile_m,
-        mma_tile_n,
-        cluster_shape_m,
-        cluster_shape_n,
-        sm_count,
-        single_work_tile_per_cta,
-        direct_one_m_tile_scheduler,
-        use_m1_non_tma,
-        split_k_slices,
-        split_k_atomic_bf16,
-        load_path,
-        swap_ab,
-    )
 
 
-@_dense_gemm_launch_op.register_fake
-def _dense_gemm_launch_fake(
-    a_tensor_gpu: torch.Tensor,
-    b_tensor_gpu: torch.Tensor,
-    sfa_tensor_gpu: torch.Tensor,
-    sfb_tensor_gpu: torch.Tensor,
-    c_tensor_gpu: torch.Tensor,
-    alpha_tensor_gpu: torch.Tensor,
-    n: int,
-    k: int,
-    l: int,
-    c_l: int,
-    ab_dtype: str,
-    sf_dtype: str,
-    c_dtype: str,
-    alpha_dtype: str,
-    sf_vec_size: int,
-    mma_k: int,
-    tile_k: int,
-    mma_tile_m: int,
-    mma_tile_n: int,
-    cluster_shape_m: int,
-    cluster_shape_n: int,
-    sm_count: int,
-    single_work_tile_per_cta: bool,
-    direct_one_m_tile_scheduler: bool,
-    use_m1_non_tma: bool,
-    split_k_slices: int,
-    split_k_atomic_bf16: bool,
-    load_path: str,
-    swap_ab: bool,
-) -> None:
-    return None
 
 
 _ALPHA_ONE_CACHE: dict = {}
 
 
-def _cached_alpha_one(device: torch.device | str) -> torch.Tensor:
-    # Per-device cached scalar-one alpha, to avoid a per-call torch.ones((1,))
-    # host/device alloc on the generic FP8 dense-GEMM path. Mirrors
-    # wo_projection._cached_alpha_one (not imported -- wo_projection imports
-    # dense, so importing back would be circular).
-    resolved = torch.device(device)
-    if resolved.type == "cuda" and resolved.index is None:
-        resolved = torch.device("cuda", torch.cuda.current_device())
-    key = (resolved.type, resolved.index)
-    alpha = _ALPHA_ONE_CACHE.get(key)
-    if alpha is None or alpha.device != resolved:
-        alpha = torch.ones((1,), dtype=torch.float32, device=resolved)
-        _ALPHA_ONE_CACHE[key] = alpha
-    return alpha
 
 
-def _empty_dense_gemm_output(
-    m: int,
-    n: int,
-    l: int,
-    *,
-    dtype: torch.dtype,
-    device: torch.device | str,
-) -> torch.Tensor:
-    """Allocate an `[M,N,L]` dense-GEMM output in the layout the kernel writes.
-
-    The CuTe dense GEMM hardcodes ``c_major='n'`` and builds the C tensor from
-    the data pointer with order ``(1,0,2)`` -- i.e. it writes the grouped output
-    as physical ``[L,M,N]`` (an ``[M,N,L]`` view with strides ``(N,1,M*N)``) and
-    ignores the runtime tensor's actual strides. A plain contiguous ``(M,N,L)``
-    buffer (strides ``(N*L,L,1)``) would scatter the ``L`` groups to the wrong
-    offsets, so back ``L>1`` with ``[L,M,N]`` physical storage. ``L==1`` is the
-    same either way. Mirrors ``empty_dense_gemm_mnl_view`` in wo_projection.
-    """
-    if l > 1:
-        return torch.empty((l, m, n), dtype=dtype, device=device).as_strided(
-            (m, n, l), (n, 1, m * n)
-        )
-    return torch.empty((m, n, l), dtype=dtype, device=device)
 
 
-@torch.library.custom_op(
-    "b12x::dense_gemm_launch_functional",
-    mutates_args=(),
-)
-def _dense_gemm_launch_functional_op(
-    a_tensor_gpu: torch.Tensor,
-    b_tensor_gpu: torch.Tensor,
-    sfa_tensor_gpu: torch.Tensor,
-    sfb_tensor_gpu: torch.Tensor,
-    alpha_tensor_gpu: torch.Tensor,
-    n: int,
-    k: int,
-    l: int,
-    kernel_c_l: int,
-    ab_dtype: str,
-    sf_dtype: str,
-    c_dtype: str,
-    kernel_c_dtype: str,
-    alpha_dtype: str,
-    sf_vec_size: int,
-    mma_k: int,
-    tile_k: int,
-    mma_tile_m: int,
-    mma_tile_n: int,
-    cluster_shape_m: int,
-    cluster_shape_n: int,
-    sm_count: int,
-    single_work_tile_per_cta: bool,
-    direct_one_m_tile_scheduler: bool,
-    use_m1_non_tma: bool,
-    split_k_slices: int,
-    split_k_atomic_bf16: bool,
-    load_path: str,
-    swap_ab: bool,
-) -> torch.Tensor:
-    m = int(a_tensor_gpu.shape[0])
-    out = _empty_dense_gemm_output(
-        m,
-        n,
-        l,
-        dtype=cutlass_to_torch_dtype(get_cutlass_dtype(c_dtype)),
-        device=a_tensor_gpu.device,
-    )
-    split_k_output = int(split_k_slices) > 1
-    if split_k_output and split_k_atomic_bf16:
-        c_tensor_gpu = out
-        out.zero_()
-    elif split_k_output:
-        split_storage = torch.empty(
-            (split_k_slices, m, n),
-            dtype=torch.float32,
-            device=a_tensor_gpu.device,
-        )
-        c_tensor_gpu = split_storage.permute(1, 2, 0)
-    else:
-        c_tensor_gpu = out
-
-    _dense_gemm_launch_flat(
-        a_tensor_gpu,
-        b_tensor_gpu,
-        sfa_tensor_gpu,
-        sfb_tensor_gpu,
-        c_tensor_gpu,
-        alpha_tensor_gpu,
-        n,
-        k,
-        l,
-        kernel_c_l,
-        ab_dtype,
-        sf_dtype,
-        kernel_c_dtype,
-        alpha_dtype,
-        sf_vec_size,
-        mma_k,
-        tile_k,
-        mma_tile_m,
-        mma_tile_n,
-        cluster_shape_m,
-        cluster_shape_n,
-        sm_count,
-        single_work_tile_per_cta,
-        direct_one_m_tile_scheduler,
-        use_m1_non_tma,
-        split_k_slices,
-        split_k_atomic_bf16,
-        load_path,
-        swap_ab,
-    )
-    if split_k_output and not split_k_atomic_bf16:
-        _reduce_split_k2_bf16(c_tensor_gpu, out, m=m, n=n)
-    return out
 
 
-@_dense_gemm_launch_functional_op.register_fake
-def _dense_gemm_launch_functional_fake(
-    a_tensor_gpu: torch.Tensor,
-    b_tensor_gpu: torch.Tensor,
-    sfa_tensor_gpu: torch.Tensor,
-    sfb_tensor_gpu: torch.Tensor,
-    alpha_tensor_gpu: torch.Tensor,
-    n: int,
-    k: int,
-    l: int,
-    kernel_c_l: int,
-    ab_dtype: str,
-    sf_dtype: str,
-    c_dtype: str,
-    kernel_c_dtype: str,
-    alpha_dtype: str,
-    sf_vec_size: int,
-    mma_k: int,
-    tile_k: int,
-    mma_tile_m: int,
-    mma_tile_n: int,
-    cluster_shape_m: int,
-    cluster_shape_n: int,
-    sm_count: int,
-    single_work_tile_per_cta: bool,
-    direct_one_m_tile_scheduler: bool,
-    use_m1_non_tma: bool,
-    split_k_slices: int,
-    split_k_atomic_bf16: bool,
-    load_path: str,
-    swap_ab: bool,
-) -> torch.Tensor:
-    del (
-        b_tensor_gpu,
-        sfa_tensor_gpu,
-        sfb_tensor_gpu,
-        alpha_tensor_gpu,
-        k,
-        kernel_c_l,
-        ab_dtype,
-        sf_dtype,
-        kernel_c_dtype,
-        alpha_dtype,
-        sf_vec_size,
-        mma_k,
-        tile_k,
-        mma_tile_m,
-        mma_tile_n,
-        cluster_shape_m,
-        cluster_shape_n,
-        sm_count,
-        single_work_tile_per_cta,
-        direct_one_m_tile_scheduler,
-        use_m1_non_tma,
-        split_k_slices,
-        split_k_atomic_bf16,
-        load_path,
-        swap_ab,
-    )
-    return _empty_dense_gemm_output(
-        int(a_tensor_gpu.shape[0]),
-        n,
-        l,
-        dtype=cutlass_to_torch_dtype(get_cutlass_dtype(c_dtype)),
-        device=a_tensor_gpu.device,
-    )
 
 
 def _select_default_mma_tiler_mn(
@@ -3407,248 +2688,6 @@ def _select_default_dense_gemm_plan(
     )
 
 
-def dense_gemm(
-    lhs: Tuple[torch.Tensor, torch.Tensor],
-    rhs: Tuple[torch.Tensor, torch.Tensor],
-    out: Optional[torch.Tensor] = None,
-    *,
-    ab_dtype: str,
-    sf_dtype: str,
-    c_dtype: str,
-    sf_vec_size: int,
-    sm_count: Optional[int] = None,
-    mma_tiler_mn: Optional[Tuple[int, int]] = None,
-    cluster_shape_mn: Tuple[int, int] = (1, 1),
-    alpha: Optional[torch.Tensor] = None,
-    alpha_dtype: Optional[str] = None,
-    expected_m: Optional[int] = None,
-    load_path: Optional[Literal["tma", "cpasync"]] = None,
-    swap_ab: Optional[bool] = None,
-) -> torch.Tensor:
-    """Execute dense block-scaled GEMM for one expert-major batch stack.
-
-    expected_m: optional regime hint (DeepGEMM-style). When set, the default tile
-    is chosen for that representative M instead of being M-independent, giving a
-    per-regime-optimal kernel that is still reused across all live M in the regime
-    (e.g. expected_m<=128 selects a decode-tuned tile). Ignored when mma_tiler_mn
-    is given. Live M stays a runtime arg; only the tile (a compile key) changes.
-    """
-    a_torch, sfa_torch = lhs
-    b_torch, sfb_torch = rhs
-    if load_path is not None and load_path not in _DENSE_LOAD_PATHS:
-        raise ValueError(f"dense_gemm load_path must be one of {_DENSE_LOAD_PATHS}, got {load_path!r}")
-
-    m, k, l = a_torch.shape
-    n, _, _ = b_torch.shape
-    if ab_dtype == "float4_e2m1fn":
-        is_mxfp8 = False
-        k *= 2
-        mma_k = 64
-        tile_k = sf_vec_size * 8
-    elif ab_dtype == "float8_e4m3fn":
-        is_mxfp8 = True
-        mma_k = 32
-        tile_k = 128
-    else:
-        raise TypeError(f"dense_gemm unsupported ab_dtype: {ab_dtype}")
-
-    if sm_count is None:
-        sm_count = get_num_sm(a_torch.device)
-    ab_cutlass_dtype = get_cutlass_dtype(ab_dtype)
-    c_cutlass_dtype = get_cutlass_dtype(c_dtype)
-    if mma_tiler_mn is None or load_path is None or swap_ab is None:
-        default_plan = _select_default_dense_gemm_plan(
-            m,
-            n,
-            k,
-            sm_count,
-            is_mxfp8=is_mxfp8,
-            expected_m=expected_m,
-        )
-        if mma_tiler_mn is None:
-            mma_tiler_mn = default_plan.mma_tiler_mn
-        if load_path is None:
-            load_path = default_plan.load_path
-        if swap_ab is None:
-            swap_ab = default_plan.swap_ab if mma_tiler_mn[1] < 64 else False
-    assert load_path is not None
-    assert swap_ab is not None
-    if alpha_dtype is None:
-        alpha_dtype = "float32" if alpha is None else str(alpha.dtype).split(".")[-1]
-    policy = _dense_gemm_policy_for(
-        m=m,
-        n=n,
-        k=k,
-        l=l,
-        ab_dtype=ab_cutlass_dtype,
-        c_dtype=c_cutlass_dtype,
-        mma_tiler_mn=mma_tiler_mn,
-        cluster_shape_mn=cluster_shape_mn,
-        sm_count=sm_count,
-    )
-    split_k_slices = policy.split_k_slices
-    if swap_ab and split_k_slices != 1:
-        policy = _DenseGemmPolicy(
-            single_work_tile_per_cta=policy.single_work_tile_per_cta,
-            direct_one_m_tile_scheduler=policy.direct_one_m_tile_scheduler,
-            use_m1_non_tma=policy.use_m1_non_tma,
-            split_k_slices=1,
-            split_k_atomic_bf16=False,
-        )
-        split_k_slices = 1
-    split_k_output = split_k_slices > 1
-    split_k_atomic_bf16 = split_k_output and policy.split_k_atomic_bf16
-    if split_k_atomic_bf16:
-        kernel_c_l = l
-    elif split_k_output:
-        kernel_c_l = split_k_slices
-    else:
-        kernel_c_l = l
-    if alpha is None:
-        alpha = _cached_alpha_one(a_torch.device)
-    kernel_c_dtype_name = (
-        "float32" if split_k_output and not split_k_atomic_bf16 else c_dtype
-    )
-    if out is None:
-        # No caller-owned output buffer: functional launch (allocate + return
-        # inside the opaque op). The compile graph then carries no
-        # auto_functionalized dense node mutating a (possibly strided) caller
-        # view -- which inductor's decompose pass cannot remove. No is_compiling;
-        # purely caller-intent, behaviorally identical to the eager out=None path.
-        return torch.ops.b12x.dense_gemm_launch_functional(
-            a_torch,
-            b_torch,
-            sfa_torch,
-            sfb_torch,
-            alpha,
-            n,
-            k,
-            l,
-            kernel_c_l,
-            ab_dtype,
-            sf_dtype,
-            c_dtype,
-            kernel_c_dtype_name,
-            alpha_dtype,
-            sf_vec_size,
-            mma_k,
-            tile_k,
-            mma_tiler_mn[0],
-            mma_tiler_mn[1],
-            cluster_shape_mn[0],
-            cluster_shape_mn[1],
-            sm_count,
-            policy.single_work_tile_per_cta,
-            policy.direct_one_m_tile_scheduler,
-            policy.use_m1_non_tma,
-            policy.split_k_slices,
-            policy.split_k_atomic_bf16,
-            load_path,
-            swap_ab,
-        )
-    split_storage = None
-    split_scratch = None
-    if split_k_output:
-        if out is None:
-            out = torch.empty(
-                (m, n, l),
-                dtype=cutlass_to_torch_dtype(c_cutlass_dtype),
-                device=a_torch.device,
-            )
-        if split_k_atomic_bf16:
-            out.zero_()
-        else:
-            split_storage = torch.empty(
-                (split_k_slices, m, n),
-                dtype=torch.float32,
-                device=a_torch.device,
-            )
-            split_scratch = split_storage.permute(1, 2, 0)
-    elif out is None:
-        out = torch.empty(
-            (m, n, l),
-            dtype=cutlass_to_torch_dtype(c_cutlass_dtype),
-            device=a_torch.device,
-        )
-    if alpha is None:
-        alpha = _cached_alpha_one(a_torch.device)
-
-    t0 = time.perf_counter() if _B12X_TIMING else 0.0
-    cache_before = _get_compiled_dense_gemm.cache_info() if _B12X_TIMING else None
-    t_compiled = t0
-    kernel_c_dtype_name = (
-        "float32" if split_k_output and not split_k_atomic_bf16 else c_dtype
-    )
-    c_tensor_gpu = (
-        out if split_k_atomic_bf16 else split_scratch if split_k_output else out
-    )
-    assert c_tensor_gpu is not None
-    torch.ops.b12x.dense_gemm_launch(
-        a_torch,
-        b_torch,
-        sfa_torch,
-        sfb_torch,
-        c_tensor_gpu,
-        alpha,
-        n,
-        k,
-        l,
-        kernel_c_l,
-        ab_dtype,
-        sf_dtype,
-        kernel_c_dtype_name,
-        alpha_dtype,
-        sf_vec_size,
-        mma_k,
-        tile_k,
-        mma_tiler_mn[0],
-        mma_tiler_mn[1],
-        cluster_shape_mn[0],
-        cluster_shape_mn[1],
-        sm_count,
-        policy.single_work_tile_per_cta,
-        policy.direct_one_m_tile_scheduler,
-        policy.use_m1_non_tma,
-        policy.split_k_slices,
-        policy.split_k_atomic_bf16,
-        load_path,
-        swap_ab,
-    )
-    result = out
-    if split_k_output and not split_k_atomic_bf16:
-        assert split_scratch is not None
-        assert out is not None
-        _reduce_split_k2_bf16(split_scratch, out, m=m, n=n)
-        result = out
-    if _B12X_TIMING:
-        t_launch = time.perf_counter()
-        cache_after = _get_compiled_dense_gemm.cache_info()
-        assert cache_before is not None
-        compile_ms = (t_compiled - t0) * 1000.0
-        launch_ms = (t_launch - t_compiled) * 1000.0
-        total_ms = (t_launch - t0) * 1000.0
-        if total_ms >= _B12X_TIMING_THRESHOLD_MS:
-            logger.warning(
-                "b12x_dense_gemm timing m=%d n=%d k=%d l=%d ab=%s sf=%s c=%s "
-                "tile=%s load=%s swap_ab=%s cache_hit=%s compile_or_lookup=%.3fms "
-                "launch_enqueue=%.3fms total=%.3fms cache=%s",
-                m,
-                n,
-                k,
-                l,
-                ab_dtype,
-                sf_dtype,
-                c_dtype,
-                mma_tiler_mn,
-                load_path,
-                swap_ab,
-                cache_after.hits > cache_before.hits,
-                compile_ms,
-                launch_ms,
-                total_ms,
-                cache_after,
-            )
-    return result
 
 
 # Alias for FlashInfer integration

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -41,7 +41,6 @@ import cutlass.utils.blackwell_helpers as sm120_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 import cutlass.utils.hopper_helpers as sm90_utils
 import logging
-import os
 from cutlass import Int32, Int64
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp.mma import Field as WarpField
@@ -101,16 +100,6 @@ def scatter_add_bf16x2(addr: Int64, val0_f32, val1_f32, *, loc=None, ip=None):
 
 
 logger = logging.getLogger(__name__)
-_B12X_TIMING = (
-    os.getenv("B12X_TIMING", "0") == "1" or os.getenv("VLLM_B12X_TIMING", "0") == "1"
-)
-_B12X_TIMING_THRESHOLD_MS = float(
-    os.getenv(
-        "B12X_TIMING_THRESHOLD_MS",
-        os.getenv("VLLM_B12X_TIMING_THRESHOLD_MS", "0"),
-    )
-)
-_B12X_DENSE_SPLITK_TURBO = os.getenv("B12X_DENSE_SPLITK_TURBO", "0") == "1"
 _DENSE_LOAD_PATHS = ("tma", "cpasync")
 
 

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -28,10 +28,9 @@
 
 # This file is ported from the CUTLASS dense block-scaled GEMM example
 # and adapted for the current Blackwell GeForce target.
-#
-# Ported from the b12x kernel library to FlashInfer.
 
-from typing import Callable, List, Optional, Tuple, Type
+from dataclasses import dataclass
+from typing import Callable, List, Literal, Optional, Tuple, Type
 
 import cuda.bindings.driver as cuda
 import cutlass
@@ -42,11 +41,20 @@ import cutlass.utils.blackwell_helpers as sm120_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 import cutlass.utils.hopper_helpers as sm90_utils
 import functools
+import logging
+import os
+import time
 import torch
+import triton
+import triton.language as tl
+from cutlass import Int32
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp.mma import Field as WarpField
+from cutlass.utils.static_persistent_tile_scheduler import WorkTileInfo
 
+from b12x.cute.compiler import KernelCompileSpec, compile as b12x_compile
 from flashinfer.cute_dsl.utils import (
+    current_cuda_stream,
     cutlass_to_torch_dtype,
     get_cutlass_dtype,
     get_max_active_clusters,
@@ -55,13 +63,192 @@ from flashinfer.cute_dsl.utils import (
     sm120_make_smem_layout_sfa,
     sm120_make_smem_layout_sfb,
 )
+from b12x.cute.fp4 import get_ptr_as_int64, scatter_add_bf16, scatter_add_bf16x2
+from b12x.cute.runtime_control import raise_if_kernel_resolution_frozen
+
+logger = logging.getLogger(__name__)
+_B12X_TIMING = os.getenv("B12X_TIMING", "0") == "1" or os.getenv(
+    "VLLM_B12X_TIMING", "0"
+) == "1"
+_B12X_TIMING_THRESHOLD_MS = float(
+    os.getenv(
+        "B12X_TIMING_THRESHOLD_MS",
+        os.getenv("VLLM_B12X_TIMING_THRESHOLD_MS", "0"),
+    )
+)
+_B12X_DENSE_SPLITK_TURBO = os.getenv("B12X_DENSE_SPLITK_TURBO", "0") == "1"
+_DENSE_LOAD_PATHS = ("tma", "cpasync")
 
 
-def current_cuda_stream():
-    """Return current CUDA stream as a CUDA driver stream handle."""
-    import cuda.bindings.driver as cuda_driver
+@dataclass(frozen=True)
+class _DenseGemmPlan:
+    mma_tiler_mn: Tuple[int, int]
+    load_path: Literal["tma", "cpasync"]
+    swap_ab: bool
 
-    return cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+@triton.jit
+def _reduce_split_k2_bf16_kernel(partials, out, total: tl.constexpr, BLOCK: tl.constexpr) -> None:
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < total
+    accum = tl.load(partials + offs, mask=mask).to(tl.float32)
+    accum += tl.load(partials + total + offs, mask=mask).to(tl.float32)
+    tl.store(out + offs, accum, mask=mask)
+
+
+def _reduce_split_k2_bf16(partials: torch.Tensor, out: torch.Tensor, *, m: int, n: int) -> None:
+    """Fused 2-way split-K FP32-partials reduction (exact); faster than torch.add.
+
+    Falls back to torch.add when the scratch/output layout is not the expected
+    [m, n, 2] / [m, n, 1] contiguous-row form.
+    """
+    total = int(m) * int(n)
+    if (
+        partials.shape == (m, n, 2)
+        and partials.stride() == (n, 1, total)
+        and out.shape == (m, n, 1)
+        and out.stride()[0] == n
+        and out.stride()[1] == 1
+    ):
+        block = 1024
+        grid = (triton.cdiv(total, block),)
+        _reduce_split_k2_bf16_kernel[grid](partials, out, total, BLOCK=block)
+    else:
+        torch.add(partials[:, :, 0], partials[:, :, 1], out=out[:, :, 0])
+
+
+# @dsl_user_op on PersistentTileSchedulerParams.__init__ can rename attributes
+# (e.g. raster_along_m -> _raster_along_m, cluster_shape_major_fdd ->
+# cluster_shape_m_fdd) but __extract_mlir_values__ (used by TVM-FFI)
+# still references the original names.
+_orig_extract = utils.PersistentTileSchedulerParams.__extract_mlir_values__
+
+# Map of source-code attr name -> runtime attr name set by @dsl_user_op
+_ATTR_RENAMES = {
+    "raster_along_m": "_raster_along_m",
+    "cluster_shape_major_fdd": "cluster_shape_m_fdd",
+    "cluster_shape_minor_fdd": "cluster_shape_n_fdd",
+}
+
+
+def _patched_extract(self):
+    for src_name, dst_name in _ATTR_RENAMES.items():
+        if not hasattr(self, src_name) and hasattr(self, dst_name):
+            setattr(self, src_name, getattr(self, dst_name))
+    return _orig_extract(self)
+
+
+utils.PersistentTileSchedulerParams.__extract_mlir_values__ = _patched_extract
+
+
+def _convert_layout_acc_mn(
+    acc_layout: cute.Layout, transpose: bool = False
+) -> cute.Layout:
+    acc_layout_col_major = cute.make_layout(acc_layout.shape)
+    shape = (
+        (acc_layout_col_major.shape[0][1], acc_layout_col_major.shape[1]),
+        (
+            acc_layout_col_major.shape[0][0],
+            *acc_layout_col_major.shape[0][2:],
+            acc_layout_col_major.shape[2],
+        ),
+        *acc_layout_col_major.shape[3:],
+    )
+    stride = (
+        (acc_layout_col_major.stride[0][1], acc_layout_col_major.stride[1]),
+        (
+            acc_layout_col_major.stride[0][0],
+            *acc_layout_col_major.stride[0][2:],
+            acc_layout_col_major.stride[2],
+        ),
+        *acc_layout_col_major.stride[3:],
+    )
+    if cutlass.const_expr(transpose):
+        shape = (shape[1], shape[0], *shape[2:])
+        stride = (stride[1], stride[0], *stride[2:])
+    return cute.composition(acc_layout, cute.make_layout(shape, stride=stride))
+
+
+def _reshape_acc_to_mn(acc: cute.Tensor, transpose: bool = False) -> cute.Tensor:
+    return cute.make_tensor(
+        acc.iterator, _convert_layout_acc_mn(acc.layout, transpose=transpose)
+    )
+
+
+@dataclass(frozen=True)
+class _DenseGemmPolicy:
+    single_work_tile_per_cta: bool
+    direct_one_m_tile_scheduler: bool
+    use_m1_non_tma: bool
+    split_k_slices: int
+    split_k_atomic_bf16: bool
+
+
+def _max_active_clusters_for(
+    cluster_shape_mn: Tuple[int, int],
+    sm_count: int,
+) -> int:
+    cluster_size = cluster_shape_mn[0] * cluster_shape_mn[1]
+    # For the default single-cluster launch, occupancy is bounded only by
+    # the SM count. Avoid the CUTLASS hardware-info probe here because it
+    # can fail on some driver/runtime combinations with INVALID_HANDLE
+    # while providing no additional information for cluster_size == 1.
+    return (
+        sm_count
+        if cluster_size == 1
+        else min(get_max_active_clusters(cluster_size), sm_count)
+    )
+
+
+def _dense_gemm_policy_for(
+    *,
+    m: int,
+    n: int,
+    k: int,
+    l: int,
+    ab_dtype: Type[cutlass.Numeric],
+    c_dtype: Type[cutlass.Numeric],
+    mma_tiler_mn: Tuple[int, int],
+    cluster_shape_mn: Tuple[int, int],
+    sm_count: int,
+) -> _DenseGemmPolicy:
+    max_active_clusters = _max_active_clusters_for(cluster_shape_mn, sm_count)
+    tile_m, tile_n = mma_tiler_mn
+    one_work_tile_per_cta = (
+        ((m + tile_m - 1) // tile_m)
+        * ((n + tile_n - 1) // tile_n)
+        * l
+        <= max_active_clusters
+    )
+    single_work_tile_per_cta = (
+        one_work_tile_per_cta and m < 16 and m <= tile_m and l == 1
+    )
+    direct_one_m_tile_scheduler = (
+        one_work_tile_per_cta and m == 1 and m <= tile_m and l == 1
+    )
+    use_m1_non_tma = ab_dtype == cutlass.Float8E4M3FN and m == 1
+    split_k_slices = (
+        2
+        if (
+            single_work_tile_per_cta
+            and ab_dtype == cutlass.Float8E4M3FN
+            and c_dtype == cutlass.BFloat16
+            and m <= 8
+            and n >= 4096
+            and k >= 4096
+            and k % 256 == 0
+            and l == 1
+        )
+        else 1
+    )
+    return _DenseGemmPolicy(
+        single_work_tile_per_cta=single_work_tile_per_cta,
+        direct_one_m_tile_scheduler=direct_one_m_tile_scheduler,
+        use_m1_non_tma=use_m1_non_tma,
+        split_k_slices=split_k_slices,
+        split_k_atomic_bf16=_B12X_DENSE_SPLITK_TURBO,
+    )
 
 
 class DenseGemmKernel:
@@ -78,13 +265,12 @@ class DenseGemmKernel:
 
     Notes:
         - Supported combinations:
-            * NVF4 only: A/B: Float4E2M1FN, SF: Float8E4M3FN, sf_vec_size: 16
-            (MXF4 / sf_vec_size=32 is not supported — the CUTLASS DSL
-            MmaMXF4NVF4Op hardcodes sf_vec_size=16 in its constructor.)
+            * NVF4: A/B: Float4E2M1FN, SF: Float8E4M3FN, sf_vec_size: 16
+            * MXF4: A/B: Float4E2M1FN, SF: Float8E8M0FNU, sf_vec_size: 32
         - Tile shape constraints:
-            * tile_m must be divisible by 64
-            * tile_n must be divisible by 64
-            * tile_k = sf_vec_size * 8 = 128
+            * tile_m must be divisible by 128
+            * tile_n must be divisible by 128
+            * tile_k must be divisible by 64 (sf_vec_size=16) or 128 (sf_vec_size=32)
     """
 
     def __init__(
@@ -92,27 +278,64 @@ class DenseGemmKernel:
         sf_vec_size: int,
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
+        mma_k: int = 64,
+        tile_k: Optional[int] = None,
+        single_work_tile_per_cta: bool = False,
         use_prefetch: bool = False,
         enable_pdl: bool = True,
+        direct_one_m_tile_scheduler: bool = False,
+        split_k_slices: int = 1,
+        split_k_atomic_bf16: bool = False,
+        use_m1_non_tma_a: bool = False,
+        use_m1_non_tma_c: bool = False,
+        use_m1_non_tma_sfa: bool = False,
+        load_path: Literal["tma", "cpasync"] = "tma",
+        swap_ab: bool = False,
     ):
         self.acc_dtype = cutlass.Float32
         self.sf_vec_size = sf_vec_size
-        # K = sf_vec_size * 8 for FP4 (each FP4 element is 0.5 bytes, sf_vec_size
-        # elements per scale factor, and we want 4 MMA k-tiles per stage)
-        tile_k = sf_vec_size * 8  # 128 for sf_vec_size=16
+        self.mma_k = mma_k
+        if tile_k is None:
+            tile_k = sf_vec_size * 8
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
+        self.mma_tile_shape_mnk = (
+            (mma_tiler_mn[1], mma_tiler_mn[0], tile_k)
+            if swap_ab
+            else self.tile_shape_mnk
+        )
         self.sfa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
         self.sfa_tiles_per_block = self.sfa_tile_shape_mk[0] // mma_tiler_mn[0]
         self.sfb_tile_shape_nk = (max(128, mma_tiler_mn[1]), tile_k)
         self.sfb_tiles_per_block = self.sfb_tile_shape_nk[0] // mma_tiler_mn[1]
         self.cluster_shape_mnk = (1, 1, 1)  # Always (1,1,1) on the current target
         self.epi_tile = (mma_tiler_mn[0], mma_tiler_mn[1])
+        self.single_work_tile_per_cta = single_work_tile_per_cta
         self.use_prefetch = use_prefetch
         self.enable_pdl = enable_pdl
+        self.direct_one_m_tile_scheduler = direct_one_m_tile_scheduler
+        self.split_k_slices = split_k_slices
+        self.split_k_atomic_bf16 = split_k_atomic_bf16
+        self.use_m1_non_tma_a = use_m1_non_tma_a
+        self.use_m1_non_tma_c = use_m1_non_tma_c
+        self.use_m1_non_tma_sfa = use_m1_non_tma_sfa
+        self.load_path = load_path
+        self.swap_ab = swap_ab
+        mma_atom_mn = (self.mma_tile_shape_mnk[0], self.mma_tile_shape_mnk[1])
+        if mma_atom_mn in ((16, 64), (16, 128)):
+            self.atom_shape = (1, 2, 1)
+        elif mma_atom_mn in ((32, 64), (32, 128)):
+            self.atom_shape = (2, 2, 1)
+        else:
+            self.atom_shape = (4, 2, 1)
 
         self.tiled_mma = None
         self.occupancy = 1
-        self.num_mma_warps = 8
+        if mma_atom_mn in ((16, 64), (16, 128)):
+            self.num_mma_warps = 2
+        elif mma_atom_mn in ((32, 64), (32, 128)):
+            self.num_mma_warps = 4
+        else:
+            self.num_mma_warps = 8
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
         self.threads_per_cta = (
@@ -141,15 +364,24 @@ class DenseGemmKernel:
         self.mma_register_requirement = 232
 
     def _setup_attributes(self):
-        mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
-            self.a_dtype,
-            self.acc_dtype,
-            self.sf_dtype,
-        )
-        atom_shape = (4, 2, 1)
+        if cutlass.const_expr(self.a_dtype == cutlass.Float8E4M3FN):
+            mma_op = cute.nvgpu.warp.MmaMXF8Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        else:
+            mma_op = cute.nvgpu.warp.MmaMXF4NVF4Op(
+                self.a_dtype,
+                self.acc_dtype,
+                self.sf_dtype,
+            )
+        atom_shape = self.atom_shape
         atom_layout = cute.make_layout(atom_shape)
         permutation_mnk = sm120_utils.get_permutation_mnk(
-            self.tile_shape_mnk, self.sf_vec_size, False
+            self.mma_tile_shape_mnk,
+            self.sf_vec_size,
+            cutlass.const_expr(self.a_dtype == cutlass.Float8E4M3FN),
         )
         self.tiled_mma = cute.make_tiled_mma(
             mma_op,
@@ -159,11 +391,11 @@ class DenseGemmKernel:
         # Bare atom for manual unroll workaround (avoids hasAuxTensor address space bug)
         self.mma_atom = cute.make_mma_atom(mma_op)
         # Compute atom loop bounds from tile shape and atom/layout shape
-        # MMA atom: m16, n8, k64; atom_layout: (4,2,1) -> group: m64, n16, k64
-        mma_m, mma_n, mma_k = 16, 8, 64
-        self.num_m_tiles = self.tile_shape_mnk[0] // (mma_m * atom_shape[0])
-        self.num_n_tiles = self.tile_shape_mnk[1] // (mma_n * atom_shape[1])
-        self.num_k_blocks = self.tile_shape_mnk[2] // mma_k
+        # MMA atom: m16n8k64 for FP4, m16n8k32 for MXFP8.
+        mma_m, mma_n, mma_k = 16, 8, self.mma_k
+        self.num_m_tiles = self.mma_tile_shape_mnk[0] // (mma_m * atom_shape[0])
+        self.num_n_tiles = self.mma_tile_shape_mnk[1] // (mma_n * atom_shape[1])
+        self.num_k_blocks = self.mma_tile_shape_mnk[2] // mma_k
 
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
 
@@ -284,13 +516,17 @@ class DenseGemmKernel:
             (self.tile_shape_mnk[1], self.tile_shape_mnk[2]),
             1,
         )
-        tma_atom_sfa, tma_tensor_sfa = self._make_tma_atoms_and_tensors(
-            sfa_tensor,
-            self.sfa_smem_layout_staged,
-            self.sfa_tile_shape_mk,
-            1,
-            internal_type=cutlass.Int16,
-        )
+        if cutlass.const_expr(self.use_m1_non_tma_sfa):
+            tma_atom_sfa = tma_atom_b
+            tma_tensor_sfa = sfa_tensor
+        else:
+            tma_atom_sfa, tma_tensor_sfa = self._make_tma_atoms_and_tensors(
+                sfa_tensor,
+                self.sfa_smem_layout_staged,
+                self.sfa_tile_shape_mk,
+                1,
+                internal_type=cutlass.Int16,
+            )
         tma_atom_sfb, tma_tensor_sfb = self._make_tma_atoms_and_tensors(
             sfb_tensor,
             self.sfb_smem_layout_staged,
@@ -308,6 +544,8 @@ class DenseGemmKernel:
             c,
             self.tile_shape_mnk,
             max_active_clusters,
+            self.direct_one_m_tile_scheduler,
+            self.split_k_slices,
         )
 
         @cute.struct
@@ -351,14 +589,19 @@ class DenseGemmKernel:
         self.kernel(
             tma_atom_a,
             tma_tensor_a,
+            a,
             tma_atom_b,
             tma_tensor_b,
+            b,
             tma_atom_sfa,
             tma_tensor_sfa,
+            sfa_tensor,
             tma_atom_sfb,
             tma_tensor_sfb,
+            sfb_tensor,
             tma_atom_c,
             tma_tensor_c,
+            c,
             self.tiled_mma,
             self.mma_atom,
             self.cta_layout_mnk,
@@ -543,20 +786,135 @@ class DenseGemmKernel:
         layout_tv = cute.composition(layout_tv, (thridx_2_thrid, None))
         return layout_tv
 
+    @cute.jit
+    def _make_cpasync_tiled_copy(
+        self,
+        dtype: cutlass.Constexpr,
+        tile_cols: cutlass.Constexpr[int],
+    ) -> cute.TiledCopy:
+        copy_bits = 128
+        atom_async_copy = cute.make_copy_atom(
+            cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+            dtype,
+            num_bits_per_copy=copy_bits,
+        )
+        async_copy_elems = copy_bits // dtype.width
+        t_shape_dim_1 = tile_cols // async_copy_elems
+        assert self.num_threads_per_warp % t_shape_dim_1 == 0
+        t_layout = cute.make_ordered_layout(
+            (self.num_threads_per_warp // t_shape_dim_1, t_shape_dim_1),
+            order=(1, 0),
+        )
+        v_layout = cute.make_layout((1, async_copy_elems))
+        return cute.make_tiled_copy_tv(atom_async_copy, t_layout, v_layout)
+
+    @cute.jit
+    def _make_scale_tiled_copy(
+        self,
+        dtype: cutlass.Constexpr,
+    ) -> cute.TiledCopy:
+        copy_bits = dtype.width
+        atom_async_copy = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            dtype,
+            num_bits_per_copy=copy_bits,
+        )
+        return cute.make_tiled_copy_tv(
+            atom_async_copy,
+            cute.make_layout((self.num_threads_per_warp,)),
+            cute.make_layout((copy_bits // dtype.width,)),
+        )
+
+    @cute.jit
+    def _predicate_cpasync_rows(
+        self,
+        tCc: cute.Tensor,
+        row_limit: Int32,
+    ) -> cute.Tensor:
+        tPred = cute.make_fragment(
+            cute.make_layout(
+                (
+                    cute.size(tCc, mode=[0, 1]),
+                    cute.size(tCc, mode=[1]),
+                    cute.size(tCc, mode=[2]),
+                ),
+                stride=(cute.size(tCc, mode=[2]), 0, 1),
+            ),
+            cutlass.Boolean,
+        )
+        for rest_v in cutlass.range_constexpr(tPred.shape[0]):
+            for rest_k in cutlass.range_constexpr(tPred.shape[2]):
+                tPred[rest_v, 0, rest_k] = (
+                    tCc[(0, rest_v), 0, rest_k][0] < row_limit
+                )
+        return tPred
+
+    @cute.jit
+    def _cpasync_copy_2d(
+        self,
+        tiled_copy: cute.TiledCopy,
+        tG: cute.Tensor,
+        tS: cute.Tensor,
+        tC: cute.Tensor,
+        row_limit: Int32,
+        predicate_rows: cutlass.Constexpr[bool],
+    ) -> None:
+        if cutlass.const_expr(predicate_rows):
+            tP = self._predicate_cpasync_rows(tC, row_limit)
+        for rest_m in cutlass.range_constexpr(cute.size(tS.shape[1])):
+            if cutlass.const_expr(predicate_rows):
+                cute.copy(
+                    tiled_copy,
+                    tG[None, rest_m, None],
+                    tS[None, rest_m, None],
+                    pred=tP[None, rest_m, None],
+                )
+            else:
+                cute.copy(
+                    tiled_copy,
+                    tG[None, rest_m, None],
+                    tS[None, rest_m, None],
+                )
+
+    @cute.jit
+    def _scale_copy_2d(
+        self,
+        tiled_copy: cute.TiledCopy,
+        tG: cute.Tensor,
+        tS: cute.Tensor,
+        tC: cute.Tensor,
+        row_limit: Int32,
+    ) -> None:
+        tP = cute.make_fragment(cute.make_layout(tS.shape), cutlass.Boolean)
+        for i in cutlass.range_constexpr(cute.size(tP)):
+            tP[i] = cute.elem_less(tC[i][0][0][0], row_limit)
+        for rest_m in cutlass.range_constexpr(cute.size(tS.shape[1])):
+            cute.copy(
+                tiled_copy,
+                tG[None, rest_m, None],
+                tS[None, rest_m, None],
+                pred=tP[None, rest_m, None],
+            )
+
     # GPU device kernel
     @cute.kernel
     def kernel(
         self,
         tma_atom_a: cute.CopyAtom,
         mA_mkl: cute.Tensor,
+        directA_mkl: cute.Tensor,
         tma_atom_b: cute.CopyAtom,
         mB_nkl: cute.Tensor,
+        directB_nkl: cute.Tensor,
         tma_atom_sfa: cute.CopyAtom,
         mSFA_mkl: cute.Tensor,
+        directSFA_mkl: cute.Tensor,
         tma_atom_sfb: cute.CopyAtom,
         mSFB_nkl: cute.Tensor,
+        directSFB_nkl: cute.Tensor,
         tma_atom_c: cute.CopyAtom,
         mC_mnl: cute.Tensor,
+        directC_mnl: cute.Tensor,
         tiled_mma: cute.TiledMma,
         mma_atom: cute.MmaAtom,
         cta_layout_mnk: cute.Layout,
@@ -578,11 +936,16 @@ class DenseGemmKernel:
 
         # Prefetch TMA descriptors
         if warp_idx == 0:
-            cpasync.prefetch_descriptor(tma_atom_a)
-            cpasync.prefetch_descriptor(tma_atom_b)
-            cpasync.prefetch_descriptor(tma_atom_sfa)
-            cpasync.prefetch_descriptor(tma_atom_sfb)
-            cpasync.prefetch_descriptor(tma_atom_c)
+            if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_a):
+                cpasync.prefetch_descriptor(tma_atom_a)
+            if cutlass.const_expr(self.load_path == "tma"):
+                cpasync.prefetch_descriptor(tma_atom_b)
+            if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_sfa):
+                cpasync.prefetch_descriptor(tma_atom_sfa)
+            if cutlass.const_expr(self.load_path == "tma"):
+                cpasync.prefetch_descriptor(tma_atom_sfb)
+            if cutlass.const_expr(not self.use_m1_non_tma_c):
+                cpasync.prefetch_descriptor(tma_atom_c)
 
         cta_rank_in_cluster = cute.arch.make_warp_uniform(
             cute.arch.block_idx_in_cluster()
@@ -593,12 +956,20 @@ class DenseGemmKernel:
         b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, 0))
         sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, 0))
         sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, 0))
-        tma_copy_bytes = (
-            cute.size_in_bytes(self.a_dtype, a_smem_layout)
-            + cute.size_in_bytes(self.b_dtype, b_smem_layout)
-            + cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
-            + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
-        )
+        if cutlass.const_expr(self.use_m1_non_tma_sfa):
+            tma_copy_bytes = (
+                cute.size_in_bytes(self.b_dtype, b_smem_layout)
+                + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+            )
+            if cutlass.const_expr(not self.use_m1_non_tma_a):
+                tma_copy_bytes += cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        else:
+            tma_copy_bytes = (
+                cute.size_in_bytes(self.a_dtype, a_smem_layout)
+                + cute.size_in_bytes(self.b_dtype, b_smem_layout)
+                + cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+                + cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+            )
 
         # Allocate shared memory
         smem = cutlass.utils.SmemAllocator()
@@ -614,14 +985,30 @@ class DenseGemmKernel:
         )
 
         cta_layout_vmnk = cute.make_layout((1, *cta_layout_mnk.shape))
-        mainloop_pipeline = pipeline.PipelineTmaAsync.create(
-            num_stages=self.ab_stage,
-            producer_group=mainloop_pipeline_producer_group,
-            consumer_group=mainloop_pipeline_consumer_group,
-            tx_count=tma_copy_bytes,
-            barrier_storage=mainloop_pipeline_array_ptr,
-            cta_layout_vmnk=cta_layout_vmnk,
-        )
+        if cutlass.const_expr(self.load_path == "cpasync"):
+            mainloop_pipeline_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_threads_per_warp,
+            )
+            mainloop_pipeline_consumer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.num_mma_warps * self.num_threads_per_warp,
+            )
+            mainloop_pipeline = pipeline.PipelineAsync.create(
+                num_stages=self.ab_stage,
+                producer_group=mainloop_pipeline_producer_group,
+                consumer_group=mainloop_pipeline_consumer_group,
+                barrier_storage=mainloop_pipeline_array_ptr,
+            )
+        else:
+            mainloop_pipeline = pipeline.PipelineTmaAsync.create(
+                num_stages=self.ab_stage,
+                producer_group=mainloop_pipeline_producer_group,
+                consumer_group=mainloop_pipeline_consumer_group,
+                tx_count=tma_copy_bytes,
+                barrier_storage=mainloop_pipeline_array_ptr,
+                cta_layout_vmnk=cta_layout_vmnk,
+            )
 
         if cute.size(self.cluster_shape_mnk) > 1:
             cute.arch.cluster_arrive_relaxed()
@@ -650,16 +1037,38 @@ class DenseGemmKernel:
             cute.slice_(self.tile_shape_mnk, (0, None, None)),
             (None, None, None),
         )
-        gSFA_mkl = cute.local_tile(
-            mSFA_mkl,
-            self.sfa_tile_shape_mk,
-            (None, None, None),
-        )
+        if cutlass.const_expr(not self.use_m1_non_tma_sfa):
+            gSFA_mkl = cute.local_tile(
+                mSFA_mkl,
+                self.sfa_tile_shape_mk,
+                (None, None, None),
+            )
         gSFB_nkl = cute.local_tile(
             mSFB_nkl,
             self.sfb_tile_shape_nk,
             (None, None, None),
         )
+        if cutlass.const_expr(self.load_path == "cpasync"):
+            gA_cpasync_mkl = cute.local_tile(
+                directA_mkl,
+                cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                (None, None, None),
+            )
+            gB_cpasync_nkl = cute.local_tile(
+                directB_nkl,
+                cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                (None, None, None),
+            )
+            gSFA_cpasync_mkl = cute.local_tile(
+                directSFA_mkl,
+                self.sfa_tile_shape_mk,
+                (None, None, None),
+            )
+            gSFB_cpasync_nkl = cute.local_tile(
+                directSFB_nkl,
+                self.sfb_tile_shape_nk,
+                (None, None, None),
+            )
         gC_mnl = cute.local_tile(
             mC_mnl,
             cute.slice_(self.tile_shape_mnk, (None, None, 0)),
@@ -672,57 +1081,125 @@ class DenseGemmKernel:
         # TMA partitions for A
         a_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (0, None, 0)).shape)
         a_cta_crd = cluster_coord_mnk[1]
-        tAsA, tAgA = cpasync.tma_partition(
-            tma_atom_a,
-            a_cta_crd,
-            a_cta_layout,
-            cute.group_modes(sA, 0, 2),
-            cute.group_modes(gA_mkl, 0, 2),
-        )
+        if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_a):
+            tAsA, tAgA = cpasync.tma_partition(
+                tma_atom_a,
+                a_cta_crd,
+                a_cta_layout,
+                cute.group_modes(sA, 0, 2),
+                cute.group_modes(gA_mkl, 0, 2),
+            )
 
         # TMA partitions for B
         b_cta_layout = cute.make_layout(cute.slice_(cta_layout_mnk, (None, 0, 0)).shape)
         b_cta_crd = cluster_coord_mnk[0]
-        tBsB, tBgB = cpasync.tma_partition(
-            tma_atom_b,
-            b_cta_crd,
-            b_cta_layout,
-            cute.group_modes(sB, 0, 2),
-            cute.group_modes(gB_nkl, 0, 2),
-        )
+        if cutlass.const_expr(self.load_path == "tma"):
+            tBsB, tBgB = cpasync.tma_partition(
+                tma_atom_b,
+                b_cta_crd,
+                b_cta_layout,
+                cute.group_modes(sB, 0, 2),
+                cute.group_modes(gB_nkl, 0, 2),
+            )
 
         # TMA partitions for SFA
-        tAsSFA, tAgSFA = cpasync.tma_partition(
-            tma_atom_sfa,
-            a_cta_crd,
-            a_cta_layout,
-            cute.group_modes(sSFA, 0, 2),
-            cute.group_modes(gSFA_mkl, 0, 2),
-        )
-        tAsSFA = cute.filter_zeros(tAsSFA)
-        tAgSFA = cute.filter_zeros(tAgSFA)
+        if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_sfa):
+            tAsSFA, tAgSFA = cpasync.tma_partition(
+                tma_atom_sfa,
+                a_cta_crd,
+                a_cta_layout,
+                cute.group_modes(sSFA, 0, 2),
+                cute.group_modes(gSFA_mkl, 0, 2),
+            )
+            tAsSFA = cute.filter_zeros(tAsSFA)
+            tAgSFA = cute.filter_zeros(tAgSFA)
 
         # TMA partitions for SFB
-        tBsSFB, tBgSFB = cpasync.tma_partition(
-            tma_atom_sfb,
-            b_cta_crd,
-            b_cta_layout,
-            cute.group_modes(sSFB, 0, 2),
-            cute.group_modes(gSFB_nkl, 0, 2),
-        )
-        tBsSFB = cute.filter_zeros(tBsSFB)
-        tBgSFB = cute.filter_zeros(tBgSFB)
+        if cutlass.const_expr(self.load_path == "tma"):
+            tBsSFB, tBgSFB = cpasync.tma_partition(
+                tma_atom_sfb,
+                b_cta_crd,
+                b_cta_layout,
+                cute.group_modes(sSFB, 0, 2),
+                cute.group_modes(gSFB_nkl, 0, 2),
+            )
+            tBsSFB = cute.filter_zeros(tBsSFB)
+            tBgSFB = cute.filter_zeros(tBgSFB)
 
-        # Make fragments
-        tCsA = thr_mma.partition_A(sA)
-        tCsB = thr_mma.partition_B(sB)
+        if cutlass.const_expr(self.load_path == "cpasync"):
+            cpasync_tiled_copy_A = self._make_cpasync_tiled_copy(
+                self.a_dtype,
+                self.tile_shape_mnk[2],
+            )
+            cpasync_tiled_copy_B = self._make_cpasync_tiled_copy(
+                self.b_dtype,
+                self.tile_shape_mnk[2],
+            )
+            cpasync_tiled_copy_SF = self._make_scale_tiled_copy(self.sf_dtype)
+            cA_mkl = cute.make_identity_tensor(cute.shape(directA_mkl))
+            cA_cpasync_mkl = cute.local_tile(
+                cA_mkl,
+                cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                (None, None, None),
+            )
+            cB_nkl = cute.make_identity_tensor(cute.shape(directB_nkl))
+            cB_cpasync_nkl = cute.local_tile(
+                cB_nkl,
+                cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                (None, None, None),
+            )
+            cSFA_mkl = cute.make_identity_tensor(cute.shape(directSFA_mkl))
+            cSFA_cpasync_mkl = cute.local_tile(
+                cSFA_mkl,
+                self.sfa_tile_shape_mk,
+                (None, None, None),
+            )
+            cSFB_nkl = cute.make_identity_tensor(cute.shape(directSFB_nkl))
+            cSFB_cpasync_nkl = cute.local_tile(
+                cSFB_nkl,
+                self.sfb_tile_shape_nk,
+                (None, None, None),
+            )
+
+            cpasync_lane = tidx % self.num_threads_per_warp
+            thr_cpasync_A = cpasync_tiled_copy_A.get_slice(cpasync_lane)
+            thr_cpasync_B = cpasync_tiled_copy_B.get_slice(cpasync_lane)
+            thr_cpasync_SF = cpasync_tiled_copy_SF.get_slice(cpasync_lane)
+            tAgA_cpasync_mkl = thr_cpasync_A.partition_S(gA_cpasync_mkl)
+            tAsA_cpasync = thr_cpasync_A.partition_D(sA)
+            tAcA_cpasync_mkl = thr_cpasync_A.partition_S(cA_cpasync_mkl)
+            tBgB_cpasync_nkl = thr_cpasync_B.partition_S(gB_cpasync_nkl)
+            tBsB_cpasync = thr_cpasync_B.partition_D(sB)
+            tBcB_cpasync_nkl = thr_cpasync_B.partition_S(cB_cpasync_nkl)
+            tAgSFA_cpasync_mkl = thr_cpasync_SF.partition_S(gSFA_cpasync_mkl)
+            tAsSFA_cpasync = thr_cpasync_SF.partition_D(sSFA)
+            tAcSFA_cpasync_mkl = thr_cpasync_SF.partition_S(cSFA_cpasync_mkl)
+            tBgSFB_cpasync_nkl = thr_cpasync_SF.partition_S(gSFB_cpasync_nkl)
+            tBsSFB_cpasync = thr_cpasync_SF.partition_D(sSFB)
+            tBcSFB_cpasync_nkl = thr_cpasync_SF.partition_S(cSFB_cpasync_nkl)
+
+        # Make fragments. swap_ab keeps public C[M,N] unchanged but presents
+        # B as MMA-A and A as MMA-B.
+        if cutlass.const_expr(self.swap_ab):
+            tCsA = thr_mma.partition_A(sB)
+            tCsB = thr_mma.partition_B(sA)
+        else:
+            tCsA = thr_mma.partition_A(sA)
+            tCsB = thr_mma.partition_B(sB)
 
         tCrA = tiled_mma.make_fragment_A(tCsA[None, None, None, 0])
         tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
-        tCrSFA_full = self._partition_fragment_SFA(sSFA[None, None, 0], thr_mma, tidx)
-        tCrSFB_full = self._partition_fragment_SFB(sSFB[None, None, 0], thr_mma, tidx)
-
-        tCgC = thr_mma.partition_C(gC_mnl)
+        if cutlass.const_expr(self.swap_ab):
+            tCrSFA_full = self._partition_fragment_SFA(sSFB[None, None, 0], thr_mma, tidx)
+            tCrSFB_full = self._partition_fragment_SFB(sSFA[None, None, 0], thr_mma, tidx)
+            c_mma = cute.make_identity_tensor(
+                (self.tile_shape_mnk[1], self.tile_shape_mnk[0])
+            )
+            tCgC = thr_mma.partition_C(c_mma)
+        else:
+            tCrSFA_full = self._partition_fragment_SFA(sSFA[None, None, 0], thr_mma, tidx)
+            tCrSFB_full = self._partition_fragment_SFB(sSFB[None, None, 0], thr_mma, tidx)
+            tCgC = thr_mma.partition_C(gC_mnl)
         acc_shape = tCgC.shape[:3]
         accumulators = cute.make_rmem_tensor(acc_shape, self.acc_dtype)
 
@@ -733,12 +1210,28 @@ class DenseGemmKernel:
             cute.arch.sync_threads()
 
         k_tile_cnt = cute.size(gA_mkl, mode=[3])
+        block_idx = cute.arch.block_idx()
+        k_tile_start = Int32(0)
+        k_tile_iter_cnt = k_tile_cnt
+        if cutlass.const_expr(self.split_k_slices > 1):
+            k_tiles_per_split = k_tile_cnt // self.split_k_slices
+            k_tile_start = Int32(block_idx[1]) * Int32(k_tiles_per_split)
+            k_tile_iter_cnt = k_tiles_per_split
 
         # Tile scheduler
-        tile_sched = utils.StaticPersistentTileScheduler.create(
-            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
-        )
-        work_tile = tile_sched.initial_work_tile_info()
+        if cutlass.const_expr(self.direct_one_m_tile_scheduler):
+            direct_tile_valid = Int32(block_idx[2]) < Int32(
+                tile_sched_params.problem_shape_ntile_mnl[1]
+            )
+            work_tile = WorkTileInfo(
+                (Int32(0), Int32(block_idx[2]), Int32(0)),
+                direct_tile_valid,
+            )
+        else:
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, block_idx, cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
 
         # Pipeline states
         mainloop_producer_state = pipeline.make_pipeline_state(
@@ -755,14 +1248,24 @@ class DenseGemmKernel:
             num_k_blocks = cute.size(tCrA, mode=[2])
 
             # Copy atoms for SMEM->RMEM
-            atom_copy_ldmatrix_A = cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
-                self.a_dtype,
-            )
-            atom_copy_ldmatrix_B = cute.make_copy_atom(
-                cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
-                self.b_dtype,
-            )
+            if cutlass.const_expr(self.swap_ab):
+                atom_copy_ldmatrix_A = cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+                    self.b_dtype,
+                )
+                atom_copy_ldmatrix_B = cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+                    self.a_dtype,
+                )
+            else:
+                atom_copy_ldmatrix_A = cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(self.a_layout.is_m_major_a(), 4),
+                    self.a_dtype,
+                )
+                atom_copy_ldmatrix_B = cute.make_copy_atom(
+                    cute.nvgpu.warp.LdMatrix8x8x16bOp(self.b_layout.is_n_major_b(), 4),
+                    self.b_dtype,
+                )
             smem_tiled_copy_A = cute.make_tiled_copy_A(atom_copy_ldmatrix_A, tiled_mma)
             smem_tiled_copy_B = cute.make_tiled_copy_B(atom_copy_ldmatrix_B, tiled_mma)
 
@@ -789,16 +1292,24 @@ class DenseGemmKernel:
 
             thr_copy_ldmatrix_A = smem_tiled_copy_A.get_slice(tidx)
             thr_copy_ldmatrix_B = smem_tiled_copy_B.get_slice(tidx)
-            tCsA_copy_view = thr_copy_ldmatrix_A.partition_S(sA)
+            tCsA_copy_view = thr_copy_ldmatrix_A.partition_S(
+                sB if cutlass.const_expr(self.swap_ab) else sA
+            )
             tCrA_copy_view = thr_copy_ldmatrix_A.retile(tCrA)
-            tCsB_copy_view = thr_copy_ldmatrix_B.partition_S(sB)
+            tCsB_copy_view = thr_copy_ldmatrix_B.partition_S(
+                sA if cutlass.const_expr(self.swap_ab) else sB
+            )
             tCrB_copy_view = thr_copy_ldmatrix_B.retile(tCrB)
 
             thr_copy_ldmatrix_SFA = smem_tiled_copy_SFA.get_slice(tidx)
             thr_copy_ldmatrix_SFB = smem_tiled_copy_SFB.get_slice(tidx)
-            tCsSFA_copy_view_full = thr_copy_ldmatrix_SFA.partition_S(sSFA)
+            tCsSFA_copy_view_full = thr_copy_ldmatrix_SFA.partition_S(
+                sSFB if cutlass.const_expr(self.swap_ab) else sSFA
+            )
             tCrSFA_copy_view_full = thr_copy_ldmatrix_SFA.retile(tCrSFA_full)
-            tCsSFB_copy_view_full = thr_copy_ldmatrix_SFB.partition_S(sSFB)
+            tCsSFB_copy_view_full = thr_copy_ldmatrix_SFB.partition_S(
+                sSFA if cutlass.const_expr(self.swap_ab) else sSFB
+            )
             tCrSFB_copy_view_full = thr_copy_ldmatrix_SFB.retile(tCrSFB_full)
 
             while work_tile.is_valid_tile:
@@ -806,43 +1317,91 @@ class DenseGemmKernel:
                 gC_mnl_slice = gC_mnl[(None, None, *tile_coord_mnl)]
                 sfa_tile_offset = tile_coord_mnl[0] % self.sfa_tiles_per_block
                 sfb_tile_offset = tile_coord_mnl[1] % self.sfb_tiles_per_block
-                if cutlass.const_expr(self.sfa_tiles_per_block > 1):
-                    sSFA_tile = cute.local_tile(
-                        sSFA,
-                        cute.slice_(self.tile_shape_mnk, (None, 0, None)),
-                        (sfa_tile_offset, 0, None),
-                    )
-                    tCsSFA_tile_copy_view = thr_copy_ldmatrix_SFA.partition_S(sSFA_tile)
-                    tCrSFA_tile = self._partition_fragment_SFA(
-                        sSFA_tile[None, None, 0], thr_mma, tidx
-                    )
-                    tCrSFA_tile_copy_view = thr_copy_ldmatrix_SFA.retile(tCrSFA_tile)
+                if cutlass.const_expr(self.swap_ab):
+                    if cutlass.const_expr(self.sfb_tiles_per_block > 1):
+                        sSFB_tile = cute.local_tile(
+                            sSFB,
+                            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                            (sfb_tile_offset, 0, None),
+                        )
+                        tCsSFA_tile_copy_view = (
+                            thr_copy_ldmatrix_SFA.partition_S(sSFB_tile)
+                        )
+                        tCrSFA_tile = self._partition_fragment_SFA(
+                            sSFB_tile[None, None, 0], thr_mma, tidx
+                        )
+                        tCrSFA_tile_copy_view = thr_copy_ldmatrix_SFA.retile(
+                            tCrSFA_tile
+                        )
+                    else:
+                        tCsSFA_tile_copy_view = tCsSFA_copy_view_full
+                        tCrSFA_tile = tCrSFA_full
+                        tCrSFA_tile_copy_view = tCrSFA_copy_view_full
+                    if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                        sSFA_tile = cute.local_tile(
+                            sSFA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (sfa_tile_offset, 0, None),
+                        )
+                        tCsSFB_tile_copy_view = (
+                            thr_copy_ldmatrix_SFB.partition_S(sSFA_tile)
+                        )
+                        tCrSFB_tile = self._partition_fragment_SFB(
+                            sSFA_tile[None, None, 0], thr_mma, tidx
+                        )
+                        tCrSFB_tile_copy_view = thr_copy_ldmatrix_SFB.retile(
+                            tCrSFB_tile
+                        )
+                    else:
+                        tCsSFB_tile_copy_view = tCsSFB_copy_view_full
+                        tCrSFB_tile = tCrSFB_full
+                        tCrSFB_tile_copy_view = tCrSFB_copy_view_full
                 else:
-                    tCsSFA_tile_copy_view = tCsSFA_copy_view_full
-                    tCrSFA_tile = tCrSFA_full
-                    tCrSFA_tile_copy_view = tCrSFA_copy_view_full
-                if cutlass.const_expr(self.sfb_tiles_per_block > 1):
-                    sSFB_tile = cute.local_tile(
-                        sSFB,
-                        cute.slice_(self.tile_shape_mnk, (0, None, None)),
-                        (sfb_tile_offset, 0, None),
-                    )
-                    tCsSFB_tile_copy_view = thr_copy_ldmatrix_SFB.partition_S(sSFB_tile)
-                    tCrSFB_tile = self._partition_fragment_SFB(
-                        sSFB_tile[None, None, 0], thr_mma, tidx
-                    )
-                    tCrSFB_tile_copy_view = thr_copy_ldmatrix_SFB.retile(tCrSFB_tile)
-                else:
-                    tCsSFB_tile_copy_view = tCsSFB_copy_view_full
-                    tCrSFB_tile = tCrSFB_full
-                    tCrSFB_tile_copy_view = tCrSFB_copy_view_full
+                    if cutlass.const_expr(self.sfa_tiles_per_block > 1):
+                        sSFA_tile = cute.local_tile(
+                            sSFA,
+                            cute.slice_(self.tile_shape_mnk, (None, 0, None)),
+                            (sfa_tile_offset, 0, None),
+                        )
+                        tCsSFA_tile_copy_view = (
+                            thr_copy_ldmatrix_SFA.partition_S(sSFA_tile)
+                        )
+                        tCrSFA_tile = self._partition_fragment_SFA(
+                            sSFA_tile[None, None, 0], thr_mma, tidx
+                        )
+                        tCrSFA_tile_copy_view = thr_copy_ldmatrix_SFA.retile(
+                            tCrSFA_tile
+                        )
+                    else:
+                        tCsSFA_tile_copy_view = tCsSFA_copy_view_full
+                        tCrSFA_tile = tCrSFA_full
+                        tCrSFA_tile_copy_view = tCrSFA_copy_view_full
+                    if cutlass.const_expr(self.sfb_tiles_per_block > 1):
+                        sSFB_tile = cute.local_tile(
+                            sSFB,
+                            cute.slice_(self.tile_shape_mnk, (0, None, None)),
+                            (sfb_tile_offset, 0, None),
+                        )
+                        tCsSFB_tile_copy_view = (
+                            thr_copy_ldmatrix_SFB.partition_S(sSFB_tile)
+                        )
+                        tCrSFB_tile = self._partition_fragment_SFB(
+                            sSFB_tile[None, None, 0], thr_mma, tidx
+                        )
+                        tCrSFB_tile_copy_view = thr_copy_ldmatrix_SFB.retile(
+                            tCrSFB_tile
+                        )
+                    else:
+                        tCsSFB_tile_copy_view = tCsSFB_copy_view_full
+                        tCrSFB_tile = tCrSFB_full
+                        tCrSFB_tile_copy_view = tCrSFB_copy_view_full
                 accumulators.fill(0.0)
 
                 # Pipelined MAINLOOP
                 mainloop_consumer_state.reset_count()
 
                 peek_ab_full_status = cutlass.Boolean(1)
-                if mainloop_consumer_state.count < k_tile_cnt:
+                if mainloop_consumer_state.count < k_tile_iter_cnt:
                     peek_ab_full_status = mainloop_pipeline.consumer_try_wait(
                         mainloop_consumer_state
                     )
@@ -885,7 +1444,7 @@ class DenseGemmKernel:
                     tCrSFB_copy_view_filtered[None, None, 0],
                 )
 
-                for _k_tile in range(0, k_tile_cnt - 1, 1, unroll=2):  # type: ignore[call-overload]
+                for k_tile in range(0, k_tile_iter_cnt - 1, 1, unroll=2):
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                         k_block_next = (
                             0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
@@ -947,12 +1506,8 @@ class DenseGemmKernel:
 
                         tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
                         tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
-                        tCrSFA_copy_view_filtered = cute.filter_zeros(
-                            tCrSFA_tile_copy_view
-                        )
-                        tCrSFB_copy_view_filtered = cute.filter_zeros(
-                            tCrSFB_tile_copy_view
-                        )
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
                         cute.copy(
                             smem_tiled_copy_SFA,
                             tCsSFA_p_filtered[None, None, k_block_next],
@@ -987,12 +1542,8 @@ class DenseGemmKernel:
                         )
                         tCsSFA_p_filtered = cute.filter_zeros(tCsSFA_p)
                         tCsSFB_p_filtered = cute.filter_zeros(tCsSFB_p)
-                        tCrSFA_copy_view_filtered = cute.filter_zeros(
-                            tCrSFA_tile_copy_view
-                        )
-                        tCrSFB_copy_view_filtered = cute.filter_zeros(
-                            tCrSFB_tile_copy_view
-                        )
+                        tCrSFA_copy_view_filtered = cute.filter_zeros(tCrSFA_tile_copy_view)
+                        tCrSFB_copy_view_filtered = cute.filter_zeros(tCrSFB_tile_copy_view)
                         cute.copy(
                             smem_tiled_copy_SFA,
                             tCsSFA_p_filtered[None, None, k_block_next],
@@ -1022,200 +1573,659 @@ class DenseGemmKernel:
                                 accumulators[None, _mt, _nt],
                             )
 
-                # EPILOGUE
-                _is_m_major = self.c_layout.is_m_major_c()
-                if cutlass.const_expr(self.c_dtype.width == 16):
-                    copy_atom_r2s = cute.make_copy_atom(
-                        cute.nvgpu.warp.StMatrix8x8x16bOp(_is_m_major, 2),
-                        self.c_dtype,
+                if cutlass.const_expr(self.swap_ab):
+                    acc_mn = _reshape_acc_to_mn(accumulators, transpose=True)
+                    c_identity = cute.make_identity_tensor(
+                        (self.tile_shape_mnk[1], self.tile_shape_mnk[0])
                     )
-                else:
-                    copy_atom_r2s = cute.make_copy_atom(
-                        cute.nvgpu.CopyUniversalOp(),
-                        self.c_dtype,
+                    coord_mn = _reshape_acc_to_mn(
+                        thr_mma.partition_C(c_identity),
+                        transpose=True,
                     )
-
-                copy_atom_C = cute.make_copy_atom(
-                    cute.nvgpu.warp.StMatrix8x8x16bOp(
-                        self.c_layout.is_m_major_c(),
-                        2,
-                    ),
-                    self.c_dtype,
-                )
-
-                tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(copy_atom_C, tiled_mma)
-
-                tiled_copy_r2s = cute.make_tiled_copy_S(
-                    copy_atom_r2s,
-                    tiled_copy_C_Atom,
-                )
-
-                thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
-                tRS_sD = thr_copy_r2s.partition_D(sC)
-                tRS_rAcc = tiled_copy_r2s.retile(accumulators)
-
-                rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
-                tRS_rD_layout = cute.make_layout(rD_shape[:3])
-                tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
-
-                sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
-                tcgc_for_tma_partition = cute.zipped_divide(gC_mnl_slice, self.epi_tile)
-
-                bSG_sD, bSG_gD = cpasync.tma_partition(
-                    tma_atom_c,
-                    0,
-                    cute.make_layout(1),
-                    sepi_for_tma_partition,
-                    tcgc_for_tma_partition,
-                )
-
-                epi_rest_m = bSG_gD.shape[1][0]
-                epi_rest_n = bSG_gD.shape[1][1]
-                epi_tile_m = self.epi_tile[0]
-                epi_tile_n = self.epi_tile[1]
-                mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rAcc, mode=[1])
-                mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rAcc, mode=[2])
-                has_multi_epi_store = cutlass.const_expr(
-                    not (self.epi_stage == 1 and epi_rest_m == 1 and epi_rest_n == 1)
-                )
-                tma_store_producer_group = pipeline.CooperativeGroup(
-                    pipeline.Agent.Thread,
-                    self.num_mma_warps * self.num_threads_per_warp,
-                )
-                tma_store_pipeline = pipeline.PipelineTmaStore.create(
-                    num_stages=self.epi_stage,
-                    producer_group=tma_store_producer_group,
-                )
-
-                for epi_m in cutlass.range_constexpr(epi_rest_m):
-                    for epi_n in cutlass.range_constexpr(epi_rest_n):
-                        MmaMPerEpiM = epi_tile_m // mma_tile_m
-                        MmaNPerEpiN = epi_tile_n // mma_tile_n
-                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
-                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
-                                mma_n = (epi_n * MmaNPerEpiN) + mma_n_in_epi
-                                mma_m = (epi_m * MmaMPerEpiM) + mma_m_in_epi
-                                tRS_rD_slice = tRS_rD[
-                                    (None, mma_m_in_epi, mma_n_in_epi)
-                                ]
-                                tRS_rAcc_slice = tRS_rAcc[(None, mma_m, mma_n)]
-                                for elem_idx in cutlass.range_constexpr(
-                                    cute.size(tRS_rD_slice)
-                                ):
-                                    tRS_rD_slice[elem_idx] = tRS_rAcc_slice[elem_idx]
-
-                        # Type conversion with alpha scaling
-                        tRS_rD_out = cute.make_rmem_tensor(
-                            tRS_rD_layout.shape, self.c_dtype
-                        )
-                        acc_vec = tRS_rD.load()
-                        # Multiply alpha in FP32 before converting to c_dtype
-                        # to avoid overflow when c_dtype is FP16
-                        acc_vec = epilogue_op((alpha_value * acc_vec).to(self.c_dtype))
-                        tRS_rD_out.store(acc_vec)
-
-                        # Register to shared memory
-                        epi_buffer = (epi_m * epi_rest_n + epi_n) % cute.size(
-                            tRS_sD, mode=[3]
-                        )
-                        if has_multi_epi_store:
-                            self.epilog_sync_barrier.arrive_and_wait()
-                        cute.copy(
-                            tiled_copy_r2s,
-                            tRS_rD_out,
-                            tRS_sD[(None, None, None, epi_buffer)],
-                        )
-                        cute.arch.fence_proxy(
-                            "async.shared",
-                            space="cta",
-                        )
-                        self.epilog_sync_barrier.arrive_and_wait()
-
-                        # Copy from shared memory to global memory
-                        gmem_coord = (epi_m, epi_n)
-                        if warp_idx == 0:
-                            cute.copy(
-                                tma_atom_c,
-                                bSG_sD[(None, epi_buffer)],
-                                bSG_gD[(None, gmem_coord)],
+                    for acc_m in cutlass.range_constexpr(cute.size(acc_mn.shape[0])):
+                        for acc_n in cutlass.range_constexpr(cute.size(acc_mn.shape[1])):
+                            coord = coord_mn[acc_m, acc_n]
+                            m_coord = (
+                                tile_coord_mnl[0] * Int32(self.tile_shape_mnk[0])
+                                + coord[1]
                             )
-                            if has_multi_epi_store:
-                                tma_store_pipeline.producer_commit()
-                                tma_store_pipeline.producer_acquire()
+                            n_coord = (
+                                tile_coord_mnl[1] * Int32(self.tile_shape_mnk[1])
+                                + coord[0]
+                            )
+                            if (
+                                m_coord < Int32(directC_mnl.shape[0])
+                                and n_coord < Int32(directC_mnl.shape[1])
+                            ):
+                                directC_mnl[
+                                    (
+                                        m_coord,
+                                        n_coord,
+                                        tile_coord_mnl[2],
+                                    )
+                                ] = epilogue_op(
+                                    (alpha_value * acc_mn[acc_m, acc_n]).to(
+                                        self.c_dtype
+                                    )
+                                )
+                    if cutlass.const_expr(self.single_work_tile_per_cta):
+                        work_tile = WorkTileInfo(
+                            work_tile.tile_idx,
+                            cutlass.Boolean(0),
+                        )
+                    else:
+                        tile_sched.advance_to_next_work()
+                        work_tile = tile_sched.get_current_work()
 
-                # Advance to the next work tile
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
-                if has_multi_epi_store:
-                    tma_store_pipeline.producer_tail()
+                if cutlass.const_expr(not self.swap_ab):
+                    # EPILOGUE
+                    _is_m_major = self.c_layout.is_m_major_c()
+                    if cutlass.const_expr(self.c_dtype.width == 16):
+                        copy_atom_r2s = cute.make_copy_atom(
+                            cute.nvgpu.warp.StMatrix8x8x16bOp(_is_m_major, 2),
+                            self.c_dtype,
+                        )
+                    else:
+                        copy_atom_r2s = cute.make_copy_atom(
+                            cute.nvgpu.CopyUniversalOp(), self.c_dtype,
+                        )
 
-        # DMA warp group
+                    if cutlass.const_expr(self.c_dtype.width == 16):
+                        copy_atom_C = cute.make_copy_atom(
+                            cute.nvgpu.warp.StMatrix8x8x16bOp(
+                                self.c_layout.is_m_major_c(),
+                                2,
+                            ),
+                            self.c_dtype,
+                        )
+                    else:
+                        copy_atom_C = cute.make_copy_atom(
+                            cute.nvgpu.CopyUniversalOp(), self.c_dtype
+                        )
+
+                    tiled_copy_C_Atom = cute.make_tiled_copy_C_atom(
+                        copy_atom_C, tiled_mma
+                    )
+
+                    tiled_copy_r2s = cute.make_tiled_copy_S(
+                        copy_atom_r2s,
+                        tiled_copy_C_Atom,
+                    )
+
+                    thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+                    tRS_sD = thr_copy_r2s.partition_D(sC)
+                    tRS_rAcc = tiled_copy_r2s.retile(accumulators)
+
+                    rD_shape = cute.shape(thr_copy_r2s.partition_S(sC))
+                    tRS_rD_layout = cute.make_layout(rD_shape[:3])
+                    tRS_rD = cute.make_rmem_tensor(tRS_rD_layout.shape, self.acc_dtype)
+
+                    sepi_for_tma_partition = cute.group_modes(sC, 0, 2)
+                    tcgc_for_tma_partition = cute.zipped_divide(gC_mnl_slice, self.epi_tile)
+
+                    bSG_sD, bSG_gD = cpasync.tma_partition(
+                        tma_atom_c,
+                        0,
+                        cute.make_layout(1),
+                        sepi_for_tma_partition,
+                        tcgc_for_tma_partition,
+                    )
+
+                    epi_rest_m = bSG_gD.shape[1][0]
+                    epi_rest_n = bSG_gD.shape[1][1]
+                    epi_tile_m = self.epi_tile[0]
+                    epi_tile_n = self.epi_tile[1]
+                    mma_tile_m = self.tile_shape_mnk[0] // cute.size(tRS_rAcc, mode=[1])
+                    mma_tile_n = self.tile_shape_mnk[1] // cute.size(tRS_rAcc, mode=[2])
+                    has_multi_epi_store = cutlass.const_expr(
+                        not (self.epi_stage == 1 and epi_rest_m == 1 and epi_rest_n == 1)
+                    )
+                    tma_store_producer_group = pipeline.CooperativeGroup(
+                        pipeline.Agent.Thread,
+                        self.num_mma_warps * self.num_threads_per_warp,
+                    )
+                    tma_store_pipeline = pipeline.PipelineTmaStore.create(
+                        num_stages=self.epi_stage,
+                        producer_group=tma_store_producer_group,
+                    )
+
+                    for epi_m in cutlass.range_constexpr(epi_rest_m):
+                        for epi_n in cutlass.range_constexpr(epi_rest_n):
+                            MmaMPerEpiM = epi_tile_m // mma_tile_m
+                            MmaNPerEpiN = epi_tile_n // mma_tile_n
+                            for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                                for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
+                                    mma_n = (epi_n * MmaNPerEpiN) + mma_n_in_epi
+                                    mma_m = (epi_m * MmaMPerEpiM) + mma_m_in_epi
+                                    tRS_rD_slice = tRS_rD[
+                                        (None, mma_m_in_epi, mma_n_in_epi)
+                                    ]
+                                    tRS_rAcc_slice = tRS_rAcc[(None, mma_m, mma_n)]
+                                    for elem_idx in cutlass.range_constexpr(
+                                        cute.size(tRS_rD_slice)
+                                    ):
+                                        tRS_rD_slice[elem_idx] = tRS_rAcc_slice[elem_idx]
+
+                            gmem_coord = (epi_m, epi_n)
+                            if cutlass.const_expr(self.split_k_slices > 1):
+                                acc_mn = _reshape_acc_to_mn(accumulators)
+                                c_identity = cute.make_identity_tensor(
+                                    cute.slice_(self.tile_shape_mnk, (None, None, 0))
+                                )
+                                coord_mn = _reshape_acc_to_mn(
+                                    thr_mma.partition_C(c_identity)
+                                )
+                                if cutlass.const_expr(self.split_k_atomic_bf16):
+                                    for acc_m in cutlass.range_constexpr(
+                                        cute.size(acc_mn.shape[0])
+                                    ):
+                                        for acc_n_pair in cutlass.range_constexpr(
+                                            cute.size(acc_mn.shape[1]) // 2
+                                        ):
+                                            acc_n0 = acc_n_pair * 2
+                                            acc_n1 = acc_n0 + 1
+                                            coord0 = coord_mn[acc_m, acc_n0]
+                                            coord1 = coord_mn[acc_m, acc_n1]
+                                            m_coord0 = (
+                                                tile_coord_mnl[0]
+                                                * Int32(self.tile_shape_mnk[0])
+                                                + coord0[0]
+                                            )
+                                            n_coord0 = (
+                                                tile_coord_mnl[1]
+                                                * Int32(self.tile_shape_mnk[1])
+                                                + coord0[1]
+                                            )
+                                            m_coord1 = (
+                                                tile_coord_mnl[0]
+                                                * Int32(self.tile_shape_mnk[0])
+                                                + coord1[0]
+                                            )
+                                            n_coord1 = (
+                                                tile_coord_mnl[1]
+                                                * Int32(self.tile_shape_mnk[1])
+                                                + coord1[1]
+                                            )
+                                            if (
+                                                m_coord0 < Int32(directC_mnl.shape[0])
+                                                and m_coord1 < Int32(directC_mnl.shape[0])
+                                                and n_coord0
+                                                < Int32(directC_mnl.shape[1])
+                                                and n_coord1
+                                                < Int32(directC_mnl.shape[1])
+                                            ):
+                                                c_offset = cute.crd2idx(
+                                                    (
+                                                        m_coord0,
+                                                        n_coord0,
+                                                        Int32(0),
+                                                    ),
+                                                    directC_mnl.layout,
+                                                )
+                                                scatter_add_bf16x2(
+                                                    get_ptr_as_int64(
+                                                        directC_mnl,
+                                                        c_offset,
+                                                    ),
+                                                    alpha_value * acc_mn[acc_m, acc_n0],
+                                                    alpha_value * acc_mn[acc_m, acc_n1],
+                                                )
+                                        if cutlass.const_expr(
+                                            cute.size(acc_mn.shape[1]) % 2 == 1
+                                        ):
+                                            acc_n = cute.size(acc_mn.shape[1]) - 1
+                                            coord = coord_mn[acc_m, acc_n]
+                                            m_coord = (
+                                                tile_coord_mnl[0]
+                                                * Int32(self.tile_shape_mnk[0])
+                                                + coord[0]
+                                            )
+                                            n_coord = (
+                                                tile_coord_mnl[1]
+                                                * Int32(self.tile_shape_mnk[1])
+                                                + coord[1]
+                                            )
+                                            if (
+                                                m_coord < Int32(directC_mnl.shape[0])
+                                                and n_coord < Int32(directC_mnl.shape[1])
+                                            ):
+                                                c_offset = cute.crd2idx(
+                                                    (
+                                                        m_coord,
+                                                        n_coord,
+                                                        Int32(0),
+                                                    ),
+                                                    directC_mnl.layout,
+                                                )
+                                                scatter_add_bf16(
+                                                    get_ptr_as_int64(
+                                                        directC_mnl,
+                                                        c_offset,
+                                                    ),
+                                                    alpha_value * acc_mn[acc_m, acc_n],
+                                                )
+                                else:
+                                    split_idx = Int32(block_idx[1])
+                                    for acc_m in cutlass.range_constexpr(
+                                        cute.size(acc_mn.shape[0])
+                                    ):
+                                        for acc_n in cutlass.range_constexpr(
+                                            cute.size(acc_mn.shape[1])
+                                        ):
+                                            coord = coord_mn[acc_m, acc_n]
+                                            m_coord = (
+                                                tile_coord_mnl[0]
+                                                * Int32(self.tile_shape_mnk[0])
+                                                + coord[0]
+                                            )
+                                            n_coord = (
+                                                tile_coord_mnl[1]
+                                                * Int32(self.tile_shape_mnk[1])
+                                                + coord[1]
+                                            )
+                                            if (
+                                                m_coord < Int32(directC_mnl.shape[0])
+                                                and n_coord < Int32(directC_mnl.shape[1])
+                                            ):
+                                                directC_mnl[
+                                                    (m_coord, n_coord, split_idx)
+                                                ] = alpha_value * acc_mn[acc_m, acc_n]
+                            else:
+                                # Type conversion with alpha scaling
+                                tRS_rD_out = cute.make_rmem_tensor(
+                                    tRS_rD_layout.shape, self.c_dtype
+                                )
+                                acc_vec = tRS_rD.load()
+                                # Multiply alpha in FP32 before converting to c_dtype
+                                # to avoid overflow when c_dtype is FP16
+                                acc_vec = epilogue_op(
+                                    (alpha_value * acc_vec).to(self.c_dtype)
+                                )
+                                tRS_rD_out.store(acc_vec)
+
+                                # Register to shared memory
+                                epi_buffer = (epi_m * epi_rest_n + epi_n) % cute.size(
+                                    tRS_sD, mode=[3]
+                                )
+                                if has_multi_epi_store:
+                                    self.epilog_sync_barrier.arrive_and_wait()
+                                cute.copy(
+                                    tiled_copy_r2s,
+                                    tRS_rD_out,
+                                    tRS_sD[(None, None, None, epi_buffer)],
+                                )
+                                cute.arch.fence_proxy(
+                                    "async.shared",
+                                    space="cta",
+                                )
+                                self.epilog_sync_barrier.arrive_and_wait()
+
+                                # Copy from shared memory to global memory
+                                if cutlass.const_expr(self.use_m1_non_tma_c):
+                                    for n_iter in cutlass.range_constexpr(
+                                        (
+                                            self.epi_tile[1]
+                                            + self.num_mma_warps
+                                            * self.num_threads_per_warp
+                                            - 1
+                                        )
+                                        // (
+                                            self.num_mma_warps
+                                            * self.num_threads_per_warp
+                                        )
+                                    ):
+                                        n_local = Int32(tidx) + Int32(
+                                            n_iter
+                                            * self.num_mma_warps
+                                            * self.num_threads_per_warp
+                                        )
+                                        n_coord = (
+                                            tile_coord_mnl[1]
+                                            * Int32(self.tile_shape_mnk[1])
+                                            + Int32(epi_n * self.epi_tile[1])
+                                            + n_local
+                                        )
+                                        if (
+                                            n_local < Int32(self.epi_tile[1])
+                                            and n_coord < Int32(directC_mnl.shape[1])
+                                        ):
+                                            directC_mnl[
+                                                (
+                                                    Int32(0),
+                                                    n_coord,
+                                                    tile_coord_mnl[2],
+                                                )
+                                            ] = sC[(Int32(0), n_local, epi_buffer)]
+                                else:
+                                    if warp_idx == 0:
+                                        cute.copy(
+                                            tma_atom_c,
+                                            bSG_sD[(None, epi_buffer)],
+                                            bSG_gD[(None, gmem_coord)],
+                                        )
+                                        if has_multi_epi_store:
+                                            tma_store_pipeline.producer_commit()
+                                            tma_store_pipeline.producer_acquire()
+
+                    # Advance to the next work tile
+                    if cutlass.const_expr(self.single_work_tile_per_cta):
+                        work_tile = WorkTileInfo(
+                            work_tile.tile_idx,
+                            cutlass.Boolean(0),
+                        )
+                    else:
+                        tile_sched.advance_to_next_work()
+                        work_tile = tile_sched.get_current_work()
+                    if (
+                        has_multi_epi_store
+                        and cutlass.const_expr(self.split_k_slices == 1)
+                    ):
+                        tma_store_pipeline.producer_tail()
+
         elif warp_idx == self.tma_load_warp_id:
             cute.arch.setmaxregister_decrease(self.load_register_requirement)
 
             while work_tile.is_valid_tile:
                 tile_coord_mnl = work_tile.tile_idx
-                tAgA_mkl = tAgA[(None, tile_coord_mnl[0], None, tile_coord_mnl[2])]
-                tBgB_nkl = tBgB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
-                sfa_tile_coord_m = tile_coord_mnl[0] // self.sfa_tiles_per_block
-                tAgSFA_mkl = tAgSFA[(None, sfa_tile_coord_m, None, tile_coord_mnl[2])]
-                sfb_tile_coord_n = tile_coord_mnl[1] // self.sfb_tiles_per_block
-                tBgSFB_nkl = tBgSFB[(None, sfb_tile_coord_n, None, tile_coord_mnl[2])]
+                if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_a):
+                    tAgA_mkl = tAgA[
+                        (None, tile_coord_mnl[0], None, tile_coord_mnl[2])
+                    ]
+                if cutlass.const_expr(self.load_path == "tma"):
+                    tBgB_nkl = tBgB[(None, tile_coord_mnl[1], None, tile_coord_mnl[2])]
+                if cutlass.const_expr(self.load_path == "tma" and not self.use_m1_non_tma_sfa):
+                    sfa_tile_coord_m = tile_coord_mnl[0] // self.sfa_tiles_per_block
+                    tAgSFA_mkl = tAgSFA[
+                        (None, sfa_tile_coord_m, None, tile_coord_mnl[2])
+                    ]
+                if cutlass.const_expr(self.load_path == "tma"):
+                    sfb_tile_coord_n = tile_coord_mnl[1] // self.sfb_tiles_per_block
+                    tBgSFB_nkl = tBgSFB[(None, sfb_tile_coord_n, None, tile_coord_mnl[2])]
+                if cutlass.const_expr(self.load_path == "cpasync"):
+                    cpasync_sfa_tile_coord_m = (
+                        tile_coord_mnl[0] // self.sfa_tiles_per_block
+                    )
+                    cpasync_sfb_tile_coord_n = (
+                        tile_coord_mnl[1] // self.sfb_tiles_per_block
+                    )
 
                 mainloop_producer_state.reset_count()
 
-                for _k_tile in range(0, k_tile_cnt, 1, unroll=2):  # type: ignore[call-overload]
+                for k_tile in range(0, k_tile_iter_cnt, 1, unroll=2):
                     mainloop_pipeline.producer_acquire(mainloop_producer_state)
 
-                    tAgA_k = tAgA_mkl[(None, mainloop_producer_state.count)]
-                    tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
+                    k_tile_global = k_tile_start + mainloop_producer_state.count
+                    if cutlass.const_expr(self.load_path == "tma"):
+                        tBgB_k = tBgB_nkl[(None, k_tile_global)]
+                        tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+                        if cutlass.const_expr(not self.use_m1_non_tma_a):
+                            tAgA_k = tAgA_mkl[(None, k_tile_global)]
+                            tAsA_pipe = tAsA[(None, mainloop_producer_state.index)]
 
-                    tBgB_k = tBgB_nkl[(None, mainloop_producer_state.count)]
-                    tBsB_pipe = tBsB[(None, mainloop_producer_state.index)]
+                            tAgSFA_k = tAgSFA_mkl[(None, k_tile_global)]
+                            tAsSFA_pipe = tAsSFA[(None, mainloop_producer_state.index)]
 
-                    tAgSFA_k = tAgSFA_mkl[(None, mainloop_producer_state.count)]
-                    tAsSFA_pipe = tAsSFA[(None, mainloop_producer_state.index)]
+                        tBgSFB_k = tBgSFB_nkl[(None, k_tile_global)]
+                        tBsSFB_pipe = tBsSFB[(None, mainloop_producer_state.index)]
 
-                    tBgSFB_k = tBgSFB_nkl[(None, mainloop_producer_state.count)]
-                    tBsSFB_pipe = tBsSFB[(None, mainloop_producer_state.index)]
+                    if cutlass.const_expr(self.load_path == "cpasync"):
+                        tAgA_cpasync_k = tAgA_cpasync_mkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_coord_mnl[0],
+                                k_tile_global,
+                                tile_coord_mnl[2],
+                            )
+                        ]
+                        tAsA_cpasync_pipe = tAsA_cpasync[
+                            (None, None, None, mainloop_producer_state.index)
+                        ]
+                        tAcA_cpasync_k = cute.slice_(
+                            tAcA_cpasync_mkl,
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_coord_mnl[0],
+                                k_tile_global,
+                                tile_coord_mnl[2],
+                            ),
+                        )
+                        tBgB_cpasync_k = tBgB_cpasync_nkl[
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_coord_mnl[1],
+                                k_tile_global,
+                                tile_coord_mnl[2],
+                            )
+                        ]
+                        tBsB_cpasync_pipe = tBsB_cpasync[
+                            (None, None, None, mainloop_producer_state.index)
+                        ]
+                        tBcB_cpasync_k = cute.slice_(
+                            tBcB_cpasync_nkl,
+                            (
+                                None,
+                                None,
+                                None,
+                                tile_coord_mnl[1],
+                                k_tile_global,
+                                tile_coord_mnl[2],
+                            ),
+                        )
+                        tAgSFA_cpasync_k = cute.filter_zeros(
+                            tAgSFA_cpasync_mkl[
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    cpasync_sfa_tile_coord_m,
+                                    k_tile_global,
+                                    tile_coord_mnl[2],
+                                )
+                            ]
+                        )
+                        tAsSFA_cpasync_pipe = cute.filter_zeros(
+                            tAsSFA_cpasync[
+                                (None, None, None, mainloop_producer_state.index)
+                            ]
+                        )
+                        tAcSFA_cpasync_k = cute.filter_zeros(
+                            cute.slice_(
+                                tAcSFA_cpasync_mkl,
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    cpasync_sfa_tile_coord_m,
+                                    k_tile_global,
+                                    tile_coord_mnl[2],
+                                ),
+                            )
+                        )
+                        tBgSFB_cpasync_k = cute.filter_zeros(
+                            tBgSFB_cpasync_nkl[
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    cpasync_sfb_tile_coord_n,
+                                    k_tile_global,
+                                    tile_coord_mnl[2],
+                                )
+                            ]
+                        )
+                        tBsSFB_cpasync_pipe = cute.filter_zeros(
+                            tBsSFB_cpasync[
+                                (None, None, None, mainloop_producer_state.index)
+                            ]
+                        )
+                        tBcSFB_cpasync_k = cute.filter_zeros(
+                            cute.slice_(
+                                tBcSFB_cpasync_nkl,
+                                (
+                                    None,
+                                    None,
+                                    None,
+                                    cpasync_sfb_tile_coord_n,
+                                    k_tile_global,
+                                    tile_coord_mnl[2],
+                                ),
+                            )
+                        )
+                        self._cpasync_copy_2d(
+                            cpasync_tiled_copy_A,
+                            tAgA_cpasync_k,
+                            tAsA_cpasync_pipe,
+                            tAcA_cpasync_k,
+                            Int32(directA_mkl.shape[0]),
+                            True,
+                        )
+                        self._cpasync_copy_2d(
+                            cpasync_tiled_copy_B,
+                            tBgB_cpasync_k,
+                            tBsB_cpasync_pipe,
+                            tBcB_cpasync_k,
+                            Int32(directC_mnl.shape[1]),
+                            True,
+                        )
+                        self._scale_copy_2d(
+                            cpasync_tiled_copy_SF,
+                            tAgSFA_cpasync_k,
+                            tAsSFA_cpasync_pipe,
+                            tAcSFA_cpasync_k,
+                            Int32(directA_mkl.shape[0]),
+                        )
+                        self._scale_copy_2d(
+                            cpasync_tiled_copy_SF,
+                            tBgSFB_cpasync_k,
+                            tBsSFB_cpasync_pipe,
+                            tBcSFB_cpasync_k,
+                            Int32(directC_mnl.shape[1]),
+                        )
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    elif cutlass.const_expr(self.use_m1_non_tma_a):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        for a_iter in cutlass.range_constexpr(
+                            (self.tile_shape_mnk[2] + self.num_threads_per_warp - 1)
+                            // self.num_threads_per_warp
+                        ):
+                            k_local = lane + Int32(a_iter * self.num_threads_per_warp)
+                            if k_local < Int32(self.tile_shape_mnk[2]):
+                                k_coord = (
+                                    k_tile_global
+                                    * Int32(self.tile_shape_mnk[2])
+                                    + k_local
+                                )
+                                sA[
+                                    (
+                                        Int32(0),
+                                        k_local,
+                                        mainloop_producer_state.index,
+                                    )
+                                ] = directA_mkl[
+                                    (
+                                        Int32(0),
+                                        k_coord,
+                                        tile_coord_mnl[2],
+                                    )
+                                ]
+                    else:
+                        cute.copy(
+                            tma_atom_a,
+                            tAgA_k,
+                            tAsA_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
+                            ),
+                        )
 
-                    cute.copy(
-                        tma_atom_a,
-                        tAgA_k,
-                        tAsA_pipe,
-                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
-                            mainloop_producer_state
+                    if cutlass.const_expr(self.load_path == "cpasync"):
+                        pass
+                    elif cutlass.const_expr(self.use_m1_non_tma_sfa):
+                        lane = Int32(tidx % self.num_threads_per_warp)
+                        scale_groups_per_k_tile = (
+                            self.tile_shape_mnk[2] // self.sf_vec_size
+                        )
+                        sfa_slots = (
+                            self.sfa_tile_shape_mk[0] * scale_groups_per_k_tile
+                        )
+                        for sfa_iter in cutlass.range_constexpr(
+                            (sfa_slots + self.num_threads_per_warp - 1)
+                            // self.num_threads_per_warp
+                        ):
+                            linear = lane + Int32(
+                                sfa_iter * self.num_threads_per_warp
+                            )
+                            m_local = linear // Int32(scale_groups_per_k_tile)
+                            scale_group = (
+                                linear - m_local * Int32(scale_groups_per_k_tile)
+                            )
+                            k_local_sfa = scale_group * Int32(self.sf_vec_size)
+                            k_coord_sfa = (
+                                k_tile_global
+                                * Int32(self.tile_shape_mnk[2])
+                                + k_local_sfa
+                            )
+                            if linear < Int32(sfa_slots):
+                                sSFA[
+                                    (
+                                        m_local,
+                                        k_local_sfa,
+                                        mainloop_producer_state.index,
+                                    )
+                                ] = directSFA_mkl[
+                                    (
+                                        Int32(0),
+                                        k_coord_sfa,
+                                        tile_coord_mnl[2],
+                                    )
+                                ]
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                    else:
+                        cute.copy(
+                            tma_atom_sfa,
+                            tAgSFA_k,
+                            tAsSFA_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
+                            ),
+                        )
+                    if cutlass.const_expr(self.load_path == "tma"):
+                        cute.copy(
+                            tma_atom_b,
+                            tBgB_k,
+                            tBsB_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
                         ),
-                    )
-                    cute.copy(
-                        tma_atom_b,
-                        tBgB_k,
-                        tBsB_pipe,
-                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
-                            mainloop_producer_state
+                        )
+                        cute.copy(
+                            tma_atom_sfb,
+                            tBgSFB_k,
+                            tBsSFB_pipe,
+                            tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
+                                mainloop_producer_state
                         ),
-                    )
-                    cute.copy(
-                        tma_atom_sfa,
-                        tAgSFA_k,
-                        tAsSFA_pipe,
-                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
-                            mainloop_producer_state
-                        ),
-                    )
-                    cute.copy(
-                        tma_atom_sfb,
-                        tBgSFB_k,
-                        tBsSFB_pipe,
-                        tma_bar_ptr=mainloop_pipeline.producer_get_barrier(
-                            mainloop_producer_state
-                        ),
-                    )
+                        )
+                    if cutlass.const_expr(self.load_path == "cpasync"):
+                        cute.arch.cp_async_commit_group()
+                        cute.arch.cp_async_wait_group(0)
                     mainloop_pipeline.producer_commit(mainloop_producer_state)
                     mainloop_producer_state.advance()
 
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
+                if cutlass.const_expr(self.single_work_tile_per_cta):
+                    work_tile = WorkTileInfo(
+                        work_tile.tile_idx,
+                        cutlass.Boolean(0),
+                    )
+                else:
+                    tile_sched.advance_to_next_work()
+                    work_tile = tile_sched.get_current_work()
 
             mainloop_pipeline.producer_tail(mainloop_producer_state)
         return
@@ -1252,12 +2262,14 @@ class DenseGemmKernel:
         )
         mbar_helpers_bytes = 1024
 
-        ab_stage = (
+        raw_ab_stage = (
             (smem_capacity - occupancy * 1024) // occupancy
             - mbar_helpers_bytes
             - epi_bytes
         ) // (ab_bytes_per_stage + sf_bytes_per_stage)
-        ab_stage = max(1, min(ab_stage, 4))
+        ab_stage = max(1, min(raw_ab_stage, 4))
+        if tile_shape_mnk[0] in (16, 64) and tile_shape_mnk[1] == 128:
+            ab_stage = max(1, min(raw_ab_stage, 5))
         return ab_stage, epi_stage
 
     @staticmethod
@@ -1353,6 +2365,8 @@ class DenseGemmKernel:
         c,
         tile_shape_mnk: tuple,
         max_active_clusters,
+        direct_one_m_tile_scheduler: bool,
+        split_k_slices: int,
     ) -> tuple:
         c_shape = cute.slice_(tile_shape_mnk, (None, None, 0))
         gc = cute.zipped_divide(c, tiler=c_shape)
@@ -1361,9 +2375,12 @@ class DenseGemmKernel:
         tile_sched_params = utils.PersistentTileSchedulerParams(
             num_ctas_mnl, cluster_shape_mnl
         )
-        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
-            tile_sched_params, max_active_clusters
-        )
+        if cutlass.const_expr(split_k_slices > 1):
+            grid = (1, split_k_slices, num_ctas_mnl[1])
+        else:
+            grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+                tile_sched_params, max_active_clusters
+            )
         return tile_sched_params, grid
 
     @staticmethod
@@ -1413,60 +2430,78 @@ class DenseGemmKernel:
         c_dtype,
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
-        m: int,
         n: int,
         k: int,
         l: int,
         a_major: str,
         b_major: str,
         c_major: str,
+        *,
+        load_path: str = "tma",
+        swap_ab: bool = False,
     ) -> bool:
         # The current target only supports cluster (1,1)
         if cluster_shape_mn != (1, 1):
             return False
-        # Tile M must be divisible by 128; tile N follows 64-column warpgroup
-        # quanta, while the SF paths round narrow tiles up to full 128-element
-        # scale-factor blocks.
-        if mma_tiler_mn[0] % 64 != 0 or mma_tiler_mn[1] % 64 != 0:
+        if load_path not in _DENSE_LOAD_PATHS:
             return False
-        # The current target only supports FP4 (MmaMXF4NVF4Op)
-        if ab_dtype != cutlass.Float4E2M1FN:
+        if swap_ab:
+            if l != 1:
+                return False
+            if not (
+                (ab_dtype == cutlass.Float4E2M1FN and sf_vec_size == 16)
+                or (ab_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32)
+            ):
+                return False
+        if load_path == "cpasync" and (
+            ab_dtype != cutlass.Float4E2M1FN or sf_vec_size != 16 or l != 1
+        ):
             return False
-        # SM120 warp-level MmaMXF4NVF4Op only supports sf_vec_size=16
-        # (CUTLASS DSL hardcodes sf_vec_size=16 in the MMA atom constructor)
-        if sf_vec_size != 16:
+        # FP4 experiments allow narrow N tiles. The scale-factor smem paths
+        # still allocate full 128-element SF blocks, but the live MMA tile may
+        # consume only 16/32 columns.
+        mma_check_mn = (
+            (mma_tiler_mn[1], mma_tiler_mn[0]) if swap_ab else mma_tiler_mn
+        )
+        if ab_dtype == cutlass.Float8E4M3FN:
+            if mma_check_mn not in ((16, 64), (16, 128), (32, 64), (32, 128)):
+                if mma_check_mn[0] % 64 != 0 or mma_check_mn[1] % 64 != 0:
+                    return False
+        elif ab_dtype == cutlass.Float4E2M1FN:
+            if (
+                mma_tiler_mn[0] % 64 != 0
+                or mma_tiler_mn[1] % 16 != 0
+                or mma_tiler_mn[1] > 128
+                or (mma_tiler_mn[1] < 64 and not swap_ab)
+            ):
+                return False
+        else:
+            if mma_check_mn[0] % 64 != 0 or mma_check_mn[1] % 64 != 0:
+                return False
+        # The current target supports FP4 and MXFP8 warp MMA paths.
+        if ab_dtype not in (cutlass.Float4E2M1FN, cutlass.Float8E4M3FN):
             return False
-        if sf_dtype != cutlass.Float8E4M3FN:
+        # Current target MMA constraints:
+        #   sf_vec_size=16 requires sf_dtype=Float8E4M3FN
+        #   sf_vec_size=32 requires sf_dtype=Float8E8M0FNU
+        if sf_vec_size == 16 and sf_dtype != cutlass.Float8E4M3FN:
             return False
-        # Only 16-bit output types supported for now
-        if c_dtype not in (cutlass.Float16, cutlass.BFloat16):
+        if sf_vec_size == 32 and sf_dtype != cutlass.Float8E8M0FNU:
+            return False
+        if ab_dtype == cutlass.Float8E4M3FN and sf_vec_size != 32:
+            return False
+        # Public output is 16-bit; split-K internally uses FP32 partial output.
+        if c_dtype not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float32):
             return False
         # A must be K-major, B must be K-major
         if a_major != "k" or b_major != "k":
             return False
         # Alignment: K must be divisible by tile_k
-        tile_k = sf_vec_size * 8
+        tile_k = 128 if ab_dtype == cutlass.Float8E4M3FN else sf_vec_size * 8
         if k % tile_k != 0:
-            return False
-        # Reject tiles that cannot fit even one pipeline stage in SM120
-        # shared memory.  A+B are FP4 (0.5 bytes/element), SF blocks are
-        # rounded up to 128-element granularity, epilogue is 16-bit output.
-        sfa_tile_m = max(128, ((mma_tiler_mn[0] + 127) // 128) * 128)
-        sfb_tile_n = max(128, ((mma_tiler_mn[1] + 127) // 128) * 128)
-        ab_bytes = (mma_tiler_mn[0] * tile_k + mma_tiler_mn[1] * tile_k) // 2
-        # SF: 128 * 4 elements per SF block, 1 byte each
-        sf_bytes = (sfa_tile_m // 128) * 4 * 128 + (sfb_tile_n // 128) * 4 * 128
-        epi_bytes = mma_tiler_mn[0] * mma_tiler_mn[1] * 2  # 16-bit output
-        mbar_bytes = 1024
-        smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
-        if ab_bytes + sf_bytes + epi_bytes + mbar_bytes > smem_capacity:
             return False
         return True
 
-    # ------------------------------------------------------------------
-    # wrapper: compile-time entry point matching the SM100 interface
-    # for FlashInfer's _compile_block_scaled_gemm
-    # ------------------------------------------------------------------
     @cute.jit
     def wrapper(
         self,
@@ -1549,17 +2584,13 @@ class DenseGemmKernel:
         )
 
 
-# Alias for FlashInfer integration
-Sm120B12xBlockScaledDenseGemmKernel = DenseGemmKernel
-
-
 class _DenseGemmLaunch:
     def __init__(
         self,
-        m: int,
         n: int,
         k: int,
         l: int,
+        c_l: int,
         a_major: str,
         b_major: str,
         c_major: str,
@@ -1568,15 +2599,20 @@ class _DenseGemmLaunch:
         c_dtype: torch.dtype,
         alpha_dtype: torch.dtype,
         sf_vec_size: int,
+        mma_k: int,
+        tile_k: int,
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
+        policy: _DenseGemmPolicy,
         sm_count: int,
         sm_version: str,
+        load_path: str,
+        swap_ab: bool,
     ):
-        self._m = m
         self._n = n
         self._k = k
         self._l = l
+        self._c_l = c_l
         self._a_major = a_major
         self._b_major = b_major
         self._c_major = c_major
@@ -1585,13 +2621,13 @@ class _DenseGemmLaunch:
         self._c_dtype = c_dtype
         self._alpha_dtype = alpha_dtype
         self._sf_vec_size = sf_vec_size
+        self._mma_k = mma_k
+        self._tile_k = tile_k
         self._mma_tiler_mn = mma_tiler_mn
         self._cluster_shape_mn = cluster_shape_mn
-
-        if sm_version not in ("sm_120", "sm_121"):
-            raise ValueError(
-                f"dense_gemm launch only supports SM12x (sm_120/sm_121), got {sm_version}"
-            )
+        self._policy = policy
+        self._load_path = load_path
+        self._swap_ab = swap_ab
 
         if not DenseGemmKernel.can_implement(
             ab_dtype,
@@ -1600,26 +2636,25 @@ class _DenseGemmLaunch:
             c_dtype,
             mma_tiler_mn,
             cluster_shape_mn,
-            m,
             n,
             k,
             l,
             a_major,
             b_major,
             c_major,
+            load_path=load_path,
+            swap_ab=swap_ab,
         ):
             raise TypeError(
                 "dense_gemm launch is unsupported with "
                 f"{ab_dtype}, {sf_dtype}, {sf_vec_size}, {c_dtype}, "
-                f"{mma_tiler_mn}, {cluster_shape_mn}, {m}, {n}, {k}, {l}, "
-                f"{a_major}, {b_major}, {c_major}"
+                f"{mma_tiler_mn}, {cluster_shape_mn}, {n}, {k}, {l}, "
+                f"{a_major}, {b_major}, {c_major}, "
+                f"load_path={load_path}, swap_ab={swap_ab}"
             )
 
-        self._max_active_clusters = min(
-            get_max_active_clusters(
-                self._cluster_shape_mn[0] * self._cluster_shape_mn[1]
-            ),
-            sm_count,
+        self._max_active_clusters = _max_active_clusters_for(
+            self._cluster_shape_mn, sm_count
         )
 
     @cute.jit
@@ -1631,12 +2666,13 @@ class _DenseGemmLaunch:
         sfb_ptr: cute.Pointer,
         c_ptr: cute.Pointer,
         alpha_ptr: cute.Pointer,
+        m: cutlass.Int32,
         current_stream: cuda.CUstream,
     ):
         a_tensor = cute.make_tensor(
             a_ptr,
             layout=cute.make_ordered_layout(
-                (self._m, self._k, self._l),
+                (m, self._k, self._l),
                 order=(0, 1, 2) if self._a_major == "m" else (1, 0, 2),
             ),
         )
@@ -1650,7 +2686,7 @@ class _DenseGemmLaunch:
         c_tensor = cute.make_tensor(
             c_ptr,
             layout=cute.make_ordered_layout(
-                (self._m, self._n, self._l),
+                (m, self._n, self._c_l),
                 order=(0, 1, 2) if self._c_major == "m" else (1, 0, 2),
             ),
         )
@@ -1660,11 +2696,25 @@ class _DenseGemmLaunch:
         )
         sfa_tensor = cute.make_tensor(sfa_ptr, layout=cute.make_layout((1,)))
         sfb_tensor = cute.make_tensor(sfb_ptr, layout=cute.make_layout((1,)))
-
+        policy = self._policy
         DenseGemmKernel(
             sf_vec_size=self._sf_vec_size,
             mma_tiler_mn=self._mma_tiler_mn,
             cluster_shape_mn=self._cluster_shape_mn,
+            mma_k=self._mma_k,
+            tile_k=self._tile_k,
+            single_work_tile_per_cta=policy.single_work_tile_per_cta,
+            direct_one_m_tile_scheduler=policy.direct_one_m_tile_scheduler,
+            split_k_slices=policy.split_k_slices,
+            split_k_atomic_bf16=policy.split_k_atomic_bf16,
+            # M=1 FP8 benefits from normal TMA loads for A/SFA on the
+            # standalone tiny-M profile. Keep C on the direct epilogue path;
+            # the normal TMA store did not beat it in the DSV4F TP=2 GPU5 run.
+            use_m1_non_tma_a=False,
+            use_m1_non_tma_c=policy.use_m1_non_tma and not self._swap_ab,
+            use_m1_non_tma_sfa=False,
+            load_path=self._load_path,
+            swap_ab=self._swap_ab,
         )(
             a_tensor,
             b_tensor,
@@ -1679,10 +2729,10 @@ class _DenseGemmLaunch:
 
 @functools.cache
 def _get_compiled_dense_gemm(
-    m: int,
     n: int,
     k: int,
     l: int,
+    c_l: int,
     a_major: str,
     b_major: str,
     c_major: str,
@@ -1691,10 +2741,15 @@ def _get_compiled_dense_gemm(
     c_dtype: Type[cutlass.Numeric],
     alpha_dtype: Type[cutlass.Numeric],
     sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
     mma_tiler_mn: Tuple[int, int],
     cluster_shape_mn: Tuple[int, int],
+    policy: _DenseGemmPolicy,
     sm_count: int,
     sm_version: str,
+    load_path: str,
+    swap_ab: bool,
 ) -> Callable:
     def _make_runtime_pointers(
         input_tensors: Optional[List[torch.Tensor]],
@@ -1739,32 +2794,63 @@ def _get_compiled_dense_gemm(
             make_ptr(sf_dtype, sfa_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
             make_ptr(sf_dtype, sfb_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
             make_ptr(c_dtype, c_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
-            make_ptr(
-                alpha_dtype, alpha_data_ptr, cute.AddressSpace.gmem, assumed_align=16
-            ),
+            make_ptr(alpha_dtype, alpha_data_ptr, cute.AddressSpace.gmem, assumed_align=16),
         ]
 
-    compiled_kernel = cute.compile(
-        _DenseGemmLaunch(
-            m=m,
-            n=n,
-            k=k,
-            l=l,
-            a_major=a_major,
-            b_major=b_major,
-            c_major=c_major,
-            ab_dtype=ab_dtype,
-            sf_dtype=sf_dtype,
-            c_dtype=c_dtype,
-            alpha_dtype=alpha_dtype,
-            sf_vec_size=sf_vec_size,
-            mma_tiler_mn=mma_tiler_mn,
-            cluster_shape_mn=cluster_shape_mn,
-            sm_count=sm_count,
-            sm_version=sm_version,
-        ),
+    launch = _DenseGemmLaunch(
+        n=n,
+        k=k,
+        l=l,
+        c_l=c_l,
+        a_major=a_major,
+        b_major=b_major,
+        c_major=c_major,
+        ab_dtype=ab_dtype,
+        sf_dtype=sf_dtype,
+        c_dtype=c_dtype,
+        alpha_dtype=alpha_dtype,
+        sf_vec_size=sf_vec_size,
+        mma_k=mma_k,
+        tile_k=tile_k,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+        policy=policy,
+        sm_count=sm_count,
+        sm_version=sm_version,
+        load_path=load_path,
+        swap_ab=swap_ab,
+    )
+    compile_key = (
+        n,
+        k,
+        l,
+        c_l,
+        ab_dtype,
+        sf_dtype,
+        c_dtype,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        policy,
+        sm_count,
+        sm_version,
+        load_path,
+        swap_ab,
+    )
+    raise_if_kernel_resolution_frozen(
+        "cute.compile",
+        target=launch,
+        cache_key=compile_key,
+    )
+    compiled_kernel = b12x_compile(
+        launch,
         *_make_runtime_pointers(None),
+        1,
         current_cuda_stream(),
+        compile_spec=KernelCompileSpec.from_key("gemm.dense", 1, compile_key),
     )
 
     def tensor_api(
@@ -1775,18 +2861,15 @@ def _get_compiled_dense_gemm(
         c_tensor_gpu: Optional[torch.Tensor] = None,
         alpha_tensor_gpu: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        m = a_tensor_gpu.shape[0]
         if c_tensor_gpu is None:
             c_tensor_gpu = torch.empty(
-                (m, n, l),
+                (m, n, c_l),
                 dtype=cutlass_to_torch_dtype(c_dtype),
                 device=a_tensor_gpu.device,
             )
         if alpha_tensor_gpu is None:
-            alpha_tensor_gpu = torch.ones(
-                (1,),
-                dtype=torch.float32,
-                device=a_tensor_gpu.device,
-            )
+            alpha_tensor_gpu = _cached_alpha_one(a_tensor_gpu.device)
 
         nonlocal compiled_kernel
         compiled_kernel(
@@ -1800,6 +2883,7 @@ def _get_compiled_dense_gemm(
                     alpha_tensor_gpu,
                 ]
             ),
+            m,
             current_cuda_stream(),
         )
         return c_tensor_gpu
@@ -1807,11 +2891,485 @@ def _get_compiled_dense_gemm(
     return tensor_api
 
 
-def _select_default_mma_tiler_mn(m: int, n: int, sm_count: int) -> Tuple[int, int]:
+def _dense_gemm_launch_flat(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    c_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    load_path: str,
+    swap_ab: bool,
+) -> None:
+    policy = _DenseGemmPolicy(
+        single_work_tile_per_cta=single_work_tile_per_cta,
+        direct_one_m_tile_scheduler=direct_one_m_tile_scheduler,
+        use_m1_non_tma=use_m1_non_tma,
+        split_k_slices=split_k_slices,
+        split_k_atomic_bf16=split_k_atomic_bf16,
+    )
+    compiled = _get_compiled_dense_gemm(
+        n=n,
+        k=k,
+        l=l,
+        c_l=c_l,
+        a_major="k",
+        b_major="k",
+        c_major="n",
+        ab_dtype=get_cutlass_dtype(ab_dtype),
+        sf_dtype=get_cutlass_dtype(sf_dtype),
+        c_dtype=get_cutlass_dtype(c_dtype),
+        alpha_dtype=get_cutlass_dtype(alpha_dtype),
+        sf_vec_size=sf_vec_size,
+        mma_k=mma_k,
+        tile_k=tile_k,
+        mma_tiler_mn=(mma_tile_m, mma_tile_n),
+        cluster_shape_mn=(cluster_shape_m, cluster_shape_n),
+        policy=policy,
+        sm_count=sm_count,
+        sm_version="sm_120",
+        load_path=load_path,
+        swap_ab=swap_ab,
+    )
+    compiled(
+        a_tensor_gpu=a_tensor_gpu,
+        b_tensor_gpu=b_tensor_gpu,
+        sfa_tensor_gpu=sfa_tensor_gpu,
+        sfb_tensor_gpu=sfb_tensor_gpu,
+        c_tensor_gpu=c_tensor_gpu,
+        alpha_tensor_gpu=alpha_tensor_gpu,
+    )
+
+
+@torch.library.custom_op(
+    "b12x::dense_gemm_launch",
+    mutates_args=("c_tensor_gpu",),
+)
+def _dense_gemm_launch_op(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    c_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    load_path: str,
+    swap_ab: bool,
+) -> None:
+    _dense_gemm_launch_flat(
+        a_tensor_gpu,
+        b_tensor_gpu,
+        sfa_tensor_gpu,
+        sfb_tensor_gpu,
+        c_tensor_gpu,
+        alpha_tensor_gpu,
+        n,
+        k,
+        l,
+        c_l,
+        ab_dtype,
+        sf_dtype,
+        c_dtype,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tile_m,
+        mma_tile_n,
+        cluster_shape_m,
+        cluster_shape_n,
+        sm_count,
+        single_work_tile_per_cta,
+        direct_one_m_tile_scheduler,
+        use_m1_non_tma,
+        split_k_slices,
+        split_k_atomic_bf16,
+        load_path,
+        swap_ab,
+    )
+
+
+@_dense_gemm_launch_op.register_fake
+def _dense_gemm_launch_fake(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    c_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    load_path: str,
+    swap_ab: bool,
+) -> None:
+    return None
+
+
+_ALPHA_ONE_CACHE: dict = {}
+
+
+def _cached_alpha_one(device: torch.device | str) -> torch.Tensor:
+    # Per-device cached scalar-one alpha, to avoid a per-call torch.ones((1,))
+    # host/device alloc on the generic FP8 dense-GEMM path. Mirrors
+    # wo_projection._cached_alpha_one (not imported -- wo_projection imports
+    # dense, so importing back would be circular).
+    resolved = torch.device(device)
+    if resolved.type == "cuda" and resolved.index is None:
+        resolved = torch.device("cuda", torch.cuda.current_device())
+    key = (resolved.type, resolved.index)
+    alpha = _ALPHA_ONE_CACHE.get(key)
+    if alpha is None or alpha.device != resolved:
+        alpha = torch.ones((1,), dtype=torch.float32, device=resolved)
+        _ALPHA_ONE_CACHE[key] = alpha
+    return alpha
+
+
+def _empty_dense_gemm_output(
+    m: int,
+    n: int,
+    l: int,
+    *,
+    dtype: torch.dtype,
+    device: torch.device | str,
+) -> torch.Tensor:
+    """Allocate an `[M,N,L]` dense-GEMM output in the layout the kernel writes.
+
+    The CuTe dense GEMM hardcodes ``c_major='n'`` and builds the C tensor from
+    the data pointer with order ``(1,0,2)`` -- i.e. it writes the grouped output
+    as physical ``[L,M,N]`` (an ``[M,N,L]`` view with strides ``(N,1,M*N)``) and
+    ignores the runtime tensor's actual strides. A plain contiguous ``(M,N,L)``
+    buffer (strides ``(N*L,L,1)``) would scatter the ``L`` groups to the wrong
+    offsets, so back ``L>1`` with ``[L,M,N]`` physical storage. ``L==1`` is the
+    same either way. Mirrors ``empty_dense_gemm_mnl_view`` in wo_projection.
+    """
+    if l > 1:
+        return torch.empty((l, m, n), dtype=dtype, device=device).as_strided(
+            (m, n, l), (n, 1, m * n)
+        )
+    return torch.empty((m, n, l), dtype=dtype, device=device)
+
+
+@torch.library.custom_op(
+    "b12x::dense_gemm_launch_functional",
+    mutates_args=(),
+)
+def _dense_gemm_launch_functional_op(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    kernel_c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    kernel_c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    load_path: str,
+    swap_ab: bool,
+) -> torch.Tensor:
+    m = int(a_tensor_gpu.shape[0])
+    out = _empty_dense_gemm_output(
+        m,
+        n,
+        l,
+        dtype=cutlass_to_torch_dtype(get_cutlass_dtype(c_dtype)),
+        device=a_tensor_gpu.device,
+    )
+    split_k_output = int(split_k_slices) > 1
+    if split_k_output and split_k_atomic_bf16:
+        c_tensor_gpu = out
+        out.zero_()
+    elif split_k_output:
+        split_storage = torch.empty(
+            (split_k_slices, m, n),
+            dtype=torch.float32,
+            device=a_tensor_gpu.device,
+        )
+        c_tensor_gpu = split_storage.permute(1, 2, 0)
+    else:
+        c_tensor_gpu = out
+
+    _dense_gemm_launch_flat(
+        a_tensor_gpu,
+        b_tensor_gpu,
+        sfa_tensor_gpu,
+        sfb_tensor_gpu,
+        c_tensor_gpu,
+        alpha_tensor_gpu,
+        n,
+        k,
+        l,
+        kernel_c_l,
+        ab_dtype,
+        sf_dtype,
+        kernel_c_dtype,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tile_m,
+        mma_tile_n,
+        cluster_shape_m,
+        cluster_shape_n,
+        sm_count,
+        single_work_tile_per_cta,
+        direct_one_m_tile_scheduler,
+        use_m1_non_tma,
+        split_k_slices,
+        split_k_atomic_bf16,
+        load_path,
+        swap_ab,
+    )
+    if split_k_output and not split_k_atomic_bf16:
+        _reduce_split_k2_bf16(c_tensor_gpu, out, m=m, n=n)
+    return out
+
+
+@_dense_gemm_launch_functional_op.register_fake
+def _dense_gemm_launch_functional_fake(
+    a_tensor_gpu: torch.Tensor,
+    b_tensor_gpu: torch.Tensor,
+    sfa_tensor_gpu: torch.Tensor,
+    sfb_tensor_gpu: torch.Tensor,
+    alpha_tensor_gpu: torch.Tensor,
+    n: int,
+    k: int,
+    l: int,
+    kernel_c_l: int,
+    ab_dtype: str,
+    sf_dtype: str,
+    c_dtype: str,
+    kernel_c_dtype: str,
+    alpha_dtype: str,
+    sf_vec_size: int,
+    mma_k: int,
+    tile_k: int,
+    mma_tile_m: int,
+    mma_tile_n: int,
+    cluster_shape_m: int,
+    cluster_shape_n: int,
+    sm_count: int,
+    single_work_tile_per_cta: bool,
+    direct_one_m_tile_scheduler: bool,
+    use_m1_non_tma: bool,
+    split_k_slices: int,
+    split_k_atomic_bf16: bool,
+    load_path: str,
+    swap_ab: bool,
+) -> torch.Tensor:
+    del (
+        b_tensor_gpu,
+        sfa_tensor_gpu,
+        sfb_tensor_gpu,
+        alpha_tensor_gpu,
+        k,
+        kernel_c_l,
+        ab_dtype,
+        sf_dtype,
+        kernel_c_dtype,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tile_m,
+        mma_tile_n,
+        cluster_shape_m,
+        cluster_shape_n,
+        sm_count,
+        single_work_tile_per_cta,
+        direct_one_m_tile_scheduler,
+        use_m1_non_tma,
+        split_k_slices,
+        split_k_atomic_bf16,
+        load_path,
+        swap_ab,
+    )
+    return _empty_dense_gemm_output(
+        int(a_tensor_gpu.shape[0]),
+        n,
+        l,
+        dtype=cutlass_to_torch_dtype(get_cutlass_dtype(c_dtype)),
+        device=a_tensor_gpu.device,
+    )
+
+
+def _select_default_mma_tiler_mn(
+    m: int,
+    n: int,
+    sm_count: int,
+    *,
+    is_mxfp8: bool,
+    expected_m: Optional[int] = None,
+    k: Optional[int] = None,
+) -> Tuple[int, int]:
     coarse_tile = (128, 128)
+    if is_mxfp8 and n > 1536:
+        # DeepGEMM-style regime hint. When a caller declares expected_m, pick the
+        # per-regime optimal tile and key the compile on it: ONE kernel per
+        # (N,K,expected_m), reused for every live M in that regime under frozen
+        # resolution (M-independent within the regime). Probe optima
+        # (benchmarks/probe_dense_fp8_tile_sweep.py): exact M=1 -> 16x64
+        # (flushed common-shape decode sweep); expected_m=2..8 -> 16x128
+        # (tiny-M decode; mirrors the no-hint m<=8 specialization so cudagraph
+        # decode batches <=8 -- where callers like vLLM set expected_m == live m
+        # -- get the decode tile instead of being lumped into the 32x128 bucket);
+        # <=128 (small batch) -> 32x128 (~25% faster than 64x128 at M=32..128);
+        # else -> 64x128 (the M-independent default, good to prefill).
+        if expected_m is not None:
+            if expected_m == 1:
+                return (16, 64)
+            if expected_m <= 8:
+                return (16, 128)
+            if expected_m <= 128:
+                return (32, 128)
+            return (64, 128)
+        # No regime hint: keep the true single-token decode specialization and
+        # use the decode-tuned tile for tiny standalone graph shapes. Broader
+        # live-M reuse still falls back to the M-independent prefill-safe tile.
+        if m == 1:
+            return (16, 64)
+        if m <= 8:
+            return (16, 128)
+        # Wide-N MXFP8: the 128x128 pin spans only ceil(N/128) column tiles, so
+        # at small/medium M it launches ~32-64 CTAs and runs flat (~80us, B-BW
+        # starved). It is in fact the WORST tile at every M (geomean ~121us over
+        # M=2..4096; see benchmarks/probe_dense_fp8_tile_sweep.py). 64x128 is the
+        # best M-INDEPENDENT tile: it beats 128x128 at every M (1.1x-2.4x; geomean
+        # ~69us) with byte-identical output. M-independence is required because
+        # dense serving warms one kernel per (N,K) and reuses it for all live M
+        # under frozen resolution (see test_block_fp8_linear_small_live_m_reuses_
+        # prefill_dense_kernel) -- an M-dependent tile forces an illegal recompile
+        # mid-serve. (Smaller 32x128/16x128 are faster at M<=128 but regress
+        # prefill M>=2k and would break that one-kernel-per-(N,K) reuse contract.)
+        return (64, 128)
+
+    if is_mxfp8:
+        # Narrow-N MXFP8 (n <= 1536; the n > 1536 case returned above). The
+        # (128,128) coarse tile spans only ceil(N/128) column tiles (<=12 at
+        # N<=1536), so at M>=512 it launches ~32-48 CTAs on a 188-SM part and
+        # runs CTA-starved -- 2x-3.5x slower than a CTA-multiplying tile
+        # (probe_dense_fp8_tile_sweep.py: N=1024 M=512 (128,128)=63.5us vs
+        # (64,64)=18.4us; N=1536 M=512 (128,128)=65.5us vs (64,128)=24.6us).
+        # Mirror the wide-N expected_m design where we have data. Exact M=1
+        # gets the flushed common-shape decode winner (16,64). Declared prefill
+        # (expected_m>128) -> (64,128): the best narrow-N tile at M>=512 for
+        # both N=1024 and N=1536 across M=512..8192 (probe sweep), recovering
+        # both the M~512 cliff and the large-M tail (N=1024 M=4096:
+        # (64,128)=80us vs (64,64)=105us vs (128,128)=125us). Other
+        # decode/small and the no-hint default use the M-independent (64,64)
+        # (max CTAs; best at M<=512), preserving the one-kernel-per-(N,K) reuse
+        # contract.
+        if expected_m == 1 or (expected_m is None and m == 1):
+            return (16, 64)
+        if expected_m is not None and expected_m > 128:
+            return (64, 128)
+        return (64, 64)
+
+    plan_m = expected_m if expected_m is not None else m
+    if plan_m == 1 and k is not None:
+        # Flushed M=1 FP4 probe (benchmarks/probe_dense_fp4_tile_load_sweep.py)
+        # across the repo's common shapes:
+        #   * wide/medium N: (64,128)/TMA has the best geomean and wins nearly all
+        #     shapes.
+        #   * N=1024,K=5376: (64,64)/TMA wins the boundary by a small margin.
+        #   * N<=512 with long K: (64,32)/TMA+swap_ab is the only clear tiny-N win.
+        # Keep the tile selector tile-only; the launch planner below attaches
+        # swap_ab to the narrow tile.
+        if n <= 512 and k >= 4096:
+            return (64, 32)
+        if n <= 1024:
+            return (64, 64)
+        return (64, 128)
+
     coarse_tiles = ((m + coarse_tile[0] - 1) // coarse_tile[0]) * (
         (n + coarse_tile[1] - 1) // coarse_tile[1]
     )
+    # The coarse CTA-count heuristic misses exact-small-M, wide-N cases: a wide
+    # N dimension can generate plenty of CTAs even while each 128-row M tile is
+    # mostly empty. Keep using the narrower 64x128 tile while the 128x128 plan
+    # still leaves the GPU below the existing half-SM occupancy proxy.
+    if n > 1536:
+        if m <= 64:
+            return (64, 128)
+        if m <= 256 and coarse_tiles < max(1, sm_count // 2):
+            return (64, 128)
     if m <= 128 and coarse_tiles < max(1, sm_count // 2):
         if n > 1536:
             return (64, 128)
@@ -1822,7 +3380,31 @@ def _select_default_mma_tiler_mn(m: int, n: int, sm_count: int) -> Tuple[int, in
         if medium_tiles < max(1, sm_count // 2):
             return (64, 64)
         return (128, 64)
-    return (128, 128)
+    return coarse_tile
+
+
+def _select_default_dense_gemm_plan(
+    m: int,
+    n: int,
+    k: int,
+    sm_count: int,
+    *,
+    is_mxfp8: bool,
+    expected_m: Optional[int] = None,
+) -> _DenseGemmPlan:
+    tile = _select_default_mma_tiler_mn(
+        m,
+        n,
+        sm_count,
+        is_mxfp8=is_mxfp8,
+        expected_m=expected_m,
+        k=k,
+    )
+    return _DenseGemmPlan(
+        mma_tiler_mn=tile,
+        load_path="tma",
+        swap_ab=(not is_mxfp8 and tile[1] < 64),
+    )
 
 
 def dense_gemm(
@@ -1839,45 +3421,235 @@ def dense_gemm(
     cluster_shape_mn: Tuple[int, int] = (1, 1),
     alpha: Optional[torch.Tensor] = None,
     alpha_dtype: Optional[str] = None,
+    expected_m: Optional[int] = None,
+    load_path: Optional[Literal["tma", "cpasync"]] = None,
+    swap_ab: Optional[bool] = None,
 ) -> torch.Tensor:
-    """Execute dense block-scaled GEMM for one expert-major batch stack."""
+    """Execute dense block-scaled GEMM for one expert-major batch stack.
+
+    expected_m: optional regime hint (DeepGEMM-style). When set, the default tile
+    is chosen for that representative M instead of being M-independent, giving a
+    per-regime-optimal kernel that is still reused across all live M in the regime
+    (e.g. expected_m<=128 selects a decode-tuned tile). Ignored when mma_tiler_mn
+    is given. Live M stays a runtime arg; only the tile (a compile key) changes.
+    """
     a_torch, sfa_torch = lhs
     b_torch, sfb_torch = rhs
+    if load_path is not None and load_path not in _DENSE_LOAD_PATHS:
+        raise ValueError(f"dense_gemm load_path must be one of {_DENSE_LOAD_PATHS}, got {load_path!r}")
 
     m, k, l = a_torch.shape
     n, _, _ = b_torch.shape
     if ab_dtype == "float4_e2m1fn":
+        is_mxfp8 = False
         k *= 2
+        mma_k = 64
+        tile_k = sf_vec_size * 8
+    elif ab_dtype == "float8_e4m3fn":
+        is_mxfp8 = True
+        mma_k = 32
+        tile_k = 128
+    else:
+        raise TypeError(f"dense_gemm unsupported ab_dtype: {ab_dtype}")
 
     if sm_count is None:
         sm_count = get_num_sm(a_torch.device)
-    if mma_tiler_mn is None:
-        mma_tiler_mn = _select_default_mma_tiler_mn(m, n, sm_count)
+    ab_cutlass_dtype = get_cutlass_dtype(ab_dtype)
+    c_cutlass_dtype = get_cutlass_dtype(c_dtype)
+    if mma_tiler_mn is None or load_path is None or swap_ab is None:
+        default_plan = _select_default_dense_gemm_plan(
+            m,
+            n,
+            k,
+            sm_count,
+            is_mxfp8=is_mxfp8,
+            expected_m=expected_m,
+        )
+        if mma_tiler_mn is None:
+            mma_tiler_mn = default_plan.mma_tiler_mn
+        if load_path is None:
+            load_path = default_plan.load_path
+        if swap_ab is None:
+            swap_ab = default_plan.swap_ab if mma_tiler_mn[1] < 64 else False
+    assert load_path is not None
+    assert swap_ab is not None
     if alpha_dtype is None:
         alpha_dtype = "float32" if alpha is None else str(alpha.dtype).split(".")[-1]
-
-    return _get_compiled_dense_gemm(
+    policy = _dense_gemm_policy_for(
         m=m,
         n=n,
         k=k,
         l=l,
-        a_major="k",
-        b_major="k",
-        c_major="n",
-        ab_dtype=get_cutlass_dtype(ab_dtype),
-        sf_dtype=get_cutlass_dtype(sf_dtype),
-        c_dtype=get_cutlass_dtype(c_dtype),
-        alpha_dtype=get_cutlass_dtype(alpha_dtype),
-        sf_vec_size=sf_vec_size,
+        ab_dtype=ab_cutlass_dtype,
+        c_dtype=c_cutlass_dtype,
         mma_tiler_mn=mma_tiler_mn,
         cluster_shape_mn=cluster_shape_mn,
         sm_count=sm_count,
-        sm_version="sm_120",
-    )(
-        a_tensor_gpu=a_torch,
-        b_tensor_gpu=b_torch,
-        sfa_tensor_gpu=sfa_torch,
-        sfb_tensor_gpu=sfb_torch,
-        c_tensor_gpu=out,
-        alpha_tensor_gpu=alpha,
     )
+    split_k_slices = policy.split_k_slices
+    if swap_ab and split_k_slices != 1:
+        policy = _DenseGemmPolicy(
+            single_work_tile_per_cta=policy.single_work_tile_per_cta,
+            direct_one_m_tile_scheduler=policy.direct_one_m_tile_scheduler,
+            use_m1_non_tma=policy.use_m1_non_tma,
+            split_k_slices=1,
+            split_k_atomic_bf16=False,
+        )
+        split_k_slices = 1
+    split_k_output = split_k_slices > 1
+    split_k_atomic_bf16 = split_k_output and policy.split_k_atomic_bf16
+    if split_k_atomic_bf16:
+        kernel_c_l = l
+    elif split_k_output:
+        kernel_c_l = split_k_slices
+    else:
+        kernel_c_l = l
+    if alpha is None:
+        alpha = _cached_alpha_one(a_torch.device)
+    kernel_c_dtype_name = (
+        "float32" if split_k_output and not split_k_atomic_bf16 else c_dtype
+    )
+    if out is None:
+        # No caller-owned output buffer: functional launch (allocate + return
+        # inside the opaque op). The compile graph then carries no
+        # auto_functionalized dense node mutating a (possibly strided) caller
+        # view -- which inductor's decompose pass cannot remove. No is_compiling;
+        # purely caller-intent, behaviorally identical to the eager out=None path.
+        return torch.ops.b12x.dense_gemm_launch_functional(
+            a_torch,
+            b_torch,
+            sfa_torch,
+            sfb_torch,
+            alpha,
+            n,
+            k,
+            l,
+            kernel_c_l,
+            ab_dtype,
+            sf_dtype,
+            c_dtype,
+            kernel_c_dtype_name,
+            alpha_dtype,
+            sf_vec_size,
+            mma_k,
+            tile_k,
+            mma_tiler_mn[0],
+            mma_tiler_mn[1],
+            cluster_shape_mn[0],
+            cluster_shape_mn[1],
+            sm_count,
+            policy.single_work_tile_per_cta,
+            policy.direct_one_m_tile_scheduler,
+            policy.use_m1_non_tma,
+            policy.split_k_slices,
+            policy.split_k_atomic_bf16,
+            load_path,
+            swap_ab,
+        )
+    split_storage = None
+    split_scratch = None
+    if split_k_output:
+        if out is None:
+            out = torch.empty(
+                (m, n, l),
+                dtype=cutlass_to_torch_dtype(c_cutlass_dtype),
+                device=a_torch.device,
+            )
+        if split_k_atomic_bf16:
+            out.zero_()
+        else:
+            split_storage = torch.empty(
+                (split_k_slices, m, n),
+                dtype=torch.float32,
+                device=a_torch.device,
+            )
+            split_scratch = split_storage.permute(1, 2, 0)
+    elif out is None:
+        out = torch.empty(
+            (m, n, l),
+            dtype=cutlass_to_torch_dtype(c_cutlass_dtype),
+            device=a_torch.device,
+        )
+    if alpha is None:
+        alpha = _cached_alpha_one(a_torch.device)
+
+    t0 = time.perf_counter() if _B12X_TIMING else 0.0
+    cache_before = _get_compiled_dense_gemm.cache_info() if _B12X_TIMING else None
+    t_compiled = t0
+    kernel_c_dtype_name = (
+        "float32" if split_k_output and not split_k_atomic_bf16 else c_dtype
+    )
+    c_tensor_gpu = (
+        out if split_k_atomic_bf16 else split_scratch if split_k_output else out
+    )
+    assert c_tensor_gpu is not None
+    torch.ops.b12x.dense_gemm_launch(
+        a_torch,
+        b_torch,
+        sfa_torch,
+        sfb_torch,
+        c_tensor_gpu,
+        alpha,
+        n,
+        k,
+        l,
+        kernel_c_l,
+        ab_dtype,
+        sf_dtype,
+        kernel_c_dtype_name,
+        alpha_dtype,
+        sf_vec_size,
+        mma_k,
+        tile_k,
+        mma_tiler_mn[0],
+        mma_tiler_mn[1],
+        cluster_shape_mn[0],
+        cluster_shape_mn[1],
+        sm_count,
+        policy.single_work_tile_per_cta,
+        policy.direct_one_m_tile_scheduler,
+        policy.use_m1_non_tma,
+        policy.split_k_slices,
+        policy.split_k_atomic_bf16,
+        load_path,
+        swap_ab,
+    )
+    result = out
+    if split_k_output and not split_k_atomic_bf16:
+        assert split_scratch is not None
+        assert out is not None
+        _reduce_split_k2_bf16(split_scratch, out, m=m, n=n)
+        result = out
+    if _B12X_TIMING:
+        t_launch = time.perf_counter()
+        cache_after = _get_compiled_dense_gemm.cache_info()
+        assert cache_before is not None
+        compile_ms = (t_compiled - t0) * 1000.0
+        launch_ms = (t_launch - t_compiled) * 1000.0
+        total_ms = (t_launch - t0) * 1000.0
+        if total_ms >= _B12X_TIMING_THRESHOLD_MS:
+            logger.warning(
+                "b12x_dense_gemm timing m=%d n=%d k=%d l=%d ab=%s sf=%s c=%s "
+                "tile=%s load=%s swap_ab=%s cache_hit=%s compile_or_lookup=%.3fms "
+                "launch_enqueue=%.3fms total=%.3fms cache=%s",
+                m,
+                n,
+                k,
+                l,
+                ab_dtype,
+                sf_dtype,
+                c_dtype,
+                mma_tiler_mn,
+                load_path,
+                swap_ab,
+                cache_after.hits > cache_before.hits,
+                compile_ms,
+                launch_ms,
+                total_ms,
+                cache_after,
+            )
+    return result
+
+
+# Alias for FlashInfer integration
+Sm120B12xBlockScaledDenseGemmKernel = DenseGemmKernel


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Summary
This PR refreshes the `b12x` dense FP4 GEMM kernel to match the latest upstream for better performance.

**No public API change.** The `auto` routing heuristic (`_heuristic_func_mm_fp4`) is **unchanged** — b12x is preferred only at SM120, not SM121.

Addresses **#3517** *[Perf][SM12x] Update mm_fp4(backend='b12x') kernels*.

### Motivation
@lukealonso has made performance improvements to b12x dense GEMMs; we'd like to port over the improvements to FlashInfer. Gains are focused on small-M.

### Benchmarks: new b12x vs old b12x

Setup per SKU: `benchmarks/flashinfer_benchmark.py --testlist <104 nvfp4 shapes> --use_nvfp4 --use_128x4_sf_layout --refcheck`, 30 iters / 5 warmup, **CUPTI timing** (harness default). 104 shapes = 13 token counts m∈{1..4096} × 8 (n,k) layer shapes taken from real **DeepSeek-R1** and **Llama-3** model layers, all K%128==0.

The refresh is a consistent small win at small `m` (where `swap_ab` and `expected_m` help most) and break-even-to-positive overall — **no SKU regresses in aggregate**.

Geomean speedup (old_time / new_time; >1 = new faster), grouped by `m`:

| SKU | overall | m≤8 | 16≤m≤128 | m≥256 |
|---|---|---|---|---|
| RTX 5080 (SM120) | 1.003× | 1.019× | 1.003× | 0.991× |
| RTX PRO 6000 (SM120) | **1.021×** | 1.060× | 1.010× | 1.000× |
| DGX Spark / GB10 (SM121) | **1.024×** | 1.021× | 1.028× | 1.022× |

The win is largest at small `m` on PRO 6000 / Spark and break-even on the 5080. A few `n=4096 k=4096/5376` shapes regress ≤5% (bolded in the per-shape tables); the PRO 6000 has a sharper `8192×2560` regression at medium `m` (down to 0.873×), which is SKU-specific and flagged as a follow-up.

Full per-shape new-vs-old tables (all 104 shapes, sorted by `n, k, m`) per SKU:

<details>
<summary><b>RTX 5080 (SM120)</b></summary>

| n | k | m | old (us) | new (us) | new TFLOPs | speedup |
|---|---|---|---|---|---|---|
| 512 | 7168 | 1 | 37.6 | 39.8 | 0.2 | **0.945x** |
| 512 | 7168 | 2 | 38.3 | 38.8 | 0.4 | 0.986x |
| 512 | 7168 | 4 | 38.8 | 38.9 | 0.8 | 0.995x |
| 512 | 7168 | 8 | 38.9 | 39.2 | 1.5 | 0.994x |
| 512 | 7168 | 16 | 39.4 | 40.4 | 2.9 | 0.975x |
| 512 | 7168 | 32 | 40.6 | 41.2 | 5.7 | 0.985x |
| 512 | 7168 | 64 | 43.8 | 43.5 | 10.8 | 1.007x |
| 512 | 7168 | 128 | 55.1 | 55.6 | 16.9 | 0.992x |
| 512 | 7168 | 256 | 67.4 | 67.7 | 27.8 | 0.995x |
| 512 | 7168 | 512 | 84.0 | 84.7 | 44.4 | 0.991x |
| 512 | 7168 | 1024 | 94.4 | 95.9 | 78.4 | 0.984x |
| 512 | 7168 | 2048 | 104.4 | 106.0 | 141.9 | 0.985x |
| 512 | 7168 | 4096 | 165.4 | 168.2 | 178.7 | 0.983x |
| 1024 | 8192 | 1 | 58.8 | 59.1 | 0.3 | 0.995x |
| 1024 | 8192 | 2 | 58.7 | 59.0 | 0.6 | 0.995x |
| 1024 | 8192 | 4 | 59.7 | 59.7 | 1.1 | 0.999x |
| 1024 | 8192 | 8 | 60.2 | 59.9 | 2.2 | 1.006x |
| 1024 | 8192 | 16 | 61.1 | 61.1 | 4.4 | 1.001x |
| 1024 | 8192 | 32 | 60.8 | 60.9 | 8.8 | 0.998x |
| 1024 | 8192 | 64 | 70.1 | 69.7 | 15.4 | 1.006x |
| 1024 | 8192 | 128 | 78.5 | 77.4 | 27.7 | 1.014x |
| 1024 | 8192 | 256 | 85.9 | 85.8 | 50.1 | 1.002x |
| 1024 | 8192 | 512 | 96.5 | 97.0 | 88.6 | 0.995x |
| 1024 | 8192 | 1024 | 97.3 | 97.5 | 176.2 | 0.998x |
| 1024 | 8192 | 2048 | 154.2 | 155.8 | 220.5 | 0.990x |
| 1024 | 8192 | 4096 | 251.2 | 254.7 | 269.8 | 0.986x |
| 2560 | 8192 | 1 | 101.1 | 87.6 | 0.5 | 1.154x |
| 2560 | 8192 | 2 | 101.1 | 91.2 | 0.9 | 1.108x |
| 2560 | 8192 | 4 | 101.5 | 93.7 | 1.8 | 1.083x |
| 2560 | 8192 | 8 | 101.9 | 95.1 | 3.5 | 1.072x |
| 2560 | 8192 | 16 | 102.3 | 100.1 | 6.7 | 1.022x |
| 2560 | 8192 | 32 | 101.6 | 95.3 | 14.1 | 1.067x |
| 2560 | 8192 | 64 | 101.2 | 95.6 | 28.1 | 1.058x |
| 2560 | 8192 | 128 | 95.3 | 94.4 | 56.9 | 1.009x |
| 2560 | 8192 | 256 | 109.3 | 106.8 | 100.5 | 1.023x |
| 2560 | 8192 | 512 | 113.9 | 114.1 | 188.2 | 0.998x |
| 2560 | 8192 | 1024 | 157.3 | 158.3 | 271.3 | 0.994x |
| 2560 | 8192 | 2048 | 252.6 | 254.9 | 337.0 | 0.991x |
| 2560 | 8192 | 4096 | 433.5 | 436.9 | 393.2 | 0.992x |
| 4096 | 4096 | 1 | 57.2 | 57.6 | 0.6 | 0.993x |
| 4096 | 4096 | 2 | 57.3 | 56.4 | 1.2 | 1.016x |
| 4096 | 4096 | 4 | 58.1 | 59.3 | 2.3 | 0.981x |
| 4096 | 4096 | 8 | 56.5 | 57.5 | 4.7 | 0.983x |
| 4096 | 4096 | 16 | 59.6 | 60.2 | 8.9 | 0.990x |
| 4096 | 4096 | 32 | 60.3 | 60.4 | 17.8 | 1.000x |
| 4096 | 4096 | 64 | 57.1 | 59.2 | 36.3 | **0.964x** |
| 4096 | 4096 | 128 | 69.9 | 72.8 | 59.0 | **0.960x** |
| 4096 | 4096 | 256 | 61.2 | 65.6 | 130.8 | **0.933x** |
| 4096 | 4096 | 512 | 112.8 | 113.9 | 150.8 | 0.991x |
| 4096 | 4096 | 1024 | 151.8 | 152.3 | 225.7 | 0.997x |
| 4096 | 4096 | 2048 | 220.7 | 223.1 | 308.0 | 0.989x |
| 4096 | 4096 | 4096 | 366.1 | 376.4 | 365.2 | 0.973x |
| 4096 | 5376 | 1 | 72.6 | 71.3 | 0.6 | 1.017x |
| 4096 | 5376 | 2 | 72.5 | 70.5 | 1.2 | 1.028x |
| 4096 | 5376 | 4 | 76.2 | 75.7 | 2.3 | 1.006x |
| 4096 | 5376 | 8 | 75.7 | 75.2 | 4.7 | 1.007x |
| 4096 | 5376 | 16 | 76.1 | 78.2 | 9.0 | 0.973x |
| 4096 | 5376 | 32 | 83.4 | 85.8 | 16.4 | 0.971x |
| 4096 | 5376 | 64 | 77.2 | 81.4 | 34.6 | **0.948x** |
| 4096 | 5376 | 128 | 84.4 | 88.6 | 63.6 | **0.953x** |
| 4096 | 5376 | 256 | 84.6 | 86.6 | 130.2 | 0.978x |
| 4096 | 5376 | 512 | 133.9 | 134.5 | 167.6 | 0.995x |
| 4096 | 5376 | 1024 | 178.8 | 180.3 | 250.1 | 0.991x |
| 4096 | 5376 | 2048 | 262.6 | 265.2 | 340.2 | 0.990x |
| 4096 | 5376 | 4096 | 464.7 | 470.1 | 383.7 | 0.988x |
| 4096 | 14336 | 1 | 176.1 | 174.6 | 0.7 | 1.009x |
| 4096 | 14336 | 2 | 176.0 | 175.2 | 1.3 | 1.005x |
| 4096 | 14336 | 4 | 176.9 | 176.7 | 2.7 | 1.001x |
| 4096 | 14336 | 8 | 177.6 | 177.5 | 5.3 | 1.000x |
| 4096 | 14336 | 16 | 178.5 | 178.6 | 10.5 | 1.000x |
| 4096 | 14336 | 32 | 178.6 | 178.9 | 21.0 | 0.999x |
| 4096 | 14336 | 64 | 180.0 | 180.3 | 41.7 | 0.998x |
| 4096 | 14336 | 128 | 182.3 | 182.7 | 82.3 | 0.998x |
| 4096 | 14336 | 256 | 194.4 | 195.0 | 154.1 | 0.997x |
| 4096 | 14336 | 512 | 253.2 | 254.7 | 236.1 | 0.994x |
| 4096 | 14336 | 1024 | 375.2 | 377.6 | 318.5 | 0.994x |
| 4096 | 14336 | 2048 | 580.2 | 585.3 | 410.9 | 0.991x |
| 4096 | 14336 | 4096 | 1049.4 | 1061.3 | 453.3 | 0.989x |
| 8192 | 2560 | 1 | 70.1 | 68.4 | 0.6 | 1.025x |
| 8192 | 2560 | 2 | 66.1 | 65.4 | 1.3 | 1.010x |
| 8192 | 2560 | 4 | 65.3 | 65.2 | 2.6 | 1.001x |
| 8192 | 2560 | 8 | 67.5 | 67.0 | 5.0 | 1.008x |
| 8192 | 2560 | 16 | 67.9 | 65.2 | 10.3 | 1.042x |
| 8192 | 2560 | 32 | 68.2 | 66.1 | 20.3 | 1.032x |
| 8192 | 2560 | 64 | 67.1 | 67.8 | 39.6 | 0.989x |
| 8192 | 2560 | 128 | 69.3 | 69.6 | 77.2 | 0.996x |
| 8192 | 2560 | 256 | 89.8 | 91.6 | 117.3 | 0.981x |
| 8192 | 2560 | 512 | 137.4 | 137.1 | 156.6 | 1.002x |
| 8192 | 2560 | 1024 | 176.3 | 177.1 | 242.5 | 0.995x |
| 8192 | 2560 | 2048 | 279.4 | 280.6 | 306.1 | 0.996x |
| 8192 | 2560 | 4096 | 489.2 | 495.3 | 346.9 | 0.988x |
| 14336 | 4096 | 1 | 171.5 | 162.8 | 0.7 | 1.053x |
| 14336 | 4096 | 2 | 171.7 | 162.1 | 1.4 | 1.059x |
| 14336 | 4096 | 4 | 171.5 | 162.0 | 2.9 | 1.059x |
| 14336 | 4096 | 8 | 171.9 | 163.3 | 5.8 | 1.053x |
| 14336 | 4096 | 16 | 171.8 | 162.9 | 11.5 | 1.054x |
| 14336 | 4096 | 32 | 173.4 | 165.2 | 22.7 | 1.049x |
| 14336 | 4096 | 64 | 176.7 | 167.4 | 44.9 | 1.055x |
| 14336 | 4096 | 128 | 181.3 | 180.4 | 83.3 | 1.005x |
| 14336 | 4096 | 256 | 188.7 | 190.3 | 158.0 | 0.992x |
| 14336 | 4096 | 512 | 253.7 | 255.0 | 235.8 | 0.995x |
| 14336 | 4096 | 1024 | 382.4 | 384.3 | 312.9 | 0.995x |
| 14336 | 4096 | 2048 | 620.9 | 624.4 | 385.2 | 0.994x |
| 14336 | 4096 | 4096 | 1140.7 | 1148.9 | 418.7 | 0.993x |

</details>

<details>
<summary><b>RTX PRO 6000 (SM120)</b></summary>

| n | k | m | old (us) | new (us) | new TFLOPs | speedup |
|---|---|---|---|---|---|---|
| 512 | 7168 | 1 | 22.3 | 21.7 | 0.3 | 1.026x |
| 512 | 7168 | 2 | 22.4 | 22.5 | 0.7 | 0.994x |
| 512 | 7168 | 4 | 22.4 | 22.5 | 1.3 | 0.998x |
| 512 | 7168 | 8 | 22.4 | 22.5 | 2.6 | 0.995x |
| 512 | 7168 | 16 | 22.4 | 22.4 | 5.2 | 0.999x |
| 512 | 7168 | 32 | 22.3 | 22.5 | 10.4 | 0.991x |
| 512 | 7168 | 64 | 22.4 | 22.7 | 20.7 | 0.991x |
| 512 | 7168 | 128 | 22.9 | 23.1 | 40.6 | 0.992x |
| 512 | 7168 | 256 | 32.6 | 32.8 | 57.2 | 0.992x |
| 512 | 7168 | 512 | 35.7 | 35.9 | 104.8 | 0.996x |
| 512 | 7168 | 1024 | 41.5 | 41.7 | 180.1 | 0.995x |
| 512 | 7168 | 2048 | 45.6 | 47.1 | 319.2 | **0.969x** |
| 512 | 7168 | 4096 | 51.4 | 53.6 | 561.2 | **0.959x** |
| 1024 | 8192 | 1 | 25.6 | 25.8 | 0.7 | 0.993x |
| 1024 | 8192 | 2 | 25.6 | 25.8 | 1.3 | 0.994x |
| 1024 | 8192 | 4 | 25.7 | 25.9 | 2.6 | 0.994x |
| 1024 | 8192 | 8 | 25.7 | 25.9 | 5.2 | 0.992x |
| 1024 | 8192 | 16 | 25.7 | 25.8 | 10.4 | 0.994x |
| 1024 | 8192 | 32 | 25.6 | 25.8 | 20.8 | 0.993x |
| 1024 | 8192 | 64 | 25.8 | 25.9 | 41.4 | 0.995x |
| 1024 | 8192 | 128 | 27.0 | 28.4 | 75.6 | **0.951x** |
| 1024 | 8192 | 256 | 39.0 | 39.6 | 108.4 | 0.985x |
| 1024 | 8192 | 512 | 43.1 | 43.5 | 197.6 | 0.991x |
| 1024 | 8192 | 1024 | 47.4 | 49.5 | 347.4 | **0.959x** |
| 1024 | 8192 | 2048 | 50.2 | 50.0 | 687.0 | 1.004x |
| 1024 | 8192 | 4096 | 89.5 | 90.9 | 756.3 | 0.985x |
| 2560 | 8192 | 1 | 34.5 | 31.6 | 1.3 | 1.092x |
| 2560 | 8192 | 2 | 34.6 | 31.7 | 2.6 | 1.092x |
| 2560 | 8192 | 4 | 34.7 | 31.8 | 5.3 | 1.090x |
| 2560 | 8192 | 8 | 34.6 | 32.1 | 10.5 | 1.079x |
| 2560 | 8192 | 16 | 34.9 | 32.7 | 20.5 | 1.069x |
| 2560 | 8192 | 32 | 34.9 | 32.8 | 40.9 | 1.065x |
| 2560 | 8192 | 64 | 35.2 | 33.3 | 80.7 | 1.059x |
| 2560 | 8192 | 128 | 41.7 | 39.9 | 134.7 | 1.046x |
| 2560 | 8192 | 256 | 48.2 | 39.9 | 269.1 | 1.207x |
| 2560 | 8192 | 512 | 48.8 | 48.6 | 442.2 | 1.004x |
| 2560 | 8192 | 1024 | 50.6 | 51.3 | 837.6 | 0.987x |
| 2560 | 8192 | 2048 | 87.5 | 88.2 | 973.8 | 0.992x |
| 2560 | 8192 | 4096 | 163.8 | 166.9 | 1029.4 | 0.982x |
| 4096 | 4096 | 1 | 23.6 | 22.4 | 1.5 | 1.053x |
| 4096 | 4096 | 2 | 23.6 | 22.7 | 3.0 | 1.038x |
| 4096 | 4096 | 4 | 23.7 | 22.8 | 5.9 | 1.041x |
| 4096 | 4096 | 8 | 23.7 | 23.2 | 11.6 | 1.021x |
| 4096 | 4096 | 16 | 23.8 | 23.2 | 23.2 | 1.029x |
| 4096 | 4096 | 32 | 24.0 | 23.6 | 45.5 | 1.020x |
| 4096 | 4096 | 64 | 24.0 | 23.8 | 90.2 | 1.009x |
| 4096 | 4096 | 128 | 31.9 | 31.2 | 137.7 | 1.022x |
| 4096 | 4096 | 256 | 35.2 | 35.2 | 244.0 | 1.000x |
| 4096 | 4096 | 512 | 36.8 | 36.7 | 467.7 | 1.001x |
| 4096 | 4096 | 1024 | 54.3 | 54.5 | 630.0 | 0.995x |
| 4096 | 4096 | 2048 | 73.0 | 73.9 | 930.3 | 0.988x |
| 4096 | 4096 | 4096 | 134.6 | 137.0 | 1003.4 | 0.983x |
| 4096 | 5376 | 1 | 30.9 | 28.9 | 1.5 | 1.068x |
| 4096 | 5376 | 2 | 30.8 | 28.8 | 3.1 | 1.069x |
| 4096 | 5376 | 4 | 30.8 | 29.4 | 6.0 | 1.046x |
| 4096 | 5376 | 8 | 30.8 | 29.2 | 12.1 | 1.055x |
| 4096 | 5376 | 16 | 30.7 | 29.5 | 23.9 | 1.042x |
| 4096 | 5376 | 32 | 31.0 | 29.9 | 47.1 | 1.035x |
| 4096 | 5376 | 64 | 31.1 | 30.0 | 93.9 | 1.037x |
| 4096 | 5376 | 128 | 37.6 | 37.0 | 152.5 | 1.018x |
| 4096 | 5376 | 256 | 41.4 | 38.3 | 294.7 | 1.083x |
| 4096 | 5376 | 512 | 43.2 | 43.2 | 522.2 | 0.999x |
| 4096 | 5376 | 1024 | 66.2 | 66.3 | 680.7 | 0.999x |
| 4096 | 5376 | 2048 | 92.4 | 92.4 | 975.8 | 0.999x |
| 4096 | 5376 | 4096 | 166.6 | 169.3 | 1065.2 | 0.984x |
| 4096 | 14336 | 1 | 64.4 | 60.0 | 2.0 | 1.072x |
| 4096 | 14336 | 2 | 64.3 | 59.8 | 3.9 | 1.075x |
| 4096 | 14336 | 4 | 64.4 | 60.3 | 7.8 | 1.067x |
| 4096 | 14336 | 8 | 64.4 | 60.2 | 15.6 | 1.070x |
| 4096 | 14336 | 16 | 64.3 | 60.4 | 31.1 | 1.064x |
| 4096 | 14336 | 32 | 64.4 | 60.9 | 61.7 | 1.059x |
| 4096 | 14336 | 64 | 64.5 | 61.3 | 122.6 | 1.053x |
| 4096 | 14336 | 128 | 65.3 | 62.8 | 239.2 | 1.040x |
| 4096 | 14336 | 256 | 77.5 | 65.2 | 460.9 | 1.188x |
| 4096 | 14336 | 512 | 80.7 | 82.3 | 730.7 | 0.981x |
| 4096 | 14336 | 1024 | 139.4 | 140.6 | 855.5 | 0.992x |
| 4096 | 14336 | 2048 | 206.0 | 206.8 | 1163.0 | 0.996x |
| 4096 | 14336 | 4096 | 395.7 | 398.7 | 1206.5 | 0.992x |
| 8192 | 2560 | 1 | 22.2 | 22.0 | 1.9 | 1.012x |
| 8192 | 2560 | 2 | 21.5 | 20.7 | 4.1 | 1.043x |
| 8192 | 2560 | 4 | 21.4 | 20.4 | 8.2 | 1.049x |
| 8192 | 2560 | 8 | 21.9 | 21.7 | 15.5 | 1.008x |
| 8192 | 2560 | 16 | 21.2 | 21.7 | 30.9 | 0.977x |
| 8192 | 2560 | 32 | 21.6 | 23.6 | 56.9 | **0.915x** |
| 8192 | 2560 | 64 | 24.6 | 26.8 | 100.2 | **0.917x** |
| 8192 | 2560 | 128 | 25.8 | 29.7 | 180.9 | **0.868x** |
| 8192 | 2560 | 256 | 29.1 | 29.6 | 362.2 | 0.981x |
| 8192 | 2560 | 512 | 43.0 | 42.8 | 501.7 | 1.005x |
| 8192 | 2560 | 1024 | 54.7 | 55.2 | 777.4 | 0.989x |
| 8192 | 2560 | 2048 | 93.2 | 93.7 | 916.9 | 0.994x |
| 8192 | 2560 | 4096 | 163.2 | 167.5 | 1025.7 | 0.974x |
| 14336 | 4096 | 1 | 49.1 | 40.3 | 2.9 | 1.218x |
| 14336 | 4096 | 2 | 48.3 | 39.1 | 6.0 | 1.235x |
| 14336 | 4096 | 4 | 49.2 | 39.9 | 11.8 | 1.231x |
| 14336 | 4096 | 8 | 47.8 | 39.5 | 23.8 | 1.211x |
| 14336 | 4096 | 16 | 46.0 | 39.7 | 47.3 | 1.158x |
| 14336 | 4096 | 32 | 44.5 | 43.1 | 87.3 | 1.033x |
| 14336 | 4096 | 64 | 40.7 | 44.2 | 170.1 | **0.922x** |
| 14336 | 4096 | 128 | 43.4 | 45.3 | 332.0 | **0.959x** |
| 14336 | 4096 | 256 | 59.5 | 60.7 | 495.0 | 0.979x |
| 14336 | 4096 | 512 | 80.0 | 79.7 | 754.6 | 1.004x |
| 14336 | 4096 | 1024 | 116.2 | 116.5 | 1032.0 | 0.997x |
| 14336 | 4096 | 2048 | 212.8 | 214.3 | 1122.6 | 0.993x |
| 14336 | 4096 | 4096 | 390.8 | 395.2 | 1217.2 | 0.989x |

</details>

<details>
<summary><b>DGX Spark / GB10 (SM121)</b></summary>

| n | k | m | old (us) | new (us) | new TFLOPs | speedup |
|---|---|---|---|---|---|---|
| 512 | 7168 | 1 | 31.1 | 31.3 | 0.2 | 0.991x |
| 512 | 7168 | 2 | 31.5 | 31.4 | 0.5 | 1.003x |
| 512 | 7168 | 4 | 31.6 | 31.1 | 0.9 | 1.016x |
| 512 | 7168 | 8 | 31.6 | 31.5 | 1.9 | 1.005x |
| 512 | 7168 | 16 | 31.7 | 31.8 | 3.7 | 0.997x |
| 512 | 7168 | 32 | 32.5 | 33.7 | 7.0 | **0.964x** |
| 512 | 7168 | 64 | 34.1 | 33.8 | 13.9 | 1.009x |
| 512 | 7168 | 128 | 49.0 | 39.3 | 23.9 | 1.245x |
| 512 | 7168 | 256 | 60.7 | 49.5 | 38.0 | 1.227x |
| 512 | 7168 | 512 | 56.8 | 56.3 | 66.7 | 1.008x |
| 512 | 7168 | 1024 | 73.1 | 73.6 | 102.2 | 0.994x |
| 512 | 7168 | 2048 | 129.0 | 129.0 | 116.5 | 1.000x |
| 512 | 7168 | 4096 | 227.0 | 225.8 | 133.1 | 1.005x |
| 1024 | 8192 | 1 | 65.4 | 59.8 | 0.3 | 1.094x |
| 1024 | 8192 | 2 | 64.7 | 60.2 | 0.6 | 1.075x |
| 1024 | 8192 | 4 | 65.9 | 59.5 | 1.1 | 1.108x |
| 1024 | 8192 | 8 | 64.1 | 60.5 | 2.2 | 1.058x |
| 1024 | 8192 | 16 | 63.6 | 57.1 | 4.7 | 1.114x |
| 1024 | 8192 | 32 | 66.5 | 58.5 | 9.2 | 1.136x |
| 1024 | 8192 | 64 | 55.5 | 58.1 | 18.5 | **0.956x** |
| 1024 | 8192 | 128 | 72.0 | 64.4 | 33.3 | 1.119x |
| 1024 | 8192 | 256 | 83.1 | 79.1 | 54.3 | 1.050x |
| 1024 | 8192 | 512 | 81.5 | 84.5 | 101.6 | **0.964x** |
| 1024 | 8192 | 1024 | 155.6 | 130.2 | 132.0 | 1.195x |
| 1024 | 8192 | 2048 | 200.4 | 191.2 | 179.7 | 1.048x |
| 1024 | 8192 | 4096 | 456.5 | 410.5 | 167.4 | 1.112x |
| 2560 | 8192 | 1 | 117.8 | 118.0 | 0.4 | 0.998x |
| 2560 | 8192 | 2 | 116.2 | 119.2 | 0.7 | 0.975x |
| 2560 | 8192 | 4 | 118.0 | 118.2 | 1.4 | 0.998x |
| 2560 | 8192 | 8 | 116.2 | 119.4 | 2.8 | 0.973x |
| 2560 | 8192 | 16 | 118.2 | 118.5 | 5.7 | 0.998x |
| 2560 | 8192 | 32 | 117.1 | 119.8 | 11.2 | 0.977x |
| 2560 | 8192 | 64 | 117.7 | 120.7 | 22.2 | 0.975x |
| 2560 | 8192 | 128 | 119.6 | 124.2 | 43.2 | **0.963x** |
| 2560 | 8192 | 256 | 124.7 | 128.5 | 83.6 | 0.970x |
| 2560 | 8192 | 512 | 151.2 | 146.9 | 146.1 | 1.029x |
| 2560 | 8192 | 1024 | 212.2 | 206.8 | 207.6 | 1.026x |
| 2560 | 8192 | 2048 | 346.6 | 337.4 | 254.6 | 1.027x |
| 2560 | 8192 | 4096 | 951.6 | 861.4 | 199.4 | 1.105x |
| 4096 | 4096 | 1 | 94.2 | 98.6 | 0.3 | **0.956x** |
| 4096 | 4096 | 2 | 113.4 | 99.0 | 0.7 | 1.146x |
| 4096 | 4096 | 4 | 111.6 | 101.8 | 1.3 | 1.096x |
| 4096 | 4096 | 8 | 113.1 | 97.4 | 2.8 | 1.161x |
| 4096 | 4096 | 16 | 113.5 | 101.6 | 5.3 | 1.117x |
| 4096 | 4096 | 32 | 113.6 | 99.6 | 10.8 | 1.141x |
| 4096 | 4096 | 64 | 112.5 | 100.6 | 21.3 | 1.119x |
| 4096 | 4096 | 128 | 111.9 | 99.2 | 43.3 | 1.128x |
| 4096 | 4096 | 256 | 107.3 | 108.4 | 79.3 | 0.991x |
| 4096 | 4096 | 512 | 115.5 | 112.7 | 152.5 | 1.025x |
| 4096 | 4096 | 1024 | 158.6 | 158.4 | 216.9 | 1.001x |
| 4096 | 4096 | 2048 | 281.3 | 272.3 | 252.3 | 1.033x |
| 4096 | 4096 | 4096 | 508.9 | 494.9 | 277.7 | 1.028x |
| 4096 | 5376 | 1 | 117.4 | 118.8 | 0.4 | 0.988x |
| 4096 | 5376 | 2 | 116.6 | 117.4 | 0.8 | 0.994x |
| 4096 | 5376 | 4 | 117.0 | 118.4 | 1.5 | 0.989x |
| 4096 | 5376 | 8 | 116.3 | 117.7 | 3.0 | 0.988x |
| 4096 | 5376 | 16 | 118.6 | 118.8 | 5.9 | 0.998x |
| 4096 | 5376 | 32 | 116.5 | 118.3 | 11.9 | 0.985x |
| 4096 | 5376 | 64 | 117.8 | 119.1 | 23.7 | 0.989x |
| 4096 | 5376 | 128 | 118.7 | 119.9 | 47.0 | 0.991x |
| 4096 | 5376 | 256 | 129.1 | 132.6 | 85.0 | 0.973x |
| 4096 | 5376 | 512 | 139.8 | 142.2 | 158.6 | 0.983x |
| 4096 | 5376 | 1024 | 200.0 | 197.5 | 228.3 | 1.012x |
| 4096 | 5376 | 2048 | 338.3 | 340.3 | 265.1 | 0.994x |
| 4096 | 5376 | 4096 | 693.6 | 645.1 | 279.6 | 1.075x |
| 4096 | 14336 | 1 | 231.6 | 231.8 | 0.5 | 0.999x |
| 4096 | 14336 | 2 | 229.6 | 229.4 | 1.0 | 1.001x |
| 4096 | 14336 | 4 | 232.6 | 232.5 | 2.0 | 1.000x |
| 4096 | 14336 | 8 | 232.1 | 228.7 | 4.1 | 1.015x |
| 4096 | 14336 | 16 | 230.7 | 232.7 | 8.1 | 0.991x |
| 4096 | 14336 | 32 | 230.2 | 228.7 | 16.4 | 1.007x |
| 4096 | 14336 | 64 | 231.9 | 232.7 | 32.3 | 0.997x |
| 4096 | 14336 | 128 | 234.1 | 234.2 | 64.2 | 1.000x |
| 4096 | 14336 | 256 | 266.6 | 265.2 | 113.4 | 1.005x |
| 4096 | 14336 | 512 | 303.0 | 302.6 | 198.7 | 1.001x |
| 4096 | 14336 | 1024 | 469.2 | 466.4 | 257.9 | 1.006x |
| 4096 | 14336 | 2048 | 902.7 | 880.0 | 273.3 | 1.026x |
| 4096 | 14336 | 4096 | 3847.1 | 3765.8 | 127.7 | 1.022x |
| 8192 | 2560 | 1 | 113.6 | 113.0 | 0.4 | 1.005x |
| 8192 | 2560 | 2 | 111.7 | 113.4 | 0.7 | 0.986x |
| 8192 | 2560 | 4 | 113.2 | 113.3 | 1.5 | 0.999x |
| 8192 | 2560 | 8 | 113.2 | 113.8 | 2.9 | 0.995x |
| 8192 | 2560 | 16 | 114.2 | 113.5 | 5.9 | 1.006x |
| 8192 | 2560 | 32 | 113.6 | 114.5 | 11.7 | 0.993x |
| 8192 | 2560 | 64 | 114.2 | 115.4 | 23.3 | 0.990x |
| 8192 | 2560 | 128 | 116.4 | 119.2 | 45.0 | 0.976x |
| 8192 | 2560 | 256 | 119.7 | 121.7 | 88.2 | 0.984x |
| 8192 | 2560 | 512 | 135.1 | 139.3 | 154.2 | 0.970x |
| 8192 | 2560 | 1024 | 200.1 | 199.5 | 215.3 | 1.003x |
| 8192 | 2560 | 2048 | 370.9 | 371.6 | 231.1 | 0.998x |
| 8192 | 2560 | 4096 | 644.3 | 641.7 | 267.7 | 1.004x |
| 14336 | 4096 | 1 | 232.3 | 226.1 | 0.5 | 1.028x |
| 14336 | 4096 | 2 | 232.5 | 226.5 | 1.0 | 1.026x |
| 14336 | 4096 | 4 | 231.8 | 225.8 | 2.1 | 1.026x |
| 14336 | 4096 | 8 | 232.2 | 226.7 | 4.1 | 1.024x |
| 14336 | 4096 | 16 | 232.7 | 226.7 | 8.3 | 1.026x |
| 14336 | 4096 | 32 | 232.1 | 226.4 | 16.6 | 1.025x |
| 14336 | 4096 | 64 | 233.3 | 229.0 | 32.8 | 1.019x |
| 14336 | 4096 | 128 | 235.8 | 232.5 | 64.7 | 1.014x |
| 14336 | 4096 | 256 | 246.5 | 239.6 | 125.5 | 1.029x |
| 14336 | 4096 | 512 | 293.4 | 287.1 | 209.4 | 1.022x |
| 14336 | 4096 | 1024 | 441.3 | 441.2 | 272.6 | 1.000x |
| 14336 | 4096 | 2048 | 838.2 | 836.7 | 287.5 | 1.002x |
| 14336 | 4096 | 4096 | 1500.5 | 1506.2 | 319.4 | 0.996x |

</details>

## 🔍 Related Issues
Closes #3517.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks
- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests
- [x] Tests have been added or updated as needed. *(covered by existing `tests/gemm/test_mm_fp4.py -k b12x`)*
- [x] All tests are passing — `pytest -k b12x` 396/0; 104-shape `--refcheck` 104/104 on 5080 / PRO 6000 / GB10.

## Reviewer Notes
- The vendored kernel is **not a verbatim upstream copy**: it carries backported scale-factor helpers so it builds on public `cutlass-dsl 4.5.2` (pure upstream b12x needs an internal/newer cutlass-dsl), and the MXFP8 path is pruned (unsupported there).
- The SFB-layout N-divisibility assertion in `cute_dsl/utils.py` is relaxed **64→16** (upstream commit `0daa6ab`) to admit the narrow-N `swap_ab` tiles. This is safe: it only *loosens* a precondition (every previously-valid N%64==0 tile still passes), the SFB smem layout already rounds N up to a full 128-wide block so the layout is unchanged for existing tiles, and the newly-admitted narrow tiles pass `--refcheck`.
- `swap_ab` here is b12x's **device-internal** transpose (public C stays row-major) — *not* the SM100 operand-swap/FFI-transpose convention. The shared `_compile_block_scaled_gemm` harness used by Sm100/Sm103 is **left untouched**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Relaxed a tile-shape constraint to allow more flexible tensor layouts.
  * Deterministic plan selection for low‑precision GEMM with a smaller, predictable candidate set.
  * Earlier, clearer validation for incompatible contraction dimensions to surface errors sooner.
  * Consistent operand orientation and compilation caching to reduce surprises in kernel selection and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
