### PR TITLE
Support GQA group_size 16 in decode dispatch

### DIFF
--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -150,6 +150,9 @@
   } else if (group_size == 8) {                              \
     constexpr size_t GROUP_SIZE = 8;                         \
     __VA_ARGS__                                              \
+  } else if (group_size == 16) {                             \
+    constexpr size_t GROUP_SIZE = 16;                        \
+    __VA_ARGS__                                              \
   } else {                                                   \
     std::ostringstream err_msg;                              \
     err_msg << "Unsupported group_size: " << group_size;     \


### PR DESCRIPTION
## Problem

`DISPATCH_GQA_GROUP_SIZE` (`include/flashinfer/utils.cuh`) enumerates group sizes `{1, 2, 3, 4, 8}` but not `16`. Decode therefore fails for models with **16 query heads per KV head**:

```
RuntimeError: Error in function 'operator()' at .../batch_decode.cu:63: Unsupported group_size: 16
```

This affects real models — e.g. **Qwen3-Coder-Next-80B** (64 query heads / 4 KV heads = group_size 16). Both `single_decode_with_kv_cache` and `BatchDecodeWithPagedKVCacheWrapper` hit it. On consumer/workstation Blackwell (**SM120** — RTX PRO 6000 Blackwell, RTX 5090) there is no other working attention path for such models, so they cannot be served at all.

## Fix

Add the `group_size == 16` case to the dispatch macro (6 lines), mirroring the existing cases.

## Testing

Verified on flashinfer 0.6.12, CUDA 12.9, RTX PRO 6000 Blackwell (cc 12.0), torch 2.9.1+cu128:

- **Before:** both `single_decode_with_kv_cache` and `BatchDecodeWithPagedKVCacheWrapper` raise `Unsupported group_size: 16` at `num_qo_heads=64, num_kv_heads=4, head_dim=128`.
- **After:** both run, and the output matches an independent fp32 reference attention implementation to **max_abs 2.0e-3** (bf16, head_dim 128) at group_size 16.

Minimal repro (fails before, passes after):

```python
import torch, flashinfer
dev='cuda'; S=512; page=16; npages=S//page; hq,hkv,D=64,4,128  # group_size 16
wb=torch.empty(128*1024*1024, dtype=torch.uint8, device=dev)
w=flashinfer.BatchDecodeWithPagedKVCacheWrapper(wb, 'NHD')
w.plan(torch.tensor([0,npages],dtype=torch.int32,device=dev),
       torch.arange(npages,dtype=torch.int32,device=dev),
       torch.tensor([page],dtype=torch.int32,device=dev),
       hq,hkv,D,page,q_data_type=torch.bfloat16,kv_data_type=torch.bfloat16)
q=torch.randn(1,hq,D,dtype=torch.bfloat16,device=dev)
kv=torch.randn(npages,2,page,hkv,D,dtype=torch.bfloat16,device=dev)
w.run(q,kv)  # before: RuntimeError Unsupported group_size: 16 ; after: OK
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional group size configuration value, enabling previously restricted operational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->