### PR TITLE
fix(gemm): pre-filter SM121 MXFP8 CUTLASS tactics that exceed device shared memory

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -18,7 +18,7 @@ import functools
 import logging
 from enum import Enum
 from types import SimpleNamespace
-from typing import List, Literal, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -4005,12 +4005,12 @@ def mm_fp8(
     return out
 
 
-def _probe_mxfp8_gemm_tactics(module) -> List[int]:
-    """Probe which CUTLASS MXFP8 GEMM tactics can initialize on the current device.
+def _probe_mxfp8_gemm_tactics(module, device_id: int) -> List[int]:
+    """Probe which CUTLASS MXFP8 GEMM tactics can initialize on a specific device.
 
     SM120 (B100/B200 data-centre, ~256 KB shared memory/SM) and SM121 (GB10 /
     DGX Spark GeForce Blackwell, ~99 KB shared memory/SM opt-in) share the same
-    compiled module.  Large CTA tiles — 256×128 and 128×256 — are compiled with
+    compiled module.  Large CTA tiles — 256x128 and 128x256 — are compiled with
     ``StageCount<2>``, which requires ~99 KB of shared memory.  On SM121 this is
     at or beyond the per-block opt-in limit (``cudaDevAttrMaxSharedMemoryPerBlockOptin
     ≈ 101376 bytes``), so the CUTLASS ``initialize()`` call returns
@@ -4019,13 +4019,20 @@ def _probe_mxfp8_gemm_tactics(module) -> List[int]:
     Rather than letting the autotuner discover this noisily (and log confusing
     "[MXFP8 SM120 gemm Runner] Failed to initialize …" messages), we pre-filter
     here with a device-capability probe so the autotuner only sees tactics that
-    will actually succeed on this GPU.
+    will actually succeed on the given GPU.
 
     The probe uses square M = N = K = 128 tensors; initialization failure is
     shape-independent (it depends only on CTA tile size and device smem capacity),
     so any valid shapes reach the same CUTLASS ``initialize()`` decision.
+
+    Parameters
+    ----------
+    module:
+        The raw TVM-FFI SM120 MXFP8 GEMM module.
+    device_id:
+        CUDA device index to probe (``torch.cuda.current_device()``).
     """
-    dev = "cuda"
+    dev = torch.device("cuda", device_id)
 
     def _pad_up(x: int, m: int) -> int:
         return ((x + m - 1) // m) * m
@@ -4048,14 +4055,15 @@ def _probe_mxfp8_gemm_tactics(module) -> List[int]:
             module.mxfp8_gemm(a, b, sfa, sfb, out, ws, t)
             valid.append(t)
         except RuntimeError:
-            device_name = torch.cuda.get_device_properties(0).name
+            device_name = torch.cuda.get_device_properties(device_id).name
             logger.debug(
-                "mxfp8_gemm tactic %d cannot initialize on %s; skipping. "
+                "mxfp8_gemm tactic %d cannot initialize on %s (device %d); skipping. "
                 "(Tip: SM121 GB10/DGX Spark has ~99 KB shared memory opt-in per SM; "
-                "256×128 and 128×256 CTA tiles require ~99 KB with StageCount<2> "
+                "256x128 and 128x256 CTA tiles require ~99 KB with StageCount<2> "
                 "and may fail on that device.)",
                 t,
                 device_name,
+                device_id,
             )
     return valid
 
@@ -4063,9 +4071,10 @@ def _probe_mxfp8_gemm_tactics(module) -> List[int]:
 def _create_cutlass_mxfp8_gemm_module(module, op_name: str, tuner_name: str):
     """Helper function to create cutlass MXFP8 GEMM module."""
 
-    # One-time probe: cache valid tactics at closure scope so all runner
-    # instances for this module share the result without re-probing.
-    _valid_tactics_cache: List[int] = []
+    # Per-device cache keyed by device index.  Heterogeneous multi-GPU systems
+    # (e.g., mixing SM120 and SM121) require independent tactic sets per GPU,
+    # so a single shared list is insufficient.
+    _valid_tactics_cache: Dict[int, List[int]] = {}
 
     def cutlass_mxfp8_gemm_runner():
         class CutlassMxfp8GemmRunner(TunableRunner):
@@ -4074,9 +4083,12 @@ def _create_cutlass_mxfp8_gemm_module(module, op_name: str, tuner_name: str):
                 inputs: List[torch.Tensor],
                 profile: OptimizationProfile,
             ) -> List[int]:
-                if not _valid_tactics_cache:
-                    _valid_tactics_cache.extend(_probe_mxfp8_gemm_tactics(module))
-                return list(_valid_tactics_cache)
+                device_id = torch.cuda.current_device()
+                if device_id not in _valid_tactics_cache:
+                    _valid_tactics_cache[device_id] = _probe_mxfp8_gemm_tactics(
+                        module, device_id
+                    )
+                return list(_valid_tactics_cache[device_id])
 
             def forward(
                 self,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -15,9 +15,12 @@ limitations under the License.
 """
 
 import functools
+import logging
 from enum import Enum
 from types import SimpleNamespace
 from typing import List, Literal, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 from flashinfer.trtllm_low_latency_gemm import trtllm_low_latency_gemm
 import torch
@@ -4002,8 +4005,67 @@ def mm_fp8(
     return out
 
 
+def _probe_mxfp8_gemm_tactics(module) -> List[int]:
+    """Probe which CUTLASS MXFP8 GEMM tactics can initialize on the current device.
+
+    SM120 (B100/B200 data-centre, ~256 KB shared memory/SM) and SM121 (GB10 /
+    DGX Spark GeForce Blackwell, ~99 KB shared memory/SM opt-in) share the same
+    compiled module.  Large CTA tiles — 256×128 and 128×256 — are compiled with
+    ``StageCount<2>``, which requires ~99 KB of shared memory.  On SM121 this is
+    at or beyond the per-block opt-in limit (``cudaDevAttrMaxSharedMemoryPerBlockOptin
+    ≈ 101376 bytes``), so the CUTLASS ``initialize()`` call returns
+    ``kErrorInternal`` for those tactics.
+
+    Rather than letting the autotuner discover this noisily (and log confusing
+    "[MXFP8 SM120 gemm Runner] Failed to initialize …" messages), we pre-filter
+    here with a device-capability probe so the autotuner only sees tactics that
+    will actually succeed on this GPU.
+
+    The probe uses square M = N = K = 128 tensors; initialization failure is
+    shape-independent (it depends only on CTA tile size and device smem capacity),
+    so any valid shapes reach the same CUTLASS ``initialize()`` decision.
+    """
+    dev = "cuda"
+
+    def _pad_up(x: int, m: int) -> int:
+        return ((x + m - 1) // m) * m
+
+    M = N = K = 128
+    sf_vec = 32
+    k_scales = (K + sf_vec - 1) // sf_vec
+
+    a = torch.zeros(M, K, dtype=torch.float8_e4m3fn, device=dev)
+    # b as [N, K] contiguous – the C++ binding expects mat2 with shape [N, K].
+    b = torch.zeros(N, K, dtype=torch.float8_e4m3fn, device=dev)
+    sfa = torch.zeros(_pad_up(M, 128) * _pad_up(k_scales, 4), dtype=torch.uint8, device=dev)
+    sfb = torch.zeros(_pad_up(N, 128) * _pad_up(k_scales, 4), dtype=torch.uint8, device=dev)
+    out = torch.zeros(M, N, dtype=torch.bfloat16, device=dev)
+    ws = torch.zeros(8 * 1024 * 1024, dtype=torch.uint8, device=dev)
+
+    valid: List[int] = []
+    for t in range(module.mxfp8_gemm_tactic_num()):
+        try:
+            module.mxfp8_gemm(a, b, sfa, sfb, out, ws, t)
+            valid.append(t)
+        except RuntimeError:
+            device_name = torch.cuda.get_device_properties(0).name
+            logger.debug(
+                "mxfp8_gemm tactic %d cannot initialize on %s; skipping. "
+                "(Tip: SM121 GB10/DGX Spark has ~99 KB shared memory opt-in per SM; "
+                "256×128 and 128×256 CTA tiles require ~99 KB with StageCount<2> "
+                "and may fail on that device.)",
+                t,
+                device_name,
+            )
+    return valid
+
+
 def _create_cutlass_mxfp8_gemm_module(module, op_name: str, tuner_name: str):
     """Helper function to create cutlass MXFP8 GEMM module."""
+
+    # One-time probe: cache valid tactics at closure scope so all runner
+    # instances for this module share the result without re-probing.
+    _valid_tactics_cache: List[int] = []
 
     def cutlass_mxfp8_gemm_runner():
         class CutlassMxfp8GemmRunner(TunableRunner):
@@ -4012,7 +4074,9 @@ def _create_cutlass_mxfp8_gemm_module(module, op_name: str, tuner_name: str):
                 inputs: List[torch.Tensor],
                 profile: OptimizationProfile,
             ) -> List[int]:
-                return list(range(module.mxfp8_gemm_tactic_num()))
+                if not _valid_tactics_cache:
+                    _valid_tactics_cache.extend(_probe_mxfp8_gemm_tactics(module))
+                return list(_valid_tactics_cache)
 
             def forward(
                 self,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4044,8 +4044,12 @@ def _probe_mxfp8_gemm_tactics(module, device_id: int) -> List[int]:
     a = torch.zeros(M, K, dtype=torch.float8_e4m3fn, device=dev)
     # b as [N, K] contiguous – the C++ binding expects mat2 with shape [N, K].
     b = torch.zeros(N, K, dtype=torch.float8_e4m3fn, device=dev)
-    sfa = torch.zeros(_pad_up(M, 128) * _pad_up(k_scales, 4), dtype=torch.uint8, device=dev)
-    sfb = torch.zeros(_pad_up(N, 128) * _pad_up(k_scales, 4), dtype=torch.uint8, device=dev)
+    sfa = torch.zeros(
+        _pad_up(M, 128) * _pad_up(k_scales, 4), dtype=torch.uint8, device=dev
+    )
+    sfb = torch.zeros(
+        _pad_up(N, 128) * _pad_up(k_scales, 4), dtype=torch.uint8, device=dev
+    )
     out = torch.zeros(M, N, dtype=torch.bfloat16, device=dev)
     ws = torch.zeros(8 * 1024 * 1024, dtype=torch.uint8, device=dev)
 

--- a/include/flashinfer/gemm/mxfp8_gemm_template_sm120.h
+++ b/include/flashinfer/gemm/mxfp8_gemm_template_sm120.h
@@ -247,21 +247,19 @@ size_t genericMxfp8GemmKernelLauncherSm120(void* D, void const* A, void const* B
     auto initStatus = gemm.initialize(args, workspace, stream);                                   \
     if (initStatus != cutlass::Status::kSuccess) {                                                \
       /* kErrorInternal from initialize() typically means cudaFuncSetAttribute failed when        \
-       * requesting more dynamic shared memory than the device allows.  SM121 (GB10 / DGX Spark  \
+       * requesting more dynamic shared memory than the device allows.  SM121 (GB10 / DGX Spark   \
        * GeForce Blackwell) has ~99 KB shared-memory opt-in per SM, while the 256×128 and        \
-       * 128×256 CTA tiles compiled with StageCount<2> require ~99 KB — right at the limit.      \
-       * The Python-side _probe_mxfp8_gemm_tactics() pre-filters these tactics so the            \
+       * 128×256 CTA tiles compiled with StageCount<2> require ~99 KB — right at the limit.    \
+       * The Python-side _probe_mxfp8_gemm_tactics() pre-filters these tactics so the             \
        * autotuner never reaches this path on SM121. */                                           \
       std::string smem_hint;                                                                      \
       if (initStatus == cutlass::Status::kErrorInternal) {                                        \
         int device_id, max_smem_optin;                                                            \
         if (cudaGetDevice(&device_id) == cudaSuccess &&                                           \
-            cudaDeviceGetAttribute(&max_smem_optin,                                               \
-                                   cudaDevAttrMaxSharedMemoryPerBlockOptin,                       \
+            cudaDeviceGetAttribute(&max_smem_optin, cudaDevAttrMaxSharedMemoryPerBlockOptin,      \
                                    device_id) == cudaSuccess) {                                   \
-          smem_hint = " (Device shared-memory opt-in limit: " +                                   \
-                      std::to_string(max_smem_optin) +                                            \
-                      " bytes.  256x128 and 128x256 tiles need ~101376 bytes with StageCount<2>" \
+          smem_hint = " (Device shared-memory opt-in limit: " + std::to_string(max_smem_optin) +  \
+                      " bytes.  256x128 and 128x256 tiles need ~101376 bytes with StageCount<2>"  \
                       " and will fail on devices with less than that.)";                          \
         }                                                                                         \
       }                                                                                           \

--- a/include/flashinfer/gemm/mxfp8_gemm_template_sm120.h
+++ b/include/flashinfer/gemm/mxfp8_gemm_template_sm120.h
@@ -246,8 +246,27 @@ size_t genericMxfp8GemmKernelLauncherSm120(void* D, void const* A, void const* B
     }                                                                                             \
     auto initStatus = gemm.initialize(args, workspace, stream);                                   \
     if (initStatus != cutlass::Status::kSuccess) {                                                \
+      /* kErrorInternal from initialize() typically means cudaFuncSetAttribute failed when        \
+       * requesting more dynamic shared memory than the device allows.  SM121 (GB10 / DGX Spark  \
+       * GeForce Blackwell) has ~99 KB shared-memory opt-in per SM, while the 256×128 and        \
+       * 128×256 CTA tiles compiled with StageCount<2> require ~99 KB — right at the limit.      \
+       * The Python-side _probe_mxfp8_gemm_tactics() pre-filters these tactics so the            \
+       * autotuner never reaches this path on SM121. */                                           \
+      std::string smem_hint;                                                                      \
+      if (initStatus == cutlass::Status::kErrorInternal) {                                        \
+        int device_id, max_smem_optin;                                                            \
+        if (cudaGetDevice(&device_id) == cudaSuccess &&                                           \
+            cudaDeviceGetAttribute(&max_smem_optin,                                               \
+                                   cudaDevAttrMaxSharedMemoryPerBlockOptin,                       \
+                                   device_id) == cudaSuccess) {                                   \
+          smem_hint = " (Device shared-memory opt-in limit: " +                                   \
+                      std::to_string(max_smem_optin) +                                            \
+                      " bytes.  256x128 and 128x256 tiles need ~101376 bytes with StageCount<2>" \
+                      " and will fail on devices with less than that.)";                          \
+        }                                                                                         \
+      }                                                                                           \
       std::string errMsg = "Failed to initialize cutlass MXFP8 gemm on sm120. Error: " +          \
-                           std::string(cutlass::cutlassGetStatusString(initStatus));              \
+                           std::string(cutlass::cutlassGetStatusString(initStatus)) + smem_hint;  \
       throw std::runtime_error("[MXFP8 SM120 gemm Runner] " + errMsg);                            \
     }                                                                                             \
     auto runStatus = gemm.run(args, workspace, stream, nullptr, /*enablePDL=*/true);              \

--- a/tests/gemm/test_mm_mxfp8_sm120.py
+++ b/tests/gemm/test_mm_mxfp8_sm120.py
@@ -1,4 +1,4 @@
-"""Tests for SM120 MXFP8 GEMM (issue #2728)."""
+"""Tests for SM120/SM121 MXFP8 GEMM."""
 
 import pytest
 import torch
@@ -121,3 +121,41 @@ def test_mm_mxfp8_sm120_rejects_linear_scales():
         mm_mxfp8(
             a_fp8, b_fp8.T, a_sf, b_sf, out_dtype=torch.bfloat16, backend="cutlass"
         )
+
+
+def test_probe_mxfp8_gemm_tactics_sm12x():
+    """_probe_mxfp8_gemm_tactics returns only device-compatible tactics.
+
+    SM120 (B100/B200, ~256 KB smem/SM) should support all 10 tactics.
+    SM121 (GB10/DGX Spark, ~99 KB smem/SM opt-in) should support only
+    tactics 0-5 (small CTA tiles); tactics 6-9 (256x128, 128x256) need
+    ~99 KB with StageCount<2> and fail on SM121.
+    """
+    _skip_if_not_sm120()
+
+    from flashinfer.gemm.gemm_base import _probe_mxfp8_gemm_tactics
+    from flashinfer.jit.gemm.core import gen_gemm_sm120_module_cutlass_mxfp8
+
+    raw_module = gen_gemm_sm120_module_cutlass_mxfp8().build_and_load()
+    valid = _probe_mxfp8_gemm_tactics(raw_module)
+
+    # At least the three small-tile configs (128x32, 128x64, 128x128) × 2 variants
+    # must be supported on any SM12x device.
+    assert len(valid) >= 6, f"Expected at least 6 valid tactics, got {len(valid)}: {valid}"
+
+    # All returned tactics must be within range.
+    total = raw_module.mxfp8_gemm_tactic_num()
+    assert all(0 <= t < total for t in valid), f"Out-of-range tactic in {valid}"
+
+    # Device-specific expectations.
+    cc = get_compute_capability(torch.device("cuda"))
+    if cc == (12, 1):
+        # SM121: large tiles (tactics 6-9) should not be valid.
+        assert 6 not in valid, "Tactic 6 (256x128 bf16) should not work on SM121"
+        assert 7 not in valid, "Tactic 7 (256x128 half) should not work on SM121"
+        assert 8 not in valid, "Tactic 8 (128x256 bf16) should not work on SM121"
+        assert 9 not in valid, "Tactic 9 (128x256 half) should not work on SM121"
+        assert valid == list(range(6)), f"SM121 expected tactics [0..5], got {valid}"
+    elif cc == (12, 0):
+        # SM120 data-centre: all 10 tactics should be valid.
+        assert valid == list(range(10)), f"SM120 expected all 10 tactics, got {valid}"

--- a/tests/gemm/test_mm_mxfp8_sm120.py
+++ b/tests/gemm/test_mm_mxfp8_sm120.py
@@ -134,12 +134,12 @@ def test_probe_mxfp8_gemm_tactics_sm12x():
     _skip_if_not_sm120()
 
     from flashinfer.gemm.gemm_base import _probe_mxfp8_gemm_tactics
-    from flashinfer.jit.gemm.core import gen_gemm_sm120_module_cutlass_mxfp8
+    from flashinfer.jit.gemm import gen_gemm_sm120_module_cutlass_mxfp8
 
     raw_module = gen_gemm_sm120_module_cutlass_mxfp8().build_and_load()
-    valid = _probe_mxfp8_gemm_tactics(raw_module)
+    valid = _probe_mxfp8_gemm_tactics(raw_module, torch.cuda.current_device())
 
-    # At least the three small-tile configs (128x32, 128x64, 128x128) × 2 variants
+    # At least the three small-tile configs (128x32, 128x64, 128x128) x 2 variants
     # must be supported on any SM12x device.
     assert len(valid) >= 6, f"Expected at least 6 valid tactics, got {len(valid)}: {valid}"
 
@@ -151,10 +151,10 @@ def test_probe_mxfp8_gemm_tactics_sm12x():
     cc = get_compute_capability(torch.device("cuda"))
     if cc == (12, 1):
         # SM121: large tiles (tactics 6-9) should not be valid.
-        assert 6 not in valid, "Tactic 6 (256x128 bf16) should not work on SM121"
-        assert 7 not in valid, "Tactic 7 (256x128 half) should not work on SM121"
-        assert 8 not in valid, "Tactic 8 (128x256 bf16) should not work on SM121"
-        assert 9 not in valid, "Tactic 9 (128x256 half) should not work on SM121"
+        assert 6 not in valid, "Tactic 6 (256x128 non-swapped) should not work on SM121"
+        assert 7 not in valid, "Tactic 7 (256x128 swapped) should not work on SM121"
+        assert 8 not in valid, "Tactic 8 (128x256 non-swapped) should not work on SM121"
+        assert 9 not in valid, "Tactic 9 (128x256 swapped) should not work on SM121"
         assert valid == list(range(6)), f"SM121 expected tactics [0..5], got {valid}"
     elif cc == (12, 0):
         # SM120 data-centre: all 10 tactics should be valid.

--- a/tests/gemm/test_mm_mxfp8_sm120.py
+++ b/tests/gemm/test_mm_mxfp8_sm120.py
@@ -141,7 +141,9 @@ def test_probe_mxfp8_gemm_tactics_sm12x():
 
     # At least the three small-tile configs (128x32, 128x64, 128x128) x 2 variants
     # must be supported on any SM12x device.
-    assert len(valid) >= 6, f"Expected at least 6 valid tactics, got {len(valid)}: {valid}"
+    assert len(valid) >= 6, (
+        f"Expected at least 6 valid tactics, got {len(valid)}: {valid}"
+    )
 
     # All returned tactics must be within range.
     total = raw_module.mxfp8_gemm_tactic_num()


### PR DESCRIPTION
## Problem

On SM121 (GB10 / DGX Spark GeForce Blackwell), 4 of the 10 SM120 MXFP8 CUTLASS tactics fail silently every model load:

```
[MXFP8 SM120 gemm Runner] Failed to initialize cutlass MXFP8 gemm on sm120. Error: Error Internal
```

**Root cause**: SM121 has ~99 KB shared-memory opt-in per SM (`cudaDevAttrMaxSharedMemoryPerBlockOptin ≈ 101376 bytes`). The 256×128 and 128×256 CTA tiles in the SM120 module are compiled with `StageCount<2>`, which requires ~99 KB of shared memory — right at SM121's device limit. CUTLASS `initialize()` calls `cudaFuncSetAttribute(..., cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size)` which fails, returning `kErrorInternal`.

## Investigation (NVIDIA GB10 / SM121)

| Tactic | CTA shape | SM121 result |
|--------|-----------|--------------|
| 0-5 | 128×32, 128×64, 128×128 (×2 swap-AB) | OK |
| 6-9 | **256×128, 128×256** (×2 swap-AB) | FAIL: kErrorInternal |

Device: `shared_memory_per_block_optin = 101376 bytes`. The failure is shape-independent — it happens at kernel initialization time regardless of M/N/K.

Reported in #3558 (comment) and #3170.

## Fix

1. **`flashinfer/gemm/gemm_base.py`**: Add `_probe_mxfp8_gemm_tactics(module)` that runs a cheap M=N=K=128 probe for each tactic (initialization failure is shape-independent). Result cached in closure scope. `get_valid_tactics()` calls this once and returns only supported tactics. On SM121: `[0,1,2,3,4,5]` (silent).

2. **`include/flashinfer/gemm/mxfp8_gemm_template_sm120.h`**: When `initialize()` fails with `kErrorInternal`, query device smem opt-in limit and include it in the exception message so the error is actionable.

3. **`tests/gemm/test_mm_mxfp8_sm120.py`**: Add `test_probe_mxfp8_gemm_tactics_sm12x` verifying ≥6 tactics on SM12x, exactly `[0..5]` on SM121, all 10 on SM120.

## Test result on GB10 (SM121)

Before: 4 tactics fail with "Error Internal" on every autotuner run
After: `_probe_mxfp8_gemm_tactics` returns `[0,1,2,3,4,5]` silently

Closes #3170 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic MXFP8 GEMM GPU-compatibility probing so only supported tiling tactics are selected, improving reliability on different GPU compute capabilities.

* **Bug Fixes**
  * Enhanced MXFP8 GEMM initialization error messages with an additional shared-memory diagnostic hint when internal initialization errors occur.

* **Tests**
  * Added coverage to verify valid MXFP8 tactic selection across SM120 vs SM121 GPUs, including expected exact tactic sets per device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->