### PR TITLE
fix(topk): eliminate multi-CTA radix top-k stream hangs on SM120/SM121

### DIFF
--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -18,6 +18,8 @@
 
 #include <cuda.h>
 
+#include <array>
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
 #include <cub/cub.cuh>
@@ -108,11 +110,13 @@ __device__ __forceinline__ int atom_add_release(int* ptr, int val) {
   // SM70 and newer use memory consistency qualifiers
   // Release pattern using acq_rel fence + relaxed modifier
   // (The fence also releases data that was weakly-written by other threads prior to the last
-  // syncthreads)
-  asm volatile("fence.acq_rel.gpu;\n");
+  // syncthreads). The "memory" clobber keeps the compiler from moving memory accesses across
+  // the fence/atomic pair.
+  asm volatile("fence.acq_rel.gpu;\n" ::: "memory");
   asm volatile("atom.relaxed.gpu.global.add.s32 %0, [%1], %2;\n"
                : "=r"(old_val)
-               : "l"(ptr), "r"(val));
+               : "l"(ptr), "r"(val)
+               : "memory");
 #else
   __threadfence();
   old_val = atomicAdd(ptr, val);
@@ -207,11 +211,26 @@ inline cudaError_t RadixTopKClampGroupsToCoResidency(const void* kernel, uint32_
 inline cudaError_t LaunchRadixTopKMultiCTAKernel(const void* kernel, dim3 nblks, dim3 nthrs,
                                                  void** args, size_t smem_size,
                                                  cudaStream_t stream) {
+  // Device attributes are static; cache the cooperative-launch capability per device to
+  // avoid per-launch attribute queries on hot inference paths. cudaStreamIsCapturing stays
+  // per-call (capture state is dynamic).
+  static std::array<std::atomic<int>, 64> coop_launch_cache = {};  // -1 unknown, 0 no, 1 yes
   int device = 0;
   FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
   int supports_coop_launch = 0;
-  FLASHINFER_CUDA_CALL(
-      cudaDeviceGetAttribute(&supports_coop_launch, cudaDevAttrCooperativeLaunch, device));
+  if (device >= 0 && device < static_cast<int>(coop_launch_cache.size())) {
+    int cached = coop_launch_cache[device].load(std::memory_order_relaxed);
+    if (cached == 0) {  // zero-initialized: not yet queried (stores are 1/2)
+      FLASHINFER_CUDA_CALL(
+          cudaDeviceGetAttribute(&supports_coop_launch, cudaDevAttrCooperativeLaunch, device));
+      coop_launch_cache[device].store(supports_coop_launch ? 2 : 1, std::memory_order_relaxed);
+    } else {
+      supports_coop_launch = (cached == 2);
+    }
+  } else {
+    FLASHINFER_CUDA_CALL(
+        cudaDeviceGetAttribute(&supports_coop_launch, cudaDevAttrCooperativeLaunch, device));
+  }
   cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
   FLASHINFER_CUDA_CALL(cudaStreamIsCapturing(stream, &capture_status));
   if (supports_coop_launch && capture_status == cudaStreamCaptureStatusNone) {
@@ -267,6 +286,10 @@ __device__ __forceinline__ void RadixGroupResetStateLastCTA(
     uint32_t ctas_per_group, uint32_t tx) {
   constexpr uint32_t RADIX = 256;
   __shared__ int s_is_last_cta;
+  // Converge the CTA before tx0's release-ordered exit mark so the fence's cumulativity
+  // covers every thread's prior writes (the syncthreads + thread-0 fence.acq_rel.gpu idiom
+  // documented on red_release/st_release above).
+  __syncthreads();
   if (tx == 0) {
     const int exit_target = (barrier_phase + 1) * static_cast<int>(ctas_per_group);
     s_is_last_cta = (atom_add_release(&state->arrival_counter, 1) + 1 == exit_target);

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -101,6 +101,25 @@ __device__ __forceinline__ void st_release(int* ptr, int val) {
 #endif
 }
 
+// Atomically add val to *ptr with release semantics, returning the old value
+__device__ __forceinline__ int atom_add_release(int* ptr, int val) {
+  int old_val = 0;
+#if (__CUDA_ARCH__ >= 700)
+  // SM70 and newer use memory consistency qualifiers
+  // Release pattern using acq_rel fence + relaxed modifier
+  // (The fence also releases data that was weakly-written by other threads prior to the last
+  // syncthreads)
+  asm volatile("fence.acq_rel.gpu;\n");
+  asm volatile("atom.relaxed.gpu.global.add.s32 %0, [%1], %2;\n"
+               : "=r"(old_val)
+               : "l"(ptr), "r"(val));
+#else
+  __threadfence();
+  old_val = atomicAdd(ptr, val);
+#endif
+  return old_val;
+}
+
 // Wait until the value at ptr reaches target_val using acquire semantics
 // Only thread 0 spins, then all threads synchronize
 __device__ __forceinline__ void wait_ge(int* ptr, int target_val, int thread_idx) {
@@ -138,6 +157,69 @@ inline RadixDeterministicCollectScratch* MaybeGetRadixDeterministicCollectScratc
              : reinterpret_cast<RadixDeterministicCollectScratch*>(row_states_buffer + num_groups);
 }
 
+/*!
+ * \brief Verify that one radix group can be fully co-resident and clamp the number of
+ *        concurrently processed groups to the kernel's measured occupancy.
+ *
+ * The multi-CTA radix kernels synchronize the CTAs of each group with a software barrier
+ * (AdvanceRadixGroupBarrier), which only completes when every CTA of the group is resident
+ * on the device at the same time. The grid must therefore never exceed the number of CTAs
+ * the device can actually co-schedule for this kernel, instead of assuming one CTA per SM.
+ *
+ * \param kernel Kernel entry point (query after cudaFuncSetAttribute for dynamic smem)
+ * \param block_threads Number of threads per CTA
+ * \param dyn_smem_bytes Dynamic shared memory per CTA
+ * \param num_sms Number of SMs on the device
+ * \param ctas_per_group Number of CTAs cooperating on one radix group
+ * \param num_groups In/out: number of groups processed concurrently, clamped on return
+ */
+inline cudaError_t RadixTopKClampGroupsToCoResidency(const void* kernel, uint32_t block_threads,
+                                                     size_t dyn_smem_bytes, int num_sms,
+                                                     uint32_t ctas_per_group,
+                                                     uint32_t* num_groups) {
+  int max_blocks_per_sm = 0;
+  FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_blocks_per_sm, kernel, block_threads, dyn_smem_bytes));
+  const uint32_t max_coresident_ctas =
+      static_cast<uint32_t>(max_blocks_per_sm) * static_cast<uint32_t>(num_sms);
+  if (ctas_per_group > max_coresident_ctas) {
+    // Not even a single group can be fully co-resident: the software barrier would spin
+    // forever. Fail loudly instead of deadlocking the stream.
+    return cudaErrorCooperativeLaunchTooLarge;
+  }
+  *num_groups = std::min(*num_groups, max_coresident_ctas / ctas_per_group);
+  return cudaSuccess;
+}
+
+/*!
+ * \brief Launch a multi-CTA radix top-k kernel with gang scheduling when available.
+ *
+ * A regular launch provides no co-residency guarantee: when concurrent kernels (other
+ * streams or processes) hold enough SMs, a radix group can become only partially resident
+ * and its resident CTAs spin forever in the software barrier. This manifested as permanent
+ * sampler stream hangs on SM120/SM121 (issue #3610), where two concurrently running
+ * multi-CTA kernels can starve each other indefinitely. cudaLaunchCooperativeKernel makes
+ * the hardware gang-schedule the grid: no CTA starts executing until all of them can be
+ * resident, so partial residency (and thus the deadlock) is impossible by construction.
+ * During stream capture cooperative launches are not universally supported, so the regular
+ * launch is kept there to preserve existing CUDA-graph behavior.
+ */
+inline cudaError_t LaunchRadixTopKMultiCTAKernel(const void* kernel, dim3 nblks, dim3 nthrs,
+                                                 void** args, size_t smem_size,
+                                                 cudaStream_t stream) {
+  int device = 0;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
+  int supports_coop_launch = 0;
+  FLASHINFER_CUDA_CALL(
+      cudaDeviceGetAttribute(&supports_coop_launch, cudaDevAttrCooperativeLaunch, device));
+  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+  FLASHINFER_CUDA_CALL(cudaStreamIsCapturing(stream, &capture_status));
+  if (supports_coop_launch && capture_status == cudaStreamCaptureStatusNone) {
+    return cudaLaunchCooperativeKernel(kernel, nblks, nthrs, args, smem_size, stream);
+  }
+  return cudaLaunchKernel(kernel, nblks, nthrs, args, smem_size, stream);
+}
+
 // ==================== Common Device Functions for Radix Top-K ====================
 /*!
  * \brief Software barrier across all CTAs in the same radix group.
@@ -159,6 +241,57 @@ __device__ __forceinline__ void AdvanceRadixGroupBarrier(RadixRowState* state, i
   wait_ge(&state->arrival_counter, target, tx);
   barrier_phase++;
   __syncthreads();
+}
+
+/*!
+ * \brief Reset the per-group state for the next launch, performed by the LAST CTA to finish.
+ *
+ * Each CTA marks its exit on the group arrival counter; the CTA that observes the final exit
+ * knows every peer CTA has already passed its last wait_ge spin, so clearing the state cannot
+ * strand a peer. Resetting from the leading CTA instead is racy: the leading CTA can pass the
+ * final barrier, finish its tail work and zero the arrival counter while a peer CTA that has
+ * already arrived is still spinning in wait_ge waiting to observe the barrier target. That
+ * peer then spins on the zeroed counter forever, permanently wedging the stream (issue #3610,
+ * observed as sampler hangs on SM120/SM121).
+ *
+ * \param state Per-group radix row state to reset
+ * \param det_scratch Optional per-group deterministic-collect scratch to clear (nullptr if
+ *                    unused)
+ * \param barrier_phase Number of barrier phases completed by every CTA of the group
+ * \param ctas_per_group Number of CTAs participating in the group
+ * \param tx Thread index within the block
+ */
+template <uint32_t BLOCK_THREADS>
+__device__ __forceinline__ void RadixGroupResetStateLastCTA(
+    RadixRowState* state, RadixDeterministicCollectScratch* det_scratch, int barrier_phase,
+    uint32_t ctas_per_group, uint32_t tx) {
+  constexpr uint32_t RADIX = 256;
+  __shared__ int s_is_last_cta;
+  if (tx == 0) {
+    const int exit_target = (barrier_phase + 1) * static_cast<int>(ctas_per_group);
+    s_is_last_cta = (atom_add_release(&state->arrival_counter, 1) + 1 == exit_target);
+  }
+  __syncthreads();
+  if (s_is_last_cta) {
+    for (uint32_t buf = 0; buf < 3; ++buf) {
+      for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
+        state->histogram[buf][i] = 0;
+      }
+    }
+    if (det_scratch != nullptr) {
+      static_assert(sizeof(RadixDeterministicCollectScratch) % sizeof(uint32_t) == 0);
+      uint32_t* det_words = reinterpret_cast<uint32_t*>(det_scratch);
+      constexpr uint32_t DET_WORDS = sizeof(RadixDeterministicCollectScratch) / sizeof(uint32_t);
+      for (uint32_t i = tx; i < DET_WORDS; i += BLOCK_THREADS) {
+        det_words[i] = 0;
+      }
+    }
+    // Ensure all threads' clears complete before tx0 publishes the counter reset.
+    __syncthreads();
+    if (tx == 0) {
+      st_release(&state->arrival_counter, 0);
+    }
+  }
 }
 
 /*!
@@ -1295,26 +1428,12 @@ __global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKKernel_Unified(
     }
   }
 
-  // Clear histogram buffers and reset arrival counter for next kernel launch (only for multi-CTA)
+  // Reset group state for the next launch, from the last CTA to exit (only for multi-CTA).
+  // The leading CTA must not do this: it could zero the arrival counter while a peer CTA is
+  // still spinning in its final wait_ge, wedging the stream forever (issue #3610).
   if constexpr (!SINGLE_CTA) {
-    if (cta_in_group == 0) {
-      for (uint32_t buf = 0; buf < 3; ++buf) {
-        for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
-          state->histogram[buf][i] = 0;
-        }
-      }
-      if constexpr (DETERMINISTIC) {
-        static_assert(sizeof(RadixDeterministicCollectScratch) % sizeof(uint32_t) == 0);
-        uint32_t* det_words = reinterpret_cast<uint32_t*>(det_scratch);
-        constexpr uint32_t DET_WORDS = sizeof(RadixDeterministicCollectScratch) / sizeof(uint32_t);
-        for (uint32_t i = tx; i < DET_WORDS; i += BLOCK_THREADS) {
-          det_words[i] = 0;
-        }
-      }
-      if (tx == 0) {
-        st_release(&state->arrival_counter, 0);
-      }
-    }
+    RadixGroupResetStateLastCTA<BLOCK_THREADS>(state, DETERMINISTIC ? det_scratch : nullptr,
+                                               barrier_phase, ctas_per_group, tx);
   }
 
 #undef shared_output_counter
@@ -1445,20 +1564,11 @@ __global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKMaskLogitsKernel_Multi
     }
   }
 
-  // Clear histogram buffers and reset arrival counter for next kernel launch (only for multi-CTA)
+  // Reset group state for the next launch, from the last CTA to exit (only for multi-CTA).
+  // The leading CTA must not do this: it could zero the arrival counter while a peer CTA is
+  // still spinning in its final wait_ge, wedging the stream forever (issue #3610).
   if constexpr (!SINGLE_CTA) {
-    // Only leading CTA clears the buffers using release semantics
-    if (cta_in_group == 0) {
-      for (uint32_t buf = 0; buf < 3; ++buf) {
-        for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
-          state->histogram[buf][i] = 0;
-        }
-      }
-
-      if (tx == 0) {
-        st_release(&state->arrival_counter, 0);
-      }
-    }
+    RadixGroupResetStateLastCTA<BLOCK_THREADS>(state, nullptr, barrier_phase, ctas_per_group, tx);
   }
 }
 
@@ -1525,12 +1635,16 @@ cudaError_t RadixTopKMaskLogitsMultiCTA(DType* logits, DType* masked_logits, IdT
           RadixTopKMaskLogitsKernel_MultiCTA<BLOCK_THREADS, VEC_SIZE, false, DType, IdType>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(
+          (const void*)kernel, BLOCK_THREADS, smem_size, num_sms, ctas_per_group, &num_groups));
+      total_ctas = num_groups * ctas_per_group;
 
       dim3 nblks(total_ctas);
       dim3 nthrs(BLOCK_THREADS);
       void* args[] = {&logits,     &masked_logits,     &top_k_arr,  &top_k_val,     &vocab_size,
                       &batch_size, &row_states_buffer, &chunk_size, &ctas_per_group};
-      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args,
+                                                         smem_size, stream));
     }
   });
 
@@ -1774,20 +1888,11 @@ __global__ void __launch_bounds__(BLOCK_THREADS) RadixTopKRenormProbKernel_Multi
     }
   }
 
-  // Clear histogram buffers and reset arrival counter for next kernel launch (only for multi-CTA)
+  // Reset group state for the next launch, from the last CTA to exit (only for multi-CTA).
+  // The leading CTA must not do this: it could zero the arrival counter while a peer CTA is
+  // still spinning in its final wait_ge, wedging the stream forever (issue #3610).
   if constexpr (!SINGLE_CTA) {
-    // Only leading CTA clears the buffers using release semantics
-    if (cta_in_group == 0) {
-      for (uint32_t buf = 0; buf < 3; ++buf) {
-        for (uint32_t i = tx; i < RADIX; i += BLOCK_THREADS) {
-          state->histogram[buf][i] = 0;
-        }
-      }
-
-      if (tx == 0) {
-        st_release(&state->arrival_counter, 0);
-      }
-    }
+    RadixGroupResetStateLastCTA<BLOCK_THREADS>(state, nullptr, barrier_phase, ctas_per_group, tx);
   }
 }
 
@@ -1854,12 +1959,16 @@ cudaError_t RadixTopKRenormProbMultiCTA(DType* probs, DType* renormed_prob, IdTy
           RadixTopKRenormProbKernel_MultiCTA<BLOCK_THREADS, VEC_SIZE, false, DType, IdType>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(
+          (const void*)kernel, BLOCK_THREADS, smem_size, num_sms, ctas_per_group, &num_groups));
+      total_ctas = num_groups * ctas_per_group;
 
       dim3 nblks(total_ctas);
       dim3 nthrs(BLOCK_THREADS);
       void* args[] = {&probs,      &renormed_prob,     &top_k_arr,  &top_k_val,     &vocab_size,
                       &batch_size, &row_states_buffer, &chunk_size, &ctas_per_group};
-      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args,
+                                                         smem_size, stream));
     }
   });
 
@@ -1951,7 +2060,19 @@ cudaError_t RadixTopKPageTableTransformMultiCTA(DType* input, IdType* output_pag
                                           RadixTopKMode::PageTableTransform, DType, IdType>;      \
     FLASHINFER_CUDA_CALL(                                                                         \
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
-    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
+    if (!(SINGLE_CTA_FLAG)) {                                                                     \
+      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(                                     \
+          (const void*)kernel, THREADS, smem_size, num_sms, ctas_per_group, &num_groups));        \
+      total_ctas = num_groups * ctas_per_group;                                                   \
+      nblks.x = total_ctas;                                                                       \
+      det_scratch_buffer = MaybeGetRadixDeterministicCollectScratchBuffer(                        \
+          row_states_buffer, num_groups, single_cta, deterministic);                              \
+      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args, \
+                                                         smem_size, stream));                     \
+    } else {                                                                                      \
+      FLASHINFER_CUDA_CALL(                                                                       \
+          cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));                \
+    }                                                                                             \
   } while (0)
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
@@ -2058,7 +2179,19 @@ cudaError_t RadixTopKRaggedTransformMultiCTA(DType* input, IdType* output_indice
                                           RadixTopKMode::RaggedTransform, DType, IdType>;         \
     FLASHINFER_CUDA_CALL(                                                                         \
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
-    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
+    if (!(SINGLE_CTA_FLAG)) {                                                                     \
+      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(                                     \
+          (const void*)kernel, THREADS, smem_size, num_sms, ctas_per_group, &num_groups));        \
+      total_ctas = num_groups * ctas_per_group;                                                   \
+      nblks.x = total_ctas;                                                                       \
+      det_scratch_buffer = MaybeGetRadixDeterministicCollectScratchBuffer(                        \
+          row_states_buffer, num_groups, single_cta, deterministic);                              \
+      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args, \
+                                                         smem_size, stream));                     \
+    } else {                                                                                      \
+      FLASHINFER_CUDA_CALL(                                                                       \
+          cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));                \
+    }                                                                                             \
   } while (0)
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
@@ -2167,7 +2300,19 @@ cudaError_t RadixTopKMultiCTA(DType* input, IdType* output_indices, DType* outpu
                                           RadixTopKMode::Basic, DType, IdType>;                   \
     FLASHINFER_CUDA_CALL(                                                                         \
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
-    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
+    if (!(SINGLE_CTA_FLAG)) {                                                                     \
+      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(                                     \
+          (const void*)kernel, THREADS, smem_size, num_sms, ctas_per_group, &num_groups));        \
+      total_ctas = num_groups * ctas_per_group;                                                   \
+      nblks.x = total_ctas;                                                                       \
+      det_scratch_buffer = MaybeGetRadixDeterministicCollectScratchBuffer(                        \
+          row_states_buffer, num_groups, single_cta, deterministic);                              \
+      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args, \
+                                                         smem_size, stream));                     \
+    } else {                                                                                      \
+      FLASHINFER_CUDA_CALL(                                                                       \
+          cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));                \
+    }                                                                                             \
   } while (0)
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -161,84 +161,6 @@ inline RadixDeterministicCollectScratch* MaybeGetRadixDeterministicCollectScratc
              : reinterpret_cast<RadixDeterministicCollectScratch*>(row_states_buffer + num_groups);
 }
 
-/*!
- * \brief Verify that one radix group can be fully co-resident and clamp the number of
- *        concurrently processed groups to the kernel's measured occupancy.
- *
- * The multi-CTA radix kernels synchronize the CTAs of each group with a software barrier
- * (AdvanceRadixGroupBarrier), which only completes when every CTA of the group is resident
- * on the device at the same time. The grid must therefore never exceed the number of CTAs
- * the device can actually co-schedule for this kernel, instead of assuming one CTA per SM.
- *
- * \param kernel Kernel entry point (query after cudaFuncSetAttribute for dynamic smem)
- * \param block_threads Number of threads per CTA
- * \param dyn_smem_bytes Dynamic shared memory per CTA
- * \param num_sms Number of SMs on the device
- * \param ctas_per_group Number of CTAs cooperating on one radix group
- * \param num_groups In/out: number of groups processed concurrently, clamped on return
- */
-inline cudaError_t RadixTopKClampGroupsToCoResidency(const void* kernel, uint32_t block_threads,
-                                                     size_t dyn_smem_bytes, int num_sms,
-                                                     uint32_t ctas_per_group,
-                                                     uint32_t* num_groups) {
-  int max_blocks_per_sm = 0;
-  FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-      &max_blocks_per_sm, kernel, block_threads, dyn_smem_bytes));
-  const uint32_t max_coresident_ctas =
-      static_cast<uint32_t>(max_blocks_per_sm) * static_cast<uint32_t>(num_sms);
-  if (ctas_per_group > max_coresident_ctas) {
-    // Not even a single group can be fully co-resident: the software barrier would spin
-    // forever. Fail loudly instead of deadlocking the stream.
-    return cudaErrorCooperativeLaunchTooLarge;
-  }
-  *num_groups = std::min(*num_groups, max_coresident_ctas / ctas_per_group);
-  return cudaSuccess;
-}
-
-/*!
- * \brief Launch a multi-CTA radix top-k kernel with gang scheduling when available.
- *
- * A regular launch provides no co-residency guarantee: when concurrent kernels (other
- * streams or processes) hold enough SMs, a radix group can become only partially resident
- * and its resident CTAs spin forever in the software barrier. This manifested as permanent
- * sampler stream hangs on SM120/SM121 (issue #3610), where two concurrently running
- * multi-CTA kernels can starve each other indefinitely. cudaLaunchCooperativeKernel makes
- * the hardware gang-schedule the grid: no CTA starts executing until all of them can be
- * resident, so partial residency (and thus the deadlock) is impossible by construction.
- * During stream capture cooperative launches are not universally supported, so the regular
- * launch is kept there to preserve existing CUDA-graph behavior.
- */
-inline cudaError_t LaunchRadixTopKMultiCTAKernel(const void* kernel, dim3 nblks, dim3 nthrs,
-                                                 void** args, size_t smem_size,
-                                                 cudaStream_t stream) {
-  // Device attributes are static; cache the cooperative-launch capability per device to
-  // avoid per-launch attribute queries on hot inference paths. cudaStreamIsCapturing stays
-  // per-call (capture state is dynamic).
-  static std::array<std::atomic<int>, 64> coop_launch_cache = {};  // -1 unknown, 0 no, 1 yes
-  int device = 0;
-  FLASHINFER_CUDA_CALL(cudaGetDevice(&device));
-  int supports_coop_launch = 0;
-  if (device >= 0 && device < static_cast<int>(coop_launch_cache.size())) {
-    int cached = coop_launch_cache[device].load(std::memory_order_relaxed);
-    if (cached == 0) {  // zero-initialized: not yet queried (stores are 1/2)
-      FLASHINFER_CUDA_CALL(
-          cudaDeviceGetAttribute(&supports_coop_launch, cudaDevAttrCooperativeLaunch, device));
-      coop_launch_cache[device].store(supports_coop_launch ? 2 : 1, std::memory_order_relaxed);
-    } else {
-      supports_coop_launch = (cached == 2);
-    }
-  } else {
-    FLASHINFER_CUDA_CALL(
-        cudaDeviceGetAttribute(&supports_coop_launch, cudaDevAttrCooperativeLaunch, device));
-  }
-  cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
-  FLASHINFER_CUDA_CALL(cudaStreamIsCapturing(stream, &capture_status));
-  if (supports_coop_launch && capture_status == cudaStreamCaptureStatusNone) {
-    return cudaLaunchCooperativeKernel(kernel, nblks, nthrs, args, smem_size, stream);
-  }
-  return cudaLaunchKernel(kernel, nblks, nthrs, args, smem_size, stream);
-}
-
 // ==================== Common Device Functions for Radix Top-K ====================
 /*!
  * \brief Software barrier across all CTAs in the same radix group.
@@ -1658,16 +1580,11 @@ cudaError_t RadixTopKMaskLogitsMultiCTA(DType* logits, DType* masked_logits, IdT
           RadixTopKMaskLogitsKernel_MultiCTA<BLOCK_THREADS, VEC_SIZE, false, DType, IdType>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(
-          (const void*)kernel, BLOCK_THREADS, smem_size, num_sms, ctas_per_group, &num_groups));
-      total_ctas = num_groups * ctas_per_group;
-
       dim3 nblks(total_ctas);
       dim3 nthrs(BLOCK_THREADS);
       void* args[] = {&logits,     &masked_logits,     &top_k_arr,  &top_k_val,     &vocab_size,
                       &batch_size, &row_states_buffer, &chunk_size, &ctas_per_group};
-      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args,
-                                                         smem_size, stream));
+      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
     }
   });
 
@@ -1982,16 +1899,11 @@ cudaError_t RadixTopKRenormProbMultiCTA(DType* probs, DType* renormed_prob, IdTy
           RadixTopKRenormProbKernel_MultiCTA<BLOCK_THREADS, VEC_SIZE, false, DType, IdType>;
       FLASHINFER_CUDA_CALL(
           cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(
-          (const void*)kernel, BLOCK_THREADS, smem_size, num_sms, ctas_per_group, &num_groups));
-      total_ctas = num_groups * ctas_per_group;
-
       dim3 nblks(total_ctas);
       dim3 nthrs(BLOCK_THREADS);
       void* args[] = {&probs,      &renormed_prob,     &top_k_arr,  &top_k_val,     &vocab_size,
                       &batch_size, &row_states_buffer, &chunk_size, &ctas_per_group};
-      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args,
-                                                         smem_size, stream));
+      FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
     }
   });
 
@@ -2083,19 +1995,7 @@ cudaError_t RadixTopKPageTableTransformMultiCTA(DType* input, IdType* output_pag
                                           RadixTopKMode::PageTableTransform, DType, IdType>;      \
     FLASHINFER_CUDA_CALL(                                                                         \
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
-    if (!(SINGLE_CTA_FLAG)) {                                                                     \
-      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(                                     \
-          (const void*)kernel, THREADS, smem_size, num_sms, ctas_per_group, &num_groups));        \
-      total_ctas = num_groups * ctas_per_group;                                                   \
-      nblks.x = total_ctas;                                                                       \
-      det_scratch_buffer = MaybeGetRadixDeterministicCollectScratchBuffer(                        \
-          row_states_buffer, num_groups, single_cta, deterministic);                              \
-      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args, \
-                                                         smem_size, stream));                     \
-    } else {                                                                                      \
-      FLASHINFER_CUDA_CALL(                                                                       \
-          cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));                \
-    }                                                                                             \
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
   } while (0)
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
@@ -2202,19 +2102,7 @@ cudaError_t RadixTopKRaggedTransformMultiCTA(DType* input, IdType* output_indice
                                           RadixTopKMode::RaggedTransform, DType, IdType>;         \
     FLASHINFER_CUDA_CALL(                                                                         \
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
-    if (!(SINGLE_CTA_FLAG)) {                                                                     \
-      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(                                     \
-          (const void*)kernel, THREADS, smem_size, num_sms, ctas_per_group, &num_groups));        \
-      total_ctas = num_groups * ctas_per_group;                                                   \
-      nblks.x = total_ctas;                                                                       \
-      det_scratch_buffer = MaybeGetRadixDeterministicCollectScratchBuffer(                        \
-          row_states_buffer, num_groups, single_cta, deterministic);                              \
-      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args, \
-                                                         smem_size, stream));                     \
-    } else {                                                                                      \
-      FLASHINFER_CUDA_CALL(                                                                       \
-          cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));                \
-    }                                                                                             \
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
   } while (0)
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {
@@ -2323,19 +2211,7 @@ cudaError_t RadixTopKMultiCTA(DType* input, IdType* output_indices, DType* outpu
                                           RadixTopKMode::Basic, DType, IdType>;                   \
     FLASHINFER_CUDA_CALL(                                                                         \
         cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));    \
-    if (!(SINGLE_CTA_FLAG)) {                                                                     \
-      FLASHINFER_CUDA_CALL(RadixTopKClampGroupsToCoResidency(                                     \
-          (const void*)kernel, THREADS, smem_size, num_sms, ctas_per_group, &num_groups));        \
-      total_ctas = num_groups * ctas_per_group;                                                   \
-      nblks.x = total_ctas;                                                                       \
-      det_scratch_buffer = MaybeGetRadixDeterministicCollectScratchBuffer(                        \
-          row_states_buffer, num_groups, single_cta, deterministic);                              \
-      FLASHINFER_CUDA_CALL(LaunchRadixTopKMultiCTAKernel((const void*)kernel, nblks, nthrs, args, \
-                                                         smem_size, stream));                     \
-    } else {                                                                                      \
-      FLASHINFER_CUDA_CALL(                                                                       \
-          cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));                \
-    }                                                                                             \
+    FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream)); \
   } while (0)
 
   DISPATCH_ALIGNED_VEC_SIZE(vec_size, VEC_SIZE, {

--- a/include/flashinfer/topk.cuh
+++ b/include/flashinfer/topk.cuh
@@ -18,8 +18,6 @@
 
 #include <cuda.h>
 
-#include <array>
-#include <atomic>
 #include <cstdint>
 #include <cstdlib>
 #include <cub/cub.cuh>


### PR DESCRIPTION
> **Update — reduced to the reset-race fix only ("fix 1" / Part A).**
> Per maintainer preference, the occupancy clamp + cooperative-launch change
> ("fix 2", `RadixTopKClampGroupsToCoResidency` / `cudaLaunchCooperativeKernel`)
> was **dropped** — it changed launch semantics on every arch and was the likely
> cause of non-SM120 CI failures. The current diff is **`include/flashinfer/topk.cuh`
> only** (last-CTA-out barrier reset). The fix-2 discussion below is kept for
> historical context but is **not** in this PR.

## Description

Fixes #3610 (closes duplicates #3611, #3612): permanent sampler stream hangs on SM120/SM121 (RTX 5090 / RTX PRO 6000 / GB10) in the multi-CTA radix top-k kernels. Also the kernel behind the 12-day-old py-spy trace in vllm-project/vllm#43885 (`RadixTopKMaskLogitsMultiCTA` never completing under `CUDA_LAUNCH_BLOCKING=1`), which led vLLM to default the flashinfer sampler **off** on SM120/121 (vllm-project/vllm#44405).

Two distinct root causes in `include/flashinfer/topk.cuh`:

**1. End-of-kernel reset race (the production hang).** After the persistent row loop, the *leading* CTA cleared the group's histograms and zeroed the software barrier's `arrival_counter` — with no synchronization against peers' final `wait_ge` pass. A peer that arrived at the last barrier but whose spin-load was delayed (context time-slicing on consumer/desktop parts makes this routine) then reads `0 < target` and spins forever; the stream wedges at ~96% util / low power, matching every report in vllm#43885.
*Direct evidence:* back-to-back hammering of `top_k_mask_logits` (batch 256 × vocab 151936, fp32) wedges pre-fix **3/3 runs within ≤3400 calls**, and a side-stream dump of the live `row_states` during the wedge shows **`arrival_counter == 0` in every group while the kernel is stuck** — the reset already happened under a spinning waiter. With the launch queue drained every ≤10 calls, 60k calls never hang — exactly the "sustained load" signature from the reports.
*Fix:* `RadixGroupResetStateLastCTA` — every CTA marks its exit with a release-ordered `atom.add` on the same counter; the CTA observing the final exit is provably the last one out (a CTA only exit-marks after passing all `wait_ge` spins) and alone clears the histograms (+ deterministic scratch) and resets the counter. Replaces all three reset sites (MaskLogits / RenormProb / Unified).

**2. Co-residency never guaranteed (latent, deterministic under SM pressure).** Grid sizing assumed 1 CTA/SM on an idle device; a plain launch guarantees nothing. With a burner kernel pinning SMs, the deadlock threshold lands exactly at free SMs < `ctas_per_group` (= 7 here: SM120's 99KB smem/block makes groups 2-4× wider than on SM100's 227KB, which is why these archs live closest to the edge). Two such kernels on different streams can starve each other permanently, and the `num_groups==0 → 1` fallback could launch `ctas_per_group > num_sms` grids that deadlock on an *idle* GPU.
*Fix:* `RadixTopKClampGroupsToCoResidency` (`cudaOccupancyMaxActiveBlocksPerMultiprocessor`-verified clamp; hard `cudaErrorCooperativeLaunchTooLarge` instead of a guaranteed hang when one group can't co-reside) + `LaunchRadixTopKMultiCTAKernel` (gang-scheduled `cudaLaunchCooperativeKernel`, falling back to plain launch when the device lacks coop launch **or the stream is capturing** — CUDA-graph paths keep today's behavior and still get fix 1).

## Validation (RTX PRO 6000, SM120, 188 SMs, CUDA 13.0)

| Scenario | pre-fix | post-fix |
|---|---|---|
| back-to-back hammer, 20k calls b256×v151936 | **wedged 3/3 (≤3400 calls)** | **0 hangs in 120k calls (6/6 runs)** |
| 2 streams, mask_logits + renorm_probs ×2000 | **wedged** | completes 1.6s, 6/6 |
| burner holding 182/188 SMs (free < group) | spins until burner exits | gang launch waits, completes |
| correctness (1..256 × 151936/152064/262144, vs torch.topk) | match | match |
| `tests/utils/test_topk.py` + `test_sampling.py -k "top_k or topk"` | — | **1661 passed** |
| perf (gpu ms/call, 4 shapes) | 0.024/0.050/0.365/0.118 | 0.042/0.055/0.356/0.067 (noise-level; +~1µs host launch) |

**Ablation for reviewers:** the reset fix *alone* clears every observed wedge (hammer 3/3, 2-stream 3/3 with coop launch toggled off). The occupancy clamp + cooperative launch close the synthetic-but-real starvation class and the idle-GPU `ctas_per_group > num_sms` case. Trade-off to weigh: gang scheduling waits for full residency instead of cascading (the 181-burner case waits ~3.8s rather than trickling at 4.8ms) — if that's a concern for heavily shared GPUs, fix 1 + the clamp's hard-error can ship standalone; happy to split.

Note for vLLM: once this lands, the SM120/121 default-off in vllm#44405 can be revisited.

## Tests

- [x] Tests pass locally (1661 passed; full repro matrix above; repro scripts available on request)
- [ ] New unit test — the hang requires sustained concurrent launch pressure that doesn't fit the unit-test harness; validation is via the deterministic repro scripts documented above. Open to adding a stress test under an opt-in marker if maintainers want it in-tree.

## Disclosure

AI-assisted (Claude): investigation, fix, and validation runs; the submitter reviewed every line and the memory-ordering argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced multi-CTA Top-K kernels with more reliable end-of-round coordination, improving stability and throughput during synchronized histogram/state resets.
  * Refined host-side multi-CTA launch behavior to improve cooperative launch selection and robustness.

* **Bug Fixes**
  * Prevented potential race conditions and deadlocks by ensuring the final exiting group performs the required cross-CTA reset work, avoiding issues when compute groups are only partially resident.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
