### PR TITLE
fix(sampling): terminate top-p search at adjacent float bounds

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -1808,7 +1808,7 @@ __global__ void TopPRenormProbKernel(DType* probs, DType* renormed_prob, float* 
     } else {
       high = min(pivot_0, max_le_high);
     }
-  } while (min_gt_low != max_le_high);
+  } while (min_gt_low < max_le_high && nextafterf(min_gt_low, max_le_high) < max_le_high);
 
   float normalizer = math::ptx_rcp(max(sum_low, 1e-8));
 


### PR DESCRIPTION
## Summary

Updates the small-vocab top-p renormalization threshold search to stop when the remaining candidate bounds are adjacent FP32 values.

## Details

The previous loop required exact equality between the candidate bounds. Once the bounds are adjacent representable floats, further ternary refinement may not collapse them to an identical value, so the loop should treat that interval as converged.

## Validation

- `git diff --check upstream/main..HEAD`
- Focused GPU top-p reference checks for small-vocab scalar and per-request `top_p`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability in the Top-P probability renormalization step by refining the floating-point loop termination logic, preventing incorrect behavior near numerical boundaries where values no longer make progress due to representation limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->