### PR TITLE
Add separate trtllm-gen KV counter buffer

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -20,9 +20,13 @@
 #include <nvrtc.h>
 #include <tvm/ffi/container/variant.h>
 
+#include <algorithm>
+#include <cstdint>
 #include <flashinfer/trtllm/fmha/fmhaRunner.cuh>
 #include <flashinfer/utils.cuh>
 #include <iostream>
+#include <memory>
+#include <mutex>
 #include <sstream>
 #include <unordered_map>
 
@@ -51,8 +55,15 @@ enum class TllmPagedAttentionMode {
 // gating behind a debug flag.
 constexpr size_t kTrtllmGenSoftmaxStatsGuardBytes = 1 * 1024 * 1024;
 
-#include <memory>
-#include <mutex>
+inline size_t getTrtllmGenMultiCtasKvCounterBytes(int64_t batch_size, int64_t num_qo_heads,
+                                                  int64_t sm_count) {
+  size_t const request_counter_slots =
+      static_cast<size_t>(batch_size) * static_cast<size_t>(num_qo_heads);
+  size_t const sm_counter_slots = static_cast<size_t>(sm_count);
+  size_t const num_semaphores =
+      round_up(std::max(request_counter_slots, sm_counter_slots), static_cast<size_t>(8));
+  return num_semaphores * sizeof(uint32_t);
+}
 
 class TllmGenFmhaRunnerCache {
  public:
@@ -95,14 +106,15 @@ class TllmGenFmhaRunnerCache {
 
 void trtllm_paged_attention_launcher(
     void* out, void* out_scale_factor, void* query, void* key_cache, void* value_cache,
-    void* workspace_buffer, int* block_tables, const void* k_block_scales_ptr,
-    const void* v_block_scales_ptr, int* seq_lens, int* cum_seq_lens_q, int* cum_seq_lens_kv,
-    float* attention_sinks, float* lse, Data_type q_data_type, Data_type kv_data_type,
-    Data_type o_data_type, TllmPagedAttentionMode mode, int64_t batch_size, int64_t max_q_len,
-    int64_t max_kv_len, int64_t num_pages_in_mem_pool, int64_t num_qo_heads, int64_t num_kv_heads,
-    int64_t head_dim_qk, int64_t head_dim_vo, int64_t page_size, int64_t q_stride_tokens,
-    int64_t q_stride_heads, int64_t kv_stride_keys_values, int64_t kv_stride_heads,
-    int64_t kv_stride_batch, int64_t max_num_blocks_per_seq, double bmm1_scale, double bmm2_scale,
+    void* workspace_buffer, void* multi_ctas_kv_counter_buffer, int64_t multi_ctas_kv_counter_size,
+    int* block_tables, const void* k_block_scales_ptr, const void* v_block_scales_ptr,
+    int* seq_lens, int* cum_seq_lens_q, int* cum_seq_lens_kv, float* attention_sinks, float* lse,
+    Data_type q_data_type, Data_type kv_data_type, Data_type o_data_type,
+    TllmPagedAttentionMode mode, int64_t batch_size, int64_t max_q_len, int64_t max_kv_len,
+    int64_t num_pages_in_mem_pool, int64_t num_qo_heads, int64_t num_kv_heads, int64_t head_dim_qk,
+    int64_t head_dim_vo, int64_t page_size, int64_t q_stride_tokens, int64_t q_stride_heads,
+    int64_t kv_stride_keys_values, int64_t kv_stride_heads, int64_t kv_stride_batch,
+    int64_t max_num_blocks_per_seq, double bmm1_scale, double bmm2_scale,
     const float* bmm1_scale_log2_ptr, const float* bmm2_scale_ptr, double o_sf_scale,
     int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t window_left, int64_t sum_seq_q,
     int64_t sparse_mla_top_k, void* sliding_window_kv_pool, int* sparse_mla_top_k_lens,
@@ -121,7 +133,7 @@ void trtllm_paged_attention_launcher(
   // For paged attention, K and V have the same dtype (kv_data_type).
   auto fmha_runner =
       TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type, o_data_type);
-  TllmGenFmhaRunnerParams runner_params;
+  TllmGenFmhaRunnerParams runner_params{};
 
   // Common params
   runner_params.qPtr = query;
@@ -222,14 +234,17 @@ void trtllm_paged_attention_launcher(
     runner_params.cumSeqLensQPtr = cum_seq_lens_q;
     runner_params.cumSeqLensKvPtr = nullptr;
 
-    size_t max_batch_size = 8192;   // todo(Yingyi): get from dlfw
-    size_t max_num_qo_heads = 256;  // todo(Yingyi): get from dlfw, in total 8MB
-    size_t num_semaphores =
-        round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-    // Workspace layout for generation: counter | (softmax if lse) | scratch. The counter slab is
-    // kept at a fixed 8MB so test guard regions around the first 8MB remain stable.
-    runner_params.multiCtasKvCounterPtr = float_allocator.aligned_alloc<int32_t>(
-        num_semaphores * sizeof(uint32_t), 16, "trtllm_gen_counter_workspace");
+    size_t const counter_bytes =
+        getTrtllmGenMultiCtasKvCounterBytes(batch_size, num_qo_heads, sm_count);
+    TVM_FFI_CHECK(multi_ctas_kv_counter_buffer != nullptr,
+                  "trtllm-gen multi-CTA KV counter buffer must not be null");
+    TVM_FFI_CHECK(reinterpret_cast<std::uintptr_t>(multi_ctas_kv_counter_buffer) % 16 == 0,
+                  "trtllm-gen multi-CTA KV counter buffer must be 16-byte aligned");
+    TVM_FFI_CHECK(static_cast<size_t>(multi_ctas_kv_counter_size) >= counter_bytes,
+                  "trtllm-gen multi-CTA KV counter buffer is too small: got " +
+                      std::to_string(multi_ctas_kv_counter_size) + " bytes, need " +
+                      std::to_string(counter_bytes) + " bytes");
+    runner_params.multiCtasKvCounterPtr = reinterpret_cast<int32_t*>(multi_ctas_kv_counter_buffer);
   }
 
   // Only allocate the softmax stats buffer when LSE is requested. The kernel's write layout is
@@ -299,8 +314,8 @@ inline bool is_4bit(Data_type data_type) { return data_type == Data_type::DATA_T
 
 void trtllm_paged_attention_decode(
     TensorView out, Optional<TensorView> out_scale_factor, TensorView query, TensorView key_cache,
-    TensorView value_cache, TensorView workspace_buffer, TensorView block_tables,
-    TensorView seq_lens, int64_t max_q_len, int64_t max_kv_len,
+    TensorView value_cache, TensorView workspace_buffer, TensorView multi_ctas_kv_counter_buffer,
+    TensorView block_tables, TensorView seq_lens, int64_t max_q_len, int64_t max_kv_len,
     Variant<double, ffi::Tensor> bmm1_scale, Variant<double, ffi::Tensor> bmm2_scale,
     double o_sf_scale, int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t batch_size,
     int64_t window_left, int64_t sparse_mla_top_k, int64_t sm_count, bool enable_pdl,
@@ -424,8 +439,10 @@ void trtllm_paged_attention_decode(
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
-      workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr,
-      v_block_scales_ptr, static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
+      workspace_buffer.data_ptr(), multi_ctas_kv_counter_buffer.data_ptr(),
+      multi_ctas_kv_counter_buffer.numel() * get_element_size(multi_ctas_kv_counter_buffer),
+      static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr, v_block_scales_ptr,
+      static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
       /*cum_seq_lens_kv*/ nullptr, attention_sinks_ptr, lse_ptr, q_data_type, kv_data_type,
       o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len, max_kv_len,
       num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_q, head_dim_o, page_size,
@@ -441,8 +458,8 @@ void trtllm_paged_attention_decode(
 
 void trtllm_paged_attention_context(
     TensorView out, Optional<TensorView> out_scale_factor, TensorView query, TensorView key_cache,
-    TensorView value_cache, TensorView workspace_buffer, TensorView block_tables,
-    TensorView seq_lens, int64_t max_q_len, int64_t max_kv_len,
+    TensorView value_cache, TensorView workspace_buffer, TensorView multi_ctas_kv_counter_buffer,
+    TensorView block_tables, TensorView seq_lens, int64_t max_q_len, int64_t max_kv_len,
     Variant<double, ffi::Tensor> bmm1_scale, Variant<double, ffi::Tensor> bmm2_scale,
     double o_sf_scale, int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t batch_size,
     int64_t window_left, TensorView cum_seq_lens_q, TensorView cum_seq_lens_kv, int64_t sm_count,
@@ -560,8 +577,10 @@ void trtllm_paged_attention_context(
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
-      workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr,
-      v_block_scales_ptr, static_cast<int*>(seq_lens.data_ptr()),
+      workspace_buffer.data_ptr(), multi_ctas_kv_counter_buffer.data_ptr(),
+      multi_ctas_kv_counter_buffer.numel() * get_element_size(multi_ctas_kv_counter_buffer),
+      static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr, v_block_scales_ptr,
+      static_cast<int*>(seq_lens.data_ptr()),
       /*cum_seq_lens_q=*/static_cast<int*>(cum_seq_lens_q.data_ptr()),
       /*cum_seq_lens_kv=*/static_cast<int*>(cum_seq_lens_kv.data_ptr()), attention_sinks_ptr,
       lse_ptr, q_data_type, kv_data_type, o_data_type, TllmPagedAttentionMode::Context, batch_size,
@@ -600,7 +619,7 @@ void trtllm_ragged_attention_launcher(
   auto fmha_runner = TllmGenFmhaRunnerCache::get(q_data_type, k_data_type, v_data_type, o_data_type,
                                                  num_elts_sage_q, num_elts_sage_k, num_elts_sage_p,
                                                  num_elts_sage_v);
-  TllmGenFmhaRunnerParams runner_params;
+  TllmGenFmhaRunnerParams runner_params{};
 
   runner_params.qPtr = query;
   runner_params.kPtr = key;
@@ -649,14 +668,6 @@ void trtllm_ragged_attention_launcher(
       is_causal ? TrtllmGenAttentionMaskType::Causal : TrtllmGenAttentionMaskType::Dense;
 
   AlignedAllocator float_allocator(workspace_buffer, workspace_size);
-  size_t max_batch_size = 8192;
-  size_t max_num_qo_heads = 256;
-  size_t num_semaphores =
-      round_up(max_batch_size * max_num_qo_heads, 8);  // max 8MB, should align to 16 bytes
-  // Workspace layout: counter | (softmax if lse) | scratch. Keep the 8MB counter at the head so
-  // test guard regions around the first 8MB remain stable across LSE on/off calls.
-  runner_params.multiCtasKvCounterPtr = float_allocator.aligned_alloc<int32_t>(
-      num_semaphores * sizeof(uint32_t), 16, "trtllm_gen_counter_workspace");
   // Only allocate the softmax stats slab when LSE is requested; size with the same
   // tile-aligned upper bound used by the paged launcher to prevent OOB writes on
   // variable-q workloads.
@@ -803,8 +814,9 @@ void trtllm_ragged_attention(
 
 void trtllm_paged_attention_decode_sparse_mla_dsv4(
     TensorView out, TensorView query, TensorView primary_kv_cache,
-    TensorView sliding_window_kv_cache, TensorView workspace_buffer, TensorView sparse_indices,
-    TensorView seq_lens, TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
+    TensorView sliding_window_kv_cache, TensorView workspace_buffer,
+    TensorView multi_ctas_kv_counter_buffer, TensorView sparse_indices, TensorView seq_lens,
+    TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
     Variant<double, ffi::Tensor> bmm2_scale, int64_t batch_size, int64_t max_q_len,
     int64_t sm_count, bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> cum_seq_lens_q) {
@@ -909,6 +921,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
   trtllm_paged_attention_launcher(
       out.data_ptr(), /*out_scale_factor=*/nullptr, query.data_ptr(), primary_kv_cache.data_ptr(),
       primary_kv_cache.data_ptr(), workspace_buffer.data_ptr(),
+      multi_ctas_kv_counter_buffer.data_ptr(),
+      multi_ctas_kv_counter_buffer.numel() * get_element_size(multi_ctas_kv_counter_buffer),
       static_cast<int*>(sparse_indices.data_ptr()), /*k_block_scales_ptr=*/nullptr,
       /*v_block_scales_ptr=*/nullptr, static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
       /*cum_seq_lens_kv=*/nullptr, attention_sinks_ptr, /*lse=*/nullptr, q_data_type, kv_data_type,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -70,12 +70,14 @@ from .utils import (
     check_shape_dtype_device,
     get_alibi_slopes,
     _get_cache_alibi_slopes_buf,
+    _get_trtllm_gen_multi_ctas_kv_counter_buffer,
     _get_range_buf,
     _unpack_paged_kv_cache,
     canonicalize_torch_dtype,
     determine_attention_backend,
     device_support_pdl,
     get_device_sm_count,
+    get_trtllm_gen_multi_ctas_kv_counter_bytes,
     is_float8,
     register_custom_op,
     register_fake_op,
@@ -825,6 +827,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             self._kv_lens_buffer = torch.empty(
                 (32768,), dtype=torch.int32, device=self.device
             )
+        self._trtllm_gen_multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None
 
         if use_cuda_graph:
             if not torch.is_tensor(paged_kv_indptr_buffer):
@@ -1342,6 +1345,17 @@ class BatchDecodeWithPagedKVCacheWrapper:
         elif self._backend == "trtllm-gen":
             assert logits_soft_cap == 0.0
             self._max_kv_len = max(kv_lens_arr_host).item()
+            # Allocated once per plan and reused across run() launches. The
+            # trtllm-gen kernel self-resets the counters at the end of each
+            # launch, so no per-launch re-zeroing is needed.
+            self._trtllm_gen_multi_ctas_kv_counter_buffer = (
+                _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+                    batch_size,
+                    num_qo_heads,
+                    get_device_sm_count(self.device),
+                    self.device,
+                )
+            )
             required_size = len(kv_lens_arr_host)
             if required_size > self._kv_lens_buffer.shape[0]:
                 self._kv_lens_buffer = torch.empty(
@@ -1804,8 +1818,11 @@ class BatchDecodeWithPagedKVCacheWrapper:
             q = q.view(q.size(0) // q_len_per_req, q_len_per_req, q.size(1), q.size(2))
 
         if self.use_tensor_cores:
-            run_args = [
-                self._float_workspace_buffer,
+            run_args = [self._float_workspace_buffer]
+            if self._backend == "trtllm-gen":
+                assert self._trtllm_gen_multi_ctas_kv_counter_buffer is not None
+                run_args.append(self._trtllm_gen_multi_ctas_kv_counter_buffer)
+            run_args += [
                 self._int_workspace_buffer,
                 self._plan_info,
                 q,
@@ -2494,6 +2511,7 @@ class TrtllmGenDecodeModule:
         k_cache: torch.Tensor,
         v_cache: torch.Tensor,
         workspace_buffer: torch.Tensor,
+        multi_ctas_kv_counter_buffer: torch.Tensor,
         block_tables: torch.Tensor,
         seq_lens: torch.Tensor,
         max_seq_len: int,
@@ -2541,6 +2559,7 @@ class TrtllmGenDecodeModule:
             k_cache,
             v_cache,
             workspace_buffer,
+            multi_ctas_kv_counter_buffer,
             block_tables,
             seq_lens,
             max_q_len,
@@ -2581,6 +2600,7 @@ def get_trtllm_gen_decode_module(*args):
         f"flashinfer::{uri}_ragged_run",
         mutates_args=(
             "float_workspace_buffer",
+            "multi_ctas_kv_counter_buffer",
             "int_workspace_buffer",
             "o",
             "maybe_lse",
@@ -2588,6 +2608,7 @@ def get_trtllm_gen_decode_module(*args):
     )
     def paged_run(
         float_workspace_buffer: torch.Tensor,
+        multi_ctas_kv_counter_buffer: torch.Tensor,
         int_workspace_buffer: torch.Tensor,
         plan_info_vec: List[int],
         q: torch.Tensor,
@@ -2645,6 +2666,7 @@ def get_trtllm_gen_decode_module(*args):
             paged_k_cache,
             paged_v_cache,
             float_workspace_buffer,
+            multi_ctas_kv_counter_buffer,
             block_tables,
             kv_lens_buffer,
             max_kv_len,
@@ -2665,6 +2687,7 @@ def get_trtllm_gen_decode_module(*args):
     @register_fake_op(f"flashinfer::{uri}_paged_run")
     def _fake_paged_run(
         float_workspace_buffer: torch.Tensor,
+        multi_ctas_kv_counter_buffer: torch.Tensor,
         int_workspace_buffer: torch.Tensor,
         plan_info_vec: List[int],
         q: torch.Tensor,
@@ -2688,9 +2711,13 @@ def get_trtllm_gen_decode_module(*args):
         maybe_max_item_len_ptr: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
+        scale_q: Optional[torch.Tensor],
+        scale_k: Optional[torch.Tensor],
+        scale_v: Optional[torch.Tensor],
         rope_scale: float,
         rope_theta: float,
         token_pos_in_items_len: int,
+        workspace_size: int,
         paged_kv_cache: Optional[torch.Tensor] = None,
         num_qo_heads: Optional[int] = None,
         num_kv_heads: Optional[int] = None,
@@ -2746,6 +2773,7 @@ def trtllm_batch_decode_with_kv_cache(
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
     bmm1_scale_log2: Optional[torch.Tensor] = None,
+    multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
 ) -> Union[
     torch.Tensor, FP4Tensor, Tuple[Union[torch.Tensor, FP4Tensor], torch.Tensor]
 ]:
@@ -2767,8 +2795,8 @@ def trtllm_batch_decode_with_kv_cache(
         - The ``head_dim`` (last dim) **must** have stride 1. This is a TMA hardware constraint
         - The head and batch/page dims can have arbitrary strides.
 
-    workspace_buffer : torch.Tensor. Must be initialized to 0 for its first use.
-        workspace
+    workspace_buffer : torch.Tensor
+        Workspace used for trtllm-gen softmax stats/scratch or xqa scratch.
 
     block_tables : torch.Tensor
         Page table of kv cache.
@@ -2891,6 +2919,13 @@ def trtllm_batch_decode_with_kv_cache(
         ``trtllm-gen`` backend. When True, the function returns a tuple
         ``(out, lse)`` where ``lse`` has shape ``[num_tokens, num_qo_heads]`` and
         dtype ``torch.float32``.
+
+    multi_ctas_kv_counter_buffer : Optional[torch.Tensor] = None
+        Optional separate counter buffer for ``trtllm-gen`` multi-CTA KV mode.
+        When omitted, FlashInfer creates a fresh zeroed internal buffer. When
+        provided, it must be zero-initialized at allocation (e.g. via
+        ``torch.zeros``); the kernel self-resets the counters at the end of each
+        launch, so it does not need to be re-zeroed between calls.
 
     Returns
     -------
@@ -3102,6 +3137,27 @@ def trtllm_batch_decode_with_kv_cache(
         _check_block_tables_shape(block_tables, uses_shared_paged_kv_idx)
 
         num_qo_heads = query.size(1)
+        required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+            batch_size, num_qo_heads, sm_count
+        )
+        if multi_ctas_kv_counter_buffer is None:
+            multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+                batch_size, num_qo_heads, sm_count, query.device
+            )
+        elif multi_ctas_kv_counter_buffer.device != query.device:
+            raise ValueError(
+                "multi_ctas_kv_counter_buffer must be on the same device as query"
+            )
+        else:
+            counter_buffer_bytes = (
+                multi_ctas_kv_counter_buffer.numel()
+                * multi_ctas_kv_counter_buffer.element_size()
+            )
+            if counter_buffer_bytes < required_counter_bytes:
+                raise ValueError(
+                    "multi_ctas_kv_counter_buffer is too small: got "
+                    f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
+                )
         lse_shape = (query.size(0), num_qo_heads)
         if lse is not None:
             check_shape_dtype_device(lse, lse_shape, torch.float32, query.device, "lse")
@@ -3122,6 +3178,7 @@ def trtllm_batch_decode_with_kv_cache(
             k_cache,
             v_cache,
             workspace_buffer,
+            multi_ctas_kv_counter_buffer,
             block_tables,
             seq_lens,
             max_q_len,

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -40,6 +40,8 @@ from ..utils import (
     device_support_pdl,
     get_compute_capability,
     get_device_sm_count,
+    _get_trtllm_gen_multi_ctas_kv_counter_buffer,
+    get_trtllm_gen_multi_ctas_kv_counter_bytes,
     is_sm12x_supported,
     log2e,
 )
@@ -1189,7 +1191,8 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         SWA KV cache. TRTLLM-GEN uses head dim 512; SM120 sparse uses packed
         uint8 head dim 584. Layout follows ``kv_layout``.
     workspace_buffer : torch.Tensor
-        Backend workspace buffer. Must be zero-initialized for first use.
+        TRTLLM-GEN workspace buffer. The multi-CTA KV counters are managed in a
+        separate internal buffer.
     sparse_indices : torch.Tensor
         TRTLLM-GEN combined sparse table, or the SM120 sparse SWA segment.
     compressed_kv_cache : Optional[torch.Tensor]
@@ -1334,12 +1337,18 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         )
 
     sm_count = get_device_sm_count(query.device)
+    # Fresh zero-initialized buffer; the kernel self-resets the counters at the
+    # end of the launch, so no explicit re-zeroing is required.
+    multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+        batch_size, query_flat.size(1), sm_count, query.device
+    )
     run_func(
         out,
         query_flat,
         primary_kv_cache,
         swa_kv_cache,
         workspace_buffer,
+        multi_ctas_kv_counter_buffer,
         sparse_indices,
         seq_lens.contiguous(),
         sparse_topk_lens,
@@ -1950,32 +1959,9 @@ class BatchMLAPagedAttentionWrapper:
 # Autotuning support for trtllm_batch_decode_with_kv_cache_mla
 # ---------------------------------------------------------------------------
 
-# Trtllm-gen kernel has a hardcoded max_batch_size = 8192 cap in
-# csrc/trtllm_fmha_kernel_launcher.cu:200 (the counter-region semaphore array
-# is sized for this max). Profiling beyond this would alias semaphores and
-# produce non-representative measurements.
+# Keep the trtllm-gen autotune sweep bounded; actual counter storage is sized
+# dynamically per profiled batch.
 _TRTLLM_GEN_MLA_MAX_BATCH = 8192
-
-# Size of the trtllm-gen workspace counter region (multi-block semaphores)
-# per csrc/trtllm_fmha_kernel_launcher.cu:200: max_batch_size * max_num_qo_heads
-# * sizeof(uint32_t) = 8192 * 256 * 4 = 8 MB. trtllm-gen places this counter
-# slab at the head of the workspace_buffer and self-resets it at the end of
-# every launch, so back-to-back trtllm-gen launches keep it valid without any
-# host-side zeroing.
-_TRTLLM_GEN_MLA_COUNTER_REGION_BYTES = 8192 * 256 * 4
-
-
-def _cute_dsl_workspace_view(workspace_buffer: torch.Tensor) -> torch.Tensor:
-    """Sub-view of the shared workspace that skips trtllm-gen's counter region.
-
-    cute-dsl carves its scratch from offset 0 of whatever buffer it is given;
-    offsetting past the 8 MB counter region keeps it from writing into the
-    bytes trtllm-gen needs zero on entry. Costs 8 MB of usable workspace
-    (callers should size the buffer accordingly; the recommended 128 MB has
-    ample headroom).
-    """
-    workspace_i8 = workspace_buffer.reshape(-1).view(torch.int8)
-    return workspace_i8[_TRTLLM_GEN_MLA_COUNTER_REGION_BYTES:]
 
 
 def _round_to_seq_len_bucket(x: int) -> int:
@@ -2048,14 +2034,8 @@ def _compute_mla_decode_buckets(
     if "cute-dsl" in runner_names:
         from ..cute_dsl.utils import get_num_sm
 
-        # cute-dsl gives up the counter region only when trtllm-gen shares the
-        # buffer, so its usable size excludes that reservation only then.
-        reserved = (
-            _TRTLLM_GEN_MLA_COUNTER_REGION_BYTES if "trtllm-gen" in runner_names else 0
-        )
         cute_dsl_cap = _cute_dsl_max_supported_batch(
-            workspace_bytes=workspace_buffer.numel() * workspace_buffer.element_size()
-            - reserved,
+            workspace_bytes=workspace_buffer.numel() * workspace_buffer.element_size(),
             q_len=q_len,
             num_heads=num_heads,
             kv_lora_rank=kv_lora_rank,
@@ -2281,6 +2261,11 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         self.uses_shared_paged_kv_idx = uses_shared_paged_kv_idx
         self.return_lse = return_lse
         self.lse = lse
+        # Allocated lazily on first forward() and reused (grown if a later call
+        # needs more). Held on the runner so its lifetime is tied to this
+        # instance rather than a leaking module-global cache. The kernel
+        # self-resets the counters after each launch, so no re-zeroing.
+        self._multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None
 
     def __hash__(self):
         # The default `TunableRunner.__hash__` walks `self.__dict__` and falls
@@ -2354,6 +2339,16 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
             lse_stride_tokens = 0
             lse_stride_heads = 0
 
+        required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+            batch_size, num_qo_heads, self.sm_count
+        )
+        counter_buffer = self._multi_ctas_kv_counter_buffer
+        if counter_buffer is None or counter_buffer.numel() < required_counter_bytes:
+            counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+                batch_size, num_qo_heads, self.sm_count, query.device
+            )
+            self._multi_ctas_kv_counter_buffer = counter_buffer
+        multi_ctas_kv_counter_buffer = counter_buffer
         self._run(
             out,
             None,  # fp4 output (unsupported by wrapper)
@@ -2361,6 +2356,7 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
             self.kv_cache,
             self.kv_cache,  # kv passed twice (K/V views over the same buffer)
             self.workspace_buffer,
+            multi_ctas_kv_counter_buffer,
             block_tables,
             seq_lens,
             max_q_len,
@@ -2420,20 +2416,12 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         return_lse: bool,
         sinks: Optional[torch.Tensor],
         cute_dsl_impl: str,
-        reserve_counter_region: bool = False,
     ):
         from ..cute_dsl.attention import cute_dsl_mla_decode
 
         self._run = cute_dsl_mla_decode
         self.kv_cache = kv_cache
-        # Only skip trtllm-gen's counter region when trtllm-gen shares this
-        # buffer (the "auto" path); a standalone cute-dsl runner owns the whole
-        # buffer and can use it from offset 0.
-        self.workspace_buffer = (
-            _cute_dsl_workspace_view(workspace_buffer)
-            if reserve_counter_region
-            else workspace_buffer
-        )
+        self.workspace_buffer = workspace_buffer
         self.kv_lora_rank = kv_lora_rank
         self.qk_nope_head_dim = qk_nope_head_dim
         self.qk_rope_head_dim = qk_rope_head_dim
@@ -2950,6 +2938,11 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 "out",
             )
 
+        # Fresh zero-initialized counter buffer; the kernel self-resets the
+        # counters at the end of the launch, so no explicit re-zeroing.
+        multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+            batch_size, query.size(1), sm_count, query.device
+        )
         get_trtllm_gen_fmha_module().trtllm_paged_attention_decode(
             out,
             None,  # fp4 output (unsupported by wrapper)
@@ -2957,6 +2950,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
             kv_cache,
             kv_cache,
             workspace_buffer,
+            multi_ctas_kv_counter_buffer,
             block_tables,
             seq_lens,
             max_q_len,
@@ -3127,9 +3121,6 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 return_lse=return_lse,
                 sinks=cute_dsl_sinks,
                 cute_dsl_impl=cute_dsl_impl,
-                # Reserve trtllm-gen's counter region only when it co-runs on
-                # the shared workspace (the "auto" path).
-                reserve_counter_region="trtllm-gen" in runner_names,
             )
         )
 
@@ -3198,7 +3189,7 @@ def xqa_batch_decode_with_kv_cache_mla(
         dimension is the concatenation ``[ckv_cache, kpe_cache]``.  Both shapes are
         accepted for backward compatibility.
     workspace_buffer : torch.Tensor
-        Pre-allocated workspace buffer.  Must be zero-initialized on first use.
+        Pre-allocated backend scratch workspace buffer.
     qk_nope_head_dim : int
         Non-RoPE head dimension.  Must be ``128``.  Will be removed in 1.0; pass
         ``kv_lora_rank`` instead going forward.

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -64,11 +64,13 @@ from .utils import (
     get_alibi_slopes,
     _get_cache_alibi_slopes_buf,
     _get_cache_buf,
+    _get_trtllm_gen_multi_ctas_kv_counter_buffer,
     _unpack_paged_kv_cache,
     canonicalize_torch_dtype,
     determine_attention_backend,
     device_support_pdl,
     get_device_sm_count,
+    get_trtllm_gen_multi_ctas_kv_counter_bytes,
     is_float8,
     is_sm100a_supported,
     is_sm110a_supported,
@@ -244,10 +246,32 @@ def get_trtllm_gen_prefill_module():
         uses_shared_paged_kv_idx: bool = True,
         is_causal: bool = True,
         lse: Optional[torch.Tensor] = None,
+        multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         sm_count = get_device_sm_count(query.device)
         if out is None:
             out = torch.empty_like(query)
+        required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+            batch_size, query.size(1), sm_count
+        )
+        if multi_ctas_kv_counter_buffer is None:
+            multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+                batch_size, query.size(1), sm_count, query.device
+            )
+        elif multi_ctas_kv_counter_buffer.device != query.device:
+            raise ValueError(
+                "multi_ctas_kv_counter_buffer must be on the same device as query"
+            )
+        else:
+            counter_buffer_bytes = (
+                multi_ctas_kv_counter_buffer.numel()
+                * multi_ctas_kv_counter_buffer.element_size()
+            )
+            if counter_buffer_bytes < required_counter_bytes:
+                raise ValueError(
+                    "multi_ctas_kv_counter_buffer is too small: got "
+                    f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
+                )
         if isinstance(bmm1_scale, torch.Tensor):
             assert bmm1_scale.dtype == torch.float32
             bmm1_scale = bmm1_scale * log2e
@@ -269,6 +293,7 @@ def get_trtllm_gen_prefill_module():
             k_cache,
             v_cache,
             workspace_buffer,
+            multi_ctas_kv_counter_buffer,
             block_tables,
             seq_lens,
             max_q_len,
@@ -626,6 +651,7 @@ def get_batch_prefill_module(backend, *args):
         mutates_args=(
             "float_workspace_buffer",
             "int_workspace_buffer",
+            "multi_ctas_kv_counter_buffer",
             "paged_k_cache",
             "paged_v_cache",
             "o",
@@ -679,6 +705,7 @@ def get_batch_prefill_module(backend, *args):
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
     ) -> None:
         if backend == "trtllm-gen":
             assert num_qo_heads is not None
@@ -691,6 +718,7 @@ def get_batch_prefill_module(backend, *args):
             assert cum_seq_lens_q is not None
             assert cum_seq_lens_kv is not None
             assert enable_pdl is not None
+            assert multi_ctas_kv_counter_buffer is not None
             assert workspace_size > 0, "workspace_size must be greater than 0"
             o = paged_run_func(
                 q.contiguous(),  # NOTE(Siyuan): without contiguous, the result is incorrect
@@ -717,6 +745,7 @@ def get_batch_prefill_module(backend, *args):
                 uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
                 is_causal=mask_mode != MaskMode.NON_CAUSAL.value,
                 lse=maybe_lse,
+                multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
             )
         elif backend == "fa2":
             assert not is_float8(q)
@@ -858,6 +887,7 @@ def get_batch_prefill_module(backend, *args):
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
     ) -> None:
         pass
 
@@ -1688,6 +1718,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             * self._float_workspace_buffer.element_size()
         )
         self.device = float_workspace_buffer.device
+        self._trtllm_gen_multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None
 
         self._kv_lens_buffer = torch.empty(
             (32768,), dtype=torch.int32, device=self.device
@@ -2304,6 +2335,16 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         self._block_tables = block_tables
         if self._backend == "trtllm-gen":
+            # Allocated once per plan and reused across run() launches; the
+            # trtllm-gen kernel self-resets the counters after each launch.
+            self._trtllm_gen_multi_ctas_kv_counter_buffer = (
+                _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+                    batch_size,
+                    num_qo_heads,
+                    get_device_sm_count(self.device),
+                    self.device,
+                )
+            )
             if logits_soft_cap != 0.0:
                 raise ValueError(
                     "logits_soft_cap must be 0.0 for trtllm-gen paged KV cache"
@@ -2764,8 +2805,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     value_block_scales,
                     skip_softmax_threshold_scale_factor,
                     True,  # uses_shared_paged_kv_idx
+                    self._trtllm_gen_multi_ctas_kv_counter_buffer,
                 ]
 
+            if self._backend == "trtllm-gen":
+                assert self._trtllm_gen_multi_ctas_kv_counter_buffer is not None
             assert self._cached_module is not None, "cached module is not initialized"
             self._cached_module.paged_run(*run_args)
 
@@ -4329,6 +4373,7 @@ def trtllm_batch_context_with_kv_cache(
     causal: bool = True,
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
+    multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
 ) -> Union[
     torch.Tensor, FP4Tensor, Tuple[Union[torch.Tensor, FP4Tensor], torch.Tensor]
 ]:
@@ -4348,8 +4393,8 @@ def trtllm_batch_context_with_kv_cache(
 
         - The ``head_dim`` (last dim) **must** have stride 1. This is a TMA hardware constraint
         - The head and batch/page dims can have arbitrary strides.
-    workspace_buffer : torch.Tensor. Must be initialized to 0 for its first use.
-        workspace
+    workspace_buffer : torch.Tensor
+        Workspace used for trtllm-gen softmax stats/scratch.
     block_tables : torch.Tensor
         Page table of kv cache.
         When ``uses_shared_paged_kv_idx`` is True (default): shape ``[batch_size, max_num_pages_per_seq]``.
@@ -4442,6 +4487,12 @@ def trtllm_batch_context_with_kv_cache(
         True and this is None, a buffer will be allocated.
     return_lse : bool = False
         Whether to return Log-Sum-Exp values. When True, returns ``(out, lse)``.
+    multi_ctas_kv_counter_buffer : Optional[torch.Tensor] = None
+        Optional separate trtllm-gen multi-CTA KV counter buffer. If not provided,
+        FlashInfer creates a fresh zeroed internal buffer. When provided, it must be
+        zero-initialized at allocation (e.g. via ``torch.zeros``); the kernel
+        self-resets the counters after each launch, so it does not need to be
+        re-zeroed between calls.
     Returns
     -------
     out: Union[torch.Tensor, FP4Tensor]
@@ -4581,6 +4632,27 @@ def trtllm_batch_context_with_kv_cache(
     workspace_size = workspace_buffer.numel() * workspace_buffer.element_size()
 
     num_qo_heads = query.size(1)
+    required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+        batch_size, num_qo_heads, sm_count
+    )
+    if multi_ctas_kv_counter_buffer is None:
+        multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+            batch_size, num_qo_heads, sm_count, query.device
+        )
+    elif multi_ctas_kv_counter_buffer.device != query.device:
+        raise ValueError(
+            "multi_ctas_kv_counter_buffer must be on the same device as query"
+        )
+    else:
+        counter_buffer_bytes = (
+            multi_ctas_kv_counter_buffer.numel()
+            * multi_ctas_kv_counter_buffer.element_size()
+        )
+        if counter_buffer_bytes < required_counter_bytes:
+            raise ValueError(
+                "multi_ctas_kv_counter_buffer is too small: got "
+                f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
+            )
     lse_shape = (query.size(0), num_qo_heads)
     if lse is not None:
         check_shape_dtype_device(lse, lse_shape, torch.float32, query.device, "lse")
@@ -4601,6 +4673,7 @@ def trtllm_batch_context_with_kv_cache(
         k_cache,
         v_cache,
         workspace_buffer,
+        multi_ctas_kv_counter_buffer,
         block_tables,
         seq_lens,
         max_q_len,
@@ -4785,7 +4858,7 @@ def trtllm_fmha_v2_prefill(
           ``[num_tokens, num_heads, head_dim]`` and K, V have shape
           ``[num_tokens, num_kv_heads, head_dim]``.
     workspace_buffer
-        The workspace buffer. Must be initialized to 0 for its first use.
+        The workspace buffer used for trtllm-gen softmax stats/scratch.
     seq_lens
         The KV sequence length of each request, shape: ``[batch_size]``.
     max_q_len

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -757,6 +757,34 @@ def get_device_sm_count(device: torch.device) -> int:
     return torch.cuda.get_device_properties(device).multi_processor_count
 
 
+def get_trtllm_gen_multi_ctas_kv_counter_bytes(
+    batch_size: int, num_qo_heads: int, sm_count: int
+) -> int:
+    """Return bytes needed by trtllm-gen multi-CTA KV counter semaphores."""
+    num_semaphores = round_up(max(batch_size * num_qo_heads, sm_count), 8)
+    return num_semaphores * 4
+
+
+def _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+    batch_size: int,
+    num_qo_heads: int,
+    sm_count: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Allocate a fresh, zero-initialized multi-CTA KV counter buffer.
+
+    The trtllm-gen kernel resets these semaphores back to zero at the end of
+    every launch, so the buffer only needs to be zeroed once at allocation and
+    can then be reused across launches without re-zeroing. Callers that reuse a
+    buffer should hold it on their own instance (e.g. a wrapper/runner) rather
+    than a module-global cache, so its lifetime is tied to the owner.
+    """
+    counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+        batch_size, num_qo_heads, sm_count
+    )
+    return torch.zeros(counter_bytes, dtype=torch.uint8, device=device)
+
+
 class FP4Tensor:
     """Wrapper class for FP4 tensors.
 

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -28,12 +28,10 @@ DTYPE_MAP = {
 GPU_DEVICE = "cuda:0"
 
 global_workspace_buffer = None  # can.be empty initialized
-global_trtllm_gen_fmha_workspace_buffer = None  # must be zero initialized
+global_trtllm_gen_fmha_workspace_buffer = None
 workspace_size = 256 * 1024 * 1024
 
-# Counter slab at the head of the generation workspace: 8192 batches * 256 heads * 4 bytes/int32.
-TRTLLM_GEN_COUNTER_BYTES = 8192 * 256 * 4
-# Size of the guard region we zero past the softmax slab (or counter slab when LSE is off).
+# Size of the guard region we zero past the softmax slab.
 TRTLLM_GEN_WORKSPACE_CHECK_BYTES = 1 * 1024 * 1024
 
 
@@ -63,10 +61,8 @@ def trtllm_gen_workspace_softmax_end_bytes_context(
 def trtllm_gen_workspace_softmax_end_bytes_decode(
     num_qo_heads: int, batch_size: int, max_q_len: int
 ) -> int:
-    """End offset of the softmax slab in the generation-mode workspace layout [counter|softmax|scratch]."""
-    return TRTLLM_GEN_COUNTER_BYTES + _trtllm_gen_softmax_slab_bytes(
-        num_qo_heads, batch_size, max_q_len
-    )
+    """End offset of the softmax slab in the generation-mode workspace layout [softmax|scratch]."""
+    return _trtllm_gen_softmax_slab_bytes(num_qo_heads, batch_size, max_q_len)
 
 
 def _skip_if_not_blackwell() -> None:
@@ -370,7 +366,7 @@ def create_workspace_buffers(device: torch.device):
             workspace_size, dtype=torch.int8, device=device
         )
     if global_trtllm_gen_fmha_workspace_buffer is None:
-        global_trtllm_gen_fmha_workspace_buffer = torch.zeros(
+        global_trtllm_gen_fmha_workspace_buffer = torch.empty(
             workspace_size, dtype=torch.int8, device=device
         )
     return global_trtllm_gen_fmha_workspace_buffer, global_workspace_buffer
@@ -971,11 +967,6 @@ def _test_trtllm_batch_decode(
     else:
         output = output_and_lse
 
-    if backend == "trtllm-gen":
-        # check if the first 8192 * 256 * 4 bytes of workspace_buffer is zero
-        # note(Yingyi): the first 8192 * 256 * 4 bytes of workspace_buffer is the counter workspace, size might change in the future
-        assert (workspace_buffer[: 8192 * 256 * 4] == 0).all().item()
-
     if o_dtype == "nvfp4":
         output, output_ref = unpack_compare_nvfp4(
             output, output_ref, o_sf_scale, o_sf_vec_size
@@ -1091,9 +1082,6 @@ def _test_trtllm_batch_decode(
                     atol=1e-1,
                     max_mismatched_elements=5,
                 )
-        # check if the first 8192 * 256 * 4 bytes of workspace_buffer is zero
-        # note(Yingyi): the first 8192 * 256 * 4 bytes of workspace_buffer is the counter workspace, size might change in the future
-        assert (workspace_buffer[: 8192 * 256 * 4] == 0).all().item()
 
 
 @pytest.mark.parametrize("backend", ["trtllm-gen"])

--- a/tests/attention/test_trtllm_gen_attention_prefill.py
+++ b/tests/attention/test_trtllm_gen_attention_prefill.py
@@ -316,14 +316,8 @@ def _test_trtllm_batch_prefill(
         assert (workspace_buffer[softmax_end:guard_end].cpu().numpy() == 0).all(), (
             "trtllm-gen context kernel wrote past the softmax slab"
         )
-        # Restore the head of the workspace so downstream wrapper runs can still assert
-        # the counter region (first 8MB) remains zero-initialized.
-        workspace_buffer[:softmax_end].zero_()
     else:
         output = output_and_lse
-        # In context mode, with LSE disabled the softmax slab is never allocated, so the
-        # head of the workspace stays zero.
-        assert (workspace_buffer[: 8192 * 256 * 4].cpu().numpy() == 0).all()
 
     if o_dtype == "nvfp4":
         output, output_ref = unpack_compare_nvfp4(
@@ -400,9 +394,6 @@ def _test_trtllm_batch_prefill(
             torch.testing.assert_close(
                 output.float(), output_wrapper.float(), rtol=1e-1, atol=1e-1
             )
-        # check if the first 8192 * 256 * 4 bytes of workspace_buffer is zero
-        # note(Yingyi): the first 8192 * 256 * 4 bytes of workspace_buffer is the counter workspace, size might change in the future
-        assert (workspace_buffer[: 8192 * 256 * 4].cpu().numpy() == 0).all()
 
 
 TRTLLM_BATCH_PREFILL_SHAPES = [
@@ -851,10 +842,6 @@ def test_trtllm_gen_prefill(
             atol=1e-3,
             rtol=1e-3,
         )
-    # check if the first 8192 * 256 * 4 bytes of workspace_buffer is zero
-    # note(Yingyi): the first 8192 * 256 * 4 bytes of workspace_buffer is the counter workspace, size might change in the future
-    if backend == "trtllm-native":
-        assert (workspace_buffer[: 8192 * 256 * 4].cpu().numpy() == 0).all()
 
 
 @pytest.mark.parametrize("backend", ["cute-dsl"])

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -12,11 +12,9 @@ from flashinfer.mla import (
 from flashinfer.utils import get_compute_capability
 
 global_workspace_buffer = None  # can.be empty initialized
-global_trtllm_gen_fmha_workspace_buffer = None  # must be zero initialized
+global_trtllm_gen_fmha_workspace_buffer = None
 workspace_size = 128 * 1024 * 1024
 
-# Generation-mode workspace prefix: 8192 batches * 256 heads * 4 bytes/int32 counter slab.
-TRTLLM_GEN_COUNTER_BYTES = 8192 * 256 * 4
 # Guard region we zero past the softmax slab so we can detect OOB writes.
 TRTLLM_GEN_WORKSPACE_CHECK_BYTES = 1 * 1024 * 1024
 
@@ -24,7 +22,7 @@ TRTLLM_GEN_WORKSPACE_CHECK_BYTES = 1 * 1024 * 1024
 def trtllm_gen_workspace_softmax_end_bytes_decode(
     num_qo_heads: int, batch_size: int, max_q_len: int
 ) -> int:
-    """End offset of the softmax slab in the generation-mode workspace [counter|softmax|scratch].
+    """End offset of the softmax slab in the generation-mode workspace [softmax|scratch].
 
     The C++ launcher allocates ``sizeof(float2) * softmax_slots`` bytes, i.e. 8 bytes per
     slot, where ``softmax_slots = num_qo_heads * batch_size * round_up(max_q_len, 256)``.
@@ -33,7 +31,7 @@ def trtllm_gen_workspace_softmax_end_bytes_decode(
     softmax_slab = (
         8 * num_qo_heads * batch_size * rounded_max_q_len
     )  # sizeof(float2) == 8
-    return TRTLLM_GEN_COUNTER_BYTES + softmax_slab
+    return softmax_slab
 
 
 def generate_sparse_indices(
@@ -424,12 +422,9 @@ def trtllm_batch_decode_mla(
             workspace_size, dtype=torch.int8, device=device
         )
     if global_trtllm_gen_fmha_workspace_buffer is None:
-        global_trtllm_gen_fmha_workspace_buffer = torch.zeros(
+        global_trtllm_gen_fmha_workspace_buffer = torch.empty(
             workspace_size, dtype=torch.int8, device=device
         )
-    # trtllm-gen requires zero-initialized workspace (counter region);
-    # re-zero each time since other backends (e.g. cute-dsl) may share and dirty it.
-    global_trtllm_gen_fmha_workspace_buffer.zero_()
     workspace_buffer = global_trtllm_gen_fmha_workspace_buffer
     workspace_buffer_ref = global_workspace_buffer
 
@@ -438,11 +433,10 @@ def trtllm_batch_decode_mla(
 
     def maybe_get_lse_guard_end(softmax_end: int) -> int | None:
         # The C++ launcher carves the workspace as
-        #     [counter (8 MB) | softmax_slab | guard (1 MB) | scratch],
+        #     [softmax_slab | guard (1 MB) | scratch],
         # where ``softmax_slab = 8 * num_heads * batch * round_up(max_q_len, 256)``
-        # bytes. ``softmax_end`` already includes the counter prefix, so the LSE
-        # guard subcheck is only meaningful when ``softmax_end + 1 MB`` still fits
-        # in the test workspace. For the largest parametrized shapes
+        # bytes. The LSE guard subcheck is only meaningful when
+        # ``softmax_end + 1 MB`` still fits in the test workspace. For the largest parametrized shapes
         # (e.g. batch=1024 * num_heads=128 * q_len=2 -> softmax_slab > 256 MB)
         # the slab alone overruns the 128 MB workspace; in that case we skip
         # the LSE subcheck and only exercise the output path (which does not
@@ -525,10 +519,6 @@ def trtllm_batch_decode_mla(
         )
     else:
         output = output_and_lse
-    # check if the first 8192 * 256 * 4 bytes of workspace_buffer is zero
-    # note(Yingyi): the first 8192 * 256 * 4 bytes of workspace_buffer is the counter workspace, size might change in the future
-    if backend == "trtllm-gen":
-        assert (workspace_buffer[: 8192 * 256 * 4].cpu().numpy() == 0).all()
 
     # Run reference attention and align output
     sm_scale = scale / (
@@ -796,7 +786,7 @@ def trtllm_batch_decode_mla_sparse(
             workspace_size, dtype=torch.int8, device=device
         )
     if global_trtllm_gen_fmha_workspace_buffer is None:
-        global_trtllm_gen_fmha_workspace_buffer = torch.zeros(
+        global_trtllm_gen_fmha_workspace_buffer = torch.empty(
             workspace_size, dtype=torch.int8, device=device
         )
     workspace_buffer = global_trtllm_gen_fmha_workspace_buffer
@@ -847,9 +837,6 @@ def trtllm_batch_decode_mla_sparse(
         cum_seq_lens_q=cum_seq_lens_q,
         max_q_len=max_q_len,
     )
-
-    # Check workspace buffer is zeroed
-    assert (workspace_buffer[: 8192 * 256 * 4].cpu().numpy() == 0).all()
 
     # For now, just check that output has correct shape and no NaNs
     assert output.shape == expected_shape, (
@@ -1153,7 +1140,7 @@ def test_trtllm_batch_decode_mla_preallocated_out(
 
     global global_trtllm_gen_fmha_workspace_buffer
     if global_trtllm_gen_fmha_workspace_buffer is None:
-        global_trtllm_gen_fmha_workspace_buffer = torch.zeros(
+        global_trtllm_gen_fmha_workspace_buffer = torch.empty(
             workspace_size,
             dtype=torch.int8,
             device=device,

--- a/tests/autotuner/test_autotuner_mla_decode.py
+++ b/tests/autotuner/test_autotuner_mla_decode.py
@@ -58,9 +58,8 @@ def _make_inputs(batch_size: int = 4, dtype: torch.dtype = torch.bfloat16):
         (batch_size,), _MAX_SEQ_LEN // 2, dtype=torch.int32, device=device
     )
 
-    # trtllm-gen requires the workspace's counter region (8 MB) to be zero;
-    # cute-dsl wants int8 dtype.
-    workspace_buffer = torch.zeros(_WORKSPACE_SIZE, dtype=torch.int8, device=device)
+    # cute-dsl wants int8 dtype; trtllm-gen counters use a separate internal buffer.
+    workspace_buffer = torch.empty(_WORKSPACE_SIZE, dtype=torch.int8, device=device)
 
     return query, kv_cache, block_tables, seq_lens, workspace_buffer
 


### PR DESCRIPTION
Thread a dedicated multi-CTA KV counter buffer through trtllm-gen decode, context, and MLA paths so workspace scratch does not need to be cleared for the counter slab.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->

Fixes https://github.com/flashinfer-ai/flashinfer/issues/3433


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional multi-CTA KV counter buffer support across TRT-LLM-gen paged prefill/decode (including sparse/MLA variants), with internal allocation/caching when omitted and buffer zeroing before execution.
* **Documentation**
  * Updated workspace guidance to remove the requirement that counters be placed/zero-initialized within the shared workspace buffer.
* **Tests**
  * Adjusted test workspace setup to use uninitialized buffers and removed assertions that depended on an initial zeroed counter region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->