### PR TITLE
fix: remove duplicate all_gather_object in create_shared_buffer

### DIFF
--- a/flashinfer/comm/cuda_ipc.py
+++ b/flashinfer/comm/cuda_ipc.py
@@ -225,8 +225,6 @@ def create_shared_buffer(
     rank = dist.get_rank(group=group)
     handles = [None] * world_size
     dist.all_gather_object(handles, handle, group=group)
-    handles = [None] * world_size
-    dist.all_gather_object(handles, handle, group=group)
 
     pointers: List[int] = []
     for i, h in enumerate(handles):


### PR DESCRIPTION
## 📌 Description

`create_shared_buffer` calls `dist.all_gather_object` twice in a row. The first call gathers IPC handles into `handles`, but `handles` is re-initialized to `[None] * world_size` on the next line before it is ever read, so the result of the first gather is always discarded and only the second is used. This removes the redundant first gather (one fewer startup collective). Behavior is unchanged.

## 🔍 Related Issues

Closes #3508

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed. — Not needed: pure dead-code removal with no behavior change (the removed gather's result was always overwritten before use). `create_shared_buffer` is already covered by `tests/comm/test_vllm_custom_allreduce.py` and `tests/utils/test_create_ipc_buffer.py`.

## Reviewer Notes

The duplicate has been present since the file was added in #1134 (adapted from vLLM). Only the dead first gather is removed; the surviving gather, the IPC-handle loop, and the trailing `dist.barrier` are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code formatting adjustment with no functional impact to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->