### PR TITLE
Accept uint8 workspaces in CUTE DSL MLA decode

### DIFF
--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
@@ -33,6 +33,7 @@ from flashinfer.utils import device_support_pdl
 from .mla_decode_fp16 import BlackwellMultiHeadLatentAttentionForwardFP16
 from .mla_decode_fp8 import BlackwellMultiHeadLatentAttentionForwardFP8
 from flashinfer.cute_dsl.utils import (
+    _as_cute_dsl_workspace_i8,
     get_max_active_clusters,
     get_num_sm,
     torch_to_cutlass_dtype,
@@ -332,7 +333,7 @@ def cute_dsl_mla_decode(
     kv_cache : torch.Tensor
         [num_pages, page_size, D_ckv + D_kpe] (3D) or [num_pages, 1, page_size, D_ckv + D_kpe] (4D)
     workspace_buffer : torch.Tensor
-        Pre-allocated workspace buffer (uint8). Required size depends on batch size
+        Pre-allocated workspace buffer (int8 or uint8). Required size depends on batch size
         and split_kv (auto-computed from B, q_len, and number of SMs):
 
         - Formula: ``B * H * q_len * split_kv * (kv_lora_rank + 1) * 4`` bytes
@@ -436,14 +437,14 @@ def cute_dsl_mla_decode(
         B, q_len, H, kv_lora_rank, max_active_blocks
     )
 
-    # Prepare workspace: slice of contiguous 1D buffer is already contiguous
-    assert workspace_buffer.dtype == torch.int8, (
-        f"workspace_buffer must be torch.int8, got {workspace_buffer.dtype}"
-    )
-    assert workspace_buffer.numel() >= workspace_size, (
-        f"workspace_buffer too small: {workspace_buffer.numel()} bytes, "
-        f"need {workspace_size} bytes"
-    )
+    # Prepare workspace: the CUTE signature uses int8, while public FlashInfer
+    # workspace buffers are byte storage and may be uint8.
+    workspace_buffer = _as_cute_dsl_workspace_i8(workspace_buffer)
+    if workspace_buffer.numel() < workspace_size:
+        raise ValueError(
+            f"workspace_buffer too small: {workspace_buffer.numel()} bytes, "
+            f"need {workspace_size} bytes"
+        )
     is_workspace_size_zero = workspace_size == 0
     if is_workspace_size_zero:
         workspace_bytes = None

--- a/flashinfer/cute_dsl/attention/wrappers/batch_mla.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_mla.py
@@ -23,6 +23,7 @@ from flashinfer.api_logging import flashinfer_api
 from flashinfer.trace.templates.attention import cute_dsl_batch_mla_run_trace
 from flashinfer.utils import device_support_pdl
 from flashinfer.cute_dsl.utils import (
+    _as_cute_dsl_workspace_i8,
     get_max_active_clusters,
     get_num_sm,
     torch_to_cutlass_dtype,
@@ -379,13 +380,10 @@ class BatchMLADecodeCuteDSLWrapper:
         ----------
         workspace_buffer : torch.Tensor
             Pre-allocated workspace buffer on the target CUDA device.  Must have
-            dtype ``torch.int8``; the size determines the maximum batch this
-            wrapper can handle without re-allocation.
+            dtype ``torch.int8`` or ``torch.uint8``; the size determines the
+            maximum batch this wrapper can handle without re-allocation.
         """
-        assert workspace_buffer.dtype == torch.int8, (
-            f"workspace_buffer must be torch.int8, got {workspace_buffer.dtype}"
-        )
-        self._workspace_buffer = workspace_buffer
+        self._workspace_buffer = _as_cute_dsl_workspace_i8(workspace_buffer)
         self._device = workspace_buffer.device
         self._compiled_kernel: Optional[Callable] = None
 
@@ -710,7 +708,7 @@ def cute_dsl_mla_decode(
     kv_cache : torch.Tensor
         [num_pages, page_size, D_ckv + D_kpe] (3D) or [num_pages, 1, page_size, D_ckv + D_kpe] (4D)
     workspace_buffer : torch.Tensor
-        Pre-allocated workspace buffer (int8). Required size depends on batch size
+        Pre-allocated workspace buffer (int8 or uint8). Required size depends on batch size
         and split_kv (auto-computed from B, q_len, and number of SMs):
 
         - Formula: ``B * H * q_len * split_kv * (kv_lora_rank + 1) * 4`` bytes
@@ -816,13 +814,12 @@ def cute_dsl_mla_decode(
     )
 
     # Prepare workspace
-    assert workspace_buffer.dtype == torch.int8, (
-        f"workspace_buffer must be torch.int8, got {workspace_buffer.dtype}"
-    )
-    assert workspace_buffer.numel() >= workspace_size, (
-        f"workspace_buffer too small: {workspace_buffer.numel()} bytes, "
-        f"need {workspace_size} bytes"
-    )
+    workspace_buffer = _as_cute_dsl_workspace_i8(workspace_buffer)
+    if workspace_buffer.numel() < workspace_size:
+        raise ValueError(
+            f"workspace_buffer too small: {workspace_buffer.numel()} bytes, "
+            f"need {workspace_size} bytes"
+        )
     is_workspace_size_zero = workspace_size == 0
     if is_workspace_size_zero:
         workspace_bytes = None

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -82,6 +82,21 @@ def torch_to_cutlass_dtype(dtype: torch.dtype) -> cutlass.dtype:
     return dtype_map[dtype]
 
 
+def _as_cute_dsl_workspace_i8(
+    workspace_buffer: torch.Tensor,
+    *,
+    name: str = "workspace_buffer",
+) -> torch.Tensor:
+    if workspace_buffer.dtype not in (torch.int8, torch.uint8):
+        raise ValueError(
+            f"{name} must be a torch.int8 or torch.uint8 byte tensor, "
+            f"got {workspace_buffer.dtype}"
+        )
+    if not workspace_buffer.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+    return workspace_buffer.view(-1).view(torch.int8)
+
+
 def cutlass_to_torch_dtype(cutlass_dtype):
     """
     Return the corresponding torch.dtype per the given DSL type


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This updates CUTE DSL MLA decode to accept `torch.uint8` workspace buffers in addition to the existing `torch.int8` buffers.

The workspace is byte storage; the CUTE kernel ABI still expects an `int8` tensor, so `uint8` buffers are validated and reinterpreted as `int8` with a zero-copy view before launch. This avoids breaking callers that follow FlashInfer’s common `uint8` workspace convention.

### Changes

- Add shared `_as_cute_dsl_workspace_i8` helper for CUTE DSL workspace validation and normalization.
- Apply it to both monolithic and modular CUTE DSL MLA decode paths.
- Preserve the internal `cutlass.Int8` kernel signature.
- Add explicit validation for dtype and contiguity.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * MLA decode now accepts workspace buffers in both int8 and uint8 formats for greater flexibility.
  * User-provided workspace buffers are handled transparently (no manual dtype coercion required).
  * Enhanced validation checks with clearer error messages when provided workspace capacity is insufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->