### PR TITLE
feat(moe): wire in-kernel routing (FromLogits) into unified MoE API + routing axes in fuzzer

### DIFF
--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -2558,11 +2558,11 @@ def testUnifiedNvfp4Moe(args):
     act_pack = MoEActivationPack(
         hidden_states_q=cute_dsl_data["x"],
         hidden_states_scale=x_sf,
-        selected_experts=cute_dsl_data["token_selected_experts"],
-        final_scales=cute_dsl_data["token_final_scales"],
+        topk_ids=cute_dsl_data["token_selected_experts"],
+        topk_weights=cute_dsl_data["token_final_scales"],
     )
 
-    num_active_experts = int(act_pack.selected_experts.unique().numel())
+    num_active_experts = int(act_pack.topk_ids.unique().numel())
 
     weight_pack = MoEWeightPack()
     weight_pack.prepare_for("cute_dsl_nvfp4", cute_dsl_view)

--- a/flashinfer/fused_moe/__init__.py
+++ b/flashinfer/fused_moe/__init__.py
@@ -39,6 +39,7 @@ from .runners import CuteDslNvfp4Runner, TrtllmFp4RoutedRunner  # noqa: F401
 
 # Legacy flat-argument APIs (unchanged, not deprecated)
 from .core import (
+    RoutingInputMode,
     convert_to_block_layout,
     cutlass_fused_moe,
     interleave_moe_scales_for_sm90_mixed_gemm,
@@ -102,6 +103,7 @@ __all__ = [
     "ExpertConfig",
     "CuteDslNvfp4Runner",
     "MoEActivationPack",
+    "RoutingInputMode",
     "MoEConfig",
     "MoELayer",
     "MoEWeightPack",

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -33,6 +33,7 @@ from typing import ClassVar, Dict, Optional, Tuple, Union
 from torch import Tensor
 
 from ..tllm_enums import ActivationType, RoutingMethodType
+from .core import RoutingInputMode  # ABI enum; core does not import api (no cycle)
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -499,27 +500,27 @@ class MoEConfig:
 
 @dataclass
 class MoEActivationPack:
-    """Per-call transient data — pre-quantized NVFP4 activations plus routing.
+    """Per-call transient data — pre-quantized NVFP4 activations plus routing inputs.
 
-    Routing is supplied one of two mutually-exclusive ways (the runner picks the
-    kernel's ``RoutingInputMode`` from which fields are populated):
+    ``routing_input_mode`` selects how routing reaches the kernel (the runner reads it directly):
 
-    * **pre-routed** (``RoutingInputMode.PackedPrecomputed``): the caller computes
-      expert selection on the host and passes ``selected_experts`` + ``final_scales``.
-      This is the original MVP path.
-    * **in-kernel** (``RoutingInputMode.FromLogits``): the caller passes raw
-      ``routing_logits`` (and, for bias-aware methods like DeepSeekV3/MiniMax2,
-      ``routing_bias``); the kernel computes the top-k selection itself per
-      ``RoutingConfig.method``.  ``selected_experts`` / ``final_scales`` are then
-      OUTPUT buffers the kernel fills, so the caller leaves them ``None``.
+    * ``PackedPrecomputed`` (default) / ``UnpackedPrecomputed`` — **pre-routed**: the caller
+      computes expert selection on the host and passes ``topk_ids`` + ``topk_weights``.
+    * ``FromLogits`` — **in-kernel**: the caller passes raw ``routing_logits`` (and, for bias-aware
+      methods like DeepSeekV3/MiniMax2, ``routing_bias``); the kernel computes the top-k selection
+      itself per ``RoutingConfig.method``, and ``topk_ids`` / ``topk_weights`` are OUTPUT buffers
+      (left ``None`` by the caller).
+
+    ``topk_ids`` / ``topk_weights`` follow the routed-MoE naming convention (gh #2425).
     """
 
     hidden_states_q: Tensor  # [M, H//2] uint8 (packed NVFP4)
     hidden_states_scale: Tensor  # [M, H//16] float8_e4m3fn
-    # Pre-routed (PackedPrecomputed):
-    selected_experts: Optional[Tensor] = None  # [M, top_k] int32
-    final_scales: Optional[Tensor] = None  # [M, top_k] float32
-    # In-kernel routing (FromLogits):
+    routing_input_mode: RoutingInputMode = RoutingInputMode.PackedPrecomputed
+    # Pre-routed top-k selection (Packed/Unpacked modes); kernel-filled OUTPUT buffers under FromLogits.
+    topk_ids: Optional[Tensor] = None  # [M, top_k] int32 (expert indices)
+    topk_weights: Optional[Tensor] = None  # [M, top_k] float32 (routing weights)
+    # In-kernel routing inputs (FromLogits):
     routing_logits: Optional[Tensor] = None  # [M, num_experts] float32 or bfloat16
     routing_bias: Optional[Tensor] = None  # [num_experts] (same dtype as logits)
 

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -499,12 +499,29 @@ class MoEConfig:
 
 @dataclass
 class MoEActivationPack:
-    """Per-call transient data — pre-quantized NVFP4 activations + pre-routed indices."""
+    """Per-call transient data — pre-quantized NVFP4 activations plus routing.
+
+    Routing is supplied one of two mutually-exclusive ways (the runner picks the
+    kernel's ``RoutingInputMode`` from which fields are populated):
+
+    * **pre-routed** (``RoutingInputMode.PackedPrecomputed``): the caller computes
+      expert selection on the host and passes ``selected_experts`` + ``final_scales``.
+      This is the original MVP path.
+    * **in-kernel** (``RoutingInputMode.FromLogits``): the caller passes raw
+      ``routing_logits`` (and, for bias-aware methods like DeepSeekV3/MiniMax2,
+      ``routing_bias``); the kernel computes the top-k selection itself per
+      ``RoutingConfig.method``.  ``selected_experts`` / ``final_scales`` are then
+      OUTPUT buffers the kernel fills, so the caller leaves them ``None``.
+    """
 
     hidden_states_q: Tensor  # [M, H//2] uint8 (packed NVFP4)
     hidden_states_scale: Tensor  # [M, H//16] float8_e4m3fn
-    selected_experts: Tensor  # [M, top_k] int32
-    final_scales: Tensor  # [M, top_k] float32
+    # Pre-routed (PackedPrecomputed):
+    selected_experts: Optional[Tensor] = None  # [M, top_k] int32
+    final_scales: Optional[Tensor] = None  # [M, top_k] float32
+    # In-kernel routing (FromLogits):
+    routing_logits: Optional[Tensor] = None  # [M, num_experts] float32 or bfloat16
+    routing_bias: Optional[Tensor] = None  # [num_experts] (same dtype as logits)
 
     @property
     def num_tokens(self) -> int:

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -126,7 +126,7 @@ class CuteDslNvfp4Runner(TunableRunner):
 
 
 class TrtllmFp4RoutedRunner(TunableRunner):
-    """Pre-routed NVFP4 adapter over the canonical trtllm-gen ``MoERunner``.
+    """NVFP4 adapter over the canonical trtllm-gen ``MoERunner``.
 
     Translates (MoEActivationPack, MoEWeightPack) into the ``MoeRunnerInputs`` list
     plus the static weight/config kwargs that ``core.MoERunner.forward``
@@ -136,8 +136,16 @@ class TrtllmFp4RoutedRunner(TunableRunner):
     the fragile raw-op positional launch in exactly one place —
     ``core.MoERunner.forward``.
 
-    Routing is pre-computed (``RoutingInputMode.PackedPrecomputed``): the packed
-    int32 top-k ids carry ``((expert_id - local_offset) << 16) | bf16(weight)``.
+    Routing mode is chosen per-call from the activation pack (``pack_inputs``):
+
+    * **pre-routed** (``RoutingInputMode.PackedPrecomputed``) when the pack carries
+      ``selected_experts`` / ``final_scales``: the packed int32 top-k ids carry
+      ``((expert_id - local_offset) << 16) | bf16(weight)``.
+    * **in-kernel** (``RoutingInputMode.FromLogits``) when the pack carries
+      ``routing_logits``: the kernel computes the top-k selection from raw logits
+      per ``RoutingConfig.method`` (+ optional ``routing_bias``), writing
+      ``topk_ids`` / ``expert_weights`` into the OUTPUT buffers we allocate.
+
     The inner ``MoERunner`` needs the hidden size for its tactic keys and tuning
     buckets, so it is built lazily on the first ``pack_inputs`` call.
     """
@@ -235,6 +243,11 @@ class TrtllmFp4RoutedRunner(TunableRunner):
         gemm1_alpha, gemm2_weights, gemm2_weights_scale, and optionally
         output1_scale_scalar, output1_scale_gate_scalar, output2_scale_scalar.
 
+        Routing mode is chosen from the activation pack: if ``act.routing_logits``
+        is set we drive ``RoutingInputMode.FromLogits`` (the kernel routes); else we
+        pack the pre-routed ``selected_experts`` / ``final_scales`` for
+        ``RoutingInputMode.PackedPrecomputed``.
+
         The local-shard offset comes from ``ExpertConfig.local_expert_offset``
         on the config this runner was built with.  For expert-parallel
         pre-routed inputs the kernel indexes local experts as
@@ -255,25 +268,55 @@ class TrtllmFp4RoutedRunner(TunableRunner):
         if hidden_states_scale.dtype == torch.uint8:
             hidden_states_scale = hidden_states_scale.view(torch.float8_e4m3fn)
 
-        # Packed pre-routed top-k ids: ((expert_id - offset) << 16) | bf16(weight)
-        ids = act.selected_experts - self._local_expert_offset
-        weight_bf16_bits = (
-            act.final_scales.to(torch.bfloat16).view(torch.int16).to(torch.int32)
-        )
-        topk_ids = (ids << 16) | (weight_bf16_bits & 0xFFFF)
-
         output = act.hidden_states_q.new_empty(
             (num_tokens, hidden_size), dtype=torch.bfloat16
         )
-        # PackedPrecomputed still requires a (kernel-side) topk_weights buffer:
-        # the raw op declares it non-Optional.  The high-level wrapper allocates
-        # an empty bf16 placeholder here; we mirror that since we bypass it.
-        expert_weights = act.final_scales.new_empty(
-            (num_tokens, routing.top_k), dtype=torch.bfloat16
-        )
+
+        if act.routing_logits is not None:
+            # FromLogits: topk_ids/expert_weights are OUTPUT buffers the kernel fills.
+            # We allocate them here (mirroring trtllm_fp4_block_scale_moe_op, core.py
+            # ~2268) because MoERunner.forward calls the raw op directly, bypassing the
+            # buffer-allocating wrapper. Weight dtype mirrors logits dtype (core.py:2253).
+            assert act.selected_experts is None and act.final_scales is None, (
+                "MoEActivationPack carries routing_logits but also selected_experts/"
+                "final_scales; supply exactly one (in-kernel vs pre-routed)."
+            )
+            routing_input_mode = RoutingInputMode.FromLogits
+            routing_logits = act.routing_logits
+            routing_bias = act.routing_bias
+            topk_ids = act.hidden_states_q.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.int32
+            )
+            # routing_logits.new_empty inherits its device + dtype (core.py:2253).
+            expert_weights = routing_logits.new_empty((num_tokens, routing.top_k))
+        else:
+            # Pre-routed packed path: ((expert_id - offset) << 16) | bf16(weight).
+            assert act.selected_experts is not None and act.final_scales is not None, (
+                "MoEActivationPack must carry either routing_logits (in-kernel) or "
+                "selected_experts + final_scales (pre-routed)."
+            )
+            assert act.routing_bias is None, (
+                "MoEActivationPack carries routing_bias but no routing_logits; "
+                "routing_bias is only consumed by in-kernel (FromLogits) routing."
+            )
+            routing_input_mode = RoutingInputMode.PackedPrecomputed
+            routing_logits = None
+            routing_bias = None
+            ids = act.selected_experts - self._local_expert_offset
+            weight_bf16_bits = (
+                act.final_scales.to(torch.bfloat16).view(torch.int16).to(torch.int32)
+            )
+            topk_ids = (ids << 16) | (weight_bf16_bits & 0xFFFF)
+            # PackedPrecomputed still requires a (kernel-side) topk_weights buffer:
+            # the raw op declares it non-Optional.  The high-level wrapper allocates
+            # an empty bf16 placeholder here; we mirror that since we bypass it.
+            expert_weights = act.final_scales.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.bfloat16
+            )
+
         moe_inputs = MoeRunnerInputs(
             output=output,
-            routing_logits=None,
+            routing_logits=routing_logits,
             topk_ids=topk_ids,
             expert_weights=expert_weights,
             hidden_states=act.hidden_states_q,
@@ -286,8 +329,8 @@ class TrtllmFp4RoutedRunner(TunableRunner):
         # MoERunner.forward.  None-valued entries are the optional gemm bias /
         # swiglu beta-clamp / per-token-scale paths not used by the MVP.
         self._static_kwargs = dict(
-            routing_input_mode=RoutingInputMode.PackedPrecomputed,
-            routing_bias=None,
+            routing_input_mode=routing_input_mode,
+            routing_bias=routing_bias,
             gemm1_weights=v["gemm1_weights"],
             gemm1_weights_scale=v["gemm1_weights_scale"],
             gemm1_bias=None,

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -104,8 +104,8 @@ class CuteDslNvfp4Runner(TunableRunner):
         return [
             act.hidden_states_q,
             act.hidden_states_scale.unsqueeze(-1),  # CuteDSL expects [M, H//16, 1]
-            act.selected_experts,
-            act.final_scales,
+            act.topk_ids,
+            act.topk_weights,
             v["w1_weight"],
             v["w1_weight_sf"],
             v["w1_alpha"],
@@ -136,15 +136,15 @@ class TrtllmFp4RoutedRunner(TunableRunner):
     the fragile raw-op positional launch in exactly one place —
     ``core.MoERunner.forward``.
 
-    Routing mode is chosen per-call from the activation pack (``pack_inputs``):
+    Routing mode is chosen per-call from ``act.routing_input_mode``:
 
-    * **pre-routed** (``RoutingInputMode.PackedPrecomputed``) when the pack carries
-      ``selected_experts`` / ``final_scales``: the packed int32 top-k ids carry
+    * **pre-routed** (``RoutingInputMode.PackedPrecomputed``): the pack carries
+      ``topk_ids`` / ``topk_weights`` and the runner packs them into int32 top-k ids
       ``((expert_id - local_offset) << 16) | bf16(weight)``.
-    * **in-kernel** (``RoutingInputMode.FromLogits``) when the pack carries
-      ``routing_logits``: the kernel computes the top-k selection from raw logits
-      per ``RoutingConfig.method`` (+ optional ``routing_bias``), writing
-      ``topk_ids`` / ``expert_weights`` into the OUTPUT buffers we allocate.
+    * **in-kernel** (``RoutingInputMode.FromLogits``): the pack carries
+      ``routing_logits`` (+ optional ``routing_bias``); the kernel computes the top-k
+      selection per ``RoutingConfig.method`` and writes ``topk_ids`` / ``topk_weights``
+      into the OUTPUT buffers we allocate.
 
     The inner ``MoERunner`` needs the hidden size for its tactic keys and tuning
     buckets, so it is built lazily on the first ``pack_inputs`` call.
@@ -243,10 +243,9 @@ class TrtllmFp4RoutedRunner(TunableRunner):
         gemm1_alpha, gemm2_weights, gemm2_weights_scale, and optionally
         output1_scale_scalar, output1_scale_gate_scalar, output2_scale_scalar.
 
-        Routing mode is chosen from the activation pack: if ``act.routing_logits``
-        is set we drive ``RoutingInputMode.FromLogits`` (the kernel routes); else we
-        pack the pre-routed ``selected_experts`` / ``final_scales`` for
-        ``RoutingInputMode.PackedPrecomputed``.
+        Routing mode is read from ``act.routing_input_mode``: ``FromLogits`` drives
+        in-kernel routing from ``act.routing_logits``; ``PackedPrecomputed`` packs the
+        pre-routed ``act.topk_ids`` / ``act.topk_weights``.
 
         The local-shard offset comes from ``ExpertConfig.local_expert_offset``
         on the config this runner was built with.  For expert-parallel
@@ -272,16 +271,18 @@ class TrtllmFp4RoutedRunner(TunableRunner):
             (num_tokens, hidden_size), dtype=torch.bfloat16
         )
 
-        if act.routing_logits is not None:
-            # FromLogits: topk_ids/expert_weights are OUTPUT buffers the kernel fills.
-            # We allocate them here (mirroring trtllm_fp4_block_scale_moe_op, core.py
-            # ~2268) because MoERunner.forward calls the raw op directly, bypassing the
-            # buffer-allocating wrapper. Weight dtype mirrors logits dtype (core.py:2253).
-            assert act.selected_experts is None and act.final_scales is None, (
-                "MoEActivationPack carries routing_logits but also selected_experts/"
-                "final_scales; supply exactly one (in-kernel vs pre-routed)."
+        routing_input_mode = act.routing_input_mode
+        if routing_input_mode == RoutingInputMode.FromLogits:
+            # In-kernel routing: topk_ids/expert_weights are OUTPUT buffers the kernel fills.
+            # We allocate them here (mirroring trtllm_fp4_block_scale_moe_op, core.py ~2268)
+            # because MoERunner.forward calls the raw op directly, bypassing the buffer-allocating
+            # wrapper. Weight dtype mirrors logits dtype (core.py:2253).
+            assert act.routing_logits is not None, (
+                "routing_input_mode=FromLogits requires routing_logits."
             )
-            routing_input_mode = RoutingInputMode.FromLogits
+            assert act.topk_ids is None and act.topk_weights is None, (
+                "FromLogits computes topk_ids/topk_weights in-kernel; leave them None."
+            )
             routing_logits = act.routing_logits
             routing_bias = act.routing_bias
             topk_ids = act.hidden_states_q.new_empty(
@@ -289,29 +290,32 @@ class TrtllmFp4RoutedRunner(TunableRunner):
             )
             # routing_logits.new_empty inherits its device + dtype (core.py:2253).
             expert_weights = routing_logits.new_empty((num_tokens, routing.top_k))
-        else:
-            # Pre-routed packed path: ((expert_id - offset) << 16) | bf16(weight).
-            assert act.selected_experts is not None and act.final_scales is not None, (
-                "MoEActivationPack must carry either routing_logits (in-kernel) or "
-                "selected_experts + final_scales (pre-routed)."
+        elif routing_input_mode == RoutingInputMode.PackedPrecomputed:
+            # Pre-routed: pack the host selection into ((expert_id - offset) << 16) | bf16(weight).
+            assert act.topk_ids is not None and act.topk_weights is not None, (
+                "routing_input_mode=PackedPrecomputed requires topk_ids + topk_weights."
             )
             assert act.routing_bias is None, (
-                "MoEActivationPack carries routing_bias but no routing_logits; "
                 "routing_bias is only consumed by in-kernel (FromLogits) routing."
             )
-            routing_input_mode = RoutingInputMode.PackedPrecomputed
             routing_logits = None
             routing_bias = None
-            ids = act.selected_experts - self._local_expert_offset
+            ids = act.topk_ids - self._local_expert_offset
             weight_bf16_bits = (
-                act.final_scales.to(torch.bfloat16).view(torch.int16).to(torch.int32)
+                act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
             )
             topk_ids = (ids << 16) | (weight_bf16_bits & 0xFFFF)
             # PackedPrecomputed still requires a (kernel-side) topk_weights buffer:
             # the raw op declares it non-Optional.  The high-level wrapper allocates
             # an empty bf16 placeholder here; we mirror that since we bypass it.
-            expert_weights = act.final_scales.new_empty(
+            expert_weights = act.topk_weights.new_empty(
                 (num_tokens, routing.top_k), dtype=torch.bfloat16
+            )
+        else:
+            raise NotImplementedError(
+                f"TrtllmFp4RoutedRunner does not support "
+                f"routing_input_mode={routing_input_mode!r} "
+                "(only FromLogits and PackedPrecomputed are wired)."
             )
 
         moe_inputs = MoeRunnerInputs(

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -648,8 +648,8 @@ def _make_packs_and_config(
     act_pack = MoEActivationPack(
         hidden_states_q=tensors["x"],
         hidden_states_scale=tensors["x_sf"].squeeze(-1),
-        selected_experts=tensors["token_selected_experts"],
-        final_scales=tensors["token_final_scales"],
+        topk_ids=tensors["token_selected_experts"],
+        topk_weights=tensors["token_final_scales"],
     )
 
     weight_pack = MoEWeightPack()
@@ -890,8 +890,8 @@ class TestTrtllmEPOffset:
             hidden_states_scale=torch.zeros(
                 num_tokens, hidden_size // sf_vec_size, dtype=torch.uint8, device=device
             ).view(torch.float8_e4m3fn),
-            selected_experts=selected_experts,
-            final_scales=final_scales,
+            topk_ids=selected_experts,
+            topk_weights=final_scales,
         )
 
         # pack_inputs only passes weight tensors through; dummies suffice since

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -85,7 +85,16 @@ whole-process device-side-assert abort that would block B200 CI. Run it explicit
 NOTE: `pytest --forked` does NOT work here (CUDA inits at collection ->
 "Cannot re-initialize CUDA in forked subprocess"); for crash-isolated enumeration run each
 test id in its own process instead (see var/03-ssh-docker-workflow.md).
-Env: FLASHINFER_UMOE_FUZZ_NUM_TESTS (default 80), FLASHINFER_UMOE_FUZZ_SEED (default 0).
+Env: FLASHINFER_UMOE_FUZZ_NUM_TESTS (default 80), FLASHINFER_UMOE_FUZZ_SEED (default 0),
+     FLASHINFER_UMOE_FUZZ_ONLY_SEED (comma-separated seeds -> run ONLY those configs; the
+     perfect-repro hook printed on every test).
+
+Determinism / repro / diagnostics: every config is fully derived from its seed -- shapes
+(random.Random(seed)), input tensors + output-buffer init (per-config torch.Generator), and the
+global RNG (torch.manual_seed(seed)) -- so a failing test reproduces bit-for-bit from the REPRO
+command it prints. Each test prints its full config + repro command (visible with `-s`, or on
+failure); on a numeric mismatch it dumps output-vs-oracle stats + the worst <=30 elements, so the
+CI log alone tells you whether the output is all-zero / all-NaN / Inf without having to rerun.
 
 ------------------------------------------------------------------------------------------------
 EXTENDING (cheap, by design):
@@ -183,6 +192,10 @@ from flashinfer.utils import get_compute_capability
 
 NUM_TESTS = int(os.environ.get("FLASHINFER_UMOE_FUZZ_NUM_TESTS", "80"))
 BASE_SEED = int(os.environ.get("FLASHINFER_UMOE_FUZZ_SEED", "0"))
+# Perfect-repro hook: if set (comma-separated seeds), the suite runs ONLY those configs. A curated
+# seed maps to its hand-written Cfg; any other seed is regenerated via the deterministic _gen(seed),
+# so a single seed reproduces exactly one config. The repro command printed on every test uses this.
+_ONLY_SEEDS = os.environ.get("FLASHINFER_UMOE_FUZZ_ONLY_SEED", "")
 
 # --- CI-safety gate: OPT-IN ----------------------------------------------------------------
 # Waived in CI pending gh #3547 + root-cause of a whole-process abort. Running the SM100 fuzzer
@@ -274,13 +287,13 @@ class DTypeHandler:
     rtol: float
 
 
-def _nvfp4_poison(buf):
-    """Fill a bf16 output buffer with large garbage + scattered NaN/±Inf. If a kernel reads or
-    scatter-adds into an uninitialized output instead of fully writing it, the poison leaks and
-    is caught by no-NaN / numeric. This is the torch->JAX buffer-hygiene guard: torch's caching
-    allocator usually hands back clean memory (masking the bug), JAX/XLA donates dirty buffers
-    (the GH-6158764 class)."""
-    g = torch.randn_like(buf) * 1e4
+def _nvfp4_poison(buf, gen):
+    """Fill a bf16 output buffer with large garbage + scattered NaN/±Inf, DETERMINISTICALLY (from a
+    per-config seeded generator, so a failure repros bit-for-bit). If a kernel reads or scatter-adds
+    into an uninitialized output instead of fully writing it, the poison leaks and is caught by
+    no-NaN / numeric. This is the torch->JAX buffer-hygiene guard: torch's caching allocator usually
+    hands back clean memory (masking the bug), JAX/XLA donates dirty buffers (the GH-6158764 class)."""
+    g = torch.randn(buf.shape, generator=gen, device=buf.device, dtype=buf.dtype) * 1e4
     flat = g.view(-1)
     flat[0::4], flat[1::4], flat[2::4] = float("nan"), float("inf"), float("-inf")
     buf.copy_(g)
@@ -618,7 +631,14 @@ _CURATED = [
         routed_scaling=1.0,
     ),  # DeepSeekV3 mid-size (top_k 8 < 2*128/4=64), non-pow2 intermediate
 ]
-_CONFIGS = _CURATED + [_gen(BASE_SEED + i) for i in range(NUM_TESTS)]
+if _ONLY_SEEDS:  # perfect-repro: run only the named seed(s)
+    _curated_by_seed = {c.seed: c for c in _CURATED}
+    _CONFIGS = [
+        _curated_by_seed.get(s) or _gen(s)
+        for s in (int(t) for t in _ONLY_SEEDS.split(",") if t.strip())
+    ]
+else:
+    _CONFIGS = _CURATED + [_gen(BASE_SEED + i) for i in range(NUM_TESTS)]
 
 
 def _route(
@@ -761,17 +781,86 @@ def _is_unsupported(e):
     return isinstance(e, NotImplementedError) or any(s in msg for s in _SKIP_SUBSTR)
 
 
+# ---------------------------------------------------------------------------
+# Diagnostics: every test prints its full config + a perfect-repro command; on a mismatch we dump
+# output-vs-oracle stats + the worst <=30 elements, so the CI log alone tells you whether the output
+# is all-zero / all-NaN / Inf without having to rerun. (Mirrors tests/gemm/test_unified_gemm_fuzz.py.)
+# ---------------------------------------------------------------------------
+def _describe(cfg: Cfg) -> str:
+    return (
+        f"CONFIG {cfg.label}\n"
+        f"  variant={cfg.variant} routing={cfg.routing_input_mode} "
+        f"method={cfg.routing_method.name} logits_dtype={cfg.logits_dtype} route={cfg.route}\n"
+        f"  shape: tokens={cfg.num_tokens} hidden={cfg.hidden} intermediate={cfg.intermediate}  "
+        f"experts={cfg.num_experts} top_k={cfg.top_k}\n"
+        f"  EP: n_local={cfg.n_local} expert_offset={cfg.expert_offset} (is_ep={cfg.is_ep})  "
+        f"group: n_group={cfg.n_group} topk_group={cfg.topk_group} "
+        f"routed_scaling={cfg.routed_scaling}  seed={cfg.seed}"
+    )
+
+
+def _repro(cfg: Cfg) -> str:
+    cuda = os.environ.get("CUDA_HOME", "<cuda>")
+    dev = os.environ.get("CUDA_VISIBLE_DEVICES", "<sm100-idx>")
+    return (
+        f"REPRO: CUDA_HOME={cuda} CUDA_VISIBLE_DEVICES={dev} FLASHINFER_UMOE_FUZZ=1 "
+        f"FLASHINFER_UMOE_FUZZ_ONLY_SEED={cfg.seed} "
+        f"pytest -s tests/moe/test_unified_moe_fuzz.py::test_unified_moe_fuzz"
+    )
+
+
+def _stats(t: torch.Tensor) -> str:
+    tf = t.float()
+    n = tf.numel()
+    return (
+        f"shape={tuple(t.shape)} dtype={t.dtype} nan={int(torch.isnan(tf).sum())} "
+        f"inf={int(torch.isinf(tf).sum())} zero={int((tf == 0).sum())}/{n} "
+        f"max|.|={tf.abs().nan_to_num().max().item():.4g}"
+    )
+
+
+def _dump(out: torch.Tensor, ref: torch.Tensor, k: int = 30) -> str:
+    of, rf = out.float().reshape(-1), ref.float().reshape(-1)
+    diff = (of - rf).abs()
+    # rank by |diff|, treating non-finite diffs as worst so NaN/Inf elems surface first.
+    diffn = torch.where(torch.isfinite(diff), diff, torch.full_like(diff, float("inf")))
+    idx = torch.topk(diffn, min(k, diffn.numel())).indices.tolist()
+    lines = [
+        f"  output: {_stats(out)}",
+        f"  oracle: {_stats(ref)}",
+        f"  worst {len(idx)} elems  [flat_idx]  output  vs  oracle:",
+    ]
+    lines += [f"    [{i}] {of[i].item():.6g}  vs  {rf[i].item():.6g}" for i in idx]
+    return "\n".join(lines)
+
+
+def _fail(cfg: Cfg, tag: str, why: str, out=None, ref=None):
+    parts = [f"{tag}: {why}", _describe(cfg)]
+    if out is not None and ref is not None:
+        parts.append(_dump(out, ref))
+    parts.append(_repro(cfg))
+    pytest.fail("\n".join(parts))
+
+
 @pytest.mark.parametrize("cfg", _CONFIGS, ids=[c.label for c in _CONFIGS])
 def test_unified_moe_fuzz(cfg):
     if not torch.cuda.is_available():
         pytest.skip("no CUDA")
-    # Full per-config determinism so any failure reproduces from the seed in the test id alone.
-    # Shapes (random.Random(seed)) and the input tensors (a per-config torch.Generator) are already
-    # seeded; this also pins the two GLOBAL-RNG draws -- the poison garbage and the device probe --
-    # so the entire run is bitwise-reproducible from `cfg.seed`. (Autotune winner selection is
-    # timing-based and may vary run-to-run, but every tactic is validated, so a correctness failure
-    # still reproduces via the tactic sweep regardless of which winner the tuner picks.)
+    # Full per-config determinism so any failure reproduces from the seed alone. Shapes
+    # (random.Random(seed)) and input tensors (a per-config torch.Generator) are already seeded;
+    # this pins the global RNG (the device probe), and the output buffer is initialized from the
+    # dedicated `poison_gen` below -- so the entire run is bitwise-reproducible from `cfg.seed`.
+    # (Autotune winner selection is timing-based and may vary run-to-run, but every tactic is
+    # validated, so a correctness failure still reproduces via the tactic sweep regardless of which
+    # winner the tuner picks.)
     torch.manual_seed(cfg.seed)
+    # Dedicated generator for output-buffer init, decoupled from the input generator's stream so the
+    # poison/zero fill is deterministic regardless of how many runners/calls a config drives.
+    poison_gen = torch.Generator(device="cuda").manual_seed(cfg.seed + 1_000_003)
+    # Every test prints its full config + the exact repro command (captured by pytest; shown on
+    # failure, or always with `-s`) so a CI log is self-explanatory without a rerun.
+    print("\n" + _describe(cfg))
+    print(_repro(cfg))
     sm = get_compute_capability(torch.device("cuda:0"))
     sm = sm[0] * 10 + sm[1]
 
@@ -855,36 +944,49 @@ def test_unified_moe_fuzz(cfg):
 
     def run(runner, poison=False):
         inputs = runner.pack_inputs(act_pack, weight_pack)
-        if poison:
-            # The output buffer is a kernel-owned `new_empty` tensor inside the inputs list
-            # (cute_dsl idx 11, trtllm the `output=`); locate it by dtype+shape and poison it.
-            bufs = [
-                t
-                for t in inputs
-                if torch.is_tensor(t)
-                and t.dtype == handler.out_dtype
-                and tuple(t.shape) == out_shape
-            ]
-            assert bufs, "could not locate the output buffer in pack_inputs to poison"
-            for b in bufs:
-                handler.poison(b)
+        # Deterministically initialize the kernel-owned output buffer (a `new_empty` in the runner's
+        # pack_inputs; cute_dsl idx 11, trtllm the `output=`), located by dtype+shape: clean=zeros,
+        # poison=seeded garbage+NaN/Inf. Both are bit-reproducible from cfg.seed, so any failure --
+        # including a partial-write that depends on the buffer -- reproduces exactly.
+        bufs = [
+            t
+            for t in inputs
+            if torch.is_tensor(t)
+            and t.dtype == handler.out_dtype
+            and tuple(t.shape) == out_shape
+        ]
+        assert bufs, "could not locate the output buffer in pack_inputs"
+        for b in bufs:
+            handler.poison(b, poison_gen) if poison else b.zero_()
         out = runner.forward(inputs, tactic=-1)
         out = (out[0] if isinstance(out, (list, tuple)) else out).float()
         torch.cuda.synchronize()
         return out
 
     def assert_correct(out, tag):
-        # no NaN/Inf where the reference is finite.
+        # (1) no NaN/Inf where the reference is finite.
         n_bad = int(((~torch.isfinite(out)) & torch.isfinite(ref)).sum().item())
-        assert n_bad == 0, f"{tag}: {n_bad} non-finite outputs vs finite reference"
-        # numeric vs the canonical quant-aware reference (the authority), magnitude-scaled.
+        if n_bad != 0:
+            _fail(
+                cfg,
+                tag,
+                f"{n_bad}/{out.numel()} non-finite outputs where oracle is finite "
+                f"(#2569/#3103-class)",
+                out,
+                ref,
+            )
+        # (2) numeric vs the canonical quant-aware reference (the authority), magnitude-scaled.
         abs_diff = (out - ref).abs()
         over_tol = abs_diff > (atol + rtol * ref.abs())
         if over_tol.any():
-            pytest.fail(
-                f"{tag}: {int(over_tol.sum())}/{out.numel()} elems exceed "
-                f"(rtol={rtol} atol={atol:.3g}); max|diff|={abs_diff.max().item():.4g}, "
-                f"‖ref‖∞={ref.abs().max().item():.4g}"
+            _fail(
+                cfg,
+                tag,
+                f"{int(over_tol.sum())}/{out.numel()} elems exceed tol "
+                f"(rtol={rtol} atol={atol:.3g}; max|diff|={abs_diff.max().item():.4g}, "
+                f"‖ref‖∞={ref.abs().max().item():.4g})",
+                out,
+                ref,
             )
 
     def check_backend(runner, out, tag):
@@ -893,11 +995,15 @@ def test_unified_moe_fuzz(cfg):
         # (3) determinism per the backend's contract: deterministic backends must reproduce
         # bitwise; non-deterministic ones (atomic-scatter finalize) are exempt.
         if _DETERMINISTIC.get(runner.backend_key, False):
-            if not torch.equal(out, run(runner)):
-                drift = (out - run(runner)).abs().max().item()
-                pytest.fail(
-                    f"{tag}: declared DETERMINISTIC but not bitwise-reproducible "
-                    f"(max abs diff {drift:.3e})"
+            out2 = run(runner)
+            if not torch.equal(out, out2):
+                _fail(
+                    cfg,
+                    tag,
+                    "declared DETERMINISTIC but not bitwise-reproducible across identical runs "
+                    "(#2514-class); 'output' = first run, 'oracle' = second run",
+                    out,
+                    out2,
                 )
         # (4) output-buffer poison: the kernel owns its (uninitialized `new_empty`) output, so the
         # result must NOT depend on it being clean. torch's allocator usually hands back zeros and
@@ -1011,6 +1117,16 @@ def test_autotune_cache_coherence(base):
 
     E, H, I = base
     top_k = 4
+    _cuda = os.environ.get("CUDA_HOME", "<cuda>")
+    _dev = os.environ.get("CUDA_VISIBLE_DEVICES", "<sm100-idx>")
+    _repro_cmd = (
+        f"REPRO: CUDA_HOME={_cuda} CUDA_VISIBLE_DEVICES={_dev} FLASHINFER_UMOE_FUZZ=1 "
+        f"pytest -s tests/moe/test_unified_moe_fuzz.py::test_autotune_cache_coherence -k e{E}h{H}i{I}"
+    )
+    print(
+        f"\nCACHE-COHERENCE base=e{E}h{H}i{I} top_k={top_k} token_seq={_CACHE_TOKEN_SEQ}"
+    )
+    print(_repro_cmd)
     g = torch.Generator(device="cuda").manual_seed(12345)
 
     def sparse(*shape):
@@ -1061,10 +1177,13 @@ def test_autotune_cache_coherence(base):
             torch.cuda.synchronize()
             tag = f"cache-seq T={num_tokens} (winner={layer.winner_backend}) {base}"
             n_bad = int(((~torch.isfinite(out)) & torch.isfinite(ref)).sum().item())
-            assert n_bad == 0, f"{tag}: {n_bad} non-finite outputs"
             atol = handler.atol_frac * ref.abs().max().item() + 1e-3
             over = (out - ref).abs() > (atol + handler.rtol * ref.abs())
-            assert not over.any(), (
-                f"{tag}: {int(over.sum())} elems exceed tol "
-                f"(max|diff|={(out - ref).abs().max().item():.4g}) -- stale/mis-keyed cached winner?"
-            )
+            if n_bad != 0 or over.any():
+                why = (
+                    f"{n_bad} non-finite outputs"
+                    if n_bad
+                    else f"{int(over.sum())} elems exceed tol "
+                    f"(max|diff|={(out - ref).abs().max().item():.4g}) -- stale/mis-keyed cached winner?"
+                )
+                pytest.fail(f"{tag}: {why}\n{_dump(out, ref)}\n{_repro_cmd}")

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -172,7 +172,12 @@ import torch.nn.functional as F
 
 from flashinfer.autotuner import autotune
 from flashinfer.fp4_quantization import fp4_quantize
-from flashinfer.fused_moe import MoEActivationPack, MoELayer, MoEWeightPack
+from flashinfer.fused_moe import (
+    MoEActivationPack,
+    MoELayer,
+    MoEWeightPack,
+    RoutingInputMode,
+)
 from flashinfer.fused_moe.api import (
     ActivationConfig,
     BackendOptions,
@@ -308,8 +313,9 @@ def _nvfp4_act_pack(x, selected_experts, final_scales):
     return MoEActivationPack(
         hidden_states_q=packed,
         hidden_states_scale=scale.squeeze(-1) if scale.dim() > 2 else scale,
-        selected_experts=selected_experts,
-        final_scales=final_scales,
+        routing_input_mode=RoutingInputMode.PackedPrecomputed,
+        topk_ids=selected_experts,
+        topk_weights=final_scales,
     )
 
 
@@ -324,6 +330,7 @@ def _nvfp4_act_pack_logits(x, routing_logits, routing_bias):
     return MoEActivationPack(
         hidden_states_q=packed,
         hidden_states_scale=scale.squeeze(-1) if scale.dim() > 2 else scale,
+        routing_input_mode=RoutingInputMode.FromLogits,
         routing_logits=routing_logits,
         routing_bias=routing_bias,
     )

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -63,7 +63,19 @@ reused for a different shape is caught (the #2933-adjacent class).
 deviating backend is caught by #2 directly, and #2 also names which backend -- so a cross-backend
 comparison adds no pass/fail power, only redundancy. See the design discussion.)
 
-Coverage today: NVFP4 (CuteDSL + TRTLLM-FP4-routed) on SM100 -- the only wired MVP runners.
+Routing coverage (both modes, axes ``routing_method`` x ``routing_input_mode`` x ``logits_dtype``):
+  * **pre-routed** (RoutingInputMode.PackedPrecomputed): the host computes the top-k per method and
+    feeds packed indices -- the original path.
+  * **in-kernel** (RoutingInputMode.FromLogits): the kernel routes from raw logits per
+    RoutingConfig.method -- reaches the bug cluster the pre-routed harness structurally can't:
+    DeepSeekV3 group-topk + bias (#2575), all-negative logits (#2822), fp32 router logits (#2796),
+    bias-method weight leakage (#2485/#2907). The SAME ``_route`` oracle (ported verbatim from the
+    kernel-validated references in ``tests/moe/test_trtllm_gen_fused_moe.py``) is the authority for
+    both modes, so a kernel that routes wrong is caught by check #2. In-kernel routing is single-GPU
+    (non-EP) here; EP + in-kernel routing semantics are a separate validation.
+
+Coverage today: NVFP4 (CuteDSL pre-routed + TRTLLM-FP4 pre-routed/in-kernel) on SM100 -- the only
+wired MVP runners (CuteDSL is pre-routed-only; FromLogits restricts to the trtllm backend).
 
 OPT-IN: this suite is gated behind FLASHINFER_UMOE_FUZZ (see the pytestmark below) and is
 SKIPPED unless that env var is set -- waived in CI pending gh #3547 and root-cause of a
@@ -166,6 +178,7 @@ from flashinfer.fused_moe.api import (
 )
 from flashinfer.fused_moe.layer import _BACKEND_RUNNERS
 from flashinfer.quantization import e2m1_and_ufp8sf_scale_to_float
+from flashinfer.tllm_enums import RoutingMethodType
 from flashinfer.utils import get_compute_capability
 
 NUM_TESTS = int(os.environ.get("FLASHINFER_UMOE_FUZZ_NUM_TESTS", "80"))
@@ -250,7 +263,10 @@ class DTypeHandler:
         tuple  # all plausible backend config classes; unwired ones auto-skip
     )
     snap: Callable  # bf16 tensor -> exactly-representable fixed point for this dtype
-    make_act_pack: Callable  # (x, selected_experts, final_scales) -> MoEActivationPack
+    make_act_pack: Callable  # (x, selected_experts, final_scales) -> MoEActivationPack (pre-routed)
+    make_act_pack_logits: (
+        Callable  # (x, routing_logits, routing_bias) -> pack (in-kernel routing)
+    )
     reference: Callable  # (x, w1, w2, selected_experts, final_scales, I) -> fp32 [T,H] authority
     poison: Callable  # in-place fill a kernel-owned output buffer with garbage + (NaN/Inf if repr.)
     out_dtype: torch.dtype  # output buffer dtype (used to locate it in the inputs list)
@@ -281,6 +297,22 @@ def _nvfp4_act_pack(x, selected_experts, final_scales):
         hidden_states_scale=scale.squeeze(-1) if scale.dim() > 2 else scale,
         selected_experts=selected_experts,
         final_scales=final_scales,
+    )
+
+
+def _nvfp4_act_pack_logits(x, routing_logits, routing_bias):
+    """In-kernel-routing pack: same nvfp4 activation quant as ``_nvfp4_act_pack`` but carrying raw
+    ``routing_logits`` (and optional ``routing_bias``) instead of pre-routed indices, so the kernel
+    computes the top-k selection itself (RoutingInputMode.FromLogits)."""
+    one = torch.tensor([1.0], device=x.device)
+    packed, scale = fp4_quantize(
+        x, global_scale=one, sf_vec_size=16, is_sf_swizzled_layout=False
+    )
+    return MoEActivationPack(
+        hidden_states_q=packed,
+        hidden_states_scale=scale.squeeze(-1) if scale.dim() > 2 else scale,
+        routing_logits=routing_logits,
+        routing_bias=routing_bias,
     )
 
 
@@ -315,6 +347,7 @@ _DTYPE = {
         candidate_configs=(CuteDslConfig, TrtllmFp4Config),
         snap=_snap_to_nvfp4,
         make_act_pack=_nvfp4_act_pack,
+        make_act_pack_logits=_nvfp4_act_pack_logits,
         reference=_nvfp4_reference,
         poison=_nvfp4_poison,
         out_dtype=torch.bfloat16,
@@ -356,7 +389,37 @@ _TOPK = [1, 2, 4, 6, 8]  # 6 non-pow2
 # num_tokens is runtime batch*seqlen -- arbitrary. Sweep odd + tile/autotune-bucket boundaries
 # (the #3168 16384-bucket / 4095-4097 tile-remainder class), not just clean powers of two.
 _TOKENS = [1, 2, 3, 7, 17, 64, 127, 129, 256, 1024, 2048, 4095, 4096, 4097]
-_ROUTE = ["uniform", "uniform", "hot1", "imbalanced"]
+# Routing-logits *distribution* skew (orthogonal to the routing METHOD below). "all_negative"
+# (#2822 all-negative-logit mis-selection) and "all_to_one" only bite the in-kernel router; the
+# pre-routed host topk handles them trivially, but exercising both modes is free coverage.
+_ROUTE = ["uniform", "uniform", "hot1", "imbalanced", "all_negative", "all_to_one"]
+
+# Routing METHOD axis (RoutingMethodType). Pre-routed mode computes the host weights per method
+# (the kernel then ignores the method, using the packed weights directly); in-kernel mode hands the
+# kernel raw logits and it routes per this method -- so the SAME _route() oracle validates both.
+# Covers the in-kernel-routing bug cluster the pre-routed harness structurally can't reach:
+# DeepSeekV3 group routing + bias (#2575), bias methods (#2485/#2907), fp32 logits (#2796).
+_ROUTING_METHODS = [
+    RoutingMethodType.RenormalizeNaive,  # == the harness's original host routing
+    RoutingMethodType.Default,
+    RoutingMethodType.Renormalize,
+    RoutingMethodType.TopK,
+    RoutingMethodType.Sigmoid,
+    RoutingMethodType.SigmoidRenorm,
+    RoutingMethodType.DeepSeekV3,  # sigmoid+bias -> group-topk -> top_k (#2575 lives here)
+    RoutingMethodType.MiniMax2,  # sigmoid+bias -> top_k -> scaled sum-norm
+    RoutingMethodType.Llama4,  # top1 -> sigmoid (top_k forced to 1)
+]
+# Routing logits dtype axis: fp32 router logits are the #2796 class; bf16 is the common case.
+_LOGITS_DTYPE = {"bf16": torch.bfloat16, "fp32": torch.float32}
+
+# Backend config classes whose runner can do in-kernel routing (RoutingInputMode.FromLogits).
+# CuteDSL is pre-routed-only, so a fromlogits config restricts the candidate list to these.
+_FROMLOGITS_BACKENDS = {TrtllmFp4Config}
+
+# Methods whose routing uses an additive bias (selection only -- weights stay unbiased). DeepSeekV3
+# REQUIRES a bias; MiniMax2's is optional but we always supply one to exercise the bias path.
+_BIAS_METHODS = {RoutingMethodType.DeepSeekV3, RoutingMethodType.MiniMax2}
 
 # Per-test weight footprint cap so one fuzz config never hogs the GPU (parallel-CI-friendly) and the
 # CPU exact-grid snap stays sub-few-seconds. ~500M bf16 weight elems ≈ 1 GB. The cap naturally pairs
@@ -381,6 +444,16 @@ class Cfg:
     seed: int
     local_experts: int = 0  # this rank's shard; 0 -> non-EP (== num_experts)
     expert_offset: int = 0  # global id of this shard's first expert (EP)
+    # Routing axes (defaults keep the original pre-routed RenormalizeNaive behavior so the
+    # positional _CURATED literals below are unaffected).
+    routing_method: RoutingMethodType = RoutingMethodType.RenormalizeNaive
+    routing_input_mode: str = (
+        "prerouted"  # "prerouted" (PackedPrecomputed) | "fromlogits"
+    )
+    logits_dtype: str = "bf16"  # "bf16" | "fp32" (#2796 fp32-router-logits class)
+    n_group: int = 0  # DeepSeekV3 group count (0 -> None)
+    topk_group: int = 0  # DeepSeekV3 groups kept (0 -> None)
+    routed_scaling: float = 0.0  # DeepSeekV3 weight scale (0.0 -> None)
 
     @property
     def n_local(self):  # experts actually held + computed on this rank
@@ -391,10 +464,18 @@ class Cfg:
         return self.expert_offset > 0 or self.n_local != self.num_experts
 
     @property
+    def is_fromlogits(self):
+        return self.routing_input_mode == "fromlogits"
+
+    @property
     def label(self):
         ep = f"L{self.n_local}o{self.expert_offset}_" if self.is_ep else ""
+        mode = "FL_" if self.is_fromlogits else ""
+        ld = "fp32_" if self.logits_dtype == "fp32" else ""
+        grp = f"g{self.n_group}x{self.topk_group}_" if self.n_group else ""
         return (
-            f"{self.variant}_{self.route}_e{self.num_experts}_{ep}k{self.top_k}_"
+            f"{self.variant}_{mode}{self.routing_method.name}_{ld}{self.route}_"
+            f"e{self.num_experts}_{ep}{grp}k{self.top_k}_"
             f"t{self.num_tokens}_h{self.hidden}_i{self.intermediate}_s{self.seed}"
         )
 
@@ -413,19 +494,55 @@ def _gen(seed):
             offset = local * rng.randrange(shards)
         if _weight_elems(local, h, i) <= _WEIGHT_ELEM_BUDGET:
             break
+
+    method = rng.choice(_ROUTING_METHODS)
+    # In-kernel routing ~half the time. FromLogits is single-shard only here: EP + in-kernel
+    # routing semantics (does the kernel route over global logits then filter to local?) are a
+    # separate validation, and EP collectives are out of scope for this single-GPU harness.
+    # DeepSeekV3 group routing scores over the full expert set, so keep it non-EP too.
+    fromlogits = rng.random() < 0.5
+    if fromlogits or method == RoutingMethodType.DeepSeekV3:
+        local, offset = ne, 0
+
+    # Method-specific top_k + group params.
+    n_group = topk_group = 0
+    routed_scaling = 0.0
+    if method == RoutingMethodType.Llama4:
+        top_k = 1  # the reference (and the kernel) only define Llama4 for top1
+    elif method == RoutingMethodType.DeepSeekV3:
+        # n_group divides ne with ne>n_group (=> >=2 experts/group for the top-2 group score);
+        # topk_group<=min(4,n_group); top_k < topk_group*ne/n_group (experts reachable after the
+        # group mask) and <= local. ne is always %4==0 (every _EXPERTS entry is).
+        n_group = rng.choice([g for g in (1, 2, 4, 8) if g < ne and ne % g == 0])
+        topk_group = rng.randint(1, min(4, n_group))
+        reachable = topk_group * ne // n_group
+        valid_k = [t for t in _TOPK if t < reachable and t <= local]
+        top_k = rng.choice(valid_k) if valid_k else 1
+        routed_scaling = rng.choice([1.0, 2.5])
+    else:
+        top_k = rng.choice(
+            [t for t in _TOPK if t <= local]
+        )  # route within the local shard
+
     return Cfg(
         num_tokens=rng.choice(_TOKENS),
         hidden=h,
         intermediate=i,
         num_experts=ne,
-        top_k=rng.choice(
-            [t for t in _TOPK if t <= local]
-        ),  # route within the local shard
+        top_k=top_k,
         variant="nvfp4",  # only wired variant today; expands with _DTYPE
         route=rng.choice(_ROUTE),
         seed=seed,
         local_experts=local,
         expert_offset=offset,
+        routing_method=method,
+        routing_input_mode="fromlogits" if fromlogits else "prerouted",
+        logits_dtype="fp32"
+        if rng.random() < 0.25
+        else "bf16",  # #2796 fp32-logits axis
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling=routed_scaling,
     )
 
 
@@ -444,15 +561,145 @@ _CURATED = [
     Cfg(
         512, 512, 512, 512, 4, "nvfp4", "hot1", 900_004
     ),  # max expert count (small H/I)
+    # In-kernel routing (FromLogits) headline cases the pre-routed harness can't reach:
+    Cfg(
+        256,
+        1024,
+        512,
+        256,
+        8,
+        "nvfp4",
+        "uniform",
+        900_005,
+        routing_method=RoutingMethodType.DeepSeekV3,
+        routing_input_mode="fromlogits",
+        n_group=8,
+        topk_group=4,
+        routed_scaling=2.5,
+    ),  # #2575 DeepSeekV3 group routing at large expert count (top_k 8 < 4*256/8=128)
+    Cfg(
+        512,
+        1024,
+        512,
+        64,
+        6,
+        "nvfp4",
+        "uniform",
+        900_006,
+        routing_method=RoutingMethodType.Default,
+        routing_input_mode="fromlogits",
+        logits_dtype="fp32",
+    ),  # #2796 fp32 router logits, in-kernel softmax->topk
+    Cfg(
+        256,
+        512,
+        512,
+        128,
+        4,
+        "nvfp4",
+        "all_negative",
+        900_007,
+        routing_method=RoutingMethodType.Renormalize,
+        routing_input_mode="fromlogits",
+    ),  # #2822 all-negative logits, in-kernel topk->softmax
+    Cfg(
+        1024,
+        1024,
+        768,
+        128,
+        8,
+        "nvfp4",
+        "uniform",
+        900_008,
+        routing_method=RoutingMethodType.DeepSeekV3,
+        routing_input_mode="fromlogits",
+        n_group=4,
+        topk_group=2,
+        routed_scaling=1.0,
+    ),  # DeepSeekV3 mid-size (top_k 8 < 2*128/4=64), non-pow2 intermediate
 ]
 _CONFIGS = _CURATED + [_gen(BASE_SEED + i) for i in range(NUM_TESTS)]
+
+
+def _route(
+    logits, method, top_k, *, bias=None, n_group=0, topk_group=0, routed_scaling=None
+):
+    """Host routing reference: logits[T,E] -> (selected[T,k] int64, weights[T,k] float32).
+
+    Mirrors the per-method math in ``tests/moe/test_trtllm_gen_fused_moe.py``
+    (``routing_reference_*`` / ``noaux_tc_ref``), which is validated against the SAME
+    trtllm-gen kernel the unified FromLogits path drives -- so the in-kernel router
+    agrees with this oracle by transitivity.  Selection/weight alignment is by column
+    (``selected[t,j]`` <-> ``weights[t,j]``); column ORDER is irrelevant downstream
+    (the reference sums over the top-k and matches experts by id, not position).
+    """
+    M = RoutingMethodType
+    lf = logits.float()
+    if (
+        method == M.Default
+    ):  # softmax -> top_k (NOT renormalized; norm_topk_prob is a no-op here)
+        w, sel = torch.topk(F.softmax(lf, dim=-1), top_k, dim=-1)
+    elif method in (M.Renormalize, M.RenormalizeNaive):
+        # top_k(raw) -> softmax over selected. The kernel aliases RenormalizeNaive to this
+        # (Softmax->TopK->SumNorm is algebraically identical to TopK->Softmax).
+        raw, sel = torch.topk(lf, top_k, dim=-1)
+        w = F.softmax(raw, dim=-1)
+    elif (
+        method == M.TopK
+    ):  # top_k of raw logits, raw logit values as weights (no normalization)
+        w, sel = torch.topk(lf, top_k, dim=-1)
+    elif method == M.Sigmoid:  # sigmoid -> top_k (no renorm)
+        w, sel = torch.topk(torch.sigmoid(lf), top_k, dim=-1)
+    elif (
+        method == M.SigmoidRenorm
+    ):  # sigmoid -> top_k -> renorm (divide by sum of selected)
+        w, sel = torch.topk(torch.sigmoid(lf), top_k, dim=-1)
+        w = w / (w.sum(dim=-1, keepdim=True) + 1e-20)
+    elif method == M.Llama4:  # top1 -> sigmoid weight (top_k forced to 1 by config gen)
+        w, sel = torch.topk(torch.sigmoid(lf), top_k, dim=-1)
+    elif method in (M.DeepSeekV3, M.MiniMax2):
+        # Sigmoid + bias drives SELECTION; the final weights use the UNBIASED sigmoid scores
+        # (the classic "bias leaks into weights" bug). DeepSeekV3 adds a group-topk pre-mask.
+        scores = torch.sigmoid(lf)
+        sel_scores = scores + bias.float() if bias is not None else scores.clone()
+        if method == M.DeepSeekV3 and n_group > 1:
+            E = sel_scores.shape[-1]
+            grp = sel_scores.view(*sel_scores.shape[:-1], n_group, E // n_group)
+            group_scores = torch.topk(grp, k=2, dim=-1).values.sum(
+                dim=-1
+            )  # top-2 sum per group
+            _, gidx = torch.topk(group_scores, k=topk_group, dim=-1)
+            gmask = torch.zeros_like(group_scores).scatter_(-1, gidx, 1.0)
+            smask = (
+                gmask.unsqueeze(-1)
+                .expand(*sel_scores.shape[:-1], n_group, E // n_group)
+                .reshape(sel_scores.shape)
+            )
+            sel_scores = (
+                sel_scores * smask
+            )  # zero out experts outside the selected groups
+        _, sel = torch.topk(sel_scores, top_k, dim=-1)
+        w = torch.gather(scores, -1, sel)  # UNBIASED sigmoid weights
+        w = w / (w.sum(dim=-1, keepdim=True) + 1e-20)
+        if routed_scaling is not None:
+            w = w * routed_scaling
+    else:
+        raise NotImplementedError(
+            f"routing method {method!r} not supported by the fuzzer oracle"
+        )
+    return sel.to(torch.int64), w.float()
 
 
 def _master(cfg, handler):
     """Sparse, exactly-representable bf16 inputs + host routing. Sparsity keeps the gemm reductions
     short so a structural bug isn't averaged away; exact-grid snapping makes input quant lossless.
     Weights cover only this rank's LOCAL shard (E_local); routing selects within the shard's GLOBAL
-    id range [offset, offset+E_local) (the EP contract -- non-EP is offset=0, E_local=num_experts)."""
+    id range [offset, offset+E_local) (the EP contract -- non-EP is offset=0, E_local=num_experts).
+
+    Routing is computed per ``cfg.routing_method`` via ``_route`` (the kernel-matching oracle). The
+    raw ``logits`` (+ ``routing_bias``) are returned so the in-kernel (FromLogits) path can feed them
+    to the kernel, while the host-computed ``selected_experts`` / ``final_scales`` remain the
+    authoritative reference for BOTH modes (the kernel must reproduce them)."""
     g = torch.Generator(device="cuda").manual_seed(cfg.seed)
     E_local, H, I, T = cfg.n_local, cfg.hidden, cfg.intermediate, cfg.num_tokens
 
@@ -464,17 +711,34 @@ def _master(cfg, handler):
     x, w1, w2 = sparse(T, H), sparse(E_local, 2 * I, H), sparse(E_local, H, I)
 
     logits = torch.randn(T, E_local, device="cuda", generator=g)  # over the local shard
-    if cfg.route == "hot1":  # pile every token onto one expert
+    if cfg.route in ("hot1", "all_to_one"):  # pile every token onto one expert
         logits[:, 0] += 50.0
     elif cfg.route == "imbalanced":  # rank-skew -> some experts get zero tokens
         logits += torch.linspace(8.0, -8.0, E_local, device="cuda")
-    weights = F.softmax(logits, dim=1, dtype=torch.float32)
-    weights, local_sel = torch.topk(weights, cfg.top_k, dim=-1)
-    final_scales = (weights / weights.sum(dim=-1, keepdim=True)).float()
+    elif (
+        cfg.route == "all_negative"
+    ):  # #2822: no positive anchor for the in-kernel router
+        logits = -logits.abs() - 1.0
+    logits = logits.to(_LOGITS_DTYPE[cfg.logits_dtype])
+
+    # Bias for bias-aware methods (affects SELECTION only); same dtype as logits per the kernel.
+    routing_bias = None
+    if cfg.routing_method in _BIAS_METHODS:
+        routing_bias = torch.randn(E_local, device="cuda", generator=g).to(logits.dtype)
+
+    local_sel, final_scales = _route(
+        logits,
+        cfg.routing_method,
+        cfg.top_k,
+        bias=routing_bias,
+        n_group=cfg.n_group,
+        topk_group=cfg.topk_group,
+        routed_scaling=cfg.routed_scaling or None,
+    )
     selected_experts = (local_sel + cfg.expert_offset).to(
         torch.int32
     )  # local -> global ids
-    return x, w1, w2, selected_experts, final_scales
+    return x, w1, w2, selected_experts, final_scales, logits, routing_bias
 
 
 _SKIP_SUBSTR = (
@@ -520,10 +784,17 @@ def test_unified_moe_fuzz(cfg):
         for BackendCfg in handler.candidate_configs
         if BackendCfg in _BACKEND_RUNNERS and BackendCfg.supported(sm)
     ]
+    if cfg.is_fromlogits:
+        # In-kernel routing restricts to FromLogits-capable backends (CuteDSL is pre-routed-only,
+        # so it cannot serve a logits-only pack and would compare apples to oranges).
+        wired_backends = [B for B in wired_backends if B in _FROMLOGITS_BACKENDS]
     if not wired_backends:
-        pytest.skip(f"no wired backend for {cfg.variant} on SM{sm}")
+        mode = "in-kernel-routing " if cfg.is_fromlogits else ""
+        pytest.skip(f"no wired {mode}backend for {cfg.variant} on SM{sm}")
 
-    x, w1, w2, selected_experts, final_scales = _master(cfg, handler)
+    x, w1, w2, selected_experts, final_scales, logits, routing_bias = _master(
+        cfg, handler
+    )
     ref = handler.reference(
         x, w1, w2, selected_experts, final_scales, cfg.intermediate, cfg.expert_offset
     )
@@ -531,8 +802,12 @@ def test_unified_moe_fuzz(cfg):
     rtol = handler.rtol
 
     # One activation pack + one weight pack with each backend's native view, all built from the
-    # SAME bf16 inputs (this rank's LOCAL shard) via the API's uniform prepare_weights.
-    act_pack = handler.make_act_pack(x, selected_experts, final_scales)
+    # SAME bf16 inputs (this rank's LOCAL shard) via the API's uniform prepare_weights. In-kernel
+    # routing hands the kernel raw logits (+ bias); pre-routed hands it the host selection.
+    if cfg.is_fromlogits:
+        act_pack = handler.make_act_pack_logits(x, logits, routing_bias)
+    else:
+        act_pack = handler.make_act_pack(x, selected_experts, final_scales)
     weight_pack = MoEWeightPack()
     for BackendCfg in wired_backends:
         weight_pack.prepare_for(
@@ -548,7 +823,14 @@ def test_unified_moe_fuzz(cfg):
         )
 
     config = MoEConfig(
-        routing=RoutingConfig(num_experts=cfg.num_experts, top_k=cfg.top_k),
+        routing=RoutingConfig(
+            num_experts=cfg.num_experts,
+            top_k=cfg.top_k,
+            method=cfg.routing_method,
+            n_group=cfg.n_group or None,
+            topk_group=cfg.topk_group or None,
+            routed_scaling_factor=cfg.routed_scaling or None,
+        ),
         quant=QuantConfig(variant=QuantVariant.NVFP4),
         experts=ExpertConfig(
             intermediate_size=cfg.intermediate,


### PR DESCRIPTION
## What

Wires **in-kernel routing** (`RoutingInputMode.FromLogits` — the kernel computes expert selection from raw `routing_logits`) into the unified MoE API (`flashinfer/fused_moe/`, PR #3093), and adds a routing-method / routing-mode axis to the merged unified fuzzer (`tests/moe/test_unified_moe_fuzz.py`).

The trtllm-gen FromLogits kernel and its dispatch were already fully implemented in `core.py`; the only reason it wasn't exercised through the unified API is that `TrtllmFp4RoutedRunner` hardcoded the pre-routed `PackedPrecomputed` mode and `MoEActivationPack` had no logits field. This is the low-hanging-fruit half of the task — the real work was the **reference**.

## Why

The merged unified fuzzer is **pre-routed** (routes on the host, feeds precomputed `selected_experts`), so the entire in-kernel-routing path is invisible to it. Exposing FromLogits lets the fuzzer finally cover the in-kernel-routing bug cluster the pre-routed harness structurally can't reach:
- **#2796** fp32 router logits
- **#2822** all-negative-logit mis-selection
- **#2575** DeepSeek-V3 grouped routing (warp-OOB at large expert counts)
- **#2485 / #2907** routing-bias

## Changes

**API / runner** (`api.py`, `runners.py`)
- `MoEActivationPack` gains optional `routing_logits` / `routing_bias`; `selected_experts` / `final_scales` become optional (back-compatible — existing keyword callers unaffected). The two routing inputs are mutually exclusive.
- `TrtllmFp4RoutedRunner.pack_inputs` branches on `act.routing_logits`: when present it drives `RoutingInputMode.FromLogits`, threads `routing_logits` / `routing_bias`, and allocates the `topk_ids` / `expert_weights` **OUTPUT** buffers itself (the runner path calls the raw op directly, not the buffer-allocating `trtllm_fp4_block_scale_moe_op` wrapper). All weight/config static kwargs are reused verbatim.
- A mode-branch was chosen over a new config/runner/registry entry to keep the diff minimal and reuse the verified machinery; the two modes have distinct autotune dynamic-tensor profiles, so there is no autotune-cache collision.

**Fuzzer** (`tests/moe/test_unified_moe_fuzz.py`)
- `_route()` — per-`RoutingMethodType` host oracle, ported verbatim from the kernel-validated references in `tests/moe/test_trtllm_gen_fused_moe.py` (`routing_reference_*` / `noaux_tc_ref`), so it agrees with the in-kernel router by transitivity. Covers all 9 methods incl. DeepSeek-V3 group-topk.
- New axes on `Cfg`: `routing_method`, `routing_input_mode` (`prerouted` | `fromlogits`), `logits_dtype` (`bf16` | `fp32`), and DeepSeek-V3 group params. `_master` is now method-aware and returns raw logits + bias; in-kernel mode feeds them to the kernel while the host-computed selection stays the authoritative reference for **both** modes.
- 4 curated FromLogits cases for the headline bugs; `_gen` mixes modes/methods with per-method constraints (Llama4 top-1, DeepSeek-V3 group divisibility, FromLogits kept non-EP). FromLogits restricts candidates to FromLogits-capable backends (CuteDSL is pre-routed-only).

## Verification

- **CPU oracle cross-check**: all 9 routing methods match the proven `test_trtllm_gen` references exactly.
- **SM100 / B200**: 10 in-kernel configs spanning all 9 methods, bf16 + fp32 logits, all 5 distribution skews (uniform / hot1 / imbalanced / all-negative / all-to-one), DeepSeek-V3 group routing (256 experts, `n_group=8`), and the autotune-ON production path — all match the host oracle at the fp4-requant tolerance. The pre-routed regression case passes (no breakage).

## Scope / follow-ups

- In-kernel routing is exercised **single-GPU (non-EP)** here; EP + in-kernel-routing semantics are a separate validation (EP collectives are out of scope for this single-GPU correctness harness).
- Once this lands and validates upstream, the parked `test_moe_fuzz.py` (branch `yanxu/moe-fuzzers-parked`) can be retired — its unique coverage is subsumed.
- Orthogonal known bug still open: #3547 (trtllm EP `local_expert_offset>0` → all-zero). FromLogits avoids the double-offset by construction; the fuzzer's `_KNOWN_FAILURES` ledger still xfails the pre-routed EP case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting routing input mode in fused MoE workflows.
  * Expanded MoE activation inputs to handle both precomputed top-k routing and logits-based routing.

* **Bug Fixes**
  * Updated MoE packing and routing logic to use the new top-k field names consistently.
  * Improved handling of routing biases and backend compatibility checks.

* **Tests**
  * Broadened MoE coverage for additional routing behaviors.
  * Added stronger diagnostics, reproducible failure output, and determinism checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->