### PR TITLE
Add non-causal TRTLLM-gen GQA decode

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -208,11 +208,10 @@ void trtllm_paged_attention_launcher(
     runner_params.cumSeqLensKvPtr = cum_seq_lens_kv;
   } else {
     // Generation.
-    // Note that kernel names are still labeled as using a dense mask even when maskType is
-    // specified as causal, this is expected for better performance as each CTA will only process
-    // one tokenQ in those cases, so dense mask works the same as causal mask.
+    // Dense and causal are equivalent only when each CTA sees one query token.
     runner_params.mMaskType =
-        is_mla_decode ? TrtllmGenAttentionMaskType::Dense : TrtllmGenAttentionMaskType::Causal;
+        (is_mla_decode || !is_causal) ? TrtllmGenAttentionMaskType::Dense
+                                      : TrtllmGenAttentionMaskType::Causal;
     runner_params.mKernelType = FmhaKernelType::Generation;
     bool use_multi_block = true;
     runner_params.mTileScheduler =
@@ -304,7 +303,7 @@ void trtllm_paged_attention_decode(
     Variant<double, ffi::Tensor> bmm1_scale, Variant<double, ffi::Tensor> bmm2_scale,
     double o_sf_scale, int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t batch_size,
     int64_t window_left, int64_t sparse_mla_top_k, int64_t sm_count, bool enable_pdl,
-    int64_t workspace_size, Optional<TensorView> attention_sinks,
+    bool is_causal, int64_t workspace_size, Optional<TensorView> attention_sinks,
     Optional<TensorView> cum_seq_lens_q, Optional<TensorView> key_block_scales,
     Optional<TensorView> value_block_scales, Optional<float> skip_softmax_threshold_scale_factor,
     Optional<bool> uses_shared_paged_kv_idx, Optional<TensorView> lse, int64_t lse_stride_tokens,
@@ -422,6 +421,11 @@ void trtllm_paged_attention_decode(
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
+  TVM_FFI_CHECK(
+      is_causal || window_left == -1,
+      "Sliding-window non-causal attention is not supported for trtllm-gen decode. "
+      "Use window_left=-1 for dense bidirectional attention.");
+
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),
       workspace_buffer.data_ptr(), static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr,
@@ -436,7 +440,7 @@ void trtllm_paged_attention_decode(
       /*sparse_mla_top_k_lens=*/nullptr, /*has_sliding_window_kv_pool=*/false,
       skip_softmax_threshold_scale_factor_value, skips_softmax, uses_shared_paged_kv_idx_value,
       sm_count, enable_pdl, workspace_size, k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads,
-      v_sf_stride_batch, /*is_causal=*/true, lse_stride_tokens, lse_stride_heads, stream);
+      v_sf_stride_batch, is_causal, lse_stride_tokens, lse_stride_heads, stream);
 }
 
 void trtllm_paged_attention_context(

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -209,9 +209,8 @@ void trtllm_paged_attention_launcher(
   } else {
     // Generation.
     // Dense and causal are equivalent only when each CTA sees one query token.
-    runner_params.mMaskType =
-        (is_mla_decode || !is_causal) ? TrtllmGenAttentionMaskType::Dense
-                                      : TrtllmGenAttentionMaskType::Causal;
+    runner_params.mMaskType = (is_mla_decode || !is_causal) ? TrtllmGenAttentionMaskType::Dense
+                                                            : TrtllmGenAttentionMaskType::Causal;
     runner_params.mKernelType = FmhaKernelType::Generation;
     bool use_multi_block = true;
     runner_params.mTileScheduler =
@@ -421,10 +420,9 @@ void trtllm_paged_attention_decode(
       skip_softmax_threshold_scale_factor.value_or(0.0f);
   bool const skips_softmax = skip_softmax_threshold_scale_factor_value != 0.0f;
 
-  TVM_FFI_CHECK(
-      is_causal || window_left == -1,
-      "Sliding-window non-causal attention is not supported for trtllm-gen decode. "
-      "Use window_left=-1 for dense bidirectional attention.");
+  TVM_FFI_CHECK(is_causal || window_left == -1,
+                "Sliding-window non-causal attention is not supported for trtllm-gen decode. "
+                "Use window_left=-1 for dense bidirectional attention.");
 
   trtllm_paged_attention_launcher(
       out.data_ptr(), output_sf_ptr, query.data_ptr(), key_cache.data_ptr(), value_cache.data_ptr(),

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -865,6 +865,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     device=float_workspace_buffer.device,
                 )
         self._backend = backend
+        self._is_causal = True
 
         self._cute_dsl_wrapper = None
         if backend == "cute-dsl":
@@ -1122,6 +1123,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
         q_len_per_req: int = 1,
+        is_causal: bool = True,
     ) -> None:
         r"""Plan batch decode for given problem specification.
 
@@ -1192,6 +1194,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             Whether to disable the split-kv for determinism in CUDA Graph, defaults to ``False``.
         q_len_per_req : int
             The number of query tokens per request. Defaults to ``1``.
+        is_causal : bool
+            Whether to apply causal masking for speculative decode. Defaults to ``True``.
         Note
         ----
         The :meth:`plan` method should be called before any :meth:`run` or
@@ -1335,7 +1339,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 kv_splits=kv_splits,
                 reduction="none" if disable_split_kv else "auto",
                 q_len_per_req=q_len_per_req,
-                is_causal=True,
+                is_causal=is_causal,
                 max_kv_len=self._max_kv_len,
                 non_blocking=non_blocking,
             )
@@ -1484,6 +1488,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
         self._q_len_per_req = q_len_per_req
+        self._is_causal = is_causal
 
     begin_forward = plan
 
@@ -1880,6 +1885,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                         value_block_scales,
                         skip_softmax_threshold_scale_factor,
                         True,  # uses_shared_paged_kv_idx
+                        self._is_causal,
                     ]
                 else:
                     run_args += [
@@ -2502,6 +2508,7 @@ class TrtllmGenDecodeModule:
         workspace_size: int,
         window_left: int = -1,
         enable_pdl: bool = None,
+        is_causal: bool = True,
         out: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         key_block_scales: Optional[torch.Tensor] = None,
@@ -2555,6 +2562,7 @@ class TrtllmGenDecodeModule:
             0,  # sparse_mla_top_k
             self._sm_count,
             enable_pdl,
+            is_causal,
             workspace_size,
             sinks,
             None,  # cum_seq_lens_q
@@ -2630,6 +2638,7 @@ def get_trtllm_gen_decode_module(*args):
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        is_causal: bool = True,
     ) -> None:
         assert paged_kv_cache is not None
         assert num_qo_heads is not None
@@ -2653,6 +2662,7 @@ def get_trtllm_gen_decode_module(*args):
             workspace_size,
             window_left,
             enable_pdl,
+            is_causal,
             out=o,
             sinks=sinks,
             key_block_scales=key_block_scales,
@@ -2703,6 +2713,7 @@ def get_trtllm_gen_decode_module(*args):
         value_block_scales: Optional[torch.Tensor] = None,
         skip_softmax_threshold_scale_factor: Optional[float] = None,
         uses_shared_paged_kv_idx: bool = True,
+        is_causal: bool = True,
     ) -> None:
         pass
 
@@ -2740,6 +2751,7 @@ def trtllm_batch_decode_with_kv_cache(
     mask: Optional[torch.Tensor] = None,
     max_q_len: Optional[int] = None,
     cum_seq_lens_q: Optional[torch.Tensor] = None,
+    is_causal: bool = True,
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     uses_shared_paged_kv_idx: bool = True,
@@ -2854,6 +2866,11 @@ def trtllm_batch_decode_with_kv_cache(
         Only supported by trtllm-gen backend. Must be provided together with ``max_q_len``.
         When None, all requests use uniform query length specified by ``q_len_per_req``.
 
+    is_causal : bool = True
+        Whether to apply causal masking in the TRTLLM-gen decode path. If ``False``,
+        use dense bidirectional attention. Only supported with ``window_left=-1``.
+        This has no numerical effect for ``q_len_per_req=1``.
+
     skip_softmax_threshold_scale_factor: Optional[float] = None
         threshold scale factor for skipping softmax operations.
         Providing a value for this parameter enables skip-softmax sparsity as described in: https://arxiv.org/abs/2512.12087
@@ -2966,6 +2983,10 @@ def trtllm_batch_decode_with_kv_cache(
             raise NotImplementedError(
                 "xqa backend does not support return_lse/lse output"
             )
+        if not is_causal:
+            raise NotImplementedError(
+                "is_causal=False is only supported by the trtllm-gen backend"
+            )
 
         # Handle out and out_dtype
         if out_dtype is None:
@@ -2994,6 +3015,11 @@ def trtllm_batch_decode_with_kv_cache(
             mask=mask,
         )
     elif backend == "trtllm-gen":
+        if not is_causal and window_left != -1:
+            raise ValueError(
+                "Sliding-window non-causal attention is not supported for "
+                "trtllm-gen decode. Use window_left=-1 for dense bidirectional attention."
+            )
         # Convert NHD layout to HND if necessary
         if kv_layout == "NHD":
             k_cache = k_cache.transpose(-3, -2)
@@ -3136,6 +3162,7 @@ def trtllm_batch_decode_with_kv_cache(
             0,  # sparse_mla_top_k
             sm_count,
             enable_pdl,
+            is_causal,
             workspace_buffer.numel() * workspace_buffer.element_size(),
             sinks,
             cum_seq_lens_q,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1308,6 +1308,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     f"cute-dsl decode backend does not support "
                     f"pos_encoding_mode={pos_encoding_mode!r}"
                 )
+            if not is_causal:
+                raise NotImplementedError(
+                    "cute-dsl decode backend does not support is_causal=False"
+                )
             self._max_kv_len = int(max(kv_lens_arr_host).item())
             kv_splits = None
             if fixed_split_size > 0:

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -1611,8 +1611,9 @@ def _trtllm_paged_attention_reference(
 def _trtllm_batch_decode_reference(
     query, kv_cache, workspace_buffer, block_tables, seq_lens, max_seq_len, **kwargs
 ):
+    is_causal = kwargs.pop("is_causal", True)
     return _trtllm_paged_attention_reference(
-        query, kv_cache, block_tables, seq_lens, causal=False, **kwargs
+        query, kv_cache, block_tables, seq_lens, causal=is_causal, **kwargs
     )
 
 
@@ -1655,6 +1656,7 @@ def _trtllm_batch_decode_init(
     kv_cache_dim: int = 2,
     batch_size: int = 1,
     max_pages_per_seq: int = 0,
+    is_causal: bool = True,
     device: str = "cuda",
     seed: int = 0,
 ):
@@ -1698,6 +1700,7 @@ def _trtllm_batch_decode_init(
         "bmm2_scale": 1.0,
         "kv_layout": "HND",
         "q_len_per_req": int(q_len_per_req),
+        "is_causal": is_causal,
     }
 
 
@@ -1804,6 +1807,11 @@ trtllm_batch_decode_trace = TraceTemplate(
         ),
         "bmm2_scale": Scalar(
             "float32", optional=True, description="Scale applied after softmax @ V."
+        ),
+        "is_causal": Scalar(
+            "bool",
+            optional=True,
+            description="Whether decode uses causal rather than dense attention.",
         ),
     },
     outputs={

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -529,6 +529,7 @@ def sdpa_paged_reference(
     head_dim: int,
     kv_layout: str,
     window_left: int,
+    is_causal: bool = True,
 ):
     """Pure PyTorch SDPA reference for head dims unsupported by FlashInfer kernels.
 
@@ -593,14 +594,16 @@ def sdpa_paged_reference(
         k_t = k_exp.transpose(0, 1).float()  # [num_qo_heads, s_len, head_dim]
         v_t = v_exp.transpose(0, 1).float()  # [num_qo_heads, s_len, head_dim]
 
-        # Build causal mask: query position i can attend to kv position j if j <= (s_len - q_len) + i
-        kv_offset = s_len - q_len
-        q_pos = torch.arange(q_len, device=q_b.device).unsqueeze(1) + kv_offset
-        k_pos = torch.arange(s_len, device=q_b.device).unsqueeze(0)
-        causal_mask = k_pos <= q_pos  # [q_len, s_len]
-        if window_left >= 0:
-            causal_mask = causal_mask & (q_pos - k_pos <= window_left)
-        attn_mask = causal_mask.unsqueeze(0).expand(num_qo_heads, -1, -1)
+        if is_causal:
+            kv_offset = s_len - q_len
+            q_pos = torch.arange(q_len, device=q_b.device).unsqueeze(1) + kv_offset
+            k_pos = torch.arange(s_len, device=q_b.device).unsqueeze(0)
+            attn_mask = k_pos <= q_pos
+            if window_left >= 0:
+                attn_mask = attn_mask & (q_pos - k_pos <= window_left)
+            attn_mask = attn_mask.unsqueeze(0).expand(num_qo_heads, -1, -1)
+        else:
+            attn_mask = None
 
         out_b = torch.nn.functional.scaled_dot_product_attention(
             q_t,
@@ -640,6 +643,7 @@ def _test_trtllm_batch_decode(
     return_lse: bool | None = None,
     provide_lse: bool = False,
     use_bmm1_scale_log2: bool = False,
+    is_causal: bool = True,
 ) -> None:
     """
     Common function for testing trtllm-gen decode.
@@ -656,6 +660,10 @@ def _test_trtllm_batch_decode(
 
     if backend == "xqa" and skips_softmax:
         pytest.skip("xqa backend does not support skips_softmax")
+    if backend == "xqa" and not is_causal:
+        pytest.skip("is_causal=False is only covered by trtllm-gen decode")
+    if enable_sink and not is_causal:
+        pytest.skip("non-causal sink attention is outside this decode coverage")
 
     if skips_softmax and q_dtype != kv_dtype:
         pytest.skip(
@@ -770,6 +778,7 @@ def _test_trtllm_batch_decode(
             head_dim,
             kv_layout,
             window_left,
+            is_causal,
         )
     elif not enable_sink:
         if q_len_per_req is not None and q_len_per_req == 1:
@@ -792,7 +801,7 @@ def _test_trtllm_batch_decode(
                     "paged_kv_indices": plan_params_prefill.pop("indices"),
                     "paged_kv_last_page_len": plan_params_prefill.pop("last_page_len"),
                     "head_dim_qk": plan_params_prefill.pop("head_dim"),
-                    "causal": True,
+                    "causal": is_causal,
                     "logits_soft_cap": 0.0,
                 }
             )
@@ -814,7 +823,7 @@ def _test_trtllm_batch_decode(
             v_flat,
             sink,
             window_left,
-            True,
+            is_causal,
             sm_scale,
             mode="varlen",
             batch_size=batch_size,
@@ -822,7 +831,35 @@ def _test_trtllm_batch_decode(
             kv_indptr=kv_indptr_tokens,
         )
 
-    if q_len_per_req and q_len_per_req > 1:
+    if (
+        not is_causal
+        and q_len_per_req is not None
+        and q_len_per_req > 1
+        and not enable_sink
+        and head_dim <= 256
+    ):
+        causal_wrapper_ref = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+            workspace_buffer_ref, kv_layout
+        )
+        causal_plan_params = plan_params.copy()
+        causal_plan_params.update(
+            {
+                "qo_indptr": q_indptr,
+                "paged_kv_indptr": causal_plan_params.pop("indptr"),
+                "paged_kv_indices": causal_plan_params.pop("indices"),
+                "paged_kv_last_page_len": causal_plan_params.pop("last_page_len"),
+                "head_dim_qk": causal_plan_params.pop("head_dim"),
+                "causal": True,
+                "logits_soft_cap": 0.0,
+            }
+        )
+        causal_wrapper_ref.plan(**causal_plan_params)
+        causal_ref = causal_wrapper_ref.run(ref_q, ref_kv_cache)
+        assert not torch.allclose(
+            output_ref.float(), causal_ref.float(), atol=1e-3, rtol=1e-3
+        )
+
+    if is_causal and q_len_per_req and q_len_per_req > 1:
         # only used for xqa speculative decoding
         mask = generate_causal_mask(batch_size, q_len_per_req, GPU_DEVICE)
     else:
@@ -932,6 +969,7 @@ def _test_trtllm_batch_decode(
         mask=mask,
         max_q_len=max_q_len if max_q_len is not None else None,
         cum_seq_lens_q=q_indptr if max_q_len is not None else None,
+        is_causal=is_causal,
         skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
         kv_cache_sf=kv_cache_sf_kernel,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
@@ -1047,10 +1085,12 @@ def _test_trtllm_batch_decode(
         wrapper_trtllm_gen = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
             workspace_buffer, kv_layout, backend="trtllm-gen"
         )
-        plan_params["q_data_type"] = q.dtype
-        plan_params["kv_data_type"] = kv_cache.dtype
-        plan_params["o_data_type"] = DTYPE_MAP[o_dtype]
-        wrapper_trtllm_gen.plan(**plan_params)
+        wrapper_plan_params = plan_params.copy()
+        wrapper_plan_params["q_data_type"] = q.dtype
+        wrapper_plan_params["kv_data_type"] = kv_cache.dtype
+        wrapper_plan_params["o_data_type"] = DTYPE_MAP[o_dtype]
+        wrapper_plan_params["is_causal"] = is_causal
+        wrapper_trtllm_gen.plan(**wrapper_plan_params)
         output_wrapper = wrapper_trtllm_gen.run(
             q_input,
             kv_cache,
@@ -1250,6 +1290,135 @@ def test_trtllm_batch_decode_bmm1_scale_log2(q_dtype, kv_dtype, o_dtype, device_
         uses_shared_paged_kv_idx=True,
         use_bmm1_scale_log2=True,
     )
+
+
+@pytest.mark.xfail(
+    reason="Dense paged GQA generation cubins (headDimQk=128) missing from flashinfer-cubin; "
+    "remove once TRT-LLM ships the matching instantiations",
+    strict=False,
+)
+def test_trtllm_batch_decode_non_causal_gqa() -> None:
+    _test_trtllm_batch_decode(
+        "trtllm-gen",
+        "HND",
+        batch_size=2,
+        q_len_per_req=4,
+        page_size=16,
+        num_kv_heads=2,
+        head_grp_size=4,
+        window_left=-1,
+        q_dtype="bf16",
+        o_dtype="bf16",
+        kv_dtype="bf16",
+        enable_pdl=None,
+        enable_sink=False,
+        max_in_kv_len=110,
+        head_dim=128,
+        is_causal=False,
+    )
+
+
+@pytest.mark.xfail(
+    reason="Dense paged GQA generation cubins (headDimQk=128) missing from flashinfer-cubin; "
+    "remove once TRT-LLM ships the matching instantiations",
+    strict=False,
+)
+def test_trtllm_batch_decode_non_causal_q_len1_compatibility() -> None:
+    _test_trtllm_batch_decode(
+        "trtllm-gen",
+        "HND",
+        batch_size=2,
+        q_len_per_req=1,
+        page_size=16,
+        num_kv_heads=2,
+        head_grp_size=4,
+        window_left=-1,
+        q_dtype="bf16",
+        o_dtype="bf16",
+        kv_dtype="bf16",
+        enable_pdl=None,
+        enable_sink=False,
+        max_in_kv_len=110,
+        head_dim=128,
+        is_causal=False,
+    )
+
+
+@pytest.mark.xfail(
+    reason="Dense paged GQA generation cubins (headDimQk=128) missing from flashinfer-cubin; "
+    "remove once TRT-LLM ships the matching instantiations",
+    strict=False,
+)
+def test_trtllm_batch_decode_non_causal_fp8_kv() -> None:
+    _test_trtllm_batch_decode(
+        "trtllm-gen",
+        "HND",
+        batch_size=2,
+        q_len_per_req=4,
+        page_size=16,
+        num_kv_heads=2,
+        head_grp_size=4,
+        window_left=-1,
+        q_dtype="fp8",
+        o_dtype="bf16",
+        kv_dtype="fp8",
+        enable_pdl=None,
+        enable_sink=False,
+        max_in_kv_len=110,
+        head_dim=128,
+        device_scale=True,
+        is_causal=False,
+    )
+
+
+@pytest.mark.xfail(
+    reason="Dense paged GQA generation cubins (headDimQk=128) missing from flashinfer-cubin; "
+    "remove once TRT-LLM ships the matching instantiations",
+    strict=False,
+)
+def test_trtllm_batch_decode_non_causal_nvfp4_kv() -> None:
+    _test_trtllm_batch_decode(
+        "trtllm-gen",
+        "HND",
+        batch_size=2,
+        q_len_per_req=4,
+        page_size=16,
+        num_kv_heads=2,
+        head_grp_size=4,
+        window_left=-1,
+        q_dtype="fp8",
+        o_dtype="fp8",
+        kv_dtype="nvfp4",
+        enable_pdl=None,
+        enable_sink=False,
+        max_in_kv_len=110,
+        head_dim=128,
+        device_scale=True,
+        is_causal=False,
+    )
+
+
+def test_trtllm_batch_decode_non_causal_rejects_sliding_window() -> None:
+    _skip_if_not_blackwell()
+    q = torch.randn(8, 8, 128, dtype=torch.bfloat16, device=GPU_DEVICE)
+    kv_cache = torch.randn(4, 2, 2, 16, 128, dtype=torch.bfloat16, device=GPU_DEVICE)
+    block_tables = torch.arange(4, dtype=torch.int32, device=GPU_DEVICE).reshape(2, 2)
+    seq_lens = torch.full((2,), 32, dtype=torch.int32, device=GPU_DEVICE)
+    workspace = torch.empty(workspace_size, dtype=torch.int8, device=GPU_DEVICE)
+
+    with pytest.raises(ValueError, match="Sliding-window non-causal"):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            q,
+            kv_cache,
+            workspace,
+            block_tables,
+            seq_lens,
+            max_seq_len=32,
+            window_left=127,
+            backend="trtllm-gen",
+            q_len_per_req=4,
+            is_causal=False,
+        )
 
 
 @pytest.mark.parametrize("kv_layout", ["HND"])  # trtllm-gen only support HND

--- a/tests/trace/test_trtllm_batch_decode_reference_correctness.py
+++ b/tests/trace/test_trtllm_batch_decode_reference_correctness.py
@@ -51,6 +51,11 @@ from tests.trace.reference_utils import (
                 is_causal=False,
             ),
             id="B2-Q4-Hq8-Hk2-D128-PS16-MP2-dense",
+            marks=pytest.mark.xfail(
+                reason="Dense paged GQA generation cubins (headDimQk=128) missing from "
+                "flashinfer-cubin; remove once TRT-LLM ships the matching instantiations",
+                strict=False,
+            ),
         ),
     ],
 )

--- a/tests/trace/test_trtllm_batch_decode_reference_correctness.py
+++ b/tests/trace/test_trtllm_batch_decode_reference_correctness.py
@@ -21,6 +21,8 @@ from tests.trace.reference_utils import (
                 head_dim=128,
                 page_size=16,
                 max_pages_per_seq=2,
+                q_len_per_req=1,
+                is_causal=True,
             ),
             id="B2-Hq8-Hk2-D128-PS16-MP2",
         ),
@@ -32,8 +34,23 @@ from tests.trace.reference_utils import (
                 head_dim=128,
                 page_size=16,
                 max_pages_per_seq=3,
+                q_len_per_req=1,
+                is_causal=True,
             ),
             id="B1-Hq8-Hk2-D128-PS16-MP3",
+        ),
+        pytest.param(
+            dict(
+                batch_size=2,
+                num_qo_heads=8,
+                num_kv_heads=2,
+                head_dim=128,
+                page_size=16,
+                max_pages_per_seq=2,
+                q_len_per_req=4,
+                is_causal=False,
+            ),
+            id="B2-Q4-Hq8-Hk2-D128-PS16-MP2-dense",
         ),
     ],
 )
@@ -52,11 +69,13 @@ def test_trtllm_batch_decode_reference_correctness(shape_kwargs):
     D = shape_kwargs["head_dim"]
     PS = shape_kwargs["page_size"]
     MP = shape_kwargs["max_pages_per_seq"]  # pages per seq
+    Q = shape_kwargs["q_len_per_req"]
+    is_causal = shape_kwargs["is_causal"]
     NP = B * MP
     kv_len = PS * MP
     # HND layout for the kernel: [num_pages, 2, num_kv_heads, page_size, head_dim]
     kv_cache_hnd = torch.randn(NP, 2, Hk, PS, D, dtype=torch.bfloat16, device="cuda")
-    q = torch.randn(B, Hq, D, dtype=torch.bfloat16, device="cuda")
+    q = torch.randn(B * Q, Hq, D, dtype=torch.bfloat16, device="cuda")
     block_tables = torch.arange(NP, dtype=torch.int32, device="cuda").reshape(B, MP)
     seq_lens = torch.full((B,), kv_len, dtype=torch.int32, device="cuda")
     workspace = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device="cuda")
@@ -71,6 +90,8 @@ def test_trtllm_batch_decode_reference_correctness(shape_kwargs):
         bmm1_scale=sm_scale,
         bmm2_scale=1.0,
         kv_layout="HND",
+        q_len_per_req=Q,
+        is_causal=is_causal,
     )
     ref_out = trtllm_batch_decode_trace.reference(
         q,
@@ -82,7 +103,24 @@ def test_trtllm_batch_decode_reference_correctness(shape_kwargs):
         bmm1_scale=sm_scale,
         bmm2_scale=1.0,
         kv_layout="HND",
+        q_len_per_req=Q,
+        is_causal=is_causal,
     )
+    if Q > 1 and not is_causal:
+        causal_ref = trtllm_batch_decode_trace.reference(
+            q,
+            kv_cache_hnd,
+            workspace,
+            block_tables,
+            seq_lens,
+            kv_len,
+            bmm1_scale=sm_scale,
+            bmm2_scale=1.0,
+            kv_layout="HND",
+            q_len_per_req=Q,
+            is_causal=True,
+        )
+        assert not torch.allclose(ref_out, causal_ref, atol=1e-3, rtol=1e-3)
     # Matches tests/attention/test_cudnn_decode.py / trtllm_gen bf16 tolerance.
     _check(trtllm_batch_decode_trace, ref_out, api_out, atol=1e-2, rtol=1e-2)
     if torch.cuda.is_available():


### PR DESCRIPTION
## 📌 Description

Add `is_causal: bool = True` to the TRTLLM-gen paged decode path, exposing dense (bidirectional) attention for diffusion LLMs (LLaDA, DiffusionGemma) and speculative decode shapes with `q_len_per_req > 1`.

Changes:
- `trtllm_fmha_kernel_launcher.cu`: add `bool is_causal` to `trtllm_paged_attention_decode`, replace hard-coded `/*is_causal=*/true`, update ForGen mask selection to `(is_mla_decode || !is_causal) ? Dense : Causal`, add sliding-window guard.
- `decode.py`: expose `is_causal` in `trtllm_batch_decode_with_kv_cache`, `TrtllmGenDecodeModule._paged_run`, and `BatchDecodeWithPagedKVCacheWrapper.plan`.
- `trace/templates/attention.py`: replace hard-coded `causal=False` in the decode reference with the runtime value; add `is_causal` to the trace inputs schema.
- Tests: 5 new non-causal test cases (GQA q_len>1, q_len=1 compat, FP8 KV, NVFP4 KV, sliding-window guard); trace correctness extended with a dense q_len=4 shape.

## 🔍 Related Issues

#3570.

## 🧪 Tests

- [x] Tests added: `test_trtllm_batch_decode_non_causal_*` (5 cases) and trace shape `B2-Q4-dense`.
- [ ] Tests passing: blocked pending Dense paged GQA generation cubins in `flashinfer-cubin`. Current package has Dense paged generation only for MLA head dims (320, 576); GQA head dims (128, 256) are missing. A follow-up TRT-LLM PR is needed to instantiate those cubins. `test_trtllm_batch_decode_non_causal_rejects_sliding_window` passes today.

## Reviewer Notes

The launcher plumbing is complete. Unblocking the remaining 4 tests requires the TRT-LLM cubin gap to be filled — no further changes to this PR are needed once those cubins are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `is_causal` option (default `true`) for paged batch decode to control causal vs. bidirectional attention end-to-end (including trace generation).
  * Added stricter runtime validation to reject unsupported combinations, such as non-causal sliding-window decode.

* **Tests**
  * Expanded coverage for non-causal decode across backends, dtypes, and configurations, including rejection tests for incompatible sliding-window usage.

* **Documentation**
  * Updated public API and trace template descriptions to reflect `is_causal` behavior and supported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->