### PR TITLE
Feat/moe autotuner ep aware

### DIFF
--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -6,6 +6,7 @@ import inspect
 import itertools
 import json
 import os
+import sys
 import tempfile
 import threading
 import weakref
@@ -647,6 +648,7 @@ def autotune(
     tuning_buckets: tuple[int, ...] | None = None,
     round_up: bool | None = None,
     skip_ops: str | set[str] | None = None,
+    distributed_process_group: Any | None = None,
 ):
     """Context manager for autotuning with optional file-based caching.
 
@@ -714,6 +716,16 @@ def autotune(
             ``autotune(skip_ops={"A"})`` skips both ``"A"`` and ``"B"``.
             Common op names: ``"fp4_gemm"``, ``"bf16_gemm"``,
             ``"fp8_gemm"``, ``"mxfp8_gemm"``.
+        distributed_process_group: Optional ``torch.distributed`` process group
+            used by the ``broadcast`` distributed tuning strategy (enabled via
+            ``FLASHINFER_AUTOTUNE_DISTRIBUTED=broadcast``) to scope the
+            cross-rank tactic broadcast.  Pass the group whose ranks shard the
+            work and must agree on the tactic -- e.g. the MoE expert-parallel
+            group.  ``None`` (default) uses the WORLD group, which is correct
+            when WORLD is a single EP group, but in multi-dimensional layouts
+            (e.g. EP8 + DP2 over 16 ranks) you should pass the EP group so the
+            broadcast does not cross independent EP-group boundaries.  No effect
+            unless the broadcast strategy is enabled.
 
     Raises:
         ValueError: If ``tuning_buckets`` is provided but empty.
@@ -850,6 +862,24 @@ def autotune(
 
         if autotune_enabled:
             logger.info("[Autotuner]: Autotuning process ends")
+            # Align tactics across ranks once the outermost tuning
+            # context closes, so every rank leaves with the same per-key
+            # decision.  No-op unless FLASHINFER_AUTOTUNE_DISTRIBUTED is set.
+            # ``distributed_process_group`` scopes the broadcast to the ranks
+            # that actually shard the work (e.g. the MoE expert-parallel group);
+            # ``None`` falls back to the default WORLD group.
+            #
+            # An exception may be propagating out of the tuning body on *some*
+            # ranks but not others. The broadcast is a collective, so the
+            # decision to run it must be identical on every rank -- otherwise a
+            # rank that raised would skip it while a rank that finished normally
+            # would block forever inside ``broadcast_object_list``. We therefore
+            # hand the local exception state to the sync, which reaches a
+            # collective agreement (all ranks broadcast, or all skip).
+            tuner._maybe_sync_distributed_cache(
+                process_group=distributed_process_group,
+                local_had_exception=sys.exc_info()[0] is not None,
+            )
 
         # Save configs on exit when tuning with a cache path, but only if
         # new profiling results were added this session.  save_configs
@@ -1088,9 +1118,24 @@ class AutoTuner:
     def __init__(
         self, warmup: int = 3, repeat: int = 10, stream_delay_micro_secs: int = 5000
     ):
-        self.repeat = repeat
-        self.warmup = warmup
+        # Allow env overrides so profiling fidelity (back-to-back iters used to
+        # rank tactics) can be tuned without code changes.  A too-small
+        # ``repeat`` can under-measure low-occupancy tactics that only show
+        # their true cost in steady state, making the autotuner pick a tactic
+        # that is slower than the heuristic default in real (CUDA-graph) decode.
+        self.repeat = int(os.environ.get("FLASHINFER_AUTOTUNE_REPEAT", repeat))
+        self.warmup = int(os.environ.get("FLASHINFER_AUTOTUNE_WARMUP", warmup))
         self.stream_delay_micro_secs = stream_delay_micro_secs
+        # Relative speed-up an explicit tactic must beat the op's built-in
+        # heuristic-default (tactic=-1) by before the autotuner switches away
+        # from that default.  This guarantees the tuned choice is *never slower
+        # than default* (the autotuner keeps the default unless a tactic is
+        # genuinely faster) and removes run-to-run / cross-rank flapping among
+        # near-tied tactics.  Override via FLASHINFER_AUTOTUNE_SWITCH_MARGIN
+        # (e.g. "0.0" to restore pure fastest-wins behavior).
+        self.switch_margin = max(
+            0.0, float(os.environ.get("FLASHINFER_AUTOTUNE_SWITCH_MARGIN", "0.03"))
+        )
         self.profiling_cache: dict[
             ProfilingCacheKey, tuple[Any, OptimizationProfile | None]
         ] = {}
@@ -1602,10 +1647,42 @@ class AutoTuner:
                                 unit="profile",
                                 leave=True,
                             )
-                        min_time = float("inf")
                         # Initialize runner and tactic as None in case of no valid tactic or runners are found
                         runner_id, tactic = None, None
                         skipped_count = 0
+
+                        # Measure the op's built-in heuristic default (tactic=-1)
+                        # on the fallback runner (runners[0]) up-front and use it
+                        # as the baseline.  An explicit tactic is only adopted when
+                        # it beats this baseline by ``switch_margin`` (decision made
+                        # after the loop) -- this guarantees the tuned choice is
+                        # *never slower than default* and removes run-to-run /
+                        # cross-rank flapping among near-tied tactics.
+                        default_time = float("inf")
+                        _default_runner = runners[0]
+                        if "do_preparation" in runner_arg_names_map[_default_runner]:
+                            _default_runner(
+                                tensors, tactic=-1, do_preparation=True, **kwargs
+                            )
+                        try:
+                            default_time = self._profile_single_kernel(
+                                _default_runner, tensors, -1, tuning_config, **kwargs
+                            )
+                        except torch.cuda.OutOfMemoryError:
+                            raise
+                        except Exception as e:
+                            with contextlib.suppress(Exception):
+                                torch.cuda.synchronize()
+                            with contextlib.suppress(Exception):
+                                torch.cuda.cudart().cudaGetLastError()
+                            logger.debug(
+                                f"[Autotuner]: default tactic (-1) baseline "
+                                f"profiling failed for {custom_op}: {e}"
+                            )
+
+                        # Best explicit (runner, tactic) candidate found so far.
+                        best_time = float("inf")
+                        best_runner_id, best_tactic = None, None
                         for r_id, r in enumerate(runners):
                             # TODO: use FakeTensor here.
                             valid_tactics = r.get_valid_tactics(tensors, p)
@@ -1691,9 +1768,51 @@ class AutoTuner:
                                     # Set time_measured to inf to notify the failure of the tactic. This can happen when `get_valid_tactics` mistakenly return wrong tactics
                                     # or some runtime error occurs during profiling.
                                     time_measured = float("inf")
-                                if time_measured < min_time:
-                                    min_time = time_measured
-                                    runner_id, tactic = r_id, tac
+                                if time_measured < best_time:
+                                    best_time = time_measured
+                                    best_runner_id, best_tactic = r_id, tac
+
+                        # Re-measure the default (tactic=-1) baseline now that the
+                        # GPU is fully warmed up by the tactic loop, and keep the
+                        # faster of the two readings.  The first baseline above is
+                        # the very first kernel profiled this round, so it pays a
+                        # cold-start penalty (SM clocks not ramped, first-touch
+                        # workspace alloc) that makes the heuristic default look
+                        # artificially slow.  Without this, a whole family of
+                        # tactics can measure "faster than default" yet run slower
+                        # in steady state (observed at near-tie buckets, e.g.
+                        # decode M=128).  Taking the min keeps the "never slower
+                        # than default" guarantee honest.
+                        try:
+                            default_time_warm = self._profile_single_kernel(
+                                _default_runner, tensors, -1, tuning_config, **kwargs
+                            )
+                            default_time = min(default_time, default_time_warm)
+                        except torch.cuda.OutOfMemoryError:
+                            raise
+                        except Exception as e:
+                            with contextlib.suppress(Exception):
+                                torch.cuda.synchronize()
+                            with contextlib.suppress(Exception):
+                                torch.cuda.cudart().cudaGetLastError()
+                            logger.debug(
+                                f"[Autotuner]: warm default (-1) baseline "
+                                f"re-profiling failed for {custom_op}: {e}"
+                            )
+
+                        # Adopt the best explicit candidate only when it beats the
+                        # heuristic-default baseline by the relative ``switch_margin``;
+                        # otherwise keep the default (tactic=-1).  If the default
+                        # baseline itself failed to profile, fall back to the best
+                        # candidate (preserving the previous fastest-wins behavior).
+                        if best_runner_id is not None and best_time < default_time * (
+                            1.0 - self.switch_margin
+                        ):
+                            runner_id, tactic = best_runner_id, best_tactic
+                        elif default_time < float("inf"):
+                            runner_id, tactic = 0, -1
+                        else:
+                            runner_id, tactic = best_runner_id, best_tactic
 
                         if skipped_count > 0:
                             logger.info(
@@ -1748,6 +1867,112 @@ class AutoTuner:
             tuple(tensor.size()) if isinstance(tensor, torch.Tensor) else (0,)
             for tensor in inputs
         )
+
+    def _maybe_sync_distributed_cache(
+        self, process_group: Any = None, local_had_exception: bool = False
+    ) -> None:
+        """Align the profiling cache across EP/TP ranks.
+
+        Mirrors TensorRT-LLM's ``DistributedTuningStrategy``:
+
+        - ``broadcast``: the source rank's chosen (runner_id, tactic) per cache
+          key wins on every rank.  This is the robust fix for the EP straggler
+          problem -- even when several tactics are near-tied and per-rank
+          profiling noise would otherwise pick different ones, all ranks end up
+          on the *same* tactic, so the slowest rank no longer bottlenecks the
+          all-to-all (and the bad-tactic-frozen-in-CUDA-graph case disappears).
+
+        Enabled via ``FLASHINFER_AUTOTUNE_DISTRIBUTED=broadcast``.  No-op when
+        torch.distributed is unavailable / uninitialized / world_size==1, so it
+        is safe to leave on for single-process use.
+
+        Args:
+            process_group: The process group whose ranks shard the work and must
+                agree on the tactic -- typically the MoE expert-parallel group.
+                ``None`` uses the default WORLD group.  Scoping matters in
+                multi-dimensional layouts (e.g. EP8 + DP2 over 16 ranks) where
+                WORLD spans several independent EP groups and a WORLD broadcast
+                would cross group boundaries.  The broadcast source is the
+                group-local rank 0 (mapped to its global rank).
+            local_had_exception: Whether the calling rank is unwinding an
+                exception out of the tuning context.  Because the broadcast is a
+                collective, every rank must make the *same* participate/skip
+                decision: a rank that raised must not skip the broadcast while a
+                peer that finished normally blocks in it forever.  All ranks
+                first exchange this flag via a small ``all_gather_object`` (a
+                collective every rank always reaches here), and the broadcast is
+                run only when *no* rank in the group failed.
+
+        Only the chosen tactic per cache key is communicated -- never the
+        ``OptimizationProfile`` object -- so there is nothing fragile to
+        pickle, and each rank keeps its own (shape-identical) profile.
+        """
+        mode = os.environ.get("FLASHINFER_AUTOTUNE_DISTRIBUTED", "").lower()
+        if mode not in ("broadcast",):
+            return
+        try:
+            import torch.distributed as dist
+        except ImportError:
+            return
+        if not dist.is_available() or not dist.is_initialized():
+            return
+        if dist.get_world_size(group=process_group) <= 1:
+            return
+
+        # Collectively agree on whether to broadcast. Every rank reaches this
+        # ``all_gather_object`` unconditionally (so it cannot deadlock on its
+        # own), then we broadcast only if no rank is unwinding an exception.
+        # This keeps the participate/skip decision identical across ranks even
+        # when a failure is asymmetric (some ranks raised, others did not).
+        try:
+            world_size = dist.get_world_size(group=process_group)
+            exc_flags: list[Any] = [None] * world_size
+            dist.all_gather_object(
+                exc_flags, bool(local_had_exception), group=process_group
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"[Autotuner]: distributed exception-state exchange failed, "
+                f"skipping cache broadcast: {e}"
+            )
+            return
+        if any(exc_flags):
+            logger.warning(
+                "[Autotuner]: a rank raised during tuning; skipping distributed "
+                "cache broadcast on all ranks and keeping per-rank tactics."
+            )
+            return
+
+        # Broadcast source = rank 0 *within the group*, expressed as a global
+        # rank (torch's ``src`` is always a global rank).  For the default WORLD
+        # group that is simply global rank 0.
+        src = 0
+        if process_group is not None:
+            try:
+                src = dist.get_global_rank(process_group, 0)
+            except Exception:  # noqa: BLE001
+                src = 0
+
+        with self._lock:
+            # Communicate only the chosen tactic per key -- the local
+            # OptimizationProfile (``v[1]``) is kept per-rank and not sent.
+            snapshot = {k: v[0] for k, v in self.profiling_cache.items()}
+        payload = [snapshot]
+        try:
+            dist.broadcast_object_list(payload, src=src, group=process_group)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"[Autotuner]: distributed cache broadcast failed, keeping "
+                f"per-rank tactics: {e}"
+            )
+            return
+        rank0_snapshot = payload[0]
+
+        with self._lock:
+            for k, tactic in rank0_snapshot.items():
+                prev = self.profiling_cache.get(k)
+                profile = prev[1] if prev is not None else None
+                self.profiling_cache[k] = (tactic, profile)
 
     def _profile_single_kernel(
         self,

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -20,10 +20,14 @@ from typing import (
     Iterable,
     Optional,
     Sequence,
+    TYPE_CHECKING,
     TypeAlias,
 )
 
 import torch
+
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
 
 from flashinfer.tllm_utils import delay_kernel
 from flashinfer.utils import (
@@ -648,7 +652,7 @@ def autotune(
     tuning_buckets: tuple[int, ...] | None = None,
     round_up: bool | None = None,
     skip_ops: str | set[str] | None = None,
-    distributed_process_group: Any | None = None,
+    distributed_process_group: "Optional[ProcessGroup]" = None,
 ):
     """Context manager for autotuning with optional file-based caching.
 
@@ -1128,10 +1132,12 @@ class AutoTuner:
         self.stream_delay_micro_secs = stream_delay_micro_secs
         # Relative speed-up an explicit tactic must beat the op's built-in
         # heuristic-default (tactic=-1) by before the autotuner switches away
-        # from that default.  This guarantees the tuned choice is *never slower
-        # than default* (the autotuner keeps the default unless a tactic is
-        # genuinely faster) and removes run-to-run / cross-rank flapping among
-        # near-tied tactics.  Override via FLASHINFER_AUTOTUNE_SWITCH_MARGIN
+        # from that default.  This strongly biases toward the default -- it is
+        # kept unless a tactic profiled meaningfully faster -- which empirically
+        # makes the tuned choice very unlikely to be slower than default and
+        # damps run-to-run / cross-rank flapping among near-tied tactics (it is
+        # not a hard guarantee; selection is based on noisy measurements).
+        # Override via FLASHINFER_AUTOTUNE_SWITCH_MARGIN
         # (e.g. "0.0" to restore pure fastest-wins behavior).
         self.switch_margin = max(
             0.0, float(os.environ.get("FLASHINFER_AUTOTUNE_SWITCH_MARGIN", "0.03"))
@@ -1655,9 +1661,10 @@ class AutoTuner:
                         # on the fallback runner (runners[0]) up-front and use it
                         # as the baseline.  An explicit tactic is only adopted when
                         # it beats this baseline by ``switch_margin`` (decision made
-                        # after the loop) -- this guarantees the tuned choice is
-                        # *never slower than default* and removes run-to-run /
-                        # cross-rank flapping among near-tied tactics.
+                        # after the loop) -- this strongly biases toward default so
+                        # the tuned choice is empirically very unlikely to be slower
+                        # than default, and damps run-to-run / cross-rank flapping
+                        # among near-tied tactics.
                         default_time = float("inf")
                         _default_runner = runners[0]
                         if "do_preparation" in runner_arg_names_map[_default_runner]:
@@ -1869,7 +1876,9 @@ class AutoTuner:
         )
 
     def _maybe_sync_distributed_cache(
-        self, process_group: Any = None, local_had_exception: bool = False
+        self,
+        process_group: "Optional[ProcessGroup]" = None,
+        local_had_exception: bool = False,
     ) -> None:
         """Align the profiling cache across EP/TP ranks.
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import functools
 import math
+import os
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -89,6 +90,7 @@ from .utils import (
     get_hybrid_num_tokens_buckets,
     make_hybrid_bucket_mapper,
     make_random_topk_ids,
+    make_balanced_local_topk_ids,
 )
 
 
@@ -1234,6 +1236,7 @@ def get_trtllm_moe_sm100_module():
             self,
             moe_inputs: "MoeRunnerInputs",
             tune_max_num_tokens: int = 8192,
+            local_expert_offset: int = 0,
             **kwargs,
         ) -> TuningConfig:
             """Build a TuningConfig for this runner instance.
@@ -1241,8 +1244,48 @@ def get_trtllm_moe_sm100_module():
             Args:
                 moe_inputs: Input parameters for this call.
                 tune_max_num_tokens: Upper bound for the num_tokens tuning buckets.
+                local_expert_offset: Global id of this rank's first local expert.
+                    Used to synthesize an EP/DP-aware tuning dummy whose top-k is
+                    routed only to this rank's local expert shard (see
+                    :func:`make_balanced_local_topk_ids`).  This makes the
+                    profiled per-expert ``M`` match the real post-all-to-all
+                    local work and makes every EP rank converge on the same
+                    tactic.
                 **kwargs: Extra TuningConfig kwargs (e.g. use_cold_l2_cache).
             """
+            num_local_experts = self.num_local_experts
+
+            # Repro/A-B toggle: when set, fall back to the legacy unseeded-random
+            # dummy routing (the 0.6.12 behavior).  Each EP rank then profiles a
+            # *different* routing distribution and can converge on a different /
+            # slower tactic -- this is the root cause of Rong Song's cross-rank
+            # divergence (issue #3537).  Leave unset for the EP/DP-aware balanced
+            # dummy.  Used only by the EP A/B micro-benchmark.
+            _legacy_random_dummy = bool(
+                os.environ.get("FLASHINFER_AUTOTUNE_LEGACY_RANDOM_DUMMY", "")
+            )
+
+            def _init_packed_topk_ids(shapes, dtype, device):
+                if _legacy_random_dummy:
+                    expert_ids = torch.randint(
+                        local_expert_offset,
+                        local_expert_offset + max(num_local_experts, 1),
+                        shapes,
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                else:
+                    expert_ids = make_balanced_local_topk_ids(
+                        num_tokens=math.prod(shapes[:-1]),
+                        top_k=shapes[-1],
+                        num_local_experts=num_local_experts,
+                        local_expert_offset=local_expert_offset,
+                        device=device,
+                    ).view(shapes)
+                expert_weights = torch.ones(
+                    shapes, dtype=torch.bfloat16, device=device
+                ).view(torch.int16)
+                return (expert_ids << 16) | expert_weights
 
             spec = {
                 "output": autotuner_initializer_empty,
@@ -1251,7 +1294,19 @@ def get_trtllm_moe_sm100_module():
             if moe_inputs.routing_logits is not None:
                 spec["routing_logits"] = autotuner_initializer_rand
             if moe_inputs.topk_ids is not None:
-                spec["topk_ids"] = _moe_topk_ids_init(self.num_experts)
+                if moe_inputs.routing_logits is not None:
+                    # ``topk_ids`` is an empty ``(0,)`` placeholder here: routing
+                    # is recomputed from ``routing_logits`` inside the kernel, so
+                    # its contents are unused. The autotuner expands the dynamic
+                    # dim to a 1-D ``(M,)`` shape, which must NOT be read as
+                    # ``(num_tokens, top_k)``. Keep the upstream random init
+                    # (shape-safe over ``num_experts``) for this placeholder.
+                    spec["topk_ids"] = _moe_topk_ids_init(self.num_experts)
+                else:
+                    # Pre-computed routing: use the EP/DP-aware balanced local
+                    # dummy so every EP rank profiles the same representative
+                    # per-expert ``M`` and converges on the same tactic.
+                    spec["topk_ids"] = _init_packed_topk_ids
             if moe_inputs.expert_weights is not None:
                 spec["expert_weights"] = autotuner_initializer_ones
             if moe_inputs.hidden_states_scale is not None:
@@ -1722,6 +1777,7 @@ def get_trtllm_moe_sm100_module():
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            local_expert_offset=local_expert_offset,
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )
@@ -1914,6 +1970,7 @@ def get_trtllm_moe_sm100_module():
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            local_expert_offset=local_expert_offset,
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )
@@ -2147,6 +2204,7 @@ def get_trtllm_moe_sm100_module():
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            local_expert_offset=local_expert_offset,
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )
@@ -2395,6 +2453,7 @@ def get_trtllm_moe_sm100_module():
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            local_expert_offset=local_expert_offset,
             use_cold_l2_cache=True,
             use_cuda_graph=True,
         )
@@ -2618,6 +2677,7 @@ def get_trtllm_moe_sm100_module():
         tuning_config = moe_runner._make_tuning_config(
             moe_inputs,
             tune_max_num_tokens=tune_max_num_tokens,
+            local_expert_offset=local_expert_offset,
             use_cuda_graph=True,
             use_cold_l2_cache=True,
         )

--- a/flashinfer/fused_moe/utils.py
+++ b/flashinfer/fused_moe/utils.py
@@ -362,3 +362,60 @@ def get_b12x_activation_name(activation_type: ActivationType) -> str:
     if activation_type is ActivationType.Relu2:
         return "relu2"
     raise ValueError(f"Unsupported b12x activation type {activation_type!r}.")
+
+
+def make_balanced_local_topk_ids(
+    num_tokens: int,
+    top_k: int,
+    num_local_experts: int,
+    local_expert_offset: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Route every token's ``top_k`` slots evenly across this rank's *local*
+    expert shard ``[local_expert_offset, local_expert_offset + num_local_experts)``.
+
+    Unlike :func:`make_random_topk_ids`, this routing is **EP/DP-aware**,
+    **deterministic** and **balanced**, which matters for autotuning an
+    expert-parallel MoE:
+
+    * **EP/DP-aware** -- only local experts receive tokens, so the per-expert
+      ``M`` profiled during autotuning equals the real post-all-to-all local
+      work ``num_tokens * top_k / num_local_experts`` instead of the
+      ``ep_size``x-smaller value produced by routing uniformly over *all*
+      (global) experts while the kernel only computes the local shard.
+    * **deterministic & balanced** -- round-robin assignment gives every local
+      expert an (almost) identical token count with zero run-to-run variance.
+      Every EP rank therefore profiles the *same* representative problem and
+      converges on the *same* tactic, avoiding the per-rank tactic divergence
+      that random routing causes (different ranks otherwise pick different
+      tile/stage cubins for an identical runtime shape).
+
+    Args:
+        num_tokens: Number of tokens (rows).
+        top_k: Experts selected per token.
+        num_local_experts: Number of experts owned by this rank.
+        local_expert_offset: Global id of this rank's first local expert.
+        device: Device for the returned tensor.
+
+    Returns:
+        A ``[num_tokens, top_k]`` int32 tensor of **global** expert ids, all
+        within the local shard.  The ``top_k`` ids within a row are distinct as
+        long as ``top_k <= num_local_experts`` (the usual case).
+    """
+    if num_tokens == 0 or num_local_experts == 0 or top_k == 0:
+        return torch.zeros(num_tokens, top_k, dtype=torch.int32, device=device)
+
+    if top_k > num_local_experts:
+        raise ValueError(
+            f"top_k ({top_k}) cannot exceed num_local_experts "
+            f"({num_local_experts}) for balanced local routing: the round-robin "
+            f"assignment would wrap and emit duplicate expert ids within a row, "
+            f"which MoE routing/sort kernels require to be distinct."
+        )
+
+    # Round-robin assignment over the local shard. The ``top_k`` consecutive
+    # values within a row are distinct mod ``num_local_experts`` whenever
+    # ``top_k <= num_local_experts``; the aggregate per-expert count differs by
+    # at most one across local experts (perfectly balanced).
+    flat = torch.arange(num_tokens * top_k, device=device) % num_local_experts
+    return (flat.view(num_tokens, top_k) + local_expert_offset).to(torch.int32)

--- a/tests/moe/bench_ep_tactic_consistency.py
+++ b/tests/moe/bench_ep_tactic_consistency.py
@@ -1,0 +1,398 @@
+"""4-GPU EP autotuner consistency / determinism / speed micro-benchmark.
+
+This is the *accurate* test for the EP/DP-aware deterministic balanced
+dummy in the trtllm-gen MoE autotuner.  The bug it targets is fundamentally a
+**multi-process** phenomenon: every EP rank is its own process with its own
+autotuner and its own RNG, so the old unseeded ``make_random_topk_ids`` routing
+made each rank profile a *different* dummy problem and converge on a *different*
+(often slower) tactic.  A single-GPU loop only approximates this; running one
+real process per GPU is how it actually happens in TRT-LLM.
+
+What it checks, per decode bucket ``M`` and per rank
+(``local_expert_offset = rank * num_local_experts``):
+
+  1. **Consistency** -- all ranks select the *same* tactic for the same shape.
+  2. **Determinism** -- re-tuning the same rank twice yields the same tactic.
+  3. **Speed**       -- the autotuner-selected tactic is *not slower* than the
+                        heuristic default (the original regression was
+                        "selected kernel slower than default").
+
+Run on a node with >= world_size Blackwell (SM100) GPUs, e.g. 4x GB200:
+
+    cd /lustre/fsw/coreai_dlfw_dev/albecheng/flashinfer-autotuner-align
+    torchrun --nproc_per_node=4 tests/moe/bench_ep_tactic_consistency.py
+
+Override the problem shape via env vars, e.g. to match a specific model:
+
+    NUM_EXPERTS=128 TOP_K=4 HIDDEN=2880 INTERMEDIATE=2880 \
+    MS="8,16,64,128,256" torchrun --nproc_per_node=4 \
+        tests/moe/bench_ep_tactic_consistency.py
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+# Make ``tests.moe.*`` importable when launched as a script from repo root.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from flashinfer import ActivationType, RoutingMethodType
+from flashinfer.autotuner import AutoTuner, autotune
+from flashinfer.fused_moe import trtllm_fp4_block_scale_routed_moe, WeightLayout  # noqa: F401
+from flashinfer.fused_moe.utils import make_balanced_local_topk_ids
+from flashinfer.utils import device_support_pdl, get_compute_capability
+
+from tests.moe.test_trtllm_gen_moe_autotune_tactics import _build_fp4_routed_moe_inputs
+
+_FP4_OP = "flashinfer::trtllm_fp4_block_scale_moe"
+
+# --- problem shape (override via env) ----------------------------------------
+# NOTE: trtllm-gen MXFP4 cubins only expose kernel configs for hidden /
+# intermediate sizes that are 128-aligned (e.g. 3072, 4096, 7168).  gpt-oss's
+# raw 2880 has *no valid config* (getValidConfigIndices throws) -- TRT-LLM pads
+# it before calling the kernel.  Since this change only affects *tactic selection*
+# (shape-independent), we default to a 128-aligned shape so the kernel runs and
+# we can observe per-rank tactic consistency / determinism.
+NUM_EXPERTS = int(os.environ.get("NUM_EXPERTS", "128"))
+TOP_K = int(os.environ.get("TOP_K", "4"))
+HIDDEN = int(os.environ.get("HIDDEN", "4096"))
+INTERMEDIATE = int(os.environ.get("INTERMEDIATE", "3072"))
+QUANT_MODE = os.environ.get("QUANT_MODE", "MxFP4xMxFP8")  # W4A8_MXFP4_FP8
+MS = [int(x) for x in os.environ.get("MS", "8,16,64,128,256").split(",")]
+TIME_ITERS = int(os.environ.get("TIME_ITERS", "50"))
+WARMUP_ITERS = int(os.environ.get("WARMUP_ITERS", "10"))
+
+
+def _selected_tactic(custom_op: str = _FP4_OP):
+    """Return the single tactic the autotuner wrote to its cache.
+
+    With ``autotune(tuning_buckets=(M,))`` exactly one bucket is profiled, so
+    there is one cache entry per (op, runner).  Cache value layout is
+    ``(tactic, profile)``.
+    """
+    tuner = AutoTuner.get()
+    tactics = {
+        tuple(v[0]) if isinstance(v[0], (list, tuple)) else v[0]
+        for k, v in tuner.profiling_cache.items()
+        if isinstance(k, tuple) and len(k) > 0 and k[0] == custom_op
+    }
+    if len(tactics) != 1:
+        raise RuntimeError(
+            f"expected exactly 1 cached tactic for {custom_op}, got {tactics!r} "
+            f"(cache size={len(tuner.profiling_cache)})"
+        )
+    return next(iter(tactics))
+
+
+def _build_call(
+    inputs,
+    num_experts,
+    local_num_experts,
+    local_expert_offset,
+    top_k,
+    intermediate_size,
+    packed_topk,
+    enable_pdl,
+    routing_method_type,
+    tune_max_num_tokens,
+):
+    def _call():
+        return trtllm_fp4_block_scale_routed_moe(
+            topk_ids=packed_topk,
+            routing_bias=None,
+            hidden_states=inputs["hidden_states"],
+            hidden_states_scale=inputs["hidden_states_scale"],
+            gemm1_weights=inputs["w13"],
+            gemm1_weights_scale=inputs["w13_scale"],
+            gemm1_bias=None,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=inputs["w2"],
+            gemm2_weights_scale=inputs["w2_scale"],
+            gemm2_bias=None,
+            output1_scale_scalar=inputs["output1_scale_scalar"],
+            output1_scale_gate_scalar=inputs["output1_scale_gate_scalar"],
+            output2_scale_scalar=inputs["output2_scale_scalar"],
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=local_expert_offset,
+            local_num_experts=local_num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=routing_method_type.value,
+            do_finalize=True,
+            enable_pdl=enable_pdl,
+            activation_type=ActivationType.Swiglu.value,
+            tune_max_num_tokens=tune_max_num_tokens,
+        )[0]
+
+    return _call
+
+
+def _time_call(call, iters, warmup):
+    for _ in range(warmup):
+        call()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        call()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms/iter
+
+
+def _time_call_graph(call, iters, warmup):
+    """Steady-state timing under a captured CUDA graph -- this matches how
+    decode actually runs in TRT-LLM (and how the autotuner profiles, with
+    ``use_cuda_graph=True``), so it is the deployment-faithful yardstick.
+
+    Eager ``_time_call`` pays per-kernel CPU launch overhead every iter, which
+    at small decode M dwarfs the kernel delta and makes the autotuner's
+    graph-profiled pick look artificially slow.  Falls back to ``inf`` on
+    capture failure so the caller can detect it.
+    """
+    # Warm up on a side stream (required before capture).
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(warmup):
+            call()
+    torch.cuda.current_stream().wait_stream(s)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    try:
+        with torch.cuda.graph(graph):
+            call()
+    except Exception as e:  # noqa: BLE001
+        print(f"[graph-capture-failed] {e}", flush=True)
+        return float("inf")
+
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        graph.replay()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms/iter
+
+
+def main():
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    if get_compute_capability(device)[0] != 10:
+        if rank == 0:
+            print("This benchmark only runs on SM100/SM103 (Blackwell).")
+        dist.destroy_process_group()
+        return
+
+    assert NUM_EXPERTS % world_size == 0, (
+        f"num_experts={NUM_EXPERTS} must be divisible by EP world_size={world_size}"
+    )
+    num_local_experts = NUM_EXPERTS // world_size
+    local_expert_offset = rank * num_local_experts
+    enable_pdl = device_support_pdl(device)
+    routing_method_type = RoutingMethodType.Renormalize
+
+    torch.manual_seed(1234 + rank)  # distinct per rank on purpose
+
+    if rank == 0:
+        print(
+            f"\n=== EP autotuner consistency benchmark ===\n"
+            f"world_size(EP)={world_size}  num_experts={NUM_EXPERTS}  "
+            f"num_local_experts={num_local_experts}  top_k={TOP_K}\n"
+            f"hidden={HIDDEN}  intermediate={INTERMEDIATE}  quant={QUANT_MODE}\n"
+            f"decode buckets M={MS}\n",
+            flush=True,
+        )
+
+    # Per-rank result: {M: dict(tactic, tactic2, t_tuned_ms, t_default_ms)}
+    results = {}
+
+    for M in MS:
+        # Local-shard weights live on every rank; build with num_experts =
+        # num_local_experts so the weight tensors are sized [num_local_experts].
+        inputs = _build_fp4_routed_moe_inputs(
+            num_tokens=M,
+            hidden_size=HIDDEN,
+            intermediate_size=INTERMEDIATE,
+            top_k=TOP_K,
+            num_experts=num_local_experts,
+            quant_mode=QUANT_MODE,
+            routing_method_type=routing_method_type,
+            device=device,
+        )
+        # Real runtime routing: global ids inside this rank's shard
+        # [offset, offset+num_local_experts).  This keeps the final real
+        # forward valid while the autotuner synthesizes its own dummy.
+        topk_ids = make_balanced_local_topk_ids(
+            num_tokens=M,
+            top_k=TOP_K,
+            num_local_experts=num_local_experts,
+            local_expert_offset=local_expert_offset,
+            device=device,
+        )
+        expert_weights = torch.ones(M, TOP_K, device=device, dtype=torch.bfloat16)
+        packed_topk = (topk_ids.to(torch.int32) << 16) | expert_weights.to(
+            torch.bfloat16
+        ).view(torch.int16)
+
+        call = _build_call(
+            inputs,
+            NUM_EXPERTS,
+            num_local_experts,
+            local_expert_offset,
+            TOP_K,
+            INTERMEDIATE,
+            packed_topk,
+            enable_pdl,
+            routing_method_type,
+            tune_max_num_tokens=M,
+        )
+
+        tuner = AutoTuner.get()
+
+        # --- pass 1: tune (pin bucket to M) and capture selected tactic ------
+        tuner.clear_cache()
+        with autotune(True, tuning_buckets=(M,)):
+            call()
+        torch.cuda.synchronize()
+        tactic = _selected_tactic()
+        # Deployment-faithful (CUDA graph) + eager timing of the tuned tactic.
+        t_tuned = _time_call_graph(call, TIME_ITERS, WARMUP_ITERS)
+        t_tuned_eager = _time_call(call, TIME_ITERS, WARMUP_ITERS)
+
+        # --- pass 2: re-tune from scratch -> determinism check ---------------
+        tuner.clear_cache()
+        with autotune(True, tuning_buckets=(M,)):
+            call()
+        torch.cuda.synchronize()
+        tactic2 = _selected_tactic()
+
+        # --- default (heuristic) baseline: empty cache, no tuning ------------
+        tuner.clear_cache()
+        t_default = _time_call_graph(call, TIME_ITERS, WARMUP_ITERS)
+        t_default_eager = _time_call(call, TIME_ITERS, WARMUP_ITERS)
+
+        results[M] = dict(
+            tactic=tactic,
+            tactic2=tactic2,
+            t_tuned_ms=t_tuned,
+            t_default_ms=t_default,
+            t_tuned_eager_ms=t_tuned_eager,
+            t_default_eager_ms=t_default_eager,
+        )
+        print(
+            f"[rank {rank}] M={M:>5}  offset={local_expert_offset:>4}  "
+            f"tactic={tactic}  redo={tactic2}\n"
+            f"           graph: tuned={t_tuned * 1e3:7.1f}us default={t_default * 1e3:7.1f}us "
+            f"speedup={t_default / max(t_tuned, 1e-9):4.2f}x  |  "
+            f"eager: tuned={t_tuned_eager * 1e3:7.1f}us default={t_default_eager * 1e3:7.1f}us "
+            f"speedup={t_default_eager / max(t_tuned_eager, 1e-9):4.2f}x",
+            flush=True,
+        )
+
+    # --- gather all ranks' results to rank 0 and assert invariants ----------
+    gathered = [None] * world_size
+    dist.all_gather_object(gathered, results)
+
+    if rank == 0:
+        # Self-identify the config so buggy-vs-fixed logs are comparable.
+        cfg = (
+            f"dist={os.environ.get('FLASHINFER_AUTOTUNE_DISTRIBUTED', '') or 'off'}  "
+            f"margin={os.environ.get('FLASHINFER_AUTOTUNE_SWITCH_MARGIN', '0.03')}  "
+            f"legacy_random_dummy="
+            f"{bool(os.environ.get('FLASHINFER_AUTOTUNE_LEGACY_RANDOM_DUMMY', ''))}"
+        )
+        print(f"\n=== verdict === [{cfg}]", flush=True)
+        all_ok = True
+        for M in MS:
+            tactics = [gathered[r][M]["tactic"] for r in range(world_size)]
+            redos = [gathered[r][M]["tactic2"] for r in range(world_size)]
+            consistent = len(set(map(str, tactics))) == 1
+            deterministic = all(
+                str(gathered[r][M]["tactic"]) == str(gathered[r][M]["tactic2"])
+                for r in range(world_size)
+            )
+            # "not slower than default" with 5% tolerance for measurement noise.
+            not_slower = all(
+                gathered[r][M]["t_tuned_ms"] <= 1.05 * gathered[r][M]["t_default_ms"]
+                for r in range(world_size)
+            )
+            # PASS criteria mirror what actually matters in deployment:
+            #   * consistent  -> all EP ranks pick the SAME tactic in one tuning
+            #                    pass, so no rank is a straggler in the all-to-all.
+            #   * not_slower  -> the tuned pick is never slower than the default.
+            # ``deterministic`` (does a *second, independent* re-tune land on the
+            # same tactic?) is reported for visibility only: at near-tied buckets
+            # rank 0 can flap between two equally-fast tactics across separate
+            # tuning runs, but deployment tunes exactly once, so this is not a
+            # correctness/perf concern as long as the single run is consistent.
+            # EP-group effective latency: the all-to-all at each decode step
+            # waits for the SLOWEST rank, so the group runs at the per-rank max
+            # (this is exactly the straggler mechanism behind Rong Song's e2e
+            # regression).  Compare the tuned EP-group latency against the
+            # default EP-group latency -- and across buggy-vs-fixed runs, the
+            # tuned EP-group max is the headline "what does the autotuner cost
+            # the group" number.
+            tuned_per_rank = [gathered[r][M]["t_tuned_ms"] for r in range(world_size)]
+            default_per_rank = [
+                gathered[r][M]["t_default_ms"] for r in range(world_size)
+            ]
+            ep_group_tuned = max(tuned_per_rank)
+            ep_group_default = max(default_per_rank)
+            straggler_ratio = ep_group_tuned / max(min(tuned_per_rank), 1e-9)
+
+            ok = consistent and not_slower
+            all_ok = all_ok and ok
+            print(
+                f"M={M:>5}  consistent={consistent!s:>5}  "
+                f"not_slower_than_default={not_slower!s:>5}  "
+                f"deterministic(info)={deterministic!s:>5}  "
+                f"{'PASS' if ok else 'FAIL'}\n"
+                f"    EP-group(max-rank): tuned={ep_group_tuned * 1e3:7.1f}us  "
+                f"default={ep_group_default * 1e3:7.1f}us  "
+                f"tuned_vs_default={ep_group_default / max(ep_group_tuned, 1e-9):4.2f}x  "
+                f"straggler(max/min tuned)={straggler_ratio:4.2f}x",
+                flush=True,
+            )
+            if not consistent:
+                print(f"    per-rank tactics: {tactics}  (redo: {redos})", flush=True)
+            if not consistent or straggler_ratio > 1.10:
+                print(
+                    f"    per-rank tuned us: "
+                    f"{[round(t * 1e3, 1) for t in tuned_per_rank]}",
+                    flush=True,
+                )
+            if not not_slower:
+                for r in range(world_size):
+                    g = gathered[r][M]
+                    print(
+                        f"    rank {r}: tuned={g['t_tuned_ms'] * 1e3:.1f}us "
+                        f"default={g['t_default_ms'] * 1e3:.1f}us",
+                        flush=True,
+                    )
+        print(f"\nOVERALL: {'PASS' if all_ok else 'FAIL'}", flush=True)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/moe/sweep_tactic_latency.py
+++ b/tests/moe/sweep_tactic_latency.py
@@ -1,0 +1,247 @@
+"""Single-GPU per-tactic latency sweep at Rong Song's exact per-rank MoE shape.
+
+Goal: turn Issue 1 ("autotuner can pick a tactic ~2x slower than default")
+from a *mechanism argument* into *direct evidence*, without needing the old
+0.6.12 build.
+
+For the exact post-pad shape Rong Song's gpt-oss-120b EP4 decode runs
+(``trtllm-gen bmm_MxE4m3_MxE2m1MxE4m3``, hidden=intermediate=3072 after
+TRT-LLM pads 2880 up to a 256-multiple, 128 experts / EP4 -> 32 local experts,
+top-4, swiglu), this script:
+
+  1. enumerates *every* valid (tile_N, config) tactic the autotuner may pick;
+  2. CUDA-graph-times each one, plus the heuristic default (tactic=-1), at the
+     real decode M;
+  3. reports the latency spread and flags how many tactics are slower than the
+     default -- i.e. the "trap" tactics a naive fastest-wins-with-noise tuner
+     could freeze into the decode CUDA graph;
+  4. applies our policy's rule (only switch off the default if a tactic beats it by
+     ``FLASHINFER_AUTOTUNE_SWITCH_MARGIN``) and prints what *our* autotuner would
+     select -- demonstrating it can never land on a slower-than-default tactic.
+
+Run on one Blackwell (SM100) GPU:
+
+    cd /lustre/fsw/coreai_dlfw_dev/albecheng/flashinfer-autotuner-align
+    python tests/moe/sweep_tactic_latency.py
+"""
+
+import os
+import sys
+
+import torch
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from flashinfer import ActivationType, RoutingMethodType
+from flashinfer.autotuner import AutoTuner
+from flashinfer.fused_moe import trtllm_fp4_block_scale_routed_moe, WeightLayout  # noqa: F401
+from flashinfer.fused_moe.utils import make_balanced_local_topk_ids
+from flashinfer.jit.fused_moe import gen_trtllm_gen_fused_moe_sm100_module
+from flashinfer.utils import device_support_pdl, get_compute_capability
+
+from tests.moe.test_trtllm_gen_moe_autotune_tactics import (
+    _build_fp4_routed_moe_inputs,
+    _enumerate_valid_tactics,
+    _force_tactic_in_autotuner_cache,
+    _last_positive_power_of_2,
+    _moe_profile_shapes,
+    _TEST_OP_FP4,
+)
+
+# --- Rong Song's exact post-pad per-rank shape (override via env) -------------
+HIDDEN = int(os.environ.get("HIDDEN", "3072"))
+INTERMEDIATE = int(os.environ.get("INTERMEDIATE", "3072"))
+NUM_LOCAL_EXPERTS = int(os.environ.get("NUM_LOCAL_EXPERTS", "32"))  # 128 / EP4
+TOP_K = int(os.environ.get("TOP_K", "4"))
+QUANT_MODE = os.environ.get("QUANT_MODE", "MxFP4xMxFP8")  # -> bmm_MxE4m3_MxE2m1MxE4m3
+MS = [int(x) for x in os.environ.get("MS", "80,160,640").split(",")]
+TIME_ITERS = int(os.environ.get("TIME_ITERS", "50"))
+WARMUP_ITERS = int(os.environ.get("WARMUP_ITERS", "10"))
+MARGIN = float(os.environ.get("FLASHINFER_AUTOTUNE_SWITCH_MARGIN", "0.03"))
+
+
+def _time_call_graph(call, iters, warmup):
+    """Steady-state latency under a captured CUDA graph (deployment-faithful)."""
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(warmup):
+            call()
+    torch.cuda.current_stream().wait_stream(s)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    try:
+        with torch.cuda.graph(graph):
+            call()
+    except Exception as e:  # noqa: BLE001
+        print(f"    [graph-capture-failed] {e}", flush=True)
+        return float("inf")
+
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        graph.replay()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters  # ms/iter
+
+
+def _build_call(inputs, packed_topk, enable_pdl, routing_method_type, tune_max):
+    def _call():
+        return trtllm_fp4_block_scale_routed_moe(
+            topk_ids=packed_topk,
+            routing_bias=None,
+            hidden_states=inputs["hidden_states"],
+            hidden_states_scale=inputs["hidden_states_scale"],
+            gemm1_weights=inputs["w13"],
+            gemm1_weights_scale=inputs["w13_scale"],
+            gemm1_bias=None,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=inputs["w2"],
+            gemm2_weights_scale=inputs["w2_scale"],
+            gemm2_bias=None,
+            output1_scale_scalar=inputs["output1_scale_scalar"],
+            output1_scale_gate_scalar=inputs["output1_scale_gate_scalar"],
+            output2_scale_scalar=inputs["output2_scale_scalar"],
+            num_experts=NUM_LOCAL_EXPERTS,
+            top_k=TOP_K,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=INTERMEDIATE,
+            local_expert_offset=0,
+            local_num_experts=NUM_LOCAL_EXPERTS,
+            routed_scaling_factor=None,
+            routing_method_type=routing_method_type.value,
+            do_finalize=True,
+            enable_pdl=enable_pdl,
+            activation_type=ActivationType.Swiglu.value,
+            tune_max_num_tokens=tune_max,
+        )[0]
+
+    return _call
+
+
+def main():
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+    if get_compute_capability(device)[0] != 10:
+        print("This sweep only runs on SM100/SM103 (Blackwell).")
+        return
+
+    enable_pdl = device_support_pdl(device)
+    routing_method_type = RoutingMethodType.Renormalize
+    moe_op = gen_trtllm_gen_fused_moe_sm100_module().build_and_load()
+
+    print(
+        f"\n=== per-tactic latency sweep (Rong Song shape) ===\n"
+        f"hidden={HIDDEN}  intermediate={INTERMEDIATE}  "
+        f"local_experts={NUM_LOCAL_EXPERTS}  top_k={TOP_K}  quant={QUANT_MODE}\n"
+        f"kernel=bmm_MxE4m3_MxE2m1MxE4m3  switch_margin={MARGIN}\n"
+        f"decode M={MS}\n",
+        flush=True,
+    )
+
+    for M in MS:
+        torch.manual_seed(42)
+        inputs = _build_fp4_routed_moe_inputs(
+            num_tokens=M,
+            hidden_size=HIDDEN,
+            intermediate_size=INTERMEDIATE,
+            top_k=TOP_K,
+            num_experts=NUM_LOCAL_EXPERTS,
+            quant_mode=QUANT_MODE,
+            routing_method_type=routing_method_type,
+            device=device,
+        )
+        # Balanced post-all-to-all local routing (matches EP-aware tuning dummy).
+        topk_ids = make_balanced_local_topk_ids(
+            num_tokens=M,
+            top_k=TOP_K,
+            num_local_experts=NUM_LOCAL_EXPERTS,
+            local_expert_offset=0,
+            device=device,
+        )
+        expert_weights = torch.ones(M, TOP_K, device=device, dtype=torch.bfloat16)
+        packed_topk = (topk_ids.to(torch.int32) << 16) | expert_weights.to(
+            torch.bfloat16
+        ).view(torch.int16)
+        inputs["packed_topk"] = packed_topk
+        inputs["expert_weights"] = expert_weights
+
+        tune_max = max(_last_positive_power_of_2(M), 16)
+        bucket_m = min(_last_positive_power_of_2(M), tune_max)
+        profile_shapes = _moe_profile_shapes(inputs, M, bucket_m)
+        call = _build_call(
+            inputs, packed_topk, enable_pdl, routing_method_type, tune_max
+        )
+
+        valid_tactics = _enumerate_valid_tactics(
+            moe_op,
+            QUANT_MODE,
+            TOP_K,
+            HIDDEN,
+            INTERMEDIATE,
+            NUM_LOCAL_EXPERTS,
+            M,
+        )
+
+        # Heuristic default baseline (tactic=-1).
+        _force_tactic_in_autotuner_cache(profile_shapes, None, custom_op=_TEST_OP_FP4)
+        t_default = _time_call_graph(call, TIME_ITERS, WARMUP_ITERS)
+
+        # Every explicit tactic.
+        rows = []  # (tactic, ms)
+        for tac in valid_tactics:
+            _force_tactic_in_autotuner_cache(
+                profile_shapes, list(tac), custom_op=_TEST_OP_FP4
+            )
+            t = _time_call_graph(call, TIME_ITERS, WARMUP_ITERS)
+            rows.append((list(tac), t))
+
+        rows_finite = [(t, ms) for t, ms in rows if ms != float("inf")]
+        rows_finite.sort(key=lambda x: x[1])
+        if not rows_finite:
+            print(f"M={M}: no tactic ran successfully", flush=True)
+            continue
+
+        fastest_tac, fastest_ms = rows_finite[0]
+        slowest_tac, slowest_ms = rows_finite[-1]
+        n_slower_than_default = sum(1 for _, ms in rows_finite if ms > t_default)
+        n_2x = sum(1 for _, ms in rows_finite if ms >= 1.8 * fastest_ms)
+
+        # What our policy would select: the fastest tactic, but only if it beats the
+        # default by the margin; otherwise keep the default (tactic=-1).
+        if fastest_ms < t_default * (1.0 - MARGIN):
+            chosen = f"tactic={fastest_tac} ({fastest_ms * 1e3:.1f}us)"
+        else:
+            chosen = f"DEFAULT (-1) ({t_default * 1e3:.1f}us)"
+
+        print(
+            f"M={M:>5}  valid_tactics={len(valid_tactics)}\n"
+            f"    default(-1) = {t_default * 1e3:7.1f}us\n"
+            f"    fastest     = {fastest_ms * 1e3:7.1f}us  {fastest_tac}\n"
+            f"    slowest     = {slowest_ms * 1e3:7.1f}us  {slowest_tac}"
+            f"   (slowest/fastest={slowest_ms / fastest_ms:.2f}x, "
+            f"slowest/default={slowest_ms / t_default:.2f}x)\n"
+            f"    #tactics slower than default = {n_slower_than_default}/{len(rows_finite)}"
+            f"   |  #tactics >=1.8x fastest = {n_2x}\n"
+            f"    -> policy selects: {chosen}",
+            flush=True,
+        )
+        # Full sorted distribution for the record.
+        dist = "  ".join(f"{ms * 1e3:.0f}" for _, ms in rows_finite)
+        print(f"    sorted us: [{dist}]", flush=True)
+
+    AutoTuner.get().profiling_cache.clear()
+    AutoTuner.get()._file_configs.clear()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/moe/verify_broadcast_group.py
+++ b/tests/moe/verify_broadcast_group.py
@@ -1,0 +1,241 @@
+"""Correctness checks for the process-group-scoped broadcast.
+
+Three sub-checks, run together under a 4-GPU torchrun:
+
+  A. WORLD (group=None) regression -- distinct per-rank tactics all converge to
+     global rank 0 (the default-WORLD path still works after adding the
+     process_group arg).
+  B. Sub-group scoping -- two independent EP groups [0,1] and [2,3]; each rank
+     ends on its *group-local* rank-0's tactic and the groups do NOT bleed into
+     each other (a WORLD broadcast would have made all four identical). Uses
+     synthetic injected tactics so the scoping is unambiguous.
+  C. Real-op API path -- run the actual trtllm_fp4_block_scale_moe under
+     ``autotune(distributed_process_group=<EP group>)`` on two 2-rank EP groups
+     and confirm the public API path aligns real tactics within each group
+     without error. (Skipped off SM100.)
+
+Single-process no-op (most users run 1 process) is checked separately, see the
+command in the PR / chat -- it does not require torchrun.
+
+Run on a 4-GPU node:
+    cd /lustre/fsw/coreai_dlfw_dev/albecheng/flashinfer-autotuner-align
+    FLASHINFER_AUTOTUNE_DISTRIBUTED=broadcast \
+    python -m torch.distributed.run --nproc_per_node=4 \
+        tests/moe/verify_broadcast_group.py
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+# Make ``tests.moe.*`` importable when launched as a script from repo root.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from flashinfer.autotuner import AutoTuner, autotune
+
+_KEY = ("flashinfer::dummy_op", "MoERunner", (1,), ())
+_FP4_OP = "flashinfer::trtllm_fp4_block_scale_moe"
+
+
+def _inject_distinct(rank):
+    tuner = AutoTuner.get()
+    tuner.profiling_cache.clear()
+    # profiling_cache values are ``(tactic, profile)``; profile stays per-rank.
+    tuner.profiling_cache[_KEY] = ([rank, rank * 100], None)
+    return tuner
+
+
+def test_world_synthetic(rank, world):
+    """A. group=None (WORLD): all ranks converge to global rank 0."""
+    tuner = _inject_distinct(rank)
+    tuner._maybe_sync_distributed_cache(process_group=None)
+    got = tuner.profiling_cache[_KEY][0]
+    gathered = [None] * world
+    dist.all_gather_object(gathered, (rank, got))
+    dist.barrier()
+    if rank == 0:
+        d = dict(gathered)
+        ok = all(d[r] == [0, 0] for r in range(world))
+        print(f"[A WORLD ] final={d}  {'PASS' if ok else 'FAIL'}", flush=True)
+        return ok
+    return None
+
+
+def test_subgroup_synthetic(rank, world):
+    """B. two EP groups [0,1] and [2,3]: scoped, no cross-group bleed."""
+    g01 = dist.new_group([0, 1])
+    g23 = dist.new_group([2, 3])
+    my_group = g01 if rank in (0, 1) else g23
+    expected_src = 0 if rank in (0, 1) else 2
+
+    src_api = dist.get_global_rank(my_group, 0)
+    assert src_api == expected_src, (
+        f"[rank {rank}] get_global_rank(group,0)={src_api} != {expected_src}"
+    )
+
+    tuner = _inject_distinct(rank)
+    tuner._maybe_sync_distributed_cache(process_group=my_group)
+    got = tuner.profiling_cache[_KEY][0]
+
+    gathered = [None] * world
+    dist.all_gather_object(gathered, (rank, got))
+    dist.barrier()
+    if rank == 0:
+        d = dict(gathered)
+        want = {0: [0, 0], 1: [0, 0], 2: [2, 200], 3: [2, 200]}
+        ok = all(d[r] == want[r] for r in range(world))
+        print(
+            f"[B scope ] final={d}  {'PASS' if ok else 'FAIL'} "
+            f"(WORLD broadcast would make all [0,0])",
+            flush=True,
+        )
+        return ok
+    return None
+
+
+def _selected_fp4_tactic(tuner):
+    tacs = {
+        tuple(v[0]) if isinstance(v[0], (list, tuple)) else v[0]
+        for k, v in tuner.profiling_cache.items()
+        if isinstance(k, tuple) and len(k) > 0 and k[0] == _FP4_OP
+    }
+    return next(iter(tacs)) if len(tacs) == 1 else None
+
+
+def test_subgroup_realop(rank, world, device):
+    """C. real MoE op via autotune(distributed_process_group=...) on 2-rank EP groups."""
+    from flashinfer import ActivationType, RoutingMethodType
+    from flashinfer.fused_moe import trtllm_fp4_block_scale_routed_moe
+    from flashinfer.fused_moe.utils import make_balanced_local_topk_ids
+    from flashinfer.utils import device_support_pdl, get_compute_capability
+
+    from tests.moe.test_trtllm_gen_moe_autotune_tactics import (
+        _build_fp4_routed_moe_inputs,
+    )
+
+    g01 = dist.new_group([0, 1])
+    g23 = dist.new_group([2, 3])
+    my_group = g01 if rank in (0, 1) else g23
+
+    if get_compute_capability(device)[0] != 10:
+        if rank == 0:
+            print("[C realop] SKIP (needs SM100)", flush=True)
+        return None
+
+    NUM_EXPERTS, EP = 128, 2
+    num_local = NUM_EXPERTS // EP
+    offset = (rank % 2) * num_local
+    HIDDEN = INTER = 3072
+    TOPK, M = 4, 128
+    enable_pdl = device_support_pdl(device)
+    rmt = RoutingMethodType.Renormalize
+
+    torch.manual_seed(1000 + rank)
+    inputs = _build_fp4_routed_moe_inputs(
+        num_tokens=M,
+        hidden_size=HIDDEN,
+        intermediate_size=INTER,
+        top_k=TOPK,
+        num_experts=num_local,
+        quant_mode="MxFP4xMxFP8",
+        routing_method_type=rmt,
+        device=device,
+    )
+    topk = make_balanced_local_topk_ids(
+        num_tokens=M,
+        top_k=TOPK,
+        num_local_experts=num_local,
+        local_expert_offset=offset,
+        device=device,
+    )
+    ew = torch.ones(M, TOPK, device=device, dtype=torch.bfloat16)
+    packed = (topk.to(torch.int32) << 16) | ew.to(torch.bfloat16).view(torch.int16)
+
+    def call():
+        return trtllm_fp4_block_scale_routed_moe(
+            topk_ids=packed,
+            routing_bias=None,
+            hidden_states=inputs["hidden_states"],
+            hidden_states_scale=inputs["hidden_states_scale"],
+            gemm1_weights=inputs["w13"],
+            gemm1_weights_scale=inputs["w13_scale"],
+            gemm1_bias=None,
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=inputs["w2"],
+            gemm2_weights_scale=inputs["w2_scale"],
+            gemm2_bias=None,
+            output1_scale_scalar=inputs["output1_scale_scalar"],
+            output1_scale_gate_scalar=inputs["output1_scale_gate_scalar"],
+            output2_scale_scalar=inputs["output2_scale_scalar"],
+            num_experts=NUM_EXPERTS,
+            top_k=TOPK,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=INTER,
+            local_expert_offset=offset,
+            local_num_experts=num_local,
+            routed_scaling_factor=None,
+            routing_method_type=rmt.value,
+            do_finalize=True,
+            enable_pdl=enable_pdl,
+            activation_type=ActivationType.Swiglu.value,
+            tune_max_num_tokens=M,
+        )[0]
+
+    tuner = AutoTuner.get()
+    tuner.clear_cache()
+    # The public API path under test: pass the EP group to autotune().
+    with autotune(True, tuning_buckets=(M,), distributed_process_group=my_group):
+        call()
+    torch.cuda.synchronize()
+    tac = _selected_fp4_tactic(tuner)
+
+    gathered = [None] * world
+    dist.all_gather_object(gathered, (rank, str(tac)))
+    dist.barrier()
+    if rank == 0:
+        d = dict(gathered)
+        # within-group consistency: pair (0,1) agree and (2,3) agree
+        ok = d[0] == d[1] and d[2] == d[3] and tac is not None
+        print(
+            f"[C realop] per-rank tactic={d}  "
+            f"{'PASS' if ok else 'FAIL'} (within-group consistent via API)",
+            flush=True,
+        )
+        return ok
+    return None
+
+
+def main():
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", rank)))
+    device = torch.device(f"cuda:{int(os.environ.get('LOCAL_RANK', rank))}")
+    assert world == 4, f"this check expects 4 ranks, got {world}"
+
+    results = []
+    results.append(test_world_synthetic(rank, world))
+    results.append(test_subgroup_synthetic(rank, world))
+    results.append(test_subgroup_realop(rank, world, device))
+
+    dist.barrier()
+    if rank == 0:
+        graded = [r for r in results if r is not None]
+        print(
+            f"\n=== verify_broadcast_group: "
+            f"{'ALL PASS' if all(graded) else 'FAIL'} "
+            f"({sum(graded)}/{len(graded)} graded checks) ===",
+            flush=True,
+        )
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added distributed autotuning synchronization to keep selected kernel tactics consistent across devices/process groups.
  - Added balanced “local expert” top‑k routing for MoE to match sharded expert layouts.
- **Bug Fixes**
  - Improved autotuning correctness for sharded expert routing and scenarios where routing logits are provided.
  - Updated legacy/opt-in dummy routing behavior via an environment-variable switch.
  - Refined autotuning selection to compare against a heuristic baseline with a configurable switch margin.
- **Tests**
  - Added multi-rank and single-rank benchmark/validation scripts for determinism, latency, and process-group behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->