### PR TITLE
fix: give concurrent streams disjoint row_states buffers in multi-CTA top-k

### DIFF
--- a/flashinfer/logits_processor/operators.py
+++ b/flashinfer/logits_processor/operators.py
@@ -129,12 +129,9 @@ class ProbsTopKOp(ParameterizedOp):
         ):
             raise ValueError("top_k must be a positive integer or a tensor array")
 
-        # Allocate row_states buffer for multi-CTA kernel (1MB is enough for any GPU)
-        row_states_buffer = _get_cache_buf(
-            f"top_k_renorm_probs_row_states_{tensor.data.device}",
-            1024 * 1024,
-            tensor.data.device,
-            zero_init=True,
+        # Per-call zeroing keeps concurrent streams disjoint; the kernel requires it.
+        row_states_buffer = torch.zeros(
+            1024 * 1024, dtype=torch.uint8, device=tensor.data.device
         )
         renorm_probs = get_sampling_module().top_k_renorm_probs(
             tensor.data, maybe_top_k_arr, top_k_val, row_states_buffer
@@ -175,12 +172,9 @@ class LogitsTopKOp(ParameterizedOp):
         ):
             raise ValueError("top_k must be a positive integer or a tensor array")
 
-        # Allocate row_states buffer for multi-CTA kernel (1MB is enough for any GPU)
-        row_states_buffer = _get_cache_buf(
-            f"top_k_mask_logits_row_states_{tensor.data.device}",
-            1024 * 1024,
-            tensor.data.device,
-            zero_init=True,
+        # Per-call zeroing keeps concurrent streams disjoint; the kernel requires it.
+        row_states_buffer = torch.zeros(
+            1024 * 1024, dtype=torch.uint8, device=tensor.data.device
         )
         masked_logits = get_sampling_module().top_k_mask_logits(
             tensor.data, maybe_top_k_arr, top_k_val, row_states_buffer

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -1887,14 +1887,8 @@ def top_k_renorm_probs(
     top_p_renorm_probs
     top_k : General-purpose top-k selection (returns indices and values)
     """
-    # Allocate row_states buffer for multi-CTA kernel (1MB is enough for any GPU)
-    buffer_bytes = 1024 * 1024  # 1MB
-    row_states_buffer = _get_cache_buf(
-        f"top_k_renorm_probs_row_states_{probs.device}",
-        buffer_bytes,
-        probs.device,
-        zero_init=True,
-    )
+    # Per-call zeroing keeps concurrent streams disjoint; the kernel requires it.
+    row_states_buffer = torch.zeros(1024 * 1024, dtype=torch.uint8, device=probs.device)
 
     return get_sampling_module().top_k_renorm_probs(
         probs, *_to_tensor_scalar_tuple(top_k), row_states_buffer
@@ -1959,17 +1953,10 @@ def top_k_mask_logits(
     top_k_renorm_probs
     top_k : General-purpose top-k selection (returns indices and values)
     """
-    # Allocate row_states buffer for multi-CTA kernel (1MB is enough for any GPU)
-    buffer_bytes = 1024 * 1024  # 1MB
-    row_states_buffer = _get_cache_buf(
-        f"top_k_mask_logits_row_states_{logits.device}",
-        buffer_bytes,
-        logits.device,
-        zero_init=True,
+    # Per-call zeroing keeps concurrent streams disjoint; the kernel requires it.
+    row_states_buffer = torch.zeros(
+        1024 * 1024, dtype=torch.uint8, device=logits.device
     )
-
-    # Note: row_states_buffer is zero-initialized on first allocation by _get_cache_buf
-    # Kernel will reset arrival_counter to 0 at the end of each launch
 
     return get_sampling_module().top_k_mask_logits(
         logits, *_to_tensor_scalar_tuple(top_k), row_states_buffer

--- a/flashinfer/topk.py
+++ b/flashinfer/topk.py
@@ -29,7 +29,6 @@ from .trace.templates.sampling import (
     top_k_ragged_transform_trace,
 )
 from .utils import (
-    _get_cache_buf,
     check_shape_dtype_device,
     get_compute_capability,
     get_shared_bytes_per_block_optin,
@@ -628,15 +627,8 @@ def top_k(
             return sorted_values, sorted_indices
         return output_values, indices
 
-    # Allocate row_states buffer for multi-CTA path
-    # 1MB is enough for any reasonable GPU (covers up to ~200 groups for deterministic
-    # mode and ~300 groups for non-deterministic mode)
-    row_states_buffer: Optional[torch.Tensor] = _get_cache_buf(
-        f"radix_topk_row_states_{input.device}",
-        1024 * 1024,  # 1MB
-        input.device,
-        zero_init=True,
-    )
+    # Per-call zeroing keeps concurrent streams disjoint; the kernel requires it.
+    row_states_buffer = torch.zeros(1024 * 1024, dtype=torch.uint8, device=input.device)
 
     # Allocate output_values for kernel to write directly
     output_values = torch.empty(batch_size, k, dtype=input.dtype, device=device)
@@ -838,13 +830,8 @@ def top_k_page_table_transform(
     ):
         return topk_clusters_page_table_transform(input, lengths, src_page_table, k)
 
-    # Allocate row_states buffer for multi-CTA path
-    row_states_buffer: Optional[torch.Tensor] = _get_cache_buf(
-        f"radix_topk_row_states_{device}",
-        1024 * 1024,  # 1MB
-        device,
-        zero_init=True,
-    )
+    # Per-call zeroing keeps concurrent streams disjoint; the kernel requires it.
+    row_states_buffer = torch.zeros(1024 * 1024, dtype=torch.uint8, device=device)
 
     if out is None:
         out = torch.empty(num_rows, k, dtype=torch.int32, device=device)
@@ -967,13 +954,8 @@ def top_k_ragged_transform(
     ):
         return topk_clusters_ragged_transform(input, lengths, offsets, k)
 
-    # Allocate row_states buffer for multi-CTA path
-    row_states_buffer: Optional[torch.Tensor] = _get_cache_buf(
-        f"radix_topk_row_states_{device}",
-        1024 * 1024,  # 1MB
-        device,
-        zero_init=True,
-    )
+    # Per-call zeroing keeps concurrent streams disjoint; the kernel requires it.
+    row_states_buffer = torch.zeros(1024 * 1024, dtype=torch.uint8, device=device)
 
     # Allocate output
     output_indices = torch.empty(num_rows, k, dtype=torch.int32, device=device)

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -54,7 +54,6 @@ _CUTE_DSL_AVAILABLE = (
 )
 
 from ..utils import (
-    _get_cache_buf,
     backend_requirement,
     get_device_sm_count,
     get_shared_bytes_per_block_optin,
@@ -816,11 +815,10 @@ def _run_radix_cutlass(
     # offsets=zeros: output indices are local column indices (0..N-1), no shift.
     offsets = torch.zeros(num_rows, dtype=torch.int32, device=logits.device)
 
-    row_states_buffer = _get_cache_buf(
-        f"radix_topk_row_states_{logits.device}",
-        1024 * 1024,
-        logits.device,
-        zero_init=True,
+    # Fresh zeroed state keeps concurrent calls disjoint and initializes the
+    # inter-CTA synchronization counters for every launch.
+    row_states_buffer = torch.zeros(
+        1024 * 1024, dtype=torch.uint8, device=logits.device
     )
     # Write directly into out_indices — no second allocation or copy_ needed.
     get_topk_module().radix_topk_ragged_transform(
@@ -917,30 +915,15 @@ def _run_radix(
         num_sms,
     )
 
-    # row_states holds the global histograms + inter-CTA barrier counters used
-    # when ctas_per_group > 1. max_num_groups must equal the compile-time value
-    # (both = num_sms // ctas_per_group) so the buffer matches the grid.
-    #
-    # The buffer is allocated for the worst case (ctas_per_group=1 → num_sms
-    # groups) and sliced to the current max_num_groups. Fixing the allocation at
-    # num_sms means the shared, device-keyed buffer never has to grow between
-    # calls with different N/ctas_per_group (a grow would re-zero and churn), and
-    # matches TRT-LLM's `[num_sms, state_size]` allocation.
-    #
-    # zero_init=True: the multi-CTA path spins on _ARRIVAL_COUNTER, so the buffer
-    # MUST be zero before the first launch. The kernel self-resets the slots it
-    # touches at end-of-kernel, so steady state stays clean without re-zeroing —
-    # but a prior single-CTA call (which never writes row_states) could otherwise
-    # leave garbage a later multi-CTA call reads. Zeroing on the one-time
-    # allocation (outside any CUDA-graph capture) keeps both paths correct.
+    # Fresh zeroed state keeps concurrent calls disjoint and initializes the
+    # inter-CTA synchronization counters for every launch.
     max_num_groups = max(1, num_sms // ctas_per_group)
     nbytes = max_num_groups * _RADIX_STATE_SIZE * 4  # int32 → 4 bytes each
     row_states = (
-        _get_cache_buf(
-            f"radix_row_states_{logits.device}",
-            num_sms * _RADIX_STATE_SIZE * 4,  # worst case: ctas_per_group=1
-            logits.device,
-            zero_init=True,
+        torch.zeros(
+            num_sms * _RADIX_STATE_SIZE * 4,
+            dtype=torch.uint8,
+            device=logits.device,
         )[:nbytes]
         .view(torch.int32)
         .view(max_num_groups, _RADIX_STATE_SIZE)

--- a/tests/topk_varlen/test_topk_varlen.py
+++ b/tests/topk_varlen/test_topk_varlen.py
@@ -846,6 +846,69 @@ def test_radix_multi_cta_regime(dtype, top_k, N, batch_size):
     _check_correct(indices, logits, seq_lens, top_k, require_all_checked=True)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA")
+@pytest.mark.parametrize("backend", ["radix", "radix_cutlass"])
+def test_multi_cta_row_states_not_shared_across_streams(backend):
+    """Concurrent multi-CTA varlen calls keep row-state scratch disjoint."""
+    device = torch.device("cuda")
+    if backend == "radix":
+        major, minor = get_compute_capability(device)
+        if not (
+            flashinfer.top_k_varlen.is_backend_supported("radix", major * 10 + minor)
+            and is_cute_dsl_available()
+        ):
+            pytest.skip("radix backend requires Blackwell+ CuTe DSL")
+
+    dtype, top_k, N = torch.float32, 512, 65536
+    if backend == "radix":
+        assert _radix_ctas(N, dtype, 1) > 1
+    seq_lens = torch.full((1,), N, dtype=torch.int32, device=device)
+    base = torch.arange(N, dtype=dtype, device=device)
+    logits_a = base.unsqueeze(0).contiguous()
+    logits_b = (-base).unsqueeze(0).contiguous()
+
+    def run(logits):
+        return flashinfer.top_k_varlen(
+            logits,
+            seq_lens,
+            top_k,
+            backend=backend,
+            return_values=True,
+        )
+
+    # Warm JIT and references on the default stream before concurrent launches.
+    ref_a = run(logits_a)
+    ref_b = run(logits_b)
+    torch.cuda.synchronize()
+
+    stream_a = torch.cuda.Stream()
+    stream_b = torch.cuda.Stream()
+    outs_a, outs_b = [], []
+    for _ in range(32):
+        with torch.cuda.stream(stream_a):
+            outs_a.append(run(logits_a))
+        with torch.cuda.stream(stream_b):
+            outs_b.append(run(logits_b))
+    torch.cuda.synchronize()
+
+    def assert_matches(actual, expected):
+        actual_i, actual_v = actual
+        expected_i, expected_v = expected
+        actual_order = actual_i.argsort(dim=-1)
+        expected_order = expected_i.argsort(dim=-1)
+        actual_i = torch.gather(actual_i, 1, actual_order)
+        actual_v = torch.gather(actual_v, 1, actual_order)
+        expected_i = torch.gather(expected_i, 1, expected_order)
+        expected_v = torch.gather(expected_v, 1, expected_order)
+        assert torch.equal(actual_i, expected_i)
+        torch.testing.assert_close(actual_v, expected_v)
+
+    for out in outs_a:
+        assert_matches(out, ref_a)
+    for out in outs_b:
+        assert_matches(out, ref_b)
+
+
 @requires_blackwell
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 @pytest.mark.parametrize("top_k", [512, 1024])

--- a/tests/utils/test_topk.py
+++ b/tests/utils/test_topk.py
@@ -20,7 +20,6 @@ import pytest
 import torch
 
 import flashinfer
-import flashinfer.utils as flashinfer_utils
 from flashinfer.topk import can_implement_filtered_topk
 from flashinfer.utils import get_compute_capability
 
@@ -77,20 +76,6 @@ def verify_topk_correctness(logits, values, indices, k):
         if values[i].min().item() < kth_largest - 1e-6:
             return False
     return True
-
-
-def _get_cached_topk_row_states_buffer(device: torch.device):
-    if device.type == "cuda" and device.index is None:
-        device = torch.device("cuda", torch.cuda.current_device())
-    key = (f"radix_topk_row_states_{device}", device)
-    return flashinfer_utils._cache_buf.get(key)
-
-
-def _clear_cached_topk_row_states_buffer(device: torch.device):
-    if device.type == "cuda" and device.index is None:
-        device = torch.device("cuda", torch.cuda.current_device())
-    key = (f"radix_topk_row_states_{device}", device)
-    flashinfer_utils._cache_buf.pop(key, None)
 
 
 def _build_strictly_descending_logits(
@@ -266,84 +251,87 @@ def test_top_k_large_batch(batch_size, vocab_size, k, det, tie_break):
 
 
 @pytest.mark.parametrize("api_kind", ["top_k", "page_table", "ragged"])
-@pytest.mark.parametrize(
-    ("first_deterministic", "second_deterministic"),
-    [(False, True), (True, False)],
-)
-def test_multi_cta_reuses_dirty_cached_row_states_buffer_across_mode_transitions(
-    api_kind, set_topk_algo, first_deterministic, second_deterministic
-):
+def test_multi_cta_row_states_not_shared_across_streams(api_kind, set_topk_algo):
+    """Concurrent multi-CTA top-k launches must not share the row_states scratch.
+
+    ``row_states`` holds the kernel's inter-CTA synchronization state. It used to
+    come from a per-device cached buffer, so two launches racing on different
+    streams corrupted each other's reduction (flashinfer-ai/flashinfer#3618). It
+    is now allocated per call from the stream-ordered caching allocator, so every
+    launch gets a disjoint buffer.
+
+    This interleaves launches on two streams without syncing between them, so the
+    sequences actually overlap on the device, and checks every result against a
+    per-stream reference. Distinct (descending vs. ascending) inputs ensure a
+    shared/raced buffer would corrupt at least one stream.
+    """
     set_topk_algo("multi_cta")
     device = torch.device("cuda")
-    _clear_cached_topk_row_states_buffer(device)
+    batch_size, vocab_size, k = 4, 131072, 512
 
-    batch_size = 4
-    vocab_size = 131072
-    k = 512
-    logits = _build_strictly_descending_logits(batch_size, vocab_size, device)
+    logits_a = _build_strictly_descending_logits(batch_size, vocab_size, device)
+    logits_b = torch.flip(logits_a, dims=(-1,)).contiguous()
 
-    if api_kind == "top_k":
-        expected_values = logits[:, :k]
-        expected_indices = (
-            torch.arange(k, device=device, dtype=torch.int64)
-            .unsqueeze(0)
-            .expand(batch_size, -1)
-        )
-
-        values_a, indices_a = flashinfer.top_k(
-            logits, k, sorted=True, deterministic=first_deterministic
-        )
-        torch.testing.assert_close(values_a, expected_values)
-        assert torch.equal(indices_a, expected_indices)
-        buf_a = _get_cached_topk_row_states_buffer(device)
-        assert buf_a is not None
-
-        values_b, indices_b = flashinfer.top_k(
-            logits, k, sorted=True, deterministic=second_deterministic
-        )
-        torch.testing.assert_close(values_b, expected_values)
-        assert torch.equal(indices_b, expected_indices)
-    else:
+    def run(logits):
+        if api_kind == "top_k":
+            return flashinfer.top_k(logits, k, sorted=True, deterministic=True)
         lengths = torch.full(
             (batch_size,), vocab_size, device=device, dtype=torch.int32
         )
-        expected = torch.arange(k, device=device, dtype=torch.int32).unsqueeze(0)
-        expected = expected.expand(batch_size, -1)
         src_page_table = None
         offsets = None
-
-        if api_kind == "ragged":
-            offsets = torch.arange(
-                0, batch_size * vocab_size, vocab_size, device=device, dtype=torch.int32
+        if api_kind == "page_table":
+            src_page_table = (
+                torch.arange(vocab_size, device=device, dtype=torch.int32)
+                .unsqueeze(0)
+                .expand(batch_size, -1)
+                .contiguous()
             )
-            expected = offsets.unsqueeze(1) + expected
-
-        output_a = _run_transform(
+        elif api_kind == "ragged":
+            offsets = torch.arange(
+                0,
+                batch_size * vocab_size,
+                vocab_size,
+                device=device,
+                dtype=torch.int32,
+            )
+        return _run_transform(
             logits,
             k,
             api_kind,
             lengths=lengths,
-            deterministic=first_deterministic,
+            deterministic=True,
             src_page_table=src_page_table,
             offsets=offsets,
         )
-        _assert_unordered_indices_match(output_a, expected)
-        buf_a = _get_cached_topk_row_states_buffer(device)
-        assert buf_a is not None
 
-        output_b = _run_transform(
-            logits,
-            k,
-            api_kind,
-            lengths=lengths,
-            deterministic=second_deterministic,
-            src_page_table=src_page_table,
-            offsets=offsets,
-        )
-        _assert_unordered_indices_match(output_b, expected)
+    def equal(x, y):
+        if isinstance(x, tuple):
+            return all(torch.equal(a, b) for a, b in zip(x, y, strict=True))
+        return torch.equal(x, y)
 
-    buf_b = _get_cached_topk_row_states_buffer(device)
-    assert buf_b is buf_a
+    # Per-stream references on the default stream; this also triggers the JIT
+    # compile so the concurrent loop below does not compile on a side stream.
+    ref_a = run(logits_a)
+    ref_b = run(logits_b)
+    torch.cuda.synchronize()
+
+    stream_a = torch.cuda.Stream()
+    stream_b = torch.cuda.Stream()
+
+    outs_a = []
+    outs_b = []
+    for _ in range(32):
+        with torch.cuda.stream(stream_a):
+            outs_a.append(run(logits_a))
+        with torch.cuda.stream(stream_b):
+            outs_b.append(run(logits_b))
+    torch.cuda.synchronize()
+
+    for out in outs_a:
+        assert equal(out, ref_a)
+    for out in outs_b:
+        assert equal(out, ref_b)
 
 
 @pytest.mark.parametrize("k", [256, 1024, 2048])


### PR DESCRIPTION
## Description

Fixes #3618.

The multi-CTA radix top-k kernels keep histograms and inter-CTA barrier counters in `RadixRowState` scratch. The Python entry points previously obtained that scratch from device-keyed `_get_cache_buf` entries, so unsynchronized launches on different CUDA streams could share the same state and corrupt results or wedge the barrier.

The original PR covered seven producers. Current main subsequently added two supported `top_k_varlen` producers (`radix` and `radix_cutlass`), so this rebuild covers all nine current Python call sites.

## Fix

Allocate zero-initialized row-state scratch per call with `torch.zeros` instead of sharing a device cache entry. PyTorch's stream-ordered caching allocator gives concurrent live launches disjoint storage, reuses it after stream work completes, and handles CUDA graph capture without a custom ring or lifetime registry.

The `top_k_varlen` radix backend preserves its existing SM-count-based allocation size and `int32` view shape; the other eight paths retain their existing 1 MiB byte-buffer contract.

## Validation

Validated on an NVIDIA RTX PRO 6000 Blackwell, SM120, 96GB with CUDA 13:

- concurrent public API regressions: 5 passed (`top_k`, page-table transform, ragged transform, and both `top_k_varlen` backends)
- public-API pointer probe: distinct row-state allocations on two streams for both `top_k_varlen` backends
- focused sampling/logits selection: 1,104 passed, 123 skipped
- focused top-k/page-table/ragged selection: 163 passed
- exact-file pre-commit, compileall, and `git diff --check`: passed
- fresh independent outcome verification: confirmed

The earlier maintainer-triggered GPU pipeline `57443299` also succeeded on the previous converged per-call-allocation head. The current push only rebuilds that design on current main and extends it to the two newly landed producers.

## Disclosure

AI-assisted (Codex); reviewed and validated on real SM120 hardware by the submitter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved top-k and variable-length top-k operations during concurrent CUDA stream execution.
  - Prevented overlapping operations from sharing temporary state and producing incorrect results.
  - Preserved synchronization correctness across supported top-k, page-table, ragged, and radix-based processing modes.
  - Improved reliability when multiple sampling and probability-processing operations run concurrently.

- **Tests**
  - Added regression coverage for concurrent top-k and variable-length top-k operations across multiple CUDA streams.
  - Verified results for standard, page-table, ragged, and radix-based processing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->