### PR TITLE
fix(jit): quote -ccbin host compiler path so it works with spaces

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -194,7 +194,10 @@ def build_cuda_cflags(
     cuda_cflags: List[str] = []
     cc_env = os.environ.get("CC")
     if cc_env is not None:
-        cuda_cflags += ["-ccbin", cc_env]
+        # Quote so a host-compiler path containing spaces (e.g. a Windows
+        # "C:\Program Files\...\cl.exe") survives shell tokenization of the
+        # generated ninja command. See #3515.
+        cuda_cflags += ["-ccbin", f'"{cc_env}"']
     cuda_cflags += [
         "$common_cflags",
         "--compiler-options=-fPIC",

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -196,7 +196,9 @@ def build_cuda_cflags(
     if cc_env is not None:
         # Quote so a host-compiler path containing spaces (e.g. a Windows
         # "C:\Program Files\...\cl.exe") survives shell tokenization of the
-        # generated ninja command. See #3515.
+        # generated ninja command. Strip any quotes the user already supplied
+        # first so a pre-quoted value is not double-quoted. See #3515.
+        cc_env = cc_env.strip().strip("\"'")
         cuda_cflags += ["-ccbin", f'"{cc_env}"']
     cuda_cflags += [
         "$common_cflags",

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -52,23 +52,30 @@ def test_ccbin_host_compiler_path_with_spaces_is_quoted(monkeypatch, tmp_path):
     # A host-compiler path with spaces (typical on Windows, e.g.
     # "C:\Program Files\...\cl.exe") must be quoted in the generated ninja
     # command, otherwise the shell splits it and nvcc fails with
-    # "A single input file is required for a non-link phase". See #3515.
+    # "A single input file is required for a non-link phase". A value the user
+    # already quoted (single or double) must not end up double-quoted. See #3515.
     monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: "/usr/local/cuda")
     monkeypatch.setattr(cpp_ext.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
     monkeypatch.setenv("FLASHINFER_CUDA_ARCH_LIST", "7.5")
-    monkeypatch.setenv("CC", r"C:\Program Files\LLVM\bin\clang-cl.exe")
 
-    ninja = cpp_ext.generate_ninja_build_for_op(
-        name="test_module",
-        sources=[tmp_path / "generated" / "kernel.cu"],
-        extra_cflags=None,
-        extra_cuda_cflags=None,
-        extra_ldflags=None,
-        extra_include_dirs=None,
-    )
+    for cc_val in [
+        r"C:\Program Files\LLVM\bin\clang-cl.exe",
+        r'"C:\Program Files\LLVM\bin\clang-cl.exe"',
+        r"'C:\Program Files\LLVM\bin\clang-cl.exe'",
+    ]:
+        monkeypatch.setenv("CC", cc_val)
+        ninja = cpp_ext.generate_ninja_build_for_op(
+            name="test_module",
+            sources=[tmp_path / "generated" / "kernel.cu"],
+            extra_cflags=None,
+            extra_cuda_cflags=None,
+            extra_ldflags=None,
+            extra_include_dirs=None,
+        )
 
-    assert "-ccbin" in ninja
-    assert r'"C:\Program Files\LLVM\bin\clang-cl.exe"' in ninja
+        assert "-ccbin" in ninja
+        assert r'"C:\Program Files\LLVM\bin\clang-cl.exe"' in ninja
+        assert r'""C:\Program Files' not in ninja  # never double-quoted
 
 
 def test_debug_jit_uses_sccache_compatible_nvcc_device_debug_flag(monkeypatch):

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -48,6 +48,29 @@ def test_generate_ninja_uses_sccache_compatible_nvcc_depfile_flag(
     assert "--dependency-output" not in ninja
 
 
+def test_ccbin_host_compiler_path_with_spaces_is_quoted(monkeypatch, tmp_path):
+    # A host-compiler path with spaces (typical on Windows, e.g.
+    # "C:\Program Files\...\cl.exe") must be quoted in the generated ninja
+    # command, otherwise the shell splits it and nvcc fails with
+    # "A single input file is required for a non-link phase". See #3515.
+    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: "/usr/local/cuda")
+    monkeypatch.setattr(cpp_ext.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
+    monkeypatch.setenv("FLASHINFER_CUDA_ARCH_LIST", "7.5")
+    monkeypatch.setenv("CC", r"C:\Program Files\LLVM\bin\clang-cl.exe")
+
+    ninja = cpp_ext.generate_ninja_build_for_op(
+        name="test_module",
+        sources=[tmp_path / "generated" / "kernel.cu"],
+        extra_cflags=None,
+        extra_cuda_cflags=None,
+        extra_ldflags=None,
+        extra_include_dirs=None,
+    )
+
+    assert "-ccbin" in ninja
+    assert r'"C:\Program Files\LLVM\bin\clang-cl.exe"' in ninja
+
+
 def test_debug_jit_uses_sccache_compatible_nvcc_device_debug_flag(monkeypatch):
     monkeypatch.setenv("FLASHINFER_JIT_DEBUG", "1")
     monkeypatch.setattr(core, "check_cuda_arch", lambda: None)


### PR DESCRIPTION
## Description

On Windows, when `CC` points at a host compiler whose path contains spaces
(e.g. `C:\Program Files\...\cl.exe`), JIT compilation fails with:

```
nvcc fatal : A single input file is required for a non-link phase
```

**Root cause:** `build_cuda_cflags` appends the host compiler as a raw
`-ccbin <CC>` pair (`flashinfer/jit/cpp_ext.py`), and `join_multiline`
performs no quoting when it flattens the flag list into the `cuda_cflags`
ninja variable. The `cuda_compile` rule expands `$cuda_cflags` directly into
the command line, so the shell splits the unquoted path — nvcc then receives
`-ccbin C:\Program` plus `Files\...\cl.exe` as a stray second input file.

**Fix:** strip any surrounding single or double quotes already supplied by the user, then quote the value once — `["-ccbin", f'"{cc_env}"']`. This is shell-agnostic
(both `cmd.exe` and POSIX `sh` strip the outer quotes before nvcc sees the
argument) and a no-op for space-free paths, so existing behavior is unchanged.

**Scope:** limited to the reported `-ccbin` argument. The `cxx`, `nvcc`, and
`cuda_home` ninja variables share the same latent unquoted-path issue; I left
them untouched to keep this focused on the reported failure — happy to extend
if maintainers prefer a single broader pass.

## Related Issues

Fixes #3515.

## Tests

Added `test_ccbin_host_compiler_path_with_spaces_is_quoted` to
`tests/test_jit_cpp_ext.py` (GPU-free): generates the ninja build with bare, single-quoted, and double-quoted spaced `CC` values and asserts the `-ccbin` value is quoted exactly once. Verified it **fails on
the pre-fix code** (the bare path is emitted) and **passes with the fix**.

- `pytest tests/test_jit_cpp_ext.py` → 9 passed.
- `pre-commit run --files flashinfer/jit/cpp_ext.py tests/test_jit_cpp_ext.py`
  → mypy / ruff-check / ruff-format all pass.

I don't have a Windows box; the fix is verified on Linux by inspecting the
generated `build.ninja` (a `CC` with spaces is now quoted), and the reporter
already confirmed a manually-quoted `-ccbin` path compiles.

---
AI-assisted (Claude).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed build argument generation for `-ccbin` so host compiler paths containing spaces are correctly quoted. Also ensures any user-supplied quotes are handled safely to avoid double-quoting.

* **Tests**
  * Added coverage for Windows-style compiler paths with spaces, including already-quoted `CC` values, verifying the generated build script contains the correct `-ccbin` string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
