### PR TITLE
jit: run `ninja -t restat` before builds to fix spurious full rebuild…

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -12,7 +12,12 @@ from filelock import FileLock
 
 from ..compilation_context import CompilationContext
 from . import env as jit_env
-from .cpp_ext import generate_ninja_build_for_op, get_nvcc_parallelism_flags, run_ninja
+from .cpp_ext import (
+    generate_ninja_build_for_op,
+    get_nvcc_parallelism_flags,
+    run_ninja,
+    run_ninja_restat,
+)
 from .utils import write_if_different
 
 os.makedirs(jit_env.FLASHINFER_WORKSPACE_DIR, exist_ok=True)
@@ -299,6 +304,7 @@ class JitSpec:
         )
         with lock:
             self.write_ninja()
+            run_ninja_restat(self.build_dir, self.ninja_path, verbose)
             run_ninja(self.build_dir, self.ninja_path, verbose)
 
     def load(self, so_path: Path):

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -348,6 +348,31 @@ def _get_num_workers() -> Optional[int]:
     return None
 
 
+def run_ninja_restat(workdir: Path, ninja_file: Path, verbose: bool) -> None:
+    """Re-sync the mtimes recorded in .ninja_log with current stat() values,
+    so that mtime skew on shared filesystems (GPFS, NFS) does not make ninja
+    rebuild up-to-date outputs. Non-fatal: worst case is a rebuild."""
+    if not (workdir / ".ninja_log").exists():
+        return
+    command = [
+        "ninja",
+        "-C",
+        str(workdir.resolve()),
+        "-f",
+        str(ninja_file.resolve()),
+        "-t",
+        "restat",
+    ]
+    subprocess.run(
+        command,
+        stdout=None if verbose else subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=str(workdir.resolve()),
+        check=False,
+        text=True,
+    )
+
+
 def run_ninja(workdir: Path, ninja_file: Path, verbose: bool) -> None:
     workdir.mkdir(parents=True, exist_ok=True)
     command = [


### PR DESCRIPTION
## 📌 Description

This PR supersedes #3556 and fixes the same problem with a better approach, following the review feedback there.

The problem:
On shared filesystems (GPFS, NFS), every vLLM restart triggers a full recompilation of the FlashInfer CUTLASS fused-MoE kernels (~180 `.cu` files, ~1.5h on GH200/sm90a), making the JIT cache useless.

Root cause:
At the end of a build, ninja records the output mtimes in `.ninja_log`. On GPFS, the value recorded at that moment and the value a later `stat()` returns disagree (inode flush timing, GPFS can commit the inode to storage tens of minutes after the write, changing the reported mtime). On the next start, ninja compares the two, sees a mismatch, concludes every output was "modified externally", and rebuilds everything.

I directly observed this skew on my cluster: for an already-built module, `.ninja_log` recorded `mtime_ns = 1781087915292417000` while a later `stat()` returned `1781087982747730813`, a ~67 s discrepancy on files nobody touched.

The fix: 
Ninja ships a tool for exactly this: [`ninja -t restat`](https://ninja-build.org/manual.html#_extra_tools) (available since ninja 1.10) rewrites the mtimes stored in `.ninja_log` to match current `stat()` values. This PR runs it inside `JitSpec.build()`, right before the existing `run_ninja()` call (and only if a `.ninja_log` exists). After the re-sync, the normal ninja invocation sees everything up to date and is a near-instant no-op.

Compared to my previous attempt in #3556, this addresses both review concerns:

- Ninja's staleness detection stays fully active: (the concern raised by @yzh119): `restat` only fixes the recorded output mtimes. Modified sources or changed compile commands are still detected and still trigger rebuilds, verified below.
- No new fast path outside the `FileLock`: (the race-condition concern): the control flow of `build_and_load()` is unchanged; the only addition is one extra cheap step inside the already-locked `build()`.

A `restat` failure is deliberately non-fatal (`check=False`): on an exotic setup (e.g. ninja < 1.10) the behavior simply degrades to today's (a rebuild), never worse.

## 🔍 Related Issues

Replace #3556 (closed in favor of this PR).

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.
Only this test failed, does not seem related to this PR :
```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

flashinfer\fi_trace.py: note: In function "build_fi_trace_fn":
flashinfer\fi_trace.py:146:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\fi_trace.py:156:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\fi_trace.py:158:13: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\fi_trace.py:165:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\fi_trace.py:187:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\fi_trace.py:208:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\jit\core.py: note: In member "__init__" of class "JitSpecRegistry":
flashinfer\jit\core.py:169:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\jit\core.py:170:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\comm\mnnvl.py: note: In member "__init__" of class "IpcSocket":
flashinfer\comm\mnnvl.py:699:35: error: Module has no attribute "AF_UNIX"; maybe "AF_IPX"?  [attr-defined]
flashinfer\comm\mnnvl.py: note: In member "send_fd" of class "IpcSocket":
flashinfer\comm\mnnvl.py:740:42: error: Module has no attribute "SCM_RIGHTS"  [attr-defined]
flashinfer\comm\mnnvl.py:743:9: error: "socket" has no attribute "sendmsg"  [attr-defined]
flashinfer\autotuner.py: note: In member "__init__" of class "AutoTuner":
flashinfer\autotuner.py:833:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\autotuner.py:835:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\autotuner.py:839:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\autotuner.py:855:9: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\gemm\gemm_base.py: note: In function "get_gemm_module":
flashinfer\gemm\gemm_base.py:138:17: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\gemm\gemm_base.py: note: In function "get_mm_bf16_cublaslt_module":
flashinfer\gemm\gemm_base.py:1058:17: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
flashinfer\aot.py: note: In function "main":
flashinfer\aot.py:1005:5: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 3 errors in 1 file (checked 333 source files)
```

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

No unit tests added, the bug depends on filesystem timing behavior (GPFS inode flush) that is not reproducible in CI. Instead, the fix was validated end-to-end on the affected setup:

Setup:
GH200 (sm90a), GPFS home, FlashInfer 0.6.11.post2 inside a vLLM 0.22.1 venv, ninja 1.11.1, model GLM-5.1-FP8 on 4 nodes (TP=4 × PP=4, Ray backend).

1. The mtime skew is real and `restat` fixes it:  On a previously built module, `.ninja_log` and `stat()` disagreed by ~67 s (values above). After `ninja -t restat`, the values stored in the log match `stat()` exactly.
2. End-to-end restart test: First server start: one missing module compiled, engine init 67.5 s. Server stopped, then restarted with this patch: zero recompilation, engine init 4.75 s, server ready in ~3m30 (vs ~1.5h full recompiles we were seeing before). The module's `.so` mtime was untouched, while `.ninja_log` was rewritten during startup, confirming the `restat` + `run_ninja` path executed and concluded "no work to do".
3. Source-change detection still works: After `touch` on a `.cu` source referenced by a module's `build.ninja`, `ninja -n -d explain` correctly marks the corresponding object dirty and schedules a rebuild. So the local development workflow is preserved.
4. With TP×PP workers all calling `build_and_load()`, the per-module `FileLock` serializes them; workers after the first go through `restat` + a no-op ninja run in negligible time.

Scope note:
this PR only touches the runtime JIT path (`JitSpec.build()`), which is where the bug was observed and tested. The batch path in `build_jit_specs()` could receive the same one-line `run_ninja_restat()` call for symmetry,  happy to add it if you prefer, but I left it out since I haven't tested that path.

## Notes

I'm not a professional developer, only a 'jack-of-all-trades' please point out anything that doesn't match the project's standards and I'll fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized JIT compilation to reduce unnecessary rebuilds on shared filesystems by properly synchronizing file timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->