### PR TITLE
[fix] Fix SM100 GDN prefill hang

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -1209,7 +1209,6 @@ class GatedDeltaNetChunkedKernel:
                 work = scheduler.get_current_work()
             a_inv_ready_producer.tail()
             qk_ready_producer.tail()
-            o_store_producer.tail()
             group_order_producer.tail()
 
         # ==============================================================


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix https://github.com/flashinfer-ai/flashinfer/issues/3565 
Root cause:
`o_store_producer` is owned by the CG1 -> epilogue pipeline. CG0 never acquires or commits this pipeline, so tailing it from CG0 can corrupt pipeline lifetime state and trigger a hang. 
The bug was shown on CUTLASS DSL 4.5.2. 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the GPU compute sequence in a core kernel, removing an unnecessary step. Expect slightly improved execution efficiency and more consistent GPU behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->