### PR TITLE
fix: fix tinygemm barrier bug

### DIFF
--- a/csrc/tinygemm2.cu
+++ b/csrc/tinygemm2.cu
@@ -314,8 +314,8 @@ __global__ __launch_bounds__(384, 1) void tinygemm_kernel(
       }
 
       while (!weight_ready || !act_ready) {
-        weight_ready = bar_try_wait(bar_ptr_wt, phase);
-        act_ready = bar_try_wait(bar_ptr_act, phase);
+        weight_ready = bar_try_wait(__cvta_generic_to_shared(&bar_wt_ready[stage]), phase);
+        act_ready = bar_try_wait(__cvta_generic_to_shared(&bar_act_ready[stage]), phase);
       }
 
       if (ki + 1 < K_LOOPS_COMPUTE) {


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix tinygemm barrier bug. Update the integration in FlashInfer. More details in https://github.com/NVIDIA/TensorRT-LLM/pull/15338

Thanks to @LorrinWWW for reporting this bug and for providing a very detailed script to reproduce it.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized GPU kernel synchronization mechanism for improved compute thread efficiency in barrier polling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->