### PR TITLE
fix(sampling): fix shared-memory race and out-of-range token id in SamplingFromLogitsKernel

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -750,15 +750,17 @@ __global__ void SamplingFromLogitsKernel(DType* logits, IdType* output, IdType* 
     DataAndIndex<DType, IdType> cur_data[VEC_SIZE];
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      cur_data[j].data = (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d
-                             ? logits_vec[j] + gumbel_noise[j]
-                             : -cuda::std::numeric_limits<DType>::infinity();
-      cur_data[j].index = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+      const uint32_t token_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+      const bool valid = token_idx < d;
+      cur_data[j].data =
+          valid ? logits_vec[j] + gumbel_noise[j] : -cuda::std::numeric_limits<DType>::infinity();
+      cur_data[j].index = valid ? token_idx : 0;
     }
 
     max_data +=
         BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage)
             .template Sum<VEC_SIZE>(cur_data);
+    __syncthreads();
   }
   if (tx == 0) {
     output[bx] = max_data.index;


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

**Summary**
SamplingFromLogitsKernel reused the CUB BlockReduce shared temp storage across reduction-loop iterations without a __syncthreads() barrier, violating CUB's contract. For large vocab (e.g. vocab_size=32000) the loop runs multiple iterations, so concurrent read/write of the shared reduction state races and can corrupt the reduced argmax. Combined with padding lanes (token_idx >= d) keeping their out-of-range index, this let the kernel occasionally return a token id >= vocab_size, breaking the invariant 0 <= sample < vocab_size and causing the flaky test_int64_indices_sampling failure.

**Changes**
Add __syncthreads() after each BlockReduce so the shared temp storage is safe to reuse next iteration (the actual data race).
Give padding lanes a valid fallback index (0) so the returned token id is always in [0, d) even under any reduction anomaly.

**Validation**
Verified with compute-sanitizer --tool racecheck: the original kernel reports hundreds of Write/Read hazards in SamplingFromLogitsKernel; the fixed kernel reports 0 hazards. sampling_from_logits output stays within range across repeated runs.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3470

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal sampling kernel robustness and thread synchronization for more reliable concurrent sampling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->