### PR TITLE
fix(jit): cap ninja parallelism by available memory to avoid OOM (#3634)

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -357,23 +357,14 @@ def _read_mem_available_gb() -> Optional[int]:
 
 @functools.cache
 def _memory_aware_job_cap() -> Optional[int]:
-    """A cap on parallel ninja jobs derived from available memory, or ``None``
-    to leave ninja's default parallelism untouched.
-
-    Cached (and so computed/logged once per process): the cap is a function of
-    available memory and CPU count, which are effectively static for a run, and
-    ``_get_num_workers`` is called for every operator's JIT compile.
-
-    When ``MAX_JOBS`` is unset, ninja runs roughly ``nproc + 2`` nvcc
-    processes. Each CUTLASS / FP4 nvcc compile can peak at several GiB, so on
-    memory-constrained or unified-memory systems (e.g. DGX Spark GB10 / SM121a)
-    the default can exhaust memory and OOM-kill nvcc (exit 137), crashing the
-    caller. Mirror the per-job memory budget the AOT build uses
-    (``scripts/jit_cache_build_common.sh``: ``max(8, FLASHINFER_NVCC_THREADS *
-    2)`` GiB/job) and cap accordingly. This only ever *lowers* parallelism
-    below ninja's default; when memory is ample it returns ``None`` so behavior
-    is unchanged.
-    """
+    """Parallel-ninja-job cap from available memory, or ``None`` to keep ninja's
+    default. Cached, so it is computed and logged once per process."""
+    # With MAX_JOBS unset, ninja runs ~nproc + 2 nvcc processes; each CUTLASS /
+    # FP4 compile can peak at several GiB, so on memory-constrained or
+    # unified-memory systems (e.g. DGX Spark GB10 / SM121a) the default
+    # OOM-kills nvcc (exit 137) and crashes the caller. Mirror the AOT per-job
+    # budget (scripts/jit_cache_build_common.sh: max(8, FLASHINFER_NVCC_THREADS
+    # * 2) GiB/job) and only ever lower below ninja's default.
     mem_available_gb = _read_mem_available_gb()
     if mem_available_gb is None:
         return None

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -379,7 +379,13 @@ def _memory_aware_job_cap() -> Optional[int]:
         return None
 
     cpu_count = os.cpu_count() or 1
-    ninja_default = cpu_count + 2  # ninja's GuessParallelism for >2 cores
+    # ninja's GuessParallelism: 2 for <=1 core, 3 for 2 cores, else N + 2.
+    if cpu_count <= 1:
+        ninja_default = 2
+    elif cpu_count == 2:
+        ninja_default = 3
+    else:
+        ninja_default = cpu_count + 2
 
     try:
         nvcc_threads = max(1, int(os.environ.get("FLASHINFER_NVCC_THREADS", "1")))

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -355,9 +355,14 @@ def _read_mem_available_gb() -> Optional[int]:
     return None
 
 
+@functools.cache
 def _memory_aware_job_cap() -> Optional[int]:
     """A cap on parallel ninja jobs derived from available memory, or ``None``
     to leave ninja's default parallelism untouched.
+
+    Cached (and so computed/logged once per process): the cap is a function of
+    available memory and CPU count, which are effectively static for a run, and
+    ``_get_num_workers`` is called for every operator's JIT compile.
 
     When ``MAX_JOBS`` is unset, ninja runs roughly ``nproc + 2`` nvcc
     processes. Each CUTLASS / FP4 nvcc compile can peak at several GiB, so on

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -7,15 +7,15 @@ import re
 import subprocess
 import sys
 import sysconfig
-from packaging.version import Version
 from pathlib import Path
 from typing import List, Optional
 
-import tvm_ffi
 import torch
+import tvm_ffi
+from packaging.version import Version
 
-from . import env as jit_env
 from ..compilation_context import CompilationContext
+from . import env as jit_env
 
 logger = logging.getLogger(__name__)
 
@@ -341,11 +341,67 @@ def generate_ninja_build_for_op(
     return "\n".join(lines)
 
 
+def _read_mem_available_gb() -> Optional[int]:
+    """Available system memory in whole GiB from ``/proc/meminfo``, or ``None``
+    when it cannot be read (e.g. non-Linux)."""
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    # MemAvailable is reported in kB.
+                    return int(line.split()[1]) // (1024 * 1024)
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def _memory_aware_job_cap() -> Optional[int]:
+    """A cap on parallel ninja jobs derived from available memory, or ``None``
+    to leave ninja's default parallelism untouched.
+
+    When ``MAX_JOBS`` is unset, ninja runs roughly ``nproc + 2`` nvcc
+    processes. Each CUTLASS / FP4 nvcc compile can peak at several GiB, so on
+    memory-constrained or unified-memory systems (e.g. DGX Spark GB10 / SM121a)
+    the default can exhaust memory and OOM-kill nvcc (exit 137), crashing the
+    caller. Mirror the per-job memory budget the AOT build uses
+    (``scripts/jit_cache_build_common.sh``: ``max(8, FLASHINFER_NVCC_THREADS *
+    2)`` GiB/job) and cap accordingly. This only ever *lowers* parallelism
+    below ninja's default; when memory is ample it returns ``None`` so behavior
+    is unchanged.
+    """
+    mem_available_gb = _read_mem_available_gb()
+    if mem_available_gb is None:
+        return None
+
+    cpu_count = os.cpu_count() or 1
+    ninja_default = cpu_count + 2  # ninja's GuessParallelism for >2 cores
+
+    try:
+        nvcc_threads = max(1, int(os.environ.get("FLASHINFER_NVCC_THREADS", "1")))
+    except ValueError:
+        nvcc_threads = 1
+    mem_per_job_gb = max(8, nvcc_threads * 2)
+
+    mem_cap = max(1, mem_available_gb // mem_per_job_gb)
+    if mem_cap >= ninja_default:
+        # Plenty of memory for the default parallelism; don't intervene.
+        return None
+    logger.warning(
+        "Capping ninja parallelism to %d job(s) (MAX_JOBS unset, %d GiB "
+        "available, budgeting %d GiB/job) to avoid OOM during JIT compilation; "
+        "set MAX_JOBS to override.",
+        mem_cap,
+        mem_available_gb,
+        mem_per_job_gb,
+    )
+    return mem_cap
+
+
 def _get_num_workers() -> Optional[int]:
     max_jobs = os.environ.get("MAX_JOBS")
     if max_jobs is not None and max_jobs.isdigit():
         return int(max_jobs)
-    return None
+    return _memory_aware_job_cap()
 
 
 def run_ninja(workdir: Path, ninja_file: Path, verbose: bool) -> None:

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 from types import SimpleNamespace
 
@@ -13,6 +14,15 @@ from flashinfer.utils import (
     is_fa3_prefill_head_dim_supported,
 )
 from tests.test_helpers import jit_utils
+
+
+@pytest.fixture(autouse=True)
+def _clear_job_cap_cache():
+    # _memory_aware_job_cap is @functools.cache'd; clear it so each test's
+    # monkeypatched memory/cpu values are recomputed.
+    cpp_ext._memory_aware_job_cap.cache_clear()
+    yield
+    cpp_ext._memory_aware_job_cap.cache_clear()
 
 
 def test_nvcc_parallelism_flags_use_flashinfer_nvcc_threads(monkeypatch):
@@ -336,3 +346,18 @@ def test_get_num_workers_none_when_meminfo_unavailable(monkeypatch):
     # Non-Linux / unreadable /proc/meminfo -> keep ninja's default parallelism.
     monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: None)
     assert cpp_ext._get_num_workers() is None
+
+
+def test_cap_warning_emitted_once_across_compiles(monkeypatch, caplog):
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.delenv("FLASHINFER_NVCC_THREADS", raising=False)
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: 32)
+    with caplog.at_level(logging.WARNING, logger="flashinfer.jit.cpp_ext"):
+        results = [cpp_ext._get_num_workers() for _ in range(5)]
+    # Every per-operator call returns the cap, but the warning is logged once.
+    assert results == [4, 4, 4, 4, 4]
+    cap_warnings = [
+        r for r in caplog.records if "Capping ninja parallelism" in r.getMessage()
+    ]
+    assert len(cap_warnings) == 1

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -286,3 +286,53 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa3", 512, 512) not in calls
     assert ("single", "fa2", 512, 512) in calls
     assert ("batch", "fa2", 512, 512) in calls
+
+
+def test_get_num_workers_respects_explicit_max_jobs(monkeypatch):
+    monkeypatch.setenv("MAX_JOBS", "4")
+    # Even with very little memory, an explicit MAX_JOBS wins unchanged.
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: 1)
+    assert cpp_ext._get_num_workers() == 4
+
+
+def test_get_num_workers_no_cap_when_memory_ample(monkeypatch):
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.delenv("FLASHINFER_NVCC_THREADS", raising=False)
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 8)
+    # 999 GiB / 8 GiB-per-job = 124 >= ninja default (10) -> don't intervene.
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: 999)
+    assert cpp_ext._get_num_workers() is None
+
+
+def test_get_num_workers_caps_when_memory_constrained(monkeypatch):
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.delenv("FLASHINFER_NVCC_THREADS", raising=False)
+    # 64 cores (ninja would run ~66 nvcc) but only 32 GiB -> 32 // 8 = 4 jobs.
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: 32)
+    assert cpp_ext._get_num_workers() == 4
+
+
+def test_get_num_workers_budgets_for_nvcc_threads(monkeypatch):
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    # nvcc threads = 8 -> per-job budget max(8, 16) = 16 GiB -> 32 // 16 = 2.
+    monkeypatch.setenv("FLASHINFER_NVCC_THREADS", "8")
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: 32)
+    assert cpp_ext._get_num_workers() == 2
+
+
+def test_get_num_workers_floors_at_one(monkeypatch):
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.delenv("FLASHINFER_NVCC_THREADS", raising=False)
+    # 4 GiB // 8 GiB-per-job = 0 -> floored to 1 (never zero).
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: 4)
+    assert cpp_ext._get_num_workers() == 1
+
+
+def test_get_num_workers_none_when_meminfo_unavailable(monkeypatch):
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    # Non-Linux / unreadable /proc/meminfo -> keep ninja's default parallelism.
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: None)
+    assert cpp_ext._get_num_workers() is None

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -361,3 +361,17 @@ def test_cap_warning_emitted_once_across_compiles(monkeypatch, caplog):
         r for r in caplog.records if "Capping ninja parallelism" in r.getMessage()
     ]
     assert len(cap_warnings) == 1
+
+
+def test_get_num_workers_low_core_matches_ninja_guess(monkeypatch):
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.delenv("FLASHINFER_NVCC_THREADS", raising=False)
+    # 2-core box: ninja's GuessParallelism is 3, not 4. 24 GiB / 8 == 3, so the
+    # default already fits -> don't intervene.
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 2)
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: 24)
+    assert cpp_ext._get_num_workers() is None
+    # 16 GiB / 8 == 2 < 3 -> cap to 2.
+    cpp_ext._memory_aware_job_cap.cache_clear()
+    monkeypatch.setattr(cpp_ext, "_read_mem_available_gb", lambda: 16)
+    assert cpp_ext._get_num_workers() == 2


### PR DESCRIPTION
## Description

Fixes #3634.

When `MAX_JOBS` is unset, `run_ninja` lets ninja choose its default parallelism (`GuessParallelism` ≈ `nproc + 2` concurrent nvcc processes). Each CUTLASS / FP4 nvcc compile can peak at several GiB, so on memory-constrained or **unified-memory** systems (e.g. DGX Spark GB10 / SM121a) the first in-process JIT compile spawns more nvcc than memory allows → the OOM killer terminates nvcc (exit 137) → the caller (e.g. vLLM `EngineCore`) crashes with no actionable message.

The **AOT** build path already guards against exactly this in `scripts/jit_cache_build_common.sh`, budgeting `max(8, FLASHINFER_NVCC_THREADS*2)` GiB per job and capping `MAX_JOBS = mem_available / per_job`. That protection lived only in the shell script — the in-process JIT path (`flashinfer/jit/cpp_ext.py`, reached via `core.py` `run_ninja`) was unguarded.

## Changes

Port the same budget into `_get_num_workers()`:

- When `MAX_JOBS` is set, it is honored unchanged (still takes precedence).
- When `MAX_JOBS` is unset, read `MemAvailable` from `/proc/meminfo` (**dependency-free**, no `psutil`) and cap jobs to `available_gb // max(8, FLASHINFER_NVCC_THREADS*2)`, mirroring the AOT formula.
- The cap **only ever lowers** parallelism below ninja's default. When memory is ample — or `/proc/meminfo` can't be read (non-Linux) — it returns `None` and behavior is **byte-identical to today** (ninja's default parallelism). So well-provisioned machines are unaffected; only memory-starved ones get the safety net.

A `logger.warning` reports the chosen cap and points to `MAX_JOBS` for an override.

## Test

GPU-free unit tests added to `tests/test_jit_cpp_ext.py` (monkeypatched, no compilation):
- explicit `MAX_JOBS` precedence
- no cap when memory is ample
- cap under memory pressure (64 cores / 32 GiB → 4 jobs)
- per-job budget scales with `FLASHINFER_NVCC_THREADS` (8 threads → 16 GiB/job → 2 jobs)
- floor at 1 job
- `/proc/meminfo` unavailable → `None` (default parallelism)

`14 passed` (6 new + 8 existing).

AI-assisted (Claude); reviewed and validated by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JIT compilation now reads available system memory and automatically adjusts build parallelism to reduce out-of-memory risk.
  * Explicit parallelism controls still win; otherwise, memory constraints and configured build threading determine the worker cap. When no cap is needed, the build uses the tool’s default parallelism. A capping warning is shown once when applicable.

* **Tests**
  * Added unit tests for precedence (valid `MAX_JOBS` vs memory-based fallback), handling missing memory info, minimum worker enforcement, `FLASHINFER_NVCC_THREADS` effects, and “warning only once” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->