### PR TITLE
feat: improve gated delta rule benchmark script

### DIFF
--- a/benchmarks/bench_gdn_prefill.py
+++ b/benchmarks/bench_gdn_prefill.py
@@ -27,6 +27,7 @@ Usage:
 
 import argparse
 import sys
+import time
 
 import numpy as np
 import torch
@@ -63,6 +64,9 @@ HEAD_CONFIGS = [
 SEQ_CONFIGS = [
     # (cu_seqlen_endpoints, label)
     # endpoints are cumulative positions (leading 0 added automatically)
+    ((65536,), "1x65536"),
+    ((32768,), "1x32768"),
+    ((16384,), "1x16384"),
     ((8192,), "1x8192"),
     ((4096,), "1x4096"),
     ((2048,), "1x2048"),
@@ -72,6 +76,9 @@ SEQ_CONFIGS = [
     ((1024 * 1, 8192), "1024+7168"),
     ((2048, 2048 * 2, 2048 * 3, 8192), "2048x4"),
     (tuple(1024 * (i + 1) for i in range(8)), "1024x8"),
+    (tuple(8192 * (i + 1) for i in range(8)), "8192x8"),
+    (tuple(8192 * (i + 1) for i in range(16)), "8192x16"),
+    (tuple(8192 * (i + 1) for i in range(32)), "8192x32"),
 ]
 
 
@@ -81,7 +88,7 @@ def _gdn_tflops(total_tokens, h_v, d, time_ms):
     return flops / time_ms / 1e9
 
 
-def bench_fi(endpoints, h_qk, h_v, d, warmup, iters):
+def bench_fi(args, endpoints, h_qk, h_v, d):
     """Benchmark FlashInfer GDN prefill."""
     device = "cuda"
     dtype = torch.float16
@@ -106,13 +113,17 @@ def bench_fi(endpoints, h_qk, h_v, d, warmup, iters):
         q, k, v, g, beta, None, h0, True, cu_seqlens, False, None, state_out
     )
     times = bench_gpu_time(
-        fn, enable_cupti=True, dry_run_iters=warmup, repeat_iters=iters
+        fn,
+        enable_cupti=args.use_cupti,
+        dry_run_iters=args.warmup,
+        repeat_iters=args.iters,
+        use_cuda_graph=args.use_cuda_graph,
     )
     torch.cuda.empty_cache()
     return np.average(times)
 
 
-def bench_fla(endpoints, h_qk, h_v, d, warmup, iters):
+def bench_fla(args, endpoints, h_qk, h_v, d):
     """Benchmark FLA baseline."""
     device = "cuda"
     dtype = torch.float16
@@ -142,7 +153,11 @@ def bench_fla(endpoints, h_qk, h_v, d, warmup, iters):
         cu_seqlens=cu_seqlens,
     )
     times = bench_gpu_time(
-        fn, enable_cupti=True, dry_run_iters=warmup, repeat_iters=iters
+        fn,
+        enable_cupti=args.use_cupti,
+        dry_run_iters=args.warmup,
+        repeat_iters=args.iters,
+        use_cuda_graph=args.use_cuda_graph,
     )
     torch.cuda.empty_cache()
     return np.average(times)
@@ -152,6 +167,9 @@ def main():
     parser = argparse.ArgumentParser(description="Benchmark GDN Prefill Kernel")
     parser.add_argument("--warmup", type=int, default=5)
     parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument("--cooling-time", type=float, default=0.1)
+    parser.add_argument("--use-cupti", action="store_true")
+    parser.add_argument("--use-cuda-graph", action="store_true")
     args = parser.parse_args()
 
     device = torch.device("cuda")
@@ -186,7 +204,10 @@ def main():
     for h_qk, h_v, d, h_label in HEAD_CONFIGS:
         for endpoints, s_label in SEQ_CONFIGS:
             T = endpoints[-1]
-            fi_ms = bench_fi(endpoints, h_qk, h_v, d, args.warmup, args.iters)
+            fi_ms = bench_fi(args, endpoints, h_qk, h_v, d)
+            time.sleep(args.cooling_time)
+            fla_ms = bench_fla(args, endpoints, h_qk, h_v, d)
+            time.sleep(args.cooling_time)
             tflops = _gdn_tflops(T, h_v, d, fi_ms)
             row = (
                 f"{h_label:<15s}  {s_label:<16s}  {h_qk:>4d} {h_v:>4d}"

--- a/benchmarks/bench_gdn_prefill.py
+++ b/benchmarks/bench_gdn_prefill.py
@@ -28,6 +28,7 @@ Usage:
 import argparse
 import sys
 import time
+import gc
 
 import numpy as np
 import torch
@@ -42,6 +43,7 @@ try:
 
     _has_fla = True
 except ImportError:
+    fla_gdn = None
     _has_fla = False
 
 HEAD_CONFIGS = [
@@ -109,9 +111,29 @@ def bench_fi(args, endpoints, h_qk, h_v, d):
     h0 = torch.randn((N, h_v, d, d), dtype=torch.float32, device=device)
     state_out = torch.zeros_like(h0)
 
-    fn = lambda: chunk_gated_delta_rule(
-        q, k, v, g, beta, None, h0, True, cu_seqlens, False, None, state_out
-    )
+    q = [q.clone() for _ in range(args.iters)]
+    k = [k.clone() for _ in range(args.iters)]
+    v = [v.clone() for _ in range(args.iters)]
+    rotation_buffer_idx = 0
+
+    def fn():
+        nonlocal rotation_buffer_idx
+        chunk_gated_delta_rule(
+            q[rotation_buffer_idx % args.iters],
+            k[rotation_buffer_idx % args.iters],
+            v[rotation_buffer_idx % args.iters],
+            g,
+            beta,
+            None,
+            h0,
+            True,
+            cu_seqlens,
+            False,
+            None,
+            state_out,
+        )
+        rotation_buffer_idx += 1
+
     times = bench_gpu_time(
         fn,
         enable_cupti=args.use_cupti,
@@ -141,17 +163,27 @@ def bench_fla(args, endpoints, h_qk, h_v, d):
     beta = torch.rand(1, T, h_v, dtype=torch.float32, device=device).sigmoid()
     h0 = torch.randn((N, h_v, d, d), dtype=torch.float32, device=device)
 
-    fn = lambda: fla_gdn(
-        q,
-        k,
-        v,
-        g,
-        beta,
-        None,
-        initial_state=h0,
-        output_final_state=True,
-        cu_seqlens=cu_seqlens,
-    )
+    q = [q.clone() for _ in range(args.iters)]
+    k = [k.clone() for _ in range(args.iters)]
+    v = [v.clone() for _ in range(args.iters)]
+
+    rotation_buffer_idx = 0
+
+    def fn():
+        nonlocal rotation_buffer_idx
+        fla_gdn(
+            q[rotation_buffer_idx % args.iters],
+            k[rotation_buffer_idx % args.iters],
+            v[rotation_buffer_idx % args.iters],
+            g,
+            beta,
+            None,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+        )
+        rotation_buffer_idx += 1
+
     times = bench_gpu_time(
         fn,
         enable_cupti=args.use_cupti,
@@ -203,10 +235,9 @@ def main():
 
     for h_qk, h_v, d, h_label in HEAD_CONFIGS:
         for endpoints, s_label in SEQ_CONFIGS:
+            gc.collect()
             T = endpoints[-1]
             fi_ms = bench_fi(args, endpoints, h_qk, h_v, d)
-            time.sleep(args.cooling_time)
-            fla_ms = bench_fla(args, endpoints, h_qk, h_v, d)
             time.sleep(args.cooling_time)
             tflops = _gdn_tflops(T, h_v, d, fi_ms)
             row = (
@@ -214,7 +245,8 @@ def main():
                 f"  {fi_ms:>21.3f}ms  {tflops:>6.1f}"
             )
             if _has_fla:
-                fla_ms = bench_fla(endpoints, h_qk, h_v, d, args.warmup, args.iters)
+                fla_ms = bench_fla(args, endpoints, h_qk, h_v, d)
+                time.sleep(args.cooling_time)
                 speedup = fla_ms / fi_ms
                 marker = "+" if speedup > 1.0 else "-"
                 row += f"  {fla_ms:>9.3f}ms  {speedup:>7.2f}x {marker}"


### PR DESCRIPTION
## 📌 Description

1. Add more benchmark cases, long single seq and large batch are now covered.
2. Use cuda graph because cutedsl and fla both have large launch overhead.
3. Add cooling time due internal machine overheat.
4. Use rotation buffer to avoid L2 caching effect.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Benchmark Improvements

* **Chores**
  * Enhanced the benchmark harness with improved timing and memory management capabilities.
  * Added new command-line options including cooling time intervals, CUPTI profiling, and CUDA graph support.
  * Updated benchmark configurations targeting larger sequence lengths and new performance patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->