### PR TITLE
feat: add FP8 per-token-head KV cache with inline float32 scales

### DIFF
--- a/csrc/batch_attention.cu
+++ b/csrc/batch_attention.cu
@@ -28,6 +28,10 @@ using tvm::ffi::Optional;
 
 template <uint32_t CTA_TILE_Q_1, uint32_t CTA_TILE_Q_2, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
           MaskMode MASK_MODE, typename AttentionVariant, typename Params>
+const void* GetBatchPagedAttentionPersistentKernel(size_t& smem_size, uint32_t& num_threads);
+
+template <uint32_t CTA_TILE_Q_1, uint32_t CTA_TILE_Q_2, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
+          MaskMode MASK_MODE, typename AttentionVariant, typename Params>
 cudaError_t BatchPagedAttentionPersistent(const Params params_1, const Params params_2,
                                           const uint32_t num_blks_x, const uint32_t num_blks_y,
                                           const cudaStream_t stream);
@@ -40,7 +44,8 @@ Array<int64_t> BatchPagedAttentionPlan(TensorView float_workspace_buffer,
                                        TensorView page_locked_int_workspace_buffer,
                                        TensorView qo_indptr, TensorView kv_indptr,
                                        TensorView kv_len, int64_t batch_size, int64_t num_qo_heads,
-                                       int64_t num_kv_heads, int64_t head_dim_o, bool causal) {
+                                       int64_t num_kv_heads, int64_t head_dim_o, bool causal,
+                                       bool use_per_token_head) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * get_element_size(float_workspace_buffer);
   size_t int_workspace_size_in_bytes =
@@ -51,12 +56,27 @@ Array<int64_t> BatchPagedAttentionPlan(TensorView float_workspace_buffer,
   ffi::CUDADeviceGuard device_guard(float_workspace_buffer.device().device_id);
   const cudaStream_t stream = get_stream(float_workspace_buffer.device());
 
-  cudaError_t status = TwoStageHolisticPlan<IdType>(
-      float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
-      int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
-      int_workspace_size_in_bytes, plan_info, static_cast<IdType*>(qo_indptr.data_ptr()),
-      static_cast<IdType*>(kv_indptr.data_ptr()), static_cast<IdType*>(kv_len.data_ptr()),
-      batch_size, num_qo_heads, num_kv_heads, head_dim_o, causal, stream);
+  cudaError_t status = cudaSuccess;
+  const MaskMode mask_mode = MaskMode::kNone;
+  DISPATCH_context(
+      DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
+      AttentionVariant, PersistentParams, [&] {
+        size_t smem_size = 0;
+        uint32_t num_threads = 0;
+        auto kernel =
+            GetBatchPagedAttentionPersistentKernel<CTA_TILE_Q_1, CTA_TILE_Q_2, HEAD_DIM_QK,
+                                                   HEAD_DIM_VO, MASK_MODE, AttentionVariant,
+                                                   PersistentParams>(smem_size, num_threads);
+
+        status = TwoStageHolisticPlan<IdType, decltype(kernel)>(
+            float_workspace_buffer.data_ptr(), float_workspace_size_in_bytes,
+            int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
+            int_workspace_size_in_bytes, plan_info, static_cast<IdType*>(qo_indptr.data_ptr()),
+            static_cast<IdType*>(kv_indptr.data_ptr()), static_cast<IdType*>(kv_len.data_ptr()),
+            batch_size, num_qo_heads, num_kv_heads, head_dim_o, causal, kernel, smem_size,
+            static_cast<int>(num_threads), stream);
+        return true;
+      });
 
   TVM_FFI_ICHECK(status == cudaSuccess)
       << "Failed to plan persistent paged attention, error: " << cudaGetErrorString(status);
@@ -71,8 +91,8 @@ void BatchPagedAttentionRun(TensorView float_workspace_buffer, TensorView int_wo
                             int64_t layout_code, int64_t num_qo_heads, int64_t num_kv_heads,
                             int64_t page_size,
                             double v_scale,  // must use double due to pytorch binding
-                            double sm_scale,
-                            double logits_soft_cap ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS) {
+                            double sm_scale, double logits_soft_cap,
+                            bool use_per_token_head ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS) {
   HolisticPlanInfo<2> plan_info;
   plan_info.FromVector(std::vector<int64_t>(plan_info_vec.begin(), plan_info_vec.end()));
 
@@ -175,11 +195,30 @@ void BatchPagedAttentionRun(TensorView float_workspace_buffer, TensorView int_wo
           // will be problematic because of the params[i]
           ADDITIONAL_PARAMS_SETTER
           PROFILER_PARAMS_SETTER
+
+          if (use_per_token_head) {
+            constexpr uint32_t elem_sz = sizeof(DTypeKV);
+            int64_t k_strides[3] = {static_cast<int64_t>(k_stride_page) * elem_sz,
+                                    static_cast<int64_t>(k_stride_n) * elem_sz,
+                                    static_cast<int64_t>(k_stride_h) * elem_sz};
+            int64_t v_strides[3] = {static_cast<int64_t>(v_stride_page) * elem_sz,
+                                    static_cast<int64_t>(v_stride_n) * elem_sz,
+                                    static_cast<int64_t>(v_stride_h) * elem_sz};
+            params[i].block_paged_k = paged_kv_t<DTypeKV, IdType>(
+                num_kv_heads, static_cast<uint32_t>(page_size), HEAD_DIM_QK, 1, kv_layout,
+                static_cast<DTypeKV*>(k_cache.data_ptr()), nullptr, k_strides,
+                static_cast<IdType*>(kv_indices.data_ptr()), nullptr, nullptr);
+            params[i].block_paged_v = paged_kv_t<DTypeKV, IdType>(
+                num_kv_heads, static_cast<uint32_t>(page_size), HEAD_DIM_VO, 1, kv_layout,
+                static_cast<DTypeKV*>(v_cache.data_ptr()), nullptr, v_strides,
+                static_cast<IdType*>(kv_indices.data_ptr()), nullptr, nullptr);
+          }
         }
 
-        cudaError_t status = BatchPagedAttentionPersistent<128, 16, HEAD_DIM_QK, HEAD_DIM_VO,
-                                                           MASK_MODE, AttentionVariant>(
-            params[0], params[1], plan_info.num_blks_x, plan_info.num_blks_y, stream);
+        cudaError_t status =
+            BatchPagedAttentionPersistent<CTA_TILE_Q_1, CTA_TILE_Q_2, HEAD_DIM_QK, HEAD_DIM_VO,
+                                          MASK_MODE, AttentionVariant>(
+                params[0], params[1], plan_info.num_blks_x, plan_info.num_blks_y, stream);
         TVM_FFI_ICHECK(status == cudaSuccess)
             << "Failed to run persistent paged attention, error: " << cudaGetErrorString(status);
         return true;

--- a/csrc/batch_attention_customize_config.jinja
+++ b/csrc/batch_attention_customize_config.jinja
@@ -22,11 +22,12 @@ using namespace flashinfer;
 
 {{ variant_decl }}
 
-template <bool UseLogitsSoftCap>
+template <bool UseLogitsSoftCap, bool UsePerTokenHead = false>
 struct StandardAttention : AttentionVariantBase {
   float sm_scale_log2;
   float soft_cap_pre_tanh_scale;
   static constexpr bool use_logits_soft_cap = UseLogitsSoftCap;
+  static constexpr bool use_per_token_head = UsePerTokenHead;
   PROFILER_CLOSURE_PARAMS_DECL
 
   template <typename Params>
@@ -49,8 +50,10 @@ struct StandardAttention : AttentionVariantBase {
 
 #define DISPATCH_context(DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, AttentionVariant, Params, ...) \
   DISPATCH_MASK_MODE(mask_mode, MASK_MODE, { \
-    using AttentionVariant = {{ variant_name }}; \
-    __VA_ARGS__(); \
+    DISPATCH_USE_PER_TOKEN_HEAD(use_per_token_head, use_per_token_head, { \
+      using AttentionVariant = {{ variant_name }}; \
+      __VA_ARGS__(); \
+    }) \
   })
 
 using DTypeQ = {{ dtype_q }};
@@ -61,6 +64,8 @@ using IdType = {{ idtype }};
 constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
 constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
 constexpr auto POS_ENCODING_MODE = {{ pos_encoding_mode }};
+constexpr static uint32_t CTA_TILE_Q_1 = 128;
+constexpr static uint32_t CTA_TILE_Q_2 = 16;
 
 struct PersistentParams {
   using DTypeQ = DTypeQ;
@@ -111,6 +116,10 @@ struct PersistentParams {
   float sm_scale;
   float logits_soft_cap;
   float v_scale;
+
+  paged_kv_t<DTypeKV, IdType> block_paged_k;
+  paged_kv_t<DTypeKV, IdType> block_paged_v;
+
   {{ additional_params_decl }}
 
   PROFILER_PARAMS_DECL

--- a/csrc/batch_attention_jit_binding.cu
+++ b/csrc/batch_attention_jit_binding.cu
@@ -24,7 +24,8 @@ Array<int64_t> BatchPagedAttentionPlan(TensorView float_workspace_buffer,
                                        TensorView page_locked_int_workspace_buffer,
                                        TensorView qo_indptr, TensorView kv_indptr,
                                        TensorView kv_len, int64_t batch_size, int64_t num_qo_heads,
-                                       int64_t num_kv_heads, int64_t head_dim_o, bool causal);
+                                       int64_t num_kv_heads, int64_t head_dim_o, bool causal,
+                                       bool use_per_token_head);
 
 void BatchPagedAttentionRun(TensorView float_workspace_buffer, TensorView int_workspace_buffer,
                             Array<int64_t> plan_info_vec, TensorView q, TensorView k_cache,
@@ -32,7 +33,8 @@ void BatchPagedAttentionRun(TensorView float_workspace_buffer, TensorView int_wo
                             Optional<TensorView> maybe_lse, int64_t mask_mode_code,
                             int64_t layout_code, int64_t num_qo_heads, int64_t num_kv_heads,
                             int64_t page_size, double v_scale, double sm_scale,
-                            double logits_soft_cap ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS);
+                            double logits_soft_cap,
+                            bool use_per_token_head ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, &BatchPagedAttentionPlan);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, &BatchPagedAttentionRun);

--- a/csrc/batch_attention_paged_kernel_inst.jinja
+++ b/csrc/batch_attention_paged_kernel_inst.jinja
@@ -2,8 +2,15 @@
 #include "batch_attention_config.inc"
 
 namespace flashinfer {
+
+constexpr auto use_per_token_head = {{ use_per_token_head }};
+
 template cudaError_t BatchPagedAttentionPersistent<
-    /*CTA_TILE_Q_1=*/128, /*CTA_TILE_Q_2=*/16, {{head_dim_qk}}, {{head_dim_vo}}, {{mask_mode}},
+    CTA_TILE_Q_1, CTA_TILE_Q_2, {{head_dim_qk}}, {{head_dim_vo}}, {{mask_mode}},
     {{ variant_name }}, PersistentParams>(const PersistentParams params_1, const PersistentParams params_2,
     const uint32_t num_blks_x, const uint32_t num_blks_y, const cudaStream_t stream);
+
+template const void* GetBatchPagedAttentionPersistentKernel<
+    CTA_TILE_Q_1, CTA_TILE_Q_2, {{head_dim_qk}}, {{head_dim_vo}}, {{mask_mode}},
+    {{ variant_name }}, PersistentParams>(size_t& smem_size, uint32_t& num_threads);
 };  // namespace flashinfer

--- a/csrc/batch_decode.cu
+++ b/csrc/batch_decode.cu
@@ -41,7 +41,7 @@ Array<int64_t> BatchDecodeWithPagedKVCachePlan(
     TensorView page_locked_int_workspace_buffer, TensorView indptr, int64_t batch_size,
     int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph,
     int64_t window_left, double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo,
-    TensorView empty_q_data, TensorView empty_kv_data) {
+    TensorView empty_q_data, TensorView empty_kv_data, bool use_per_token_head) {
   CHECK_INPUT_TYPE(indptr, dl_int32);
 
   size_t float_workspace_size_in_bytes =
@@ -86,8 +86,8 @@ void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                     TensorView paged_v_cache, TensorView paged_kv_indptr,
                                     TensorView paged_kv_indices, TensorView paged_kv_last_page_len,
                                     TensorView o, Optional<TensorView> maybe_lse,
-                                    int64_t kv_layout_code, int64_t window_left,
-                                    bool enable_pdl ADDITIONAL_FUNC_PARAMS) {
+                                    int64_t kv_layout_code, int64_t window_left, bool enable_pdl,
+                                    bool use_per_token_head ADDITIONAL_FUNC_PARAMS) {
   CHECK_INPUT_TYPE(paged_kv_indptr, dl_int32);
   CHECK_INPUT_TYPE(paged_kv_indices, dl_int32);
   CHECK_INPUT_TYPE(paged_kv_last_page_len, dl_int32);

--- a/csrc/batch_decode_customize_config.jinja
+++ b/csrc/batch_decode_customize_config.jinja
@@ -9,8 +9,10 @@
 #define ADDITIONAL_PARAMS_SETTER {{ additional_params_setter }}
 
 #define DISPATCH_context(DTypeQ, DTypeKV, DTypeO, IdType, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, AttentionVariant, Params, ...) { \
-  using AttentionVariant = {{ variant_name }}; \
-  __VA_ARGS__(); \
+  DISPATCH_USE_PER_TOKEN_HEAD(use_per_token_head, use_per_token_head, { \
+    using AttentionVariant = {{ variant_name }}; \
+    __VA_ARGS__(); \
+  }) \
 }
 
 using namespace flashinfer;

--- a/csrc/batch_decode_jit_binding.cu
+++ b/csrc/batch_decode_jit_binding.cu
@@ -25,7 +25,7 @@ Array<int64_t> BatchDecodeWithPagedKVCachePlan(
     TensorView page_locked_int_workspace_buffer, TensorView indptr, int64_t batch_size,
     int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph,
     int64_t window_left, double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo,
-    TensorView empty_q_data, TensorView empty_kv_data);
+    TensorView empty_q_data, TensorView empty_kv_data, bool use_per_token_head);
 
 void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                     TensorView int_workspace_buffer, Array<int64_t> plan_info_vec,
@@ -33,8 +33,8 @@ void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                     TensorView paged_v_cache, TensorView paged_kv_indptr,
                                     TensorView paged_kv_indices, TensorView paged_kv_last_page_len,
                                     TensorView o, Optional<TensorView> maybe_lse,
-                                    int64_t kv_layout_code, int64_t window_left,
-                                    bool enable_pdl ADDITIONAL_FUNC_PARAMS);
+                                    int64_t kv_layout_code, int64_t window_left, bool enable_pdl,
+                                    bool use_per_token_head ADDITIONAL_FUNC_PARAMS);
 
 // Batched decode with paged KV-Cache plan
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, BatchDecodeWithPagedKVCachePlan);

--- a/csrc/batch_decode_kernel_inst.jinja
+++ b/csrc/batch_decode_kernel_inst.jinja
@@ -5,6 +5,8 @@ using namespace flashinfer;
 
 namespace flashinfer {
 
+constexpr auto use_per_token_head = {{ use_per_token_head }};
+
 template cudaError_t
 BatchDecodeWithPagedKVCacheDispatched<{{ head_dim_qk }}, {{ pos_encoding_mode }}, {{ variant_name }}, Params>(
     Params params, {{ dtype_o }}* tmp_v,

--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -25,14 +25,14 @@ namespace flashinfer {
 
 template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
           PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename AttentionVariant, typename Params>
+          bool FORCE_DISABLE_KV_REPACK, typename AttentionVariant, typename Params>
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
                                                    float* tmp_s, bool enable_pdl,
                                                    cudaStream_t stream);
 
 template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
           PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename AttentionVariant, typename Params>
+          bool FORCE_DISABLE_KV_REPACK, typename AttentionVariant, typename Params>
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
                                                     float* tmp_s, bool enable_pdl,
                                                     cudaStream_t stream);
@@ -43,6 +43,15 @@ using namespace flashinfer;
 
 using tvm::ffi::Array;
 using tvm::ffi::Optional;
+
+#define DISPATCH_KV_REPACK(compute_capacity, FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, ...) \
+  if (compute_capacity.first >= 8) {                                                    \
+    constexpr bool FORCE_DISABLE_KV_REPACK = false;                                     \
+    __VA_ARGS__                                                                         \
+  } else {                                                                              \
+    constexpr bool FORCE_DISABLE_KV_REPACK = HEAD_DIM_VO >= 128;                        \
+    __VA_ARGS__                                                                         \
+  }
 
 Array<int64_t> BatchPrefillWithKVCachePlan(
     TensorView float_workspace_buffer, TensorView int_workspace_buffer,
@@ -80,8 +89,8 @@ void BatchPrefillWithRaggedKVCacheRun(TensorView float_workspace_buffer,
                                       TensorView q, TensorView k, TensorView v,
                                       TensorView qo_indptr, TensorView kv_indptr, TensorView o,
                                       Optional<TensorView> maybe_lse, int64_t mask_mode_code,
-                                      int64_t layout, int64_t window_left,
-                                      bool enable_pdl ADDITIONAL_FUNC_PARAMS) {
+                                      int64_t layout, int64_t window_left, bool enable_pdl,
+                                      bool use_per_token_head ADDITIONAL_FUNC_PARAMS) {
   PrefillPlanInfo plan_info;
   plan_info.FromVector(std::vector<int64_t>(plan_info_vec.begin(), plan_info_vec.end()));
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
@@ -188,10 +197,13 @@ void BatchPrefillWithRaggedKVCacheRun(TensorView float_workspace_buffer,
         cudaError_t status = cudaSuccess;
 
         DISPATCH_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
-          status = flashinfer::BatchPrefillWithRaggedKVCacheDispatched<
-              CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
-              /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, AttentionVariant,
-              RaggedParams>(params, tmp_v, tmp_s, enable_pdl, stream);
+          auto compute_capacity = GetCudaComputeCapability();
+          DISPATCH_KV_REPACK(compute_capacity, FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, {
+            status = flashinfer::BatchPrefillWithRaggedKVCacheDispatched<
+                CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
+                /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, FORCE_DISABLE_KV_REPACK,
+                AttentionVariant, RaggedParams>(params, tmp_v, tmp_s, enable_pdl, stream);
+          });
         });
 
         TVM_FFI_ICHECK(status == cudaSuccess)
@@ -207,8 +219,8 @@ void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                      TensorView paged_kv_indptr, TensorView paged_kv_indices,
                                      TensorView paged_kv_last_page_len, TensorView o,
                                      Optional<TensorView> maybe_lse, int64_t mask_mode_code,
-                                     int64_t layout, int64_t window_left,
-                                     bool enable_pdl ADDITIONAL_FUNC_PARAMS) {
+                                     int64_t layout, int64_t window_left, bool enable_pdl,
+                                     bool use_per_token_head ADDITIONAL_FUNC_PARAMS) {
   PrefillPlanInfo plan_info;
   plan_info.FromVector(std::vector<int64_t>(plan_info_vec.begin(), plan_info_vec.end()));
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
@@ -321,10 +333,13 @@ void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
         cudaError_t status = cudaSuccess;
 
         DISPATCH_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
-          status = flashinfer::BatchPrefillWithPagedKVCacheDispatched<
-              CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
-              /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, AttentionVariant,
-              PagedParams>(params, tmp_v, tmp_s, enable_pdl, stream);
+          auto compute_capacity = GetCudaComputeCapability();
+          DISPATCH_KV_REPACK(compute_capacity, FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, {
+            status = flashinfer::BatchPrefillWithPagedKVCacheDispatched<
+                CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
+                /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, FORCE_DISABLE_KV_REPACK,
+                AttentionVariant, PagedParams>(params, tmp_v, tmp_s, enable_pdl, stream);
+          });
         });
 
         TVM_FFI_ICHECK(status == cudaSuccess)

--- a/csrc/batch_prefill_customize_config.jinja
+++ b/csrc/batch_prefill_customize_config.jinja
@@ -13,8 +13,10 @@
 #define DISPATCH_context(DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, USE_FP16_QK_REDUCTION, AttentionVariant, RaggedParams, PagedParams, ...) \
   DISPATCH_MASK_MODE(mask_mode, MASK_MODE, { \
     constexpr auto use_custom_mask = MASK_MODE == MaskMode::kCustom; \
-    using AttentionVariant = {{ variant_name }}; \
-    __VA_ARGS__(); \
+    DISPATCH_USE_PER_TOKEN_HEAD(use_per_token_head, use_per_token_head, { \
+      using AttentionVariant = {{ variant_name }}; \
+      __VA_ARGS__(); \
+    }) \
   })
 
 using namespace flashinfer;

--- a/csrc/batch_prefill_jit_binding.cu
+++ b/csrc/batch_prefill_jit_binding.cu
@@ -32,8 +32,8 @@ void BatchPrefillWithRaggedKVCacheRun(TensorView float_workspace_buffer,
                                       TensorView q, TensorView k, TensorView v,
                                       TensorView qo_indptr, TensorView kv_indptr, TensorView o,
                                       Optional<TensorView> maybe_lse, int64_t mask_mode_code,
-                                      int64_t layout, int64_t window_left,
-                                      bool enable_pdl ADDITIONAL_FUNC_PARAMS);
+                                      int64_t layout, int64_t window_left, bool enable_pdl,
+                                      bool use_per_token_head ADDITIONAL_FUNC_PARAMS);
 
 void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                      TensorView int_workspace_buffer, Array<int64_t> plan_info_vec,
@@ -42,8 +42,8 @@ void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                      TensorView paged_kv_indptr, TensorView paged_kv_indices,
                                      TensorView paged_kv_last_page_len, TensorView o,
                                      Optional<TensorView> maybe_lse, int64_t mask_mode_code,
-                                     int64_t layout, int64_t window_left,
-                                     bool enable_pdl ADDITIONAL_FUNC_PARAMS);
+                                     int64_t layout, int64_t window_left, bool enable_pdl,
+                                     bool use_per_token_head ADDITIONAL_FUNC_PARAMS);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, BatchPrefillWithKVCachePlan);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(ragged_run, BatchPrefillWithRaggedKVCacheRun);

--- a/csrc/batch_prefill_paged_kernel_inst.jinja
+++ b/csrc/batch_prefill_paged_kernel_inst.jinja
@@ -4,10 +4,14 @@
 namespace flashinfer {
 
 constexpr auto use_custom_mask = {{ mask_mode }} == MaskMode::kCustom;
+constexpr auto use_per_token_head = {{ use_per_token_head }};
 
 {% for cta_tile_q in [16, 64, 128] %}
 template cudaError_t BatchPrefillWithPagedKVCacheDispatched<
-    /*CTA_TILE_Q=*/{{cta_tile_q}}, {{head_dim_qk}}, {{head_dim_vo}}, {{pos_encoding_mode}}, {{use_fp16_qk_reduction}}, {{mask_mode}},
+    /*CTA_TILE_Q=*/{{cta_tile_q}}, {{head_dim_qk}}, {{head_dim_vo}}, {{pos_encoding_mode}}, {{use_fp16_qk_reduction}}, {{mask_mode}}, false,
+    {{ variant_name }}, PagedParams>(PagedParams params, {{ dtype_o }}* tmp_v, float* tmp_s, bool enable_pdl, cudaStream_t stream);
+template cudaError_t BatchPrefillWithPagedKVCacheDispatched<
+    /*CTA_TILE_Q=*/{{cta_tile_q}}, {{head_dim_qk}}, {{head_dim_vo}}, {{pos_encoding_mode}}, {{use_fp16_qk_reduction}}, {{mask_mode}}, true,
     {{ variant_name }}, PagedParams>(PagedParams params, {{ dtype_o }}* tmp_v, float* tmp_s, bool enable_pdl, cudaStream_t stream);
 {% endfor %}
 

--- a/csrc/batch_prefill_ragged_kernel_inst.jinja
+++ b/csrc/batch_prefill_ragged_kernel_inst.jinja
@@ -4,10 +4,14 @@
 namespace flashinfer {
 
 constexpr auto use_custom_mask = {{ mask_mode }} == MaskMode::kCustom;
+constexpr auto use_per_token_head = {{ use_per_token_head }};
 
 {% for cta_tile_q in [16, 64, 128] %}
 template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<
-    /*CTA_TILE_Q=*/{{cta_tile_q}}, {{head_dim_qk}}, {{head_dim_vo}}, {{pos_encoding_mode}}, {{use_fp16_qk_reduction}}, {{mask_mode}},
+    /*CTA_TILE_Q=*/{{cta_tile_q}}, {{head_dim_qk}}, {{head_dim_vo}}, {{pos_encoding_mode}}, {{use_fp16_qk_reduction}}, {{mask_mode}}, false,
+    {{ variant_name }}, RaggedParams>(RaggedParams params, {{ dtype_o }}* tmp_v, float* tmp_s, bool enable_pdl, cudaStream_t stream);
+template cudaError_t BatchPrefillWithRaggedKVCacheDispatched<
+    /*CTA_TILE_Q=*/{{cta_tile_q}}, {{head_dim_qk}}, {{head_dim_vo}}, {{pos_encoding_mode}}, {{use_fp16_qk_reduction}}, {{mask_mode}}, true,
     {{ variant_name }}, RaggedParams>(RaggedParams params, {{ dtype_o }}* tmp_v, float* tmp_s, bool enable_pdl, cudaStream_t stream);
 {% endfor %}
 

--- a/csrc/single_decode.cu
+++ b/csrc/single_decode.cu
@@ -32,10 +32,11 @@ using namespace flashinfer;
 
 void single_decode_with_kv_cache(TensorView q, TensorView k, TensorView v, TensorView tmp,
                                  TensorView o, Optional<TensorView> maybe_lse, int64_t layout,
-                                 int64_t window_left ADDITIONAL_FUNC_PARAMS) {
+                                 int64_t window_left,
+                                 bool use_per_token_head ADDITIONAL_FUNC_PARAMS) {
   CHECK_INPUT(q);
-  CHECK_INPUT(k);
-  CHECK_INPUT(v);
+  CHECK_CUDA(k);
+  CHECK_CUDA(v);
   CHECK_INPUT(tmp);
   CHECK_DEVICE(k, q);
   CHECK_DEVICE(v, q);
@@ -85,9 +86,29 @@ void single_decode_with_kv_cache(TensorView q, TensorView k, TensorView v, Tenso
         params.num_kv_heads = num_kv_heads;
         params.q_stride_n = num_qo_heads * head_dim_qk;
         params.q_stride_h = head_dim_qk;
+        unsigned int head_dim_vo_pad = head_dim_vo;
+        if constexpr (AttentionVariant::use_per_token_head) {
+          // inline scale into k/v cache and padding to 16B
+          head_dim_vo_pad = head_dim_vo + 16;
+          if (kv_layout == QKVLayout::kNHD) {
+            TVM_FFI_ICHECK_EQ(k.stride(0), num_kv_heads * head_dim_vo_pad);
+            TVM_FFI_ICHECK_EQ(v.stride(0), num_kv_heads * head_dim_vo_pad);
+          } else {
+            TVM_FFI_ICHECK_EQ(k.stride(0), kv_len * head_dim_vo_pad);
+            TVM_FFI_ICHECK_EQ(v.stride(0), kv_len * head_dim_vo_pad);
+          }
+          TVM_FFI_ICHECK_EQ(k.stride(1), head_dim_vo_pad);
+          TVM_FFI_ICHECK_EQ(v.stride(1), head_dim_vo_pad);
+          TVM_FFI_ICHECK_EQ(k.stride(2), 1);
+          TVM_FFI_ICHECK_EQ(v.stride(2), 1);
+        } else {
+          CHECK_CONTIGUOUS(k);
+          CHECK_CONTIGUOUS(v);
+        }
         params.kv_stride_n =
-            (kv_layout == QKVLayout::kNHD) ? num_kv_heads * head_dim_vo : head_dim_vo;
-        params.kv_stride_h = (kv_layout == QKVLayout::kNHD) ? head_dim_vo : kv_len * head_dim_vo;
+            (kv_layout == QKVLayout::kNHD) ? num_kv_heads * head_dim_vo_pad : head_dim_vo_pad;
+        params.kv_stride_h =
+            (kv_layout == QKVLayout::kNHD) ? head_dim_vo_pad : kv_len * head_dim_vo_pad;
         params.window_left = window_left;
         params.kv_chunk_size = 0;
 

--- a/csrc/single_decode_customize_config.jinja
+++ b/csrc/single_decode_customize_config.jinja
@@ -8,8 +8,10 @@
 #define ADDITIONAL_PARAMS_SETTER {{ additional_params_setter }}
 
 #define DISPATCH_context(DTypeQ, DTypeKV, DTypeO, IdType, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, AttentionVariant, Params, ...) {\
-  using AttentionVariant = {{ variant_name }}; \
-  __VA_ARGS__(); \
+  DISPATCH_USE_PER_TOKEN_HEAD(use_per_token_head, use_per_token_head, { \
+    using AttentionVariant = {{ variant_name }}; \
+    __VA_ARGS__(); \
+  }) \
 }
 
 using namespace flashinfer;

--- a/csrc/single_decode_jit_binding.cu
+++ b/csrc/single_decode_jit_binding.cu
@@ -21,7 +21,8 @@ using tvm::ffi::Optional;
 
 void single_decode_with_kv_cache(TensorView q, TensorView k, TensorView v, TensorView tmp,
                                  TensorView o, Optional<TensorView> maybe_lse, int64_t layout,
-                                 int64_t window_left ADDITIONAL_FUNC_PARAMS);
+                                 int64_t window_left,
+                                 bool use_per_token_head ADDITIONAL_FUNC_PARAMS);
 
 // Single-request decode with KV-Cache operator
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, single_decode_with_kv_cache);

--- a/csrc/single_decode_kernel_inst.jinja
+++ b/csrc/single_decode_kernel_inst.jinja
@@ -5,6 +5,8 @@ using namespace flashinfer;
 
 namespace flashinfer {
 
+constexpr auto use_per_token_head = {{ use_per_token_head }};
+
 template cudaError_t SingleDecodeWithKVCacheDispatched<
     {{ head_dim_qk }}, {{ pos_encoding_mode }}, {{ variant_name }}, Params>(
     Params params, {{ dtype_o }}* tmp,

--- a/csrc/single_prefill.cu
+++ b/csrc/single_prefill.cu
@@ -25,8 +25,8 @@ using tvm::ffi::Optional;
 namespace flashinfer {
 
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
-          bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename AttentionVariant,
-          typename Params>
+          bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE, bool FORCE_DISABLE_KV_REPACK,
+          typename AttentionVariant, typename Params>
 cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp,
                                                cudaStream_t stream);
 
@@ -34,10 +34,20 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
 
 using namespace flashinfer;
 
+#define DISPATCH_KV_REPACK(compute_capacity, FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, ...) \
+  if (compute_capacity.first >= 8) {                                                    \
+    constexpr bool FORCE_DISABLE_KV_REPACK = false;                                     \
+    __VA_ARGS__                                                                         \
+  } else {                                                                              \
+    constexpr bool FORCE_DISABLE_KV_REPACK = HEAD_DIM_VO >= 128;                        \
+    __VA_ARGS__                                                                         \
+  }
+
 void single_prefill_with_kv_cache(ffi::TensorView q, ffi::TensorView k, ffi::TensorView v,
                                   ffi::TensorView tmp, ffi::TensorView o,
                                   Optional<ffi::TensorView> maybe_lse, int64_t mask_mode_code,
-                                  int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS) {
+                                  int64_t layout, int64_t window_left,
+                                  bool use_per_token_head ADDITIONAL_FUNC_PARAMS) {
   unsigned int head_dim_qk = q.size(2);
   unsigned int kv_len, qo_len, num_kv_heads, num_qo_heads;
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
@@ -100,10 +110,14 @@ void single_prefill_with_kv_cache(ffi::TensorView q, ffi::TensorView k, ffi::Ten
 
         ADDITIONAL_PARAMS_SETTER
 
-        cudaError_t status = flashinfer::SinglePrefillWithKVCacheDispatched<
-            HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
-            /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, AttentionVariant>(
-            params, static_cast<DTypeO*>(tmp.data_ptr()), stream);
+        cudaError_t status;
+        auto compute_capacity = GetCudaComputeCapability();
+        DISPATCH_KV_REPACK(compute_capacity, FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, {
+          status = flashinfer::SinglePrefillWithKVCacheDispatched<
+              HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
+              /*use_fp16_qk_reduction=*/USE_FP16_QK_REDUCTION, MASK_MODE, FORCE_DISABLE_KV_REPACK,
+              AttentionVariant>(params, static_cast<DTypeO*>(tmp.data_ptr()), stream);
+        });
         TVM_FFI_ICHECK(status == cudaSuccess)
             << "SinglePrefillWithKVCache kernel launch failed, error: "
             << cudaGetErrorString(status);

--- a/csrc/single_prefill_customize_config.jinja
+++ b/csrc/single_prefill_customize_config.jinja
@@ -9,12 +9,13 @@
 #define ADDITIONAL_FUNC_PARAMS {{ additional_func_params }}
 #define ADDITIONAL_PARAMS_SETTER {{ additional_params_setter }}
 
-
 #define DISPATCH_context(DTypeQ, DTypeKV, DTypeO, IdType, MASK_MODE, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, USE_FP16_QK_REDUCTION, AttentionVariant, Params, ...) \
   DISPATCH_MASK_MODE(mask_mode, MASK_MODE, { \
     constexpr bool use_custom_mask = MASK_MODE == MaskMode::kCustom; \
-    using AttentionVariant = {{ variant_name }}; \
-    __VA_ARGS__(); \
+    DISPATCH_USE_PER_TOKEN_HEAD(use_per_token_head, use_per_token_head, { \
+      using AttentionVariant = {{ variant_name }}; \
+      __VA_ARGS__(); \
+    }) \
   })
 
 

--- a/csrc/single_prefill_jit_binding.cu
+++ b/csrc/single_prefill_jit_binding.cu
@@ -21,7 +21,8 @@ using tvm::ffi::Optional;
 void single_prefill_with_kv_cache(ffi::TensorView q, ffi::TensorView k, ffi::TensorView v,
                                   ffi::TensorView tmp, ffi::TensorView o,
                                   Optional<ffi::TensorView> maybe_lse, int64_t mask_mode_code,
-                                  int64_t layout, int64_t window_left ADDITIONAL_FUNC_PARAMS);
+                                  int64_t layout, int64_t window_left,
+                                  bool use_per_token_head ADDITIONAL_FUNC_PARAMS);
 
 // Single-request prefill attention with KV-Cache operator
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, single_prefill_with_kv_cache);

--- a/csrc/single_prefill_kernel_inst.jinja
+++ b/csrc/single_prefill_kernel_inst.jinja
@@ -6,10 +6,16 @@ using namespace flashinfer;
 namespace flashinfer {
 
 constexpr auto use_custom_mask = {{ mask_mode }} == MaskMode::kCustom;
+constexpr auto use_per_token_head = {{ use_per_token_head }};
 
 template cudaError_t SinglePrefillWithKVCacheDispatched<
-    {{ head_dim_qk }}, {{ head_dim_vo }}, {{ pos_encoding_mode }}, {{ use_fp16_qk_reduction }}, {{ mask_mode }}, {{ variant_name }}, Params>(
+    {{ head_dim_qk }}, {{ head_dim_vo }}, {{ pos_encoding_mode }}, {{ use_fp16_qk_reduction }}, {{ mask_mode }}, false, {{ variant_name }}, Params>(
     Params params, {{ dtype_o }}* tmp,
     cudaStream_t stream);
+template cudaError_t SinglePrefillWithKVCacheDispatched<
+    {{ head_dim_qk }}, {{ head_dim_vo }}, {{ pos_encoding_mode }}, {{ use_fp16_qk_reduction }}, {{ mask_mode }}, true, {{ variant_name }}, Params>(
+    Params params, {{ dtype_o }}* tmp,
+    cudaStream_t stream);
+
 
 };

--- a/flashinfer/attention/_core.py
+++ b/flashinfer/attention/_core.py
@@ -59,6 +59,13 @@ class BatchAttention:
     device : str
         CUDA device that owns the internal workspace buffers, e.g. ``"cuda"`` or
         ``"cuda:0"``.  Defaults to ``"cuda"``.
+    use_per_token_head : bool
+        Whether to use FP8 per-token-head inline scales. When enabled, the KV cache
+        should have a float32 scale stored immediately after each token-head's FP8 data
+        (at offset ``head_dim`` in bytes). The KV cache tensor should be created with
+        stride ``head_dim + 16`` (16B aligned) along the head dimension to accommodate
+        the inline scale.
+        Defaults to ``False``.
     """
 
     @flashinfer_api
@@ -66,6 +73,7 @@ class BatchAttention:
         self,
         kv_layout: str = "NHD",
         device: str = "cuda",
+        use_per_token_head: bool = False,
     ):
         r"""Allocate workspace buffers and bind the wrapper to a CUDA device.
 
@@ -90,6 +98,7 @@ class BatchAttention:
             device=torch.device("cpu"),
             pin_memory=True,
         )
+        self._use_per_token_head = use_per_token_head
 
     @flashinfer_api
     def plan(
@@ -200,6 +209,7 @@ class BatchAttention:
             num_kv_heads,
             head_dim_vo,
             causal,
+            self._use_per_token_head,
         )
 
     @flashinfer_api(trace=batch_attention_run_trace)
@@ -209,8 +219,8 @@ class BatchAttention:
         kv_cache: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
-        k_scale: Optional[torch.Tensor] = None,
-        v_scale: Optional[torch.Tensor] = None,
+        k_scale: Optional[float] = None,
+        v_scale: Optional[float] = None,
         logits_soft_cap: float = 0.0,
         profiler_buffer: Optional[torch.Tensor] = None,
         kv_cache_sf: Optional[
@@ -233,9 +243,9 @@ class BatchAttention:
         lse : Optional[torch.Tensor]
             Optional log-sum-exp buffer, shape ``[total_qo_tokens, num_qo_heads]``, dtype
             ``float32``.  Allocated if ``None``.
-        k_scale : Optional[torch.Tensor]
+        k_scale : Optional[float]
             FP8 dequantization scale for ``k``.  Pre-multiplied into ``sm_scale``.
-        v_scale : Optional[torch.Tensor]
+        v_scale : Optional[float]
             FP8 dequantization scale for ``v``.  Applied to the output.
         logits_soft_cap : float
             Logits soft-cap value.  Must be consistent with the ``logits_soft_cap``
@@ -307,6 +317,7 @@ class BatchAttention:
             v_scale,
             sm_scale,
             logits_soft_cap,
+            self._use_per_token_head,
             # ADDITIONAL_FUNC_PARAMS (maybe_k_cache_sf, maybe_v_cache_sf)
             k_cache_sf,
             v_cache_sf,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -106,6 +106,7 @@ def get_single_decode_module(*args):
         alibi_slopes: Optional[torch.Tensor],
         kv_layout_code: int,
         window_left: int,
+        use_per_token_head: bool,
         logits_soft_cap: float,
         sm_scale: float,
         rope_scale: float,
@@ -120,6 +121,7 @@ def get_single_decode_module(*args):
             maybe_lse,
             kv_layout_code,
             window_left,
+            use_per_token_head,
             alibi_slopes,
             logits_soft_cap,
             sm_scale,
@@ -138,6 +140,7 @@ def get_single_decode_module(*args):
         alibi_slopes: Optional[torch.Tensor],
         kv_layout_code: int,
         window_left: int,
+        use_per_token_head: bool,
         logits_soft_cap: float,
         sm_scale: float,
         rope_scale: float,
@@ -261,6 +264,7 @@ def get_batch_decode_module(*args):
         kv_layout_code: int,
         window_left: int,
         enable_pdl: bool,
+        use_per_token_head: bool,
         alibi_slopes: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
@@ -282,6 +286,7 @@ def get_batch_decode_module(*args):
             kv_layout_code,
             window_left,
             enable_pdl,
+            use_per_token_head,
             alibi_slopes,
             logits_soft_cap,
             sm_scale,
@@ -305,6 +310,7 @@ def get_batch_decode_module(*args):
         kv_layout_code: int,
         window_left: int,
         enable_pdl: bool,
+        use_per_token_head: bool,
         alibi_slopes: Optional[torch.Tensor],
         logits_soft_cap: float,
         sm_scale: float,
@@ -425,6 +431,7 @@ def single_decode_with_kv_cache(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     return_lse: Literal[False] = False,
+    use_per_token_head: bool = False,
 ) -> torch.Tensor: ...
 
 
@@ -445,6 +452,7 @@ def single_decode_with_kv_cache(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     return_lse: Literal[True] = True,
+    use_per_token_head: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
 
@@ -465,6 +473,7 @@ def single_decode_with_kv_cache(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     return_lse: bool = False,
+    use_per_token_head: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Decode attention with KV Cache for single request, return attention output.
 
@@ -512,6 +521,8 @@ def single_decode_with_kv_cache(
         The theta used in RoPE, if not provided, will be set to ``1e4``.
     return_lse : bool
         Whether to return the log sum exp value of the attention logits.
+    use_per_token_head : bool
+        Whether to use FP8 per-token-head inline scales.
 
     Returns
     -------
@@ -589,6 +600,7 @@ def single_decode_with_kv_cache(
             MaskMode.NON_CAUSAL.value,
             TensorLayout[kv_layout].value,
             window_left,
+            use_per_token_head,
             None,  # packed_custom_mask
             get_alibi_slopes(num_qo_heads, device=q.device)
             if pos_encoding_mode == "ALIBI"
@@ -627,6 +639,7 @@ def single_decode_with_kv_cache(
             else None,
             TensorLayout[kv_layout].value,
             window_left,
+            use_per_token_head,
             logits_soft_cap,
             sm_scale,
             rope_scale,
@@ -723,6 +736,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         paged_kv_last_page_len_buffer: Optional[torch.Tensor] = None,
         backend: str = "auto",
         jit_args: Optional[List[Any]] = None,
+        use_per_token_head: bool = False,
     ) -> None:
         r"""Constructor of :class:`BatchDecodeWithPagedKVCacheWrapper`.
 
@@ -773,6 +787,14 @@ class BatchDecodeWithPagedKVCacheWrapper:
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
             otherwise, the wrapper will use default attention implementation.
+
+        use_per_token_head : bool,
+            Whether to use FP8 per-token-head inline scales. When enabled, the KV cache
+            should have a float32 scale stored immediately after each token-head's FP8 data
+            (at offset ``head_dim`` in bytes). The KV cache tensor should be created with
+            stride ``head_dim + 16`` (16B aligned) along the head dimension to accommodate
+            the inline scale.
+            Defaults to ``False``.
         """
         _check_kv_layout(kv_layout)
 
@@ -856,6 +878,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     device=float_workspace_buffer.device,
                 )
         self._backend = backend
+        self._use_per_token_head = use_per_token_head
 
         self._cute_dsl_wrapper = None
         if backend == "cute-dsl":
@@ -1198,6 +1221,11 @@ class BatchDecodeWithPagedKVCacheWrapper:
                         )
                     else:
                         self._backend = "fa2"
+                if self._use_per_token_head and self._backend != "fa2":
+                    raise ValueError(
+                        f"Per-token-head scaling is only supported with the fa2 backend, "
+                        f"but backend is {self._backend!r}"
+                    )
                 self._cached_module = get_batch_prefill_module(
                     self._backend,
                     q_data_type,
@@ -1268,6 +1296,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 head_dim,
                 torch.empty(0, dtype=q_data_type),
                 torch.empty(0, dtype=kv_data_type),
+                self._use_per_token_head,
             )
 
         self._pos_encoding_mode = pos_encoding_mode
@@ -1614,6 +1643,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 TensorLayout[self._kv_layout].value,
                 window_left,
                 enable_pdl,
+                self._use_per_token_head,
             ]
 
             if self._jit_module is not None:
@@ -1717,6 +1747,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 TensorLayout[self._kv_layout].value,
                 window_left,
                 enable_pdl,
+                self._use_per_token_head,
             ]
 
             if self._jit_module is not None:
@@ -3242,7 +3273,7 @@ def fast_decode_plan(
                 raise RuntimeError(f"Error in standard plan: {e}") from e
         else:
             try:
-                # Make sure we pass exactly 15 arguments for standard version
+                # Make sure we pass exactly 16 arguments for standard version
                 self._plan_info = self._cached_module.plan(
                     self._float_workspace_buffer,
                     self._int_workspace_buffer,
@@ -3259,6 +3290,7 @@ def fast_decode_plan(
                     head_dim,
                     empty_q_data,
                     empty_kv_cache,
+                    self._use_per_token_head,
                 )
             except Exception as e:
                 raise RuntimeError(f"Error in standard plan: {e}") from e

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -479,7 +479,7 @@ def gen_single_decode_module(
             "rope_rcp_theta",
         ],  # additional_scalar_names
         ["double", "double", "double", "double"],  # additional_scalar_dtypes
-        f"DefaultAttention<false, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>",  # variant_name
+        f"DefaultAttention<false, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}, use_per_token_head>",  # variant_name
         "#include<flashinfer/attention/variants.cuh>",  # variant_decl
         pos_encoding_mode=pos_encoding_mode,
         use_sliding_window=use_sliding_window,
@@ -533,7 +533,7 @@ def gen_single_prefill_module(
             "rope_rcp_theta",
         ]
         additional_scalar_dtypes = ["double", "double", "double", "double"]
-        variant_name = f"DefaultAttention<use_custom_mask, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>"
+        variant_name = f"DefaultAttention<use_custom_mask, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}, use_per_token_head>"
         variant_decl = "#include<flashinfer/attention/variants.cuh>"
     else:
         if not fp8_enabled:
@@ -951,7 +951,7 @@ def gen_batch_decode_module(
             "rope_rcp_theta",
         ],  # additional_scalar_names
         ["double", "double", "double", "double"],  # additional_scalar_dtypes
-        f"DefaultAttention<false, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>",  # variant_name
+        f"DefaultAttention<false, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}, use_per_token_head>",  # variant_name
         "#include<flashinfer/attention/variants.cuh>",  # variant_decl
         pos_encoding_mode=pos_encoding_mode,
         use_sliding_window=use_sliding_window,
@@ -1028,7 +1028,7 @@ def gen_batch_prefill_module(
             "token_pos_in_items_len",
         ]
         additional_scalar_dtypes = ["double", "double", "double", "double", "int64_t"]
-        variant_name = f"DefaultAttention<use_custom_mask, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>"
+        variant_name = f"DefaultAttention<use_custom_mask, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}, use_per_token_head>"
         variant_decl = "#include<flashinfer/attention/variants.cuh>"
     else:
         if not fp8_enabled:
@@ -1163,7 +1163,9 @@ def gen_batch_attention_module(
     additional_tensor_dtypes: List[str] = ["uint8_t", "uint8_t"]
     additional_scalar_names: List[str] = []
     additional_scalar_dtypes: List[str] = []
-    variant_name = f"StandardAttention<{str(use_logits_soft_cap).lower()}>"
+    variant_name = (
+        f"StandardAttention<{str(use_logits_soft_cap).lower()}, use_per_token_head>"
+    )
     variant_decl = "#include<flashinfer/attention/variants.cuh>"
 
     return gen_customize_batch_attention_module(
@@ -1184,6 +1186,14 @@ def gen_batch_attention_module(
         use_logits_soft_cap=use_logits_soft_cap,
         use_profiler=use_profiler,
     )
+
+
+def _use_pth_literal(dtype_kv: torch.dtype):
+    fp8_dtypes = [torch.float8_e4m3fn, torch.float8_e5m2]
+    if dtype_kv in fp8_dtypes:
+        return [False, True]
+    else:
+        return [False]
 
 
 def gen_customize_single_decode_module(
@@ -1248,12 +1258,16 @@ def gen_customize_single_decode_module(
 
     source_paths = []
 
-    dest_path = gen_directory / "single_decode_kernel.cu"
-    source_paths.append(dest_path)
-    source = kernel_inst_templ.render(
-        **kwargs,
-    )
-    write_if_different(dest_path, source)
+    for use_per_token_head in _use_pth_literal(dtype_kv):
+        dest_path = (
+            gen_directory / f"single_decode_kernel_pth_{int(use_per_token_head)}.cu"
+        )
+        source_paths.append(dest_path)
+        source = kernel_inst_templ.render(
+            use_per_token_head=str(use_per_token_head).lower(),
+            **kwargs,
+        )
+        write_if_different(dest_path, source)
 
     for filename in [
         "single_decode.cu",
@@ -1341,14 +1355,16 @@ def gen_customize_single_prefill_module(
 
         source_paths = []
         for mask_mode in [0, 1, 2, 3]:
-            filename = f"single_prefill_kernel_mask_{mask_mode}.cu"
-            dest_path = gen_directory / filename
-            source_paths.append(dest_path)
-            source = kernel_inst_templ.render(
-                mask_mode=mask_mode_literal[mask_mode],
-                **kwargs,
-            )
-            write_if_different(dest_path, source)
+            for use_per_token_head in _use_pth_literal(dtype_kv):
+                filename = f"single_prefill_kernel_mask_{mask_mode}_pth_{int(use_per_token_head)}.cu"
+                dest_path = gen_directory / filename
+                source_paths.append(dest_path)
+                source = kernel_inst_templ.render(
+                    mask_mode=mask_mode_literal[mask_mode],
+                    use_per_token_head=str(use_per_token_head).lower(),
+                    **kwargs,
+                )
+                write_if_different(dest_path, source)
 
         for filename in [
             "single_prefill.cu",
@@ -1493,12 +1509,16 @@ def gen_customize_batch_decode_module(
 
     source_paths = []
 
-    dest_path = gen_directory / "batch_decode_kernel.cu"
-    source_paths.append(dest_path)
-    source = kernel_inst_templ.render(
-        **kwargs,
-    )
-    write_if_different(dest_path, source)
+    for use_per_token_head in _use_pth_literal(dtype_kv):
+        dest_path = (
+            gen_directory / f"batch_decode_kernel_pth_{int(use_per_token_head)}.cu"
+        )
+        source_paths.append(dest_path)
+        source = kernel_inst_templ.render(
+            use_per_token_head=str(use_per_token_head).lower(),
+            **kwargs,
+        )
+        write_if_different(dest_path, source)
 
     for filename in [
         "batch_decode.cu",
@@ -1592,25 +1612,30 @@ def gen_customize_batch_prefill_module(
 
         source_paths = []
         for mask_mode in [0, 1, 2, 3]:
-            dest_path = (
-                gen_directory / f"batch_prefill_paged_kernel_mask_{mask_mode}.cu"
-            )
-            source_paths.append(dest_path)
-            source = paged_kernel_inst_templ.render(
-                mask_mode=mask_mode_literal[mask_mode],
-                **kwargs,
-            )
-            write_if_different(dest_path, source)
+            for use_per_token_head in _use_pth_literal(dtype_kv):
+                dest_path = (
+                    gen_directory
+                    / f"batch_prefill_paged_kernel_mask_{mask_mode}_pth_{int(use_per_token_head)}.cu"
+                )
+                source_paths.append(dest_path)
+                source = paged_kernel_inst_templ.render(
+                    mask_mode=mask_mode_literal[mask_mode],
+                    use_per_token_head=str(use_per_token_head).lower(),
+                    **kwargs,
+                )
+                write_if_different(dest_path, source)
 
-            dest_path = (
-                gen_directory / f"batch_prefill_ragged_kernel_mask_{mask_mode}.cu"
-            )
-            source_paths.append(dest_path)
-            source = ragged_kernel_inst_templ.render(
-                mask_mode=mask_mode_literal[mask_mode],
-                **kwargs,
-            )
-            write_if_different(dest_path, source)
+                dest_path = (
+                    gen_directory
+                    / f"batch_prefill_ragged_kernel_mask_{mask_mode}_pth_{int(use_per_token_head)}.cu"
+                )
+                source_paths.append(dest_path)
+                source = ragged_kernel_inst_templ.render(
+                    mask_mode=mask_mode_literal[mask_mode],
+                    use_per_token_head=str(use_per_token_head).lower(),
+                    **kwargs,
+                )
+                write_if_different(dest_path, source)
 
         for filename in [
             "batch_prefill.cu",
@@ -1882,13 +1907,18 @@ def gen_customize_batch_attention_module(
 
     source_paths = []
     for mask_mode in [0, 1, 2, 3]:
-        dest_path = gen_directory / f"batch_attention_paged_kernel_mask_{mask_mode}.cu"
-        source_paths.append(dest_path)
-        source = paged_kernel_inst_templ.render(
-            mask_mode=mask_mode_literal[mask_mode],
-            **kwargs,
-        )
-        write_if_different(dest_path, source)
+        for use_per_token_head in _use_pth_literal(dtype_kv):
+            dest_path = (
+                gen_directory
+                / f"batch_attention_paged_kernel_mask_{mask_mode}_pth_{int(use_per_token_head)}.cu"
+            )
+            source_paths.append(dest_path)
+            source = paged_kernel_inst_templ.render(
+                mask_mode=mask_mode_literal[mask_mode],
+                use_per_token_head=str(use_per_token_head).lower(),
+                **kwargs,
+            )
+            write_if_different(dest_path, source)
 
     for filename in [
         "batch_attention.cu",

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -334,6 +334,7 @@ def get_single_prefill_module(backend, *args):
         mask_mode: int,
         layout: int,
         window_left: int,
+        use_per_token_head: bool,
         maybe_packed_custom_mask: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
         logits_soft_cap: float,
@@ -397,6 +398,7 @@ def get_single_prefill_module(backend, *args):
                 mask_mode,
                 layout,
                 window_left,
+                use_per_token_head,
                 maybe_packed_custom_mask,
                 maybe_alibi_slopes,
                 maybe_k_cache_sf,
@@ -475,6 +477,7 @@ def get_batch_prefill_module(backend, *args):
         layout: int,
         window_left: int,
         enable_pdl: bool,
+        use_per_token_head: bool,
         maybe_custom_mask: Optional[torch.Tensor],
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
@@ -511,6 +514,7 @@ def get_batch_prefill_module(backend, *args):
                 layout,
                 window_left,
                 enable_pdl,
+                use_per_token_head,
                 maybe_custom_mask,
                 maybe_mask_indptr,
                 maybe_alibi_slopes,
@@ -646,6 +650,7 @@ def get_batch_prefill_module(backend, *args):
         layout: int,
         window_left: int,
         enable_pdl: bool,
+        use_per_token_head: bool,
         maybe_custom_mask: Optional[torch.Tensor],
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
@@ -734,6 +739,7 @@ def get_batch_prefill_module(backend, *args):
                 layout,
                 window_left,
                 enable_pdl,
+                use_per_token_head,
                 maybe_custom_mask,
                 maybe_mask_indptr,
                 maybe_alibi_slopes,
@@ -825,6 +831,7 @@ def get_batch_prefill_module(backend, *args):
         layout: int,
         window_left: int,
         enable_pdl: bool,
+        use_per_token_head: bool,
         maybe_custom_mask: Optional[torch.Tensor],
         maybe_mask_indptr: Optional[torch.Tensor],
         maybe_alibi_slopes: Optional[torch.Tensor],
@@ -1115,6 +1122,7 @@ def single_prefill_with_kv_cache(
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    use_per_token_head: bool = False,
 ) -> torch.Tensor: ...
 
 
@@ -1143,6 +1151,7 @@ def single_prefill_with_kv_cache(
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    use_per_token_head: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
 
@@ -1171,6 +1180,7 @@ def single_prefill_with_kv_cache(
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    use_per_token_head: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Prefill/Append attention with KV cache for single request, return the attention
     output.
@@ -1251,10 +1261,17 @@ def single_prefill_with_kv_cache(
         Both ``k_scales`` and ``v_scales`` use a linear (row-major) layout, and both have dtype ``torch.float8_e4m3fn``.
 
         Currently, NVFP4 KV only supports `fa2` backend.
-    k_scale : Optional[Union[float, torch.Tensor]]
+    k_scale : Optional[float]
         The calibration scale of key for fp8 or nvfp4 input, if not provided, will be set to ``1.0``.
-    v_scale : Optional[Union[float, torch.Tensor]]
+    v_scale : Optional[float]
         The calibration scale of value for fp8 or nvfp4 input, if not provided, will be set to ``1.0``.
+    use_per_token_head : bool
+        Whether to use FP8 per-token-head inline scales. When enabled, the KV cache
+        should have a float32 scale stored immediately after each token-head's FP8 data
+        (at offset ``head_dim`` in bytes). The KV cache tensor should be created with
+        stride ``head_dim + 16`` (16B aligned) along the head dimension to accommodate
+        the inline scale. Only ``fa2`` backend is supported.
+        Defaults to ``False``.
 
     Returns
     -------
@@ -1348,13 +1365,22 @@ def single_prefill_with_kv_cache(
             scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
 
     if backend == "auto":
-        backend = determine_attention_backend(
-            q.device,
-            PosEncodingMode[pos_encoding_mode].value,
-            use_fp16_qk_reduction,
-            packed_custom_mask is not None,  # use_custom_mask
-            q.dtype,
-            k.dtype,
+        backend = (
+            "fa2"
+            if use_per_token_head
+            else determine_attention_backend(
+                q.device,
+                PosEncodingMode[pos_encoding_mode].value,
+                use_fp16_qk_reduction,
+                packed_custom_mask is not None,  # use_custom_mask
+                q.dtype,
+                k.dtype,
+            )
+        )
+    if use_per_token_head and backend != "fa2":
+        raise ValueError(
+            f"Per-token-head scaling is only supported with the fa2 backend, "
+            f"but backend is {backend!r}"
         )
 
     # Unpack NVFP4 scale factors
@@ -1395,6 +1421,7 @@ def single_prefill_with_kv_cache(
         mask_mode,
         TensorLayout[kv_layout].value,
         window_left,
+        use_per_token_head,
         packed_custom_mask,
         get_alibi_slopes(q.shape[1], device=q.device)
         if pos_encoding_mode == "ALIBI"
@@ -1580,6 +1607,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         backend: str = "auto",
         jit_args: Optional[List[Any]] = None,
         jit_kwargs: Optional[Dict[str, Any]] = None,
+        use_per_token_head: bool = False,
     ) -> None:
         r"""Constructor of :class:`BatchPrefillWithPagedKVCacheWrapper`.
 
@@ -1643,6 +1671,14 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         jit_kwargs : Optional[Dict[str, Any]]
             The keyword arguments to create the JIT module, defaults to None.
+
+        use_per_token_head : bool
+            Whether to use FP8 per-token-head inline scales. When enabled, the KV cache
+            should have a float32 scale stored immediately after each token-head's FP8 data
+            (at offset ``head_dim`` in bytes). The KV cache tensor should be created with
+            stride ``head_dim + 16`` (16B aligned) along the head dimension to accommodate
+            the inline scale. Only ``fa2`` backend is supported.
+            Defaults to ``False``.
         """
         _check_kv_layout(kv_layout)
 
@@ -1732,6 +1768,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._seq_lens_kv = None
         self._seq_lens_q = None
         self._block_tables = None
+        self._use_per_token_head = use_per_token_head
 
     @property
     def is_cuda_graph_enabled(self) -> bool:
@@ -2069,13 +2106,22 @@ class BatchPrefillWithPagedKVCacheWrapper:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
-                self._backend = determine_attention_backend(
-                    self.device,
-                    PosEncodingMode[pos_encoding_mode].value,
-                    use_fp16_qk_reduction,
-                    self._custom_mask_buf is not None,  # use_custom_mask
-                    q_data_type,
-                    kv_data_type,
+                self._backend = (
+                    "fa2"
+                    if self._use_per_token_head
+                    else determine_attention_backend(
+                        self.device,
+                        PosEncodingMode[pos_encoding_mode].value,
+                        use_fp16_qk_reduction,
+                        self._custom_mask_buf is not None,  # use_custom_mask
+                        q_data_type,
+                        kv_data_type,
+                    )
+                )
+            if self._use_per_token_head and self._backend != "fa2":
+                raise ValueError(
+                    f"Per-token-head scaling is only supported with the fa2 backend, "
+                    f"but backend is {self._backend!r}"
                 )
             if self._backend != "cudnn":
                 get_module_args = (
@@ -2502,6 +2548,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 TensorLayout[self._kv_layout].value,
                 window_left,
                 enable_pdl,
+                self._use_per_token_head,
             ]
             if self._jit_module is not None:
                 run_args.extend(
@@ -2723,6 +2770,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         backend: str = "auto",
         jit_args: Optional[List[Any]] = None,
         jit_kwargs: Optional[Dict[str, Any]] = None,
+        use_per_token_head: bool = False,
     ) -> None:
         r"""Constructor of :class:`BatchPrefillWithRaggedKVCacheWrapper`.
 
@@ -2776,6 +2824,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         jit_kwargs : Optional[Dict[str, Any]]
             The keyword arguments to create the JIT module, defaults to None.
+
+        use_per_token_head : bool
+            Whether to use FP8 per-token-head inline scales. When enabled, the KV cache
+            should have a float32 scale stored immediately after each token-head's FP8 data
+            (at offset ``head_dim`` in bytes). The KV cache tensor should be created with
+            stride ``head_dim + 16`` (16B aligned) along the head dimension to accommodate
+            the inline scale. Only ``fa2`` backend is supported.
+            Defaults to ``False``.
         """
         _check_kv_layout(kv_layout)
         if jit_args is not None and backend != "cute-dsl":
@@ -2838,6 +2894,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._max_total_num_rows: Optional[int] = None
         self._backend = backend
         self._cached_module = None
+        self._use_per_token_head = use_per_token_head
 
     @property
     def is_cuda_graph_enabled(self) -> bool:
@@ -3179,13 +3236,22 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
-                self._backend = determine_attention_backend(
-                    self.device,
-                    PosEncodingMode[pos_encoding_mode].value,
-                    use_fp16_qk_reduction,
-                    self._custom_mask_buf is not None,  # use_custom_mask
-                    q_data_type,
-                    kv_data_type,
+                self._backend = (
+                    "fa2"
+                    if self._use_per_token_head
+                    else determine_attention_backend(
+                        self.device,
+                        PosEncodingMode[pos_encoding_mode].value,
+                        use_fp16_qk_reduction,
+                        self._custom_mask_buf is not None,  # use_custom_mask
+                        q_data_type,
+                        kv_data_type,
+                    )
+                )
+            if self._use_per_token_head and self._backend != "fa2":
+                raise ValueError(
+                    f"Per-token-head scaling is only supported with the fa2 backend, "
+                    f"but backend is {self._backend!r}"
                 )
 
             get_module_args = (
@@ -3553,6 +3619,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             TensorLayout[self._kv_layout].value,
             window_left,
             enable_pdl,
+            self._use_per_token_head,
         ]
         if self._jit_module is not None:
             run_args.extend(

--- a/include/flashinfer/attention/batch_pod.cuh
+++ b/include/flashinfer/attention/batch_pod.cuh
@@ -248,10 +248,11 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
 
   // control NUM_MMA_KV for maximum warp occupancy
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_p, max_num_mma_kv_reg_p), NUM_MMA_KV_P, {
-    using KTraits_P = KernelTraits<MASK_MODE_P, CTA_TILE_Q_P, NUM_MMA_Q_P, NUM_MMA_KV_P,
-                                   NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_WARPS_Q_P, NUM_WARPS_KV_P,
-                                   POS_ENCODING_MODE, DTypeQ_P, DTypeKV_P, DTypeO_P, DTypeQKAccum_P,
-                                   typename PrefillParams::IdType, PrefillAttentionVariant>;
+    using KTraits_P =
+        KernelTraits<MASK_MODE_P, CTA_TILE_Q_P, NUM_MMA_Q_P, NUM_MMA_KV_P, NUM_MMA_D_QK,
+                     NUM_MMA_D_VO, NUM_WARPS_Q_P, NUM_WARPS_KV_P, POS_ENCODING_MODE, false,
+                     DTypeQ_P, DTypeKV_P, DTypeO_P, DTypeQKAccum_P, typename PrefillParams::IdType,
+                     PrefillAttentionVariant>;
 
     if constexpr (KTraits_P::IsInvalid()) {
       // Invalid configuration, skip
@@ -269,9 +270,9 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
       DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_d, max_num_mma_kv_reg_d), NUM_MMA_KV_D, {
         using KTraits_D =
             KernelTraits<MASK_MODE_D, CTA_TILE_Q_D, NUM_MMA_Q_D, NUM_MMA_KV_D, NUM_MMA_D_QK,
-                         NUM_MMA_D_VO, NUM_WARPS_Q_D, NUM_WARPS_KV_D, POS_ENCODING_MODE, DTypeQ_D,
-                         DTypeKV_D, DTypeO_D, DTypeQKAccum_D, typename DecodeParams::IdType,
-                         DecodeAttentionVariant>;
+                         NUM_MMA_D_VO, NUM_WARPS_Q_D, NUM_WARPS_KV_D, POS_ENCODING_MODE, false,
+                         DTypeQ_D, DTypeKV_D, DTypeO_D, DTypeQKAccum_D,
+                         typename DecodeParams::IdType, DecodeAttentionVariant>;
         if constexpr (KTraits_D::IsInvalid()) {
           // Invalid configuration, skip
           std::ostringstream err_msg;

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -65,7 +65,8 @@ __device__ __forceinline__ void compute_qk(
     const Params& params, AttentionVariant variant, const uint32_t batch_idx, const T* smem,
     const vec_t<float, vec_size>& q_vec, const vec_t<float, vec_size>& freq, uint32_t kv_idx_base,
     uint32_t iter_base, uint32_t iter_bound, uint32_t qo_head_idx, uint32_t kv_head_idx, float* s,
-    state_t<vec_size>& st, const uint32_t tx, const uint32_t ty, const uint32_t tz) {
+    state_t<vec_size>& st, const uint32_t tx, const uint32_t ty, const uint32_t tz,
+    const float* k_sf_pth_smem) {
   float m_prev = st.m;
 #pragma unroll
   for (uint32_t j = 0; j < tile_size; ++j) {
@@ -77,6 +78,13 @@ __device__ __forceinline__ void compute_qk(
     } else {
       // do not apply rotary embedding
       k_vec.cast_load(smem + (j * bdx + tx) * vec_size);
+    }
+    if constexpr (AttentionVariant::use_per_token_head) {
+      const float k_sc = k_sf_pth_smem[j];
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size; ++i) {
+        k_vec[i] *= k_sc;
+      }
     }
     s[j] = 0.f;
 #pragma unroll
@@ -128,14 +136,23 @@ __device__ __forceinline__ void compute_qk(
  * \param compute_stage_idx A integer indicates the compute stage index in the pipeline
  * \param st The flashattention state to be updated
  */
-template <uint32_t vec_size, uint32_t bdx, uint32_t tile_size, typename T>
+template <uint32_t vec_size, uint32_t bdx, uint32_t tile_size, typename AttentionVariant,
+          typename T>
 __device__ __forceinline__ void update_local_state(const T* smem, const float* s,
                                                    uint32_t compute_stage_idx,
-                                                   state_t<vec_size>& st, uint32_t tx) {
+                                                   state_t<vec_size>& st, uint32_t tx,
+                                                   const float* v_sf_pth_smem) {
 #pragma unroll
   for (uint32_t j = 0; j < tile_size; ++j) {
     vec_t<float, vec_size> v_vec;
     v_vec.cast_load(smem + (j * bdx + tx) * vec_size);
+    if constexpr (AttentionVariant::use_per_token_head) {
+      const float v_sc = v_sf_pth_smem[j];
+#pragma unroll
+      for (uint32_t i = 0; i < vec_size; ++i) {
+        v_vec[i] *= v_sc;
+      }
+    }
 #pragma unroll
     for (uint32_t i = 0; i < vec_size; ++i) {
       st.o[i] = st.o[i] + s[j] * v_vec[i];
@@ -184,6 +201,20 @@ __device__ __forceinline__ void sync_state(AttentionVariant variant, state_t<vec
           st.o[i] += oz[i];
         }
       }
+    }
+  }
+}
+
+template <uint32_t tile_size_per_bdx, uint32_t bdx, typename AttentionVariant, typename IsValidFn,
+          typename GetScalePtrFn>
+__device__ __forceinline__ void load_kv_sf_pth(float* scale_smem, uint32_t tx, IsValidFn is_valid,
+                                               GetScalePtrFn get_scale_ptr) {
+  if constexpr (AttentionVariant::use_per_token_head) {
+#pragma unroll
+    for (uint32_t j = tx; j < tile_size_per_bdx; j += bdx) {
+      cp_async::pred_load_32b<cp_async::SharedMemFillMode::kFillZero>(
+          reinterpret_cast<uint32_t*>(scale_smem + j),
+          reinterpret_cast<const uint32_t*>(get_scale_ptr(j)), is_valid(j));
     }
   }
 }
@@ -241,11 +272,19 @@ __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params par
   extern __shared__ uint8_t smem[];
   AttentionVariant variant(params, /*batch_idx=*/0, smem);
   const uint32_t seq_len = variant.kv_len;
+  constexpr uint32_t num_heads = num_stages_smem * bdy * tile_size_per_bdx * bdz;
+  constexpr uint32_t kv_size = num_heads * head_dim * sizeof(DTypeKV);
+  constexpr uint32_t kv_sf_pth_size =
+      AttentionVariant::use_per_token_head ? (num_heads * sizeof(float)) : 0;
+  constexpr uint32_t sync_state_size = bdy * bdz * head_dim * sizeof(float);
   DTypeKV* k_smem = (DTypeKV*)smem;
-  DTypeKV* v_smem = (DTypeKV*)(smem + num_stages_smem * bdy * tile_size_per_bdx * bdz * head_dim *
-                                          sizeof(DTypeKV));
-  float* smem_md = (float*)(smem + 2 * num_stages_smem * bdy * tile_size_per_bdx * bdz * head_dim *
-                                       sizeof(DTypeKV));
+  DTypeKV* v_smem = (DTypeKV*)(smem + kv_size);
+  float* k_sf_pth_smem =
+      AttentionVariant::use_per_token_head ? (float*)(smem + 2 * kv_size) : nullptr;
+  float* v_sf_pth_smem = AttentionVariant::use_per_token_head
+                             ? (float*)(smem + 2 * kv_size + kv_sf_pth_size)
+                             : nullptr;
+  float* smem_md = (float*)(smem + std::max(2 * kv_size + 2 * kv_sf_pth_size, sync_state_size));
 
   uint32_t tx = threadIdx.x, ty = threadIdx.y, tz = threadIdx.z;
   vec_t<float, vec_size> q_vec;
@@ -286,6 +325,16 @@ __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params par
               kv_head_idx * kv_stride_h + tx * vec_size,
           producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j < chunk_end);
     }
+    load_kv_sf_pth<tile_size_per_bdx, bdx, AttentionVariant>(
+        k_sf_pth_smem + ((iter * bdz + tz) * bdy + ty) * tile_size_per_bdx, tx,
+        [&, producer_kv_idx_base, chunk_end](uint32_t j) {
+          return producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j < chunk_end;
+        },
+        [&, k, kv_stride_n, kv_stride_h, kv_head_idx, head_dim](uint32_t j) -> const float* {
+          uint32_t kv_idx = producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j;
+          return reinterpret_cast<const float*>((const DTypeKV*)k + kv_idx * kv_stride_n +
+                                                kv_head_idx * kv_stride_h + head_dim);
+        });
     cp_async::commit_group();
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
       cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kFillZero>(
@@ -295,6 +344,16 @@ __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params par
               kv_head_idx * kv_stride_h + tx * vec_size,
           producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j < chunk_end);
     }
+    load_kv_sf_pth<tile_size_per_bdx, bdx, AttentionVariant>(
+        v_sf_pth_smem + ((iter * bdz + tz) * bdy + ty) * tile_size_per_bdx, tx,
+        [&, producer_kv_idx_base, chunk_end](uint32_t j) {
+          return producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j < chunk_end;
+        },
+        [&, v, kv_stride_n, kv_stride_h, kv_head_idx, head_dim](uint32_t j) -> const float* {
+          uint32_t kv_idx = producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j;
+          return reinterpret_cast<const float*>((const DTypeKV*)v + kv_idx * kv_stride_n +
+                                                kv_head_idx * kv_stride_h + head_dim);
+        });
     cp_async::commit_group();
     producer_kv_idx_base += bdy * bdz * tile_size_per_bdx;
   }
@@ -309,11 +368,14 @@ __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params par
     // compute qk
     cp_async::wait_group<2 * num_stages_smem - 1>();
     block.sync();
+    float* k_sf_pth = AttentionVariant::use_per_token_head
+                          ? (k_sf_pth_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx)
+                          : nullptr;
     compute_qk<pos_encoding_mode, vec_size, bdx, bdy * tile_size_per_bdx>(
         params, variant, /*batch_idx=*/0,
         k_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx * head_dim, q_vec, freq,
         consumer_kv_idx_base, iter * bdy * tile_size_per_bdx * bdz, kv_chunk_size, qo_head_idx,
-        kv_head_idx, s, st_local, tx, ty, tz);
+        kv_head_idx, s, st_local, tx, ty, tz, k_sf_pth);
     block.sync();
     // load k
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
@@ -324,14 +386,27 @@ __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params par
               kv_head_idx * kv_stride_h + tx * vec_size,
           producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j < chunk_end);
     }
+    load_kv_sf_pth<tile_size_per_bdx, bdx, AttentionVariant>(
+        k_sf_pth_smem + ((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx, tx,
+        [&, producer_kv_idx_base, chunk_end](uint32_t j) {
+          return producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j < chunk_end;
+        },
+        [&, k, kv_stride_n, kv_stride_h, kv_head_idx, head_dim](uint32_t j) -> const float* {
+          uint32_t kv_idx = producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j;
+          return reinterpret_cast<const float*>((const DTypeKV*)k + kv_idx * kv_stride_n +
+                                                kv_head_idx * kv_stride_h + head_dim);
+        });
     cp_async::commit_group();
 
     // update m/d/o state
     cp_async::wait_group<2 * num_stages_smem - 1>();
     block.sync();
-    update_local_state<vec_size, bdx, bdy * tile_size_per_bdx>(
+    auto v_sf_pth = AttentionVariant::use_per_token_head
+                        ? (v_sf_pth_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx)
+                        : nullptr;
+    update_local_state<vec_size, bdx, bdy * tile_size_per_bdx, AttentionVariant>(
         v_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx * head_dim, s, stage_idx,
-        st_local, tx);
+        st_local, tx, v_sf_pth);
     block.sync();
 
     // load v
@@ -343,6 +418,16 @@ __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params par
               kv_head_idx * kv_stride_h + tx * vec_size,
           producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j < chunk_end);
     }
+    load_kv_sf_pth<tile_size_per_bdx, bdx, AttentionVariant>(
+        v_sf_pth_smem + ((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx, tx,
+        [&, producer_kv_idx_base, chunk_end](uint32_t j) {
+          return producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j < chunk_end;
+        },
+        [&, v, kv_stride_n, kv_stride_h, kv_head_idx, head_dim](uint32_t j) -> const float* {
+          uint32_t kv_idx = producer_kv_idx_base + (tz * bdy + ty) * tile_size_per_bdx + j;
+          return reinterpret_cast<const float*>((const DTypeKV*)v + kv_idx * kv_stride_n +
+                                                kv_head_idx * kv_stride_h + head_dim);
+        });
     cp_async::commit_group();
 
     stage_idx = (stage_idx + 1) % num_stages_smem;
@@ -430,13 +515,21 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
   const uint32_t chunk_size = chunk_end - chunk_start;
 
   AttentionVariant variant(params, batch_idx, smem);
+  constexpr uint32_t num_heads = num_stages_smem * tile_size_per_bdx * bdy * bdz;
+  constexpr uint32_t kv_size = num_heads * head_dim * sizeof(DTypeKV);
+  constexpr uint32_t kv_sf_pth_size =
+      AttentionVariant::use_per_token_head ? (num_heads * sizeof(float)) : 0;
+  constexpr uint32_t sync_state_size = bdy * bdz * head_dim * sizeof(float);
   DTypeKV* k_smem = (DTypeKV*)smem;
-  DTypeKV* v_smem = (DTypeKV*)(smem + num_stages_smem * tile_size_per_bdx * bdy * bdz * head_dim *
-                                          sizeof(DTypeKV));
-  size_t* kv_offset_smem = (size_t*)(smem + 2 * num_stages_smem * tile_size_per_bdx * bdy * bdz *
-                                                head_dim * sizeof(DTypeKV));
-  float* smem_md = (float*)(smem + 2 * num_stages_smem * tile_size_per_bdx * bdy * bdz * head_dim *
-                                       sizeof(DTypeKV));
+  DTypeKV* v_smem = (DTypeKV*)(smem + kv_size);
+  float* k_sf_pth_smem =
+      AttentionVariant::use_per_token_head ? (float*)(smem + 2 * kv_size) : nullptr;
+  float* v_sf_pth_smem = AttentionVariant::use_per_token_head
+                             ? (float*)(smem + 2 * kv_size + kv_sf_pth_size)
+                             : nullptr;
+  size_t* kv_offset_smem =
+      (size_t*)(smem + std::max(2 * kv_size + 2 * kv_sf_pth_size, sync_state_size));
+  float* smem_md = (float*)(smem + std::max(2 * kv_size + 2 * kv_sf_pth_size, sync_state_size));
 
   vec_t<float, vec_size> q_vec;
   vec_t<float, vec_size> freq;
@@ -503,6 +596,17 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
           paged_kv.k_data + kv_offset[j],
           ((iter * bdz + tz) * bdy + ty) * tile_size_per_bdx + j < chunk_size);
     }
+    load_kv_sf_pth<tile_size_per_bdx, bdx, AttentionVariant>(
+        k_sf_pth_smem + ((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx, tx,
+        [&, chunk_size](uint32_t j) {
+          return ((iter * bdz + tz) * bdy + ty) * tile_size_per_bdx + j < chunk_size;
+        },
+        [&, paged_kv, head_dim](uint32_t j) -> const float* {
+          size_t scale_offset =
+              kv_offset_smem[((iter * bdz + tz) * bdy + ty) * tile_size_per_bdx + j];
+          return reinterpret_cast<const float*>(reinterpret_cast<const uint8_t*>(paged_kv.k_data) +
+                                                scale_offset + head_dim);
+        });
     cp_async::commit_group();
 #pragma unroll
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
@@ -512,6 +616,17 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
           paged_kv.v_data + kv_offset[j],
           ((iter * bdz + tz) * bdy + ty) * tile_size_per_bdx + j < chunk_size);
     }
+    load_kv_sf_pth<tile_size_per_bdx, bdx, AttentionVariant>(
+        v_sf_pth_smem + ((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx, tx,
+        [&, chunk_size](uint32_t j) {
+          return ((iter * bdz + tz) * bdy + ty) * tile_size_per_bdx + j < chunk_size;
+        },
+        [&, paged_kv, head_dim](uint32_t j) -> const float* {
+          size_t scale_offset =
+              kv_offset_smem[((iter * bdz + tz) * bdy + ty) * tile_size_per_bdx + j];
+          return reinterpret_cast<const float*>(reinterpret_cast<const uint8_t*>(paged_kv.v_data) +
+                                                scale_offset + head_dim);
+        });
     cp_async::commit_group();
     stage_idx = (stage_idx + 1) % num_stages_smem;
   }
@@ -536,13 +651,16 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
     // compute qk
     cp_async::wait_group<2 * num_stages_smem - 1>();
     block.sync();
+    float* k_sf_pth = AttentionVariant::use_per_token_head
+                          ? (k_sf_pth_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx)
+                          : nullptr;
     compute_qk<POS_ENCODING_MODE, vec_size, bdx, bdy * tile_size_per_bdx>(
         params, variant, batch_idx,
         k_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx * head_dim, q_vec, freq,
         (paged_kv.rope_pos_offset == nullptr ? 0 : paged_kv.rope_pos_offset[batch_idx]) +
             chunk_start + iter * tile_size_per_bdx * bdy * bdz,
         iter * tile_size_per_bdx * bdy * bdz, chunk_size, qo_head_idx, kv_head_idx, s, st, tx, ty,
-        tz);
+        tz, k_sf_pth);
     block.sync();
 
 #pragma unroll
@@ -562,13 +680,31 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
           paged_kv.k_data + kv_offset[j],
           (((iter + num_stages_smem) * bdz + tz) * bdy + ty) * tile_size_per_bdx + j < chunk_size);
     }
+    load_kv_sf_pth<tile_size_per_bdx, bdx, AttentionVariant>(
+        k_sf_pth_smem + ((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx, tx,
+        [&, chunk_size](uint32_t j) {
+          return ((((iter + num_stages_smem) * bdz + tz) * bdy + ty) * tile_size_per_bdx + j) <
+                 chunk_size;
+        },
+        [&, paged_kv, head_dim](uint32_t j) -> const float* {
+          size_t scale_offset =
+              kv_offset_smem[((((iter + num_stages_smem) % bdx) * bdz + tz) * bdy + ty) *
+                                 tile_size_per_bdx +
+                             j];
+          return reinterpret_cast<const float*>(reinterpret_cast<const uint8_t*>(paged_kv.k_data) +
+                                                scale_offset + head_dim);
+        });
     cp_async::commit_group();
 
     // update m/d/o states
     cp_async::wait_group<2 * num_stages_smem - 1>();
     block.sync();
-    update_local_state<vec_size, bdx, bdy * tile_size_per_bdx>(
-        v_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx * head_dim, s, stage_idx, st, tx);
+    auto v_sf_pth = AttentionVariant::use_per_token_head
+                        ? (v_sf_pth_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx)
+                        : nullptr;
+    update_local_state<vec_size, bdx, bdy * tile_size_per_bdx, AttentionVariant>(
+        v_smem + (stage_idx * bdz + tz) * bdy * tile_size_per_bdx * head_dim, s, stage_idx, st, tx,
+        v_sf_pth);
     block.sync();
 
     // load v tiles
@@ -580,6 +716,20 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
           paged_kv.v_data + kv_offset[j],
           (((iter + num_stages_smem) * bdz + tz) * bdy + ty) * tile_size_per_bdx + j < chunk_size);
     }
+    load_kv_sf_pth<tile_size_per_bdx, bdx, AttentionVariant>(
+        v_sf_pth_smem + ((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx, tx,
+        [&, chunk_size](uint32_t j) {
+          return ((((iter + num_stages_smem) * bdz + tz) * bdy + ty) * tile_size_per_bdx + j) <
+                 chunk_size;
+        },
+        [&, paged_kv, head_dim](uint32_t j) -> const float* {
+          size_t scale_offset =
+              kv_offset_smem[((((iter + num_stages_smem) % bdx) * bdz + tz) * bdy + ty) *
+                                 tile_size_per_bdx +
+                             j];
+          return reinterpret_cast<const float*>(reinterpret_cast<const uint8_t*>(paged_kv.v_data) +
+                                                scale_offset + head_dim);
+        });
     cp_async::commit_group();
     stage_idx = (stage_idx + 1) % num_stages_smem;
   }
@@ -677,9 +827,15 @@ cudaError_t SingleDecodeWithKVCacheDispatched(Params params, typename Params::DT
     constexpr uint32_t bdz = num_threads / (bdx * bdy);
     constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (sizeof(DTypeKV) == 1 ? 2U : 8U) : 1U;
     DISPATCH_COMPUTE_CAP_DECODE_NUM_STAGES_SMEM(compute_capacity, NUM_STAGES_SMEM, {
-      const uint32_t smem_size =
-          2U * NUM_STAGES_SMEM * bdy * tile_size_per_bdx * bdz * HEAD_DIM * sizeof(DTypeKV) +
-          2U * bdy * bdz * sizeof(float);
+      constexpr auto num_heads = NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz;
+      constexpr uint32_t kv_size = 2U * num_heads * HEAD_DIM * sizeof(DTypeKV);
+      constexpr uint32_t kv_sf_pth_size =
+          AttentionVariant::use_per_token_head ? (2U * num_heads * sizeof(float)) : 0;
+      constexpr uint32_t sync_state_size = bdy * bdz * HEAD_DIM * sizeof(float);
+      constexpr uint32_t smem_md_size = 2U * bdy * bdz * sizeof(float);
+
+      const uint32_t smem_size = std::max(kv_size + kv_sf_pth_size, sync_state_size) + smem_md_size;
+
       auto kernel =
           SingleDecodeWithKVCacheKernel<POS_ENCODING_MODE, NUM_STAGES_SMEM, tile_size_per_bdx,
                                         vec_size, bdx, bdy, bdz, AttentionVariant, Params>;
@@ -759,10 +915,16 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(Params params, typename Params
     constexpr uint32_t bdz = num_threads / (bdx * bdy);
     constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (sizeof(DTypeKV) == 1 ? 2U : 4U) : 1U;
     DISPATCH_COMPUTE_CAP_DECODE_NUM_STAGES_SMEM(compute_capacity, NUM_STAGES_SMEM, {
-      const uint32_t smem_size =
-          2 * NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz * HEAD_DIM * sizeof(DTypeKV) +
-          std::max(tile_size_per_bdx * num_threads * sizeof(DTypeKV*),
-                   2 * bdy * bdz * sizeof(float));
+      constexpr auto num_heads = NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz;
+      constexpr uint32_t kv_size = 2 * num_heads * HEAD_DIM * sizeof(DTypeKV);
+      constexpr uint32_t kv_sf_pth_size =
+          AttentionVariant::use_per_token_head ? (2 * num_heads * sizeof(float)) : 0;
+      constexpr uint32_t sync_state_size = bdy * bdz * HEAD_DIM * sizeof(float);
+      constexpr uint32_t kv_offset_size = tile_size_per_bdx * num_threads * sizeof(size_t);
+      constexpr uint32_t smem_md_size = 2 * bdy * bdz * sizeof(float);
+      const uint32_t smem_size = std::max(kv_size + kv_sf_pth_size, sync_state_size) +
+                                 std::max(kv_offset_size, smem_md_size);
+
       auto kernel =
           BatchDecodeWithPagedKVCacheKernel<POS_ENCODING_MODE, NUM_STAGES_SMEM, tile_size_per_bdx,
                                             vec_size, bdx, bdy, bdz, AttentionVariant, Params>;
@@ -939,13 +1101,16 @@ __global__ void BatchDecodeWithPagedKVCacheKernelMLA(Params params) {
   constexpr uint32_t compute_qk_tile = bdy;
 
   extern __attribute__((shared)) uint8_t smem[];
+  constexpr uint32_t ckv_size = num_stages_smem * kv_iter_len * head_dim_ckv * sizeof(DTypeKV);
+  constexpr uint32_t kpe_size = num_stages_smem * kv_iter_len * head_dim_kpe * sizeof(DTypeKV);
+  constexpr uint32_t sync_state_size = bdy * bdz * head_dim_ckv * sizeof(float);
+  constexpr uint32_t ckv_offset_size = bdx * bdy * bdz * sizeof(size_t);
+  [[maybe_unused]] constexpr uint32_t kpe_offset_size = bdx * bdy * bdz * sizeof(size_t);
   DTypeKV* ckv_smem = (DTypeKV*)smem;
-  DTypeKV* kpe_smem = (DTypeKV*)((uint8_t*)ckv_smem +
-                                 num_stages_smem * kv_iter_len * head_dim_ckv * sizeof(DTypeKV));
-  size_t* ckv_offset_smem = (size_t*)((uint8_t*)kpe_smem + num_stages_smem * kv_iter_len *
-                                                               head_dim_kpe * sizeof(DTypeKV));
-  size_t* kpe_offset_smem = (size_t*)((uint8_t*)ckv_offset_smem + bdx * bdy * bdz * sizeof(size_t));
-  float* smem_md = (float*)ckv_offset_smem;
+  DTypeKV* kpe_smem = (DTypeKV*)((uint8_t*)ckv_smem + ckv_size);
+  size_t* ckv_offset_smem = (size_t*)((uint8_t*)kpe_smem + kpe_size);
+  size_t* kpe_offset_smem = (size_t*)((uint8_t*)ckv_offset_smem + ckv_offset_size);
+  float* smem_md = (float*)((uint8_t*)smem + std::max(ckv_size + kpe_size, sync_state_size));
 
   AttentionVariant variant(params, batch_idx, smem);
 
@@ -1117,9 +1282,14 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatchedMLA(Params params, typename Par
 
   auto compute_capacity = GetCudaComputeCapability();
   DISPATCH_COMPUTE_CAP_DECODE_NUM_STAGES_SMEM(compute_capacity, NUM_STAGES_SMEM, {
-    const uint32_t smem_size =
-        NUM_STAGES_SMEM * bdy * bdz * (HEAD_DIM_CKV + HEAD_DIM_KPE) * sizeof(DTypeKV) +
-        std::max(num_threads * sizeof(size_t) * 2, 2 * bdy * bdz * sizeof(float));
+    constexpr uint32_t ckv_size = NUM_STAGES_SMEM * bdy * bdz * HEAD_DIM_CKV * sizeof(DTypeKV);
+    constexpr uint32_t kpe_size = NUM_STAGES_SMEM * bdy * bdz * HEAD_DIM_KPE * sizeof(DTypeKV);
+    constexpr uint32_t sync_state_size = bdy * bdz * HEAD_DIM_CKV * sizeof(float);
+    constexpr uint32_t ckv_offset_size = num_threads * sizeof(size_t);
+    constexpr uint32_t kpe_offset_size = num_threads * sizeof(size_t);
+    constexpr uint32_t smem_md_size = 2 * bdy * bdz * sizeof(float);
+    const uint32_t smem_size = std::max(ckv_size + kpe_size, sync_state_size) +
+                               std::max(ckv_offset_size + kpe_offset_size, smem_md_size);
 
     auto kernel =
         BatchDecodeWithPagedKVCacheKernelMLA<NUM_STAGES_SMEM, vec_size_ckv, vec_size_kpe, bdx, bdy,

--- a/include/flashinfer/attention/persistent.cuh
+++ b/include/flashinfer/attention/persistent.cuh
@@ -280,6 +280,17 @@ struct BlockBatchPagedAttentionPersistent {
       const auto [q_indptr, kv_indptr, o_indptr, q_len, kv_len, packed_qo_start, kv_start, kv_end,
                   kv_head_idx, len_kv_chunk] = get_block_coord(params, work_idx);
 
+      [[maybe_unused]] paged_kv_t<DTypeKV, IdType> block_paged_k;
+      [[maybe_unused]] paged_kv_t<DTypeKV, IdType> block_paged_v;
+      if constexpr (KTraits::USE_PER_TOKEN_HEAD) {
+        block_paged_k = params.block_paged_k;
+        block_paged_v = params.block_paged_v;
+        [[maybe_unused]] const IdType pth_indptr[2] = {
+            kv_indptr, kv_indptr + (kv_len + block_size - 1) / block_size};
+        block_paged_k.indptr = const_cast<IdType*>(pth_indptr);
+        block_paged_v.indptr = const_cast<IdType*>(pth_indptr);
+      }
+
       const uint32_t kv_chunk_idx = kv_start / len_kv_chunk;
       const uint32_t num_kv_chunks = ceil_div(
           CAUSAL
@@ -330,6 +341,9 @@ struct BlockBatchPagedAttentionPersistent {
           smem_storage, maybe_k_cache_sf, block_iter_base + kv_tile_idx * CTA_TILE_KV,
           packed_kv_bound, kv_head_idx, k_stride_page, k_stride_h, k_stride_n, block_size,
           kv_indices, kv_start + kv_tile_idx * CTA_TILE_KV, kv_end, warp_idx, lane_idx);
+      page_produce_kv_sf_pth<false, KTraits>(
+          smem_storage, k, block_paged_k, kv_head_idx, block_iter_base + kv_tile_idx * CTA_TILE_KV,
+          kv_start + kv_tile_idx * CTA_TILE_KV, kv_len, warp_idx, lane_idx);
       cp_async::commit_group();
       page_produce_kv<true, KTraits>(smem_storage, &v_smem_offset_w, v,
                                      kv_start + kv_tile_idx * CTA_TILE_KV, thr_local_kv_offset,
@@ -338,6 +352,9 @@ struct BlockBatchPagedAttentionPersistent {
           smem_storage, maybe_v_cache_sf, block_iter_base + kv_tile_idx * CTA_TILE_KV,
           packed_kv_bound, kv_head_idx, v_stride_page, v_stride_h, v_stride_n, block_size,
           kv_indices, kv_start + kv_tile_idx * CTA_TILE_KV, kv_end, warp_idx, lane_idx);
+      page_produce_kv_sf_pth<true, KTraits>(
+          smem_storage, v, block_paged_v, kv_head_idx, block_iter_base + kv_tile_idx * CTA_TILE_KV,
+          kv_start + kv_tile_idx * CTA_TILE_KV, kv_len, warp_idx, lane_idx);
       cp_async::commit_group();
 
       // loop with mask
@@ -350,11 +367,12 @@ struct BlockBatchPagedAttentionPersistent {
             cp_async::wait_group<1>();
             __syncthreads();
 
-            compute_qk<KTraits>(&q_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-                                smem_storage->k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                              KTraits::NUM_MMA_KV * 16 *
-                                                              KTraits::NUM_MMA_D_QK,
-                                lane_idx, s_frag);
+            compute_qk<KTraits>(
+                &q_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
+                smem_storage->k_sf_ptr() + get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV *
+                                               16 * KTraits::NUM_MMA_D_QK,
+                smem_storage->k_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
+                lane_idx, s_frag);
             if constexpr (AttentionVariant::use_logits_soft_cap) {
               logits_transform<KTraits>(
                   params, variant, /*batch_idx=*/0, qo_packed_idx_base,
@@ -379,15 +397,20 @@ struct BlockBatchPagedAttentionPersistent {
                 smem_storage, maybe_k_cache_sf, block_iter_base + (kv_tile_idx - 1) * CTA_TILE_KV,
                 packed_kv_bound, kv_head_idx, k_stride_page, k_stride_h, k_stride_n, block_size,
                 kv_indices, kv_start + (kv_tile_idx - 1) * CTA_TILE_KV, kv_end, warp_idx, lane_idx);
+            page_produce_kv_sf_pth<false, KTraits>(
+                smem_storage, k, block_paged_k, kv_head_idx,
+                block_iter_base + (kv_tile_idx - 1) * CTA_TILE_KV,
+                kv_start + (kv_tile_idx - 1) * CTA_TILE_KV, kv_len, warp_idx, lane_idx);
             cp_async::commit_group();
             cp_async::wait_group<1>();
 
             __syncthreads();
-            compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r,
-                                   smem_storage->v_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                                 KTraits::NUM_MMA_KV * 16 *
-                                                                 KTraits::NUM_MMA_D_VO,
-                                   lane_idx, s_frag, o_frag, d);
+            compute_sfm_v<KTraits>(
+                &v_smem, &v_smem_offset_r,
+                smem_storage->v_sf_ptr() + get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV *
+                                               16 * KTraits::NUM_MMA_D_VO,
+                smem_storage->v_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
+                lane_idx, s_frag, o_frag, d);
             __syncthreads();
 
             page_produce_kv<true, KTraits>(smem_storage, &v_smem_offset_w, v,
@@ -397,6 +420,10 @@ struct BlockBatchPagedAttentionPersistent {
                 smem_storage, maybe_v_cache_sf, block_iter_base + (kv_tile_idx - 1) * CTA_TILE_KV,
                 packed_kv_bound, kv_head_idx, v_stride_page, v_stride_h, v_stride_n, block_size,
                 kv_indices, kv_start + (kv_tile_idx - 1) * CTA_TILE_KV, kv_end, warp_idx, lane_idx);
+            page_produce_kv_sf_pth<true, KTraits>(smem_storage, v, block_paged_v, kv_head_idx,
+                                                  block_iter_base + (kv_tile_idx - 1) * CTA_TILE_KV,
+                                                  kv_start + (kv_tile_idx - 1) * CTA_TILE_KV,
+                                                  kv_len, warp_idx, lane_idx);
             cp_async::commit_group();
           });
       cp_async::wait_group<0>();
@@ -405,10 +432,11 @@ struct BlockBatchPagedAttentionPersistent {
 #pragma unroll
       for (; kv_tile_idx >= 0; --kv_tile_idx) {
         compute_qk<KTraits>(&q_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-                            smem_storage->k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                          KTraits::NUM_MMA_KV * 16 *
-                                                          KTraits::NUM_MMA_D_QK,
-                            lane_idx, s_frag);
+                            smem_storage->k_sf_ptr() + get_warp_idx_kv<KTraits>(tid.z) *
+                                                           KTraits::NUM_MMA_KV * 16 *
+                                                           KTraits::NUM_MMA_D_QK,
+                            smem_storage->k_sf_pth_ptr(),
+                            get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16, lane_idx, s_frag);
         if constexpr (AttentionVariant::use_logits_soft_cap) {
           logits_transform<KTraits>(
               params, variant, /*batch_idx=*/0, qo_packed_idx_base,
@@ -422,11 +450,12 @@ struct BlockBatchPagedAttentionPersistent {
                 (kv_tile_idx * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16,
             q_len, kv_len, kv_end, gqa_group_size, s_frag, tid, kv_head_idx);
         update_mdo_states<KTraits>(variant, s_frag, o_frag, m, d);
-        compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r,
-                               smem_storage->v_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                             KTraits::NUM_MMA_KV * 16 *
-                                                             KTraits::NUM_MMA_D_VO,
-                               lane_idx, s_frag, o_frag, d);
+        compute_sfm_v<KTraits>(
+            &v_smem, &v_smem_offset_r,
+            smem_storage->v_sf_ptr() +
+                get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_VO,
+            smem_storage->v_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
+            lane_idx, s_frag, o_frag, d);
       }
 
       __syncthreads();
@@ -637,48 +666,88 @@ struct BlockBatchReductionPersistent {
 };
 
 template <uint32_t CTA_TILE_Q_1, uint32_t CTA_TILE_Q_2, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
-          MaskMode MASK_MODE, typename AttentionVariant, typename Params>
-cudaError_t BatchPagedAttentionPersistent(const Params params_1, const Params params_2,
-                                          const uint32_t num_blks_x, const uint32_t num_blks_y,
-                                          const cudaStream_t stream) {
+          MaskMode MASK_MODE, bool FORCE_DISABLE_KV_REPACK, typename AttentionVariant,
+          typename Params>
+static const void* _GetBatchPagedAttentionPersistentKernel(size_t& smem_size,
+                                                           uint32_t& num_threads) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
   using DTypeO = typename Params::DTypeO;
   using IdType = typename Params::IdType;
+
   constexpr uint32_t NUM_WARPS_Q_1 = get_num_warps_q(CTA_TILE_Q_1);
   constexpr uint32_t NUM_WARPS_KV_1 = get_num_warps_kv(CTA_TILE_Q_1);
   constexpr uint32_t NUM_MMA_Q_1 = get_num_mma_q(CTA_TILE_Q_1);
   constexpr uint32_t NUM_MMA_KV_1 = 4;
   constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
   constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
-  using KTraits1 = KernelTraits<MASK_MODE, CTA_TILE_Q_1, NUM_MMA_Q_1, NUM_MMA_KV_1, NUM_MMA_D_QK,
-                                NUM_MMA_D_VO, NUM_WARPS_Q_1, NUM_WARPS_KV_1, PosEncodingMode::kNone,
-                                DTypeQ, DTypeKV, DTypeO, float, IdType, AttentionVariant>;
+  using KTraits1 =
+      KernelTraits<MASK_MODE, CTA_TILE_Q_1, NUM_MMA_Q_1, NUM_MMA_KV_1, NUM_MMA_D_QK, NUM_MMA_D_VO,
+                   NUM_WARPS_Q_1, NUM_WARPS_KV_1, PosEncodingMode::kNone, FORCE_DISABLE_KV_REPACK,
+                   DTypeQ, DTypeKV, DTypeO, float, IdType, AttentionVariant>;
   constexpr uint32_t NUM_WARPS_Q_2 = get_num_warps_q(CTA_TILE_Q_2);
   constexpr uint32_t NUM_WARPS_KV_2 = get_num_warps_kv(CTA_TILE_Q_2);
   constexpr uint32_t NUM_MMA_Q_2 = get_num_mma_q(CTA_TILE_Q_2);
   constexpr uint32_t NUM_MMA_KV_2 = 2;
-  using KTraits2 = KernelTraits<MASK_MODE, CTA_TILE_Q_2, NUM_MMA_Q_2, NUM_MMA_KV_2, NUM_MMA_D_QK,
-                                NUM_MMA_D_VO, NUM_WARPS_Q_2, NUM_WARPS_KV_2, PosEncodingMode::kNone,
-                                DTypeQ, DTypeKV, DTypeO, float, IdType, AttentionVariant>;
+  using KTraits2 =
+      KernelTraits<MASK_MODE, CTA_TILE_Q_2, NUM_MMA_Q_2, NUM_MMA_KV_2, NUM_MMA_D_QK, NUM_MMA_D_VO,
+                   NUM_WARPS_Q_2, NUM_WARPS_KV_2, PosEncodingMode::kNone, FORCE_DISABLE_KV_REPACK,
+                   DTypeQ, DTypeKV, DTypeO, float, IdType, AttentionVariant>;
 
   // Attention state reduction kernel
   constexpr uint32_t NUM_THREADS =
       KTraits1::NUM_THREADS > KTraits2::NUM_THREADS ? KTraits1::NUM_THREADS : KTraits2::NUM_THREADS;
   using ReductionKTraits =
       StateReductionKernelTraits<HEAD_DIM_VO, 4, NUM_THREADS, DTypeO, DTypeO, IdType>;
-  size_t smem_size =
+
+  smem_size =
       max(sizeof(typename KTraits1::SharedStorage), sizeof(typename KTraits2::SharedStorage));
   smem_size = max(smem_size, ReductionKTraits::SMEM_SIZE);
+  num_threads = NUM_THREADS;
 
-  // Launch persistent kernel
-  auto kernel = PersistentKernelTemplate<BlockBatchPagedAttentionPersistent<KTraits1, Params>,
+  // persistent kernel
+  return (void*)PersistentKernelTemplate<BlockBatchPagedAttentionPersistent<KTraits1, Params>,
                                          BlockBatchPagedAttentionPersistent<KTraits2, Params>,
                                          BlockBatchReductionPersistent<ReductionKTraits>>;
+}
+
+#define DISPATCH_KV_REPACK(compute_capacity, FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, ...) \
+  if (compute_capacity.first >= 8) {                                                    \
+    constexpr bool FORCE_DISABLE_KV_REPACK = HEAD_DIM_VO > 128;                         \
+    __VA_ARGS__                                                                         \
+  } else {                                                                              \
+    constexpr bool FORCE_DISABLE_KV_REPACK = HEAD_DIM_VO >= 128;                        \
+    __VA_ARGS__                                                                         \
+  }
+
+template <uint32_t CTA_TILE_Q_1, uint32_t CTA_TILE_Q_2, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
+          MaskMode MASK_MODE, typename AttentionVariant, typename Params>
+const void* GetBatchPagedAttentionPersistentKernel(size_t& smem_size, uint32_t& num_threads) {
+  auto compute_capacity = GetCudaComputeCapability();
+  DISPATCH_KV_REPACK(compute_capacity, FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, {
+    return _GetBatchPagedAttentionPersistentKernel<CTA_TILE_Q_1, CTA_TILE_Q_2, HEAD_DIM_QK,
+                                                   HEAD_DIM_VO, MASK_MODE, FORCE_DISABLE_KV_REPACK,
+                                                   AttentionVariant, Params>(smem_size,
+                                                                             num_threads);
+  });
+}
+
+template <uint32_t CTA_TILE_Q_1, uint32_t CTA_TILE_Q_2, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
+          MaskMode MASK_MODE, typename AttentionVariant, typename Params>
+cudaError_t BatchPagedAttentionPersistent(const Params params_1, const Params params_2,
+                                          const uint32_t num_blks_x, const uint32_t num_blks_y,
+                                          const cudaStream_t stream) {
+  size_t smem_size = 0;
+  uint32_t num_threads = 0;
+  // Launch persistent kernel
+  auto kernel =
+      GetBatchPagedAttentionPersistentKernel<CTA_TILE_Q_1, CTA_TILE_Q_2, HEAD_DIM_QK, HEAD_DIM_VO,
+                                             MASK_MODE, AttentionVariant, Params>(smem_size,
+                                                                                  num_threads);
   FLASHINFER_CUDA_CALL(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
   dim3 nblks(num_blks_x, num_blks_y);
-  dim3 nthrs(NUM_THREADS);
+  dim3 nthrs(num_threads);
   void* args[] = {(void*)&params_1, (void*)&params_2};
   FLASHINFER_CUDA_CALL(
       cudaLaunchCooperativeKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));

--- a/include/flashinfer/attention/pod.cuh
+++ b/include/flashinfer/attention/pod.cuh
@@ -299,9 +299,9 @@ cudaError_t PODWithKVCacheTensorDispatched(PrefillParams prefill_params,
     DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_p, max_num_mma_kv_reg_p), NUM_MMA_KV_P, {
       using KTraits_P =
           KernelTraits<MASK_MODE_P, CTA_TILE_Q_P, NUM_MMA_Q_P, NUM_MMA_KV_P, NUM_MMA_D_QK,
-                       NUM_MMA_D_VO, NUM_WARPS_Q_P, NUM_WARPS_KV_P, POS_ENCODING_MODE, DTypeQ_P,
-                       DTypeKV_P, DTypeO_P, DTypeQKAccum_P, typename PrefillParams::IdType,
-                       PrefillAttentionVariant>;
+                       NUM_MMA_D_VO, NUM_WARPS_Q_P, NUM_WARPS_KV_P, POS_ENCODING_MODE, false,
+                       DTypeQ_P, DTypeKV_P, DTypeO_P, DTypeQKAccum_P,
+                       typename PrefillParams::IdType, PrefillAttentionVariant>;
 
       if constexpr (KTraits_P::IsInvalid()) {
         // Invalid configuration, skip
@@ -319,9 +319,9 @@ cudaError_t PODWithKVCacheTensorDispatched(PrefillParams prefill_params,
         DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_d, max_num_mma_kv_reg_d), NUM_MMA_KV_D, {
           using KTraits_D =
               KernelTraits<MASK_MODE_D, CTA_TILE_Q_D, NUM_MMA_Q_D, NUM_MMA_KV_D, NUM_MMA_D_QK,
-                           NUM_MMA_D_VO, NUM_WARPS_Q_D, NUM_WARPS_KV_D, POS_ENCODING_MODE, DTypeQ_D,
-                           DTypeKV_D, DTypeO_D, DTypeQKAccum_D, typename DecodeParams::IdType,
-                           DecodeAttentionVariant>;
+                           NUM_MMA_D_VO, NUM_WARPS_Q_D, NUM_WARPS_KV_D, POS_ENCODING_MODE, false,
+                           DTypeQ_D, DTypeKV_D, DTypeO_D, DTypeQKAccum_D,
+                           typename DecodeParams::IdType, DecodeAttentionVariant>;
           if constexpr (KTraits_D::IsInvalid()) {
             // Invalid configuration, skip
             std::ostringstream err_msg;

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -89,9 +89,86 @@ constexpr uint32_t get_num_mma_q(const uint32_t cta_tile_q) {
   }
 }
 
+template <typename T, uint32_t N, bool scalar>
+__device__ __forceinline__ void pth_scale_frag_inplace(uint32_t* frag, const float* scale) {
+  T* b = reinterpret_cast<T*>(frag);
+#pragma unroll
+  for (uint32_t i = 0; i < N; ++i) {
+    auto sc = scalar ? *scale : scale[i];
+    if constexpr (std::is_same_v<T, nv_bfloat16>) {
+      b[i] = __float2bfloat16_rn(__bfloat162float(b[i]) * sc);
+    } else if constexpr (std::is_same_v<T, half>) {
+      b[i] = __float2half(__half2float(b[i]) * sc);
+    } else {
+      b[i] = static_cast<T>(float(b[i]) * sc);
+    }
+  }
+}
+
+// Empty when DTypeKV is not FP4 to avoid wasting shared memory.
+template <bool IsFP4, uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO>
+struct Fp4ScaleSmemStorage {
+  __device__ __forceinline__ uint8_t* k_sf_ptr() { return nullptr; }
+  __device__ __forceinline__ uint8_t* v_sf_ptr() { return nullptr; }
+};
+// Scale factors for NVFP4 KV cache: one UE4M3 byte per NVFP4_SF_VEC_SIZE elements.
+template <uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO>
+struct Fp4ScaleSmemStorage<true, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO> {
+  alignas(16) uint8_t k_sf_smem[CTA_TILE_KV * HEAD_DIM_QK / NVFP4_SF_VEC_SIZE];
+  alignas(16) uint8_t v_sf_smem[CTA_TILE_KV * HEAD_DIM_VO / NVFP4_SF_VEC_SIZE];
+
+  __device__ __forceinline__ uint8_t* k_sf_ptr() { return this->k_sf_smem; }
+  __device__ __forceinline__ uint8_t* v_sf_ptr() { return this->v_sf_smem; }
+};
+
+template <typename DTypeKV, typename AttentionVariant>
+static constexpr bool kUsePerTokenHead =
+    is_fp8_type_v<DTypeKV> && AttentionVariant::use_per_token_head;
+template <bool UsePTH, uint32_t CTA_TILE_KV>
+struct PthScaleSmemStorage {
+  __device__ __forceinline__ float* k_sf_pth_ptr() { return nullptr; }
+  __device__ __forceinline__ float* v_sf_pth_ptr() { return nullptr; }
+};
+template <uint32_t CTA_TILE_KV>
+struct PthScaleSmemStorage<true, CTA_TILE_KV> {
+  alignas(16) float k_sf_pth_smem[CTA_TILE_KV];
+  alignas(16) float v_sf_pth_smem[CTA_TILE_KV];
+
+  __device__ __forceinline__ float* k_sf_pth_ptr() { return this->k_sf_pth_smem; }
+  __device__ __forceinline__ float* v_sf_pth_ptr() { return this->v_sf_pth_smem; }
+};
+
+template <bool FORCE_DISABLE_KV_REPACK, uint32_t HEAD_DIM_VO, typename DTypeKV>
+static constexpr bool kUseKvRepack = !FORCE_DISABLE_KV_REPACK && (sizeof(DTypeKV) == 1) &&
+                                     !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO != 64);
+template <bool UseKvRepack, uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
+          typename DTypeQ>
+struct KvSmemRepackStorage {
+  __device__ __forceinline__ DTypeQ* kv_smem_repack_ptr() { return nullptr; }
+};
+// BF16/FP16 staging buffer for the FP8 "repack" path: K (then V) is dequantized
+// once per tile into this, then read with the standard (shuffle-free) 16-bit
+// ldmatrix path. A single buffer is time-shared between K and V because K is
+// repacked+consumed (compute_qk) before V is repacked+consumed (compute_sfm_v).
+// Sized to max(HEAD_DIM_QK, HEAD_DIM_VO); 1 unless DTypeKV is an 8-bit (FP8)
+// type and not FP4 (FP4 keeps its in-loop dequant).
+template <uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, typename DTypeQ>
+struct KvSmemRepackStorage<true, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ> {
+  static constexpr uint32_t REPACK_BUF_ELEMS =
+      CTA_TILE_KV * (HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO);
+
+  alignas(16) DTypeQ kv_smem_repack[REPACK_BUF_ELEMS];
+
+  __device__ __forceinline__ DTypeQ* kv_smem_repack_ptr() { return this->kv_smem_repack; }
+};
+
 template <uint32_t NUM_WARPS_KV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK,
-          uint32_t HEAD_DIM_VO, typename DTypeQ, typename DTypeKV, typename DTypeO>
-struct SharedStorageQKVO {
+          uint32_t HEAD_DIM_VO, bool USE_KV_REPACK, typename DTypeQ, typename DTypeKV,
+          typename DTypeO, typename AttentionVariant>
+struct SharedStorageQKVO
+    : public Fp4ScaleSmemStorage<is_fp4_type_v<DTypeKV>, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO>,
+      public PthScaleSmemStorage<kUsePerTokenHead<DTypeKV, AttentionVariant>, CTA_TILE_KV>,
+      public KvSmemRepackStorage<USE_KV_REPACK, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ> {
   union {
     struct {
       alignas(16) DTypeQ q_smem[CTA_TILE_Q * HEAD_DIM_QK];
@@ -107,32 +184,13 @@ struct SharedStorageQKVO {
     };
     alignas(16) DTypeO smem_o[CTA_TILE_Q * HEAD_DIM_VO];
   };
-  // Scale factors for NVFP4 KV cache: one UE4M3 byte per NVFP4_SF_VEC_SIZE elements.
-  // Sized to 1 when DTypeKV is not FP4 to avoid wasting shared memory.
-  alignas(16) std::conditional_t<is_fp4_type_v<DTypeKV>,
-                                 uint8_t[CTA_TILE_KV * HEAD_DIM_QK / NVFP4_SF_VEC_SIZE],
-                                 uint8_t[1]> k_sf_smem;
-  alignas(16) std::conditional_t<is_fp4_type_v<DTypeKV>,
-                                 uint8_t[CTA_TILE_KV * HEAD_DIM_VO / NVFP4_SF_VEC_SIZE],
-                                 uint8_t[1]> v_sf_smem;
-  // BF16/FP16 staging buffer for the FP8 "repack" path: K (then V) is dequantized
-  // once per tile into this, then read with the standard (shuffle-free) 16-bit
-  // ldmatrix path. A single buffer is time-shared between K and V because K is
-  // repacked+consumed (compute_qk) before V is repacked+consumed (compute_sfm_v).
-  // Sized to max(HEAD_DIM_QK, HEAD_DIM_VO); 1 unless DTypeKV is an 8-bit (FP8)
-  // type and not FP4 (FP4 keeps its in-loop dequant).
-  static constexpr bool USE_KV_REPACK =
-      (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO != 64);
-  static constexpr uint32_t REPACK_BUF_ELEMS =
-      CTA_TILE_KV * (HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO);
-  alignas(16) std::conditional_t<USE_KV_REPACK, DTypeQ[REPACK_BUF_ELEMS], DTypeQ[1]> kv_smem_repack;
 };
 
 template <MaskMode MASK_MODE_, uint32_t CTA_TILE_Q_, uint32_t NUM_MMA_Q_, uint32_t NUM_MMA_KV_,
           uint32_t NUM_MMA_D_QK_, uint32_t NUM_MMA_D_VO_, uint32_t NUM_WARPS_Q_,
-          uint32_t NUM_WARPS_KV_, PosEncodingMode POS_ENCODING_MODE_, typename DTypeQ_,
-          typename DTypeKV_, typename DTypeO_, typename DTypeQKAccum_, typename IdType_,
-          typename AttentionVariant_>
+          uint32_t NUM_WARPS_KV_, PosEncodingMode POS_ENCODING_MODE_, bool FORCE_DISABLE_KV_REPACK,
+          typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename DTypeQKAccum_,
+          typename IdType_, typename AttentionVariant_>
 struct KernelTraits {
   static constexpr uint32_t NUM_STAGES = 1;  // used for BatchAttention Template
   static constexpr MaskMode MASK_MODE = MASK_MODE_;
@@ -168,11 +226,12 @@ struct KernelTraits {
   // When set, FP8 K/V are dequantized once per tile into BF16/FP16 staging smem
   // and read via the standard (shuffle-free) 16-bit ldmatrix path. Only for the
   // k128B-swizzle case (HEAD_DIM_VO != 64); FP4 keeps its in-loop dequant.
-  static constexpr bool USE_KV_REPACK =
-      (sizeof(DTypeKV_) == 1) && !is_fp4_type_v<DTypeKV_> && (HEAD_DIM_VO != 64);
+  static constexpr bool USE_KV_REPACK = kUseKvRepack<FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, DTypeKV>;
   // b128 columns per KV row in the FP8 (packed) and BF16 (repacked) layouts.
   static constexpr uint32_t REPACK_STRIDE_QK = HEAD_DIM_QK / upcast_size<DTypeQ_>();
   static constexpr uint32_t REPACK_STRIDE_VO = HEAD_DIM_VO / upcast_size<DTypeQ_>();
+
+  static constexpr bool USE_PER_TOKEN_HEAD = kUsePerTokenHead<DTypeKV, AttentionVariant>;
 
   static constexpr bool IsInvalid() {
     return ((NUM_MMA_D_VO < 4) || (NUM_MMA_D_VO == 4 && NUM_MMA_KV % 2 == 1) ||
@@ -183,8 +242,9 @@ struct KernelTraits {
             (sizeof(DTypeKV) == 1 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama));
   }
 
-  using SharedStorage = SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK,
-                                          HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>;
+  using SharedStorage =
+      SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO,
+                        USE_KV_REPACK, DTypeQ, DTypeKV, DTypeO, AttentionVariant>;
 #ifdef FP16_QK_REDUCTION_SUPPORTED
   template <typename DT>
   static constexpr DT getNegInf() {
@@ -485,54 +545,58 @@ __device__ __forceinline__ void page_produce_kv_sf(
     const uint32_t kv_stride_n, const uint_fastdiv& page_size, const IdType* indices,
     const uint32_t kv_idx_base, const uint32_t kv_len, const uint32_t warp_idx,
     const uint32_t lane_idx) {
-  if constexpr (!is_fp4_type_v<typename KTraits::DTypeKV>) return;
+  if constexpr (is_fp4_type_v<typename KTraits::DTypeKV>) {
+    constexpr uint32_t HEAD_DIM = produce_v ? KTraits::HEAD_DIM_VO : KTraits::HEAD_DIM_QK;
+    constexpr uint32_t SF_COLS = HEAD_DIM / NVFP4_SF_VEC_SIZE;  // SF bytes per KV row
+    constexpr uint32_t NUM_WARPS = KTraits::NUM_WARPS;
+    constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+    // DTypeKV containers per SF byte: NVFP4_SF_VEC_SIZE FP4 / 2 FP4-per-container.
+    constexpr uint32_t SF_CONTAINERS = NVFP4_SF_VEC_SIZE / 2;  // = 8
+    constexpr uint32_t SF_TOTAL_BYTES = CTA_TILE_KV * SF_COLS;
+    static_assert(SF_TOTAL_BYTES % 4 == 0, "SF smem size must be 4-byte aligned for 32-bit LDGSTS");
+    // Each thread loads 4 SF bytes (32 bits) per iteration via LDGSTS.32.
+    constexpr uint32_t THREADS_PER_CTA = NUM_WARPS * 32;
+    constexpr uint32_t NUM_SF_ITERS = (SF_TOTAL_BYTES / 4 + THREADS_PER_CTA - 1) / THREADS_PER_CTA;
 
-  constexpr uint32_t HEAD_DIM = produce_v ? KTraits::HEAD_DIM_VO : KTraits::HEAD_DIM_QK;
-  constexpr uint32_t SF_COLS = HEAD_DIM / NVFP4_SF_VEC_SIZE;  // SF bytes per KV row
-  constexpr uint32_t NUM_WARPS = KTraits::NUM_WARPS;
-  constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
-  // DTypeKV containers per SF byte: NVFP4_SF_VEC_SIZE FP4 / 2 FP4-per-container.
-  constexpr uint32_t SF_CONTAINERS = NVFP4_SF_VEC_SIZE / 2;  // = 8
-  constexpr uint32_t SF_TOTAL_BYTES = CTA_TILE_KV * SF_COLS;
-  static_assert(SF_TOTAL_BYTES % 4 == 0, "SF smem size must be 4-byte aligned for 32-bit LDGSTS");
-  // Each thread loads 4 SF bytes (32 bits) per iteration via LDGSTS.32.
-  constexpr uint32_t THREADS_PER_CTA = NUM_WARPS * 32;
-  constexpr uint32_t NUM_SF_ITERS = (SF_TOTAL_BYTES / 4 + THREADS_PER_CTA - 1) / THREADS_PER_CTA;
-
-  uint8_t* sf_smem = produce_v ? smem_storage->v_sf_smem : smem_storage->k_sf_smem;
-  const uint32_t thread_id = warp_idx * 32 + lane_idx;
+    uint8_t* sf_smem = produce_v ? smem_storage->v_sf_ptr() : smem_storage->k_sf_ptr();
+    const uint32_t thread_id = warp_idx * 32 + lane_idx;
 
 #pragma unroll
-  for (uint32_t k = 0; k < NUM_SF_ITERS; ++k) {
-    const uint32_t flat_uint32_idx = thread_id + k * THREADS_PER_CTA;
-    const uint32_t flat_byte = flat_uint32_idx * 4;
-    // sf_smem_col is 4-byte aligned: flat_byte is a multiple of 4, and SF_COLS is a power of 2
-    // (HEAD_DIM / 16), so flat_byte % SF_COLS is always a multiple of 4 (or 0 when SF_COLS < 4).
-    const uint32_t sf_smem_row = flat_byte / SF_COLS;
-    const uint32_t sf_smem_col = flat_byte % SF_COLS;
-    // For k < NUM_SF_ITERS-1, (flat_byte < SF_TOTAL_BYTES) is always true (optimized away).
-    const bool in_bounds = (flat_byte < SF_TOTAL_BYTES) && (kv_idx_base + sf_smem_row < kv_len);
+    for (uint32_t k = 0; k < NUM_SF_ITERS; ++k) {
+      const uint32_t flat_uint32_idx = thread_id + k * THREADS_PER_CTA;
+      const uint32_t flat_byte = flat_uint32_idx * 4;
+      // sf_smem_col is 4-byte aligned: flat_byte is a multiple of 4, and SF_COLS is a power of 2
+      // (HEAD_DIM / 16), so flat_byte % SF_COLS is always a multiple of 4 (or 0 when SF_COLS < 4).
+      const uint32_t sf_smem_row = flat_byte / SF_COLS;
+      const uint32_t sf_smem_col = flat_byte % SF_COLS;
+      // For k < NUM_SF_ITERS-1, (flat_byte < SF_TOTAL_BYTES) is always true (optimized away).
+      const bool smem_in_bounds = flat_byte < SF_TOTAL_BYTES;
+      const bool in_bounds = smem_in_bounds && (kv_idx_base + sf_smem_row < kv_len);
 
-    // SF strides are KV byte strides / SF_CONTAINERS (1 SF byte per SF_CONTAINERS KV containers).
-    // packed_kv_bound guards indices[] access; returns offset 0 for out-of-range rows.
-    uint32_t page_iter, entry_idx;
-    const uint32_t packed_block_iter = packed_page_iter_base + sf_smem_row;
-    page_size.divmod(packed_block_iter, page_iter, entry_idx);
-    const size_t sf_gmem_offset =
-        static_cast<size_t>(packed_block_iter < packed_kv_bound ? indices[page_iter] : 0) *
-            (kv_stride_page / SF_CONTAINERS) +
-        kv_head_idx * (kv_stride_h / SF_CONTAINERS) + entry_idx * (kv_stride_n / SF_CONTAINERS) +
-        sf_smem_col;
+      // SF strides are KV byte strides / SF_CONTAINERS (1 SF byte per SF_CONTAINERS KV containers).
+      // packed_kv_bound guards indices[] access; returns offset 0 for out-of-range rows.
+      uint32_t page_iter, entry_idx;
+      const uint32_t packed_block_iter = packed_page_iter_base + sf_smem_row;
+      page_size.divmod(packed_block_iter, page_iter, entry_idx);
+      const size_t sf_gmem_offset =
+          static_cast<size_t>(packed_block_iter < packed_kv_bound ? indices[page_iter] : 0) *
+              (kv_stride_page / SF_CONTAINERS) +
+          kv_head_idx * (kv_stride_h / SF_CONTAINERS) + entry_idx * (kv_stride_n / SF_CONTAINERS) +
+          sf_smem_col;
 
-    // V SF must zero-fill out-of-bounds entries: compute_sfm_v reads SF for all CTA_TILE_KV rows
-    // including padding, and 0 (softmax weight) * NaN (uninitialized SF) = NaN (IEEE 754).
-    // K SF can use kNoFill since NaN K scores are replaced by -inf via logits_mask before
-    // update_mdo_states, so they never reach the accumulator.
-    constexpr auto fill_mode =
-        produce_v ? cp_async::SharedMemFillMode::kFillZero : cp_async::SharedMemFillMode::kNoFill;
-    cp_async::pred_load_32b<fill_mode>(reinterpret_cast<uint32_t*>(sf_smem + flat_byte),
-                                       reinterpret_cast<const uint32_t*>(sf_ptr + sf_gmem_offset),
-                                       in_bounds);
+      // V SF must zero-fill out-of-bounds entries: compute_sfm_v reads SF for all CTA_TILE_KV rows
+      // including padding, and 0 (softmax weight) * NaN (uninitialized SF) = NaN (IEEE 754).
+      // K SF can use kNoFill since NaN K scores are replaced by -inf via logits_mask before
+      // update_mdo_states, so they never reach the accumulator.
+      constexpr auto fill_mode =
+          produce_v ? cp_async::SharedMemFillMode::kFillZero : cp_async::SharedMemFillMode::kNoFill;
+      const bool smem_prot = !produce_v || smem_in_bounds;
+      if (smem_prot) {
+        cp_async::pred_load_32b<fill_mode>(
+            reinterpret_cast<uint32_t*>(sf_smem + flat_byte),
+            reinterpret_cast<const uint32_t*>(sf_ptr + sf_gmem_offset), in_bounds);
+      }
+    }
   }
 }
 
@@ -566,42 +630,141 @@ __device__ __forceinline__ void produce_kv_sf(typename KTraits::SharedStorage* s
                                               const uint32_t kv_stride_h,
                                               const uint32_t kv_idx_base, const uint32_t kv_len,
                                               const uint32_t warp_idx, const uint32_t lane_idx) {
-  if constexpr (!is_fp4_type_v<typename KTraits::DTypeKV>) return;
+  if constexpr (is_fp4_type_v<typename KTraits::DTypeKV>) {
+    constexpr uint32_t HEAD_DIM = produce_v ? KTraits::HEAD_DIM_VO : KTraits::HEAD_DIM_QK;
+    constexpr uint32_t SF_COLS = HEAD_DIM / NVFP4_SF_VEC_SIZE;
+    constexpr uint32_t NUM_WARPS = KTraits::NUM_WARPS;
+    constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+    // DTypeKV containers per SF byte: NVFP4_SF_VEC_SIZE FP4 / 2 FP4-per-container.
+    constexpr uint32_t SF_CONTAINERS = NVFP4_SF_VEC_SIZE / 2;  // = 8
+    constexpr uint32_t SF_TOTAL_BYTES = CTA_TILE_KV * SF_COLS;
+    static_assert(SF_TOTAL_BYTES % 4 == 0, "SF smem size must be 4-byte aligned for 32-bit LDGSTS");
+    // Each thread loads 4 SF bytes (32 bits) per iteration via LDGSTS.32.
+    constexpr uint32_t THREADS_PER_CTA = NUM_WARPS * 32;
+    constexpr uint32_t NUM_SF_ITERS = (SF_TOTAL_BYTES / 4 + THREADS_PER_CTA - 1) / THREADS_PER_CTA;
 
-  constexpr uint32_t HEAD_DIM = produce_v ? KTraits::HEAD_DIM_VO : KTraits::HEAD_DIM_QK;
-  constexpr uint32_t SF_COLS = HEAD_DIM / NVFP4_SF_VEC_SIZE;
-  constexpr uint32_t NUM_WARPS = KTraits::NUM_WARPS;
-  constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
-  // DTypeKV containers per SF byte: NVFP4_SF_VEC_SIZE FP4 / 2 FP4-per-container.
-  constexpr uint32_t SF_CONTAINERS = NVFP4_SF_VEC_SIZE / 2;  // = 8
-  constexpr uint32_t SF_TOTAL_BYTES = CTA_TILE_KV * SF_COLS;
-  static_assert(SF_TOTAL_BYTES % 4 == 0, "SF smem size must be 4-byte aligned for 32-bit LDGSTS");
-  // Each thread loads 4 SF bytes (32 bits) per iteration via LDGSTS.32.
-  constexpr uint32_t THREADS_PER_CTA = NUM_WARPS * 32;
-  constexpr uint32_t NUM_SF_ITERS = (SF_TOTAL_BYTES / 4 + THREADS_PER_CTA - 1) / THREADS_PER_CTA;
-
-  uint8_t* sf_smem = produce_v ? smem_storage->v_sf_smem : smem_storage->k_sf_smem;
-  const uint32_t thread_id = warp_idx * 32 + lane_idx;
-  const uint32_t sf_stride_n = kv_stride_n / SF_CONTAINERS;
-  const uint32_t sf_stride_h = kv_stride_h / SF_CONTAINERS;
+    uint8_t* sf_smem = produce_v ? smem_storage->v_sf_ptr() : smem_storage->k_sf_ptr();
+    const uint32_t thread_id = warp_idx * 32 + lane_idx;
+    const uint32_t sf_stride_n = kv_stride_n / SF_CONTAINERS;
+    const uint32_t sf_stride_h = kv_stride_h / SF_CONTAINERS;
 
 #pragma unroll
-  for (uint32_t i = 0; i < NUM_SF_ITERS; ++i) {
-    const uint32_t flat_byte = (thread_id + i * THREADS_PER_CTA) * 4;
-    const uint32_t sf_smem_row = flat_byte / SF_COLS;
-    const uint32_t sf_smem_col = flat_byte % SF_COLS;
-    const uint32_t abs_kv_row = kv_idx_base + sf_smem_row;
-    const bool in_bounds = (flat_byte < SF_TOTAL_BYTES) && (abs_kv_row < kv_len);
-    const size_t sf_gmem_offset =
-        in_bounds ? (static_cast<size_t>(kv_abs_base + abs_kv_row) * sf_stride_n +
-                     kv_head_idx * sf_stride_h + sf_smem_col)
-                  : 0;
-    // Same rationale as page_produce_kv_sf: zero-fill V SF to prevent 0*NaN=NaN in compute_sfm_v.
-    constexpr auto fill_mode =
-        produce_v ? cp_async::SharedMemFillMode::kFillZero : cp_async::SharedMemFillMode::kNoFill;
-    cp_async::pred_load_32b<fill_mode>(reinterpret_cast<uint32_t*>(sf_smem + flat_byte),
-                                       reinterpret_cast<const uint32_t*>(sf_ptr + sf_gmem_offset),
-                                       in_bounds);
+    for (uint32_t i = 0; i < NUM_SF_ITERS; ++i) {
+      const uint32_t flat_byte = (thread_id + i * THREADS_PER_CTA) * 4;
+      const uint32_t sf_smem_row = flat_byte / SF_COLS;
+      const uint32_t sf_smem_col = flat_byte % SF_COLS;
+      const uint32_t abs_kv_row = kv_idx_base + sf_smem_row;
+      const bool smem_in_bounds = flat_byte < SF_TOTAL_BYTES;
+      const bool in_bounds = smem_in_bounds && (abs_kv_row < kv_len);
+      const size_t sf_gmem_offset =
+          in_bounds ? (static_cast<size_t>(kv_abs_base + abs_kv_row) * sf_stride_n +
+                       kv_head_idx * sf_stride_h + sf_smem_col)
+                    : 0;
+      // Same rationale as page_produce_kv_sf: zero-fill V SF to prevent 0*NaN=NaN in compute_sfm_v.
+      constexpr auto fill_mode =
+          produce_v ? cp_async::SharedMemFillMode::kFillZero : cp_async::SharedMemFillMode::kNoFill;
+      const bool smem_prot = !produce_v || smem_in_bounds;
+      if (smem_prot) {
+        cp_async::pred_load_32b<fill_mode>(
+            reinterpret_cast<uint32_t*>(sf_smem + flat_byte),
+            reinterpret_cast<const uint32_t*>(sf_ptr + sf_gmem_offset), in_bounds);
+      }
+    }
+  }
+}
+
+/*!
+ * \brief Load inline per-token-head scales from paged global memory into shared memory.
+ *
+ * Each scale is a float32 stored at offset HEAD_DIM from the start of each row.
+ */
+template <bool produce_v, typename KTraits, typename IdType>
+__device__ __forceinline__ void page_produce_kv_sf_pth(
+    typename KTraits::SharedStorage* smem_storage, const typename KTraits::DTypeKV* kv_base,
+    const paged_kv_t<typename KTraits::DTypeKV, IdType>& paged_kv, const uint32_t kv_head_idx,
+    const uint32_t packed_page_iter_base, const uint32_t tile_start, const uint32_t kv_len,
+    const uint32_t warp_idx, const uint32_t lane_idx) {
+  if constexpr (KTraits::USE_PER_TOKEN_HEAD) {
+    constexpr uint32_t HEAD_DIM = produce_v ? KTraits::HEAD_DIM_VO : KTraits::HEAD_DIM_QK;
+    constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+    constexpr uint32_t THREADS_PER_CTA = KTraits::NUM_WARPS * 32;
+    // One float32 (4 bytes) per row.
+    static_assert(CTA_TILE_KV * 4 % 4 == 0, "PTH scale smem size must be 4-byte aligned");
+    constexpr uint32_t NUM_SF_ITERS = (CTA_TILE_KV * 4 / 4 + THREADS_PER_CTA - 1) / THREADS_PER_CTA;
+
+    uint32_t* sf_pth_smem = reinterpret_cast<uint32_t*>(produce_v ? smem_storage->v_sf_pth_ptr()
+                                                                  : smem_storage->k_sf_pth_ptr());
+    const uint32_t last_indptr = paged_kv.indptr[paged_kv.batch_size];
+    const uint32_t thread_id = warp_idx * 32 + lane_idx;
+
+#pragma unroll
+    for (uint32_t i = 0; i < NUM_SF_ITERS; ++i) {
+      const uint32_t row = thread_id + i * THREADS_PER_CTA;
+      const bool smem_in_bounds = row < CTA_TILE_KV;
+      const bool in_bounds = smem_in_bounds && (tile_start + row < kv_len);
+      uint32_t page_iter = 0, entry_idx = 0;
+      paged_kv.page_size.divmod(packed_page_iter_base + row, page_iter, entry_idx);
+      const size_t offset = in_bounds
+                                ? paged_kv.protective_get_kv_offset(
+                                      page_iter, kv_head_idx, entry_idx, HEAD_DIM, last_indptr)
+                                : 0;
+      // Same rationale as page_produce_kv_sf: zero-fill V SF PTH to prevent 0*NaN=NaN in
+      // compute_sfm_v.
+      constexpr auto fill_mode =
+          produce_v ? cp_async::SharedMemFillMode::kFillZero : cp_async::SharedMemFillMode::kNoFill;
+      const bool smem_prot = !produce_v || smem_in_bounds;
+      if (smem_prot) {
+        cp_async::pred_load_32b<fill_mode>(
+            sf_pth_smem + row, reinterpret_cast<const uint32_t*>(kv_base + offset), in_bounds);
+      }
+    }
+  }
+}
+
+/*!
+ * \brief Load inline per-token-head scales from global memory (contiguous/ragged layout).
+ *
+ * Each scale is a float32 stored at offset HEAD_DIM from the start of each row.
+ * kv_base_offset adds an optional base offset (e.g., kv_indptr[request_idx] * stride_n
+ * for batch ragged prefill) to the computed scale offset so the absolute tensor position
+ * is used for the memory access while tile_start/kv_len remain relative for bounds checking.
+ */
+template <bool produce_v, typename KTraits>
+__device__ __forceinline__ void produce_kv_sf_pth(typename KTraits::SharedStorage* smem_storage,
+                                                  const typename KTraits::DTypeKV* kv_base,
+                                                  const uint32_t stride_n, const uint32_t stride_h,
+                                                  const uint32_t kv_head_idx,
+                                                  const uint32_t tile_start, const uint32_t kv_len,
+                                                  const uint32_t warp_idx, const uint32_t lane_idx,
+                                                  const size_t kv_base_offset = 0) {
+  if constexpr (KTraits::USE_PER_TOKEN_HEAD) {
+    constexpr uint32_t HEAD_DIM = produce_v ? KTraits::HEAD_DIM_VO : KTraits::HEAD_DIM_QK;
+    constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+    constexpr uint32_t THREADS_PER_CTA = KTraits::NUM_WARPS * 32;
+    constexpr uint32_t NUM_SF_ITERS = (CTA_TILE_KV * 4 / 4 + THREADS_PER_CTA - 1) / THREADS_PER_CTA;
+
+    uint32_t* sf_pth_smem = reinterpret_cast<uint32_t*>(produce_v ? smem_storage->v_sf_pth_ptr()
+                                                                  : smem_storage->k_sf_pth_ptr());
+    const uint32_t thread_id = warp_idx * 32 + lane_idx;
+
+#pragma unroll
+    for (uint32_t i = 0; i < NUM_SF_ITERS; ++i) {
+      const uint32_t row = thread_id + i * THREADS_PER_CTA;
+      const bool smem_in_bounds = row < CTA_TILE_KV;
+      const uint32_t kv_idx = tile_start + row;
+      const bool in_bounds = smem_in_bounds && (kv_idx < kv_len);
+      const size_t offset =
+          in_bounds ? (kv_idx * stride_n + kv_head_idx * stride_h + HEAD_DIM) + kv_base_offset : 0;
+      // Same rationale as page_produce_kv_sf: zero-fill V SF PTH to prevent 0*NaN=NaN in
+      // compute_sfm_v.
+      constexpr auto fill_mode =
+          produce_v ? cp_async::SharedMemFillMode::kFillZero : cp_async::SharedMemFillMode::kNoFill;
+      const bool smem_prot = !produce_v || smem_in_bounds;
+      if (smem_prot) {
+        cp_async::pred_load_32b<fill_mode>(
+            sf_pth_smem + row, reinterpret_cast<const uint32_t*>(kv_base + offset), in_bounds);
+      }
+    }
   }
 }
 
@@ -842,13 +1005,15 @@ __device__ __forceinline__ void k_smem_inplace_apply_rotary(
 // Dequantize one FP8 K or V tile from its packed smem buffer into a BF16/FP16
 // staging buffer, laid out exactly as a native 16-bit tile (same k128B swizzle).
 // Shuffle-free, vectorized: each thread reads packed 16-byte (b128) chunks of 16
-// FP8 elements and writes two 16-byte chunks of 8 BF16 elements. Afterwards the
+// FP8 elements and writes two 16-byte chunks of 8 BF16/FP16 elements. Afterwards the
 // QK/PV MMAs use the standard 16-bit ldmatrix path (no per-fragment cross-lane
 // swizzle). Numerically identical to the in-loop dequant.
+// When sf_pth is non-null (USE_PER_TOKEN_HEAD), each row is multiplied by its
+// float32 scale inline, avoiding a second smem round-trip.
 template <typename KTraits, uint32_t HEAD_DIM>
-__device__ __forceinline__ void repack_fp8_tile_to_bf16(typename KTraits::DTypeKV* smem_fp8,
-                                                        typename KTraits::DTypeQ* smem_bf16,
-                                                        uint32_t thread_id) {
+__device__ __forceinline__ void repack_fp8_tile(typename KTraits::DTypeKV* smem_fp8,
+                                                typename KTraits::DTypeQ* smem_bf16,
+                                                uint32_t thread_id, const float* sf_pth = nullptr) {
   using DTypeKV = typename KTraits::DTypeKV;
   using DTypeQ = typename KTraits::DTypeQ;
   constexpr SwizzleMode SWIZZLE = KTraits::SWIZZLE_MODE_KV;
@@ -869,6 +1034,9 @@ __device__ __forceinline__ void repack_fp8_tile_to_bf16(typename KTraits::DTypeK
     // so it must be 16-byte aligned (DTypeQ alone only guarantees 2B alignment).
     alignas(16) DTypeQ conv[16];
     vec_cast<DTypeQ, DTypeKV>::template cast<16>(conv, (DTypeKV*)&packed);
+    if constexpr (KTraits::USE_PER_TOKEN_HEAD) {
+      pth_scale_frag_inplace<DTypeQ, 16, true>(reinterpret_cast<uint32_t*>(conv), sf_pth + row);
+    }
     dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col)] = *(b128_t*)&conv[0];
     dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col + 1)] = *(b128_t*)&conv[8];
   }
@@ -878,7 +1046,8 @@ template <typename KTraits, bool REPACK_BF16 = false>
 __device__ __forceinline__ void compute_qk(
     smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem, uint32_t* q_smem_offset_r,
     smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem, uint32_t* k_smem_offset_r, uint8_t* k_sf_smem,
-    uint32_t lane_idx, typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8]) {
+    const float* k_sf_pth_smem, const uint32_t kv_tile_offset, uint32_t lane_idx,
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8]) {
   constexpr uint32_t UPCAST_STRIDE_Q = KTraits::UPCAST_STRIDE_Q;
   constexpr uint32_t UPCAST_STRIDE_K = KTraits::UPCAST_STRIDE_K;
   // When reading from the BF16 repack buffer, K is laid out as native 16-bit, so
@@ -936,6 +1105,13 @@ __device__ __forceinline__ void compute_qk(
           *(packed2_*)&b_frag[1] = __hmul2(*(packed2_*)&b_frag[1], scale_a);
           *(packed2_*)&b_frag[2] = __hmul2(*(packed2_*)&b_frag[2], scale_b);
           *(packed2_*)&b_frag[3] = __hmul2(*(packed2_*)&b_frag[3], scale_b);
+        } else if constexpr (KTraits::USE_PER_TOKEN_HEAD) {
+          uint32_t kv_base = kv_tile_offset + mma_kv * 16;
+          uint32_t row = lane_idx / 4;
+          float k_sc[8];
+          k_sc[0] = k_sc[1] = k_sc[2] = k_sc[3] = k_sf_pth_smem[kv_base + row];
+          k_sc[4] = k_sc[5] = k_sc[6] = k_sc[7] = k_sf_pth_smem[kv_base + row + 8];
+          pth_scale_frag_inplace<typename KTraits::DTypeQ, 8, false>(b_frag, k_sc);
         }
       } else {
         k_smem->ldmatrix_m8n8x4(*k_smem_offset_r, b_frag);
@@ -1246,7 +1422,8 @@ __device__ __forceinline__ void update_mdo_states(
 template <typename KTraits, bool REPACK_BF16 = false>
 __device__ __forceinline__ void compute_sfm_v(
     smem_t<KTraits::SWIZZLE_MODE_KV>* v_smem, uint32_t* v_smem_offset_r, uint8_t* v_sf_smem,
-    uint32_t lane_idx, typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+    const float* v_sf_pth_smem, const uint32_t kv_tile_offset, uint32_t lane_idx,
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
     float (*o_frag)[KTraits::NUM_MMA_D_VO][8], float (*d)[2]) {
   constexpr uint32_t UPCAST_STRIDE_V = KTraits::UPCAST_STRIDE_V;
   // When reading from the BF16 repack buffer, V is native 16-bit.
@@ -1324,6 +1501,15 @@ __device__ __forceinline__ void compute_sfm_v(
           *(packed2_*)&b_frag[1] = __hmul2(*(packed2_*)&b_frag[1], scale_hi);
           *(packed2_*)&b_frag[2] = __hmul2(*(packed2_*)&b_frag[2], scale_lo);
           *(packed2_*)&b_frag[3] = __hmul2(*(packed2_*)&b_frag[3], scale_hi);
+        } else if constexpr (KTraits::USE_PER_TOKEN_HEAD) {
+          uint32_t kv_base = kv_tile_offset + mma_kv * 16;
+          uint32_t row = (threadIdx.x % 4) * 2;
+          float v_sc[8];
+          v_sc[0] = v_sc[4] = v_sf_pth_smem[kv_base + row];
+          v_sc[1] = v_sc[5] = v_sf_pth_smem[kv_base + row + 1];
+          v_sc[2] = v_sc[6] = v_sf_pth_smem[kv_base + row + 8];
+          v_sc[3] = v_sc[7] = v_sf_pth_smem[kv_base + row + 9];
+          pth_scale_frag_inplace<typename KTraits::DTypeQ, 8, false>(b_frag, v_sc);
         }
       } else {
         v_smem->ldmatrix_m8n8x4_trans(*v_smem_offset_r, b_frag);
@@ -1816,11 +2002,15 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
                                                            k_stride_n, 0, chunk_size, tid);
     produce_kv_sf<false, KTraits>(&smem_storage, maybe_k_cache_sf, kv_abs_base, kv_head_idx,
                                   k_stride_n, k_stride_h, 0, chunk_size, warp_idx, lane_idx);
+    produce_kv_sf_pth<false, KTraits>(&smem_storage, k, k_stride_n, k_stride_h, kv_head_idx,
+                                      chunk_start, kv_len, warp_idx, lane_idx);
     cp_async::commit_group();
     produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(v_smem, &v_smem_offset_w, &v_ptr,
                                                             v_stride_n, 0, chunk_size, tid);
     produce_kv_sf<true, KTraits>(&smem_storage, maybe_v_cache_sf, kv_abs_base, kv_head_idx,
                                  v_stride_n, v_stride_h, 0, chunk_size, warp_idx, lane_idx);
+    produce_kv_sf_pth<true, KTraits>(&smem_storage, v, v_stride_n, v_stride_h, kv_head_idx,
+                                     chunk_start, kv_len, warp_idx, lane_idx);
     cp_async::commit_group();
 
 #pragma unroll 1
@@ -1836,10 +2026,11 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
 
       // compute attention score
       compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-                          smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                       KTraits::NUM_MMA_KV * 16 *
-                                                       KTraits::NUM_MMA_D_QK,
-                          lane_idx, s_frag);
+                          smem_storage.k_sf_ptr() + get_warp_idx_kv<KTraits>(tid.z) *
+                                                        KTraits::NUM_MMA_KV * 16 *
+                                                        KTraits::NUM_MMA_D_QK,
+                          smem_storage.k_sf_pth_ptr(),
+                          get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16, lane_idx, s_frag);
       uint32_t kv_idx_base =
           chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
       logits_transform<KTraits>(params, variant, /*batch_idx=*/0, qo_packed_idx_base, kv_idx_base,
@@ -1860,16 +2051,20 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
       produce_kv_sf<false, KTraits>(&smem_storage, maybe_k_cache_sf, kv_abs_base, kv_head_idx,
                                     k_stride_n, k_stride_h, (iter + 1) * CTA_TILE_KV, chunk_size,
                                     warp_idx, lane_idx);
+      produce_kv_sf_pth<false, KTraits>(&smem_storage, k, k_stride_n, k_stride_h, kv_head_idx,
+                                        chunk_start + (iter + 1) * CTA_TILE_KV, kv_len, warp_idx,
+                                        lane_idx);
       cp_async::commit_group();
       cp_async::wait_group<1>();
       block.sync();
 
       // compute sfm*v
-      compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r,
-                             smem_storage.v_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                          KTraits::NUM_MMA_KV * 16 *
-                                                          KTraits::NUM_MMA_D_VO,
-                             lane_idx, s_frag, o_frag, d);
+      compute_sfm_v<KTraits>(
+          &v_smem, &v_smem_offset_r,
+          smem_storage.v_sf_ptr() +
+              get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_VO,
+          smem_storage.v_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16, lane_idx,
+          s_frag, o_frag, d);
 
       block.sync();
       produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
@@ -1877,6 +2072,9 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
       produce_kv_sf<true, KTraits>(&smem_storage, maybe_v_cache_sf, kv_abs_base, kv_head_idx,
                                    v_stride_n, v_stride_h, (iter + 1) * CTA_TILE_KV, chunk_size,
                                    warp_idx, lane_idx);
+      produce_kv_sf_pth<true, KTraits>(&smem_storage, v, v_stride_n, v_stride_h, kv_head_idx,
+                                       chunk_start + (iter + 1) * CTA_TILE_KV, kv_len, warp_idx,
+                                       lane_idx);
       cp_async::commit_group();
     }
     cp_async::wait_group<0>();
@@ -1938,8 +2136,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void SinglePrefillWithKVCache
 }
 
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
-          bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename AttentionVariant,
-          typename Params>
+          bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE, bool FORCE_DISABLE_KV_REPACK,
+          typename AttentionVariant, typename Params>
 cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp,
                                                cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
@@ -1983,8 +2181,7 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
     // path is active, so NUM_MMA_KV is chosen to keep base+staging within the
     // occupancy budget. NOTE: single-prefill doesn't use the repack, but the
     // staging buffer still lives in SharedStorageQKVO, so it must be accounted.
-    constexpr bool kUseRepack =
-        (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO != 64);
+    constexpr bool kUseRepack = kUseKvRepack<FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, DTypeKV>;
     constexpr uint32_t kKVSmemPerMmaKV =
         (HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV) +
         (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
@@ -2007,15 +2204,18 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
          !USE_FP16_QK_REDUCTION)
             ? 2
             : (8 / NUM_MMA_Q);
+    constexpr uint32_t scale_smem_per_mma =
+        kUsePerTokenHead<DTypeKV, AttentionVariant> ? 2 * 16 * NUM_WARPS_KV * sizeof(float) : 0;
     const uint32_t max_num_mma_kv_smem =
-        (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) / kKVSmemPerMmaKV;
+        (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) /
+        (kKVSmemPerMmaKV + scale_smem_per_mma);
 
     // control NUM_MMA_KV for maximum warp occupancy
     DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
-      using KTraits =
-          KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
-                       NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                       DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+      using KTraits = KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK,
+                                   NUM_MMA_D_VO, NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE,
+                                   FORCE_DISABLE_KV_REPACK, DTypeQ, DTypeKV, DTypeO, DTypeQKAccum,
+                                   typename Params::IdType, AttentionVariant>;
       if constexpr (KTraits::IsInvalid()) {
         // Invalid configuration, skip
         std::ostringstream err_msg;
@@ -2280,8 +2480,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     // FP8 repack path: BF16 staging buffers + their (16-bit-strided) read offsets.
     // Guard offsets by USE_KV_REPACK so the stride-8 get_permuted_offset isn't
     // instantiated for the k64B swizzle (HEAD_DIM_VO == 64), which requires stride==4.
-    smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack),
-        v_smem_bf16(smem_storage.kv_smem_repack);
+    smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack_ptr()),
+        v_smem_bf16(smem_storage.kv_smem_repack_ptr());
     uint32_t k_smem_offset_r_bf16 = 0, v_smem_offset_r_bf16 = 0;
     if constexpr (KTraits::USE_KV_REPACK) {
       k_smem_offset_r_bf16 = k_smem_bf16.template get_permuted_offset<KTraits::REPACK_STRIDE_QK>(
@@ -2309,11 +2509,17 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
                                                            k_stride_n, 0, chunk_size, tid);
     produce_kv_sf<false, KTraits>(&smem_storage, maybe_k_cache_sf, kv_abs_base, kv_head_idx,
                                   k_stride_n, k_stride_h, 0, chunk_size, warp_idx, lane_idx);
+    produce_kv_sf_pth<false, KTraits>(&smem_storage, k, k_stride_n, k_stride_h, kv_head_idx,
+                                      chunk_start, kv_len, warp_idx, lane_idx,
+                                      kv_indptr[request_idx] * k_stride_n);
     cp_async::commit_group();
     produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(v_smem, &v_smem_offset_w, &v_ptr,
                                                             v_stride_n, 0, chunk_size, tid);
     produce_kv_sf<true, KTraits>(&smem_storage, maybe_v_cache_sf, kv_abs_base, kv_head_idx,
                                  v_stride_n, v_stride_h, 0, chunk_size, warp_idx, lane_idx);
+    produce_kv_sf_pth<true, KTraits>(&smem_storage, v, v_stride_n, v_stride_h, kv_head_idx,
+                                     chunk_start, kv_len, warp_idx, lane_idx,
+                                     kv_indptr[request_idx] * v_stride_n);
     cp_async::commit_group();
 
 #pragma unroll 1
@@ -2335,21 +2541,24 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
 
       // compute attention score
       if constexpr (KTraits::USE_KV_REPACK) {
-        // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
-        repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
-            smem_storage.k_smem, smem_storage.kv_smem_repack, warp_idx * WARP_SIZE + lane_idx);
+        // Dequantize FP8 K -> BF16/FP16 staging smem (shuffle-free), then read native 16-bit.
+        repack_fp8_tile<KTraits, KTraits::HEAD_DIM_QK>(
+            smem_storage.k_smem, smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx,
+            smem_storage.k_sf_pth_ptr());
         block.sync();
         compute_qk<KTraits, /*REPACK_BF16=*/true>(
             &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
-            smem_storage.k_sf_smem +
+            smem_storage.k_sf_ptr() +
                 get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_QK,
+            smem_storage.k_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
             lane_idx, s_frag);
       } else {
         compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-                            smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                         KTraits::NUM_MMA_KV * 16 *
-                                                         KTraits::NUM_MMA_D_QK,
-                            lane_idx, s_frag);
+                            smem_storage.k_sf_ptr() + get_warp_idx_kv<KTraits>(tid.z) *
+                                                          KTraits::NUM_MMA_KV * 16 *
+                                                          KTraits::NUM_MMA_D_QK,
+                            smem_storage.k_sf_pth_ptr(),
+                            get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16, lane_idx, s_frag);
       }
       uint32_t kv_idx_base =
           chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
@@ -2372,27 +2581,33 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
       produce_kv_sf<false, KTraits>(&smem_storage, maybe_k_cache_sf, kv_abs_base, kv_head_idx,
                                     k_stride_n, k_stride_h, (iter + 1) * CTA_TILE_KV, chunk_size,
                                     warp_idx, lane_idx);
+      produce_kv_sf_pth<false, KTraits>(&smem_storage, k, k_stride_n, k_stride_h, kv_head_idx,
+                                        chunk_start + (iter + 1) * CTA_TILE_KV, kv_len, warp_idx,
+                                        lane_idx, kv_indptr[request_idx] * k_stride_n);
       cp_async::commit_group();
       cp_async::wait_group<1>();
       block.sync();
 
       // compute sfm*v
       if constexpr (KTraits::USE_KV_REPACK) {
-        // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
-        repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
-            smem_storage.v_smem, smem_storage.kv_smem_repack, warp_idx * WARP_SIZE + lane_idx);
+        // Dequantize FP8 V -> BF16/FP16 staging smem (shuffle-free), then read native 16-bit.
+        repack_fp8_tile<KTraits, KTraits::HEAD_DIM_VO>(
+            smem_storage.v_smem, smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx,
+            smem_storage.v_sf_pth_ptr());
         block.sync();
         compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
             &v_smem_bf16, &v_smem_offset_r_bf16,
-            smem_storage.v_sf_smem +
+            smem_storage.v_sf_ptr() +
                 get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_VO,
+            smem_storage.v_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
             lane_idx, s_frag, o_frag, d);
       } else {
-        compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r,
-                               smem_storage.v_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                            KTraits::NUM_MMA_KV * 16 *
-                                                            KTraits::NUM_MMA_D_VO,
-                               lane_idx, s_frag, o_frag, d);
+        compute_sfm_v<KTraits>(
+            &v_smem, &v_smem_offset_r,
+            smem_storage.v_sf_ptr() +
+                get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_VO,
+            smem_storage.v_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
+            lane_idx, s_frag, o_frag, d);
       }
 
       block.sync();
@@ -2401,6 +2616,9 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
       produce_kv_sf<true, KTraits>(&smem_storage, maybe_v_cache_sf, kv_abs_base, kv_head_idx,
                                    v_stride_n, v_stride_h, (iter + 1) * CTA_TILE_KV, chunk_size,
                                    warp_idx, lane_idx);
+      produce_kv_sf_pth<true, KTraits>(&smem_storage, v, v_stride_n, v_stride_h, kv_head_idx,
+                                       chunk_start + (iter + 1) * CTA_TILE_KV, kv_len, warp_idx,
+                                       lane_idx, kv_indptr[request_idx] * v_stride_n);
       cp_async::commit_group();
     }
     cp_async::wait_group<0>();
@@ -2637,8 +2855,8 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     // Guard the offset computation by USE_KV_REPACK: for the k64B swizzle
     // (HEAD_DIM_VO == 64, where repack is disabled) get_permuted_offset requires
     // stride == 4, so the stride-8 repack offset must not be instantiated there.
-    smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack),
-        v_smem_bf16(smem_storage.kv_smem_repack);
+    smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack_ptr()),
+        v_smem_bf16(smem_storage.kv_smem_repack_ptr());
     uint32_t k_smem_offset_r_bf16 = 0, v_smem_offset_r_bf16 = 0;
     if constexpr (KTraits::USE_KV_REPACK) {
       k_smem_offset_r_bf16 = k_smem_bf16.template get_permuted_offset<KTraits::REPACK_STRIDE_QK>(
@@ -2673,6 +2891,9 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                                        paged_kv.stride_page, paged_kv.stride_h, paged_kv.stride_n,
                                        paged_kv.page_size, paged_kv.indices, 0, chunk_size,
                                        warp_idx, lane_idx);
+    page_produce_kv_sf_pth<false, KTraits>(&smem_storage, paged_kv.k_data, paged_kv, kv_head_idx,
+                                           packed_page_iter_base, chunk_start, kv_len, warp_idx,
+                                           lane_idx);
     cp_async::commit_group();
     page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data, 0,
                                    thr_local_kv_offset, chunk_size, warp_idx, lane_idx);
@@ -2681,6 +2902,9 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                                       paged_kv.stride_page, paged_kv.stride_h, paged_kv.stride_n,
                                       paged_kv.page_size, paged_kv.indices, 0, chunk_size, warp_idx,
                                       lane_idx);
+    page_produce_kv_sf_pth<true, KTraits>(&smem_storage, paged_kv.v_data, paged_kv, kv_head_idx,
+                                          packed_page_iter_base, chunk_start, kv_len, warp_idx,
+                                          lane_idx);
     cp_async::commit_group();
 
     uint32_t num_iterations_prefix;
@@ -2775,21 +2999,24 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
 
       // compute attention score
       if constexpr (KTraits::USE_KV_REPACK) {
-        // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
-        repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
-            smem_storage.k_smem, smem_storage.kv_smem_repack, warp_idx * WARP_SIZE + lane_idx);
+        // Dequantize FP8 K -> BF16/FP16 staging smem (shuffle-free), then read native 16-bit.
+        repack_fp8_tile<KTraits, KTraits::HEAD_DIM_QK>(
+            smem_storage.k_smem, smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx,
+            smem_storage.k_sf_pth_ptr());
         block.sync();
         compute_qk<KTraits, /*REPACK_BF16=*/true>(
             &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
-            smem_storage.k_sf_smem +
+            smem_storage.k_sf_ptr() +
                 get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_QK,
+            smem_storage.k_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
             lane_idx, s_frag);
       } else {
         compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-                            smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                         KTraits::NUM_MMA_KV * 16 *
-                                                         KTraits::NUM_MMA_D_QK,
-                            lane_idx, s_frag);
+                            smem_storage.k_sf_ptr() + get_warp_idx_kv<KTraits>(tid.z) *
+                                                          KTraits::NUM_MMA_KV * 16 *
+                                                          KTraits::NUM_MMA_D_QK,
+                            smem_storage.k_sf_pth_ptr(),
+                            get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16, lane_idx, s_frag);
       }
       uint32_t kv_idx_base =
           chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
@@ -2838,27 +3065,33 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                                          paged_kv.stride_page, paged_kv.stride_h, paged_kv.stride_n,
                                          paged_kv.page_size, paged_kv.indices,
                                          (iter + 1) * CTA_TILE_KV, chunk_size, warp_idx, lane_idx);
+      page_produce_kv_sf_pth<false, KTraits>(
+          &smem_storage, paged_kv.k_data, paged_kv, kv_head_idx, packed_page_iter_base,
+          chunk_start + (iter + 1) * CTA_TILE_KV, kv_len, warp_idx, lane_idx);
       cp_async::commit_group();
       cp_async::wait_group<1>();
       block.sync();
 
       // compute sfm*v
       if constexpr (KTraits::USE_KV_REPACK) {
-        // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
-        repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
-            smem_storage.v_smem, smem_storage.kv_smem_repack, warp_idx * WARP_SIZE + lane_idx);
+        // Dequantize FP8 V -> BF16/FP16 staging smem (shuffle-free), then read native 16-bit.
+        repack_fp8_tile<KTraits, KTraits::HEAD_DIM_VO>(
+            smem_storage.v_smem, smem_storage.kv_smem_repack_ptr(), warp_idx * WARP_SIZE + lane_idx,
+            smem_storage.v_sf_pth_ptr());
         block.sync();
         compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
             &v_smem_bf16, &v_smem_offset_r_bf16,
-            smem_storage.v_sf_smem +
+            smem_storage.v_sf_ptr() +
                 get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_VO,
+            smem_storage.v_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
             lane_idx, s_frag, o_frag, d);
       } else {
-        compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r,
-                               smem_storage.v_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                            KTraits::NUM_MMA_KV * 16 *
-                                                            KTraits::NUM_MMA_D_VO,
-                               lane_idx, s_frag, o_frag, d);
+        compute_sfm_v<KTraits>(
+            &v_smem, &v_smem_offset_r,
+            smem_storage.v_sf_ptr() +
+                get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_VO,
+            smem_storage.v_sf_pth_ptr(), get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16,
+            lane_idx, s_frag, o_frag, d);
       }
 
       block.sync();
@@ -2870,6 +3103,9 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                                         paged_kv.stride_page, paged_kv.stride_h, paged_kv.stride_n,
                                         paged_kv.page_size, paged_kv.indices,
                                         (iter + 1) * CTA_TILE_KV, chunk_size, warp_idx, lane_idx);
+      page_produce_kv_sf_pth<true, KTraits>(
+          &smem_storage, paged_kv.v_data, paged_kv, kv_head_idx, packed_page_iter_base,
+          chunk_start + (iter + 1) * CTA_TILE_KV, kv_len, warp_idx, lane_idx);
       cp_async::commit_group();
     }
     cp_async::wait_group<0>();
@@ -2941,7 +3177,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithPagedKVC
 
 template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
           PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename AttentionVariant, typename Params>
+          bool FORCE_DISABLE_KV_REPACK, typename AttentionVariant, typename Params>
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
                                                     float* tmp_s, bool enable_pdl,
                                                     cudaStream_t stream) {
@@ -2979,8 +3215,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
   // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack path
   // is active, so NUM_MMA_KV is chosen to keep base+staging within the occupancy
   // budget (otherwise the staging silently drops blocks/SM at large head dims).
-  constexpr bool kUseRepack =
-      (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO != 64);
+  constexpr bool kUseRepack = kUseKvRepack<FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, DTypeKV>;
   constexpr uint32_t kKVSmemPerMmaKV =
       (HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV) +
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
@@ -3004,14 +3239,17 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
        !USE_FP16_QK_REDUCTION)
           ? 2
           : (8 / NUM_MMA_Q);
+  constexpr uint32_t scale_smem_per_mma =
+      kUsePerTokenHead<DTypeKV, AttentionVariant> ? 2 * 16 * NUM_WARPS_KV * sizeof(float) : 0;
   const uint32_t max_num_mma_kv_smem =
-      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) / kKVSmemPerMmaKV;
+      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) /
+      (kKVSmemPerMmaKV + scale_smem_per_mma);
 
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
     using KTraits =
         KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
-                     NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                     DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+                     NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, FORCE_DISABLE_KV_REPACK, DTypeQ,
+                     DTypeKV, DTypeO, DTypeQKAccum, typename Params::IdType, AttentionVariant>;
     if constexpr (KTraits::IsInvalid()) {
       // Invalid configuration, skip
       std::ostringstream err_msg;
@@ -3082,7 +3320,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
 
 template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
           PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename AttentionVariant, typename Params>
+          bool FORCE_DISABLE_KV_REPACK, typename AttentionVariant, typename Params>
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
                                                    float* tmp_s, bool enable_pdl,
                                                    cudaStream_t stream) {
@@ -3121,8 +3359,7 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
   // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack path
   // is active, so NUM_MMA_KV is chosen to keep base+staging within the occupancy
   // budget (otherwise the staging silently drops blocks/SM at large head dims).
-  constexpr bool kUseRepack =
-      (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO != 64);
+  constexpr bool kUseRepack = kUseKvRepack<FORCE_DISABLE_KV_REPACK, HEAD_DIM_VO, DTypeKV>;
   constexpr uint32_t kKVSmemPerMmaKV =
       (HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV) +
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
@@ -3146,14 +3383,17 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
        !USE_FP16_QK_REDUCTION)
           ? 2
           : (8 / NUM_MMA_Q);
+  constexpr uint32_t scale_smem_per_mma =
+      kUsePerTokenHead<DTypeKV, AttentionVariant> ? 2 * 16 * NUM_WARPS_KV * sizeof(float) : 0;
   const uint32_t max_num_mma_kv_smem =
-      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) / kKVSmemPerMmaKV;
+      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) /
+      (kKVSmemPerMmaKV + scale_smem_per_mma);
 
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
     using KTraits =
         KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
-                     NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                     DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+                     NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, FORCE_DISABLE_KV_REPACK, DTypeQ,
+                     DTypeKV, DTypeO, DTypeQKAccum, typename Params::IdType, AttentionVariant>;
     if constexpr (KTraits::IsInvalid()) {
       // Invalid configuration, skip
       std::ostringstream err_msg;

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -76,7 +76,7 @@ inline auto PartitionPagedKVCacheBinarySearchMinNumPagePerBatch(
     const uint32_t min_num_pages_per_batch = 1) {
   uint32_t low = min_num_pages_per_batch, high = 0;
   for (const IdType& elem : num_pages) {
-    high = max(high, elem);
+    high = max(high, static_cast<uint32_t>(elem));
   }
   uint32_t new_batch_size;
   while (low < high) {
@@ -93,7 +93,7 @@ inline auto PartitionPagedKVCacheBinarySearchMinNumPagePerBatch(
   }
   new_batch_size = 0;
   for (const IdType& elem : num_pages) {
-    new_batch_size += ceil_div(std::max(elem, 1), low);
+    new_batch_size += ceil_div(std::max(static_cast<uint32_t>(elem), 1u), low);
   }
   return std::make_tuple(low, new_batch_size);
 }
@@ -165,9 +165,17 @@ inline cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatched(
     constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (sizeof(DTypeKV) == 1 ? 2U : 4U) : 1U;
     const uint32_t num_kv_heads = num_qo_heads / GROUP_SIZE;
     gdy = num_kv_heads;
-    const uint32_t smem_size =
-        2 * NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz * HEAD_DIM * sizeof(DTypeKV) +
-        std::max(tile_size_per_bdx * num_threads * sizeof(DTypeKV*), 2 * bdy * bdz * sizeof(float));
+    constexpr uint32_t kv_size =
+        NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz * HEAD_DIM * sizeof(DTypeKV);
+    constexpr uint32_t kv_sf_pth_size =
+        AttentionVariant::use_per_token_head
+            ? (NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz * sizeof(float))
+            : 0;
+    constexpr uint32_t sync_state_size = bdy * bdz * HEAD_DIM * sizeof(float);
+    constexpr uint32_t kv_offset_size = tile_size_per_bdx * num_threads * sizeof(size_t);
+    constexpr uint32_t smem_md_size = 2 * bdy * bdz * sizeof(float);
+    const uint32_t smem_size = std::max(2 * kv_size + 2 * kv_sf_pth_size, sync_state_size) +
+                               std::max(kv_offset_size, smem_md_size);
 
     auto kernel =
         BatchDecodeWithPagedKVCacheKernel<POS_ENCODING_MODE, NUM_STAGES_SMEM, tile_size_per_bdx,
@@ -1099,32 +1107,32 @@ struct HolisticPlanInfo {
   }
 };
 
-template <typename IdType>
-inline cudaError_t TwoStageHolisticPlan(void* float_buffer, size_t float_workspace_size_in_bytes,
-                                        void* int_buffer, void* page_locked_int_buffer,
-                                        size_t int_workspace_size_in_bytes,
-                                        HolisticPlanInfo<2>& plan_info, IdType* qo_indptr_h,
-                                        IdType* kv_indptr_h, IdType* kv_len_arr_h,
-                                        uint32_t batch_size, uint32_t num_qo_heads,
-                                        uint32_t num_kv_heads, uint32_t head_dim, bool causal,
-                                        cudaStream_t stream) {
+template <typename IdType, typename Kernel>
+inline cudaError_t TwoStageHolisticPlan(
+    void* float_buffer, size_t float_workspace_size_in_bytes, void* int_buffer,
+    void* page_locked_int_buffer, size_t int_workspace_size_in_bytes,
+    HolisticPlanInfo<2>& plan_info, IdType* qo_indptr_h, IdType* kv_indptr_h, IdType* kv_len_arr_h,
+    uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t head_dim,
+    bool causal, Kernel kernel, size_t smem_size, int num_threads, cudaStream_t stream) {
   constexpr uint32_t NUM_TASKS = 2;
   const uint32_t CTA_TILE_Q_SIZES[NUM_TASKS] = {128, 16};
   int num_sm = 0;
+  int max_blocks_per_sm = 0;
   int dev_id = 0;
 
   uint32_t gqa_group_size = num_qo_heads / num_kv_heads;
   FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
   FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
-
-  if (head_dim >= 256) {
-    // NOTE (Yilong): optimize this code path
-    // constraint gridDim due to cooperative group
-    num_sm *= 1;
-  } else {
-    // NOTE(Zihao): two cta per sm
-    num_sm *= 2;
+  FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                            static_cast<int>(smem_size)));
+  FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_blocks_per_sm, kernel, num_threads, static_cast<int>(smem_size)));
+  if (max_blocks_per_sm < 1) {
+    FLASHINFER_ERROR(
+        "The kernel requires too much shared memory or registers. "
+        "Consider using FP8 KV cache or a different backend.");
   }
+  num_sm *= std::min(max_blocks_per_sm, 2);
 
   // step 0. determine the number of blocks in x and y dimensions
   std::vector<std::tuple<int, int, int>> idx_qo_kv_len_vec[NUM_TASKS];

--- a/include/flashinfer/attention/variant_helper.cuh
+++ b/include/flashinfer/attention/variant_helper.cuh
@@ -74,6 +74,7 @@ DEFINE_HAS_MEMBER(v_scale)
 
 struct AttentionVariantBase {
   constexpr static bool use_softmax = true;
+  constexpr static bool use_per_token_head = false;
   REGISTER_LOGITS_TRANSFORM(params, logits, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx,
                             { return logits; })
 

--- a/include/flashinfer/attention/variants.cuh
+++ b/include/flashinfer/attention/variants.cuh
@@ -28,9 +28,11 @@ namespace flashinfer {
 
 DEFINE_HAS_MEMBER(maybe_mask_indptr)
 
-template <bool use_custom_mask, bool use_sliding_window, bool use_logits_soft_cap, bool use_alibi>
+template <bool use_custom_mask, bool use_sliding_window, bool use_logits_soft_cap, bool use_alibi,
+          bool UsePerTokenHead = false>
 struct DefaultAttention : AttentionVariantBase {
   static constexpr bool use_softmax = true;
+  static constexpr bool use_per_token_head = UsePerTokenHead;
 
   uint8_t* custom_mask_ptr;
   uint32_t qo_len, kv_len;

--- a/include/flashinfer/utils.cuh
+++ b/include/flashinfer/utils.cuh
@@ -328,7 +328,31 @@
     __VA_ARGS__                                                                             \
   }
 
+#define DISPATCH_USE_PER_TOKEN_HEAD(use_per_token_head, USE_PER_TOKEN_HEAD, ...) \
+  if constexpr (is_fp8_type_v<DTypeKV>) {                                        \
+    if (use_per_token_head) {                                                    \
+      constexpr bool USE_PER_TOKEN_HEAD = true;                                  \
+      __VA_ARGS__                                                                \
+    } else {                                                                     \
+      constexpr bool USE_PER_TOKEN_HEAD = false;                                 \
+      __VA_ARGS__                                                                \
+    }                                                                            \
+  } else {                                                                       \
+    constexpr bool USE_PER_TOKEN_HEAD = false;                                   \
+    __VA_ARGS__                                                                  \
+  }
+
 namespace flashinfer {
+
+// Type trait to detect FP8 KV cache types.
+template <typename T>
+struct is_fp8_type : std::false_type {};
+template <>
+struct is_fp8_type<__nv_fp8_e4m3> : std::true_type {};
+template <>
+struct is_fp8_type<__nv_fp8_e5m2> : std::true_type {};
+template <typename T>
+inline constexpr bool is_fp8_type_v = is_fp8_type<T>::value;
 
 template <typename T1, typename T2>
 __forceinline__ __device__ __host__ constexpr T1 ceil_div(const T1 x, const T2 y) noexcept {

--- a/tests/attention/test_batch_attention.py
+++ b/tests/attention/test_batch_attention.py
@@ -270,6 +270,12 @@ def test_batch_attention_correctness(
     test_dtype,
     logits_soft_cap,
 ):
+    cc = get_compute_capability(torch.device(device="cuda"))
+    if cc[0] < 8 and head_dim >= 256:
+        pytest.skip(
+            "BatchAttention CTA128 exceeds SM75 64KiB shared memory limit for hd>=256"
+        )
+
     num_qo_heads = num_kv_heads * gqa_group_size
     kv_lens = [p[0] for p in seq_len_pairs]
     qo_lens = [p[1] for p in seq_len_pairs]

--- a/tests/attention/test_batch_attention_per_tensor.py
+++ b/tests/attention/test_batch_attention_per_tensor.py
@@ -1,0 +1,226 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+BatchAttention (persistent holistic attention) with FP8 per-tensor KV cache tests.
+"""
+
+import pytest
+import torch
+import flashinfer
+from tests.test_helpers.rope_reference import (
+    apply_rotary_pos_emb,
+    generate_cos_sin_f32_cache,
+)
+from tests.utils_fp8 import to_float8
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _cc():
+    return torch.cuda.get_device_capability(0)
+
+
+def _skip_if_sm75_limits(head_dim, dtype: torch.dtype, kv_dtype: torch.dtype):
+    if _cc()[0] > 7:
+        return
+    if dtype != torch.float16:
+        pytest.skip(f"{dtype} skipped on SM75")
+    if head_dim >= 256:
+        pytest.skip(
+            f"BatchAttention CTA128 exceeds SM75 64KiB shared memory limit for hd={head_dim}"
+        )
+
+
+def check_accuracy(
+    o_ref: torch.Tensor,
+    o: torch.Tensor,
+    kv_dtype: torch.dtype,
+    mode,
+    label="",
+):
+    cos_sim = torch.nn.functional.cosine_similarity(
+        o_ref.reshape(-1).float(), o.reshape(-1).float(), dim=0
+    ).item()
+    max_diff = (o_ref - o).abs().max().item()
+    prefix = f"[{label}] " if label else ""
+    threshold = 0.999
+    print(f"{prefix}{kv_dtype} cos_sim={cos_sim:.8f} max_diff={max_diff:.8f}")
+    assert cos_sim >= threshold, (
+        f"{prefix}cos_sim={cos_sim:.8f} < {threshold} ({kv_dtype})"
+    )
+    return cos_sim, max_diff
+
+
+# ============================================================
+# Test
+# ============================================================
+
+
+@pytest.mark.parametrize("batch_size", [3, 4, 5])
+@pytest.mark.parametrize(
+    "qo_len,kv_len", [(8, 32), (128, 2048)], ids=["small", "large"]
+)
+@pytest.mark.parametrize(
+    "num_kv_heads,num_qo_heads",
+    [(1, 1), (2, 4), (1, 16), (4, 4), (4, 32)],
+    ids=["1x1", "gqa4x2", "16x1", "mha4", "gqa32x4"],
+)
+@pytest.mark.parametrize("head_dim", [64, 128, 256], ids=["hd64", "hd128", "hd256"])
+@pytest.mark.parametrize("page_size", [16, 32], ids=["ps16", "ps32"])
+@pytest.mark.parametrize("causal", [False, True], ids=["no-causal", "causal"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+def test_batch_attention_per_tensor(
+    batch_size,
+    qo_len,
+    kv_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    page_size,
+    causal,
+    dtype,
+    kv_dtype,
+):
+    _skip_if_sm75_limits(head_dim, dtype, kv_dtype)
+    device = "cuda:0"
+    kv_layout = "NHD"
+
+    total_qo = batch_size * qo_len
+    q = torch.randn(total_qo, num_qo_heads, head_dim, dtype=dtype, device=device)
+    k_ref = 0.1 * torch.randn(
+        batch_size, kv_len, num_kv_heads, head_dim, dtype=dtype, device=device
+    )
+    v_ref = 0.1 * torch.randn(
+        batch_size, kv_len, num_kv_heads, head_dim, dtype=dtype, device=device
+    )
+    cos, sin = generate_cos_sin_f32_cache(max(qo_len, kv_len), head_dim, device=device)
+    q_reshaped = q.view(batch_size, qo_len, num_qo_heads, head_dim)
+    q_reshaped, _ = apply_rotary_pos_emb(
+        q_reshaped, q_reshaped, cos[:qo_len], sin[:qo_len]
+    )
+    _, k_ref = apply_rotary_pos_emb(k_ref, k_ref, cos[:kv_len], sin[:kv_len])
+    q = q_reshaped.view(total_qo, num_qo_heads, head_dim)
+
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+    kv_len_arr = torch.full((batch_size,), kv_len, dtype=torch.int32, device=device)
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * qo_len
+    )
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    # Baseline via BatchPrefill
+    k_paged = k_ref.reshape(total_num_pages, page_size, num_kv_heads, head_dim)
+    v_paged = v_ref.reshape(total_num_pages, page_size, num_kv_heads, head_dim)
+    bp_base = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, kv_layout, backend="fa2"
+    )
+    bp_base.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o_baseline = bp_base.run(q, (k_paged, v_paged))
+
+    # FP8 per-tensor via BatchAttention
+    k_cache, k_scale = to_float8(k_ref, kv_dtype)
+    v_cache, v_scale = to_float8(v_ref, kv_dtype)
+    k_cache = k_cache.reshape(total_num_pages, page_size, num_kv_heads, head_dim)
+    v_cache = v_cache.reshape(total_num_pages, page_size, num_kv_heads, head_dim)
+
+    ba_pt = flashinfer.BatchAttention(kv_layout=kv_layout)
+    ba_pt.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_len_arr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=kv_dtype,
+    )
+    o_ba_pt, _ = ba_pt.run(
+        q, (k_cache, v_cache), k_scale=k_scale.item(), v_scale=v_scale.item()
+    )
+    assert not torch.isnan(o_ba_pt).any(), (
+        "BatchAttention FP8 per-tensor output contains NaN"
+    )
+    check_accuracy(o_baseline, o_ba_pt, kv_dtype, "prefill", label="batch attention")
+
+
+# ============================================================
+# Smoke tests
+# ============================================================
+
+if __name__ == "__main__":
+    dtypes = [torch.float16]
+    if _cc()[0] > 7:
+        dtypes.append(torch.bfloat16)
+    for dtype in dtypes:
+        kv_dtype = torch.float8_e4m3fn
+
+        test_batch_attention_per_tensor(
+            batch_size=4,
+            qo_len=8,
+            kv_len=32,
+            num_kv_heads=4,
+            num_qo_heads=4,
+            head_dim=128,
+            page_size=16,
+            causal=True,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+        )
+        print(f"MHA {dtype}/{kv_dtype} causal smoke passed")
+
+        test_batch_attention_per_tensor(
+            batch_size=3,
+            qo_len=128,
+            kv_len=2048,
+            num_kv_heads=2,
+            num_qo_heads=32,
+            head_dim=64,
+            page_size=32,
+            causal=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+        )
+        print(f"GQA {dtype}/{kv_dtype} no-causal smoke passed")
+
+    print("\nAll batch attention per-tensor smoke tests passed")

--- a/tests/attention/test_batch_attention_per_token_head.py
+++ b/tests/attention/test_batch_attention_per_token_head.py
@@ -1,0 +1,303 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+BatchAttention (persistent holistic attention) with FP8 per-token-head KV cache tests.
+"""
+
+import pytest
+import torch
+import flashinfer
+from tests.test_helpers.rope_reference import (
+    apply_rotary_pos_emb,
+    generate_cos_sin_f32_cache,
+)
+from tests.utils_fp8 import get_cos_sim_threshold, to_float8_per_token_head
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _cc():
+    return torch.cuda.get_device_capability(0)
+
+
+def _skip_if_sm_below_75():
+    if _cc()[0] < 7 or (_cc()[0] == 7 and _cc()[1] < 5):
+        pytest.skip("Persistent batch attention requires SM75+")
+
+
+def _skip_if_sm75_limits(head_dim, dtype: torch.dtype, kv_dtype: torch.dtype):
+    if _cc()[0] > 7:
+        return
+    if dtype != torch.float16:
+        pytest.skip(f"{dtype} skipped on SM75")
+    if head_dim >= 256:
+        pytest.skip(
+            f"BatchAttention CTA128 exceeds SM75 64KiB shared memory limit for hd={head_dim}"
+        )
+
+
+def check_accuracy(
+    o_ref: torch.Tensor,
+    o: torch.Tensor,
+    kv_dtype: torch.dtype,
+    mode,
+    label="",
+):
+    cos_sim = torch.nn.functional.cosine_similarity(
+        o_ref.reshape(-1).float(), o.reshape(-1).float(), dim=0
+    ).item()
+    max_diff = (o_ref - o).abs().max().item()
+    prefix = f"[{label}] " if label else ""
+    threshold = get_cos_sim_threshold(kv_dtype, mode)
+    print(f"{prefix}{kv_dtype} cos_sim={cos_sim:.8f} max_diff={max_diff:.8f}")
+    assert cos_sim >= threshold, (
+        f"{prefix}cos_sim={cos_sim:.8f} < {threshold} ({kv_dtype})"
+    )
+    return cos_sim, max_diff
+
+
+def _alloc_paged_cache(shape, head_dim, dtype, device):
+    max_pages, page_size, num_kv_heads = shape[0], shape[1], shape[2]
+    total_tokens = max_pages * page_size * num_kv_heads
+    stride = head_dim + 16
+    buf_size = total_tokens * stride
+    k_buf = torch.empty(buf_size, dtype=torch.uint8, device=device)
+    v_buf = torch.empty(buf_size, dtype=torch.uint8, device=device)
+    s = (page_size * num_kv_heads * stride, num_kv_heads * stride, stride, 1)
+    k_cache = torch.as_strided(k_buf, shape, s).view(dtype)
+    v_cache = torch.as_strided(v_buf, shape, s).view(dtype)
+    return k_cache, v_cache, k_buf, v_buf
+
+
+def _write_scales(cache_tensor, buf, scales, head_dim):
+    assert head_dim % 4 == 0, (
+        f"head_dim={head_dim} must be divisible by 4 for float32 offset"
+    )
+    stride = head_dim + 16
+    assert stride % 4 == 0, f"stride={stride} must be divisible by 4 for float32 stride"
+    scale_stride_f32 = stride // 4
+    scale_offset_f32 = head_dim // 4
+    max_pages, page_size, num_kv_heads = (
+        cache_tensor.shape[0],
+        cache_tensor.shape[1],
+        cache_tensor.shape[2],
+    )
+    s = (
+        page_size * num_kv_heads * scale_stride_f32,
+        num_kv_heads * scale_stride_f32,
+        scale_stride_f32,
+    )
+    scale_view = torch.as_strided(
+        buf.view(torch.float32),
+        (max_pages, page_size, num_kv_heads),
+        s,
+        storage_offset=scale_offset_f32,
+    )
+    scale_view.copy_(scales.to(torch.float32).reshape(scale_view.shape))
+
+
+def _build_pth_data(
+    k_ref, v_ref, total_num_pages, page_size, num_kv_heads, head_dim, kv_dtype, device
+):
+    k_flat = k_ref.reshape(-1, num_kv_heads, head_dim)
+    v_flat = v_ref.reshape(-1, num_kv_heads, head_dim)
+    k_fp8, k_scales = to_float8_per_token_head(k_flat, kv_dtype)
+    v_fp8, v_scales = to_float8_per_token_head(v_flat, kv_dtype)
+
+    cache_shape = (total_num_pages, page_size, num_kv_heads, head_dim)
+    k_cache, v_cache, k_buf, v_buf = _alloc_paged_cache(
+        cache_shape, head_dim, kv_dtype, device
+    )
+
+    k_paged_fp8 = k_fp8.reshape(total_num_pages, page_size, num_kv_heads, head_dim)
+    v_paged_fp8 = v_fp8.reshape(total_num_pages, page_size, num_kv_heads, head_dim)
+    k_scales_paged = k_scales.reshape(total_num_pages, page_size, num_kv_heads)
+    v_scales_paged = v_scales.reshape(total_num_pages, page_size, num_kv_heads)
+
+    k_cache.copy_(k_paged_fp8)
+    v_cache.copy_(v_paged_fp8)
+    _write_scales(k_cache, k_buf, k_scales_paged, head_dim)
+    _write_scales(v_cache, v_buf, v_scales_paged, head_dim)
+    return k_cache, v_cache
+
+
+# ============================================================
+# Test
+# ============================================================
+
+
+@pytest.mark.parametrize("batch_size", [3, 4, 5])
+@pytest.mark.parametrize(
+    "qo_len,kv_len", [(8, 32), (128, 2048)], ids=["small", "large"]
+)
+@pytest.mark.parametrize(
+    "num_kv_heads,num_qo_heads",
+    [(1, 1), (2, 4), (1, 16), (4, 4), (4, 32)],
+    ids=["1x1", "gqa4x2", "16x1", "mha4", "gqa32x4"],
+)
+@pytest.mark.parametrize("head_dim", [64, 128, 256], ids=["hd64", "hd128", "hd256"])
+@pytest.mark.parametrize("page_size", [16, 32], ids=["ps16", "ps32"])
+@pytest.mark.parametrize("causal", [False, True], ids=["no-causal", "causal"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+def test_batch_attention_per_token_head(
+    batch_size,
+    qo_len,
+    kv_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    page_size,
+    causal,
+    dtype,
+    kv_dtype,
+):
+    _skip_if_sm_below_75()
+    _skip_if_sm75_limits(head_dim, dtype, kv_dtype)
+    device = "cuda:0"
+    kv_layout = "NHD"
+
+    total_qo = batch_size * qo_len
+    q = torch.randn(total_qo, num_qo_heads, head_dim, dtype=dtype, device=device)
+    k_ref = 0.1 * torch.randn(
+        batch_size, kv_len, num_kv_heads, head_dim, dtype=dtype, device=device
+    )
+    v_ref = 0.1 * torch.randn(
+        batch_size, kv_len, num_kv_heads, head_dim, dtype=dtype, device=device
+    )
+    cos, sin = generate_cos_sin_f32_cache(max(qo_len, kv_len), head_dim, device=device)
+    q_reshaped = q.view(batch_size, qo_len, num_qo_heads, head_dim)
+    q_reshaped, _ = apply_rotary_pos_emb(
+        q_reshaped, q_reshaped, cos[:qo_len], sin[:qo_len]
+    )
+    _, k_ref = apply_rotary_pos_emb(k_ref, k_ref, cos[:kv_len], sin[:kv_len])
+    q = q_reshaped.view(total_qo, num_qo_heads, head_dim)
+
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+    kv_len_arr = torch.full((batch_size,), kv_len, dtype=torch.int32, device=device)
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * qo_len
+    )
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    # Baseline via BatchPrefill
+    k_paged = k_ref.reshape(total_num_pages, page_size, num_kv_heads, head_dim)
+    v_paged = v_ref.reshape(total_num_pages, page_size, num_kv_heads, head_dim)
+    bp_base = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, kv_layout, backend="fa2"
+    )
+    bp_base.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o_baseline = bp_base.run(q, (k_paged, v_paged))
+
+    # FP8 per-token-head via BatchAttention
+    k_cache, v_cache = _build_pth_data(
+        k_ref,
+        v_ref,
+        total_num_pages,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        kv_dtype,
+        device,
+    )
+    ba_pth = flashinfer.BatchAttention(
+        kv_layout=kv_layout,
+        use_per_token_head=True,
+    )
+    ba_pth.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_len_arr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=kv_dtype,
+    )
+    o_ba_pth, _ = ba_pth.run(q, (k_cache, v_cache))
+    assert not torch.isnan(o_ba_pth).any(), (
+        "BatchAttention FP8 per-token-head output contains NaN"
+    )
+    check_accuracy(o_baseline, o_ba_pth, kv_dtype, "prefill", label="batch attention")
+
+
+# ============================================================
+# Smoke tests
+# ============================================================
+
+if __name__ == "__main__":
+    dtypes = [torch.float16]
+    if _cc()[0] > 7:
+        dtypes.append(torch.bfloat16)
+    for dtype in dtypes:
+        kv_dtype = torch.float8_e4m3fn
+
+        test_batch_attention_per_token_head(
+            batch_size=4,
+            qo_len=8,
+            kv_len=32,
+            num_kv_heads=4,
+            num_qo_heads=4,
+            head_dim=128,
+            page_size=16,
+            causal=True,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+        )
+        print(f"MHA {dtype}/{kv_dtype} causal smoke passed")
+
+        test_batch_attention_per_token_head(
+            batch_size=3,
+            qo_len=128,
+            kv_len=2048,
+            num_kv_heads=2,
+            num_qo_heads=32,
+            head_dim=64,
+            page_size=32,
+            causal=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+        )
+        print(f"GQA {dtype}/{kv_dtype} no-causal smoke passed")
+
+    print("\nAll batch attention per-token-head smoke tests passed")

--- a/tests/attention/test_batch_per_token_head.py
+++ b/tests/attention/test_batch_per_token_head.py
@@ -1,0 +1,1234 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Batch prefill/decode FP8 per-token-head KV cache tests.
+"""
+
+import pytest
+import torch
+import flashinfer
+from tests.test_helpers.rope_reference import (
+    apply_rotary_pos_emb,
+    generate_cos_sin_f32_cache,
+)
+from tests.utils_fp8 import get_cos_sim_threshold, to_float8_per_token_head
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _cc():
+    return torch.cuda.get_device_capability(0)
+
+
+def _skip_if_sm_below_75():
+    if _cc()[0] < 7 or (_cc()[0] == 7 and _cc()[1] < 5):
+        pytest.skip("Requires SM75+")
+
+
+def _skip_if_not_fp16_sm75(dtype: torch.dtype):
+    if dtype != torch.float16 and _cc()[0] <= 7:
+        pytest.skip(f"{dtype} skipped on SM75")
+
+
+def check_accuracy(
+    o_ref: torch.Tensor,
+    o: torch.Tensor,
+    kv_dtype: torch.dtype,
+    mode,
+    label="",
+):
+    cos_sim = torch.nn.functional.cosine_similarity(
+        o_ref.reshape(-1).float(), o.reshape(-1).float(), dim=0
+    ).item()
+    max_diff = (o_ref - o).abs().max().item()
+    prefix = f"[{label}] " if label else ""
+    threshold = get_cos_sim_threshold(kv_dtype, mode)
+    print(f"{prefix}{kv_dtype} cos_sim={cos_sim:.8f} max_diff={max_diff:.8f}")
+    assert cos_sim >= threshold, (
+        f"{prefix}cos_sim={cos_sim:.8f} < {threshold} ({kv_dtype})"
+    )
+    return cos_sim, max_diff
+
+
+def _alloc_paged_cache(shape, head_dim, dtype, device, layout):
+    if layout == "NHD":
+        max_pages, page_size, num_kv_heads = shape
+        full_shape = (max_pages, page_size, num_kv_heads, head_dim)
+        s = (
+            page_size * num_kv_heads * (head_dim + 16),
+            num_kv_heads * (head_dim + 16),
+            head_dim + 16,
+            1,
+        )
+    else:
+        max_pages, num_kv_heads, page_size = shape
+        full_shape = (max_pages, num_kv_heads, page_size, head_dim)
+        s = (
+            num_kv_heads * page_size * (head_dim + 16),
+            page_size * (head_dim + 16),
+            head_dim + 16,
+            1,
+        )
+    total_tokens = max_pages * page_size * num_kv_heads
+    buf_size = total_tokens * (head_dim + 16)
+    k_buf = torch.empty(buf_size, dtype=torch.uint8, device=device)
+    v_buf = torch.empty(buf_size, dtype=torch.uint8, device=device)
+    k_cache = torch.as_strided(k_buf, full_shape, s).view(dtype)
+    v_cache = torch.as_strided(v_buf, full_shape, s).view(dtype)
+    return k_cache, v_cache, k_buf, v_buf
+
+
+def _write_scales_paged(cache_tensor, buf, scales, head_dim, layout):
+    stride = head_dim + 16
+    scale_stride_f32 = stride // 4
+    scale_offset_f32 = head_dim // 4
+    cache_shape = cache_tensor.shape
+    if layout == "NHD":
+        max_pages, page_size, num_kv_heads, _ = cache_shape
+        s = (
+            page_size * num_kv_heads * scale_stride_f32,
+            num_kv_heads * scale_stride_f32,
+            scale_stride_f32,
+        )
+        scale_view = torch.as_strided(
+            buf.view(torch.float32),
+            (max_pages, page_size, num_kv_heads),
+            s,
+            storage_offset=scale_offset_f32,
+        )
+    else:
+        max_pages, num_kv_heads, page_size, _ = cache_shape
+        s = (
+            num_kv_heads * page_size * scale_stride_f32,
+            page_size * scale_stride_f32,
+            scale_stride_f32,
+        )
+        scale_view = torch.as_strided(
+            buf.view(torch.float32),
+            (max_pages, num_kv_heads, page_size),
+            s,
+            storage_offset=scale_offset_f32,
+        )
+    scale_view.copy_(scales.to(torch.float32).reshape(scale_view.shape))
+
+
+def _build_paged_indices(kv_lens, page_size, device):
+    num_pages_per_seq = [(kv + page_size - 1) // page_size for kv in kv_lens]
+    total_num_pages = sum(num_pages_per_seq)
+    kv_indptr = torch.cat(
+        [
+            torch.tensor([0], dtype=torch.int32, device=device),
+            torch.tensor(num_pages_per_seq, dtype=torch.int32, device=device)
+            .cumsum(0)
+            .to(torch.int32),
+        ]
+    )
+    kv_indices = torch.arange(0, total_num_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.tensor(
+        [(kv - 1) % page_size + 1 for kv in kv_lens],
+        dtype=torch.int32,
+        device=device,
+    )
+    return kv_indptr, kv_indices, kv_last_page_len, num_pages_per_seq, total_num_pages
+
+
+def _pad_to_pages(data_list, num_pages_per_seq, page_size):
+    padded = []
+    for data, n_pages in zip(data_list, num_pages_per_seq, strict=True):
+        pad_len = n_pages * page_size - len(data)
+        if pad_len > 0:
+            data = torch.nn.functional.pad(data, (0, 0, 0, 0, 0, pad_len))
+        padded.append(data)
+    return padded
+
+
+def _concat_to_pages(data_list, num_pages_per_seq, page_size, num_kv_heads):
+    pages = [
+        d.reshape(n, page_size, num_kv_heads, -1)
+        for d, n in zip(data_list, num_pages_per_seq, strict=True)
+    ]
+    return torch.cat(pages, dim=0)
+
+
+# ============================================================
+# Batch Prefill
+# ============================================================
+
+
+def run_batch_prefill_pth(
+    qo_lens,
+    kv_lens,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    page_size,
+    layout,
+    dtype,
+    kv_dtype,
+    backend,
+):
+    device = "cuda:0"
+    batch_size = len(kv_lens)
+    total_qo = sum(qo_lens)
+    q = torch.randn(total_qo, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    k_f16_list = [
+        0.1
+        * torch.randn(kv_lens[i], num_kv_heads, head_dim, dtype=dtype, device=device)
+        for i in range(batch_size)
+    ]
+    v_f16_list = [
+        0.1
+        * torch.randn(kv_lens[i], num_kv_heads, head_dim, dtype=dtype, device=device)
+        for i in range(batch_size)
+    ]
+
+    # Apply RoPE for realistic KV cache
+    for i in range(batch_size):
+        q_start = sum(qo_lens[:i])
+        q_slice = q[q_start : q_start + qo_lens[i]]
+        cos, sin = generate_cos_sin_f32_cache(
+            max(qo_lens[i], kv_lens[i]), head_dim, device=device
+        )
+        q[q_start : q_start + qo_lens[i]] = apply_rotary_pos_emb(
+            q_slice, q_slice, cos[: qo_lens[i]], sin[: qo_lens[i]]
+        )[0]
+        k_f16_list[i] = apply_rotary_pos_emb(
+            k_f16_list[i], k_f16_list[i], cos[: kv_lens[i]], sin[: kv_lens[i]]
+        )[1]
+
+    kv_indptr, kv_indices, kv_last_page_len, num_pages_per_seq, total_num_pages = (
+        _build_paged_indices(kv_lens, page_size, device)
+    )
+    qo_indptr = torch.cat(
+        [
+            torch.tensor([0], dtype=torch.int32, device=device),
+            torch.tensor(qo_lens, dtype=torch.int32, device=device)
+            .cumsum(0)
+            .to(torch.int32),
+        ]
+    )
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    # FP16 baseline
+    k_f16_paged = _pad_to_pages(k_f16_list, num_pages_per_seq, page_size)
+    v_f16_paged = _pad_to_pages(v_f16_list, num_pages_per_seq, page_size)
+    k_p_flat = _concat_to_pages(k_f16_paged, num_pages_per_seq, page_size, num_kv_heads)
+    v_p_flat = _concat_to_pages(v_f16_paged, num_pages_per_seq, page_size, num_kv_heads)
+    if layout == "NHD":
+        k_p, v_p = k_p_flat, v_p_flat
+    else:
+        k_p, v_p = k_p_flat.transpose(1, 2), v_p_flat.transpose(1, 2)
+    k_p = k_p.to(dtype)
+    v_p = v_p.to(dtype)
+
+    wrapper_f16 = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, layout, backend=backend
+    )
+    wrapper_f16.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o_fp16 = wrapper_f16.run(q, (k_p, v_p))
+
+    # FP8 per-token-head
+    k_fp8_paged = []
+    v_fp8_paged = []
+    k_scales_paged = []
+    v_scales_paged = []
+    for i in range(batch_size):
+        k_fp8, k_s = to_float8_per_token_head(k_f16_paged[i], kv_dtype)
+        v_fp8, v_s = to_float8_per_token_head(v_f16_paged[i], kv_dtype)
+        k_fp8_paged.append(k_fp8)
+        v_fp8_paged.append(v_fp8)
+        k_scales_paged.append(k_s)
+        v_scales_paged.append(v_s)
+
+    k_fp8_flat = _concat_to_pages(
+        k_fp8_paged, num_pages_per_seq, page_size, num_kv_heads
+    )
+    v_fp8_flat = _concat_to_pages(
+        v_fp8_paged, num_pages_per_seq, page_size, num_kv_heads
+    )
+    k_s_flat = torch.cat(
+        [
+            s.reshape(n, page_size, num_kv_heads)
+            for s, n in zip(k_scales_paged, num_pages_per_seq, strict=True)
+        ]
+    )
+    v_s_flat = torch.cat(
+        [
+            s.reshape(n, page_size, num_kv_heads)
+            for s, n in zip(v_scales_paged, num_pages_per_seq, strict=True)
+        ]
+    )
+
+    if layout == "NHD":
+        cache_shape = (total_num_pages, page_size, num_kv_heads)
+        k_fp8_p, v_fp8_p, k_s_p, v_s_p = k_fp8_flat, v_fp8_flat, k_s_flat, v_s_flat
+    else:
+        cache_shape = (total_num_pages, num_kv_heads, page_size)
+        k_fp8_p = k_fp8_flat.transpose(1, 2)
+        v_fp8_p = v_fp8_flat.transpose(1, 2)
+        k_s_p = k_s_flat.transpose(1, 2)
+        v_s_p = v_s_flat.transpose(1, 2)
+
+    k_cache, v_cache, k_buf, v_buf = _alloc_paged_cache(
+        cache_shape, head_dim, kv_dtype, device, layout
+    )
+    k_cache.copy_(k_fp8_p)
+    v_cache.copy_(v_fp8_p)
+    _write_scales_paged(k_cache, k_buf, k_s_p, head_dim, layout)
+    _write_scales_paged(v_cache, v_buf, v_s_p, head_dim, layout)
+
+    wrapper_fp8 = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace,
+        layout,
+        backend=backend,
+        use_per_token_head=True,
+    )
+    wrapper_fp8.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=kv_dtype,
+        o_data_type=dtype,
+    )
+    o_fp8 = wrapper_fp8.run(q, (k_cache, v_cache))
+
+    return check_accuracy(
+        o_fp16, o_fp8, kv_dtype, "prefill", label=f"batch prefill {backend}"
+    )
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("layout", ["NHD", "HND"], ids=["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256], ids=["hd64", "hd128", "hd256"])
+@pytest.mark.parametrize("backend", ["fa2"], ids=["fa2"])
+def test_batch_prefill_pth_paged(is_gqa, dtype, kv_dtype, layout, head_dim, backend):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    if _cc()[0] <= 7 and head_dim > 256:
+        pytest.skip("head_dim>256 exceeds SM75 smem limit")
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+    batch = 3
+    run_batch_prefill_pth(
+        [8] * batch,
+        [32] * batch,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        16,
+        layout,
+        dtype,
+        kv_dtype,
+        backend,
+    )
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("layout", ["NHD", "HND"], ids=["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256], ids=["hd64", "hd128", "hd256"])
+@pytest.mark.parametrize("backend", ["fa2"], ids=["fa2"])
+def test_batch_prefill_pth_ragged(is_gqa, dtype, kv_dtype, layout, head_dim, backend):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+    run_batch_prefill_pth(
+        [6, 10, 8],
+        [16, 48, 32],
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        16,
+        layout,
+        dtype,
+        kv_dtype,
+        backend,
+    )
+
+
+# ============================================================
+# Batch Decode
+# ============================================================
+
+
+def run_batch_decode_pth(
+    kv_lens,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    page_size,
+    layout,
+    dtype,
+    kv_dtype,
+    backend,
+    pos_encoding_mode="NONE",
+):
+    device = "cuda:0"
+    batch_size = len(kv_lens)
+    q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    k_f16_list = [
+        0.1
+        * torch.randn(kv_lens[i], num_kv_heads, head_dim, dtype=dtype, device=device)
+        for i in range(batch_size)
+    ]
+    v_f16_list = [
+        0.1
+        * torch.randn(kv_lens[i], num_kv_heads, head_dim, dtype=dtype, device=device)
+        for i in range(batch_size)
+    ]
+
+    # Apply RoPE for realistic KV cache
+    for i in range(batch_size):
+        cos, sin = generate_cos_sin_f32_cache(kv_lens[i], head_dim, device=device)
+        k_f16_list[i] = apply_rotary_pos_emb(k_f16_list[i], k_f16_list[i], cos, sin)[1]
+
+    kv_indptr, kv_indices, kv_last_page_len, num_pages_per_seq, total_num_pages = (
+        _build_paged_indices(kv_lens, page_size, device)
+    )
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    # FP16 baseline
+    k_f16_paged = _pad_to_pages(k_f16_list, num_pages_per_seq, page_size)
+    v_f16_paged = _pad_to_pages(v_f16_list, num_pages_per_seq, page_size)
+    k_p_flat = _concat_to_pages(k_f16_paged, num_pages_per_seq, page_size, num_kv_heads)
+    v_p_flat = _concat_to_pages(v_f16_paged, num_pages_per_seq, page_size, num_kv_heads)
+    if layout == "NHD":
+        k_p, v_p = k_p_flat, v_p_flat
+    else:
+        k_p, v_p = k_p_flat.transpose(1, 2), v_p_flat.transpose(1, 2)
+    k_p = k_p.to(dtype)
+    v_p = v_p.to(dtype)
+
+    wrapper_f16 = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, layout, backend=backend
+    )
+    wrapper_f16.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        pos_encoding_mode=pos_encoding_mode,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o_fp16 = wrapper_f16.run(q, (k_p, v_p))
+
+    # FP8 per-token-head
+    k_fp8_paged = []
+    k_scales_paged = []
+    v_fp8_paged = []
+    v_scales_paged = []
+    for i in range(batch_size):
+        k_fp8_i, k_s_i = to_float8_per_token_head(k_f16_list[i], kv_dtype)
+        v_fp8_i, v_s_i = to_float8_per_token_head(v_f16_list[i], kv_dtype)
+        n_pages = num_pages_per_seq[i]
+        pad_len = n_pages * page_size - kv_lens[i]
+        if pad_len > 0:
+            k_fp8_i = torch.nn.functional.pad(k_fp8_i, (0, 0, 0, 0, 0, pad_len))
+            k_s_i = torch.nn.functional.pad(k_s_i, (0, 0, 0, pad_len))
+            v_fp8_i = torch.nn.functional.pad(v_fp8_i, (0, 0, 0, 0, 0, pad_len))
+            v_s_i = torch.nn.functional.pad(v_s_i, (0, 0, 0, pad_len))
+        k_fp8_paged.append(k_fp8_i)
+        k_scales_paged.append(k_s_i)
+        v_fp8_paged.append(v_fp8_i)
+        v_scales_paged.append(v_s_i)
+
+    k_fp8_flat = _concat_to_pages(
+        k_fp8_paged, num_pages_per_seq, page_size, num_kv_heads
+    )
+    v_fp8_flat = _concat_to_pages(
+        v_fp8_paged, num_pages_per_seq, page_size, num_kv_heads
+    )
+    k_s_flat = torch.cat(
+        [
+            s.reshape(n, page_size, num_kv_heads)
+            for s, n in zip(k_scales_paged, num_pages_per_seq, strict=True)
+        ]
+    )
+    v_s_flat = torch.cat(
+        [
+            s.reshape(n, page_size, num_kv_heads)
+            for s, n in zip(v_scales_paged, num_pages_per_seq, strict=True)
+        ]
+    )
+
+    if layout == "NHD":
+        cache_shape = (total_num_pages, page_size, num_kv_heads)
+        k_fp8_p, v_fp8_p, k_s_p, v_s_p = k_fp8_flat, v_fp8_flat, k_s_flat, v_s_flat
+    else:
+        cache_shape = (total_num_pages, num_kv_heads, page_size)
+        k_fp8_p = k_fp8_flat.transpose(1, 2)
+        v_fp8_p = v_fp8_flat.transpose(1, 2)
+        k_s_p = k_s_flat.transpose(1, 2)
+        v_s_p = v_s_flat.transpose(1, 2)
+
+    k_cache, v_cache, k_buf, v_buf = _alloc_paged_cache(
+        cache_shape, head_dim, kv_dtype, device, layout
+    )
+    k_cache.copy_(k_fp8_p)
+    v_cache.copy_(v_fp8_p)
+    _write_scales_paged(k_cache, k_buf, k_s_p, head_dim, layout)
+    _write_scales_paged(v_cache, v_buf, v_s_p, head_dim, layout)
+
+    wrapper_fp8 = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace,
+        layout,
+        backend=backend,
+        use_per_token_head=True,
+    )
+    wrapper_fp8.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        pos_encoding_mode=pos_encoding_mode,
+        q_data_type=dtype,
+        kv_data_type=kv_dtype,
+        o_data_type=dtype,
+    )
+    o_fp8 = wrapper_fp8.run(q, (k_cache, v_cache))
+
+    return check_accuracy(
+        o_fp16, o_fp8, kv_dtype, "decode", label=f"batch decode {backend}"
+    )
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("layout", ["NHD", "HND"], ids=["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256], ids=["hd64", "hd128", "hd256"])
+@pytest.mark.parametrize("backend", ["fa2"], ids=["fa2"])
+def test_batch_decode_pth_paged(is_gqa, dtype, kv_dtype, layout, head_dim, backend):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    if _cc()[0] <= 7 and head_dim > 256:
+        pytest.skip("head_dim>256 exceeds SM75 smem limit")
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+    run_batch_decode_pth(
+        [32] * 4,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        16,
+        layout,
+        dtype,
+        kv_dtype,
+        backend,
+    )
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("layout", ["NHD", "HND"], ids=["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256], ids=["hd64", "hd128", "hd256"])
+@pytest.mark.parametrize("backend", ["fa2"], ids=["fa2"])
+def test_batch_decode_pth_ragged(is_gqa, dtype, kv_dtype, layout, head_dim, backend):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+    run_batch_decode_pth(
+        [16, 48, 32, 64],
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        16,
+        layout,
+        dtype,
+        kv_dtype,
+        backend,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("backend", ["fa2"], ids=["fa2"])
+def test_batch_decode_pth_rope_llama(dtype, kv_dtype, backend):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    run_batch_decode_pth(
+        [32] * 4,
+        4,
+        2,
+        128,
+        16,
+        "NHD",
+        dtype,
+        kv_dtype,
+        backend,
+        pos_encoding_mode="ROPE_LLAMA",
+    )
+
+
+# ============================================================
+# BatchPrefillWithRaggedKVCacheWrapper + PTH (continuous mode)
+# ============================================================
+
+
+def run_batch_prefill_ragged_continuous_pth(
+    qo_lens,
+    kv_lens,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    layout,
+    dtype,
+    kv_dtype,
+    causal,
+):
+    """Batch prefill with ragged (continuous) KV cache + FP8 per-token-head."""
+    device = "cuda:0"
+    batch_size = len(kv_lens)
+    total_qo = sum(qo_lens)
+    q = torch.randn(total_qo, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    k_f16_list = [
+        0.3
+        * torch.randn(kv_lens[i], num_kv_heads, head_dim, dtype=dtype, device=device)
+        for i in range(batch_size)
+    ]
+    v_f16_list = [
+        0.3
+        * torch.randn(kv_lens[i], num_kv_heads, head_dim, dtype=dtype, device=device)
+        for i in range(batch_size)
+    ]
+
+    # Apply RoPE for realistic KV cache
+    for i in range(batch_size):
+        q_start = sum(qo_lens[:i])
+        q_slice = q[q_start : q_start + qo_lens[i]]
+        cos, sin = generate_cos_sin_f32_cache(
+            max(qo_lens[i], kv_lens[i]), head_dim, device=device
+        )
+        q[q_start : q_start + qo_lens[i]] = apply_rotary_pos_emb(
+            q_slice, q_slice, cos[: qo_lens[i]], sin[: qo_lens[i]]
+        )[0]
+        k_f16_list[i] = apply_rotary_pos_emb(
+            k_f16_list[i], k_f16_list[i], cos[: kv_lens[i]], sin[: kv_lens[i]]
+        )[1]
+
+    k_f16 = torch.cat(k_f16_list, dim=0)
+    v_f16 = torch.cat(v_f16_list, dim=0)
+
+    qo_indptr = torch.cat(
+        [
+            torch.tensor([0], dtype=torch.int32, device=device),
+            torch.tensor(qo_lens, dtype=torch.int32, device=device)
+            .cumsum(0)
+            .to(torch.int32),
+        ]
+    )
+    kv_indptr = torch.cat(
+        [
+            torch.tensor([0], dtype=torch.int32, device=device),
+            torch.tensor(kv_lens, dtype=torch.int32, device=device)
+            .cumsum(0)
+            .to(torch.int32),
+        ]
+    )
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    wrapper_f16 = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, layout, backend="fa2"
+    )
+    wrapper_f16.plan(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o_fp16 = wrapper_f16.run(q, k_f16, v_f16)
+
+    # FP8 per-token-head: build strided continuous cache
+    k_fp8_list = []
+    v_fp8_list = []
+    k_scales_list = []
+    v_scales_list = []
+    for i in range(batch_size):
+        k_fp8, k_s = to_float8_per_token_head(k_f16_list[i], kv_dtype)
+        v_fp8, v_s = to_float8_per_token_head(v_f16_list[i], kv_dtype)
+        k_fp8_list.append(k_fp8)
+        v_fp8_list.append(v_fp8)
+        k_scales_list.append(k_s)
+        v_scales_list.append(v_s)
+
+    k_fp8 = torch.cat(k_fp8_list, dim=0)
+    v_fp8 = torch.cat(v_fp8_list, dim=0)
+    k_scales = torch.cat(k_scales_list, dim=0)
+    v_scales = torch.cat(v_scales_list, dim=0)
+
+    k_cache = _build_strided_cache(k_fp8, k_scales, head_dim)
+    v_cache = _build_strided_cache(v_fp8, v_scales, head_dim)
+
+    wrapper_fp8 = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, layout, backend="fa2", use_per_token_head=True
+    )
+    wrapper_fp8.plan(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=kv_dtype,
+        o_data_type=dtype,
+    )
+    o_fp8 = wrapper_fp8.run(q, k_cache, v_cache)
+
+    assert not torch.isnan(o_fp8).any(), "PTH output contains NaN"
+    return check_accuracy(
+        o_fp16, o_fp8, kv_dtype, "prefill", label=f"ragged-continuous prefill {layout}"
+    )
+
+
+def _build_strided_cache(x, scales, head_dim):
+    """Build a continuous KV cache tensor with head_dim+16 stride for PTH."""
+    kv_len, num_kv_heads = x.shape[0], x.shape[1]
+    stride = head_dim + 16
+    buf_size = kv_len * num_kv_heads * stride
+    buf = torch.zeros(buf_size, dtype=torch.uint8, device=x.device)
+    rows = buf.reshape(-1, stride)
+    fp8_flat = x.reshape(-1, head_dim).view(torch.uint8)
+    rows[:, :head_dim].copy_(fp8_flat)
+    scales_f32 = scales.reshape(-1).to(torch.float32)
+    scales_bytes = scales_f32.view(torch.uint8)
+    rows[:, head_dim : head_dim + 4].copy_(scales_bytes.reshape(-1, 4))
+    cache = torch.as_strided(
+        buf.view(x.dtype),
+        (kv_len, num_kv_heads, head_dim),
+        (num_kv_heads * stride, stride, 1),
+        storage_offset=0,
+    )
+    return cache
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("layout", ["NHD"], ids=["NHD"])
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["hd64", "hd128"])
+@pytest.mark.parametrize("causal", [True, False], ids=["causal", "no-causal"])
+def test_batch_prefill_ragged_continuous_pth(
+    is_gqa, dtype, kv_dtype, layout, head_dim, causal
+):
+    """BatchPrefillWithRaggedKVCacheWrapper with FP8 per-token-head."""
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+    run_batch_prefill_ragged_continuous_pth(
+        qo_lens=[6, 10, 8],
+        kv_lens=[16, 48, 32],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        layout=layout,
+        dtype=dtype,
+        kv_dtype=kv_dtype,
+        causal=causal,
+    )
+
+
+# ============================================================
+# BatchDecode + PTH + non-page-aligned ragged lengths
+# ============================================================
+
+
+def run_batch_decode_non_page_aligned_pth(
+    kv_lens,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    layout,
+    dtype,
+    kv_dtype,
+):
+    """Batch decode with non-page-aligned KV lengths + PTH."""
+    device = "cuda:0"
+    batch_size = len(kv_lens)
+    q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    k_f16_list = [
+        0.3
+        * torch.randn(kv_lens[i], num_kv_heads, head_dim, dtype=dtype, device=device)
+        for i in range(batch_size)
+    ]
+    v_f16_list = [
+        0.3
+        * torch.randn(kv_lens[i], num_kv_heads, head_dim, dtype=dtype, device=device)
+        for i in range(batch_size)
+    ]
+
+    # Apply RoPE for realistic KV cache
+    for i in range(batch_size):
+        cos, sin = generate_cos_sin_f32_cache(kv_lens[i], head_dim, device=device)
+        k_f16_list[i] = apply_rotary_pos_emb(k_f16_list[i], k_f16_list[i], cos, sin)[1]
+
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    # Single page per sequence, page_size = max(kv_lens)
+    page_size = max(kv_lens)
+    kv_indptr = torch.cat(
+        [
+            torch.tensor([0], dtype=torch.int32, device=device),
+            torch.arange(1, batch_size + 1, dtype=torch.int32, device=device),
+        ]
+    )
+    kv_indices = torch.arange(batch_size, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.tensor(kv_lens, dtype=torch.int32, device=device)
+
+    # FP16 baseline (padded)
+    k_f16_padded = []
+    v_f16_padded = []
+    for i in range(batch_size):
+        pad_len = page_size - kv_lens[i]
+        if pad_len > 0:
+            k_f16_padded.append(
+                torch.nn.functional.pad(k_f16_list[i], (0, 0, 0, 0, 0, pad_len))
+            )
+            v_f16_padded.append(
+                torch.nn.functional.pad(v_f16_list[i], (0, 0, 0, 0, 0, pad_len))
+            )
+        else:
+            k_f16_padded.append(k_f16_list[i])
+            v_f16_padded.append(v_f16_list[i])
+
+    k_f16_paged = torch.stack(k_f16_padded).reshape(
+        batch_size, page_size, num_kv_heads, head_dim
+    )
+    v_f16_paged = torch.stack(v_f16_padded).reshape(
+        batch_size, page_size, num_kv_heads, head_dim
+    )
+    if layout == "HND":
+        k_f16_paged = k_f16_paged.transpose(1, 2)
+        v_f16_paged = v_f16_paged.transpose(1, 2)
+
+    wrapper_f16 = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, layout, backend="fa2"
+    )
+    wrapper_f16.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o_fp16 = wrapper_f16.run(q, (k_f16_paged, v_f16_paged))
+
+    # FP8 per-token-head with strided cache
+    k_fp8_padded = []
+    v_fp8_padded = []
+    k_scales_padded = []
+    v_scales_padded = []
+    for i in range(batch_size):
+        k_fp8, k_s = to_float8_per_token_head(k_f16_list[i], kv_dtype)
+        v_fp8, v_s = to_float8_per_token_head(v_f16_list[i], kv_dtype)
+        pad_len = page_size - kv_lens[i]
+        if pad_len > 0:
+            k_fp8 = torch.nn.functional.pad(k_fp8, (0, 0, 0, 0, 0, pad_len))
+            k_s = torch.nn.functional.pad(k_s, (0, 0, 0, pad_len))
+            v_fp8 = torch.nn.functional.pad(v_fp8, (0, 0, 0, 0, 0, pad_len))
+            v_s = torch.nn.functional.pad(v_s, (0, 0, 0, pad_len))
+        k_fp8_padded.append(k_fp8)
+        v_fp8_padded.append(v_fp8)
+        k_scales_padded.append(k_s)
+        v_scales_padded.append(v_s)
+
+    k_fp8_flat = torch.stack(k_fp8_padded).reshape(
+        batch_size, page_size, num_kv_heads, head_dim
+    )
+    v_fp8_flat = torch.stack(v_fp8_padded).reshape(
+        batch_size, page_size, num_kv_heads, head_dim
+    )
+    k_s_flat = torch.stack(k_scales_padded).reshape(batch_size, page_size, num_kv_heads)
+    v_s_flat = torch.stack(v_scales_padded).reshape(batch_size, page_size, num_kv_heads)
+
+    if layout == "HND":
+        k_fp8_flat = k_fp8_flat.transpose(1, 2)
+        v_fp8_flat = v_fp8_flat.transpose(1, 2)
+        k_s_flat = k_s_flat.transpose(1, 2)
+        v_s_flat = v_s_flat.transpose(1, 2)
+
+    k_cache, v_cache, k_buf, v_buf = _alloc_cache_decode_strided(
+        batch_size, page_size, num_kv_heads, head_dim, kv_dtype, device, layout
+    )
+    k_cache.copy_(k_fp8_flat)
+    v_cache.copy_(v_fp8_flat)
+    _write_scales_decode_strided(
+        k_cache, k_buf, k_s_flat.to(torch.float32), head_dim, layout
+    )
+    _write_scales_decode_strided(
+        v_cache, v_buf, v_s_flat.to(torch.float32), head_dim, layout
+    )
+
+    wrapper_fp8 = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, layout, backend="fa2", use_per_token_head=True
+    )
+    wrapper_fp8.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=kv_dtype,
+        o_data_type=dtype,
+    )
+    o_fp8 = wrapper_fp8.run(q, (k_cache, v_cache))
+
+    assert not torch.isnan(o_fp8).any(), "PTH output contains NaN"
+    return check_accuracy(
+        o_fp16, o_fp8, kv_dtype, "decode", label=f"decode non-page-aligned {layout}"
+    )
+
+
+def _alloc_cache_decode_strided(
+    batch_size, page_size, num_kv_heads, head_dim, dtype, device, layout
+):
+    """Allocate strided cache for batch decode with non-page-aligned lengths."""
+    stride = head_dim + 16
+    if layout == "NHD":
+        buf_size = batch_size * page_size * num_kv_heads * stride
+        s = (
+            page_size * num_kv_heads * stride,
+            num_kv_heads * stride,
+            stride,
+            1,
+        )
+        shape = (batch_size, page_size, num_kv_heads, head_dim)
+    else:
+        buf_size = batch_size * num_kv_heads * page_size * stride
+        s = (
+            num_kv_heads * page_size * stride,
+            page_size * stride,
+            stride,
+            1,
+        )
+        shape = (batch_size, num_kv_heads, page_size, head_dim)
+    k_buf = torch.empty(buf_size, dtype=torch.uint8, device=device)
+    v_buf = torch.empty(buf_size, dtype=torch.uint8, device=device)
+    k_cache = torch.as_strided(k_buf, shape, s).view(dtype)
+    v_cache = torch.as_strided(v_buf, shape, s).view(dtype)
+    return k_cache, v_cache, k_buf, v_buf
+
+
+def _write_scales_decode_strided(cache_tensor, buf, scales, head_dim, layout):
+    """Write float32 scales into the strided cache buffer for decode."""
+    stride = head_dim + 16
+    scale_stride_f32 = stride // 4
+    scale_offset_f32 = head_dim // 4
+    if layout == "NHD":
+        batch_size, page_size, num_kv_heads, _ = cache_tensor.shape
+        shape = (batch_size, page_size, num_kv_heads)
+        strides = (
+            page_size * num_kv_heads * scale_stride_f32,
+            num_kv_heads * scale_stride_f32,
+            scale_stride_f32,
+        )
+    else:
+        batch_size, num_kv_heads, page_size, _ = cache_tensor.shape
+        shape = (batch_size, num_kv_heads, page_size)
+        strides = (
+            num_kv_heads * page_size * scale_stride_f32,
+            page_size * scale_stride_f32,
+            scale_stride_f32,
+        )
+    scale_view = torch.as_strided(
+        buf.view(torch.float32), shape, strides, storage_offset=scale_offset_f32
+    )
+    scale_view.copy_(scales.reshape(shape))
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("layout", ["NHD", "HND"], ids=["NHD", "HND"])
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["hd64", "hd128"])
+def test_batch_decode_non_page_aligned_pth(is_gqa, dtype, kv_dtype, layout, head_dim):
+    """Batch decode with non-page-aligned KV lengths + PTH."""
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+    run_batch_decode_non_page_aligned_pth(
+        kv_lens=[17, 43, 31, 59],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        layout=layout,
+        dtype=dtype,
+        kv_dtype=kv_dtype,
+    )
+
+
+# ============================================================
+# Backend assertion: PTH + non-fa2 should be rejected
+# ============================================================
+
+
+def test_pth_backend_assertion_prefill_ragged():
+    """PTH + non-fa2 backend raises ValueError in ragged prefill plan."""
+    _skip_if_sm_below_75()
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, backend="cudnn", use_per_token_head=True
+    )
+    qo_indptr = torch.tensor([0, 8], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, 16], dtype=torch.int32, device="cuda:0")
+    with pytest.raises(ValueError, match="only supported with the fa2 backend"):
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            num_qo_heads=4,
+            num_kv_heads=4,
+            head_dim_qk=128,
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+        )
+
+
+def test_pth_backend_assertion_prefill_paged():
+    """PTH + non-fa2 backend raises ValueError in paged prefill plan."""
+    _skip_if_sm_below_75()
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, backend="cudnn", use_per_token_head=True
+    )
+    qo_indptr = torch.tensor([0, 8], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, 2], dtype=torch.int32, device="cuda:0")
+    kv_indices = torch.tensor([0, 1], dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.tensor([16], dtype=torch.int32, device="cuda:0")
+    with pytest.raises(ValueError, match="only supported with the fa2 backend"):
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            4,
+            4,
+            128,
+            16,
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+        )
+
+
+def test_pth_backend_assertion_decode():
+    """PTH + non-fa2 backend raises ValueError in batch decode."""
+    _skip_if_sm_below_75()
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, backend="fa3", use_tensor_cores=True, use_per_token_head=True
+    )
+    indptr = torch.tensor([0, 1], dtype=torch.int32, device="cuda:0")
+    indices = torch.tensor([0], dtype=torch.int32, device="cuda:0")
+    last_page_len = torch.tensor([1], dtype=torch.int32, device="cuda:0")
+    with pytest.raises(ValueError, match="only supported with the fa2 backend"):
+        wrapper.plan(
+            indptr,
+            indices,
+            last_page_len,
+            num_qo_heads=4,
+            num_kv_heads=4,
+            head_dim=64,
+            page_size=16,
+        )
+
+
+def test_pth_auto_backend_allowed():
+    """PTH + auto backend is allowed and forced to fa2."""
+    _skip_if_sm_below_75()
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, backend="auto", use_per_token_head=True
+    )
+    qo_indptr = torch.tensor([0, 16], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, 64], dtype=torch.int32, device="cuda:0")
+    num_qo_heads, num_kv_heads, head_dim = 4, 4, 64
+    q = torch.randn(16, num_qo_heads, head_dim, dtype=torch.float16, device="cuda:0")
+    k = 0.3 * torch.randn(
+        64, num_kv_heads, head_dim, dtype=torch.float16, device="cuda:0"
+    )
+    v = 0.3 * torch.randn(
+        64, num_kv_heads, head_dim, dtype=torch.float16, device="cuda:0"
+    )
+    cos, sin = generate_cos_sin_f32_cache(64, head_dim, device="cuda:0")
+    k = apply_rotary_pos_emb(k, k, cos, sin)[1]
+    k_fp8, k_s = to_float8_per_token_head(k, torch.float8_e4m3fn)
+    v_fp8, v_s = to_float8_per_token_head(v, torch.float8_e4m3fn)
+    k_cache = _build_strided_cache(k_fp8, k_s, head_dim)
+    v_cache = _build_strided_cache(v_fp8, v_s, head_dim)
+
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        causal=True,
+        q_data_type=torch.float16,
+        kv_data_type=torch.float8_e4m3fn,
+        o_data_type=torch.float16,
+    )
+    assert wrapper._backend == "fa2", (
+        f"Expected backend 'fa2' but got '{wrapper._backend}'"
+    )
+    o = wrapper.run(q, k_cache, v_cache)
+    assert not torch.isnan(o).any(), "Output contains NaN"
+
+
+# ============================================================
+# Smoke tests
+# ============================================================
+
+if __name__ == "__main__":
+    dtypes = [torch.float16]
+    if _cc()[0] > 7:
+        dtypes.append(torch.bfloat16)
+    for dtype in dtypes:
+        kv_dtype = torch.float8_e4m3fn
+
+        test_batch_prefill_pth_paged(
+            is_gqa=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            layout="NHD",
+            head_dim=128,
+            backend="fa2",
+        )
+        print(f"batch prefill MHA {dtype}/{kv_dtype} paged smoke passed")
+
+        test_batch_prefill_pth_paged(
+            is_gqa=True,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            layout="NHD",
+            head_dim=64,
+            backend="fa2",
+        )
+        print(f"batch prefill GQA {dtype}/{kv_dtype} paged smoke passed")
+
+        test_batch_prefill_pth_ragged(
+            is_gqa=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            layout="NHD",
+            head_dim=128,
+            backend="fa2",
+        )
+        print(f"batch prefill {dtype}/{kv_dtype} ragged smoke passed")
+
+        test_batch_decode_pth_paged(
+            is_gqa=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            layout="NHD",
+            head_dim=128,
+            backend="fa2",
+        )
+        print(f"batch decode MHA {dtype}/{kv_dtype} paged smoke passed")
+
+        test_batch_decode_pth_paged(
+            is_gqa=True,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            layout="NHD",
+            head_dim=64,
+            backend="fa2",
+        )
+        print(f"batch decode GQA {dtype}/{kv_dtype} paged smoke passed")
+
+        test_batch_decode_pth_ragged(
+            is_gqa=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            layout="NHD",
+            head_dim=64,
+            backend="fa2",
+        )
+        print(f"batch decode {dtype}/{kv_dtype} ragged smoke passed")
+
+        test_batch_prefill_ragged_continuous_pth(
+            is_gqa=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            layout="NHD",
+            head_dim=128,
+            causal=True,
+        )
+        print(f"batch prefill {dtype}/{kv_dtype} ragged-continuous smoke passed")
+
+        test_batch_decode_non_page_aligned_pth(
+            is_gqa=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            layout="NHD",
+            head_dim=128,
+        )
+        print(f"batch decode {dtype}/{kv_dtype} non-page-aligned smoke passed")
+
+    test_pth_backend_assertion_prefill_ragged()
+    print("pth backend assertion ragged prefill OK")
+
+    test_pth_backend_assertion_prefill_paged()
+    print("pth backend assertion paged prefill OK")
+
+    test_pth_backend_assertion_decode()
+    print("pth backend assertion decode OK")
+
+    test_pth_auto_backend_allowed()
+    print("pth auto backend forced to fa2 OK")
+
+    print("\nAll batch per-token-head smoke tests passed")

--- a/tests/attention/test_batch_prefill.py
+++ b/tests/attention/test_batch_prefill.py
@@ -6,6 +6,9 @@ from flashinfer import BatchPrefillWithPagedKVCacheWrapper
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_kv_scale_forwarding_effect(dtype):
+    cc = torch.cuda.get_device_capability(device="cuda")
+    if dtype != torch.float16 and cc[0] < 8:
+        pytest.skip(f"{dtype} need SM80+")
     torch.manual_seed(42)
 
     H_QO, H_KV, N_CTX, HEAD_DIM, PAGE_SIZE = 1, 1, 8, 64, 16
@@ -57,6 +60,9 @@ def test_kv_scale_forwarding_effect(dtype):
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_kv_scale_forwarding_math_property(dtype: torch.dtype):
+    cc = torch.cuda.get_device_capability(device="cuda")
+    if dtype != torch.float16 and cc[0] < 8:
+        pytest.skip(f"{dtype} need SM80+")
     torch.manual_seed(0)
 
     # ---------------- parameters ----------------

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -1056,6 +1056,9 @@ def test_batch_prefill_with_paged_kv_cache_nvfp4(
     Reference is computed by dequantizing the packed KV back to q_dtype and running
     single_prefill_with_kv_cache per batch item.
     """
+    cc = torch.cuda.get_device_capability(device="cuda:0")
+    if q_dtype != torch.float16 and cc[0] < 8:
+        pytest.skip(f"{q_dtype} need SM80+")
     if qo_len > kv_len and causal:
         pytest.skip("qo_len > kv_len and causal is not supported")
 
@@ -1192,6 +1195,9 @@ def test_batch_prefill_with_ragged_kv_cache_nvfp4(
     Reference is computed by dequantizing the packed KV back to q_dtype and running
     single_prefill_with_kv_cache per batch item.
     """
+    cc = torch.cuda.get_device_capability(device="cuda:0")
+    if q_dtype != torch.float16 and cc[0] < 8:
+        pytest.skip(f"{q_dtype} need SM80+")
     if qo_len > kv_len and causal:
         pytest.skip("qo_len > kv_len and causal is not supported")
 

--- a/tests/attention/test_single_per_token_head.py
+++ b/tests/attention/test_single_per_token_head.py
@@ -1,0 +1,479 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Single prefill/decode FP8 per-token-head KV cache tests.
+"""
+
+import pytest
+import torch
+import flashinfer
+from tests.test_helpers.rope_reference import (
+    apply_rotary_pos_emb,
+    generate_cos_sin_f32_cache,
+)
+from tests.utils_fp8 import get_cos_sim_threshold, to_float8, to_float8_per_token_head
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _cc():
+    return torch.cuda.get_device_capability(0)
+
+
+def _skip_if_sm_below_75():
+    if _cc()[0] < 7 or (_cc()[0] == 7 and _cc()[1] < 5):
+        pytest.skip("Requires SM75+")
+
+
+def _skip_if_not_fp16_sm75(dtype: torch.dtype):
+    if dtype != torch.float16 and _cc()[0] <= 7:
+        pytest.skip(f"{dtype} skipped on SM75")
+
+
+def _skip_if_sm75_head_dim_256(head_dim):
+    if _cc()[0] <= 7 and head_dim > 256:
+        pytest.skip("head_dim>256 exceeds SM75 smem limit")
+
+
+def check_accuracy(
+    o_ref: torch.Tensor, o: torch.Tensor, kv_dtype: torch.dtype, mode, label=""
+):
+    cos_sim = torch.nn.functional.cosine_similarity(
+        o_ref.reshape(-1).float(), o.reshape(-1).float(), dim=0
+    ).item()
+    max_diff = (o_ref - o).abs().max().item()
+    prefix = f"[{label}] " if label else ""
+    threshold = get_cos_sim_threshold(kv_dtype, mode)
+    print(f"{prefix}{kv_dtype} cos_sim={cos_sim:.8f} max_diff={max_diff:.8f}")
+    assert cos_sim >= threshold, (
+        f"{prefix}cos_sim={cos_sim:.8f} < {threshold} ({kv_dtype})"
+    )
+    return cos_sim, max_diff
+
+
+def build_strided_cache(x, scales, head_dim):
+    kv_len, num_kv_heads = x.shape[0], x.shape[1]
+    stride = head_dim + 16
+    buf_size = kv_len * num_kv_heads * stride
+    buf = torch.zeros(buf_size, dtype=torch.uint8, device=x.device)
+    rows = buf.reshape(-1, stride)
+    fp8_flat = x.reshape(-1, head_dim).view(torch.uint8)
+    rows[:, :head_dim].copy_(fp8_flat)
+    scales_f32 = scales.reshape(-1).to(torch.float32)
+    scales_bytes = scales_f32.view(torch.uint8)
+    rows[:, head_dim : head_dim + 4].copy_(scales_bytes.reshape(-1, 4))
+    cache = torch.as_strided(
+        buf.view(x.dtype),
+        (kv_len, num_kv_heads, head_dim),
+        (num_kv_heads * stride, stride, 1),
+        storage_offset=0,
+    )
+    return cache
+
+
+def _make_rand_kv(kv_len, num_kv_heads, head_dim, device, dtype):
+    k = 0.3 * torch.randn(kv_len, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v = 0.3 * torch.randn(kv_len, num_kv_heads, head_dim, dtype=dtype, device=device)
+    cos, sin = generate_cos_sin_f32_cache(kv_len, head_dim, device=device)
+    k = apply_rotary_pos_emb(k, k, cos, sin)[1]
+    return k, v
+
+
+def _build_pth_caches(k, v, kv_dtype):
+    head_dim = k.shape[-1]
+    k_fp8, k_scales = to_float8_per_token_head(k, kv_dtype)
+    v_fp8, v_scales = to_float8_per_token_head(v, kv_dtype)
+    k_cache = build_strided_cache(k_fp8, k_scales, head_dim)
+    v_cache = build_strided_cache(v_fp8, v_scales, head_dim)
+    return k_cache, v_cache
+
+
+def _run_single_prefill_pth(q, k, v, kv_dtype, label="", **kwargs):
+    k_cache, v_cache = _build_pth_caches(k, v, kv_dtype)
+    o_ref = flashinfer.single_prefill_with_kv_cache(q, k, v, **kwargs)
+    o_pth = flashinfer.single_prefill_with_kv_cache(
+        q, k_cache, v_cache, use_per_token_head=True, **kwargs
+    )
+    return *check_accuracy(o_ref, o_pth, kv_dtype, "prefill", label=label), o_ref
+
+
+def _run_single_decode_pth(
+    q, k, v, kv_dtype, pos_encoding_mode="NONE", label="", **kwargs
+):
+    k_cache, v_cache = _build_pth_caches(k, v, kv_dtype)
+
+    if pos_encoding_mode != "NONE":
+        kwargs["pos_encoding_mode"] = pos_encoding_mode
+    o_ref = flashinfer.single_decode_with_kv_cache(q, k, v, **kwargs)
+    o_pth = flashinfer.single_decode_with_kv_cache(
+        q, k_cache, v_cache, use_per_token_head=True, **kwargs
+    )
+    return *check_accuracy(o_ref, o_pth, kv_dtype, "decode", label=label), o_ref
+
+
+def _run_single_prefill_pth_vs_pt(q, k, v, kv_dtype, dtype, backend="fa2", **kwargs):
+    label = "single prefill"
+    kwargs = {"causal": True, "backend": backend, "o_dtype": dtype, **kwargs}
+    cos_sim_pth, _, o_ref = _run_single_prefill_pth(
+        q, k, v, kv_dtype, label=f"{label} pth", **kwargs
+    )
+
+    k_fp8_pt, k_scale_pt = to_float8(k, kv_dtype)
+    v_fp8_pt, v_scale_pt = to_float8(v, kv_dtype)
+    o_pt = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k_fp8_pt,
+        v_fp8_pt,
+        k_scale=k_scale_pt.item(),
+        v_scale=v_scale_pt.item(),
+        **kwargs,
+    )
+    cos_sim_pt, _ = check_accuracy(
+        o_ref, o_pt, kv_dtype, "prefill", label=f"{label} pt"
+    )
+
+    if cos_sim_pth < cos_sim_pt:
+        pytest.xfail(
+            f"[{label}] cos_sim_pth={cos_sim_pth:.8f} < cos_sim_pt={cos_sim_pt} ({kv_dtype})"
+        )
+
+
+def _run_single_decode_pth_vs_pt(q, k, v, kv_dtype, **kwargs):
+    label = "single decode"
+    cos_sim_pth, _, o_ref = _run_single_decode_pth(
+        q, k, v, kv_dtype, label=f"{label} pth", **kwargs
+    )
+
+    k_fp8_pt, k_scale_pt = to_float8(k, kv_dtype)
+    v_fp8_pt, v_scale_pt = to_float8(v, kv_dtype)
+    o_pt = flashinfer.single_decode_with_kv_cache(
+        q,
+        k_fp8_pt,
+        v_fp8_pt,
+        k_scale=k_scale_pt.item(),
+        v_scale=v_scale_pt.item(),
+        **kwargs,
+    )
+    cos_sim_pt, _ = check_accuracy(o_ref, o_pt, kv_dtype, "decode", label=f"{label} pt")
+
+    if cos_sim_pth < cos_sim_pt:
+        pytest.xfail(
+            f"[{label}] cos_sim_pth={cos_sim_pth:.8f} < cos_sim_pt={cos_sim_pt} ({kv_dtype})"
+        )
+
+
+# ============================================================
+# Single Prefill
+# ============================================================
+
+
+def run_single_prefill_pth(
+    qo_len,
+    kv_len,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    kv_dtype,
+    causal,
+    backend,
+):
+    device = "cuda:0"
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=dtype, device=device)
+    k, v = _make_rand_kv(kv_len, num_kv_heads, head_dim, device, dtype)
+    cos, sin = generate_cos_sin_f32_cache(qo_len, head_dim, device=device)
+    q = apply_rotary_pos_emb(q, q, cos, sin)[0]
+    kwargs = {"causal": causal, "backend": backend, "o_dtype": dtype}
+    return _run_single_prefill_pth(
+        q, k, v, kv_dtype, label=f"single prefill {backend}", **kwargs
+    )
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("causal", [True, False], ids=["causal", "no-causal"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256], ids=["hd64", "hd128", "hd256"])
+@pytest.mark.parametrize("kv_len", [16, 1024], ids=["kv16", "long_seq"])
+@pytest.mark.parametrize("backend", ["fa2"], ids=["fa2"])
+def test_single_prefill_pth(is_gqa, dtype, kv_dtype, causal, head_dim, kv_len, backend):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    _skip_if_sm75_head_dim_256(head_dim)
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+    run_single_prefill_pth(
+        8,
+        kv_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        dtype,
+        kv_dtype,
+        causal,
+        backend,
+    )
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("backend", ["fa2"], ids=["fa2"])
+def test_single_prefill_pth_vs_pt(is_gqa, dtype, kv_dtype, backend):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    device = "cuda:0"
+    qo_len, kv_len, head_dim = 16, 64, 128
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=dtype, device=device)
+    k, v = _make_rand_kv(kv_len, num_kv_heads, head_dim, device, dtype)
+    cos, sin = generate_cos_sin_f32_cache(qo_len, head_dim, device=device)
+    q = apply_rotary_pos_emb(q, q, cos, sin)[0]
+    _run_single_prefill_pth_vs_pt(q, k, v, kv_dtype, dtype, backend=backend)
+
+
+# ============================================================
+# Single Decode
+# ============================================================
+
+
+def run_single_decode_pth(
+    kv_len,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    dtype,
+    kv_dtype,
+    pos_encoding_mode="NONE",
+):
+    device = "cuda:0"
+    q = torch.randn(num_qo_heads, head_dim, dtype=dtype, device=device)
+    k, v = _make_rand_kv(kv_len, num_kv_heads, head_dim, device, dtype)
+    cos, sin = generate_cos_sin_f32_cache(kv_len, head_dim, device=device)
+    q = apply_rotary_pos_emb(q[None], q[None], cos[:1], sin[:1])[0].squeeze(0)
+    return _run_single_decode_pth(
+        q,
+        k,
+        v,
+        kv_dtype,
+        pos_encoding_mode=pos_encoding_mode,
+        label="single decode",
+    )
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+@pytest.mark.parametrize("head_dim", [64, 128, 256], ids=["hd64", "hd128", "hd256"])
+@pytest.mark.parametrize("kv_len", [64, 1024], ids=["kv64", "long_seq"])
+def test_single_decode_pth(is_gqa, dtype, kv_dtype, head_dim, kv_len):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    _skip_if_sm75_head_dim_256(head_dim)
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+    run_single_decode_pth(kv_len, num_qo_heads, num_kv_heads, head_dim, dtype, kv_dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+def test_single_decode_pth_rope_llama(dtype, kv_dtype):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    kv_len, num_qo_heads, num_kv_heads, head_dim = 64, 4, 2, 128
+    run_single_decode_pth(
+        kv_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        dtype,
+        kv_dtype,
+        pos_encoding_mode="ROPE_LLAMA",
+    )
+
+
+@pytest.mark.parametrize("is_gqa", [False, True], ids=["mha", "gqa"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["fp16", "bf16"])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn], ids=["e4m3"])
+def test_single_decode_pth_vs_per_tensor(is_gqa, dtype, kv_dtype):
+    _skip_if_sm_below_75()
+    _skip_if_not_fp16_sm75(dtype)
+    device = "cuda:0"
+    head_dim, kv_len = 128, 128
+    num_qo_heads, num_kv_heads = (4, 2) if is_gqa else (4, 4)
+
+    q = torch.randn(num_qo_heads, head_dim, dtype=dtype, device=device)
+    k, v = _make_rand_kv(kv_len, num_kv_heads, head_dim, device, dtype)
+    cos, sin = generate_cos_sin_f32_cache(kv_len, head_dim, device=device)
+    q = apply_rotary_pos_emb(q[None], q[None], cos[:1], sin[:1])[0].squeeze(0)
+    _run_single_decode_pth_vs_pt(q, k, v, kv_dtype)
+
+
+# ============================================================
+# Single Prefill/Decode with explicit non-contiguous stride
+# ============================================================
+
+
+def test_single_prefill_pth_non_contiguous_stride():
+    """Single prefill with PTH using explicitly non-contiguous stride.
+
+    Verifies that the kernel correctly reads inline scales from the
+    head_dim+16 stride offset when the tensor is not contiguous.
+    """
+    _skip_if_sm_below_75()
+    device = "cuda:0"
+    qo_len, kv_len, head_dim = 32, 64, 64
+    num_qo_heads, num_kv_heads = 4, 4
+    dtype = torch.float16
+    kv_dtype = torch.float8_e4m3fn
+
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=dtype, device=device)
+    k, v = _make_rand_kv(kv_len, num_kv_heads, head_dim, device, dtype)
+    cos, sin = generate_cos_sin_f32_cache(qo_len, head_dim, device=device)
+    q = apply_rotary_pos_emb(q, q, cos, sin)[0]
+
+    k_fp8, k_s = to_float8_per_token_head(k, kv_dtype)
+    v_fp8, v_s = to_float8_per_token_head(v, kv_dtype)
+
+    k_cache = build_strided_cache(k_fp8, k_s, head_dim)
+    v_cache = build_strided_cache(v_fp8, v_s, head_dim)
+
+    assert k_cache.stride(1) == head_dim + 16, (
+        f"Expected stride {head_dim + 16}, got {k_cache.stride(1)}"
+    )
+    assert not k_cache.is_contiguous(), "Cache should not be contiguous"
+
+    o_ref = flashinfer.single_prefill_with_kv_cache(
+        q, k, v, causal=True, backend="fa2", o_dtype=dtype
+    )
+    o_pth = flashinfer.single_prefill_with_kv_cache(
+        q,
+        k_cache,
+        v_cache,
+        causal=True,
+        backend="fa2",
+        o_dtype=dtype,
+        use_per_token_head=True,
+    )
+
+    assert not torch.isnan(o_pth).any(), "PTH output contains NaN"
+    check_accuracy(o_ref, o_pth, kv_dtype, "prefill", label="single non-contig stride")
+
+
+def test_single_decode_pth_non_contiguous_stride():
+    """Single decode with PTH using explicitly non-contiguous stride."""
+    _skip_if_sm_below_75()
+    device = "cuda:0"
+    kv_len, head_dim = 64, 128
+    num_qo_heads, num_kv_heads = 4, 4
+    dtype = torch.float16
+    kv_dtype = torch.float8_e4m3fn
+
+    q = torch.randn(num_qo_heads, head_dim, dtype=dtype, device=device)
+    k, v = _make_rand_kv(kv_len, num_kv_heads, head_dim, device, dtype)
+    cos, sin = generate_cos_sin_f32_cache(kv_len, head_dim, device=device)
+    q = apply_rotary_pos_emb(q[None], q[None], cos[:1], sin[:1])[0].squeeze(0)
+
+    k_fp8, k_s = to_float8_per_token_head(k, kv_dtype)
+    v_fp8, v_s = to_float8_per_token_head(v, kv_dtype)
+
+    k_cache = build_strided_cache(k_fp8, k_s, head_dim)
+    v_cache = build_strided_cache(v_fp8, v_s, head_dim)
+
+    assert k_cache.stride(1) == head_dim + 16
+    assert not k_cache.is_contiguous()
+
+    o_ref = flashinfer.single_decode_with_kv_cache(q, k, v)
+    o_pth = flashinfer.single_decode_with_kv_cache(
+        q,
+        k_cache,
+        v_cache,
+        use_per_token_head=True,
+    )
+
+    assert not torch.isnan(o_pth).any(), "PTH output contains NaN"
+    check_accuracy(o_ref, o_pth, kv_dtype, "decode", label="single decode non-contig")
+
+
+# ============================================================
+# Smoke tests
+# ============================================================
+
+if __name__ == "__main__":
+    dtypes = [torch.float16]
+    if _cc()[0] > 7:
+        dtypes.append(torch.bfloat16)
+    for dtype in dtypes:
+        kv_dtype = torch.float8_e4m3fn
+
+        test_single_prefill_pth(
+            is_gqa=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            causal=True,
+            head_dim=128,
+            kv_len=16,
+            backend="fa2",
+        )
+        print(f"single prefill MHA {dtype}/{kv_dtype} smoke passed")
+
+        test_single_prefill_pth(
+            is_gqa=True,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            causal=False,
+            head_dim=64,
+            kv_len=16,
+            backend="fa2",
+        )
+        print(f"single prefill GQA {dtype}/{kv_dtype} smoke passed")
+
+        test_single_decode_pth(
+            is_gqa=False,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            head_dim=128,
+            kv_len=64,
+        )
+        print(f"single decode MHA {dtype}/{kv_dtype} smoke passed")
+
+        test_single_decode_pth(
+            is_gqa=True,
+            dtype=dtype,
+            kv_dtype=kv_dtype,
+            head_dim=64,
+            kv_len=64,
+        )
+        print(f"single decode GQA {dtype}/{kv_dtype} smoke passed")
+
+        test_single_prefill_pth_vs_pt(
+            is_gqa=False, dtype=dtype, kv_dtype=kv_dtype, backend="fa2"
+        )
+        print(f"single prefill per-token-head vs per-tensor {dtype} smoke passed")
+
+        test_single_decode_pth_vs_per_tensor(
+            is_gqa=False, dtype=dtype, kv_dtype=kv_dtype
+        )
+        print(f"single decode per-token-head vs per-tensor {dtype} smoke passed")
+
+    test_single_prefill_pth_non_contiguous_stride()
+    print("single prefill non-contiguous stride OK")
+
+    test_single_decode_pth_non_contiguous_stride()
+    print("single decode non-contiguous stride OK")
+
+    print("\nAll single per-token-head smoke tests passed")

--- a/tests/attention/test_single_prefill.py
+++ b/tests/attention/test_single_prefill.py
@@ -128,6 +128,9 @@ def test_single_prefill_with_kv_cache_nvfp4(
 
     Reference uses dequantized KV with the standard fp16 kernel.
     """
+    cc = torch.cuda.get_device_capability(device="cuda:0")
+    if q_dtype != torch.float16 and cc[0] < 8:
+        pytest.skip(f"{q_dtype} need SM80+")
     if qo_len > kv_len and causal:
         pytest.skip("qo_len > kv_len and causal is not supported")
 

--- a/tests/utils_fp8.py
+++ b/tests/utils_fp8.py
@@ -3,15 +3,30 @@ import torch
 from flashinfer import SfLayout
 
 
+def get_cos_sim_threshold(dtype: torch.dtype, mode: str = "prefill") -> float:
+    """Return cosine similarity threshold for FP8 per-token-head accuracy check."""
+    return 0.999
+
+
 def to_float8(
     x: torch.Tensor, dtype=torch.float8_e4m3fn
 ) -> tuple[torch.Tensor, torch.Tensor]:
     finfo = torch.finfo(dtype)
     min_val, max_val = x.aminmax()
-    amax = torch.maximum(min_val.abs(), max_val.abs()).clamp(min=1e-12)
+    amax = (
+        torch.maximum(min_val.abs(), max_val.abs()).to(torch.float32).clamp(min=1e-12)
+    )
     scale = finfo.max / amax
     x_scl_sat = (x * scale).clamp(min=finfo.min, max=finfo.max)
     return x_scl_sat.to(dtype), scale.float().reciprocal()
+
+
+def to_float8_per_token_head(x: torch.Tensor, dtype=torch.float8_e4m3fn):
+    finfo = torch.finfo(dtype)
+    amax = x.abs().amax(dim=-1, keepdim=True).to(torch.float32).clamp(min=1e-12)
+    scales = finfo.max / amax
+    x_scl_sat = (x * scales).clamp(min=finfo.min, max=finfo.max)
+    return x_scl_sat.to(dtype), scales.squeeze(-1).reciprocal()
 
 
 @torch.no_grad()


### PR DESCRIPTION
Implement FP8 per-token-head KV cache where a float32 scale is stored inline immediately after each head's FP8 data, with stride padded to head_dim + 16 (16B aligned). Covers prefill and decode for single/batch, paged/ragged, MHA/GQA.

Kernel changes:
  - Add AttentionVariant::use_per_token_head flag for compile-time scale-aware dispatch
  - Decode: multiply float32 scales after cast_load in compute_qk and update_local_state, with async scale load pipelined alongside KV
  - page_produce_kv_sf_pth / produce_kv_sf_pth: load inline scales from global memory into shared memory (requires sizeof(DTypeKV) == 1)
  - Conditional scale smem via empty-base-class inheritance to avoid SM75 head_dim=256 overflow (49,152B standard vs 45,148B FP8-PTH)

Launcher changes:
  - batch_attention plan: resolve kernel pointer at plan time via get_persistent_kernel to pass smem_size to TwoStageHolisticPlan

Python API:
  - Add use_per_token_head param to single_prefill/decode, batch prefill/decode, and BatchAttention wrappers; forces backend="fa2" when enabled
  - Update JIT URI and AOT generator to emit per-token-head variants for FP8 KV

Other:
  - scheduler.cuh: fix int64→uint32 narrowing with static_cast for CUDA 13
    + GCC 14 (PartitionPagedKVCacheBinarySearchMinNumPagePerBatch)

Tests: all pass across 10 files (include 4 new files) covering jit/non-jit, paged/ragged, fp16/bf16, fp8_e4m3, MHA/GQA, head_dim 64/128/256, NHD/HND, ROPE_LLAMA, causal and large-batch.

<!-- .github/pull_request_template.md -->

## 📌 Description

Add fp8 per-token-head inline scale kv cache quantization.

## 🔍 Related Issues

#3617

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an FP8 per‑token‑head (PTH) scaling option across single/batch prefill, single/batch decode, and BatchAttention via a boolean flag.

* **Improvements**
  * JIT now generates and dispatches dedicated PTH kernel variants and adjusts shared-memory/launch parameters accordingly.
  * Public APIs accept scalar float K/V FP8 dequantization scales.
  * When PTH is enabled, backend selection/validation is enforced (including rejecting unsupported backends).

* **Tests**
  * Added GPU-focused correctness/accuracy test coverage for PTH, plus SM capability guards and backend assertion checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->