### PR TITLE
Draft fix for 3057 NaN quant op bug

### DIFF
--- a/csrc/nv_internal/cpp/kernels/quantization.cu
+++ b/csrc/nv_internal/cpp/kernels/quantization.cu
@@ -743,6 +743,22 @@ void invokeSiluAndMulNVFP4Quantization(void* output, void* output_scale, void* i
   TLLM_CHECK_WITH_INFO(mask != nullptr, "mask must be non-null for expert NVFP4 path");
   TLLM_CHECK_WITH_INFO(n_experts > 0, "n_experts must be > 0");
   grid.x = (grid.x + n_experts - 1) / n_experts * n_experts;
+
+  // Zero unwritten padding (masked rows and the [m, padded_m) scale region) so
+  // it can't retain stale NaN; real rows are overwritten below (Issue #3057)
+  {
+    int const m_per_expert = m_topk / n_experts;
+    int const padded_m = (m_per_expert + 127) / 128 * 128;
+    int const scales_k = k / CVT_FP4_SF_VEC_SIZE;
+    int const padded_k = (scales_k + 3) / 4 * 4;
+    int const padded_k_int32 = padded_k / 4;
+    size_t const out_bytes = static_cast<size_t>(m_topk) * (k / 2);
+    size_t const scale_bytes =
+        static_cast<size_t>(n_experts) * padded_m * padded_k_int32 * sizeof(int32_t);
+    TLLM_CUDA_CHECK(cudaMemsetAsync(output, 0, out_bytes, stream));
+    TLLM_CUDA_CHECK(cudaMemsetAsync(output_scale, 0, scale_bytes, stream));
+  }
+
   bool const disableFP4QuantFastMath = tensorrt_llm::common::getEnvDisableFP4QuantFastMath();
   bool const use4Over6 = tensorrt_llm::common::getEnvNVFP4Use4Over6();
 


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

https://github.com/flashinfer-ai/flashinfer/issues/3057 finds that the quantization op leaves NaN in the output scale padding (what we can fix by zero-ing in this PR change). On its own it doesn't corrupt real rows. But it does result in NaN propagation downstream into another issue, https://github.com/flashinfer-ai/flashinfer/issues/3103.

## 🔍 Related Issues

[<!-- Link any related issues here -->](https://github.com/flashinfer-ai/flashinfer/issues/3057)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
