### PR TITLE
Add Relu2 + ungated MoE to CuteDSL MoE

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell/__init__.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/__init__.py
@@ -23,7 +23,7 @@ These kernels are adapted from TensorRT-LLM.
 from .blockscaled_contiguous_grouped_gemm_finalize_fusion import (
     Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel,
 )
-from .blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion import (
+from .blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
     BlockScaledContiguousGatherGroupedGemmKernel,
 )
 from .utils import (

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -404,9 +404,10 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         topk: cutlass.Int64,
         raster_along_m: bool = False,
         enable_pdl: bool = True,
+        gated: bool = True,
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel with
-        gather operation and SwiGLU fusion.
+        gather operation and FC1 activation fusion.
 
         This configuration includes several key aspects:
 
@@ -444,6 +445,8 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         self.sf_vec_size = sf_vec_size
         self.enable_pdl = enable_pdl
         self.topk = topk
+        self.gated = gated
+        self.out_n_factor = 2 if gated else 1
         self.acc_dtype = cutlass.Float32
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
         self.cluster_shape_mn = cluster_shape_mn
@@ -593,7 +596,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
 
         self.mma_tiler_c = (
             self.mma_inst_shape_mn[0],
-            self.mma_inst_shape_mn[1] // 2,
+            self.mma_inst_shape_mn[1] // self.out_n_factor,
             mma_inst_shape_k * mma_inst_tile_k,
         )
 
@@ -714,7 +717,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             else self.cta_tile_shape_mnk[1] * 2 - self.num_sf_tmem_cols
         )
 
-        self.epi_tile_n_required = 2 * cute.size(self.epi_tile[1])
+        self.epi_tile_n_required = self.out_n_factor * cute.size(self.epi_tile[1])
         # Only when overlapping_accum is enabled, we need to release accumulator buffer early in epilogue
         self.iter_acc_early_release_in_epilogue = (
             self.num_sf_tmem_cols // self.epi_tile_n_required
@@ -2554,116 +2557,145 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
                 bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
 
-                #
-                # Process accumulator subtiles with SwiGLU fusion and store to global memory
-                # Each iteration processes a pair of subtiles (up, gate) and computes
-                # up * silu(gate)
-                #
                 subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
 
-                for subtile_idx in cutlass.range(0, subtile_cnt, 2):
-                    real_subtile_idx = subtile_idx // 2
+                for subtile_idx in cutlass.range(
+                    0, subtile_cnt, 2 if self.gated else 1
+                ):
+                    if cutlass.const_expr(self.gated):
+                        real_subtile_idx = subtile_idx // 2
+                    else:
+                        real_subtile_idx = subtile_idx
                     if cutlass.const_expr(self.overlapping_accum):
                         if reverse_subtile:
                             real_subtile_idx = (
                                 self.cta_tile_shape_mnk[1] // self.epi_tile_n_required
                                 - 1
-                                - subtile_idx // 2
+                                - real_subtile_idx
                             )
                     #
                     # Load accumulator from tensor memory buffer to register
                     #
-                    tTR_tAcc_mn_up = tTR_tAcc[(None, None, None, real_subtile_idx * 2)]
-                    tTR_tAcc_mn_gate = tTR_tAcc[
-                        (None, None, None, real_subtile_idx * 2 + 1)
-                    ]
-
-                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn_up, tTR_rAcc_up)
-                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn_gate, tTR_rAcc_gate)
+                    if cutlass.const_expr(self.gated):
+                        tTR_tAcc_mn_up = tTR_tAcc[
+                            (None, None, None, real_subtile_idx * 2)
+                        ]
+                        tTR_tAcc_mn_gate = tTR_tAcc[
+                            (None, None, None, real_subtile_idx * 2 + 1)
+                        ]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn_up, tTR_rAcc_up)
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn_gate, tTR_rAcc_gate)
+                    else:
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc_up)
 
                     #
                     # Async arrive accumulator buffer empty earlier when overlapping_accum is enabled
                     #
                     if cutlass.const_expr(self.overlapping_accum):
-                        if subtile_idx // 2 == self.iter_acc_early_release_in_epilogue:
+                        if real_subtile_idx == self.iter_acc_early_release_in_epilogue:
                             # Fence for TMEM load
                             cute.arch.fence_view_async_tmem_load()
                             with cute.arch.elect_one():
                                 acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
 
-                    acc_vec_up = tTR_rAcc_up.load()
-                    acc_vec_gate = tTR_rAcc_gate.load()
-
-                    #
-                    # SwiGLU activation: output = up * silu(gate)
-                    # where silu(x) = x * sigmoid(x)
-                    # up and gate are extracted from interleaved accumulator subtiles
-                    #
-                    tCompute = cute.make_rmem_tensor(acc_vec_gate.shape, self.acc_dtype)
-                    if cutlass.const_expr(self.vectorized_f32):
-                        # SwiGLU Packed Version: uses f32x2 packed operations for better performance
-                        # Computes: output = (alpha * up) * silu(alpha * gate)
-                        # where silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
-                        LOG2_E = cutlass.Float32(1.4426950408889634)
-                        for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc_up), 2):
-                            acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
-                                (acc_vec_up[i], acc_vec_up[i + 1]),
+                    if cutlass.const_expr(not self.gated):
+                        acc_vec = tTR_rAcc_up.load()
+                        tCompute = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
+                        if cutlass.const_expr(self.vectorized_f32):
+                            for i in cutlass.range_constexpr(
+                                0, cute.size(tTR_rAcc_up), 2
+                            ):
+                                acc_alpha = cute.arch.mul_packed_f32x2(
+                                    (acc_vec[i], acc_vec[i + 1]),
+                                    (
+                                        cutlass.Float32(alpha_val),
+                                        cutlass.Float32(alpha_val),
+                                    ),
+                                )
+                                r0 = cute.arch.fmax(acc_alpha[0], cutlass.Float32(0.0))
+                                r1 = cute.arch.fmax(acc_alpha[1], cutlass.Float32(0.0))
                                 (
-                                    cutlass.Float32(alpha_val),
-                                    cutlass.Float32(alpha_val),
-                                ),
-                            )
-                            acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
-                                (acc_vec_gate[i], acc_vec_gate[i + 1]),
-                                (
-                                    cutlass.Float32(alpha_val),
-                                    cutlass.Float32(alpha_val),
-                                ),
-                            )
-                            tCompute_log2e = cute.arch.mul_packed_f32x2(
-                                (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
-                                (-LOG2_E, -LOG2_E),
-                            )
-                            (
-                                tCompute[i],
-                                tCompute[i + 1],
-                            ) = cute.arch.add_packed_f32x2(
-                                (
-                                    cute.math.exp2(tCompute_log2e[0], fastmath=True),
-                                    cute.math.exp2(tCompute_log2e[1], fastmath=True),
-                                ),
-                                (1.0, 1.0),
-                            )
-                            tCompute[i] = cute.arch.rcp_approx(tCompute[i])
-                            tCompute[i + 1] = cute.arch.rcp_approx(tCompute[i + 1])
-                            (
-                                tCompute[i],
-                                tCompute[i + 1],
-                            ) = cute.arch.mul_packed_f32x2(
-                                (tCompute[i], tCompute[i + 1]),
-                                (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
-                            )
-                            (
-                                tCompute[i],
-                                tCompute[i + 1],
-                            ) = cute.arch.mul_packed_f32x2(
-                                (tCompute[i], tCompute[i + 1]),
-                                (acc_vec_up_alpha[0], acc_vec_up_alpha[1]),
-                            )
+                                    tCompute[i],
+                                    tCompute[i + 1],
+                                ) = cute.arch.mul_packed_f32x2((r0, r1), (r0, r1))
+                        else:
+                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
+                                v = acc_vec[i] * cutlass.Float32(alpha_val)
+                                v = cute.arch.fmax(v, cutlass.Float32(0.0))
+                                tCompute[i] = v * v
                     else:
-                        # SwiGLU Unpacked Version: scalar operations
-                        # Computes: output = (alpha * up) * silu(alpha * gate)
-                        for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
-                            acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(
-                                alpha_val
-                            )
-                            acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(
-                                alpha_val
-                            )
-                            tCompute[i] = acc_vec_up_alpha * silu_f32(
-                                acc_vec_gate_alpha, fastmath=True
-                            )
+                        acc_vec_up = tTR_rAcc_up.load()
+                        acc_vec_gate = tTR_rAcc_gate.load()
+
+                        tCompute = cute.make_rmem_tensor(
+                            acc_vec_gate.shape, self.acc_dtype
+                        )
+                        if cutlass.const_expr(self.vectorized_f32):
+                            LOG2_E = cutlass.Float32(1.4426950408889634)
+                            for i in cutlass.range_constexpr(
+                                0, cute.size(tTR_rAcc_up), 2
+                            ):
+                                acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
+                                    (acc_vec_up[i], acc_vec_up[i + 1]),
+                                    (
+                                        cutlass.Float32(alpha_val),
+                                        cutlass.Float32(alpha_val),
+                                    ),
+                                )
+                                acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
+                                    (acc_vec_gate[i], acc_vec_gate[i + 1]),
+                                    (
+                                        cutlass.Float32(alpha_val),
+                                        cutlass.Float32(alpha_val),
+                                    ),
+                                )
+                                tCompute_log2e = cute.arch.mul_packed_f32x2(
+                                    (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
+                                    (-LOG2_E, -LOG2_E),
+                                )
+                                (
+                                    tCompute[i],
+                                    tCompute[i + 1],
+                                ) = cute.arch.add_packed_f32x2(
+                                    (
+                                        cute.math.exp2(
+                                            tCompute_log2e[0], fastmath=True
+                                        ),
+                                        cute.math.exp2(
+                                            tCompute_log2e[1], fastmath=True
+                                        ),
+                                    ),
+                                    (1.0, 1.0),
+                                )
+                                tCompute[i] = cute.arch.rcp_approx(tCompute[i])
+                                tCompute[i + 1] = cute.arch.rcp_approx(tCompute[i + 1])
+                                (
+                                    tCompute[i],
+                                    tCompute[i + 1],
+                                ) = cute.arch.mul_packed_f32x2(
+                                    (tCompute[i], tCompute[i + 1]),
+                                    (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
+                                )
+                                (
+                                    tCompute[i],
+                                    tCompute[i + 1],
+                                ) = cute.arch.mul_packed_f32x2(
+                                    (tCompute[i], tCompute[i + 1]),
+                                    (acc_vec_up_alpha[0], acc_vec_up_alpha[1]),
+                                )
+                        else:
+                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
+                                acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(
+                                    alpha_val
+                                )
+                                acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(
+                                    alpha_val
+                                )
+                                tCompute[i] = acc_vec_up_alpha * silu_f32(
+                                    acc_vec_gate_alpha, fastmath=True
+                                )
 
                     if cutlass.const_expr(self.generate_sfc):
                         #
@@ -3520,7 +3552,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         epilogue_op: cutlass.Constexpr = lambda x: x,
     ):
         scale_k = k // scaling_vector_size
-        interm_size = n // 2
+        interm_size = n // self.out_n_factor
         num_tiles = m // tile_size
         a = cute.make_tensor(
             a_ptr, layout=cute.make_ordered_layout((orig_m, k, 1), order=(1, 0, 2))

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -59,8 +59,7 @@ from flashinfer.cute_dsl.utils import (
     make_ptr,
 )
 
-# Import the TRT-LLM kernel implementation
-from .blackwell.blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion import (
+from .blackwell.blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
     BlockScaledContiguousGatherGroupedGemmKernel,
 )
 
@@ -221,8 +220,9 @@ def _get_compiled_gather_kernel(
     vectorized_f32: bool,
     raster_along_m: bool,
     enable_pdl: bool = True,
+    gated: bool = True,
 ):
-    """Get or compile the gather grouped GEMM with SwiGLU kernel.
+    """Get or compile the gather grouped GEMM with FC1 activation fusion.
 
     This function caches compiled kernels by tactic and dtype parameters.
     Problem dimensions (m, n, k, num_experts) are runtime parameters.
@@ -250,6 +250,7 @@ def _get_compiled_gather_kernel(
         vectorized_f32,
         raster_along_m,
         enable_pdl,
+        gated,
     )
 
     if cache_key not in _gather_kernel_cache:
@@ -262,6 +263,7 @@ def _get_compiled_gather_kernel(
             topk=topk,
             raster_along_m=raster_along_m,
             enable_pdl=enable_pdl,
+            gated=gated,
         )
 
         # Compile with runtime parameters - they can vary across calls
@@ -300,7 +302,7 @@ def _get_compiled_gather_kernel(
     return _gather_kernel_cache[cache_key]
 
 
-def blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_nvfp4(
+def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
     a: torch.Tensor,
     b: torch.Tensor,
     a_scale: torch.Tensor,
@@ -325,6 +327,7 @@ def blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_nvfp4(
     raster_along_m: bool = False,
     sm_count: Optional[int] = None,
     enable_pdl: bool = True,
+    gated: bool = True,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     """Blockscaled Contiguous Gather Grouped GEMM with SwiGLU Fusion for MoE workloads.
 
@@ -393,7 +396,7 @@ def blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_nvfp4(
         ... )
         >>>
         >>> # Run gathered GEMM with SwiGLU fusion - NO moe_permute needed!
-        >>> out, _ = blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_nvfp4(
+        >>> out, _ = blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
         ...     a=original_input_fp4,            # (seq_len, hidden_dim//2) - UNPERMUTED!
         ...     b=expert_gate_up_weights_fp4,    # (num_experts, 2*intermediate_dim, hidden_dim//2)
         ...     a_scale=input_scale,
@@ -413,12 +416,12 @@ def blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_nvfp4(
     # Get dimensions
     seq_len = a.shape[0]
     num_experts = b.shape[0]
-    n = b.shape[1]  # This is 2*intermediate_size
+    n = b.shape[1]
     k = a.shape[1]
     if ab_dtype == "float4_e2m1fn":
         k = k * 2  # FP4 is packed 2 elements per byte
 
-    intermediate_size = n // 2  # Output dimension after SwiGLU
+    intermediate_size = n // (2 if gated else 1)
     permuted_m = token_id_mapping.shape[0]
 
     # Check compute capability
@@ -585,6 +588,7 @@ def blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_nvfp4(
         vectorized_f32=vectorized_f32,
         raster_along_m=raster_along_m,
         enable_pdl=enable_pdl,
+        gated=gated,
     )
 
     # Execute kernel with runtime parameters

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -424,6 +424,9 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
     intermediate_size = n // (2 if gated else 1)
     permuted_m = token_id_mapping.shape[0]
 
+    if n % 128 != 0:
+        raise ValueError(f"GEMM1 output dim n={n} must be a multiple of 128.")
+
     # Check compute capability
     major, minor = get_compute_capability(a.device)
     if major != 10:

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -67,8 +67,8 @@ from .moe_utils import (
     moe_output_memset_inplace,
     moe_sort,
 )
-from .blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion import (
-    blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_nvfp4,
+from .blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
+    blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4,
 )
 from .blockscaled_contiguous_grouped_gemm_finalize_fusion import (
     blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4,
@@ -77,7 +77,6 @@ from .tuner import (
     ALL_MOE_TACTICS,
     CuteDslFusedMoENvfp4Runner,
 )
-
 
 # =============================================================================
 # Module-level Resources for CUDA Graph Compatibility
@@ -144,6 +143,7 @@ def _moe_core_impl(
     output_dtype: torch.dtype = torch.bfloat16,
     use_async_memset: bool = True,
     enable_pdl: bool = True,
+    activation: str = "silu",
 ) -> torch.Tensor:
     """Core MoE implementation shared by functional and wrapper APIs.
 
@@ -238,9 +238,17 @@ def _moe_core_impl(
         main_event.record()
         moe_output.record_stream(aux_stream)
 
-    # Step 2: GEMM1 + SwiGLU
+    # Step 2: GEMM1 + activation
+    if activation == "silu":
+        gated = True
+    elif activation == "relu2":
+        gated = False
+    else:
+        raise ValueError(
+            f"CuteDSL MoE GEMM1 supports activation 'silu' or 'relu2', got {activation!r}."
+        )
     intermediate, intermediate_sf = (
-        blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_nvfp4(
+        blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
             a=x,
             b=w1_weight,
             a_scale=x_sf,
@@ -258,6 +266,7 @@ def _moe_core_impl(
             mma_tiler_mn=gemm1_mma_tiler_mn,
             cluster_shape_mn=gemm1_cluster_shape_mn,
             enable_pdl=enable_pdl,
+            gated=gated,
         )
     )
 
@@ -370,6 +379,7 @@ class CuteDslMoEWrapper:
         output_dtype: torch.dtype = torch.bfloat16,
         device: str = "cuda",
         enable_pdl: bool = True,
+        activation: str = "silu",
     ):
         r"""Configure the CuTe-DSL NVFP4 fused-MoE wrapper.
 
@@ -418,6 +428,7 @@ class CuteDslMoEWrapper:
         self.output_dtype = output_dtype
         self.device = device
         self.enable_pdl = enable_pdl
+        self.activation = activation
 
         # Persistent CUDA resources for async-memset / GEMM1 overlap. These
         # are created outside graph capture (so they can be reused inside it)
@@ -449,6 +460,7 @@ class CuteDslMoEWrapper:
             use_fused_finalize=True,
             output_dtype=output_dtype,
             enable_pdl=enable_pdl,
+            activation=activation,
         )
 
         if use_cuda_graph:
@@ -516,6 +528,7 @@ class CuteDslMoEWrapper:
             output_dtype=output_dtype,
             use_async_memset=True,
             enable_pdl=enable_pdl,
+            activation=self.activation,
         )
 
     @flashinfer_api(trace=cute_dsl_moe_wrapper_run_trace)
@@ -649,6 +662,7 @@ def _cute_dsl_fused_moe_nvfp4_impl(
     moe_output: Optional[torch.Tensor] = None,
     aux_stream: Optional[torch.cuda.Stream] = None,
     enable_pdl: bool = True,
+    activation: str = "silu",
 ) -> torch.Tensor:
     """Internal implementation called by auto-tuner for functional API."""
     return _moe_core_impl(
@@ -677,6 +691,7 @@ def _cute_dsl_fused_moe_nvfp4_impl(
         output_dtype=output_dtype,
         use_async_memset=True,
         enable_pdl=enable_pdl,
+        activation=activation,
     )
 
 
@@ -703,6 +718,7 @@ def cute_dsl_fused_moe_nvfp4(
     moe_output: Optional[torch.Tensor] = None,
     aux_stream: Optional[torch.cuda.Stream] = None,
     enable_pdl: bool = True,
+    activation: str = "silu",
 ) -> torch.Tensor:
     r"""Run a fused MoE forward pass using the CuTe-DSL NVFP4 kernels.
 
@@ -757,6 +773,9 @@ def cute_dsl_fused_moe_nvfp4(
         main computation.
     enable_pdl : bool
         Enable Programmatic Dependent Launch.  Defaults to ``True``.
+    activation : str
+        FC1 activation: ``"silu"`` for gated SwiGLU (default) or ``"relu2"``
+        for non-gated ReLU^2.
 
     Returns
     -------
@@ -787,6 +806,7 @@ def cute_dsl_fused_moe_nvfp4(
         use_fused_finalize=use_fused_finalize,
         output_dtype=output_dtype,
         enable_pdl=enable_pdl,
+        activation=activation,
     )
 
     inputs = [

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -267,6 +267,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         use_fused_finalize: bool = True,
         output_dtype: torch.dtype = torch.bfloat16,
         enable_pdl: bool = True,
+        activation: str = "silu",
     ):
         self.forward_impl = forward_impl
         self.num_experts = num_experts
@@ -276,6 +277,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         self.use_fused_finalize = use_fused_finalize
         self.output_dtype = output_dtype
         self.enable_pdl = enable_pdl
+        self.activation = activation
 
         # Helper that builds a deterministic balanced approx-max-load
         # assignment for token_selected_experts during autotune profiling.
@@ -367,6 +369,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                 self.local_expert_offset,
                 self.use_fused_finalize,
                 self.output_dtype,
+                self.activation,
             )
         )
 
@@ -404,10 +407,14 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         x = inputs[0]
         w1_weight = inputs[4]
 
+        gated = self.activation == "silu"
         num_tokens = x.shape[0]
         hidden_size = x.shape[1] * 2  # FP4 packed
         num_local_experts = w1_weight.shape[0]
-        intermediate_size = w1_weight.shape[1] // 2  # gate+up fused
+        # Gated SwiGLU fuses gate+up (2*intermediate rows); non-gated ReLU^2
+        # has a single intermediate-row projection.
+        gemm1_n = w1_weight.shape[1]
+        intermediate_size = gemm1_n // 2 if gated else gemm1_n
 
         # Fixed dtypes/layouts for NVFP4 MoE
         ab_dtype = cutlass.Float4E2M1FN
@@ -437,7 +444,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                 mma_tiler_mn=gemm1_mma_tiler_mn,
                 cluster_shape_mn=gemm1_cluster_shape_mn,
                 m=permuted_m,
-                n=2 * intermediate_size,
+                n=gemm1_n,
                 k=hidden_size,
                 l=num_local_experts,
                 a_major="k",
@@ -552,6 +559,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
             use_fused_finalize=self.use_fused_finalize,
             moe_output=moe_output,
             enable_pdl=self.enable_pdl,
+            activation=self.activation,
             **kwargs,
         )
 

--- a/flashinfer/trace/templates/moe.py
+++ b/flashinfer/trace/templates/moe.py
@@ -1820,8 +1820,9 @@ def _moe_bf16_run_experts(
     gemm1_alpha=None,
     gemm1_beta=None,
     gemm1_clamp_limit=None,
+    activation="silu",
 ):
-    """Un-quantized (bf16) MoE expert computation with SwiGLU."""
+    """Un-quantized (bf16) MoE expert computation (SwiGLU or ReLU^2)."""
     T, H = hidden_states.shape
     E_local, gemm1_out, _ = gemm1_weights.shape
     I = gemm1_out // 2
@@ -1841,31 +1842,34 @@ def _moe_bf16_run_experts(
         token_idx = torch.nonzero(sel_mask, as_tuple=False).squeeze(1)
         A_e = A.index_select(0, token_idx)
         G1 = A_e.matmul(W1[le].t())
-        X1, X2 = G1[:, :I], G1[:, I:]
-        if gemm1_clamp_limit is not None:
-            limit = gemm1_clamp_limit[le].to(device=X1.device, dtype=torch.float32)
-            X1 = torch.clamp(X1, min=-limit, max=limit)
-            X2 = torch.clamp(X2, max=limit)
-        if (
-            gemm1_alpha is not None
-            or gemm1_beta is not None
-            or gemm1_clamp_limit is not None
-        ):
-            alpha = (
-                1.0
-                if gemm1_alpha is None
-                else gemm1_alpha[le].to(device=X2.device, dtype=torch.float32)
-            )
-            beta = (
-                0.0
-                if gemm1_beta is None
-                else gemm1_beta[le].to(device=X1.device, dtype=torch.float32)
-            )
-            activation = X2 * torch.sigmoid(alpha * X2) * (X1 + beta)
+        if activation == "relu2":
+            act = torch.relu(G1) ** 2
         else:
-            silu_X2 = X2 / (1.0 + torch.exp(-X2))
-            activation = silu_X2 * X1
-        expert_out = activation.matmul(W2[le].t())
+            X1, X2 = G1[:, :I], G1[:, I:]
+            if gemm1_clamp_limit is not None:
+                limit = gemm1_clamp_limit[le].to(device=X1.device, dtype=torch.float32)
+                X1 = torch.clamp(X1, min=-limit, max=limit)
+                X2 = torch.clamp(X2, max=limit)
+            if (
+                gemm1_alpha is not None
+                or gemm1_beta is not None
+                or gemm1_clamp_limit is not None
+            ):
+                alpha = (
+                    1.0
+                    if gemm1_alpha is None
+                    else gemm1_alpha[le].to(device=X2.device, dtype=torch.float32)
+                )
+                beta = (
+                    0.0
+                    if gemm1_beta is None
+                    else gemm1_beta[le].to(device=X1.device, dtype=torch.float32)
+                )
+                act = X2 * torch.sigmoid(alpha * X2) * (X1 + beta)
+            else:
+                silu_X2 = X2 / (1.0 + torch.exp(-X2))
+                act = silu_X2 * X1
+        expert_out = act.matmul(W2[le].t())
         w_tok = weights.index_select(0, token_idx)
         match = (topk_idx.index_select(0, token_idx) == ge).float()
         w_e = (w_tok * match).sum(dim=1)
@@ -2551,7 +2555,13 @@ cute_dsl_fused_moe_nvfp4_trace = TraceTemplate(
         "num_fp4_intermediate_blocks": Var(
             description="NvFP4 scale-factor count along intermediate_size."
         ),
-        "gemm1_out_size": Const(abbrev="", description="2 * intermediate_size."),
+        "gemm1_out_size": Const(
+            abbrev="",
+            description=(
+                "FC1 output rows: 2 * intermediate_size for gated SwiGLU, "
+                "intermediate_size for non-gated ReLU^2."
+            ),
+        ),
     },
     inputs={
         "x": Tensor(
@@ -2608,6 +2618,14 @@ cute_dsl_fused_moe_nvfp4_trace = TraceTemplate(
         "local_expert_offset": Scalar(
             "int32", optional=True, description="Offset of local experts."
         ),
+        "activation": Scalar(
+            "string",
+            optional=True,
+            description=(
+                "FC1 activation: 'silu' for gated SwiGLU (default) or 'relu2' "
+                "for non-gated ReLU^2. Determines gemm1_out_size."
+            ),
+        ),
     },
     outputs={
         "output": Tensor(
@@ -2633,6 +2651,11 @@ _cute_dsl_wrapper_inputs["top_k"] = Scalar(
     "int32",
     optional=True,
     description="Set at wrapper __init__, not passed to run().",
+)
+_cute_dsl_wrapper_inputs["activation"] = Scalar(
+    "string",
+    optional=True,
+    description="Set at wrapper __init__ ('silu'/'relu2'), not passed to run().",
 )
 
 _cute_dsl_wrapper_axes = dict(cute_dsl_fused_moe_nvfp4_trace.axes)
@@ -2815,6 +2838,7 @@ def _cute_dsl_fused_moe_nvfp4_reference(
     w2_alpha,
     num_experts,
     top_k,
+    activation="silu",
     **_unused,
 ):
     """Reference for CuteDSL NvFP4 fused MoE — bridges to the FP4
@@ -2835,6 +2859,7 @@ def _cute_dsl_fused_moe_nvfp4_reference(
         token_selected_experts.to(torch.int64),
         local_expert_offset=0,
         E_global=int(num_experts),
+        activation=str(activation),
     )
 
 

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -121,6 +121,7 @@ def compute_reference_moe_fp4(
     fc2_input_scale: torch.Tensor = None,
     num_local_experts: int = None,
     local_expert_offset: int = 0,
+    gated: bool = True,
 ) -> torch.Tensor:
     """Compute reference MoE output using PyTorch operations on GPU.
 
@@ -173,17 +174,20 @@ def compute_reference_moe_fp4(
             w1 = gemm1_weights[local_idx]
             gemm1_out = token_input @ w1.T
 
-            linear = gemm1_out[:, :intermediate_size]
-            gate = gemm1_out[:, intermediate_size:]
-            swiglu_out = silu(gate) * linear
+            if gated:
+                linear = gemm1_out[:, :intermediate_size]
+                gate = gemm1_out[:, intermediate_size:]
+                act_out = silu(gate) * linear
+            else:
+                act_out = torch.relu(gemm1_out) ** 2
 
             if fc2_input_scale is not None:
-                swiglu_out = quant_dequant_fp4_reference(
-                    swiglu_out, fc2_input_scale, sf_vec_size=16
+                act_out = quant_dequant_fp4_reference(
+                    act_out, fc2_input_scale, sf_vec_size=16
                 )
 
             w2 = gemm2_weights[local_idx]
-            gemm2_out = swiglu_out @ w2.T
+            gemm2_out = act_out @ w2.T
 
             output[token_idx] += scale * gemm2_out.squeeze(0)
 
@@ -199,6 +203,7 @@ def create_moe_tensors(
     top_k: int,
     device: str = "cuda",
     seed: int = 42,
+    gated: bool = True,
 ):
     """Create properly quantized MoE tensors for testing."""
     from flashinfer.fp4_quantization import fp4_quantize
@@ -226,11 +231,13 @@ def create_moe_tensors(
     routing_weights = routing_weights.float()
     selected_experts = selected_experts.to(torch.int32)
 
-    # GEMM1 weights
+    # GEMM1 weights: gated SwiGLU has 2*intermediate rows (interleaved
+    # linear+gate); non-gated ReLU^2 has a single intermediate-row projection.
+    fc1_rows = 2 * intermediate_size if gated else intermediate_size
     w1_bf16 = (
         torch.randn(
             num_local_experts,
-            2 * intermediate_size,
+            fc1_rows,
             hidden_size,
             dtype=torch.bfloat16,
             device=device,
@@ -238,19 +245,18 @@ def create_moe_tensors(
         / 10
     )
 
-    w1_bf16_interleaved = interleave_linear_and_gate(w1_bf16, group_size=64, dim=1)
     w1_gs = torch.tensor([1.0], device=device, dtype=torch.float32)
-
-    w1_flat = w1_bf16_interleaved.view(
-        num_local_experts * 2 * intermediate_size, hidden_size
+    w1_for_quant = (
+        interleave_linear_and_gate(w1_bf16, group_size=64, dim=1) if gated else w1_bf16
     )
+    w1_flat = w1_for_quant.reshape(num_local_experts * fc1_rows, hidden_size)
     w1_q_flat, w1_sf_flat = fp4_quantize(
         w1_flat, global_scale=w1_gs, sf_vec_size=sf_vec_size, is_sf_swizzled_layout=True
     )
-    w1_q = w1_q_flat.view(num_local_experts, 2 * intermediate_size, hidden_size // 2)
+    w1_q = w1_q_flat.view(num_local_experts, fc1_rows, hidden_size // 2)
     w1_weight_sf = convert_sf_to_mma_layout(
         w1_sf_flat,
-        m=2 * intermediate_size,
+        m=fc1_rows,
         k=hidden_size,
         num_groups=num_local_experts,
         sf_vec_size=sf_vec_size,
@@ -1063,6 +1069,78 @@ class TestCuteDslFusedMoeFunctional:
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
 
+    @pytest.mark.parametrize(
+        "hidden_size,intermediate_size", [(256, 512), (1024, 2048)]
+    )
+    @pytest.mark.parametrize("top_k", [1, 8, 22])
+    @pytest.mark.parametrize("num_tokens", [128, 1024])
+    @pytest.mark.parametrize("num_experts", [512])
+    def test_numerical_accuracy_relu2(
+        self,
+        num_tokens: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        num_experts: int,
+    ):
+        """Accuracy test for the non-gated ReLU^2 activation path."""
+        from flashinfer import cute_dsl_fused_moe_nvfp4
+
+        num_local_experts = num_experts
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_local_experts,
+            top_k=top_k,
+            gated=False,
+        )
+
+        result = cute_dsl_fused_moe_nvfp4(
+            x=tensors["x"],
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            num_experts=num_experts,
+            top_k=top_k,
+            num_local_experts=num_local_experts,
+            activation="relu2",
+        )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert result.dtype == torch.bfloat16
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_local_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            gated=False,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+        )
+
     def test_with_autotune(self):
         """Test functional API with autotune context."""
         from flashinfer import autotune
@@ -1099,6 +1177,75 @@ class TestCuteDslFusedMoeFunctional:
 
         assert result.shape == (num_tokens, hidden_size)
         assert not torch.isnan(result).any()
+
+    def test_wrapper_autotune_relu2(self):
+        """Wrapper + autotune on the non-gated ReLU^2 path.
+
+        Exercises get_valid_tactics / runner caching for activation="relu2",
+        which a no-autotune run skips (it falls back to the default tactic).
+        """
+        from flashinfer import CuteDslMoEWrapper, autotune
+
+        num_tokens, hidden_size, intermediate_size = 256, 1024, 2048
+        num_experts, top_k = 384, 22
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            gated=False,
+        )
+
+        moe = CuteDslMoEWrapper(
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            use_cuda_graph=False,
+            activation="relu2",
+        )
+
+        with autotune(True):
+            result = moe.run(
+                x=tensors["x"],
+                x_sf=tensors["x_sf"],
+                token_selected_experts=tensors["token_selected_experts"],
+                token_final_scales=tensors["token_final_scales"],
+                w1_weight=tensors["w1_weight"],
+                w1_weight_sf=tensors["w1_weight_sf"],
+                w1_alpha=tensors["w1_alpha"],
+                fc2_input_scale=tensors["fc2_input_scale"],
+                w2_weight=tensors["w2_weight"],
+                w2_weight_sf=tensors["w2_weight_sf"],
+                w2_alpha=tensors["w2_alpha"],
+            )
+
+        assert result.shape == (num_tokens, hidden_size)
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_bf16"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            gated=False,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+        )
 
 
 # =============================================================================

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1006,8 +1006,10 @@ class TestCuteDslFusedMoeFunctional:
     @pytest.mark.parametrize("top_k", [1, 2, 8])
     @pytest.mark.parametrize("num_tokens", [128, 515, 1024])
     @pytest.mark.parametrize("num_experts", [256, 384])
+    @pytest.mark.parametrize("activation", ["silu", "relu2"])
     def test_numerical_accuracy(
         self,
+        activation: str,
         num_tokens: int,
         top_k: int,
         hidden_size: int,
@@ -1017,6 +1019,7 @@ class TestCuteDslFusedMoeFunctional:
         """Accuracy test for functional API across configurations."""
         from flashinfer import cute_dsl_fused_moe_nvfp4
 
+        gated = activation == "silu"
         num_local_experts = num_experts
 
         tensors = create_moe_tensors(
@@ -1026,6 +1029,7 @@ class TestCuteDslFusedMoeFunctional:
             num_experts=num_experts,
             num_local_experts=num_local_experts,
             top_k=top_k,
+            gated=gated,
         )
 
         result = cute_dsl_fused_moe_nvfp4(
@@ -1043,6 +1047,7 @@ class TestCuteDslFusedMoeFunctional:
             num_experts=num_experts,
             top_k=top_k,
             num_local_experts=num_local_experts,
+            activation=activation,
         )
 
         assert result.shape == (num_tokens, hidden_size)
@@ -1062,78 +1067,7 @@ class TestCuteDslFusedMoeFunctional:
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             fc2_input_scale=tensors["fc2_input_scale"],
-        )
-
-        passed, percent_within, atol = check_accuracy(result, ref_output)
-        assert passed, (
-            f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
-        )
-
-    @pytest.mark.parametrize(
-        "hidden_size,intermediate_size", [(256, 512), (1024, 2048)]
-    )
-    @pytest.mark.parametrize("top_k", [1, 8, 22])
-    @pytest.mark.parametrize("num_tokens", [128, 1024])
-    @pytest.mark.parametrize("num_experts", [512])
-    def test_numerical_accuracy_relu2(
-        self,
-        num_tokens: int,
-        top_k: int,
-        hidden_size: int,
-        intermediate_size: int,
-        num_experts: int,
-    ):
-        """Accuracy test for the non-gated ReLU^2 activation path."""
-        from flashinfer import cute_dsl_fused_moe_nvfp4
-
-        num_local_experts = num_experts
-
-        tensors = create_moe_tensors(
-            num_tokens=num_tokens,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            num_experts=num_experts,
-            num_local_experts=num_local_experts,
-            top_k=top_k,
-            gated=False,
-        )
-
-        result = cute_dsl_fused_moe_nvfp4(
-            x=tensors["x"],
-            x_sf=tensors["x_sf"],
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
-            w1_weight=tensors["w1_weight"],
-            w1_weight_sf=tensors["w1_weight_sf"],
-            w1_alpha=tensors["w1_alpha"],
-            fc2_input_scale=tensors["fc2_input_scale"],
-            w2_weight=tensors["w2_weight"],
-            w2_weight_sf=tensors["w2_weight_sf"],
-            w2_alpha=tensors["w2_alpha"],
-            num_experts=num_experts,
-            top_k=top_k,
-            num_local_experts=num_local_experts,
-            activation="relu2",
-        )
-
-        assert result.shape == (num_tokens, hidden_size)
-        assert result.dtype == torch.bfloat16
-        assert not torch.isnan(result).any()
-        assert not torch.isinf(result).any()
-
-        ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_bf16"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
-            num_tokens=num_tokens,
-            num_experts=num_local_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
-            gated=False,
+            gated=gated,
         )
 
         passed, percent_within, atol = check_accuracy(result, ref_output)
@@ -1177,75 +1111,6 @@ class TestCuteDslFusedMoeFunctional:
 
         assert result.shape == (num_tokens, hidden_size)
         assert not torch.isnan(result).any()
-
-    def test_wrapper_autotune_relu2(self):
-        """Wrapper + autotune on the non-gated ReLU^2 path.
-
-        Exercises get_valid_tactics / runner caching for activation="relu2",
-        which a no-autotune run skips (it falls back to the default tactic).
-        """
-        from flashinfer import CuteDslMoEWrapper, autotune
-
-        num_tokens, hidden_size, intermediate_size = 256, 1024, 2048
-        num_experts, top_k = 384, 22
-
-        tensors = create_moe_tensors(
-            num_tokens=num_tokens,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            num_experts=num_experts,
-            num_local_experts=num_experts,
-            top_k=top_k,
-            gated=False,
-        )
-
-        moe = CuteDslMoEWrapper(
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            use_cuda_graph=False,
-            activation="relu2",
-        )
-
-        with autotune(True):
-            result = moe.run(
-                x=tensors["x"],
-                x_sf=tensors["x_sf"],
-                token_selected_experts=tensors["token_selected_experts"],
-                token_final_scales=tensors["token_final_scales"],
-                w1_weight=tensors["w1_weight"],
-                w1_weight_sf=tensors["w1_weight_sf"],
-                w1_alpha=tensors["w1_alpha"],
-                fc2_input_scale=tensors["fc2_input_scale"],
-                w2_weight=tensors["w2_weight"],
-                w2_weight_sf=tensors["w2_weight_sf"],
-                w2_alpha=tensors["w2_alpha"],
-            )
-
-        assert result.shape == (num_tokens, hidden_size)
-        assert not torch.isnan(result).any()
-        assert not torch.isinf(result).any()
-
-        ref_output = compute_reference_moe_fp4(
-            hidden_states=tensors["x_bf16"].float().cuda(),
-            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
-            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
-            token_selected_experts=tensors["token_selected_experts"],
-            token_final_scales=tensors["token_final_scales"],
-            num_tokens=num_tokens,
-            num_experts=num_experts,
-            top_k=top_k,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            fc2_input_scale=tensors["fc2_input_scale"],
-            gated=False,
-        )
-
-        passed, percent_within, atol = check_accuracy(result, ref_output)
-        assert passed, (
-            f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
-        )
 
 
 # =============================================================================
@@ -1430,11 +1295,13 @@ class TestCuteDslMoEWrapper:
             f"CUDA graph accuracy: {percent_within * 100:.2f}% (atol={atol:.4f})"
         )
 
-    def test_wrapper_with_autotune(self):
+    @pytest.mark.parametrize("activation", ["silu", "relu2"])
+    def test_wrapper_with_autotune(self, activation: str):
         """Test wrapper API with autotune context."""
         from flashinfer import autotune
         from flashinfer import CuteDslMoEWrapper
 
+        gated = activation == "silu"
         num_tokens, hidden_size, intermediate_size = 256, 256, 512
         num_experts, top_k = 256, 2
 
@@ -1445,6 +1312,7 @@ class TestCuteDslMoEWrapper:
             num_experts=num_experts,
             num_local_experts=num_experts,
             top_k=top_k,
+            gated=gated,
         )
 
         moe = CuteDslMoEWrapper(
@@ -1453,6 +1321,7 @@ class TestCuteDslMoEWrapper:
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             use_cuda_graph=False,
+            activation=activation,
         )
 
         with autotune(True):
@@ -1485,6 +1354,7 @@ class TestCuteDslMoEWrapper:
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             fc2_input_scale=tensors["fc2_input_scale"],
+            gated=gated,
         )
 
         passed, percent_within, atol = check_accuracy(result, ref_output)


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

It's needed for Nemotron-3 (currently, only SwiGLU is supported)

Validated E2E in SGLang. Ref: https://github.com/sgl-project/sglang/pull/28309

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

N/A

<!-- Link any related issues here -->

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

SM103 test result:
```
python tests/moe/test_cute_dsl_fused_moe.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: anyio-4.13.0, typeguard-4.5.2
collected 205 items                                                                                                                                                                                                                       
...

============================================================================================================ warnings summary =============================================================================================================
tests/moe/test_cute_dsl_fused_moe.py: 80 warnings
  /usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/_mlir_helpers/op.py:121: DeprecationWarning: make_blockscaled_trivial_tiled_mma with ab_dtype is deprecated, use the overload with separate a_dtype and b_dtype instead
    res_or_list = opFunc(*args, **kwargs, loc=loc)

tests/moe/test_cute_dsl_fused_moe.py: 16 warnings
  /usr/local/lib/python3.12/dist-packages/nvidia_cutlass_dsl/python_packages/cutlass/base_dsl/_mlir_helpers/op.py:121: DeprecationWarning: API is deprecated, use setmaxregister_decrease instead
    res_or_list = opFunc(*args, **kwargs, loc=loc)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================== 205 passed, 96 warnings in 140.16s (0:02:20) ===============================================================================================
```

## Reviewer Notes

Does not break public APIs

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added configurable FC1 activation to CuteDSL fused MoE via a new `activation: str` parameter (default: `"silu"`), supporting both gated (SiLU/SwiGLU) and non-gated (ReLU²) activation modes.
  * Updated the fused MoE tracing/trace template to carry the activation setting and adjust FC1 output sizing accordingly.

* **Tests**
  * Extended reference computation and test tensor setup for `activation="relu2"`.
  * Updated numerical accuracy and wrapper autotune tests to validate both `"silu"` and `"relu2"` paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->