### PR TITLE
Add trtllm-gen decode log2 bmm1 scale override

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2454,6 +2454,31 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
     run_return_lse = functools.partialmethod(run, return_lse=True)
 
 
+def _get_trtllm_gen_bmm1_scale_arg(
+    bmm1_scale: Union[float, torch.Tensor],
+    bmm1_scale_log2: Optional[torch.Tensor],
+    device: torch.device,
+) -> Union[float, torch.Tensor]:
+    if bmm1_scale_log2 is not None:
+        if not isinstance(bmm1_scale_log2, torch.Tensor):
+            raise TypeError("bmm1_scale_log2 must be a torch.Tensor")
+        if bmm1_scale_log2.dtype != torch.float32:
+            raise TypeError("bmm1_scale_log2 tensor must have dtype torch.float32")
+        if bmm1_scale_log2.device != device:
+            raise ValueError("bmm1_scale_log2 must be on the same device as query")
+        if bmm1_scale_log2.numel() != 1:
+            raise ValueError(
+                "bmm1_scale_log2 must be a single-element tensor "
+                "(e.g. a narrow(0, i, 1) view of the precomputed scale workspace)"
+            )
+        return bmm1_scale_log2
+    if isinstance(bmm1_scale, torch.Tensor):
+        if bmm1_scale.dtype != torch.float32:
+            raise TypeError("bmm1_scale tensor must have dtype torch.float32")
+        return bmm1_scale * log2e
+    return bmm1_scale
+
+
 class TrtllmGenDecodeModule:
     def __init__(self) -> None:
         self._sm_count: Optional[int] = None
@@ -2490,9 +2515,7 @@ class TrtllmGenDecodeModule:
         if self._sm_count is None:
             self._sm_count = get_device_sm_count(query.device)
 
-        if isinstance(bmm1_scale, torch.Tensor):
-            assert bmm1_scale.dtype == torch.float32
-            bmm1_scale = bmm1_scale * log2e
+        bmm1_scale = _get_trtllm_gen_bmm1_scale_arg(bmm1_scale, None, query.device)
         if isinstance(bmm2_scale, torch.Tensor):
             assert bmm2_scale.dtype == torch.float32
 
@@ -2722,6 +2745,7 @@ def trtllm_batch_decode_with_kv_cache(
     uses_shared_paged_kv_idx: bool = True,
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
+    bmm1_scale_log2: Optional[torch.Tensor] = None,
 ) -> Union[
     torch.Tensor, FP4Tensor, Tuple[Union[torch.Tensor, FP4Tensor], torch.Tensor]
 ]:
@@ -2761,6 +2785,11 @@ def trtllm_batch_decode_with_kv_cache(
     bmm1_scale : Union[float, torch.Tensor]
         fused scale for bmm1 input.
         when using trtllm-gen backend, it can be a torch.Tensor with dtype torch.float32.
+
+    bmm1_scale_log2 : Optional[torch.Tensor] = None
+        Optional precomputed log2-form bmm1 scale for ``trtllm-gen``. When provided,
+        this single-element FP32 device tensor is passed directly to the FFI and takes precedence over
+        tensor ``bmm1_scale``, avoiding the internal ``bmm1_scale * log2e`` CUDA kernel.
 
     bmm2_scale : Union[float, torch.Tensor]
         fused scale for bmm2 input.
@@ -2918,6 +2947,9 @@ def trtllm_batch_decode_with_kv_cache(
             "trtllm-gen" if get_compute_capability(query.device)[0] == 10 else "xqa"
         )
 
+    if backend != "trtllm-gen" and bmm1_scale_log2 is not None:
+        raise ValueError("bmm1_scale_log2 is only supported by the trtllm-gen backend")
+
     if backend == "xqa":
         # xqa backend doesn't support nvfp4 output
         if out_dtype == "nvfp4" or (out_dtype is None and isinstance(out, FP4Tensor)):
@@ -3054,9 +3086,9 @@ def trtllm_batch_decode_with_kv_cache(
         else:
             raise ValueError(f"Invalid out_dtype: {out_dtype}")
 
-        if isinstance(bmm1_scale, torch.Tensor):
-            assert bmm1_scale.dtype == torch.float32
-            bmm1_scale = bmm1_scale * log2e
+        bmm1_scale = _get_trtllm_gen_bmm1_scale_arg(
+            bmm1_scale, bmm1_scale_log2, query.device
+        )
         if isinstance(bmm2_scale, torch.Tensor):
             assert bmm2_scale.dtype == torch.float32
 

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -639,6 +639,7 @@ def _test_trtllm_batch_decode(
     uses_shared_paged_kv_idx: bool = True,
     return_lse: bool | None = None,
     provide_lse: bool = False,
+    use_bmm1_scale_log2: bool = False,
 ) -> None:
     """
     Common function for testing trtllm-gen decode.
@@ -838,6 +839,27 @@ def _test_trtllm_batch_decode(
         bmm2_scale = bmm2_scale.item()
     elif not isinstance(bmm2_scale, torch.Tensor) and device_scale:
         bmm2_scale = torch.tensor(bmm2_scale, device=GPU_DEVICE, dtype=torch.float32)
+    bmm1_scale_log2 = None
+    if use_bmm1_scale_log2:
+        if backend != "trtllm-gen":
+            pytest.skip("bmm1_scale_log2 is only supported by trtllm-gen")
+        raw_bmm1_scale = (
+            float(bmm1_scale.item())
+            if isinstance(bmm1_scale, torch.Tensor)
+            else float(bmm1_scale)
+        )
+        bmm1_scale_workspace = torch.tensor(
+            [raw_bmm1_scale, raw_bmm1_scale * math.log2(math.e)],
+            device=GPU_DEVICE,
+            dtype=torch.float32,
+        )
+        bmm1_scale_log2 = bmm1_scale_workspace.narrow(0, 1, 1)
+        if isinstance(bmm1_scale, torch.Tensor):
+            # Poison the tensor bmm1_scale so precedence is output-observable: the
+            # result only matches the reference (computed from sm_scale above) if the
+            # log2 override takes priority over this tensor. Safe because bmm1_scale
+            # has no consumer after the API call under test.
+            bmm1_scale = bmm1_scale * 7.0
 
     # Optionally make query non-contiguous for testing stride support
     if non_contiguous_query:
@@ -915,6 +937,7 @@ def _test_trtllm_batch_decode(
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
         lse=provided_lse,
         return_lse=effective_return_lse,
+        bmm1_scale_log2=bmm1_scale_log2,
     )
     if expects_lse:
         if effective_return_lse:
@@ -1192,6 +1215,40 @@ def test_trtllm_batch_decode_lse_contract(return_lse, provide_lse):
         uses_shared_paged_kv_idx=True,
         return_lse=return_lse,
         provide_lse=provide_lse,
+    )
+
+
+# device_scale=True exercises the precedence branch where a tensor ``bmm1_scale``
+# is also supplied and the log2 override must take priority. kv_dtype="fp8" covers
+# the motivating FP8 KV use case (#3500).
+@pytest.mark.parametrize("device_scale", [False, True])
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype,o_dtype",
+    [
+        ("bf16", "bf16", "bf16"),
+        ("bf16", "fp8", "bf16"),
+    ],
+)
+def test_trtllm_batch_decode_bmm1_scale_log2(q_dtype, kv_dtype, o_dtype, device_scale):
+    _test_trtllm_batch_decode(
+        "trtllm-gen",
+        "HND",
+        2,
+        1,
+        16,
+        2,
+        2,
+        -1,
+        q_dtype,
+        o_dtype,
+        kv_dtype,
+        False,
+        False,
+        128,
+        128,
+        device_scale=device_scale,
+        uses_shared_paged_kv_idx=True,
+        use_bmm1_scale_log2=True,
     )
 
 


### PR DESCRIPTION
## Description

Adds an optional `bmm1_scale_log2` tensor override to `trtllm_batch_decode_with_kv_cache` for the TRT-LLM Gen decode path. When provided, FlashInfer validates the FP32 device tensor and forwards it directly to the TRT-LLM Gen FFI instead of launching the Python-side `bmm1_scale * log2e` conversion kernel.

This enables callers that already maintain both raw and log2-form bmm1 scales, such as TensorRT-LLM, to pass a narrow view of the precomputed log2 value directly.

## Validation

- `python3 -m py_compile flashinfer/decode.py tests/attention/test_trtllm_gen_attention_decode.py`
- `git diff --check`
- `docker exec -w /code/flashinfer backup-tensorrt_llm-devel-yihwang /usr/bin/python -m pytest tests/attention/test_trtllm_gen_attention_decode.py::test_trtllm_batch_decode_lse_contract tests/attention/test_trtllm_gen_attention_decode.py::test_trtllm_batch_decode_bmm1_scale_log2 -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `bmm1_scale_log2` support for TRT-LLM generation decoding on the `trtllm-gen` backend. When provided, it takes precedence over `bmm1_scale`.

* **Bug Fixes**
  * Added stricter validation to reject `bmm1_scale_log2` unless the `trtllm-gen` backend is selected.

* **Tests**
  * Extended TRT-LLM decode coverage to exercise `bmm1_scale_log2`.
  * Added a dedicated test to verify correct `bmm1_scale_log2` behavior across supported dtype/device configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes https://github.com/flashinfer-ai/flashinfer/issues/3500