### PR TITLE
docs: add missing parameter entries to docstrings and env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -522,6 +522,8 @@ Used by `flashinfer.trace` / `fi_trace`.
 |----------|---------|---------|--------|
 | `FLASHINFER_TRACE_DUMP` | unset | `flashinfer/fi_trace.py` | If set, decorated APIs auto-dump benchmark-definition JSON for each call (the "fi_trace" feature). |
 | `FLASHINFER_TRACE_DUMP_DIR` | cwd | `flashinfer/fi_trace.py` | Directory where the trace JSON files are written. |
+| `FLASHINFER_TRACE_APPLY` | `0` | `flashinfer/__init__.py`, `flashinfer/trace_apply/config.py` | Set to `1` to enable Trace Apply (runtime kernel substitution) when FlashInfer is imported. |
+| `FLASHINFER_TRACE_APPLY_PATH` | unset | `flashinfer/trace_apply/config.py` | Directory from which deployment-configured solutions are loaded for Trace Apply. |
 
 ##### Validation / Autotuning / Routing / Kernel Selection
 

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -426,6 +426,14 @@ def moe_a2a_combine(
     payload_in_workspace : bool
         ``True`` if ``payload`` is already a workspace-backed view (skips
         the staging copy).  Defaults to ``False``.
+    output_dtype : Optional[torch.dtype]
+        Optional output data type.  Currently supports ``torch.bfloat16``
+        and ``torch.float8_e4m3fn``.
+    output_scales : Optional[torch.Tensor]
+        Optional output scale tensor for quantized outputs.  Currently
+        supports UE8M0 (packed in ``torch.uint8``) with vector size 32.
+    sf_layout : SfLayout
+        Output swizzle layout.  Defaults to ``SfLayout.layout_linear``.
 
     Returns
     -------
@@ -846,6 +854,14 @@ class MoeAlltoAll:
         payload_in_workspace : bool
             ``True`` if ``payload`` is already a workspace-backed view (skips
             the staging copy).  Defaults to ``False``.
+        output_dtype : Optional[torch.dtype]
+            Optional output data type.  Currently supports ``torch.bfloat16``
+            and ``torch.float8_e4m3fn``.
+        output_scales : Optional[torch.Tensor]
+            Optional output scale tensor for quantized outputs.  Currently
+            supports UE8M0 (packed in ``torch.uint8``) with vector size 32.
+        sf_layout : SfLayout
+            Output swizzle layout.  Defaults to ``SfLayout.layout_linear``.
 
         Returns
         -------

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2882,17 +2882,26 @@ def trtllm_bf16_moe(
         kernel skips the write entirely.  The buffer may be larger than
         ``num_tokens`` for CUDA-graph pre-allocation; only rows
         ``[0, num_tokens)`` are written.
-    gemm1_alpha / gemm1_beta / gemm1_clamp_limit : Optional[torch.Tensor]
+    gemm1_alpha : Optional[torch.Tensor]
         Optional ``[local_num_experts]`` float32 CUDA per-expert SwiGLU OA
-        parameters.  They are supported with ``ActivationType.Swiglu``.  Any
-        subset can be provided: ``gemm1_alpha=None`` uses ``alpha=1.0``,
-        ``gemm1_beta=None`` uses ``beta=0.0``, and
-        ``gemm1_clamp_limit=None`` applies no clamp.  Let GEMM1 output be split
-        as ``X1`` (linear/up half) and ``X2`` (gate half).  If a clamp limit is
-        provided, ``X1 = clamp(X1, -limit, limit)`` and
-        ``X2 = clamp(X2, max=limit)``.  The fused activation output is
-        ``X2 * sigmoid(alpha * X2) * (X1 + beta)``.  Pass raw BF16-path values;
-        no host-side scalar dequant-scale conversion is applied.
+        alpha parameter.  Supported with ``ActivationType.Swiglu``.  Any
+        subset of ``gemm1_alpha``, ``gemm1_beta``, ``gemm1_clamp_limit``
+        can be provided independently.  When ``None`` (default),
+        ``alpha=1.0`` is used.  Let GEMM1 output be split as ``X1``
+        (linear/up half) and ``X2`` (gate half).  The fused activation
+        output is ``X2 * sigmoid(alpha * X2) * (X1 + beta)``.  Pass raw
+        BF16-path values; no host-side scalar dequant-scale conversion is
+        applied.
+    gemm1_beta : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 CUDA per-expert SwiGLU OA
+        beta parameter.  Supported with ``ActivationType.Swiglu``.  When
+        ``None`` (default), ``beta=0.0`` is used.
+    gemm1_clamp_limit : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 CUDA per-expert clamp
+        limit.  Supported with ``ActivationType.Swiglu``.  When provided,
+        ``X1 = clamp(X1, -limit, limit)`` and
+        ``X2 = clamp(X2, max=limit)``.  When ``None`` (default), no clamp
+        is applied.
 
     Returns
     -------
@@ -3064,17 +3073,26 @@ def trtllm_bf16_routed_moe(
         kernel skips the write entirely.  The buffer may be larger than
         ``num_tokens`` for CUDA-graph pre-allocation; only rows
         ``[0, num_tokens)`` are written.
-    gemm1_alpha / gemm1_beta / gemm1_clamp_limit : Optional[torch.Tensor]
+    gemm1_alpha : Optional[torch.Tensor]
         Optional ``[local_num_experts]`` float32 CUDA per-expert SwiGLU OA
-        parameters.  They are supported with ``ActivationType.Swiglu``.  Any
-        subset can be provided: ``gemm1_alpha=None`` uses ``alpha=1.0``,
-        ``gemm1_beta=None`` uses ``beta=0.0``, and
-        ``gemm1_clamp_limit=None`` applies no clamp.  Let GEMM1 output be split
-        as ``X1`` (linear/up half) and ``X2`` (gate half).  If a clamp limit is
-        provided, ``X1 = clamp(X1, -limit, limit)`` and
-        ``X2 = clamp(X2, max=limit)``.  The fused activation output is
-        ``X2 * sigmoid(alpha * X2) * (X1 + beta)``.  Pass raw BF16-path values;
-        no host-side scalar dequant-scale conversion is applied.
+        alpha parameter.  Supported with ``ActivationType.Swiglu``.  Any
+        subset of ``gemm1_alpha``, ``gemm1_beta``, ``gemm1_clamp_limit``
+        can be provided independently.  When ``None`` (default),
+        ``alpha=1.0`` is used.  Let GEMM1 output be split as ``X1``
+        (linear/up half) and ``X2`` (gate half).  The fused activation
+        output is ``X2 * sigmoid(alpha * X2) * (X1 + beta)``.  Pass raw
+        BF16-path values; no host-side scalar dequant-scale conversion is
+        applied.
+    gemm1_beta : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 CUDA per-expert SwiGLU OA
+        beta parameter.  Supported with ``ActivationType.Swiglu``.  When
+        ``None`` (default), ``beta=0.0`` is used.
+    gemm1_clamp_limit : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 CUDA per-expert clamp
+        limit.  Supported with ``ActivationType.Swiglu``.  When provided,
+        ``X1 = clamp(X1, -limit, limit)`` and
+        ``X2 = clamp(X2, max=limit)``.  When ``None`` (default), no clamp
+        is applied.
 
     Returns
     -------
@@ -3403,18 +3421,29 @@ def trtllm_fp8_block_scale_moe(
         matches ``topk_indices``.  When ``None`` (default) the kernel skips
         the write entirely.  The buffer may be larger than ``num_tokens`` for
         CUDA-graph pre-allocation; only rows ``[0, num_tokens)`` are written.
-    gemm1_alpha / gemm1_beta / gemm1_clamp_limit : Optional[torch.Tensor]
-        Optional ``[local_num_experts]`` float32 per-expert SwiGLU OA
-        parameters. They are currently supported only for
-        ``Fp8QuantizationType.MxFp8`` with ``ActivationType.Swiglu``. Any
-        subset can be provided: ``gemm1_alpha=None`` uses ``alpha=1.0``,
-        ``gemm1_beta=None`` uses ``beta=0.0``, and
-        ``gemm1_clamp_limit=None`` applies no clamp. Let GEMM1 output be split
-        as ``X1`` (linear/up half) and ``X2`` (gate half). If a clamp limit is
-        provided, ``X1 = clamp(X1, -limit, limit)`` and
-        ``X2 = clamp(X2, max=limit)``. The fused activation output is
-        ``X2 * sigmoid(alpha * X2) * (X1 + beta)``. Pass raw values for MxFp8;
-        no host-side scalar dequant-scale conversion is applied.
+    gemm1_alpha : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 per-expert SwiGLU OA alpha
+        parameter.  Currently supported only for
+        ``Fp8QuantizationType.MxFp8`` with ``ActivationType.Swiglu``.  Any
+        subset of ``gemm1_alpha``, ``gemm1_beta``, ``gemm1_clamp_limit``
+        can be provided independently.  When ``None`` (default),
+        ``alpha=1.0`` is used.  Let GEMM1 output be split as ``X1``
+        (linear/up half) and ``X2`` (gate half).  The fused activation
+        output is ``X2 * sigmoid(alpha * X2) * (X1 + beta)``.  Pass raw
+        values for MxFp8; no host-side scalar dequant-scale conversion is
+        applied.
+    gemm1_beta : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 per-expert SwiGLU OA beta
+        parameter.  Currently supported only for
+        ``Fp8QuantizationType.MxFp8`` with ``ActivationType.Swiglu``.
+        When ``None`` (default), ``beta=0.0`` is used.
+    gemm1_clamp_limit : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 per-expert clamp limit.
+        Currently supported only for ``Fp8QuantizationType.MxFp8`` with
+        ``ActivationType.Swiglu``.  When provided,
+        ``X1 = clamp(X1, -limit, limit)`` and
+        ``X2 = clamp(X2, max=limit)``.  When ``None`` (default), no clamp
+        is applied.
 
     Returns
     -------
@@ -3610,18 +3639,29 @@ def trtllm_fp8_block_scale_routed_moe(
     activation_type : int
         Activation type (default ``3`` — Swiglu).  ``3`` Swiglu; ``4`` Geglu;
         ``6`` Relu2; ``7`` Identity.
-    gemm1_alpha / gemm1_beta / gemm1_clamp_limit : Optional[torch.Tensor]
-        Optional ``[local_num_experts]`` float32 per-expert SwiGLU OA
-        parameters. They are currently supported only for
-        ``Fp8QuantizationType.MxFp8`` with ``ActivationType.Swiglu``. Any
-        subset can be provided: ``gemm1_alpha=None`` uses ``alpha=1.0``,
-        ``gemm1_beta=None`` uses ``beta=0.0``, and
-        ``gemm1_clamp_limit=None`` applies no clamp. Let GEMM1 output be split
-        as ``X1`` (linear/up half) and ``X2`` (gate half). If a clamp limit is
-        provided, ``X1 = clamp(X1, -limit, limit)`` and
-        ``X2 = clamp(X2, max=limit)``. The fused activation output is
-        ``X2 * sigmoid(alpha * X2) * (X1 + beta)``. Pass raw values for MxFp8;
-        no host-side scalar dequant-scale conversion is applied.
+    gemm1_alpha : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 per-expert SwiGLU OA alpha
+        parameter.  Currently supported only for
+        ``Fp8QuantizationType.MxFp8`` with ``ActivationType.Swiglu``.  Any
+        subset of ``gemm1_alpha``, ``gemm1_beta``, ``gemm1_clamp_limit``
+        can be provided independently.  When ``None`` (default),
+        ``alpha=1.0`` is used.  Let GEMM1 output be split as ``X1``
+        (linear/up half) and ``X2`` (gate half).  The fused activation
+        output is ``X2 * sigmoid(alpha * X2) * (X1 + beta)``.  Pass raw
+        values for MxFp8; no host-side scalar dequant-scale conversion is
+        applied.
+    gemm1_beta : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 per-expert SwiGLU OA beta
+        parameter.  Currently supported only for
+        ``Fp8QuantizationType.MxFp8`` with ``ActivationType.Swiglu``.
+        When ``None`` (default), ``beta=0.0`` is used.
+    gemm1_clamp_limit : Optional[torch.Tensor]
+        Optional ``[local_num_experts]`` float32 per-expert clamp limit.
+        Currently supported only for ``Fp8QuantizationType.MxFp8`` with
+        ``ActivationType.Swiglu``.  When provided,
+        ``X1 = clamp(X1, -limit, limit)`` and
+        ``X2 = clamp(X2, max=limit)``.  When ``None`` (default), no clamp
+        is applied.
 
     Returns
     -------

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -7243,6 +7243,11 @@ def group_gemm_fp8_nt_groupwise(
     out_dtype: Optional[torch.dtype]
         The data type of the output tensor, must be ``torch.bfloat16`` or ``torch.float16``.
 
+    backend: Literal["trtllm", "cutile"]
+        Backend implementation to use.  ``"trtllm"`` uses the TensorRT-LLM
+        grouped GEMM kernel; ``"cutile"`` uses the cuTile Python kernel.
+        Defaults to ``"trtllm"``.
+
     Returns
     -------
     out: torch.Tensor


### PR DESCRIPTION
## Summary

- **moe_a2a_combine / MoeAlltoAll.combine**: document `output_dtype`, `output_scales`, `sf_layout` parameters that were present in the signature but missing from the numpydoc Parameters section.
- **trtllm_bf16_moe / trtllm_bf16_routed_moe**: split the combined `gemm1_alpha / gemm1_beta / gemm1_clamp_limit` entry into three separate numpydoc entries so automated doc checkers can parse them.
- **group_gemm_fp8_nt_groupwise**: document the `backend` parameter (added in #3426).
- **CLAUDE.md**: add `FLASHINFER_TRACE_APPLY` and `FLASHINFER_TRACE_APPLY_PATH` to the Trace Capture env var table.

## Test plan

- [ ] Verify `pre-commit run -a` passes (already verified at commit time)
- [ ] Confirm Sphinx doc build does not regress on the modified modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for two new Trace Apply environment variables, including their defaults and where they’re read.
  * Expanded parameter documentation for expert routing and fused/matrix operations, clarifying supported output/data/layout options, default behaviors, quantization scale packing, activation/clamping semantics, and the default backend selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->