### PR TITLE
test: bound peak memory in mxfp4 groupwise group GEMM test (32GB OOM)

### DIFF
--- a/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
+++ b/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
@@ -220,6 +220,15 @@ def quantize_tensor(x, tile_size, n_padded, k_padded, quant_mode):
 
 
 def _quantize_tensor_impl(x, tile_size, n_padded, k_padded, quant_mode):
+    r"""Single-shot tile-wise MXFP4/MXFP8 quantization (see ``quantize_tensor``).
+
+    Pads ``x`` to ``n_padded`` (dim -2, optional) / ``k_padded`` (dim -1),
+    computes per-``tile_size``-group ue8m0 scales along the last dim, and
+    quantizes to the ``quant_mode`` target format.  Returns
+    ``(x_quant_data, x_scale_data)``.  Materializes ~10 fp32 temporaries the
+    size of ``x`` — call through the chunked ``quantize_tensor`` wrapper for
+    large inputs.
+    """
     # 1. Initial Setup
     ue8m0_bias = 127
     if quant_mode == QuantMode.MXFP8_E4M3:

--- a/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
+++ b/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
@@ -131,6 +131,24 @@ def dequantize_e2m1(x):
     return x_dequant
 
 
+def assert_close_chunked(actual, expected, *, atol, rtol, chunk_rows=2048):
+    """Row-chunked ``torch.testing.assert_close``.
+
+    The comparison allocates several temporaries proportional to the operand
+    size; for the large cases here that pushes a 32GB GPU over the edge after
+    the kernel outputs are resident (gh #3527). Chunking caps the comparison
+    overhead while checking exactly the same elements.
+    """
+    assert actual.shape == expected.shape
+    for i in range(0, actual.shape[0], chunk_rows):
+        torch.testing.assert_close(
+            actual[i : i + chunk_rows],
+            expected[i : i + chunk_rows],
+            atol=atol,
+            rtol=rtol,
+        )
+
+
 def gemm_mxfp8_mxfp4_nt_groupwise_ref(
     A, B, As, Bs, tile_size, n, k, output_dtype=torch.bfloat16
 ):
@@ -158,7 +176,15 @@ def gemm_mxfp8_mxfp4_nt_groupwise_ref(
 
 def quantize_tensor(x, tile_size, n_padded, k_padded, quant_mode):
     r"""
-    Quantizes a tensor to MXFP4 or MXFP8.
+    Quantizes a tensor to MXFP4 or MXFP8, chunked over the leading dim.
+
+    The underlying reference quantization materializes ~10 fp32 temporaries
+    the size of its input (log2/exp2/round/sign/... in ``quantize_e2m1`` and
+    the tiled-scale math below), so quantizing a large operand in one shot
+    peaks at ~10x its fp32 size — the dominant allocation behind the 32GB-GPU
+    OOMs in gh #3527.  Chunking over the leading dimension bounds the
+    temporaries while producing identical bytes (every step is elementwise or
+    tiled along the last dim only).
 
     Args:
         x (torch.Tensor): The input tensor.
@@ -171,6 +197,21 @@ def quantize_tensor(x, tile_size, n_padded, k_padded, quant_mode):
         tuple: A tuple containing the quantized tensor and the
                calculated scales.
     """
+    # ~32M fp32 elements (~128MB) per chunk keeps the ~10x temporary
+    # footprint near 1GB regardless of the test case size.
+    elems_per_lead = x[0].numel()
+    lead_per_chunk = max(1, (1 << 25) // max(1, elems_per_lead))
+    if x.shape[0] <= lead_per_chunk:
+        return _quantize_tensor_impl(x, tile_size, n_padded, k_padded, quant_mode)
+    quants, scales = [], []
+    for x_chunk in x.split(lead_per_chunk, dim=0):
+        q, s = _quantize_tensor_impl(x_chunk, tile_size, n_padded, k_padded, quant_mode)
+        quants.append(q)
+        scales.append(s)
+    return torch.cat(quants), torch.cat(scales)
+
+
+def _quantize_tensor_impl(x, tile_size, n_padded, k_padded, quant_mode):
     # 1. Initial Setup
     ue8m0_bias = 127
     if quant_mode == QuantMode.MXFP8_E4M3:
@@ -281,6 +322,9 @@ def test_mxfp8_mxfp4_groupwise_group_gemm(
     b_fp4, b_scale = quantize_tensor(
         b_val, tile_size, n_padded, k_padded, QuantMode.MXFP4
     )
+    # The fp32 sources are only needed for quantization; freeing them matters
+    # on 32GB GPUs where the large cases otherwise OOM (gh #3527).
+    del a_val, b_val
 
     a_scale_swizzled = swizzle_blockscale(
         a_scale.unflatten(0, (group_size, m)), group_size, m, k_padded, tile_size
@@ -314,6 +358,7 @@ def test_mxfp8_mxfp4_groupwise_group_gemm(
         for i, x in enumerate(a_scale_chunked)
     ]
     a_scale_swizzled = torch.cat(a_scale_chunked)
+    del a_scale_chunked
 
     out_ref = torch.empty((group_size * m, n), dtype=out_dtype, device="cuda")
     for i in range(group_size):
@@ -357,7 +402,8 @@ def test_mxfp8_mxfp4_groupwise_group_gemm(
             swap_ab=swap_ab,
             out_dtype=out_dtype,
         )[:, :n]
-        torch.testing.assert_close(out, out_ref, atol=1e-2, rtol=1e-2)
+        assert_close_chunked(out, out_ref, atol=1e-2, rtol=1e-2)
+        del out
 
 
 if __name__ == "__main__":

--- a/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
+++ b/tests/gemm/test_groupwise_scaled_gemm_mxfp4.py
@@ -140,6 +140,9 @@ def assert_close_chunked(actual, expected, *, atol, rtol, chunk_rows=2048):
     overhead while checking exactly the same elements.
     """
     assert actual.shape == expected.shape
+    if actual.ndim == 0 or actual.shape[0] == 0:
+        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+        return
     for i in range(0, actual.shape[0], chunk_rows):
         torch.testing.assert_close(
             actual[i : i + chunk_rows],
@@ -197,9 +200,14 @@ def quantize_tensor(x, tile_size, n_padded, k_padded, quant_mode):
         tuple: A tuple containing the quantized tensor and the
                calculated scales.
     """
+    # Chunking splits dim 0, which is only safe when it is not the dim that
+    # n_padded pads (dim -2): for 2-D inputs they coincide, so fall through
+    # to the unchunked path there (this test only pads the 3-D B operand).
+    if x.ndim < 3 and n_padded is not None:
+        return _quantize_tensor_impl(x, tile_size, n_padded, k_padded, quant_mode)
     # ~32M fp32 elements (~128MB) per chunk keeps the ~10x temporary
     # footprint near 1GB regardless of the test case size.
-    elems_per_lead = x[0].numel()
+    elems_per_lead = x.numel() // max(1, x.shape[0])
     lead_per_chunk = max(1, (1 << 25) // max(1, elems_per_lead))
     if x.shape[0] <= lead_per_chunk:
         return _quantize_tensor_impl(x, tile_size, n_padded, k_padded, quant_mode)
@@ -372,6 +380,8 @@ def test_mxfp8_mxfp4_groupwise_group_gemm(
             k,
             out_dtype,
         )
+    # The unswizzled scales are only consumed by the reference above.
+    del a_scale, b_scale
 
     if compute_capability[0] == 12:
         mma_sm_list = [1]


### PR DESCRIPTION
## Description

`test_mxfp8_mxfp4_groupwise_group_gemm` OOMs on ~32GB GPUs (5090 CI runner) in several large cases (#3527). Profiling the failing ids shows the dominant allocation is the **reference quantization**: `quantize_e2m1` + the tiled-scale math materialize ~10 fp32 temporaries the size of the operand, so a single case peaks at ~11GB; on a 32GB card the accumulated test session then dies inside `assert_close` (the 360MB allocation in the issue is just the straw).

Fix (test-only):
- `quantize_tensor`: chunk over the leading dim (~32M elements/chunk) — **byte-identical output** (verified `torch.equal` chunked vs unchunked for both 2-D A and 3-D B operands), bounds the temporary footprint.
- free the fp32 sources (`a_val`/`b_val`) after quantization + the padded scale chunk list.
- `assert_close_chunked`: row-chunked comparison, same elements checked, caps the comparison temporaries.

Measured peak (RTX PRO 6000 Blackwell, the failing ids from the issue, `torch.cuda.max_memory_allocated`):

| case (g, m, n, k) | before | after |
|---|---|---|
| 8, 128, 2879, 8192 | 10.96 GiB | **2.10 GiB** |
| 8, 128, 4096, 4096 | 7.36 GiB | **2.33 GiB** |
| 8, 256, 2879, 4096 | 5.57 GiB | **1.77 GiB** |
| 8, 256, 4096, 4096 | 7.38 GiB | **2.35 GiB** |
| 8, 512, 2879, 4096 | 5.61 GiB | **1.81 GiB** |

The failing ids also pass under a 31.36GiB `set_per_process_memory_fraction` cap emulating the CI runner, with the real SM120 kernels.

## Related Issues

Fixes #3527.

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Test-only change; kernels untouched. The honest caveat: individual failing ids fit even unfixed when run alone under the 32GB cap — the CI OOM needs the accumulated multi-case session, so the validation here is the measured 3–5× peak reduction + byte-identity rather than an exact CI reproduction. AI-assisted (Claude Code), reviewed and measured by me on hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added chunked tensor comparison and chunked quantization to avoid large in-memory operations during verification.
  * Reduced GPU/CPU memory use by cleaning up large intermediate tensors throughout test runs.
  * Improved robustness of large-data GEMM tests, enabling reliable execution on GPUs with less memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->