### PR TITLE
fix(moe): thread calibrated NVFP4 global scales through the unified MoE API

### DIFF
--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -245,6 +245,9 @@ class TrtllmFp4Config:
         intermediate_size: int,
         device=None,
         permute_cache=None,
+        gemm1_scales_global=None,
+        gemm2_scales_global=None,
+        intermediate_scale_global=None,
     ):
         """Build the ``trtllm_fp4_routed`` weight view from canonical bf16 weights.
 
@@ -261,6 +264,9 @@ class TrtllmFp4Config:
             intermediate_size=intermediate_size,
             device=device,
             permute_cache=permute_cache,
+            gemm1_scales_global=gemm1_scales_global,
+            gemm2_scales_global=gemm2_scales_global,
+            intermediate_scale_global=intermediate_scale_global,
         )
 
     def __repr__(self) -> str:
@@ -376,6 +382,9 @@ class CuteDslConfig:
         hidden_size: int,
         intermediate_size: int,
         device=None,
+        gemm1_scales_global=None,
+        gemm2_scales_global=None,
+        intermediate_scale_global=None,
     ):
         """Build the ``cute_dsl_nvfp4`` weight view from canonical bf16 weights.
 
@@ -391,6 +400,9 @@ class CuteDslConfig:
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             device=device,
+            gemm1_scales_global=gemm1_scales_global,
+            gemm2_scales_global=gemm2_scales_global,
+            intermediate_scale_global=intermediate_scale_global,
         )
 
     def __repr__(self) -> str:
@@ -548,6 +560,12 @@ class MoEActivationPack:
     keep the field positions of the former ``selected_experts`` / ``final_scales``, so
     positional construction of pre-routed packs is unchanged.  The in-kernel routing fields
     are keyword-only.
+
+    ``hidden_states_scale_global`` is the global scale that was used to
+    quantize ``hidden_states_q`` (e.g. the calibrated ``(448 * 6) / amax``
+    from an NVFP4 checkpoint).  Runners fold it into the per-expert dequant
+    scalars at pack time (gh #3548).  ``None`` means the activations were
+    quantized with global scale 1.0 — full backward compatibility.
     """
 
     hidden_states_q: Tensor  # [M, H//2] uint8 (packed NVFP4) or [M, H] bf16
@@ -568,6 +586,9 @@ class MoEActivationPack:
     routing_bias: Optional[Tensor] = field(
         default=None, kw_only=True
     )  # [num_experts] bfloat16 or float32 (independent of logits dtype)
+    hidden_states_scale_global: Optional[Tensor] = field(
+        default=None, kw_only=True
+    )  # scalar float32; folded into per-expert dequant scalars at pack time (gh #3548)
 
     def __post_init__(self) -> None:
         """Fail fast on mode/field mismatches at construction time.
@@ -615,6 +636,7 @@ class MoEActivationPack:
             "topk_weights",
             "routing_logits",
             "routing_bias",
+            "hidden_states_scale_global",
         ):
             t = getattr(self, name)
             if t is not None and t.device != dev:

--- a/flashinfer/fused_moe/prepare.py
+++ b/flashinfer/fused_moe/prepare.py
@@ -413,6 +413,9 @@ def _resolve_expert_global_scales(
     """
     if scales is None:
         amax = weights_bf16.float().abs().nan_to_num().amax(dim=(1, 2))
+        # Guard all-zero (e.g. pruned/dummy) experts: amax = 0 would make the
+        # global scale inf and poison the block scales with non-finite values.
+        amax = amax.clamp_(min=torch.finfo(torch.float32).tiny)
         return (448.0 * 6.0) / amax
     scales = scales.to(device=device, dtype=torch.float32).reshape(-1)
     if scales.numel() == 1:

--- a/flashinfer/fused_moe/prepare.py
+++ b/flashinfer/fused_moe/prepare.py
@@ -413,10 +413,15 @@ def _resolve_expert_global_scales(
     """
     if scales is None:
         amax = weights_bf16.float().abs().nan_to_num().amax(dim=(1, 2))
-        # Guard all-zero (e.g. pruned/dummy) experts: amax = 0 would make the
-        # global scale inf and poison the block scales with non-finite values.
-        amax = amax.clamp_(min=torch.finfo(torch.float32).tiny)
-        return (448.0 * 6.0) / amax
+        # Guard all-zero (e.g. pruned/dummy) experts: amax == 0 makes the
+        # global scale inf and poisons the block scales. Clamping amax to
+        # finfo.tiny is not enough -- (448 * 6) / tiny still overflows to inf.
+        # Such experts quantize to 0 regardless of scale, so give them 1.0.
+        return torch.where(
+            amax > 0,
+            (448.0 * 6.0) / amax,
+            torch.ones_like(amax),
+        )
     scales = scales.to(device=device, dtype=torch.float32).reshape(-1)
     if scales.numel() == 1:
         scales = scales.expand(num_local_experts)

--- a/flashinfer/fused_moe/prepare.py
+++ b/flashinfer/fused_moe/prepare.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import functools
 import struct
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 
@@ -397,6 +397,39 @@ def interleave_moe_weights_for_sm90_mixed_gemm(
         weight, out, qtype_map[quant_type]
     )
     return out
+def _resolve_expert_global_scales(
+    scales: Optional[torch.Tensor],
+    weights_bf16: torch.Tensor,
+    num_local_experts: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Per-expert float32 ``[num_local_experts]`` NVFP4 global scales.
+
+    ``None`` computes the calibrated scale ``(448 * 6) / amax`` per expert,
+    mirroring the canonical trtllm-gen quantize path
+    (``calculate_fp4_global_scale_factor`` / ``quant_fp4_batches`` in
+    ``tests/moe/test_trtllm_gen_fused_moe.py``).  A scalar broadcasts to all
+    local experts.
+    """
+    if scales is None:
+        amax = weights_bf16.float().abs().nan_to_num().amax(dim=(1, 2))
+        return (448.0 * 6.0) / amax
+    scales = scales.to(device=device, dtype=torch.float32).reshape(-1)
+    if scales.numel() == 1:
+        scales = scales.expand(num_local_experts)
+    return scales.contiguous()
+
+
+def _resolve_intermediate_global_scale(
+    scale: Optional[Union[float, torch.Tensor]], device: torch.device
+) -> torch.Tensor:
+    """Scalar float32 ``[1]`` global scale for the gemm1→gemm2 activation
+    requantization (``c_global_sf`` / ``fc2_input_scale``).  ``None`` → 1.0."""
+    if scale is None:
+        return torch.ones(1, device=device, dtype=torch.float32)
+    if not isinstance(scale, torch.Tensor):
+        return torch.tensor([float(scale)], device=device, dtype=torch.float32)
+    return scale.to(device=device, dtype=torch.float32).reshape(1)
 
 
 def prepare_trtllm_fp4_weights(
@@ -408,6 +441,9 @@ def prepare_trtllm_fp4_weights(
     intermediate_size: int,
     device: Optional[torch.device] = None,
     permute_cache: Optional[dict] = None,
+    gemm1_scales_global: Optional[torch.Tensor] = None,
+    gemm2_scales_global: Optional[torch.Tensor] = None,
+    intermediate_scale_global: Optional[Union[float, torch.Tensor]] = None,
 ) -> Dict[str, torch.Tensor]:
     """Build the TRTLLM NVFP4 ``trtllm_fp4_routed`` weight view.
 
@@ -427,6 +463,14 @@ def prepare_trtllm_fp4_weights(
         Target device; defaults to ``w1_bf16.device``.
     permute_cache : dict, optional
         Shape-keyed permute-index cache; defaults to a module-level cache.
+    gemm1_scales_global, gemm2_scales_global : Tensor, optional
+        Per-expert float32 ``[num_local_experts]`` (or scalar) NVFP4 global
+        scales used to quantize the weights — e.g. the calibrated values from
+        a ModelOpt checkpoint.  ``None`` computes the canonical
+        ``(448 * 6) / amax`` per expert.
+    intermediate_scale_global : float or Tensor, optional
+        Global scale (``c_global_sf``) for requantizing the gemm1 activation
+        output that feeds gemm2.  ``None`` → 1.0.
 
     Returns
     -------
@@ -434,7 +478,12 @@ def prepare_trtllm_fp4_weights(
         Keys expected by ``TrtllmFp4RoutedRunner.pack_inputs``: ``gemm1_weights``,
         ``gemm1_weights_scale``, ``gemm1_alpha``, ``gemm2_weights``,
         ``gemm2_weights_scale``, ``output1_scale_scalar``,
-        ``output1_scale_gate_scalar``, ``output2_scale_scalar``.
+        ``output1_scale_gate_scalar``, ``output2_scale_scalar`` (the
+        weight-side dequant factors, canonical formulas from
+        ``tests/moe/test_trtllm_gen_fused_moe.py`` at activation global scale
+        1.0), plus the raw ``gemm1_scales_global`` / ``gemm2_scales_global`` /
+        ``intermediate_scale_global`` so the runner can fold the activation
+        global scale in at pack time (gh #3548).
     """
     from ..fp4_quantization import fp4_quantize
     from ..quantization.fp4_quantization import block_scale_interleave
@@ -456,34 +505,46 @@ def prepare_trtllm_fp4_weights(
     sf_vec_size = 16
     epilogue_tile_m = 128  # TRTLLM kernel-internal constant
 
-    w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
-    w1_flat = w1_bf16.view(num_local_experts * 2 * intermediate_size, hidden_size)
-    w1_q_flat, w1_sf_flat = fp4_quantize(
-        w1_flat,
-        global_scale=w1_gs,
-        sf_vec_size=sf_vec_size,
-        is_sf_swizzled_layout=False,
+    g1_gs = _resolve_expert_global_scales(
+        gemm1_scales_global, w1_bf16, num_local_experts, device
     )
-    g1_w = w1_q_flat.view(
-        num_local_experts, 2 * intermediate_size, hidden_size // 2
-    ).view(torch.uint8)
-    g1_s = w1_sf_flat.view(torch.float8_e4m3fn).reshape(
-        num_local_experts, 2 * intermediate_size, hidden_size // sf_vec_size
+    g2_gs = _resolve_expert_global_scales(
+        gemm2_scales_global, w2_bf16, num_local_experts, device
     )
+    c_gs = _resolve_intermediate_global_scale(intermediate_scale_global, device)
 
-    w2_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
-    w2_flat = w2_bf16.view(num_local_experts * hidden_size, intermediate_size)
-    w2_q_flat, w2_sf_flat = fp4_quantize(
-        w2_flat,
-        global_scale=w2_gs,
-        sf_vec_size=sf_vec_size,
-        is_sf_swizzled_layout=False,
+    # Quantize per expert — the global scale is per-expert (mirrors
+    # quant_fp4_batches in the canonical trtllm-gen test path).
+    w1_q_list, w1_sf_list, w2_q_list, w2_sf_list = [], [], [], []
+    for i in range(num_local_experts):
+        q, sf = fp4_quantize(
+            w1_bf16[i],
+            global_scale=g1_gs[i : i + 1],
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=False,
+        )
+        w1_q_list.append(q)
+        w1_sf_list.append(sf)
+        q, sf = fp4_quantize(
+            w2_bf16[i],
+            global_scale=g2_gs[i : i + 1],
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=False,
+        )
+        w2_q_list.append(q)
+        w2_sf_list.append(sf)
+
+    g1_w = torch.stack(w1_q_list).view(torch.uint8)
+    g1_s = (
+        torch.stack(w1_sf_list)
+        .view(torch.float8_e4m3fn)
+        .reshape(num_local_experts, 2 * intermediate_size, hidden_size // sf_vec_size)
     )
-    g2_w = w2_q_flat.view(num_local_experts, hidden_size, intermediate_size // 2).view(
-        torch.uint8
-    )
-    g2_s = w2_sf_flat.view(torch.float8_e4m3fn).reshape(
-        num_local_experts, hidden_size, intermediate_size // sf_vec_size
+    g2_w = torch.stack(w2_q_list).view(torch.uint8)
+    g2_s = (
+        torch.stack(w2_sf_list)
+        .view(torch.float8_e4m3fn)
+        .reshape(num_local_experts, hidden_size, intermediate_size // sf_vec_size)
     )
 
     g1_w_sh, g1_s_sh, g2_w_sh, g2_s_sh = [], [], [], []
@@ -522,6 +583,10 @@ def prepare_trtllm_fp4_weights(
         )
 
     ones = torch.ones(num_local_experts, device=device, dtype=torch.float32)
+    # Weight-side dequant scalars (activation global scale folded in by the
+    # runner) — canonical formulas, gated activation, from
+    # tests/moe/test_trtllm_gen_fused_moe.py (scale_c_fc1 / scale_gate_fc1 /
+    # scale_c_fc2 with hidden_states_scale_global = 1).
     return {
         "gemm1_weights": torch.stack(g1_w_sh),
         "gemm1_weights_scale": torch.stack(g1_s_sh)
@@ -532,9 +597,12 @@ def prepare_trtllm_fp4_weights(
         "gemm2_weights_scale": torch.stack(g2_s_sh)
         .view(torch.float8_e4m3fn)
         .reshape(num_local_experts, hidden_size, intermediate_size // sf_vec_size),
-        "output1_scale_scalar": ones,
-        "output1_scale_gate_scalar": ones,
-        "output2_scale_scalar": ones,
+        "output1_scale_scalar": c_gs * (1.0 / g1_gs),
+        "output1_scale_gate_scalar": 1.0 / g1_gs,
+        "output2_scale_scalar": (1.0 / c_gs) * (1.0 / g2_gs),
+        "gemm1_scales_global": g1_gs,
+        "gemm2_scales_global": g2_gs,
+        "intermediate_scale_global": c_gs,
     }
 
 
@@ -653,6 +721,9 @@ def prepare_cute_dsl_nvfp4_weights(
     hidden_size: int,
     intermediate_size: int,
     device: Optional[torch.device] = None,
+    gemm1_scales_global: Optional[torch.Tensor] = None,
+    gemm2_scales_global: Optional[torch.Tensor] = None,
+    intermediate_scale_global: Optional[Union[float, torch.Tensor]] = None,
 ) -> Dict[str, torch.Tensor]:
     """Build the CuteDSL NVFP4 ``cute_dsl_nvfp4`` weight view.
 
@@ -662,12 +733,22 @@ def prepare_cute_dsl_nvfp4_weights(
     :func:`prepare_trtllm_fp4_weights`, so a single weight set can feed both
     backends and a shared reference.
 
+    ``gemm1_scales_global`` / ``gemm2_scales_global`` /
+    ``intermediate_scale_global`` follow the same semantics as in
+    :func:`prepare_trtllm_fp4_weights`.
+
     Returns
     -------
     dict
         Keys expected by ``CuteDslNvfp4Runner.pack_inputs``: ``w1_weight``,
         ``w1_weight_sf``, ``w1_alpha``, ``fc2_input_scale``, ``w2_weight``,
-        ``w2_weight_sf``, ``w2_alpha``.
+        ``w2_weight_sf``, ``w2_alpha``, plus the raw global scales as in
+        :func:`prepare_trtllm_fp4_weights`.  The kernel computes
+        ``alpha * (A @ B)`` on a dequantized NVFP4 product that carries
+        ``act_gs * weight_gs``, so ``w1_alpha = 1 / gemm1_scales_global``
+        (``act_gs`` folded in by the runner, gh #3548), ``fc2_input_scale =
+        intermediate_scale_global`` (the requant global scale itself), and
+        ``w2_alpha = 1 / (intermediate_scale_global * gemm2_scales_global)``.
     """
     from ..cute_dsl.utils import convert_sf_to_mma_layout
     from ..fp4_quantization import fp4_quantize
@@ -680,46 +761,69 @@ def prepare_cute_dsl_nvfp4_weights(
     w2_bf16 = w2_bf16.to(device)
 
     sf_vec_size = 16
-    gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+    g1_gs = _resolve_expert_global_scales(
+        gemm1_scales_global, w1_bf16, num_local_experts, device
+    )
+    g2_gs = _resolve_expert_global_scales(
+        gemm2_scales_global, w2_bf16, num_local_experts, device
+    )
+    c_gs = _resolve_intermediate_global_scale(intermediate_scale_global, device)
 
+    # Quantize per expert (per-expert global scales).  The swizzled-sf layout
+    # is tiled in 128-row blocks, and each expert's rows (2*intermediate_size
+    # / hidden_size) are 128-aligned, so per-expert sf blocks concatenate to
+    # the same bytes the flat quantization produced.
     w1_interleaved = _interleave_linear_and_gate(w1_bf16, group_size=64, dim=1)
-    w1_flat = w1_interleaved.view(
-        num_local_experts * 2 * intermediate_size, hidden_size
-    )
-    w1_q_flat, w1_sf_flat = fp4_quantize(
-        w1_flat, global_scale=gs, sf_vec_size=sf_vec_size, is_sf_swizzled_layout=True
-    )
-    w1_weight = w1_q_flat.view(
+    w1_q_list, w1_sf_list, w2_q_list, w2_sf_list = [], [], [], []
+    for i in range(num_local_experts):
+        q, sf = fp4_quantize(
+            w1_interleaved[i],
+            global_scale=g1_gs[i : i + 1],
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=True,
+        )
+        w1_q_list.append(q)
+        w1_sf_list.append(sf)
+        q, sf = fp4_quantize(
+            w2_bf16[i],
+            global_scale=g2_gs[i : i + 1],
+            sf_vec_size=sf_vec_size,
+            is_sf_swizzled_layout=True,
+        )
+        w2_q_list.append(q)
+        w2_sf_list.append(sf)
+
+    w1_weight = torch.stack(w1_q_list).view(
         num_local_experts, 2 * intermediate_size, hidden_size // 2
     )
     w1_weight_sf = convert_sf_to_mma_layout(
-        w1_sf_flat,
+        torch.cat([sf.reshape(-1) for sf in w1_sf_list]),
         m=2 * intermediate_size,
         k=hidden_size,
         num_groups=num_local_experts,
         sf_vec_size=sf_vec_size,
     )
 
-    w2_flat = w2_bf16.view(num_local_experts * hidden_size, intermediate_size)
-    w2_q_flat, w2_sf_flat = fp4_quantize(
-        w2_flat, global_scale=gs, sf_vec_size=sf_vec_size, is_sf_swizzled_layout=True
+    w2_weight = torch.stack(w2_q_list).view(
+        num_local_experts, hidden_size, intermediate_size // 2
     )
-    w2_weight = w2_q_flat.view(num_local_experts, hidden_size, intermediate_size // 2)
     w2_weight_sf = convert_sf_to_mma_layout(
-        w2_sf_flat,
+        torch.cat([sf.reshape(-1) for sf in w2_sf_list]),
         m=hidden_size,
         k=intermediate_size,
         num_groups=num_local_experts,
         sf_vec_size=sf_vec_size,
     )
 
-    ones = torch.ones(num_local_experts, device=device, dtype=torch.float32)
     return {
         "w1_weight": w1_weight,
         "w1_weight_sf": w1_weight_sf,
-        "w1_alpha": ones,
-        "fc2_input_scale": torch.tensor([1.0], device=device, dtype=torch.float32),
+        "w1_alpha": 1.0 / g1_gs,
+        "fc2_input_scale": c_gs,
         "w2_weight": w2_weight,
         "w2_weight_sf": w2_weight_sf,
-        "w2_alpha": ones,
+        "w2_alpha": (1.0 / c_gs) * (1.0 / g2_gs),
+        "gemm1_scales_global": g1_gs,
+        "gemm2_scales_global": g2_gs,
+        "intermediate_scale_global": c_gs,
     }

--- a/flashinfer/fused_moe/prepare.py
+++ b/flashinfer/fused_moe/prepare.py
@@ -397,6 +397,8 @@ def interleave_moe_weights_for_sm90_mixed_gemm(
         weight, out, qtype_map[quant_type]
     )
     return out
+
+
 def _resolve_expert_global_scales(
     scales: Optional[torch.Tensor],
     weights_bf16: torch.Tensor,

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -199,6 +199,14 @@ class CuteDslNvfp4Runner(TunableRunner):
         tuning_config declares index 11 as a dynamic tensor, so it must be
         present for the autotuner profiling path to assign it a per-bucket
         initializer.
+
+        When the Pack carries ``hidden_states_scale_global`` (gh #3548) it is
+        folded into the gemm1 dequant: the kernel computes
+        ``w1_alpha * (A @ B)`` and the dequantized NVFP4 product carries
+        ``act_gs * weight_gs``, so the combined alpha is the view's
+        weight-side ``w1_alpha`` (``1 / weight_gs``) divided by ``act_gs``.
+        ``fc2_input_scale`` / ``w2_alpha`` do not involve ``act_gs``.  ``None``
+        keeps the view tensors untouched (bit-identical to act_gs = 1.0).
         """
         # MoELayer already filters by supported_routing_modes; this guards the
         # direct-runner path (tests/benchmarks) against silently forwarding a
@@ -210,6 +218,9 @@ class CuteDslNvfp4Runner(TunableRunner):
                 "(only PackedPrecomputed is wired; CuteDSL has no in-kernel router)."
             )
         v = weights.get_view(self.backend_key)
+        w1_alpha = v["w1_alpha"]
+        if act.hidden_states_scale_global is not None:
+            w1_alpha = w1_alpha / act.hidden_states_scale_global
         num_tokens = act.hidden_states_q.shape[0]
         _validate_prerouted_inputs(
             act, num_tokens, self._inner.top_k, "CuteDslNvfp4Runner"
@@ -225,7 +236,7 @@ class CuteDslNvfp4Runner(TunableRunner):
             act.topk_weights,
             v["w1_weight"],
             v["w1_weight_sf"],
-            v["w1_alpha"],
+            w1_alpha,
             v["fc2_input_scale"],
             v["w2_weight"],
             v["w2_weight_sf"],
@@ -375,11 +386,38 @@ class TrtllmFp4RoutedRunner(TunableRunner):
         global→local mapping itself by subtracting ``local_expert_offset``
         (passed via the static kwargs) and dropping ids outside
         ``[offset, offset + local_num_experts)``.
+
+        When the Pack carries ``hidden_states_scale_global`` (gh #3548), its
+        reciprocal is folded into ``output1_scale_scalar`` /
+        ``output1_scale_gate_scalar``, mirroring the canonical gated-act
+        formulas in tests/moe/test_trtllm_gen_fused_moe.py (``scale_c_fc1 =
+        c_global_sf / (gemm1_gs * act_gs)``, ``scale_gate_fc1 =
+        1 / (gemm1_gs * act_gs)``; ``scale_c_fc2`` has no ``act_gs`` term).
+        The view's scalars are the weight-side factors (``act_gs = 1``), so
+        folding is a division; ``None`` keeps them untouched (bit-identical
+        to act_gs = 1.0).
         """
         from .core import MoeRunnerInputs, RoutingInputMode
 
         v = weights.get_view(self.backend_key)
         routing = self.config.routing
+
+        output1_scale_scalar = v.get("output1_scale_scalar")
+        output1_scale_gate_scalar = v.get("output1_scale_gate_scalar")
+        a1_gs = act.hidden_states_scale_global
+        if a1_gs is not None:
+            inv_a1 = 1.0 / a1_gs.to(torch.float32)
+            ones = torch.ones(
+                self._num_local_experts, device=a1_gs.device, dtype=torch.float32
+            )
+            # Views without precomputed scalars imply weight-side factors of
+            # 1.0 (weights quantized at global scale 1.0).
+            if output1_scale_scalar is None:
+                output1_scale_scalar = ones
+            if output1_scale_gate_scalar is None:
+                output1_scale_gate_scalar = ones
+            output1_scale_scalar = output1_scale_scalar * inv_a1
+            output1_scale_gate_scalar = output1_scale_gate_scalar * inv_a1
 
         num_tokens = act.hidden_states_q.shape[0]
         hidden_size = act.hidden_states_q.shape[1] * 2  # FP4 packed
@@ -471,8 +509,8 @@ class TrtllmFp4RoutedRunner(TunableRunner):
             gemm2_weights=v["gemm2_weights"],
             gemm2_weights_scale=v["gemm2_weights_scale"],
             gemm2_bias=None,
-            output1_scale_scalar=v.get("output1_scale_scalar"),
-            output1_scale_gate_scalar=v.get("output1_scale_gate_scalar"),
+            output1_scale_scalar=output1_scale_scalar,
+            output1_scale_gate_scalar=output1_scale_gate_scalar,
             output2_scale_scalar=v.get("output2_scale_scalar"),
             per_token_scale=None,
             num_experts=routing.num_experts,

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -220,7 +220,11 @@ class CuteDslNvfp4Runner(TunableRunner):
         v = weights.get_view(self.backend_key)
         w1_alpha = v["w1_alpha"]
         if act.hidden_states_scale_global is not None:
-            w1_alpha = w1_alpha / act.hidden_states_scale_global
+            # Match w1_alpha's device: a CPU-resident Pack scale would
+            # otherwise raise (or sync) on the GPU division.
+            w1_alpha = w1_alpha / act.hidden_states_scale_global.to(
+                device=w1_alpha.device, dtype=torch.float32
+            )
         num_tokens = act.hidden_states_q.shape[0]
         _validate_prerouted_inputs(
             act, num_tokens, self._inner.top_k, "CuteDslNvfp4Runner"
@@ -406,9 +410,11 @@ class TrtllmFp4RoutedRunner(TunableRunner):
         output1_scale_gate_scalar = v.get("output1_scale_gate_scalar")
         a1_gs = act.hidden_states_scale_global
         if a1_gs is not None:
-            inv_a1 = 1.0 / a1_gs.to(torch.float32)
+            # Pin to the runner's device: a CPU-resident Pack scale would
+            # otherwise produce CPU scalars feeding a GPU kernel.
+            inv_a1 = 1.0 / a1_gs.to(device=self.device, dtype=torch.float32)
             ones = torch.ones(
-                self._num_local_experts, device=a1_gs.device, dtype=torch.float32
+                self._num_local_experts, device=self.device, dtype=torch.float32
             )
             # Views without precomputed scalars imply weight-side factors of
             # 1.0 (weights quantized at global scale 1.0).

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -952,6 +952,110 @@ def _compute_ref(act_pack, tensors, shape):
     )
 
 
+
+
+@sm100_required
+class TestCalibratedGlobalScales:
+    """The unified API must reproduce the reference when the activations were
+    quantized with a real calibrated NVFP4 global scale, not just the trivial
+    1.0 the other tests use (gh #3548)."""
+
+    @pytest.mark.parametrize("backend_key", ["cute_dsl_nvfp4", "trtllm_fp4_routed"])
+    def test_backend_matches_reference_with_calibrated_scales(self, backend_key):
+        device = torch.device("cuda", torch.cuda.current_device())
+        num_tokens = 256
+        hidden_size = SMALL["hidden_size"]
+        intermediate_size = SMALL["intermediate_size"]
+        num_experts = SMALL["num_experts"]
+        top_k = SMALL["top_k"]
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            calibrated_activation_scale=True,
+        )
+        # The case is only meaningful if the calibrated scale is non-trivial.
+        assert float(tensors["a1_gs"]) > 100.0
+
+        # Calibrated intermediate (c_global_sf / a2) scale from the bf16
+        # swiglu outputs over all (token, expert) pairs.
+        gemm1_out = torch.einsum(
+            "th,eoh->teo",
+            tensors["x_bf16"].float(),
+            tensors["w1_weight_bf16"].float(),
+        )
+        swiglu_out = (
+            torch.nn.functional.silu(gemm1_out[..., intermediate_size:])
+            * gemm1_out[..., :intermediate_size]
+        )
+        a2_gs = ((448 * 6) / swiglu_out.abs().nan_to_num().max()).reshape(1)
+
+        act_pack = MoEActivationPack(
+            hidden_states_q=tensors["x"],
+            hidden_states_scale=tensors["x_sf"].squeeze(-1),
+            topk_ids=tensors["token_selected_experts"],
+            topk_weights=tensors["token_final_scales"],
+            hidden_states_scale_global=tensors["a1_gs"],
+        )
+        weight_pack = MoEWeightPack()
+        prepare_kwargs = dict(
+            num_local_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            device=device,
+            intermediate_scale_global=a2_gs,
+        )
+        weight_pack.prepare_for(
+            "cute_dsl_nvfp4",
+            CuteDslConfig.prepare_weights(
+                tensors["w1_weight_bf16"], tensors["w2_weight_bf16"], **prepare_kwargs
+            ),
+        )
+        weight_pack.prepare_for(
+            "trtllm_fp4_routed",
+            TrtllmFp4Config.prepare_weights(
+                tensors["w1_weight_bf16"], tensors["w2_weight_bf16"], **prepare_kwargs
+            ),
+        )
+
+        config = MoEConfig(
+            routing=RoutingConfig(num_experts=num_experts, top_k=top_k),
+            quant=QuantConfig(variant=QuantVariant.NVFP4),
+            experts=ExpertConfig(intermediate_size=intermediate_size),
+            activation=ActivationConfig(),
+            backend=BackendOptions(candidates=(CuteDslConfig(), TrtllmFp4Config())),
+        )
+        layer = MoELayer(config)
+        runner = next(r for r in layer.runners if r.backend_key == backend_key)
+
+        inputs = runner.pack_inputs(act_pack, weight_pack)
+        out = runner.forward(inputs, tactic=-1)
+
+        ref = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float(),
+            gemm1_weights=tensors["w1_weight_bf16"].float(),
+            gemm2_weights=tensors["w2_weight_bf16"].float(),
+            token_selected_experts=act_pack.topk_ids,
+            token_final_scales=act_pack.topk_weights,
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=a2_gs,
+        )
+        passed, pct, atol = check_accuracy(out, ref)
+        assert passed, (
+            f"{backend_key} with calibrated scales (a1_gs="
+            f"{float(tensors['a1_gs']):.1f}, a2_gs={float(a2_gs):.1f}): "
+            f"{pct * 100:.2f}% within tolerance (atol={atol:.4f}) vs bf16 "
+            f"reference — gh #3548 regression"
+        )
+
 # ---------------------------------------------------------------------------
 # 2. Dispatch plumbing
 # ---------------------------------------------------------------------------

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -955,10 +955,15 @@ def _compute_ref(act_pack, tensors, shape):
 
 
 @sm100_required
-class TestCalibratedGlobalScales:
-    """The unified API must reproduce the reference when the activations were
-    quantized with a real calibrated NVFP4 global scale, not just the trivial
-    1.0 the other tests use (gh #3548)."""
+class TestUnifiedMoECalibratedScales:
+    """Calibrated (non-1.0) global scales must reach the kernels (gh #3548).
+
+    The activations are quantized with the real calibrated scale ``(448*6)/amax``
+    with real per-expert global scales (the ``prepare_*_weights`` default),
+    and the gemm1→gemm2 requant uses a calibrated intermediate scale.  Before
+    the fix the activation scale never reached the kernel and the output
+    silently inflated by ~``a1_gs``.
+    """
 
     @pytest.mark.parametrize("backend_key", ["cute_dsl_nvfp4", "trtllm_fp4_routed"])
     def test_backend_matches_reference_with_calibrated_scales(self, backend_key):

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -952,8 +952,6 @@ def _compute_ref(act_pack, tensors, shape):
     )
 
 
-
-
 @sm100_required
 class TestUnifiedMoECalibratedScales:
     """Calibrated (non-1.0) global scales must reach the kernels (gh #3548).
@@ -1060,6 +1058,7 @@ class TestUnifiedMoECalibratedScales:
             f"{pct * 100:.2f}% within tolerance (atol={atol:.4f}) vs bf16 "
             f"reference — gh #3548 regression"
         )
+
 
 # ---------------------------------------------------------------------------
 # 2. Dispatch plumbing

--- a/tests/moe/utils.py
+++ b/tests/moe/utils.py
@@ -482,12 +482,17 @@ def create_moe_tensors(
     use_per_token_activation: bool = False,
     interleave_gated_weights: bool = True,
     use_nontrivial_alphas: bool = True,
+    calibrated_activation_scale: bool = False,
 ):
     """Create properly quantized MoE tensors for testing.
 
     CuTe SM100 kernels consume interleaved gated weights and the tests exercise
     nontrivial per-expert alpha scales. B12x kernels use the opposite settings;
     callers should use :func:`create_b12x_moe_tensors` for that configuration.
+
+    ``calibrated_activation_scale`` quantizes the activations with the real
+    calibrated NVFP4 global scale ``(448 * 6) / amax`` instead of 1.0; the
+    scale used is returned under the ``a1_gs`` key (gh #3548).
     """
     from flashinfer.fp4_quantization import fp4_quantize
     from flashinfer.quantization import (
@@ -510,6 +515,12 @@ def create_moe_tensors(
     )
     x_per_token_scale = None
     if use_per_token_activation:
+        if calibrated_activation_scale:
+            raise ValueError(
+                "calibrated_activation_scale applies to the global-scale "
+                "quantization path (use_per_token_activation=False)."
+            )
+        a1_gs = None
         x_global_scale = make_nvfp4_global_scale(
             x_bf16,
             per_token_activation=True,
@@ -533,7 +544,10 @@ def create_moe_tensors(
         ).to(device)
         x_ref = x_ref.float() * x_per_token_scale.unsqueeze(1)
     else:
-        a1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
+        if calibrated_activation_scale:
+            a1_gs = ((448 * 6) / x_bf16.float().abs().nan_to_num().max()).reshape(1)
+        else:
+            a1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
         x_quantized, x_sf = fp4_quantize(
             x_bf16,
             global_scale=a1_gs,
@@ -543,7 +557,7 @@ def create_moe_tensors(
         x_ref = e2m1_and_ufp8sf_scale_to_float(
             x_quantized.cpu(),
             x_sf.view(torch.uint8).cpu().reshape(-1),
-            torch.ones(1, dtype=torch.float32),
+            (1.0 / a1_gs).cpu(),
             sf_vec_size=sf_vec_size,
             ufp8_type=1,
             is_sf_swizzled_layout=False,
@@ -637,6 +651,7 @@ def create_moe_tensors(
         "x_sf": x_sf,
         "x_bf16": x_bf16,
         "x_ref": x_ref,
+        "a1_gs": a1_gs,
         "x_per_token_scale": x_per_token_scale,
         "token_selected_experts": selected_experts,
         "token_final_scales": routing_weights,


### PR DESCRIPTION
## Description

**Stacked on #3591** (same API surface, the PRs are a series) — please review only the last commit (cb7a6a0); the first two are #3591.

The unified MoE API was wired only for `global_scale = 1.0`: `MoEActivationPack` had no field for the activation global scale, and both `prepare_*_weights` helpers hardcoded `gs = 1.0` / `ones` for every dequant scalar. Quantizing activations with a real calibrated scale (`a1_gs = (448·6)/amax ≈ 2.6e3`) silently inflated the output by ~that factor (#3548).

Changes:
- `MoEActivationPack` gains optional `hidden_states_scale_global` (`None` = 1.0, fully backward compatible).
- `prepare_trtllm_fp4_weights` / `prepare_cute_dsl_nvfp4_weights` accept calibrated `gemm1_scales_global` / `gemm2_scales_global` (per-expert, `None` → canonical `(448·6)/amax`) and `intermediate_scale_global`; weights are now actually quantized per expert with those scales, the weight-side dequant scalars use the canonical formulas, and the raw scales ride along in the view.
- Runners fold the activation scale in at pack time:
  - trtllm: `output1_scale_scalar` / `output1_scale_gate_scalar` ÷ `act_gs`, exactly matching the canonical gated-act formulas in `tests/moe/test_trtllm_gen_fused_moe.py` (`scale_c_fc1 = c_gs/(w1_gs·a1_gs)`, `scale_gate_fc1 = 1/(w1_gs·a1_gs)`, `scale_c_fc2` has no `a1_gs` term).
  - cute_dsl: `w1_alpha ÷ act_gs`. Formula evidence: the kernel computes `alpha·(A@B)` (`blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py:332`) on a dequantized product carrying `a1_gs·w1_gs`; `fc2_input_scale` is the requant global scale itself (epilogue `q·SFC = acc·a2_gs`, `blackwell/...swiglu_fusion.py:2724-2789`, confirmed by `quant_dequant_fp4_reference` usage in `test_cute_dsl_fused_moe.py:180-183`); `w2_alpha = 1/(a2_gs·w2_gs)` (`...finalize_fusion.py:287`).
- New sm100-gated `TestUnifiedMoECalibratedScales`: end-to-end vs the bf16 reference with real `a1_gs`, per-expert weight scales, and a non-trivial intermediate scale.

## Related Issues

Fixes #3548. Stacked on #3591 (fixes #3547). Both found by the unified-API fuzzer.

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

No SM100 hardware here (SM120 box), so beyond the full non-gated suite (98 passed) I hardware-verified what does run locally: per-expert quantization at `gs = 1` is **byte-identical** to the old flat path for both backends (packed weights *and* swizzled-sf bytes — the 128-row tile alignment argument holds), the trtllm scalars match the canonical formulas numerically, and a calibrated quant→dequant round-trip lands at rel-err ≈ 0.14 (fp4 envelope). The two new gated tests are the kernel-level proof and need an SM100 runner. Note the prepare helpers' default weight scale changed from `1.0` to the canonical per-expert `(448·6)/amax` (mirrors `quant_fp4_batches`); existing gated accuracy tests therefore now exercise calibrated weight scales — tolerances should hold (the reference uses the same scales) but that's worth one CI look. AI-assisted (Claude Code), reviewed line-by-line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional calibrated global scales for NVFP4 MoE weights and activations.
  * Added per-expert weight scaling and intermediate activation scaling for supported FP4 backends.
  * Added backward-compatible activation scale handling for pre-routed execution.

* **Bug Fixes**
  * Improved FP4 dequantization and activation scaling by incorporating provided calibration values.

* **Tests**
  * Added coverage verifying calibrated-scale results against reference MoE outputs across supported backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Rebased 2026-07-18 onto the routing-modes rework of `MoEActivationPack` and the test-helper move to `tests/moe/utils.py`: the new field is now keyword-only (matching the reworked pack's convention) and participates in its `__post_init__` same-device validation; the pack construction in the test uses the renamed `topk_ids` / `topk_weights`; `calibrated_activation_scale` ported into `tests/moe/utils.py::create_moe_tensors` (with the dequant reference scaled by `1/a1_gs`). File:line citations in the formula evidence above refer to the pre-rebase tree. Re-verified what runs on my SM120 box: the scale-resolver unit behavior (all-zero-expert guard, scalar broadcast, device check) and the full non-SM100 `test_unified_moe.py` suite (126 passed); the SM100-gated kernel tests collect but skip here.
