### PR TITLE
[fix] explicitly validate grouped_gemm_nt_masked layout contract to prevent NaN contamination

### DIFF
--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -3647,19 +3647,22 @@ def grouped_gemm_nt_masked(
     # The (M, N)-tile TMA C store requires the output contiguous in the c_major
     # dim; an expert-innermost output (e.g. torch.empty(m, n, l)) silently
     # corrupts results across experts, so reject it up front (issue #3103).
-    _c_major = "m" if is_swap_ab else "n"
-    _c_perm = (2, 1, 0) if _c_major == "m" else (2, 0, 1)
-    if out.dim() != 3 or not out.permute(*_c_perm).is_contiguous():
-        raise ValueError(
-            "grouped_gemm_nt_masked: `out` must be a 3D (m, n, l) tensor that is "
-            f"contiguous in the layout implied by c_major='{_c_major}' (the "
-            f"'{_c_major}' dimension contiguous and the batch/expert dim "
-            "outermost). For c_major='n' allocate e.g. "
-            "`torch.empty(l, m, n, ...).permute(1, 2, 0)`. Got out.shape="
-            f"{tuple(out.shape)}, out.stride()={tuple(out.stride())}. A "
-            "non-compliant layout (e.g. the expert dim innermost) causes silent "
-            "cross-expert output corruption."
-        )
+    # The combine-fusion path uses a 2D scatter output (not the (M, N) TMA
+    # store), so this layout contract does not apply there.
+    if not is_combine_fusion:
+        _c_major = "m" if is_swap_ab else "n"
+        _c_perm = (2, 1, 0) if _c_major == "m" else (2, 0, 1)
+        if out.dim() != 3 or not out.permute(*_c_perm).is_contiguous():
+            raise ValueError(
+                "grouped_gemm_nt_masked: `out` must be a 3D (m, n, l) tensor that is "
+                f"contiguous in the layout implied by c_major='{_c_major}' (the "
+                f"'{_c_major}' dimension contiguous and the batch/expert dim "
+                "outermost). For c_major='n' allocate e.g. "
+                "`torch.empty(l, m, n, ...).permute(1, 2, 0)`. Got out.shape="
+                f"{tuple(out.shape)}, out.stride()={tuple(out.stride())}. A "
+                "non-compliant layout (e.g. the expert dim innermost) causes silent "
+                "cross-expert output corruption."
+            )
 
     m, k, l = a_torch.shape
     n, _, _ = b_torch.shape

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -3644,6 +3644,23 @@ def grouped_gemm_nt_masked(
 
     c_torch = out
 
+    # The (M, N)-tile TMA C store requires the output contiguous in the c_major
+    # dim; an expert-innermost output (e.g. torch.empty(m, n, l)) silently
+    # corrupts results across experts, so reject it up front (issue #3103).
+    _c_major = "m" if is_swap_ab else "n"
+    _c_perm = (2, 1, 0) if _c_major == "m" else (2, 0, 1)
+    if out.dim() != 3 or not out.permute(*_c_perm).is_contiguous():
+        raise ValueError(
+            "grouped_gemm_nt_masked: `out` must be a 3D (m, n, l) tensor that is "
+            f"contiguous in the layout implied by c_major='{_c_major}' (the "
+            f"'{_c_major}' dimension contiguous and the batch/expert dim "
+            "outermost). For c_major='n' allocate e.g. "
+            "`torch.empty(l, m, n, ...).permute(1, 2, 0)`. Got out.shape="
+            f"{tuple(out.shape)}, out.stride()={tuple(out.stride())}. A "
+            "non-compliant layout (e.g. the expert dim innermost) causes silent "
+            "cross-expert output corruption."
+        )
+
     m, k, l = a_torch.shape
     n, _, _ = b_torch.shape
 

--- a/tests/gemm/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/gemm/test_cute_dsl_blockscaled_gemm.py
@@ -22,6 +22,7 @@ from flashinfer.cute_dsl.utils import (
     get_num_sm,
     is_cute_dsl_available,
 )
+from flashinfer.utils import is_sm100a_supported, is_sm100f_supported
 
 
 @pytest.mark.skipif(
@@ -274,11 +275,11 @@ def test_grouped_gemm_nt_masked_output_layout_contract():
     """
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
-    major, _ = torch.cuda.get_device_capability("cuda:0")
-    if major < 10:
-        pytest.skip("NVFP4 grouped GEMM requires SM100+")
-
     dev = torch.device("cuda:0")
+    # cute-dsl grouped GEMM is SM100-only (SM110 is explicitly unsupported).
+    if not (is_sm100a_supported(dev) or is_sm100f_supported(dev)):
+        pytest.skip("NVFP4 grouped GEMM requires SM100")
+
     sf_vec = 16
     m, n, k, E = 128, 128, 256, 2
     k_packed, rm, k_sf = k // 2, m // 128, k // sf_vec

--- a/tests/gemm/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/gemm/test_cute_dsl_blockscaled_gemm.py
@@ -259,6 +259,73 @@ def test_blockscaled_gemm_python_interface(
             )
 
 
+@pytest.mark.skipif(
+    not is_cute_dsl_available(), reason="Please `pip install nvidia-cutlass-dsl`"
+)
+def test_grouped_gemm_nt_masked_output_layout_contract():
+    """Regression test for issue #3103.
+
+    grouped_gemm_nt_masked builds the C tensor with a canonical ordered layout
+    derived from c_major (it ignores the output's actual strides) and stores it
+    via TMA over (M, N) tiles. An output whose contiguous dim is the expert/batch
+    (L) dim cannot be stored correctly and previously caused SILENT cross-expert
+    output corruption. It must now be rejected, and a compliant (N-contiguous)
+    output must not leak across experts.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    major, _ = torch.cuda.get_device_capability("cuda:0")
+    if major < 10:
+        pytest.skip("NVFP4 grouped GEMM requires SM100+")
+
+    dev = torch.device("cuda:0")
+    sf_vec = 16
+    m, n, k, E = 128, 128, 256, 2
+    k_packed, rm, k_sf = k // 2, m // 128, k // sf_vec
+    rk = k_sf // 4
+    sf_shape = (32, 4, rm, 4, rk, E)
+
+    def run(out, scale_byte):
+        aq = torch.full((m, k_packed, E), 0x11, dtype=torch.uint8, device=dev)
+        w = torch.full((n, k_packed, E), 0x11, dtype=torch.uint8, device=dev)
+        w_bs = torch.ones(E, n, k_sf, dtype=torch.float8_e4m3fn, device=dev)
+        masked_m = torch.full((E,), m, dtype=torch.int32, device=dev)
+        alpha = torch.ones(1, 1, E, dtype=torch.float32, device=dev)
+        sf = torch.ones(sf_shape, dtype=torch.float8_e4m3fn, device=dev)
+        raw = sf.view(torch.uint8)
+        raw[0, 0, 0, 0, 0, 0] = scale_byte  # perturb expert 0 only
+        sf = raw.view(torch.float8_e4m3fn).reshape(sf_shape)
+        out.zero_()
+        grouped_gemm_nt_masked(
+            (aq, sf),
+            (w, w_bs),
+            out,
+            masked_m,
+            ab_dtype="float4_e2m1fn",
+            sf_dtype="float8_e4m3fn",
+            c_dtype="bfloat16",
+            sf_vec_size=sf_vec,
+            alpha=alpha,
+            alpha_dtype="float32",
+        )
+        torch.cuda.synchronize()
+        return out.permute(2, 0, 1).clone()  # [E, m, n]
+
+    # Compliant output (N contiguous, expert dim outermost): no cross-expert leak.
+    def canonical_out():
+        return torch.zeros(E, m, n, dtype=torch.bfloat16, device=dev).permute(1, 2, 0)
+
+    base = run(canonical_out(), 0x3C)  # all scales = 1.0
+    perturbed = run(canonical_out(), 0x7F)  # expert 0 scale = NaN
+    assert not torch.isnan(perturbed[1]).any(), "NaN leaked into expert 1"
+    torch.testing.assert_close(base[1], perturbed[1], atol=0.0, rtol=0.0)
+
+    # Non-compliant output (expert dim innermost) must be rejected, not silently
+    # corrupt results across experts.
+    with pytest.raises(ValueError, match="cross-expert|c_major|contiguous"):
+        run(torch.zeros(m, n, E, dtype=torch.bfloat16, device=dev), 0x7F)
+
+
 if __name__ == "__main__":
     test_blockscaled_gemm_python_interface(
         lm=(1, 1024),


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

See comment here for description of root cause + rationale for PR change/solution: https://github.com/flashinfer-ai/flashinfer/issues/3103#issuecomment-4675817973 . Ended up at this issue from debugging this other 2nd issue: https://github.com/flashinfer-ai/flashinfer/issues/3057#issuecomment-4675866789 

## 🔍 Related Issues

[<!-- Link any related issues here -->](https://github.com/flashinfer-ai/flashinfer/issues/3103)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented silent data corruption in grouped GEMM by enforcing expected tensor memory-layout for expert/batch dimensions; invalid layouts now raise an error.

* **Tests**
  * Added a regression test that verifies the output-layout validation and correct expert-dimension ordering (accepts compliant layouts, rejects non-compliant ones).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->