### PR TITLE
fix: pass XQA NVFP4 scale-factor strides

### DIFF
--- a/csrc/xqa/mha.cu
+++ b/csrc/xqa/mha.cu
@@ -2911,8 +2911,7 @@ void launchMHA(
   uint32_t const stride_token_in_heads = static_cast<uint32_t>(kv_stride_token / validElemsPerHead);
   uint32_t const stride_head_in_heads = static_cast<uint32_t>(kv_stride_head / validElemsPerHead);
 #if ENABLE_4BIT_KV_CACHE
-  uint32_t const sf_elems_per_head =
-      validElemsPerHead / CacheElemConverter::QuantVectorSize;
+  uint32_t const sf_elems_per_head = validElemsPerHead / CacheElemConverter::QuantVectorSize;
   uint32_t const sf_stride_page_in_heads =
       static_cast<uint32_t>(sf_stride_page / sf_elems_per_head);
   uint32_t const sf_stride_token_in_heads =
@@ -2945,8 +2944,7 @@ void launchMHA(
                      batchSize, kvCacheScale, kvScalePtr, stride_page_in_heads,
                      stride_token_in_heads, stride_head_in_heads,
 #if ENABLE_4BIT_KV_CACHE
-                     sf_stride_page_in_heads, sf_stride_token_in_heads,
-                     sf_stride_head_in_heads,
+                     sf_stride_page_in_heads, sf_stride_token_in_heads, sf_stride_head_in_heads,
 #endif
                      semaphores, scratch);
   checkCuda(cudaPeekAtLastError());
@@ -2982,8 +2980,7 @@ void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32
                          uint32_t* semaphores, void* scratch, bool enable_pdl,
                          uint64_t kv_stride_page, uint64_t kv_stride_token, uint64_t kv_stride_head,
 #if ENABLE_4BIT_KV_CACHE
-                         uint64_t sf_stride_page, uint64_t sf_stride_token,
-                         uint64_t sf_stride_head,
+                         uint64_t sf_stride_page, uint64_t sf_stride_token, uint64_t sf_stride_head,
 #endif
                          cudaStream_t stream) {
   uint32_t const nbSubSeqPerSeq = [&]() -> uint32_t {
@@ -3017,8 +3014,7 @@ void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32
   uint32_t const stride_head_in_heads =
       static_cast<uint32_t>(kv_stride_head / container_elems_per_head);
 #if ENABLE_4BIT_KV_CACHE
-  uint32_t const sf_elems_per_head =
-      validElemsPerHead / CacheElemConverter::QuantVectorSize;
+  uint32_t const sf_elems_per_head = validElemsPerHead / CacheElemConverter::QuantVectorSize;
   uint32_t const sf_stride_page_in_heads =
       static_cast<uint32_t>(sf_stride_page / sf_elems_per_head);
   uint32_t const sf_stride_token_in_heads =
@@ -3047,8 +3043,7 @@ void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32
                      attentionSinks, cacheList, batchSize, kvCacheScale, kvScalePtr,
                      stride_page_in_heads, stride_token_in_heads, stride_head_in_heads,
 #if ENABLE_4BIT_KV_CACHE
-                     sf_stride_page_in_heads, sf_stride_token_in_heads,
-                     sf_stride_head_in_heads,
+                     sf_stride_page_in_heads, sf_stride_token_in_heads, sf_stride_head_in_heads,
 #endif
                      semaphores, scratch);
   checkCuda(cudaPeekAtLastError());

--- a/csrc/xqa/mha.cu
+++ b/csrc/xqa/mha.cu
@@ -1558,6 +1558,9 @@ CUBIN_EXPORT __global__
         uint32_t const batchSize, float kvCacheScale,
         float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
         uint32_t kv_stride_page, uint32_t kv_stride_token, uint32_t kv_stride_head,
+#if ENABLE_4BIT_KV_CACHE
+        uint32_t sf_stride_page, uint32_t sf_stride_token, uint32_t sf_stride_head,
+#endif
         uint32_t* __restrict__ semaphores = nullptr, void* __restrict__ scratch = nullptr) {
 
   float const qScaleValue = qScalePtr != nullptr ? qScalePtr[0] : qScale;
@@ -1818,7 +1821,7 @@ CUBIN_EXPORT __global__
 #if ENABLE_4BIT_KV_CACHE
       HeadPtr<GMemCacheHeadSf const, tokensPerPage, nbPagesPerWarpTile> const srcSf{
           cacheList.kSfCacheVLLM, pageIdx,         tokenOffset,   idxHeadGrp,
-          kv_stride_page,         kv_stride_token, kv_stride_head};
+          sf_stride_page,         sf_stride_token, sf_stride_head};
 #endif
 
 #else
@@ -2160,7 +2163,7 @@ CUBIN_EXPORT __global__
 #if ENABLE_4BIT_KV_CACHE
       HeadPtr<GMemCacheHeadSf const, tokensPerPage, nbPagesPerVTile> const srcSf{
           cacheList.vSfCacheVLLM, pageIdx,         tokenOffset,   idxHeadGrp,
-          kv_stride_page,         kv_stride_token, kv_stride_head};
+          sf_stride_page,         sf_stride_token, sf_stride_head};
 #endif
 #else
       IndexedHeadPtr<GMemCacheHead const, tokensPerPage, nbPagesPerVTile> const src{
@@ -2779,6 +2782,9 @@ CUBIN_EXPORT __global__ __launch_bounds__(256, nbCtaPerSM) void kernel_mha(
     uint32_t const batchSize, float kvCacheScale,
     float const* kvScalePtr,  // Same scale for K and V cache. Used only for int8/fp8 KV cache.
     uint32_t kv_stride_page, uint32_t kv_stride_token, uint32_t kv_stride_head,
+#if ENABLE_4BIT_KV_CACHE
+    uint32_t sf_stride_page, uint32_t sf_stride_token, uint32_t sf_stride_head,
+#endif
     uint32_t* __restrict__ semaphores = nullptr, void* __restrict__ scratch = nullptr) {
 #if SPEC_DEC
   kernel_mha_impl(qSeqLen, nbKHeads, headGrpSize, qCuSeqLens,
@@ -2801,7 +2807,11 @@ CUBIN_EXPORT __global__ __launch_bounds__(256, nbCtaPerSM) void kernel_mha(
                   beamSearchParams,
 #endif
                   batchSize, kvCacheScale, kvScalePtr, kv_stride_page, kv_stride_token,
-                  kv_stride_head, semaphores, scratch);
+                  kv_stride_head,
+#if ENABLE_4BIT_KV_CACHE
+                  sf_stride_page, sf_stride_token, sf_stride_head,
+#endif
+                  semaphores, scratch);
 }
 #else
 static constexpr auto kernel_mha = kernel_mha_impl;
@@ -2843,7 +2853,11 @@ void launchMHA(
     SpecDecParams const& specDecParams,
 #endif
     uint32_t* semaphores, void* scratch, bool enable_pdl, uint64_t kv_stride_page,
-    uint64_t kv_stride_token, uint64_t kv_stride_head, cudaStream_t stream) {
+    uint64_t kv_stride_token, uint64_t kv_stride_head,
+#if ENABLE_4BIT_KV_CACHE
+    uint64_t sf_stride_page, uint64_t sf_stride_token, uint64_t sf_stride_head,
+#endif
+    cudaStream_t stream) {
 #if SPEC_DEC
   auto const qSeqLen = specDecParams.qSeqLen;
   auto const qCuSeqLens = specDecParams.qCuSeqLens;
@@ -2896,6 +2910,16 @@ void launchMHA(
   uint32_t const stride_page_in_heads = static_cast<uint32_t>(kv_stride_page / validElemsPerHead);
   uint32_t const stride_token_in_heads = static_cast<uint32_t>(kv_stride_token / validElemsPerHead);
   uint32_t const stride_head_in_heads = static_cast<uint32_t>(kv_stride_head / validElemsPerHead);
+#if ENABLE_4BIT_KV_CACHE
+  uint32_t const sf_elems_per_head =
+      validElemsPerHead / CacheElemConverter::QuantVectorSize;
+  uint32_t const sf_stride_page_in_heads =
+      static_cast<uint32_t>(sf_stride_page / sf_elems_per_head);
+  uint32_t const sf_stride_token_in_heads =
+      static_cast<uint32_t>(sf_stride_token / sf_elems_per_head);
+  uint32_t const sf_stride_head_in_heads =
+      static_cast<uint32_t>(sf_stride_head / sf_elems_per_head);
+#endif
 
   cudaLaunchKernelEx(&launchCfg, kernel_mha,
 #if SPEC_DEC
@@ -2919,7 +2943,12 @@ void launchMHA(
                      beamSearchParams,
 #endif
                      batchSize, kvCacheScale, kvScalePtr, stride_page_in_heads,
-                     stride_token_in_heads, stride_head_in_heads, semaphores, scratch);
+                     stride_token_in_heads, stride_head_in_heads,
+#if ENABLE_4BIT_KV_CACHE
+                     sf_stride_page_in_heads, sf_stride_token_in_heads,
+                     sf_stride_head_in_heads,
+#endif
+                     semaphores, scratch);
   checkCuda(cudaPeekAtLastError());
 #endif  // USE_INPUT_KV
 }
@@ -2952,6 +2981,10 @@ void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32
 #endif
                          uint32_t* semaphores, void* scratch, bool enable_pdl,
                          uint64_t kv_stride_page, uint64_t kv_stride_token, uint64_t kv_stride_head,
+#if ENABLE_4BIT_KV_CACHE
+                         uint64_t sf_stride_page, uint64_t sf_stride_token,
+                         uint64_t sf_stride_head,
+#endif
                          cudaStream_t stream) {
   uint32_t const nbSubSeqPerSeq = [&]() -> uint32_t {
     if (!allowMultiBlockMode) {
@@ -2983,6 +3016,16 @@ void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32
       static_cast<uint32_t>(kv_stride_token / container_elems_per_head);
   uint32_t const stride_head_in_heads =
       static_cast<uint32_t>(kv_stride_head / container_elems_per_head);
+#if ENABLE_4BIT_KV_CACHE
+  uint32_t const sf_elems_per_head =
+      validElemsPerHead / CacheElemConverter::QuantVectorSize;
+  uint32_t const sf_stride_page_in_heads =
+      static_cast<uint32_t>(sf_stride_page / sf_elems_per_head);
+  uint32_t const sf_stride_token_in_heads =
+      static_cast<uint32_t>(sf_stride_token / sf_elems_per_head);
+  uint32_t const sf_stride_head_in_heads =
+      static_cast<uint32_t>(sf_stride_head / sf_elems_per_head);
+#endif
 
   cudaLaunchKernelEx(&launchCfg, kernel_mha,
 #if SPEC_DEC
@@ -3002,8 +3045,12 @@ void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32
                      mask,
 #endif
                      attentionSinks, cacheList, batchSize, kvCacheScale, kvScalePtr,
-                     stride_page_in_heads, stride_token_in_heads, stride_head_in_heads, semaphores,
-                     scratch);
+                     stride_page_in_heads, stride_token_in_heads, stride_head_in_heads,
+#if ENABLE_4BIT_KV_CACHE
+                     sf_stride_page_in_heads, sf_stride_token_in_heads,
+                     sf_stride_head_in_heads,
+#endif
+                     semaphores, scratch);
   checkCuda(cudaPeekAtLastError());
 }
 #endif

--- a/csrc/xqa/mha.h
+++ b/csrc/xqa/mha.h
@@ -141,7 +141,11 @@ void launchMHA(
     SpecDecParams const& specDecParams,
 #endif
     uint32_t* semaphores, void* scratch, bool enable_pdl, uint64_t kv_stride_page,
-    uint64_t kv_stride_token, uint64_t kv_stride_head, cudaStream_t stream);
+    uint64_t kv_stride_token, uint64_t kv_stride_head,
+#if ENABLE_4BIT_KV_CACHE
+    uint64_t sf_stride_page, uint64_t sf_stride_token, uint64_t sf_stride_head,
+#endif
+    cudaStream_t stream);
 
 void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32_t slidingWinSize,
                          float qScale, float const* qScalePtr, OutputHead* output,
@@ -161,6 +165,10 @@ void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32
 #endif
                          uint32_t* semaphores, void* scratch, bool enable_pdl,
                          uint64_t kv_stride_page, uint64_t kv_stride_token, uint64_t kv_stride_head,
+#if ENABLE_4BIT_KV_CACHE
+                         uint64_t sf_stride_page, uint64_t sf_stride_token,
+                         uint64_t sf_stride_head,
+#endif
                          cudaStream_t stream);
 
 void launchHopperF8MHA(

--- a/csrc/xqa/mha.h
+++ b/csrc/xqa/mha.h
@@ -166,8 +166,7 @@ void launchMHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads, uint32
                          uint32_t* semaphores, void* scratch, bool enable_pdl,
                          uint64_t kv_stride_page, uint64_t kv_stride_token, uint64_t kv_stride_head,
 #if ENABLE_4BIT_KV_CACHE
-                         uint64_t sf_stride_page, uint64_t sf_stride_token,
-                         uint64_t sf_stride_head,
+                         uint64_t sf_stride_page, uint64_t sf_stride_token, uint64_t sf_stride_head,
 #endif
                          cudaStream_t stream);
 

--- a/csrc/xqa/xqa_wrapper.cu
+++ b/csrc/xqa/xqa_wrapper.cu
@@ -69,16 +69,20 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
   float const* kvScalePtr = kvScaleTensor.has_value()
                                 ? reinterpret_cast<float const*>(kvScaleTensor.value().data_ptr())
                                 : nullptr;
-#if USE_SM90_MHA
-  auto const mha_func = run_sm90_fp8_mha ? &launchHopperF8MHAFlashInfer : &launchMHAFlashInfer;
-#else
-  auto const mha_func = &launchMHAFlashInfer;
-#endif
-
   // Extract strides from TensorView (in elements, not bytes)
   uint64_t kv_stride_page = kCacheVLLM.stride(0);
   uint64_t kv_stride_token = kCacheVLLM.stride(-3);
   uint64_t kv_stride_head = kCacheVLLM.stride(-2);
+#if ENABLE_4BIT_KV_CACHE
+  uint64_t sf_stride_page = kv_stride_page;
+  uint64_t sf_stride_token = kv_stride_token;
+  uint64_t sf_stride_head = kv_stride_head;
+  if (kSfCacheVLLM.has_value()) {
+    sf_stride_page = kSfCacheVLLM.value().stride(0);
+    sf_stride_token = kSfCacheVLLM.value().stride(-3);
+    sf_stride_head = kSfCacheVLLM.value().stride(-2);
+  }
+#endif
 
 #if SPEC_DEC
   MaskType const* maskPtr =
@@ -88,26 +92,56 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
   void* kSfCachePtr = kSfCacheVLLM.has_value() ? kSfCacheVLLM.value().data_ptr() : nullptr;
   void* vSfCachePtr = vSfCacheVLLM.has_value() ? vSfCacheVLLM.value().data_ptr() : nullptr;
 
-  mha_func(multiProcessorCount, nbKHeads, slidingWinSize, qScale, qScalePtr,
-           reinterpret_cast<OutputHead*>(output.data_ptr()),
+#if USE_SM90_MHA
+  if (run_sm90_fp8_mha) {
+    launchHopperF8MHAFlashInfer(multiProcessorCount, nbKHeads, slidingWinSize, qScale,
+                                qScalePtr, reinterpret_cast<OutputHead*>(output.data_ptr()),
 #if LOW_PREC_OUTPUT
-           rcpOutScale,
+                                rcpOutScale,
 #endif
-           reinterpret_cast<InputHead const*>(q.data_ptr()), attentionSinksPtr,
-           reinterpret_cast<GMemCacheHead*>(kCacheVLLM.data_ptr()),
-           reinterpret_cast<GMemCacheHead*>(vCacheVLLM.data_ptr()),
-#if ENABLE_4BIT_KV_CACHE
-           reinterpret_cast<GMemCacheHeadSf*>(kSfCachePtr),
-           reinterpret_cast<GMemCacheHeadSf*>(vSfCachePtr),
-#endif
-           reinterpret_cast<KVCachePageIndex const*>(kvCachePageList.data_ptr()), maxSeqLen,
-           reinterpret_cast<uint32_t const*>(seqLen.data_ptr()), batchSize, kvCacheScale,
-           kvScalePtr,
+                                reinterpret_cast<InputHead const*>(q.data_ptr()),
+                                attentionSinksPtr,
+                                reinterpret_cast<GMemCacheHead*>(kCacheVLLM.data_ptr()),
+                                reinterpret_cast<GMemCacheHead*>(vCacheVLLM.data_ptr()),
+                                reinterpret_cast<KVCachePageIndex const*>(
+                                    kvCachePageList.data_ptr()),
+                                maxSeqLen,
+                                reinterpret_cast<uint32_t const*>(seqLen.data_ptr()),
+                                batchSize, kvCacheScale, kvScalePtr,
 #if SPEC_DEC
-           qSeqLen, nullptr, maskPtr,
+                                qSeqLen, nullptr, maskPtr,
 #endif
-           reinterpret_cast<uint32_t*>(semaphores.data_ptr()),
-           reinterpret_cast<void*>(scratch.data_ptr()), enable_pdl, kv_stride_page, kv_stride_token,
-           kv_stride_head, stream);
+                                reinterpret_cast<uint32_t*>(semaphores.data_ptr()),
+                                reinterpret_cast<void*>(scratch.data_ptr()), enable_pdl,
+                                kv_stride_page, kv_stride_token, kv_stride_head, stream);
+    return;
+  }
+#endif
+
+  launchMHAFlashInfer(multiProcessorCount, nbKHeads, slidingWinSize, qScale, qScalePtr,
+                      reinterpret_cast<OutputHead*>(output.data_ptr()),
+#if LOW_PREC_OUTPUT
+                      rcpOutScale,
+#endif
+                      reinterpret_cast<InputHead const*>(q.data_ptr()), attentionSinksPtr,
+                      reinterpret_cast<GMemCacheHead*>(kCacheVLLM.data_ptr()),
+                      reinterpret_cast<GMemCacheHead*>(vCacheVLLM.data_ptr()),
+#if ENABLE_4BIT_KV_CACHE
+                      reinterpret_cast<GMemCacheHeadSf*>(kSfCachePtr),
+                      reinterpret_cast<GMemCacheHeadSf*>(vSfCachePtr),
+#endif
+                      reinterpret_cast<KVCachePageIndex const*>(kvCachePageList.data_ptr()),
+                      maxSeqLen, reinterpret_cast<uint32_t const*>(seqLen.data_ptr()),
+                      batchSize, kvCacheScale, kvScalePtr,
+#if SPEC_DEC
+                      qSeqLen, nullptr, maskPtr,
+#endif
+                      reinterpret_cast<uint32_t*>(semaphores.data_ptr()),
+                      reinterpret_cast<void*>(scratch.data_ptr()), enable_pdl, kv_stride_page,
+                      kv_stride_token, kv_stride_head,
+#if ENABLE_4BIT_KV_CACHE
+                      sf_stride_page, sf_stride_token, sf_stride_head,
+#endif
+                      stream);
 }
 #endif

--- a/csrc/xqa/xqa_wrapper.cu
+++ b/csrc/xqa/xqa_wrapper.cu
@@ -94,26 +94,23 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
 
 #if USE_SM90_MHA
   if (run_sm90_fp8_mha) {
-    launchHopperF8MHAFlashInfer(multiProcessorCount, nbKHeads, slidingWinSize, qScale,
-                                qScalePtr, reinterpret_cast<OutputHead*>(output.data_ptr()),
+    launchHopperF8MHAFlashInfer(
+        multiProcessorCount, nbKHeads, slidingWinSize, qScale, qScalePtr,
+        reinterpret_cast<OutputHead*>(output.data_ptr()),
 #if LOW_PREC_OUTPUT
-                                rcpOutScale,
+        rcpOutScale,
 #endif
-                                reinterpret_cast<InputHead const*>(q.data_ptr()),
-                                attentionSinksPtr,
-                                reinterpret_cast<GMemCacheHead*>(kCacheVLLM.data_ptr()),
-                                reinterpret_cast<GMemCacheHead*>(vCacheVLLM.data_ptr()),
-                                reinterpret_cast<KVCachePageIndex const*>(
-                                    kvCachePageList.data_ptr()),
-                                maxSeqLen,
-                                reinterpret_cast<uint32_t const*>(seqLen.data_ptr()),
-                                batchSize, kvCacheScale, kvScalePtr,
+        reinterpret_cast<InputHead const*>(q.data_ptr()), attentionSinksPtr,
+        reinterpret_cast<GMemCacheHead*>(kCacheVLLM.data_ptr()),
+        reinterpret_cast<GMemCacheHead*>(vCacheVLLM.data_ptr()),
+        reinterpret_cast<KVCachePageIndex const*>(kvCachePageList.data_ptr()), maxSeqLen,
+        reinterpret_cast<uint32_t const*>(seqLen.data_ptr()), batchSize, kvCacheScale, kvScalePtr,
 #if SPEC_DEC
-                                qSeqLen, nullptr, maskPtr,
+        qSeqLen, nullptr, maskPtr,
 #endif
-                                reinterpret_cast<uint32_t*>(semaphores.data_ptr()),
-                                reinterpret_cast<void*>(scratch.data_ptr()), enable_pdl,
-                                kv_stride_page, kv_stride_token, kv_stride_head, stream);
+        reinterpret_cast<uint32_t*>(semaphores.data_ptr()),
+        reinterpret_cast<void*>(scratch.data_ptr()), enable_pdl, kv_stride_page, kv_stride_token,
+        kv_stride_head, stream);
     return;
   }
 #endif
@@ -131,8 +128,8 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
                       reinterpret_cast<GMemCacheHeadSf*>(vSfCachePtr),
 #endif
                       reinterpret_cast<KVCachePageIndex const*>(kvCachePageList.data_ptr()),
-                      maxSeqLen, reinterpret_cast<uint32_t const*>(seqLen.data_ptr()),
-                      batchSize, kvCacheScale, kvScalePtr,
+                      maxSeqLen, reinterpret_cast<uint32_t const*>(seqLen.data_ptr()), batchSize,
+                      kvCacheScale, kvScalePtr,
 #if SPEC_DEC
                       qSeqLen, nullptr, maskPtr,
 #endif

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2485,6 +2485,20 @@ def get_trtllm_gen_decode_module(*args):
     )
 
 
+def _check_xqa_nvfp4_page_size(page_size: int) -> None:
+    """Validate page_size for the XQA backend with an NVFP4 KV cache.
+
+    XQA's NVFP4 path only supports page_size 64 or 128; page_size 16/32 reach
+    the kernel but silently produce wrong results, so reject them early.
+    """
+    if page_size in (16, 32):
+        raise ValueError(
+            "NVFP4 KV cache page_size 16 and 32 are not supported by "
+            "FlashInfer XQA. Use page_size 64 or 128 instead. "
+            f"Got page_size={page_size}."
+        )
+
+
 @flashinfer_api(trace=trtllm_batch_decode_trace)
 def trtllm_batch_decode_with_kv_cache(
     query: torch.Tensor,
@@ -2717,12 +2731,7 @@ def trtllm_batch_decode_with_kv_cache(
             nvfp4_page_size = (
                 k_cache.shape[-2] if kv_layout == "HND" else k_cache.shape[-3]
             )
-            if nvfp4_page_size in (16, 32):
-                raise ValueError(
-                    "NVFP4 KV cache page_size 16 and 32 are not supported by "
-                    "FlashInfer XQA. Use page_size 64 or 128 instead. "
-                    f"Got page_size={nvfp4_page_size}."
-                )
+            _check_xqa_nvfp4_page_size(nvfp4_page_size)
 
         # xqa backend doesn't support nvfp4 output
         if out_dtype == "nvfp4" or (out_dtype is None and isinstance(out, FP4Tensor)):
@@ -3063,6 +3072,16 @@ def xqa_batch_decode_with_kv_cache(
         # or [num_pages, num_kv_heads, page_size, head_dim// 2] for NVFP4 KV cache with packed head dim
         num_kv_heads = k_cache.shape[1]
         page_size = k_cache.shape[2]
+
+    # NVFP4 KV cache (uint8 storage + scale factors) only supports page_size
+    # 64/128 on XQA; reject 16/32 early to avoid silently wrong results.
+    is_nvfp4_kvcache = (
+        k_cache.dtype == torch.uint8
+        and v_cache.dtype == torch.uint8
+        and k_cache_sf is not None
+    )
+    if is_nvfp4_kvcache:
+        _check_xqa_nvfp4_page_size(page_size)
 
     # query shape: [num_tokens, num_heads, head_dim]
     head_dim = query.shape[-1]

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2628,6 +2628,8 @@ def trtllm_batch_decode_with_kv_cache(
         Per-block scale factors for NVFP4 KV cache, as a tuple of ``(k_scales, v_scales)``.
         Each scale tensor has shape ``[num_pages, num_kv_heads, page_size, head_dim // 16]``
         in HND layout, with dtype ``torch.float8_e4m3fn``.
+        NVFP4 KV cache does not support page sizes 16 or 32 in the XQA backend;
+        use page size 64 or 128 instead.
 
         **Contiguity requirements (trtllm-gen backend):**
 
@@ -2711,6 +2713,17 @@ def trtllm_batch_decode_with_kv_cache(
         )
 
     if backend == "xqa":
+        if is_nvfp4_kvcache:
+            nvfp4_page_size = (
+                k_cache.shape[-2] if kv_layout == "HND" else k_cache.shape[-3]
+            )
+            if nvfp4_page_size in (16, 32):
+                raise ValueError(
+                    "NVFP4 KV cache page_size 16 and 32 are not supported by "
+                    "FlashInfer XQA. Use page_size 64 or 128 instead. "
+                    f"Got page_size={nvfp4_page_size}."
+                )
+
         # xqa backend doesn't support nvfp4 output
         if out_dtype == "nvfp4" or (out_dtype is None and isinstance(out, FP4Tensor)):
             raise ValueError("xqa backend does not support nvfp4 output")

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -589,6 +589,7 @@ def test_xqa_batch_decode(
         (4, 4, 64, 4, 2),
         (1, 1, 64, 2, 4),
         (1, 1, 64, 2, 8),
+        (1, 1, 128, 2, 4),
     ],
 )
 @pytest.mark.parametrize("window_left", [-1])
@@ -601,8 +602,19 @@ def test_xqa_batch_decode(
 )
 @pytest.mark.parametrize("enable_pdl", [False])
 @pytest.mark.parametrize("enable_sink", [False])
-@pytest.mark.parametrize("max_in_kv_len", [110])
+# max_in_kv_len must exceed page_size so sequences span multiple pages; otherwise
+# the scale-factor *page* stride is never exercised and the sf_layout="separate"
+# case below cannot catch a wrong SF page stride.
+@pytest.mark.parametrize("max_in_kv_len", [300])
 @pytest.mark.parametrize("kv_layout", ["NHD"])
+# "stacked": SF cache shares the torch.stack([k, v], dim=1) layout of the data
+# cache, so after conversion to head units the SF strides equal the data-cache
+# strides -- this passes identically with or without the SF-stride fix.
+# "separate": K/V scale factors are allocated as independent contiguous tensors
+# (no interleave dim), so the SF page stride differs from the data-cache page
+# stride by the factor-2 stacking. This exercises the dedicated sf_stride_*
+# plumbing and regresses if the kernel falls back to the data-cache strides.
+@pytest.mark.parametrize("sf_layout", ["stacked", "separate"])
 def test_xqa_batch_decode_nvfp4_kv(
     batch_size,
     q_len_per_req,
@@ -617,6 +629,7 @@ def test_xqa_batch_decode_nvfp4_kv(
     enable_sink,
     max_in_kv_len,
     kv_layout,
+    sf_layout,
 ):
     """Test xqa_batch_decode_with_kv_cache function.
 
@@ -651,7 +664,16 @@ def test_xqa_batch_decode_nvfp4_kv(
         )
     )
 
-    kv_cache_sf = torch.stack([k_scale, v_scale], dim=1)
+    if sf_layout == "stacked":
+        # SF cache interleaved like the data cache: kv_cache_sf[:, 0/1] are
+        # non-contiguous views whose head-unit strides match the data cache.
+        kv_cache_sf = torch.stack([k_scale, v_scale], dim=1)
+    else:
+        # SF cache as two independently-allocated contiguous tensors. The SF
+        # page stride (page_size * num_kv_heads * head_dim/16) no longer carries
+        # the factor-2 from interleaving K and V, so it diverges from the data
+        # cache page stride and exercises the separate sf_stride_* path.
+        kv_cache_sf = (k_scale.contiguous(), v_scale.contiguous())
 
     page_table, all_page_ids, page_per_seq = create_page_table(
         batch_size, seq_lens, page_size


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended MHA and FlashInfer launches to pass through additional 4-bit KV-cache stride parameters for SF (“scaling factor”) layouts, improving correct SF-based K/V loading.
* **Bug Fixes**
  * Added runtime validation to reject unsupported NVFP4 KV cache page sizes (16–32), matching documented support.
* **Documentation**
  * Clarified that NVFP4 KV cache page sizes 64–128 are supported; 16–32 are not.
* **Tests**
  * Expanded NVFP4 batch decode coverage with additional SF layouts/stride scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->