### PR TITLE
fix(gemm): relax b12x FP4 K constraint from 128 to 32 (TMA alignment)

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5542,14 +5542,15 @@ def _b12x_gemm_fp4_requirement(
         raise ValueError("b12x FP4 GEMM only supports 128x4 scale factor layout.")
     if not use_nvfp4:
         raise ValueError("b12x FP4 GEMM only supports NVFP4 (sf_vec_size=16).")
-    # K must be a multiple of 128 (tile_k = sf_vec_size * 8); a is packed FP4 (M, K//2).
+    # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not tile_k=128: the
+    # mainloop predicates the partial tile, so ragged K (192) works. Mirror can_implement.
     real_k = a.shape[1] * 2
-    if real_k % 128 != 0:
+    if real_k % 32 != 0:
         if backend != "b12x":
             return False  # let "auto" fall back to cutlass/cudnn
         raise ValueError(
-            "b12x FP4 GEMM requires the contraction dim K to be a multiple of 128 "
-            f"(tile_k = sf_vec_size * 8). Got K={real_k}."
+            "b12x FP4 GEMM requires the contraction dim K to be a multiple of 32 "
+            f"(TMA 16-byte alignment). Got K={real_k}."
         )
     _check_cute_dsl_availability()
     return True

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -2413,9 +2413,9 @@ class DenseGemmKernel:
         # A must be K-major, B must be K-major
         if a_major != "k" or b_major != "k":
             return False
-        # Alignment: K must be divisible by tile_k
-        tile_k = sf_vec_size * 8
-        if k % tile_k != 0:
+        # K floor is 32 (TMA assumed_align=16 on K-major packed FP4), not tile_k: the
+        # mainloop predicates the partial tile, so ragged K works. Mirror gemm_base.py.
+        if k % 32 != 0:
             return False
         return True
 

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -8,7 +8,12 @@ from flashinfer import (
     nvfp4_quantize,
     mxfp4_quantize,
 )
-from flashinfer.utils import get_compute_capability, LibraryError
+from flashinfer.utils import (
+    get_compute_capability,
+    is_sm12x_supported,
+    version_at_least,
+    LibraryError,
+)
 from flashinfer.gemm.gemm_base import CUDNN_FP4_MXFP4_SM120_CUDNN_VERSION_ERROR
 
 
@@ -139,6 +144,59 @@ def test_mm_fp4_backend_auto(
 ):
     # Some test cases for auto backend.
     _test_mm_fp4(m, n, k, res_dtype, "auto", use_128x4_sf_layout, auto_tuning, fp4_type)
+
+
+# Regression (#3560): b12x must accept ragged K (real floor K%32==0, not tile_k=128).
+# K=192 (packed_k=96) is the shape #3560 broke; both auto_tuning values hit distinct paths.
+@pytest.mark.parametrize("k", [96, 192])
+@pytest.mark.parametrize("auto_tuning", [False, True])
+def test_mm_fp4_b12x_ragged_k(k, auto_tuning):
+    _test_mm_fp4(
+        m=64,
+        n=512,
+        k=k,
+        res_dtype=torch.bfloat16,
+        backend="b12x",
+        use_128x4_sf_layout=True,
+        auto_tuning=auto_tuning,
+        fp4_type="nvfp4",
+    )
+
+
+# K % 32 != 0 violates TMA 16-byte alignment; explicit b12x must reject cleanly.
+def test_mm_fp4_b12x_misaligned_k_raises():
+    device = torch.device("cuda")
+    if not (
+        is_sm12x_supported(device) and version_at_least(torch.version.cuda, "13.0")
+    ):
+        pytest.skip("b12x backend requires SM120/SM121 + CUDA 13+.")
+    m, n, k = 64, 512, 112  # k % 32 == 16
+    a = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
+    b = torch.randn([n, k], device="cuda", dtype=torch.bfloat16)
+    g_in = (448 * 6) / a.float().abs().nan_to_num().max()
+    g_w = (448 * 6) / b.float().abs().nan_to_num().max()
+    a_fp4, a_s = nvfp4_quantize(
+        a, g_in, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    b_fp4, b_s = nvfp4_quantize(
+        b, g_w, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    res = torch.empty([m, n], device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="multiple of 32"):
+        mm_fp4(
+            a_fp4,
+            b_fp4.T,
+            a_s,
+            b_s.T,
+            1.0 / (g_in * g_w),
+            torch.bfloat16,
+            res,
+            block_size=16,
+            use_8x4_sf_layout=False,
+            backend="b12x",
+            use_nvfp4=True,
+            skip_check=False,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

PR #3560 added a precheck in `_b12x_gemm_fp4_requirement` that rejects `K` not a multiple of `tile_k = sf_vec_size * 8 = 128`. For explicit `backend="b12x"` this `raise`s, breaking shapes like **K=192** (`packed_k=96`):

```
ValueError: b12x FP4 GEMM requires the contraction dim K to be a multiple of 128
(tile_k = sf_vec_size * 8). Got K=192.
```

These shapes ran before #3560.

## Root cause

`K % 128` is the *full MMA K-tile* condition, not the kernel's real correctness floor. The actual floor is **`K % 32 == 0`**:

- `A` is K-major packed FP4, `(M, K/2)` bytes, loaded via TMA with `assumed_align=16`, so `K/2 % 16 == 0` → `K % 32 == 0`.
- `K` need **not** divide `tile_k=128`: the mainloop predicates the partial final K-tile and the swizzled SF layout zero-pads scale-groups, so ragged K (96, 160, 192, 224, …) computes correctly.

Verified on GB10 (SM121): `cos_sim` 0.98–0.99 for K ∈ {64, 96, 160, 192, 224, 320} across M ∈ {1, 8, 256}, narrow-N (swap_ab), and both autotune paths; `K % 32 == 16` (e.g. 112, 176) yields garbage and is correctly rejected.

## Fix

Relax both K guards to `% 32`:

- `_b12x_gemm_fp4_requirement` precheck (gates the non-autotune default-plan path).
- `DenseGemmKernel.can_implement` (gates the autotune candidate enumeration).

Both sites move together so the autotune and non-autotune paths accept the same shapes.

## Tests

`tests/gemm/test_mm_fp4.py`:
- `test_mm_fp4_b12x_ragged_k` — K ∈ {96, 192} × `auto_tuning` ∈ {False, True} (both `auto_tuning` values exercise the distinct guard paths).
- `test_mm_fp4_b12x_misaligned_k_raises` — K=112 must reject cleanly.

All new tests pass; the 396 existing b12x NVFP4 cases (K=128/256/512) remain green on SM121.

## Note for reviewers

#3560's precheck mirrored the b12x donor's `can_implement` contract (which hard-`raise`s on `k % tile_k`). This PR intentionally **extends past** that contract to `% 32`, justified by the correctness data above — the kernel's mainloop already handles ragged K via partial-tile predication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Relaxed the b12x FP4 GEMM K-dimension alignment requirement from multiples of 128 to multiples of 32 to improve support for more matrix shapes.

* **Tests**
  * Added regression coverage for ragged K values across auto-tuning settings.
  * Added a test ensuring misaligned K values are rejected with a clear “multiple of 32” error (under supported GPU/CUDA conditions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->