### PR TITLE
feat: add mxfp4/nvfp4 quant to moe a2a combine

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -134,6 +134,16 @@ __host__ __device__ inline T ceilDiv(T m, T n) {
         __VA_ARGS__;                                                                   \
         break;                                                                         \
       }                                                                                \
+      case MoeA2ACombineQuantMode::NVFP4: {                                            \
+        constexpr auto QUANT_MODE = MoeA2ACombineQuantMode::NVFP4;                     \
+        __VA_ARGS__;                                                                   \
+        break;                                                                         \
+      }                                                                                \
+      case MoeA2ACombineQuantMode::MXFP4: {                                            \
+        constexpr auto QUANT_MODE = MoeA2ACombineQuantMode::MXFP4;                     \
+        __VA_ARGS__;                                                                   \
+        break;                                                                         \
+      }                                                                                \
       default: {                                                                       \
         FLASHINFER_CHECK(false, "Unsupported quant_mode for moe_a2a_combine");         \
       }                                                                                \
@@ -551,7 +561,8 @@ template <int VEC_SIZE_BYTES, int TOP_K, typename T,
           MoeA2ACombineSwizzleSFMode SwizzleMode = MoeA2ACombineSwizzleSFMode::LINEAR>
 __device__ void vectorized_combine_impl(void* output_buffer, void* sf_output, int row_idx,
                                         int row_size, int rank_id, int max_tokens_per_rank,
-                                        CombineKernelPointers const& ptrs) {
+                                        CombineKernelPointers const& ptrs,
+                                        float OutputScalarScale = 1.0f) {
   constexpr int elems_per_vec = VEC_SIZE_BYTES / sizeof(T);
   const int size_per_token = row_size * sizeof(T);
   using flashinfer::vec_t;
@@ -560,9 +571,12 @@ __device__ void vectorized_combine_impl(void* output_buffer, void* sf_output, in
   if constexpr (QuantMode == MoeA2ACombineQuantMode::NONE) {
     dst_bytes = reinterpret_cast<uint8_t*>(static_cast<T*>(output_buffer) + row_idx * row_size);
   } else {
-    // MXFP8 output stores one byte per logical element while accumulation reads T-sized inputs.
-    dst_bytes = static_cast<uint8_t*>(output_buffer) +
-                static_cast<size_t>(row_idx) * static_cast<size_t>(row_size);
+    // MXFP8 stores one byte per logical element; FP4 packs two e2m1 values per byte, so its
+    // rows are half as wide. The accumulation still reads T-sized inputs either way.
+    size_t const bytes_per_row = QuantMode == MoeA2ACombineQuantMode::MXFP8
+                                     ? static_cast<size_t>(row_size)
+                                     : static_cast<size_t>(row_size) / 2;
+    dst_bytes = static_cast<uint8_t*>(output_buffer) + static_cast<size_t>(row_idx) * bytes_per_row;
   }
 
   int const stride = blockDim.x * VEC_SIZE_BYTES;
@@ -751,7 +765,9 @@ __device__ void vectorized_combine_impl(void* output_buffer, void* sf_output, in
     if constexpr (QuantMode == MoeA2ACombineQuantMode::NONE) {
       acc[0].store(dst_bytes + offset);
     } else {
-      constexpr uint32_t sf_vec_size = QuantMode == MoeA2ACombineQuantMode::MXFP8 ? 32 : 16;
+      // Scale-factor block size: NVFP4 uses 16, MXFP8 and MXFP4 use 32. Must match the
+      // SF_VEC_SIZE passed to the cvt routines below so SF indexing/layout stays consistent.
+      constexpr uint32_t sf_vec_size = QuantMode == MoeA2ACombineQuantMode::NVFP4 ? 16 : 32;
       constexpr uint32_t threads_per_sf = sf_vec_size / elems_per_vec;
       uint8_t scale;
       auto store_sf = [&]() {
@@ -769,15 +785,28 @@ __device__ void vectorized_combine_impl(void* output_buffer, void* sf_output, in
           reinterpret_cast<uint8_t*>(sf_output)[sf_offset] = scale;
         }
       };
+      auto packed_vec =
+          reinterpret_cast<tensorrt_llm::kernels::PackedVec<T, elems_per_vec>&>(acc[0]);
       if constexpr (QuantMode == MoeA2ACombineQuantMode::MXFP8) {
         static_assert(elems_per_vec == 8, "MXFP8 quantization requires 8 elements per vector");
-        auto packed_vec =
-            reinterpret_cast<tensorrt_llm::kernels::PackedVec<T, elems_per_vec>&>(acc[0]);
         uint64_t fp8x8 =
             tensorrt_llm::kernels::cvt_warp_fp16_to_mxfp8<T, 32, elems_per_vec>(packed_vec, &scale);
         reinterpret_cast<uint64_t*>(dst_bytes)[logical_offset / elems_per_vec] = fp8x8;
-        store_sf();
+      } else if constexpr (QuantMode == MoeA2ACombineQuantMode::NVFP4 ||
+                           QuantMode == MoeA2ACombineQuantMode::MXFP4) {
+        static_assert(elems_per_vec == 8 || elems_per_vec == 16,
+                      "FP4 quantization requires 8 or 16 elements per vector");
+        constexpr int SF_VEC_SIZE = QuantMode == MoeA2ACombineQuantMode::MXFP4 ? 32 : 16;
+        auto fp4_packed = tensorrt_llm::kernels::cvt_warp_fp16_to_fp4 < T, SF_VEC_SIZE,
+             elems_per_vec,
+             QuantMode == MoeA2ACombineQuantMode::MXFP4 > (packed_vec, OutputScalarScale, &scale);
+        // cvt_warp_fp16_to_fp4 returns uint32_t for 8 elems (4 packed bytes) and uint64_t for 16
+        // (8 packed bytes); store at the matching width so packed rows stay contiguous and fit the
+        // dim/2-byte output buffer (a wider store would overflow into the next token's row).
+        reinterpret_cast<decltype(fp4_packed)*>(dst_bytes)[logical_offset / elems_per_vec] =
+            fp4_packed;
       }
+      store_sf();
     }
   }
 }
@@ -787,10 +816,12 @@ template <int TOP_K, typename T, MoeA2ACombineQuantMode QuantMode = MoeA2ACombin
           MoeA2ACombineSwizzleSFMode SwizzleMode = MoeA2ACombineSwizzleSFMode::LINEAR>
 __device__ void vectorized_combine(void* output_buffer, void* sf_output, int row_idx, int row_size,
                                    int rank_id, int max_tokens_per_rank,
-                                   CombineKernelPointers const& ptrs) {
+                                   CombineKernelPointers const& ptrs,
+                                   float OutputScalarScale = 1.0f) {
   if constexpr (QuantMode != MoeA2ACombineQuantMode::NONE) {
     vectorized_combine_impl<16, TOP_K, T, QuantMode, SwizzleMode>(
-        output_buffer, sf_output, row_idx, row_size, rank_id, max_tokens_per_rank, ptrs);
+        output_buffer, sf_output, row_idx, row_size, rank_id, max_tokens_per_rank, ptrs,
+        OutputScalarScale);
   } else {
     if (row_size % 16 == 0) {
       vectorized_combine_impl<16, TOP_K, T>(output_buffer, nullptr, row_idx, row_size, rank_id,
@@ -852,8 +883,8 @@ template <typename T, int TOP_K, MoeA2ACombineQuantMode QuantMode = MoeA2ACombin
           MoeA2ACombineSwizzleSFMode SwizzleMode = MoeA2ACombineSwizzleSFMode::LINEAR>
 __global__ void moeA2ACombineKernel(
     const CombineKernelPointers ptrs,  // Combine-specific struct, src_data_ptrs[0] is output
-    int max_tokens_per_rank, int elements_per_token, int local_num_tokens, int rank_id,
-    int ep_size) {
+    int max_tokens_per_rank, int elements_per_token, int local_num_tokens, int rank_id, int ep_size,
+    float OutputScalarScale) {
   int local_token_idx = blockIdx.x;
 
   if (local_num_tokens == 0) {
@@ -926,9 +957,9 @@ __global__ void moeA2ACombineKernel(
   if (local_num_tokens == 0) return;
 
   // Accumulate across ranks in registers, then store once per segment
-  vectorized_combine<TOP_K, T, QuantMode, SwizzleMode>(ptrs.src_data_ptrs[0], ptrs.output_scales,
-                                                       local_token_idx, elements_per_token, rank_id,
-                                                       max_tokens_per_rank, ptrs);
+  vectorized_combine<TOP_K, T, QuantMode, SwizzleMode>(
+      ptrs.src_data_ptrs[0], ptrs.output_scales, local_token_idx, elements_per_token, rank_id,
+      max_tokens_per_rank, ptrs, OutputScalarScale);
 }
 
 void moe_a2a_prepare_combine_launch(MoeA2ACombineParams const& params) {
@@ -1011,7 +1042,8 @@ void moe_a2a_combine_launch(MoeA2ACombineParams const& params) {
           moeA2ACombineKernel<TKernelType, TOP_K, QUANT_MODE, SWIZZLE_MODE>
               <<<grid_size_block, kBlockSize, 0, params.stream>>>(
                   kernel_ptrs, params.max_tokens_per_rank, params.elements_per_token,
-                  params.local_num_tokens, params.ep_rank, params.ep_size);
+                  params.local_num_tokens, params.ep_rank, params.ep_size,
+                  params.output_scalar_scale);
         });
       });
     });

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -765,8 +765,6 @@ __device__ void vectorized_combine_impl(void* output_buffer, void* sf_output, in
     if constexpr (QuantMode == MoeA2ACombineQuantMode::NONE) {
       acc[0].store(dst_bytes + offset);
     } else {
-      // Scale-factor block size: NVFP4 uses 16, MXFP8 and MXFP4 use 32. Must match the
-      // SF_VEC_SIZE passed to the cvt routines below so SF indexing/layout stays consistent.
       constexpr uint32_t sf_vec_size = QuantMode == MoeA2ACombineQuantMode::NVFP4 ? 16 : 32;
       constexpr uint32_t threads_per_sf = sf_vec_size / elems_per_vec;
       uint8_t scale;

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h
@@ -124,6 +124,8 @@ void moe_a2a_prepare_dispatch_launch(MoeA2ADispatchParams const& params);
 enum class MoeA2ACombineQuantMode : uint32_t {
   NONE,
   MXFP8,
+  MXFP4,
+  NVFP4,
 };
 
 // NOTE(siyuan): keep this align with include/flashinfer/fp4_layout.cuh
@@ -154,6 +156,8 @@ struct MoeA2ACombineParams {
       MoeA2ACombineSwizzleSFMode::LINEAR};  // Output swizzle mode
   void* output_data;                        // Output buffer [local_num_tokens, elements_per_token]
   void* output_scales;                      // Optional output scales for quantized outputs
+  float output_scalar_scale{1.0f};  // Per-tensor global scale applied before FP4 block scaling
+                                    // (SFScaleVal); ignored by MXFP8/MXFP4 paths
 
   // Payload information
   int elements_per_token;    // Number of elements per token

--- a/csrc/trtllm_moe_alltoall.cu
+++ b/csrc/trtllm_moe_alltoall.cu
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "flashinfer/utils.cuh"
+#include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/dataType.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h"
@@ -341,6 +342,10 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
 
   // Handle quantization parameters if output scales are provided
   if (outputScales.has_value()) {
+    // Quantized combine (MXFP8/MXFP4/NVFP4) relies on Blackwell-only conversion instructions.
+    auto const sm_version = tensorrt_llm::common::getSMVersion();
+    TVM_FFI_ICHECK(sm_version >= 100)
+        << "Quantized moe_a2a_combine requires SM>=100 (Blackwell), but got SM" << sm_version;
     TVM_FFI_ICHECK(payload.dtype() == dl_bfloat16 || payload.dtype() == dl_float16)
         << "Quantization only supports for fp16 or bf16 inputs";
     params.output_scales = outputScales.value().data_ptr();

--- a/csrc/trtllm_moe_alltoall.cu
+++ b/csrc/trtllm_moe_alltoall.cu
@@ -26,6 +26,7 @@
 
 #include "flashinfer/utils.cuh"
 #include "tensorrt_llm/common/dataType.h"
+#include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.h"
 #include "tensorrt_llm/thop/moeAlltoAllMeta.h"
 #include "tvm_ffi_utils.h"
@@ -275,7 +276,8 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
                        TensorView metainfo, int64_t runtimeMaxTokensPerRank, int64_t epRank,
                        int64_t epSize, int64_t topK, int64_t combinePayloadOffset,
                        bool payloadInWorkspace, Optional<DLDataType> outputDtype_,
-                       Optional<TensorView> outputScales, int64_t sfLayout) {
+                       Optional<TensorView> outputScales, double outputScalarScale,
+                       int64_t sfLayout) {
   using tl_throughput::MoeA2ACombineParams;
   using tl_throughput::MoeA2ACombineQuantMode;
   using tl_throughput::MoeA2ACombineSwizzleSFMode;
@@ -320,8 +322,11 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
 
   auto stream = get_current_stream();
   MoeA2ACombineParams params{};
-  Tensor output = alloc_tensor({localNumTokens, elementsPerToken},
-                               outputDtype_.value_or(payload.dtype()), payload.device());
+  auto const output_shape = outputDtype_.has_value() && outputDtype_.value() == dl_uint8
+                                ? tvm::ffi::Shape{localNumTokens, elementsPerToken / 2}
+                                : tvm::ffi::Shape{localNumTokens, elementsPerToken};
+  Tensor output =
+      alloc_tensor(output_shape, outputDtype_.value_or(payload.dtype()), payload.device());
   params.ep_size = static_cast<int>(epSize);
   params.ep_rank = static_cast<int>(epRank);
   params.local_num_tokens = static_cast<int>(localNumTokens);
@@ -332,15 +337,22 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
   params.elements_per_token = static_cast<int>(elementsPerToken);
   params.dtype = toNvDataType(payload.dtype());
   params.swizzle_mode = static_cast<MoeA2ACombineSwizzleSFMode>(sfLayout);
+  params.output_scalar_scale = static_cast<float>(outputScalarScale);
 
+  // Handle quantization parameters if output scales are provided
   if (outputScales.has_value()) {
-    CHECK_INPUT_AND_TYPE(outputScales.value(), dl_uint8);
     TVM_FFI_ICHECK(payload.dtype() == dl_bfloat16 || payload.dtype() == dl_float16)
-        << "Quantization only supported for fp16 or bf16 inputs";
+        << "Quantization only supports for fp16 or bf16 inputs";
+    params.output_scales = outputScales.value().data_ptr();
+
     if (output.dtype() == dl_float8_e4m3fn) {
       // TODO(siyuan): currently only support MXFP8 quantization
+      CHECK_INPUT_AND_TYPE(outputScales.value(), dl_uint8);
       params.quant_mode = MoeA2ACombineQuantMode::MXFP8;
-      params.output_scales = outputScales.value().data_ptr();
+    } else if (output.dtype() == dl_uint8) {
+      // packed fp4
+      params.quant_mode = outputScales.value().dtype() == dl_uint8 ? MoeA2ACombineQuantMode::MXFP4
+                                                                   : MoeA2ACombineQuantMode::NVFP4;
     } else {
       TVM_FFI_LOG_AND_THROW(NotImplementedError)
           << "Quantization not supported for output dtype: " << output.dtype();
@@ -349,6 +361,12 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
     TVM_FFI_ICHECK(output.dtype() == payload.dtype())
         << "output_dtype without output_scales must match payload dtype";
     params.quant_mode = MoeA2ACombineQuantMode::NONE;
+  }
+
+  if (params.quant_mode != MoeA2ACombineQuantMode::NVFP4 && outputScalarScale != 1.0) {
+    TLLM_LOG_WARNING(
+        "moe_a2a_combine: output_scalar_scale=%f is ignored unless output quantization is NVFP4",
+        outputScalarScale);
   }
 
   params.flag_val =

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -110,7 +110,8 @@ def get_moe_alltoall_module():
         payload_in_workspace: bool = False,
         output_dtype: Optional[torch.dtype] = None,
         output_scales: Optional[torch.Tensor] = None,
-        sf_layout: SfLayout = SfLayout.layout_linear,
+        output_scalar_scale: float = 1.0,
+        sf_layout: Optional[SfLayout] = None,
     ) -> torch.Tensor:
         """
         Combine expert outputs back to originating tokens.
@@ -126,11 +127,16 @@ def get_moe_alltoall_module():
             top_k: Number of experts per token
             combine_payload_offset: Offset from dispatch
             payload_in_workspace: If True, payload is workspace-backed
-            output_dtype: Optional output data type
-                currently supports [torch.bfloat16, torch.float8_e4m3fn]
-            output_scales: Optional output scale tensor for quantized outputs
-                currently support ue8m0 (packed in torch.uint8) with vector size of 32
-            sf_layout: Output swizzle layout
+            output_dtype: Optional output data type. Supported types:
+                torch.bfloat16,
+                torch.float8_e4m3fn,
+                torch.uint8 (packed fp4)
+            output_scales: Optional output scale tensor for quantized outputs. Support types:
+                torch.uint8 (packed ue8m0), vector size of 32
+                torch.float8_e4m3fn, vector size of 16
+            output_scalar_scale: Per-tensor global scale applied before FP4 block scaling
+                (NVFP4 SFScaleVal). Defaults to 1.0; ignored by MXFP8/MXFP4 paths.
+            sf_layout: Output swizzle layout. Defaults to linear.
         Returns:
             output: [local_num_tokens, elements_per_token] tensor
         """
@@ -147,7 +153,8 @@ def get_moe_alltoall_module():
             payload_in_workspace,
             output_dtype,
             output_scales,
-            sf_layout.value,
+            output_scalar_scale,
+            sf_layout.value if sf_layout is not None else SfLayout.layout_linear.value,
         )
 
     @register_custom_op(
@@ -391,6 +398,7 @@ def moe_a2a_combine(
     payload_in_workspace: bool = False,
     output_dtype: Optional[torch.dtype] = None,
     output_scales: Optional[torch.Tensor] = None,
+    output_scalar_scale: float = 1.0,
     sf_layout: SfLayout = SfLayout.layout_linear,
 ) -> torch.Tensor:
     r"""Combine per-expert outputs back to the originating ranks.
@@ -445,6 +453,7 @@ def moe_a2a_combine(
         payload_in_workspace,
         output_dtype,
         output_scales,
+        output_scalar_scale,
         sf_layout,
     )
 
@@ -831,6 +840,7 @@ class MoeAlltoAll:
         payload_in_workspace: bool = False,
         output_dtype: Optional[torch.dtype] = None,
         output_scales: Optional[torch.Tensor] = None,
+        output_scalar_scale: float = 1.0,
         sf_layout: SfLayout = SfLayout.layout_linear,
     ) -> torch.Tensor:
         r"""Run the MoE all-to-all combine phase.
@@ -872,6 +882,7 @@ class MoeAlltoAll:
             payload_in_workspace,
             output_dtype,
             output_scales,
+            output_scalar_scale,
             sf_layout,
         )
 

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -779,8 +779,6 @@ def test_moe_combine_multi_rank_single_gpu(
         # e2m1_and_ufp8sf_scale_to_float: ufp8_type 1 = UE4M3 (NVFP4), 0 = UE8M0 (MXFP4).
         ufp8_type = 1 if is_nvfp4 else 0
         is_swizzled = sf_layout != SfLayout.layout_linear
-        # The combine ran with the default output_scalar_scale (SFScaleVal = 1.0), which
-        # NVFP4 applies and MXFP4 (UE8M0) ignores; decode with the matching global scale.
         global_sf = torch.tensor([1.0], dtype=torch.float32, device="cuda")
         for rank in range(world_size):
             if is_nvfp4:

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -694,7 +694,11 @@ def test_moe_combine_multi_rank_single_gpu(
             )
         )
 
+    output_scalar_scale = 1.0
     if quant_mode != CombineQuantMode.NONE:
+        output_scalar_scale = (
+            2.5  # arbitrary non-one scalar to test scaling path in the kernel
+        )
         # High-precision (bf16) combine output. The quantized kernel output is
         # validated by dequantizing it and comparing against this reference.
         reference_result = combine_from_single_rank(
@@ -741,6 +745,7 @@ def test_moe_combine_multi_rank_single_gpu(
         output_dtype=output_dtype,
         output_scales_list=output_scales_list,
         sf_layout=sf_layout,
+        output_scalar_scale=output_scalar_scale,
     )
 
     if quant_mode == CombineQuantMode.NONE:
@@ -779,7 +784,9 @@ def test_moe_combine_multi_rank_single_gpu(
         # e2m1_and_ufp8sf_scale_to_float: ufp8_type 1 = UE4M3 (NVFP4), 0 = UE8M0 (MXFP4).
         ufp8_type = 1 if is_nvfp4 else 0
         is_swizzled = sf_layout != SfLayout.layout_linear
-        global_sf = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+        global_sf = torch.tensor(
+            [output_scalar_scale], dtype=torch.float32, device="cuda"
+        )
         for rank in range(world_size):
             if is_nvfp4:
                 ref_fp4, ref_sf = nvfp4_quantize(

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -15,13 +15,17 @@ limitations under the License.
 """
 
 from enum import IntEnum
+import itertools
 import pytest
-import torch
 import pynvml
+import torch
+
 from flashinfer.comm.mapping import Mapping
 from flashinfer.fused_moe.utils import make_random_topk_ids
 from flashinfer.tllm_enums import SfLayout
 from flashinfer.utils import get_compute_capability
+from flashinfer import mxfp4_quantize, nvfp4_quantize
+from flashinfer.fp4_quantization import e2m1_and_ufp8sf_scale_to_float
 from tests.utils_fp8 import mxfp8_quantize_reference
 
 import flashinfer.comm.trtllm_moe_alltoall as trtllm_moe_alltoall
@@ -66,187 +70,62 @@ LARGER_PAYLOADS_PARAMS = [
 class CombineQuantMode(IntEnum):
     NONE = 0
     MXFP8 = 1
+    MXFP4 = 2
+    NVFP4 = 3
 
 
-# (world_size, num_tokens, vector_dim, top_k, dtype, payload_in_workspace, quant_mode)
+# (world_size, num_tokens, vector_dim, top_k, dtype, payload_in_workspace)
 COMBINE_PARAMS = [
     # Coverage for popular model specifications
-    (
-        4,
-        16,
-        4096,
-        2,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),  # Mixtral-8x7B
-    (
-        4,
-        16,
-        2880,
-        4,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),  # GPT-OSS-120B
-    (
-        8,
-        16,
-        5120,
-        6,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),  # DeepSeek-V2
-    (
-        8,
-        16,
-        7168,
-        8,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),  # DeepSeek-V3
-    (
-        8,
-        16,
-        4096,
-        8,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),  # Qwen3-235B-A22B
-    (
-        8,
-        16,
-        4096,
-        10,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),  # Qwen3.5-397B-A17B
-    (
-        8,
-        16,
-        4096,
-        16,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),  # Fake, no known model with top_k=16
-    (
-        8,
-        16,
-        4096,
-        22,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),  # Nemotron-3-Super-120B-A12B
-    # Coverage for num_tokens
-    (
-        8,
-        1,
-        4096,
-        8,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),
-    # Coverage for dtype
-    (
-        8,
-        16,
-        4096,
-        8,
-        torch.float16,
-        True,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),
-    # Coverage for payload_in_workspace
-    (
-        8,
-        16,
-        4096,
-        8,
-        torch.bfloat16,
-        False,
-        CombineQuantMode.NONE,
-        SfLayout.layout_linear,
-    ),
-    # MXFP8 quantized combine output
-    (
-        4,
-        16,
-        4096,
-        2,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.MXFP8,
-        SfLayout.layout_linear,
-    ),
-    (
-        8,
-        16,
-        4096,
-        8,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.MXFP8,
-        SfLayout.layout_linear,
-    ),
-    (
-        4,
-        16,
-        4096,
-        2,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.MXFP8,
-        SfLayout.layout_128x4,
-    ),
-    (
-        8,
-        16,
-        4096,
-        8,
-        torch.bfloat16,
-        True,
-        CombineQuantMode.MXFP8,
-        SfLayout.layout_128x4,
-    ),
-    (4, 16, 4096, 2, torch.bfloat16, True, CombineQuantMode.MXFP8, SfLayout.layout_8x4),
-    (8, 16, 4096, 8, torch.bfloat16, True, CombineQuantMode.MXFP8, SfLayout.layout_8x4),
+    (4, 16, 4096, 2, torch.bfloat16, True),  # Mixtral-8x7B
+    (4, 16, 2880, 4, torch.bfloat16, True),  # GPT-OSS-120B
+    (8, 16, 5120, 6, torch.bfloat16, True),  # DeepSeek-V2
+    (8, 16, 7168, 8, torch.bfloat16, True),  # DeepSeek-V3
+    (8, 16, 4096, 8, torch.bfloat16, True),  # Qwen3-235B-A22B
+    (8, 16, 4096, 10, torch.bfloat16, True),  # Qwen3.5-397B-A17B
+    (8, 16, 4096, 16, torch.bfloat16, True),  # Fake, no known model with top_k=16
+    (8, 16, 4096, 22, torch.bfloat16, True),  # Nemotron-3-Super-120B-A12B
 ]
 
 
-def _compute_mxfp8_sf_size(num_rows, hidden_size, sf_layout):
-    """Number of uint8 scale-factor bytes needed for an [num_rows, hidden_size] MXFP8 tensor."""
-    assert hidden_size % 32 == 0, (
-        "hidden_size must be a multiple of 32 for MXFP8 (sf_vec_size=32)"
-    )
-    cols = hidden_size // 32
+# (quant_mode, sf_layout)
+QUANT_PARAMS = [
+    (CombineQuantMode.NONE, SfLayout.layout_linear),
+    (CombineQuantMode.MXFP8, SfLayout.layout_linear),
+    (CombineQuantMode.MXFP8, SfLayout.layout_128x4),
+    (CombineQuantMode.MXFP8, SfLayout.layout_8x4),
+    (CombineQuantMode.MXFP4, SfLayout.layout_128x4),
+    (CombineQuantMode.NVFP4, SfLayout.layout_128x4),
+]
+
+
+def ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def _compute_sf_size(
+    combine_quant_mode: CombineQuantMode,
+    num_rows: int,
+    hidden_size: int,
+    sf_layout: SfLayout,
+):
+    """Number of scale-factor bytes needed for an [num_rows, hidden_size] tensor."""
+    assert combine_quant_mode != CombineQuantMode.NONE
+    sf_vec_size = 16 if combine_quant_mode == CombineQuantMode.NVFP4 else 32
+    cols = ceil_div(hidden_size, sf_vec_size)
+
     if sf_layout == SfLayout.layout_linear:
         return num_rows * cols
-    if sf_layout == SfLayout.layout_128x4:
+    elif sf_layout == SfLayout.layout_128x4:
         padded_row = (num_rows + 127) // 128 * 128
         padded_col = (cols + 3) // 4 * 4
         return padded_row * padded_col
-    if sf_layout == SfLayout.layout_8x4:
+    elif sf_layout == SfLayout.layout_8x4:
         padded_row = (num_rows + 7) // 8 * 8
         padded_col = (cols + 3) // 4 * 4
         return padded_row * padded_col
-    raise ValueError(f"Unsupported sf_layout: {sf_layout}")
+    else:
+        raise ValueError(f"Unsupported sf_layout: {sf_layout}")
 
 
 # This is a hack to ensure we get forward progress when running multiple kernels on a single GPU
@@ -463,6 +342,7 @@ def combine_from_single_rank(
     payload_in_workspace,
     output_dtype=None,
     output_scales_list=None,
+    output_scalar_scale=1.0,
     sf_layout=SfLayout.layout_linear,
 ):
     combine_results = []
@@ -490,6 +370,7 @@ def combine_from_single_rank(
                         if output_scales_list is not None
                         else None
                     ),
+                    output_scalar_scale=output_scalar_scale,
                     sf_layout=sf_layout,
                 )
             )
@@ -704,7 +585,7 @@ def fake_moe(
 
 @pytest.mark.parametrize(
     "world_size,num_tokens,vector_dim,top_k,dtype,payload_in_workspace,quant_mode,sf_layout",
-    COMBINE_PARAMS,
+    [(*x, *y) for x, y in itertools.product(COMBINE_PARAMS, QUANT_PARAMS)],
 )
 def test_moe_combine_multi_rank_single_gpu(
     world_size,
@@ -719,9 +600,9 @@ def test_moe_combine_multi_rank_single_gpu(
     torch.cuda.set_device(0)
     compute_capability = get_compute_capability(torch.device("cuda"))
     compute_capability_number = compute_capability[0] * 10 + compute_capability[1]
-    if quant_mode == CombineQuantMode.MXFP8 and compute_capability_number < 100:
+    if quant_mode != CombineQuantMode.NONE and compute_capability_number < 100:
         pytest.skip(
-            f"MXFP8 quantized combine requires CUDA platform >= 100, got {compute_capability_number}."
+            f"Combine-quantization fusion requires CUDA platform >= 100, got {compute_capability_number}."
         )
 
     check_sufficient_sm_count(num_tokens, world_size)
@@ -813,7 +694,9 @@ def test_moe_combine_multi_rank_single_gpu(
             )
         )
 
-    if quant_mode == CombineQuantMode.MXFP8:
+    if quant_mode != CombineQuantMode.NONE:
+        # High-precision (bf16) combine output. The quantized kernel output is
+        # validated by dequantizing it and comparing against this reference.
         reference_result = combine_from_single_rank(
             inplace_combine_tensors,
             num_tokens,
@@ -824,10 +707,22 @@ def test_moe_combine_multi_rank_single_gpu(
             combine_payload_offsets,
             payload_in_workspace=payload_in_workspace,
         )
-        output_dtype = torch.float8_e4m3fn
-        sf_size = _compute_mxfp8_sf_size(num_tokens, vector_dim, sf_layout)
+        sf_size = _compute_sf_size(quant_mode, num_tokens, vector_dim, sf_layout)
+        if quant_mode == CombineQuantMode.MXFP8:
+            output_dtype = torch.float8_e4m3fn
+            sf_dtype = torch.uint8  # UE8M0 scale factors, packed as bytes
+        else:
+            # MXFP4 / NVFP4: two FP4 (e2m1) values packed per uint8 byte. The scale
+            # dtype is how the binding distinguishes the two: uint8 (UE8M0) -> MXFP4,
+            # float8_e4m3fn (UE4M3) -> NVFP4.
+            output_dtype = torch.uint8
+            sf_dtype = (
+                torch.uint8
+                if quant_mode == CombineQuantMode.MXFP4
+                else torch.float8_e4m3fn
+            )
         output_scales_list = [
-            torch.zeros(sf_size, dtype=torch.uint8, device=torch.device("cuda"))
+            torch.zeros(sf_size, dtype=sf_dtype, device=torch.device("cuda"))
             for _ in range(world_size)
         ]
     else:
@@ -878,6 +773,47 @@ def test_moe_combine_multi_rank_single_gpu(
                 atol=0,
                 rtol=0,
             )
+    elif quant_mode in (CombineQuantMode.MXFP4, CombineQuantMode.NVFP4):
+        is_nvfp4 = quant_mode == CombineQuantMode.NVFP4
+        sf_vec_size = 16 if is_nvfp4 else 32
+        # e2m1_and_ufp8sf_scale_to_float: ufp8_type 1 = UE4M3 (NVFP4), 0 = UE8M0 (MXFP4).
+        ufp8_type = 1 if is_nvfp4 else 0
+        is_swizzled = sf_layout != SfLayout.layout_linear
+        # The combine ran with the default output_scalar_scale (SFScaleVal = 1.0), which
+        # NVFP4 applies and MXFP4 (UE8M0) ignores; decode with the matching global scale.
+        global_sf = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+        for rank in range(world_size):
+            if is_nvfp4:
+                ref_fp4, ref_sf = nvfp4_quantize(
+                    reference_result[rank],
+                    global_sf,
+                    sfLayout=sf_layout,
+                    sf_vec_size=16,
+                    do_shuffle=False,
+                )
+            else:
+                ref_fp4, ref_sf = mxfp4_quantize(reference_result[rank])
+            # Packed FP4 bytes can't be compared directly (two e2m1 codes share a byte),
+            # so dequantize both the kernel output and the reference identically and
+            # compare in float space. Both paths share the cvt_warp_fp16_to_fp4 routine,
+            # so the dequantized values should match within FP4 granularity.
+            actual = e2m1_and_ufp8sf_scale_to_float(
+                combine_results[rank].view(torch.uint8),
+                output_scales_list[rank].view(torch.uint8).reshape(-1),
+                global_sf,
+                sf_vec_size,
+                ufp8_type,
+                is_swizzled,
+            )
+            expected = e2m1_and_ufp8sf_scale_to_float(
+                ref_fp4.view(torch.uint8),
+                ref_sf.view(torch.uint8).reshape(-1),
+                global_sf,
+                sf_vec_size,
+                ufp8_type,
+                is_swizzled,
+            )
+            torch.testing.assert_close(actual, expected, atol=1.5e-2, rtol=1.5e-2)
     else:
         raise ValueError(f"Unsupported quant_mode: {quant_mode}")
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Follow up PR for #3376. Implement mxfp4/nvfp4 quant in moe a2a combine.

Add `output_scalar_scale: float = 1.0` to API.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added FP4 output quantization modes for MoE all-to-all combine (MXFP4 and NVFP4).
  * Added an `output_scalar_scale` parameter to control FP4 scaling behavior.

* **Behavior Changes**
  * Quantized combine now supports additional packing/output layout for FP4-related outputs, and validates supported dtype combinations and compute capability.

* **Tests**
  * Expanded and refactored MoE all-to-all combine tests to cover MXFP4/NVFP4 end-to-end (including result comparison via FP4 quant/dequant).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->