### PR TITLE
test(moe): align EP-offset tests and docs with global expert ids (gh #3547)

### DIFF
--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -137,7 +137,8 @@ class TrtllmFp4RoutedRunner(TunableRunner):
     ``core.MoERunner.forward``.
 
     Routing is pre-computed (``RoutingInputMode.PackedPrecomputed``): the packed
-    int32 top-k ids carry ``((expert_id - local_offset) << 16) | bf16(weight)``.
+    int32 top-k ids carry ``(global_expert_id << 16) | bf16(weight)``; the
+    kernel maps global ids onto the local shard via ``local_expert_offset``.
     The inner ``MoERunner`` needs the hidden size for its tactic keys and tuning
     buckets, so it is built lazily on the first ``pack_inputs`` call.
     """
@@ -236,10 +237,11 @@ class TrtllmFp4RoutedRunner(TunableRunner):
         output1_scale_scalar, output1_scale_gate_scalar, output2_scale_scalar.
 
         The local-shard offset comes from ``ExpertConfig.local_expert_offset``
-        on the config this runner was built with.  For expert-parallel
-        pre-routed inputs the kernel indexes local experts as
-        ``[0, local_num_experts)``, so global expert ids are shifted down by the
-        local offset before packing.
+        on the config this runner was built with.  ``selected_experts`` carries
+        GLOBAL expert ids and is packed as-is; the kernel performs the
+        global→local mapping itself by subtracting ``local_expert_offset``
+        (passed via the static kwargs) and dropping ids outside
+        ``[offset, offset + local_num_experts)``.
         """
         from .core import MoeRunnerInputs, RoutingInputMode
 

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -886,6 +886,9 @@ class TestTrtllmEPOffset:
             + local_expert_offset
         )
         final_scales = torch.rand(num_tokens, top_k, device=device)
+        # One negative weight makes the low-16-bit check below sensitive to a
+        # dropped & 0xFFFF mask (bf16 sign bit would smear into the id field).
+        final_scales[0, 0] = -final_scales[0, 0]
         act_pack = MoEActivationPack(
             hidden_states_q=torch.zeros(
                 num_tokens, hidden_size // 2, dtype=torch.uint8, device=device
@@ -925,7 +928,13 @@ class TestTrtllmEPOffset:
         # Global ids land inside this rank's shard; the kernel maps them to
         # [0, local_num_experts) by subtracting local_expert_offset.
         assert int(decoded_ids.min()) >= local_expert_offset
-        assert int(decoded_ids.max()) < local_expert_offset + local_num_experts
+        # Low 16 bits hold the bf16 gate-weight bits.
+        expected_bits = (
+            final_scales.to(torch.bfloat16).view(torch.int16).to(torch.int32) & 0xFFFF
+        )
+        assert torch.equal(topk_ids & 0xFFFF, expected_bits)
+        # The offset travels to the kernel as a separate argument.
+        assert runner._static_kwargs["local_expert_offset"] == local_expert_offset
 
     @pytest.mark.parametrize("local_expert_offset", [32, 96])
     def test_ep_shard_forward_matches_offset_zero(self, local_expert_offset):

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -847,17 +847,18 @@ class TestUnifiedMoEDispatch:
 
 @sm100_required
 class TestTrtllmEPOffset:
-    """TRTLLM routed packing must shift global expert ids down by the local
-    shard offset.
+    """TRTLLM routed packing must keep expert ids GLOBAL.
 
-    The packed int32 top-k id is ``((expert_id - offset) << 16) | bf16(weight)``;
-    the kernel indexes local experts as ``[0, local_num_experts)``.  Before the
-    CR3 fix, ``pack_inputs`` defaulted the offset to 0, so a nonzero local shard
-    produced out-of-range local expert ids.
+    The packed int32 top-k id is ``(global_expert_id << 16) | bf16(weight)``;
+    the kernel performs the global→local mapping itself by subtracting
+    ``local_expert_offset`` (``mLocalExpertsStartIdx`` in RoutingKernel.h).
+    Pre-subtracting the offset in ``pack_inputs`` applied it twice, pushing
+    every id below the local shard and silently zeroing the output for any
+    ``local_expert_offset > 0`` (gh #3547).
     """
 
     @pytest.mark.parametrize("local_expert_offset", [0, 32, 96])
-    def test_pack_inputs_applies_local_expert_offset(self, local_expert_offset):
+    def test_pack_inputs_preserves_global_expert_ids(self, local_expert_offset):
         device = torch.device("cuda", torch.cuda.current_device())
         num_experts = 128
         local_num_experts = 32
@@ -915,13 +916,84 @@ class TestTrtllmEPOffset:
         inputs = runner.pack_inputs(act_pack, weight_pack)
         topk_ids = MoEInputs.from_list(inputs).topk_ids
 
-        # Upper 16 bits hold the (offset-shifted) local expert id.
-        decoded_local_ids = topk_ids >> 16
-        expected_local_ids = selected_experts - local_expert_offset
-        assert torch.equal(decoded_local_ids, expected_local_ids), (
-            f"offset={local_expert_offset}: packed local ids "
-            f"{decoded_local_ids} != expected {expected_local_ids}"
+        # Upper 16 bits hold the GLOBAL expert id, exactly as selected.
+        decoded_ids = topk_ids >> 16
+        assert torch.equal(decoded_ids, selected_experts), (
+            f"offset={local_expert_offset}: packed ids "
+            f"{decoded_ids} != global ids {selected_experts}"
         )
-        # Local ids must land inside the kernel's [0, local_num_experts) range.
-        assert int(decoded_local_ids.min()) >= 0
-        assert int(decoded_local_ids.max()) < local_num_experts
+        # Global ids land inside this rank's shard; the kernel maps them to
+        # [0, local_num_experts) by subtracting local_expert_offset.
+        assert int(decoded_ids.min()) >= local_expert_offset
+        assert int(decoded_ids.max()) < local_expert_offset + local_num_experts
+
+    @pytest.mark.parametrize("local_expert_offset", [32, 96])
+    def test_ep_shard_forward_matches_offset_zero(self, local_expert_offset):
+        """Full EP-shard forward equals the identical offset-0 run.
+
+        Same local-shard weights, same tokens, global ids shifted up by the
+        shard offset — the output must match the offset-0 baseline.  Before
+        the gh #3547 fix the EP run returned bit-exactly zero output.
+        """
+        device = torch.device("cuda", torch.cuda.current_device())
+        num_experts = 128  # global expert count across all EP ranks
+        local_num_experts = 32
+        top_k = 4
+        num_tokens = 64
+        hidden_size = 512
+        intermediate_size = 512
+
+        # Sample routing within one shard so the same tensors serve both runs.
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=local_num_experts,
+            num_local_experts=local_num_experts,
+            top_k=top_k,
+        )
+        weight_pack = MoEWeightPack()
+        weight_pack.prepare_for(
+            "trtllm_fp4_routed",
+            TrtllmFp4Config.prepare_weights(
+                tensors["w1_weight_bf16"],
+                tensors["w2_weight_bf16"],
+                num_local_experts=local_num_experts,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                device=device,
+            ),
+        )
+
+        def run(offset: int) -> torch.Tensor:
+            config = MoEConfig(
+                routing=RoutingConfig(num_experts=num_experts, top_k=top_k),
+                quant=QuantConfig(variant=QuantVariant.NVFP4),
+                experts=ExpertConfig(
+                    intermediate_size=intermediate_size,
+                    local_expert_offset=offset,
+                    local_num_experts=local_num_experts,
+                ),
+            )
+            act_pack = MoEActivationPack(
+                hidden_states_q=tensors["x"],
+                hidden_states_scale=tensors["x_sf"].squeeze(-1),
+                selected_experts=tensors["token_selected_experts"] + offset,
+                final_scales=tensors["token_final_scales"],
+            )
+            runner = TrtllmFp4RoutedRunner(config, device=device)
+            inputs = runner.pack_inputs(act_pack, weight_pack)
+            return runner.forward(inputs, tactic=-1).clone()
+
+        baseline = run(0)
+        ep_out = run(local_expert_offset)
+
+        # gh #3547 symptom: the EP-shard output was bit-exactly zero.
+        assert not bool((ep_out == 0).all()), (
+            f"offset={local_expert_offset}: EP-shard output is all-zero (gh #3547)"
+        )
+        passed, pct, atol = check_accuracy(ep_out, baseline)
+        assert passed, (
+            f"offset={local_expert_offset}: EP-shard output diverges from the "
+            f"offset-0 baseline ({pct * 100:.2f}% within tolerance, atol={atol:.4f})"
+        )

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -19,9 +19,9 @@ weight-memory budget so one config never hogs the GPU (parallel-CI-friendly), pl
 larger-end shapes. Large expert counts are reached with small H/I and/or **expert-parallel shards**
 (global>local + ``local_expert_offset``, the real deployment shape), not by filling the GPU.
 
-A small ``_KNOWN_FAILURES`` ledger xfails already-filed bugs (e.g. trtllm EP offset>0 -> all-zero,
-EP_OFFSET_FINDING.md): the case is still *run* so the suite stays green on a tracked bug yet flags
-loudly the day it starts passing (fixed). A crash is never tolerated -- only a wrong answer.
+A small ``_KNOWN_FAILURES`` ledger xfails already-filed bugs (e.g. the since-fixed trtllm EP
+offset>0 all-zero bug, gh #3547): the case is still *run* so the suite stays green on a tracked bug
+yet flags loudly the day it starts passing (fixed). A crash is never tolerated -- only a wrong answer.
 
 Verification model (single mode, uniform -- every config that runs gets the same checks):
   1. **no crash / no NaN-Inf** where the reference is finite.
@@ -66,7 +66,7 @@ comparison adds no pass/fail power, only redundancy. See the design discussion.)
 Coverage today: NVFP4 (CuteDSL + TRTLLM-FP4-routed) on SM100 -- the only wired MVP runners.
 
 OPT-IN: this suite is gated behind FLASHINFER_UMOE_FUZZ (see the pytestmark below) and is
-SKIPPED unless that env var is set -- waived in CI pending gh #3547 and root-cause of a
+SKIPPED unless that env var is set -- waived in CI pending root-cause of a
 whole-process device-side-assert abort that would block B200 CI. Run it explicitly:
   FLASHINFER_UMOE_FUZZ=1 CUDA_HOME=<cuda> CUDA_VISIBLE_DEVICES=<sm100-idx> \
     pytest tests/moe/test_unified_moe_fuzz.py
@@ -129,8 +129,8 @@ OUT OF SCOPE for this single-GPU correctness harness (must live elsewhere, do NO
 POINTERS for future agents (point me at this file and I know the rest):
   * Full context (this fuzzer + the older adapter/GEMM fuzzers + the audit + findings): cuDNN-
     project auto-memory ``flashinfer_quality_fuzzers.md``.
-  * Bugs THIS fuzzer found + filed: gh #3547 (trtllm EP offset>0 all-zero -- encoded in the
-    ``_KNOWN_FAILURES`` ledger below: xfailed but still RUN, so an xpass announces the fix) and
+  * Bugs THIS fuzzer found + filed: gh #3547 (trtllm EP offset>0 all-zero -- tracked in the
+    ``_KNOWN_FAILURES`` ledger below until fixed) and
     gh #3548 (activation global-scale gap == roadmap #5's scale-policy fix).
   * Findings writeups: flashinfer_triage/EP_OFFSET_FINDING.md, flashinfer_triage/WEIGHT_SCALE_FINDING.md.
   * The unified API under test: PR #3093 (branch ``moe_api``); this fuzzer is PR aleozlx/flashinfer#6
@@ -172,20 +172,20 @@ NUM_TESTS = int(os.environ.get("FLASHINFER_UMOE_FUZZ_NUM_TESTS", "80"))
 BASE_SEED = int(os.environ.get("FLASHINFER_UMOE_FUZZ_SEED", "0"))
 
 # --- CI-safety gate: OPT-IN ----------------------------------------------------------------
-# Waived in CI pending gh #3547 + root-cause of a whole-process abort. Running the SM100 fuzzer
+# Waived in CI pending root-cause of a whole-process abort. Running the SM100 fuzzer
 # in a single `pytest` process can hit `CUDA error: device-side assert triggered` ->
 # `Fatal Python error: Aborted`, which would BLOCK B200 CI (an abort fails the whole job, not one
 # test). Notes from triage (2026-06-09): per-config isolation (one process each) passes 68/86
-# incl. EP offset>0 -- so the abort is NOT cleanly attributable to one config (the gh #3547 EP
-# case returns tolerated zeros, no assert, under torch.cuda.synchronize); it surfaces only in the
-# accumulated single-process run that CI uses. `pytest --forked` can't isolate it here either
-# (CUDA inits at collection -> "Cannot re-initialize CUDA in forked subprocess"). Until the abort
-# is root-caused and #3547 fixed (follow-up PR), this suite is opt-in: set FLASHINFER_UMOE_FUZZ=1
+# incl. EP offset>0 -- so the abort is NOT cleanly attributable to one config (the since-fixed
+# gh #3547 EP case returned tolerated zeros, no assert, under torch.cuda.synchronize); it surfaces
+# only in the accumulated single-process run that CI uses. `pytest --forked` can't isolate it
+# either (CUDA inits at collection -> "Cannot re-initialize CUDA in forked subprocess"). Until the
+# abort is root-caused, this suite is opt-in: set FLASHINFER_UMOE_FUZZ=1
 # to run it (developer / nightly / SM100 box). Unset (CI default) -> collected-and-skipped, so it
 # never launches a kernel and cannot abort the job.
 pytestmark = pytest.mark.skipif(
     not os.environ.get("FLASHINFER_UMOE_FUZZ"),
-    reason="opt-in fuzzer (set FLASHINFER_UMOE_FUZZ=1); waived in CI pending gh #3547 and "
+    reason="opt-in fuzzer (set FLASHINFER_UMOE_FUZZ=1); waived in CI pending "
     "root-cause of the whole-process device-side-assert abort",
 )
 
@@ -202,11 +202,8 @@ _DETERMINISTIC = {
 # bug while still EXERCISING it, so the day the bug is fixed the case starts passing and we get a loud
 # "unexpectedly passed -> remove this entry" signal. A crash is never tolerated (only wrong answers).
 _KNOWN_FAILURES = [
-    (
-        "trtllm_fp4_routed",
-        lambda c: c.expert_offset > 0,
-        "trtllm EP local_expert_offset>0 -> all-zero output (offset applied twice); gh #3547",
-    ),
+    # Entries: (backend_key, predicate(cfg), "reason; gh #NNNN").
+    # Empty since the gh #3547 EP-offset double-subtraction fix.
 ]
 
 


### PR DESCRIPTION
## Description

**Rebased 2026-07-02 — scope reduced to tests + docs.** The EP-offset double-subtraction this PR originally fixed was fixed on main by #3686 (`pack_inputs` now packs GLOBAL expert ids; the kernel owns the global→local mapping via `mLocalExpertsStartIdx` in `include/flashinfer/trtllm/fused_moe/RoutingKernel.h`). What #3686 did **not** update:

- `tests/moe/test_unified_moe.py::TestTrtllmEPOffset::test_pack_inputs_applies_local_expert_offset` still asserts the **old** pre-subtracted packing (`decoded == selected_experts - local_expert_offset`), which now contradicts `pack_inputs` — for `local_expert_offset > 0` it fails wherever it runs (it is `sm100_required`).
- `tests/moe/test_unified_moe_fuzz.py` still carries the gh #3547 `_KNOWN_FAILURES` xfail entry for a now-fixed bug (per the ledger's own design, a fixed bug's entry must be removed) plus stale "pending gh #3547" CI-gate comments.
- The `TrtllmFp4RoutedRunner` class/`pack_inputs` docstrings still describe the pre-subtracted packing.

This PR aligns all of the above with the merged contract and adds an EP-shard forward regression test (`test_ep_shard_forward_matches_offset_zero`): `offset > 0` output must match the bit-identical `offset = 0` run and must not be all-zero (the gh #3547 symptom), so the double-subtraction can't silently come back.

Fixes #3547 (the code fix landed in #3686; this closes the loop with regression coverage).

## Related Issues

gh #3547 · supersedes-note: code fix landed via #3686

## Verification

- `ruff check` + `ruff format --check` clean on the three touched files
- `pytest tests/moe/test_unified_moe.py` on RTX PRO 6000 (SM120, CUDA 13): **99 passed, 11 skipped** (the `sm100_required` tests, including the ones this PR edits, skip on SM120 — they need SM100 CI to execute)
- `pytest --collect-only` on both test files: 196 collected, no import errors

AI-assisted (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TRTLLM FP4 routed MoE all-zero outputs for nonzero expert offsets by keeping global expert IDs in packed top-k IDs and applying expert offset remapping during kernel execution.

* **Tests**
  * Updated input-packing assertions to verify global expert ID preservation and correct shard-range mapping.
  * Added a GPU correctness regression test comparing nonzero-offset results against the zero-offset baseline.
  * Removed the prior expected-failure entry for this configuration from the fuzz/ledger logic.

* **Documentation**
  * Clarified routed MoE packed top-k ID semantics and kernel-side offset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->