### PR TITLE
feat: Expose disabling finalize fusion in TRTLLM cutlass moe backend

### DIFF
--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -121,7 +121,7 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
 
   FusedMoeRunner(DLDataType activation_dtype, DLDataType weight_dtype, DLDataType output_dtype,
                  bool use_deepseek_fp8_block_scale, bool use_w4_group_scaling,
-                 bool use_mxfp8_act_scaling, bool use_packed_weights) {
+                 bool use_mxfp8_act_scaling, bool use_packed_weights, bool use_fused_finalize) {
     mActivationDtype = activation_dtype;
     mWeightDtype = weight_dtype;
     mUsePackedWeights = use_packed_weights;
@@ -129,6 +129,7 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
     mUseDeepSeekFP8BlockScaling = use_deepseek_fp8_block_scale;
     mUseW4GroupScaling = use_w4_group_scaling;
     mUseMxfp8ActScaling = use_mxfp8_act_scaling;
+    mUseFusedFinalize = use_fused_finalize;
     mInnerDimMultiplier = 1;
 
     // keep consistent with cpp/tensorrt_llm/plugins/mixtureOfExperts/mixtureOfExpertsPlugin.cpp
@@ -226,6 +227,10 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
           << ", Weight: " << DLDataTypeToString(mWeightDtype)
           << ", Output: " << DLDataTypeToString(mOutputDtype);
     }
+
+    // Must be set before enumerating tactics below: it gates whether GEMM2 finalize-fusion
+    // tactics are produced (mayHaveFinalizeFused) and the corresponding workspace sizing.
+    mKernelRunner->use_fused_finalize_ = mUseFusedFinalize;
 
     mProfiler = std::make_shared<kernels::GemmProfilerBackend>();
     // Get tactics for both GEMM1 and GEMM2, combine them
@@ -806,6 +811,7 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
   bool mUseW4GroupScaling = false;
   bool mUseMxfp8ActScaling = false;
   bool mUsePackedWeights = false;
+  bool mUseFusedFinalize = true;
 
   using Profile = tensorrt_llm::cutlass_extensions::CutlassGemmConfig;
   std::vector<Profile> mAllProfiles;
@@ -1289,10 +1295,11 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
 
 tvm::ffi::Module init(DLDataType activation_dtype, DLDataType weight_dtype, DLDataType output_dtype,
                       bool use_deepseek_fp8_block_scale, bool use_w4_group_scaling,
-                      bool use_mxfp8_act_scaling, bool use_packed_weights) {
+                      bool use_mxfp8_act_scaling, bool use_packed_weights,
+                      bool use_fused_finalize) {
   auto ptr = tvm::ffi::make_object<FusedMoeRunner>(
       activation_dtype, weight_dtype, output_dtype, use_deepseek_fp8_block_scale,
-      use_w4_group_scaling, use_mxfp8_act_scaling, use_packed_weights);
+      use_w4_group_scaling, use_mxfp8_act_scaling, use_packed_weights, use_fused_finalize);
   return tvm::ffi::Module(ptr);
 }
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -678,9 +678,10 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         min_latency_mode: bool = False,
         tune_max_num_tokens: int = 8192,
         enable_pdl: Optional[bool] = None,
+        activation_type: ActivationType = ActivationType.Swiglu,
         use_packed_weights: bool = False,
         use_fused_finalize: bool = True,
-    ):
+    ) -> List[torch.Tensor]:
         seq_len = input.shape[0]
         hidden_size = fc2_expert_weights.shape[1]
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -298,7 +298,8 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
     class MoERunner(TunableRunner):
         # avoid overhead of creating a new runner in forward pass
         runner_dict: Dict[
-            Tuple[torch.dtype, torch.dtype, torch.dtype, bool, bool, bool, bool], Any
+            Tuple[torch.dtype, torch.dtype, torch.dtype, bool, bool, bool, bool, bool],
+            Any,
         ] = dict()
         tuning_config = TuningConfig(
             dynamic_tensor_specs=(
@@ -331,6 +332,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             enable_pdl: bool,
             activation_type: ActivationType,
             use_packed_weights: bool,
+            use_fused_finalize: bool,
         ):
             self.x_dtype = x_dtype
             self.weight_dtype = weight_dtype
@@ -349,6 +351,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             self.min_latency_mode = min_latency_mode
             self.enable_pdl = enable_pdl
             self.use_packed_weights = use_packed_weights
+            self.use_fused_finalize = use_fused_finalize
             instance_key = (
                 x_dtype,
                 weight_dtype,
@@ -357,6 +360,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
                 use_w4_group_scaling,
                 use_mxfp8_act_scaling,
                 use_packed_weights,
+                use_fused_finalize,
             )
             self.activation_type = activation_type
             # Set by tuning flow to indicate which GEMM stage (1 or 2) to filter tactics for
@@ -371,6 +375,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
                     use_w4_group_scaling,
                     use_mxfp8_act_scaling,
                     use_packed_weights,
+                    use_fused_finalize,
                 )
 
             self.fused_moe_runner = MoERunner.runner_dict[instance_key]
@@ -514,6 +519,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         enable_pdl: Optional[bool] = None,
         activation_type: ActivationType = ActivationType.Swiglu,
         use_packed_weights: bool = False,
+        use_fused_finalize: bool = True,
     ) -> List[torch.Tensor]:
         if enable_pdl is None:
             enable_pdl = device_support_pdl(input.device)
@@ -540,6 +546,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             enable_pdl=enable_pdl,
             activation_type=activation_type,
             use_packed_weights=use_packed_weights,
+            use_fused_finalize=use_fused_finalize,
         )
 
         # Limit tactics to GEMM1 during tuning
@@ -672,6 +679,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         tune_max_num_tokens: int = 8192,
         enable_pdl: Optional[bool] = None,
         use_packed_weights: bool = False,
+        use_fused_finalize: bool = True,
     ):
         seq_len = input.shape[0]
         hidden_size = fc2_expert_weights.shape[1]
@@ -842,6 +850,7 @@ def cutlass_fused_moe(
     enable_pdl: Optional[bool] = None,
     activation_type: ActivationType = ActivationType.Swiglu,
     swizzled_input_sf: bool = True,
+    use_fused_finalize: bool = True,
 ) -> torch.Tensor:
     """Compute a Mixture of Experts (MoE) layer using CUTLASS backend.
 
@@ -964,6 +973,12 @@ def cutlass_fused_moe(
         communication where the scaling factors are received in linear (non-swizzled) format.
         Only relevant when input_sf is not None.
 
+    use_fused_finalize : bool = True
+        Whether to fuse the top-k expert reduction ("finalize") into the GEMM2 epilogue.
+        Defaults to True for best performance. The fused epilogue reduces expert outputs via
+        non-associative atomics, so results are not deterministic run-to-run. Set to
+        False to use the non-fused, deterministic finalize path.
+
     Returns
     -------
     out: torch.Tensor
@@ -1046,6 +1061,7 @@ def cutlass_fused_moe(
         tune_max_num_tokens=tune_max_num_tokens,
         enable_pdl=enable_pdl,
         activation_type=activation_type,
+        use_fused_finalize=use_fused_finalize,
     )
 
 

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -537,6 +537,74 @@ def test_moe_gelu_tanh(batch_size, hidden_size, num_experts, top_k, intermediate
 @pytest.mark.parametrize("num_experts", NUM_EXPERTS)
 @pytest.mark.parametrize("top_k", TOP_K_VALUES)
 @pytest.mark.parametrize("intermediate_size", INTERMEDIATE_SIZES)
+def test_moe_unfused_finalize(
+    batch_size, hidden_size, num_experts, top_k, intermediate_size
+):
+    """``use_fused_finalize=False`` selects the non-fused finalize path.
+
+    Unlike the fused GEMM2 epilogue (which reduces expert outputs via non-associative
+    atomics), this path must be bit-wise reproducible run-to-run while still matching
+    the reference.
+    """
+    if top_k > num_experts:
+        pytest.skip(
+            f"top_k ({top_k}) cannot be greater than num_experts ({num_experts})"
+        )
+
+    torch.manual_seed(42)
+    x = torch.randn(batch_size, hidden_size, dtype=torch.float16).cuda() / 5
+    router_logits = torch.randn(batch_size, num_experts, dtype=torch.float32).cuda()
+    w31_weight = (
+        torch.randn(
+            num_experts, 2 * intermediate_size, hidden_size, dtype=torch.float16
+        ).cuda()
+        / 5
+    )
+    w2_weight = (
+        torch.randn(
+            num_experts, hidden_size, intermediate_size, dtype=torch.float16
+        ).cuda()
+        / 5
+    )
+
+    routing_weights, selected_experts = compute_routing(router_logits, top_k)
+    ref_output = compute_with_experts(
+        num_experts,
+        x,
+        w31_weight,
+        w2_weight,
+        selected_experts,
+        routing_weights,
+    )
+
+    def run_unfused():
+        out = torch.empty_like(ref_output)
+        return fused_moe.cutlass_fused_moe(
+            x,
+            selected_experts.to(torch.int),
+            routing_weights,
+            w31_weight,
+            w2_weight,
+            out.dtype,
+            output=out,
+            quant_scales=None,
+            use_fused_finalize=False,
+        )[0]
+
+    out1 = run_unfused()
+    out2 = run_unfused()
+
+    torch.testing.assert_close(ref_output, out1, rtol=1e-2, atol=1e-2)
+    assert torch.equal(out1, out2), (
+        "non-fused finalize path must produce deterministic results"
+    )
+
+
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("num_experts", NUM_EXPERTS)
+@pytest.mark.parametrize("top_k", TOP_K_VALUES)
+@pytest.mark.parametrize("intermediate_size", INTERMEDIATE_SIZES)
 @pytest.mark.parametrize("otype, wtype", [(torch.float16, torch.float8_e4m3fn)])
 @pytest.mark.parametrize(
     "activation_type",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
CUTLASS MOE backend supports a fused finalize reduction when performing a local reduction. This reduction uses atomics which can introduce run-run variance. Some applications depend on being able to get reproducible/exact results which requires disabling this feature.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `use_fused_finalize` parameter to CUTLASS MoE operations (default: enabled) to select fused vs non-fused expert finalization. This can affect performance and whether outputs are guaranteed deterministic between runs.

* **Tests**
  * Added `test_moe_unfused_finalize` to validate the non-fused finalize path (`use_fused_finalize=False`) against a reference implementation and to confirm determinism by running the kernel twice with identical inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->