### PR TITLE
Fix prefill shared-memory budget so kernels launch on small-smem GPUs (SM75)

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -3718,16 +3718,23 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
   // affine in NUM_MMA_KV once the q/k/v arrays dominate the storage union, so two
   // large sample points recover the exact bytes-per-tile and fixed base.
   // max_smem_per_threadblock is already clamped to the per-block opt-in limit above.
-  // Note: kVOSplitDispatch is false for HEAD_DIM_VO < 512; the VO-split fixed
-  // overhead is zero for that regime and is captured by the SharedStorageQKVO samples.
+  // Sample the SAME struct the paged kernel instantiates: SharedStoragePaged sets
+  // kEnableVOSplitOpt=true. For HEAD_DIM_VO >= 512 the VO-split p_smem buffer
+  // (DTypeQ[CTA_TILE_Q * CTA_TILE_KV]) is active and SCALES with the tile, so it
+  // must be in the per-tile slope; sampling it with the default (false) under-counts
+  // smem_per_mma_kv, overshoots max_num_mma_kv_smem, and the final size check below
+  // hard-fails instead of selecting a smaller valid tile. No-op for HEAD_DIM_VO < 512
+  // (kVOSplit stays false there regardless of kEnableVOSplitOpt).
   constexpr uint32_t smem_sample_lo_mma = 128;
   constexpr uint32_t smem_sample_hi_mma = 256;
   constexpr size_t smem_sample_lo = sizeof(
       SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, smem_sample_lo_mma * NUM_WARPS_KV * 16,
-                        HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>);
+                        HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO,
+                        /*kEnableVOSplitOpt=*/true>);
   constexpr size_t smem_sample_hi = sizeof(
       SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, smem_sample_hi_mma * NUM_WARPS_KV * 16,
-                        HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>);
+                        HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO,
+                        /*kEnableVOSplitOpt=*/true>);
   constexpr size_t smem_per_mma_kv =
       (smem_sample_hi - smem_sample_lo) / (smem_sample_hi_mma - smem_sample_lo_mma);
   constexpr size_t smem_mma_kv_base = smem_sample_lo - smem_sample_lo_mma * smem_per_mma_kv;

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 by FlashInfer team.
+ * Modifications Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2100,17 +2101,29 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
          !USE_FP16_QK_REDUCTION)
             ? 2
             : (8 / NUM_MMA_Q);
-    const uint32_t max_num_mma_kv_smem =
-        (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) / kKVSmemPerMmaKV;
-    if (max_num_mma_kv_smem < 1) {
-      std::ostringstream err_msg;
-      err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
-              << ", head_dim_vo=" << HEAD_DIM_VO << ", cta_tile_q=" << CTA_TILE_Q
-              << " exceeds this GPU's " << max_smem_per_block_optin
-              << " bytes of shared memory per block; this configuration is not supported on "
-                 "this architecture.";
-      FLASHINFER_ERROR(err_msg.str());
-    }
+    // Size the largest KV tile from the exact shared-memory footprint rather than
+    // the analytic per-tile estimate, which omits the k/v scale-factor buffers and
+    // alignment padding carried in SharedStorageQKVO and is not clamped to the
+    // per-block opt-in limit. On GPUs with a 64 KB per-block limit there is no
+    // headroom, so the real sizeof(SharedStorage) overshoots and the launch fails
+    // with cudaErrorInvalidArgument (larger-smem GPUs hide the gap). The layout is
+    // affine in NUM_MMA_KV once the q/k/v arrays dominate the storage union, so two
+    // large sample points recover the exact bytes-per-tile and fixed base.
+    // max_smem_per_threadblock is already clamped to the per-block opt-in limit above.
+    constexpr uint32_t smem_sample_lo_mma = 128;
+    constexpr uint32_t smem_sample_hi_mma = 256;
+    constexpr size_t smem_sample_lo = sizeof(
+        SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, smem_sample_lo_mma * NUM_WARPS_KV * 16,
+                          HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>);
+    constexpr size_t smem_sample_hi = sizeof(
+        SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, smem_sample_hi_mma * NUM_WARPS_KV * 16,
+                          HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>);
+    constexpr size_t smem_per_mma_kv =
+        (smem_sample_hi - smem_sample_lo) / (smem_sample_hi_mma - smem_sample_lo_mma);
+    constexpr size_t smem_mma_kv_base = smem_sample_lo - smem_sample_lo_mma * smem_per_mma_kv;
+    const uint32_t max_num_mma_kv_smem = static_cast<uint32_t>(
+        (static_cast<int>(max_smem_per_threadblock) - static_cast<int>(smem_mma_kv_base)) /
+        static_cast<int>(smem_per_mma_kv));
 
     // control NUM_MMA_KV for maximum warp occupancy
     DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
@@ -3502,17 +3515,29 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
        !USE_FP16_QK_REDUCTION)
           ? 2
           : (8 / NUM_MMA_Q);
-  const uint32_t max_num_mma_kv_smem =
-      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) / kKVSmemPerMmaKV;
-  if (max_num_mma_kv_smem < 1) {
-    std::ostringstream err_msg;
-    err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
-            << ", head_dim_vo=" << HEAD_DIM_VO << ", cta_tile_q=" << CTA_TILE_Q
-            << " exceeds this GPU's " << max_smem_per_block_optin
-            << " bytes of shared memory per block; this configuration is not supported on "
-               "this architecture.";
-    FLASHINFER_ERROR(err_msg.str());
-  }
+  // Size the largest KV tile from the exact shared-memory footprint rather than
+  // the analytic per-tile estimate, which omits the k/v scale-factor buffers and
+  // alignment padding carried in SharedStorageQKVO and is not clamped to the
+  // per-block opt-in limit. On GPUs with a 64 KB per-block limit there is no
+  // headroom, so the real sizeof(SharedStorage) overshoots and the launch fails
+  // with cudaErrorInvalidArgument (larger-smem GPUs hide the gap). The layout is
+  // affine in NUM_MMA_KV once the q/k/v arrays dominate the storage union, so two
+  // large sample points recover the exact bytes-per-tile and fixed base.
+  // max_smem_per_threadblock is already clamped to the per-block opt-in limit above.
+  constexpr uint32_t smem_sample_lo_mma = 128;
+  constexpr uint32_t smem_sample_hi_mma = 256;
+  constexpr size_t smem_sample_lo = sizeof(
+      SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, smem_sample_lo_mma * NUM_WARPS_KV * 16,
+                        HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>);
+  constexpr size_t smem_sample_hi = sizeof(
+      SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, smem_sample_hi_mma * NUM_WARPS_KV * 16,
+                        HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>);
+  constexpr size_t smem_per_mma_kv =
+      (smem_sample_hi - smem_sample_lo) / (smem_sample_hi_mma - smem_sample_lo_mma);
+  constexpr size_t smem_mma_kv_base = smem_sample_lo - smem_sample_lo_mma * smem_per_mma_kv;
+  const uint32_t max_num_mma_kv_smem = static_cast<uint32_t>(
+      (static_cast<int>(max_smem_per_threadblock) - static_cast<int>(smem_mma_kv_base)) /
+      static_cast<int>(smem_per_mma_kv));
 
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
     using KTraits =
@@ -3684,20 +3709,31 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
        !USE_FP16_QK_REDUCTION)
           ? 2
           : (8 / NUM_MMA_Q);
-  constexpr uint32_t kVOSplitFixedSmem =
-      kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
-  const uint32_t max_num_mma_kv_smem =
-      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) - kVOSplitFixedSmem) /
-      kKVSmemPerMmaKV;
-  if (max_num_mma_kv_smem < 1) {
-    std::ostringstream err_msg;
-    err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
-            << ", head_dim_vo=" << HEAD_DIM_VO << ", cta_tile_q=" << CTA_TILE_Q
-            << " exceeds this GPU's " << max_smem_per_block_optin
-            << " bytes of shared memory per block; this configuration is not supported on "
-               "this architecture.";
-    FLASHINFER_ERROR(err_msg.str());
-  }
+  // Size the largest KV tile from the exact shared-memory footprint rather than
+  // the analytic per-tile estimate, which omits the k/v scale-factor buffers and
+  // alignment padding carried in SharedStorageQKVO and is not clamped to the
+  // per-block opt-in limit. On GPUs with a 64 KB per-block limit there is no
+  // headroom, so the real sizeof(SharedStorage) overshoots and the launch fails
+  // with cudaErrorInvalidArgument (larger-smem GPUs hide the gap). The layout is
+  // affine in NUM_MMA_KV once the q/k/v arrays dominate the storage union, so two
+  // large sample points recover the exact bytes-per-tile and fixed base.
+  // max_smem_per_threadblock is already clamped to the per-block opt-in limit above.
+  // Note: kVOSplitDispatch is false for HEAD_DIM_VO < 512; the VO-split fixed
+  // overhead is zero for that regime and is captured by the SharedStorageQKVO samples.
+  constexpr uint32_t smem_sample_lo_mma = 128;
+  constexpr uint32_t smem_sample_hi_mma = 256;
+  constexpr size_t smem_sample_lo = sizeof(
+      SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, smem_sample_lo_mma * NUM_WARPS_KV * 16,
+                        HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>);
+  constexpr size_t smem_sample_hi = sizeof(
+      SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, smem_sample_hi_mma * NUM_WARPS_KV * 16,
+                        HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>);
+  constexpr size_t smem_per_mma_kv =
+      (smem_sample_hi - smem_sample_lo) / (smem_sample_hi_mma - smem_sample_lo_mma);
+  constexpr size_t smem_mma_kv_base = smem_sample_lo - smem_sample_lo_mma * smem_per_mma_kv;
+  const uint32_t max_num_mma_kv_smem = static_cast<uint32_t>(
+      (static_cast<int>(max_smem_per_threadblock) - static_cast<int>(smem_mma_kv_base)) /
+      static_cast<int>(smem_per_mma_kv));
 
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
     using KTraits =


### PR DESCRIPTION
## Purpose

FlashInfer's prefill launchers size the largest KV tile from a q-only
shared-memory estimate (`max_num_mma_kv_smem`) that omits the k/v scale-factor
buffers and alignment padding actually carried in `SharedStorageQKVO`, and the
budget is not clamped to the per-block opt-in limit. On GPUs with a 64 KB
per-block shared-memory limit (SM75 / Turing, e.g. Tesla T4) there is no
headroom, so the dispatched `sizeof(SharedStorage)` overshoots 64 KB and the
launch is rejected with `cudaErrorInvalidArgument`. GPUs with larger shared
memory (SM80+) have slack that hides the miscount.

Fixes #3620.

## Changes

Size the tile from the exact layout instead of a hand-written estimate: sample
`sizeof(SharedStorageQKVO<...>)` at two tile counts to recover the exact
bytes-per-tile and fixed base (which include the previously omitted buffers),
and clamp the budget to the real per-block opt-in limit
(`cudaDevAttrMaxSharedMemoryPerBlockOptin`). The samples are taken in the regime
where the q/k/v arrays dominate the storage union, so the result is exact and
the per-step value is always positive (no divide-by-zero for multi-warp KV
configs). Applied to all three prefill launchers (single, ragged-paged, paged).
Aligned/large-smem shapes are unaffected: the register-bound tile still wins
`min(max_num_mma_kv_smem, max_num_mma_kv_reg)`.

## Test Plan / Result

- **SM75 (Tesla T4)** — built and run on real hardware. With the fix, the
  single- and paged-prefill kernels JIT-compile for `sm_75`, the FlashInfer
  attention backend serves an NVFP4 model end-to-end through vLLM, captures full
  CUDA graphs, and generates correct output. The same run fails with
  `BatchPrefillWithPagedKVCache ... invalid argument` without the fix.
- **No regression on larger-smem GPUs** — gemma NVFP4 served via vLLM (FlashInfer
  selected) on RTX 3090 (SM86) and A100 (SM80): both pass with throughput on par
  with the unpatched baseline (the dispatched tile is register-bound there, so it
  is unchanged).

AI assistance (Claude Code) was used; all changes reviewed by the submitter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved shared-memory sizing for prefill attention to better match real shared-memory usage when selecting kernel launch configurations across single and batch prefill, including ragged and paged KV-cache layouts, for more consistent efficiency across GPU hardware.
* **Updates**
  * Refreshed copyright attribution and vendor details in the attention module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->