### PR TITLE
test: fix CUDA OOM in batch-prefill custom-mask test on 24GB CI GPUs

### DIFF
--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -20,6 +20,7 @@ import torch
 from tests.test_helpers.jit_utils import gen_prefill_attention_modules
 
 import flashinfer
+from tests.test_helpers.test_helpers import assert_close_chunked
 from tests.test_helpers.utils_fp4 import create_nvfp4_kv, nvfp4_to_float
 from flashinfer.utils import has_flashinfer_jit_cache
 
@@ -813,7 +814,12 @@ def test_batch_prefill_with_ragged_kv_cache_custom_mask(
         o_causal, _ = wrapper.run(q, k, v, return_lse=True)
     else:
         o_causal = wrapper.run(q, k, v)
-    torch.testing.assert_close(o_custom, o_causal, rtol=1e-3, atol=1e-3)
+    # Free everything but the two outputs before comparing: for the largest
+    # parametrizations o_custom/o_causal are ~1.1 GiB each and
+    # torch.testing.assert_close allocates several full-size temporaries
+    # inside torch.isclose, which OOMs 24 GB CI GPUs (issue #3603).
+    del q, k, v, custom_mask, wrapper, workspace_buffer
+    assert_close_chunked(o_custom, o_causal, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("batch_size", [1])

--- a/tests/test_helpers/test_helpers.py
+++ b/tests/test_helpers/test_helpers.py
@@ -77,3 +77,36 @@ def assert_close_with_mismatch_tolerance(
             f"Greatest absolute difference: {torch.max(abs_diff).item():.4g} (atol={atol})\n"
             f"Greatest relative difference: {torch.max(rel_diff).item():.4g} (rtol={rtol})"
         )
+
+
+def assert_close_chunked(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    rtol: float,
+    atol: float,
+    chunk_rows: int = 4096,
+):
+    """Memory-frugal drop-in for torch.testing.assert_close on large tensors.
+
+    torch.testing.assert_close allocates several full-size temporaries inside
+    torch.isclose; on multi-GiB operands that transient spike is enough to OOM
+    a 24 GB CI GPU. Comparing in row chunks along dim 0 bounds the transient
+    to the chunk size while keeping identical pass/fail semantics
+    (equal_nan default matches torch.testing.assert_close).
+    """
+    assert actual.shape == expected.shape, (
+        f"shape mismatch: {actual.shape} vs {expected.shape}"
+    )
+    if actual.ndim == 0 or actual.numel() == 0:
+        torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+        return
+    for start in range(0, actual.shape[0], chunk_rows):
+        end = min(start + chunk_rows, actual.shape[0])
+        torch.testing.assert_close(
+            actual[start:end],
+            expected[start:end],
+            rtol=rtol,
+            atol=atol,
+            msg=lambda m, s=start, e=end: f"rows [{s}:{e}]: {m}",
+        )

--- a/tests/test_helpers/test_helpers.py
+++ b/tests/test_helpers/test_helpers.py
@@ -86,20 +86,21 @@ def assert_close_chunked(
     rtol: float,
     atol: float,
     chunk_rows: int = 4096,
+    **kwargs,
 ):
     """Memory-frugal drop-in for torch.testing.assert_close on large tensors.
 
     torch.testing.assert_close allocates several full-size temporaries inside
     torch.isclose; on multi-GiB operands that transient spike is enough to OOM
     a 24 GB CI GPU. Comparing in row chunks along dim 0 bounds the transient
-    to the chunk size while keeping identical pass/fail semantics
-    (equal_nan default matches torch.testing.assert_close).
+    to the chunk size while keeping identical pass/fail semantics. Extra
+    keyword arguments (e.g. equal_nan, check_dtype) are forwarded to
+    torch.testing.assert_close.
     """
-    assert actual.shape == expected.shape, (
-        f"shape mismatch: {actual.shape} vs {expected.shape}"
-    )
+    if actual.shape != expected.shape:
+        raise AssertionError(f"shape mismatch: {actual.shape} vs {expected.shape}")
     if actual.ndim == 0 or actual.numel() == 0:
-        torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+        torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol, **kwargs)
         return
     for start in range(0, actual.shape[0], chunk_rows):
         end = min(start + chunk_rows, actual.shape[0])
@@ -109,4 +110,5 @@ def assert_close_chunked(
             rtol=rtol,
             atol=atol,
             msg=lambda m, s=start, e=end: f"rows [{s}:{e}]: {m}",
+            **kwargs,
         )


### PR DESCRIPTION
## Description

Fixes #3603 (nightly CI OOM in `test_batch_prefill_with_ragged_kv_cache_custom_mask`).

For the failing parametrizations (`batch=128, qo_len=577, heads=32, head_dim=256`) the two fp16 outputs are ~1.1 GiB each, and `torch.testing.assert_close` allocates several full-size temporaries inside `torch.isclose` — on top of the still-live `q`/`k`/`v`, bool custom mask, and 256 MB workspace buffer. That transient spike is what pushes 22–24 GB CI GPUs over the edge.

Two changes:
1. Free everything except the two output tensors before the comparison.
2. Compare via a new shared `assert_close_chunked` helper in `tests/test_helpers/test_helpers.py` (row-chunked `torch.testing.assert_close`; bounds the comparison transient to the chunk size, identical pass/fail semantics, scalar/empty fall-through).

## Validation

Measured on RTX PRO 6000 (96 GB, SM120) running exactly the two failing parametrizations:

| | peak `torch.cuda.max_memory_allocated` |
|---|---|
| before | **9.333 GiB** |
| after | **3.694 GiB** |

Both parametrizations pass after the change (`2 passed`). Sensitivity-probed the chunked compare: identical tensors pass, a single corrupted mid-tensor element is caught, scalar/empty guards work.

## Tests

- [x] Tests have been added or updated as needed (test-only change)
- [x] All tests are passing (`2 passed` on the failing parametrizations; pre-commit clean)

## Disclosure

AI-assisted (Claude); reviewed and validated by the submitter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved memory efficiency in tests to avoid out-of-memory errors on large tensor comparisons.
  * Added a memory-frugal tensor comparison helper that compares tensors in row-wise chunks.
  * Updated tests to release large intermediate tensors before comparison and to use chunked comparisons for the largest configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->