### PR TITLE
fix(ci): skip TRT-LLM Gen BF16 MoE SwiGLU test outside SM10.x

### DIFF
--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -4808,8 +4808,8 @@ def test_bf16_moe_swiglu_oa_activation_params(cache_permute_indices):
     if not torch.cuda.is_available():
         pytest.skip("TRT-LLM Gen BF16 MoE test requires CUDA.")
     compute_capability = get_compute_capability(torch.device(device="cuda"))
-    if compute_capability[0] not in [10, 12]:
-        pytest.skip("TRT-LLM Gen BF16 MoE requires SM10.x or SM12.x.")
+    if compute_capability[0] != 10:
+        pytest.skip("TRT-LLM Gen BF16 MoE requires SM10.x.")
 
     num_experts = 64
     num_tokens = 8


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Restrict `test_bf16_moe_swiglu_oa_activation_params` to SM10.x only.

This matches the existing TRT-LLM Gen MoE test gating in `tests/moe/utils.py`, where the shared `BF16Moe` parameterized tests are only guaranteed on SM100/SM103. The new BF16 SwiGLU OA params test had allowed SM12.x, which caused it to run on RTX 5090 / SM120 and fail when launching the SM100 TRT-LLM Gen BF16 BatchedGemm cubin.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined GPU compute capability compatibility checks in the test suite, improving validation accuracy for GPU-accelerated features on supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->