### PR TITLE
perf(gdn): make GDN kernels compilation batch-size agnostic (support dynamic batch shapes for vLLM integration)

### DIFF
--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -1729,12 +1729,18 @@ def gated_delta_rule_mtp_wide_vec(
         output_state_indices is None or output_state_indices is initial_state_indices
     )
 
-    # Slot stride may be larger than HV*V*K (vLLM packs conv+ssm on the same
-    # page). Include in the cache key so padded vs tight pools each get their
-    # own compiled kernel — cute.compile bakes the stride into the cubin.
-    pool_slot_stride = int(initial_state_source.stride(0))
     # B is absent from the key: per-batch tensors are marked dynamic below so one
-    # cubin serves every batch size (no inference-time recompile).
+    # cubin serves every batch size (no inference-time recompile). A contiguous
+    # pool also marks its slot dim dynamic (sentinel -1 keys) so the cubin is
+    # pool-size agnostic; a padded/strided pool (vLLM packs conv+ssm on one page)
+    # keeps its real pool_size/stride baked into the cubin via the cache key.
+    contiguous_pool = initial_state_source.is_contiguous()
+    if contiguous_pool:
+        pool_size_key = -1
+        pool_slot_stride = -1
+    else:
+        pool_size_key = pool_size
+        pool_slot_stride = int(initial_state_source.stride(0))
     cache_key = (
         "v3_mtp_bf16_tiled_dynB",
         T_val,
@@ -1742,7 +1748,7 @@ def gated_delta_rule_mtp_wide_vec(
         HV_val,
         K_val,
         V_val,
-        pool_size,
+        pool_size_key,
         pool_slot_stride,
         tile_v,
         effective_disable_final,
@@ -1763,7 +1769,11 @@ def gated_delta_rule_mtp_wide_vec(
         )
 
     if cache_key not in _compiled_kernels_wide_vec:
-        h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
+        if contiguous_pool:
+            # Mark the pool slot dim dynamic so one cubin serves all pool sizes.
+            h_ = _mark_batch_dynamic(h0_source)
+        else:
+            h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
         if cache_intermediate_states:
             # Dummy [1,1,1] tensor (caching off) has no unique stride-1 dim.
@@ -1983,11 +1993,17 @@ def gated_delta_rule_mtp(
         output_state_indices is None or output_state_indices is initial_state_indices
     )
 
-    # Slot stride may be larger than HV*V*K (vLLM's packed conv+ssm page).
-    # Include in cache key — cute.compile bakes the stride into the cubin.
-    pool_slot_stride = int(initial_state_source.stride(0))
     # B is absent from the key: per-batch tensors are marked dynamic below so one
-    # cubin serves every batch size (no inference-time recompile).
+    # cubin serves every batch size. A contiguous pool also marks its slot dim
+    # dynamic (sentinel -1 keys) for pool-size agnosticism; a padded/strided pool
+    # keeps its real pool_size/stride baked into the cubin via the cache key.
+    contiguous_pool = initial_state_source.is_contiguous()
+    if contiguous_pool:
+        pool_size_key = -1
+        pool_slot_stride = -1
+    else:
+        pool_size_key = pool_size
+        pool_slot_stride = int(initial_state_source.stride(0))
     cache_key = (
         "mtp_bf16_dynB",
         T,
@@ -1995,7 +2011,7 @@ def gated_delta_rule_mtp(
         HV,
         K,
         V,
-        pool_size,
+        pool_size_key,
         pool_slot_stride,
         tile_v,
         ilp_rows,
@@ -2015,7 +2031,11 @@ def gated_delta_rule_mtp(
         output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
 
     if cache_key not in _compiled_kernels_mtp:
-        h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
+        if contiguous_pool:
+            # Mark the pool slot dim dynamic so one cubin serves all pool sizes.
+            h_ = _mark_batch_dynamic(h0_source)
+        else:
+            h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
         if cache_intermediate_states:
             inter_ = _mark_batch_dynamic(intermediate_states)

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -50,6 +50,16 @@ from cutlass.cute.runtime import from_dlpack
 from flashinfer.cute_dsl.fp4_common import get_sm_version
 from flashinfer.cute_dsl.utils import get_num_sm
 
+
+def _mark_batch_dynamic(torch_t: torch.Tensor, *, assumed_align: int = 32):
+    # stride_order is explicit because auto-deduction is ambiguous when the
+    # batch dim is size 1 (B=1, T=1 -> several dims share equal strides).
+    stride_order = tuple(sorted(range(torch_t.dim()), key=lambda d: -torch_t.stride(d)))
+    return from_dlpack(
+        torch_t, assumed_align=assumed_align, enable_tvm_ffi=True
+    ).mark_compact_shape_dynamic(mode=0, stride_order=stride_order)
+
+
 # ==============================================================================
 # FMA WRAPPER FUNCTIONS (SM90 Compatibility)
 # ==============================================================================
@@ -129,7 +139,6 @@ def gdn_decode_bf16state_mtp_ilp4_kernel(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -749,7 +758,6 @@ def gdn_wide_vec_kernel(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1248,7 +1256,6 @@ def run_gdn_decode_bf16state_mtp_ilp4(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1273,6 +1280,8 @@ def run_gdn_decode_bf16state_mtp_ilp4(
     )
 
     num_v_tiles = cute.ceil_div(v_dim, tile_v)
+    # Runtime batch extent (q's leading dim is dynamic): keeps B out of the cubin.
+    B = cute.size(q.shape[0])
     grid_size = B * HV * num_v_tiles
 
     smem_bytes = 128
@@ -1299,7 +1308,6 @@ def run_gdn_decode_bf16state_mtp_ilp4(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -1340,7 +1348,6 @@ def _run_wide_vec(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1354,6 +1361,8 @@ def _run_wide_vec(
     stream: cuda.CUstream,
 ):
     num_v_tiles: cutlass.Constexpr[int] = V // tile_v
+    # Runtime batch extent (q's leading dim is dynamic): keeps B out of the cubin.
+    B = cute.size(q.shape[0])
     grid_size = B * HV * num_v_tiles
     smem_bytes = (
         4 * T * (K + 8)  # sQ FP32
@@ -1378,7 +1387,6 @@ def _run_wide_vec(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -1725,9 +1733,10 @@ def gated_delta_rule_mtp_wide_vec(
     # page). Include in the cache key so padded vs tight pools each get their
     # own compiled kernel — cute.compile bakes the stride into the cubin.
     pool_slot_stride = int(initial_state_source.stride(0))
+    # B is absent from the key: per-batch tensors are marked dynamic below so one
+    # cubin serves every batch size (no inference-time recompile).
     cache_key = (
-        "v3_mtp_bf16_tiled",
-        B_val,
+        "v3_mtp_bf16_tiled_dynB",
         T_val,
         H_val,
         HV_val,
@@ -1745,36 +1754,30 @@ def gated_delta_rule_mtp_wide_vec(
         use_packed_fma,
         same_pool,
     )
-    if cache_key not in _compiled_kernels_wide_vec:
-        default_indices = torch.arange(B_val, dtype=torch.int32, device=q.device)
-        default_output = torch.empty(
+
+    if initial_state_indices is None:
+        initial_state_indices = torch.arange(B_val, dtype=torch.int32, device=q.device)
+    if output is None:
+        output = torch.empty(
             B_val, T_val, HV_val, V_val, device=q.device, dtype=q.dtype
         )
 
-        if initial_state_indices is None:
-            initial_state_indices = default_indices
-        if output is None:
-            output = default_output
-
-        # Compile-time indices template: any [B] int32 on the right device.
-        # Both read and write index tensors share the same shape/dtype so
-        # the same dlpack handle works for both slots.
+    if cache_key not in _compiled_kernels_wide_vec:
         h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
-        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
-        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
-        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
-        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
-        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
+        if cache_intermediate_states:
+            # Dummy [1,1,1] tensor (caching off) has no unique stride-1 dim.
+            inter_ = _mark_batch_dynamic(intermediate_states)
+        q_ = _mark_batch_dynamic(q)
+        k_ = _mark_batch_dynamic(k)
+        v_ = _mark_batch_dynamic(v)
+        a_ = _mark_batch_dynamic(a)
+        b_ = _mark_batch_dynamic(b)
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
-        o_ = from_dlpack(output, assumed_align=32, enable_tvm_ffi=True)
-        h0_idx_ = from_dlpack(
-            initial_state_indices, assumed_align=32, enable_tvm_ffi=True
-        )
-        h0_out_idx_ = from_dlpack(
-            initial_state_indices, assumed_align=32, enable_tvm_ffi=True
-        )
+        o_ = _mark_batch_dynamic(output)
+        h0_idx_ = _mark_batch_dynamic(initial_state_indices)
+        h0_out_idx_ = _mark_batch_dynamic(initial_state_indices)
 
         _compiled_kernels_wide_vec[cache_key] = {
             "compiled": cute.compile(
@@ -1795,7 +1798,6 @@ def gated_delta_rule_mtp_wide_vec(
                 softplus_threshold,
                 scale,
                 HV_val,
-                B_val,
                 T_val,
                 H_val,
                 K_val,
@@ -1809,19 +1811,13 @@ def gated_delta_rule_mtp_wide_vec(
                 stream,
                 options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
-            "default_indices": default_indices,
-            "output": default_output,
         }
 
     cache = _compiled_kernels_wide_vec[cache_key]
-    if initial_state_indices is None:
-        initial_state_indices = cache["default_indices"]
     if output_state_indices is None:
         # Single-pool: read==write. Reuse the same indices tensor — no extra
         # allocation, kernel still produces the same address for both slots.
         output_state_indices = initial_state_indices
-    if output is None:
-        output = cache["output"]
 
     cache["compiled"](
         h0_source,
@@ -1990,9 +1986,10 @@ def gated_delta_rule_mtp(
     # Slot stride may be larger than HV*V*K (vLLM's packed conv+ssm page).
     # Include in cache key — cute.compile bakes the stride into the cubin.
     pool_slot_stride = int(initial_state_source.stride(0))
+    # B is absent from the key: per-batch tensors are marked dynamic below so one
+    # cubin serves every batch size (no inference-time recompile).
     cache_key = (
-        "mtp_bf16",
-        B,
+        "mtp_bf16_dynB",
         T,
         H,
         HV,
@@ -2011,29 +2008,27 @@ def gated_delta_rule_mtp(
         use_packed_fma,
         same_pool,
     )
-    if cache_key not in _compiled_kernels_mtp:
-        # First call for this shape: allocate default indices/output and do
-        # dlpack conversions once for compilation. Steady-state calls pass
-        # torch tensors straight to the compiled callable (tvm-ffi accepts
-        # either) and reuse these cached defaults when the caller doesn't
-        # provide their own.
-        default_indices = torch.arange(B, dtype=torch.int32, device=q.device)
-        default_output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
 
+    if initial_state_indices is None:
+        initial_state_indices = torch.arange(B, dtype=torch.int32, device=q.device)
+    if output is None:
+        output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
+
+    if cache_key not in _compiled_kernels_mtp:
         h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
-        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
-        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
-        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
-        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
-        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
+        if cache_intermediate_states:
+            inter_ = _mark_batch_dynamic(intermediate_states)
+        q_ = _mark_batch_dynamic(q)
+        k_ = _mark_batch_dynamic(k)
+        v_ = _mark_batch_dynamic(v)
+        a_ = _mark_batch_dynamic(a)
+        b_ = _mark_batch_dynamic(b)
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
-        o_ = from_dlpack(default_output, assumed_align=32, enable_tvm_ffi=True)
-        h0_idx_ = from_dlpack(default_indices, assumed_align=32, enable_tvm_ffi=True)
-        h0_out_idx_ = from_dlpack(
-            default_indices, assumed_align=32, enable_tvm_ffi=True
-        )
+        o_ = _mark_batch_dynamic(output)
+        h0_idx_ = _mark_batch_dynamic(initial_state_indices)
+        h0_out_idx_ = _mark_batch_dynamic(initial_state_indices)
 
         _compiled_kernels_mtp[cache_key] = {
             "compiled": cute.compile(
@@ -2054,7 +2049,6 @@ def gated_delta_rule_mtp(
                 softplus_threshold,
                 scale,
                 HV,
-                B,
                 T,
                 H,
                 K,
@@ -2068,16 +2062,12 @@ def gated_delta_rule_mtp(
                 stream,
                 options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
-            "default_indices": default_indices,
-            "output": default_output,
         }
 
     cache = _compiled_kernels_mtp[cache_key]
 
     if output_state_indices is None:
         output_state_indices = initial_state_indices
-    if output is None:
-        output = cache["output"]
 
     cache["compiled"](
         h0_source,

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -52,8 +52,7 @@ from flashinfer.cute_dsl.utils import get_num_sm
 
 
 def _mark_batch_dynamic(torch_t: torch.Tensor, *, assumed_align: int = 32):
-    # stride_order is explicit because auto-deduction is ambiguous when the
-    # batch dim is size 1 (B=1, T=1 -> several dims share equal strides).
+    # explicit stride_order: auto-deduction is ambiguous at B=1/T=1.
     stride_order = tuple(sorted(range(torch_t.dim()), key=lambda d: -torch_t.stride(d)))
     return from_dlpack(
         torch_t, assumed_align=assumed_align, enable_tvm_ffi=True
@@ -1280,7 +1279,6 @@ def run_gdn_decode_bf16state_mtp_ilp4(
     )
 
     num_v_tiles = cute.ceil_div(v_dim, tile_v)
-    # Runtime batch extent (q's leading dim is dynamic): keeps B out of the cubin.
     B = cute.size(q.shape[0])
     grid_size = B * HV * num_v_tiles
 
@@ -1361,7 +1359,6 @@ def _run_wide_vec(
     stream: cuda.CUstream,
 ):
     num_v_tiles: cutlass.Constexpr[int] = V // tile_v
-    # Runtime batch extent (q's leading dim is dynamic): keeps B out of the cubin.
     B = cute.size(q.shape[0])
     grid_size = B * HV * num_v_tiles
     smem_bytes = (
@@ -1729,11 +1726,8 @@ def gated_delta_rule_mtp_wide_vec(
         output_state_indices is None or output_state_indices is initial_state_indices
     )
 
-    # B is absent from the key: per-batch tensors are marked dynamic below so one
-    # cubin serves every batch size (no inference-time recompile). A contiguous
-    # pool also marks its slot dim dynamic (sentinel -1 keys) so the cubin is
-    # pool-size agnostic; a padded/strided pool (vLLM packs conv+ssm on one page)
-    # keeps its real pool_size/stride baked into the cubin via the cache key.
+    # Contiguous pool -> sentinel keys + slot dim marked dynamic (pool-size
+    # agnostic); padded/strided pool keeps real pool_size/stride in the key.
     contiguous_pool = initial_state_source.is_contiguous()
     if contiguous_pool:
         pool_size_key = -1
@@ -1770,7 +1764,6 @@ def gated_delta_rule_mtp_wide_vec(
 
     if cache_key not in _compiled_kernels_wide_vec:
         if contiguous_pool:
-            # Mark the pool slot dim dynamic so one cubin serves all pool sizes.
             h_ = _mark_batch_dynamic(h0_source)
         else:
             h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
@@ -1993,10 +1986,8 @@ def gated_delta_rule_mtp(
         output_state_indices is None or output_state_indices is initial_state_indices
     )
 
-    # B is absent from the key: per-batch tensors are marked dynamic below so one
-    # cubin serves every batch size. A contiguous pool also marks its slot dim
-    # dynamic (sentinel -1 keys) for pool-size agnosticism; a padded/strided pool
-    # keeps its real pool_size/stride baked into the cubin via the cache key.
+    # Contiguous pool -> sentinel keys + slot dim marked dynamic (pool-size
+    # agnostic); padded/strided pool keeps real pool_size/stride in the key.
     contiguous_pool = initial_state_source.is_contiguous()
     if contiguous_pool:
         pool_size_key = -1
@@ -2032,7 +2023,6 @@ def gated_delta_rule_mtp(
 
     if cache_key not in _compiled_kernels_mtp:
         if contiguous_pool:
-            # Mark the pool slot dim dynamic so one cubin serves all pool sizes.
             h_ = _mark_batch_dynamic(h0_source)
         else:
             h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -1731,10 +1731,10 @@ def gated_delta_rule_mtp_wide_vec(
     contiguous_pool = initial_state_source.is_contiguous()
     if contiguous_pool:
         pool_size_key = -1
-        pool_slot_stride = -1
+        pool_slot_stride: tuple[int, ...] = (-1,)
     else:
         pool_size_key = pool_size
-        pool_slot_stride = int(initial_state_source.stride(0))
+        pool_slot_stride = tuple(int(s) for s in initial_state_source.stride())
     cache_key = (
         "v3_mtp_bf16_tiled_dynB",
         T_val,
@@ -1991,10 +1991,10 @@ def gated_delta_rule_mtp(
     contiguous_pool = initial_state_source.is_contiguous()
     if contiguous_pool:
         pool_size_key = -1
-        pool_slot_stride = -1
+        pool_slot_stride: tuple[int, ...] = (-1,)
     else:
         pool_size_key = pool_size
-        pool_slot_stride = int(initial_state_source.stride(0))
+        pool_slot_stride = tuple(int(s) for s in initial_state_source.stride())
     cache_key = (
         "mtp_bf16_dynB",
         T,

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -2336,17 +2336,22 @@ def run_mtp_decode(
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        # Mark the batch (mode 0) dim dynamic so one cubin serves all batch
+        # Mark the leading (mode 0) dim dynamic so one cubin serves all batch
         # sizes; explicit stride_order avoids ambiguous auto-deduction at
-        # B=1/T=1. h0_source/intermediate_states are pool-scoped — their dim 0
-        # (pool_size*HV / pool_size*T*HV) is also marked dynamic since pool_size
-        # left the cache key.
+        # B=1/T=1. h0_source's pool-slot dim is marked too since pool_size left
+        # the cache key.
         h0_source_tensor = from_dlpack(
             h0_source, assumed_align=16
         ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
-        intermediate_states_tensor = from_dlpack(
-            intermediate_states, assumed_align=16
-        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
+        intermediate_states_tensor = from_dlpack(intermediate_states, assumed_align=16)
+        if cache_intermediate_states:
+            # Only the real cache buffer has a meaningful leading dim; the
+            # caching-off dummy ([1,1,1]) is never read by the kernel.
+            intermediate_states_tensor = (
+                intermediate_states_tensor.mark_compact_shape_dynamic(
+                    mode=0, stride_order=(0, 1, 2), divisibility=1
+                )
+            )
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
         a_tensor = from_dlpack(a, assumed_align=16).mark_compact_shape_dynamic(
             mode=0, stride_order=(0, 1, 2), divisibility=1

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -213,7 +213,6 @@ def gdn_verify_kernel_mtp(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1352,7 +1351,6 @@ def run_gdn_verify_kernel_mtp(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1378,7 +1376,7 @@ def run_gdn_verify_kernel_mtp(
     num_v_tiles = cute.ceil_div(v_dim, tile_v)
 
     # Grid: (B * HV * num_v_tiles, 1, 1) - parallelize across V dimension
-    grid_size = B * HV * num_v_tiles
+    grid_size = q.shape[0] * HV * num_v_tiles
 
     # Shared memory for pre-computed q, k, g, beta, preloaded v data, and output
     smem_bytes = (
@@ -1411,7 +1409,6 @@ def run_gdn_verify_kernel_mtp(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -1455,7 +1452,6 @@ def gdn_verify_kernel_mtp_inline(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -2127,7 +2123,6 @@ def run_gdn_verify_kernel_mtp_inline(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -2153,7 +2148,7 @@ def run_gdn_verify_kernel_mtp_inline(
     num_v_tiles = cute.ceil_div(v_dim, tile_v)
 
     # Grid: (B * HV * num_v_tiles, 1, 1) - parallelize across V dimension
-    grid_size = B * HV * num_v_tiles
+    grid_size = q.shape[0] * HV * num_v_tiles
 
     # v10: No sQ/sK/sG/sBeta — only sVdata + sOutput
     smem_bytes = (
@@ -2182,7 +2177,6 @@ def run_gdn_verify_kernel_mtp_inline(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -2205,13 +2199,11 @@ def run_gdn_verify_kernel_mtp_inline(
 
 @functools.cache
 def _get_compiled_mtp_kernel(
-    B: int,
     T: int,
     H: int,
     HV: int,
     K: int,
     V: int,
-    pool_size: int,
     cache_steps: int,
     disable_state_update: bool,
     cache_intermediate_states: bool,
@@ -2229,13 +2221,11 @@ def _get_compiled_mtp_kernel(
 
 @functools.cache
 def _get_compiled_mtp_kernel_inline(
-    B: int,
     T: int,
     H: int,
     HV: int,
     K: int,
     V: int,
-    pool_size: int,
     cache_steps: int,
     disable_state_update: bool,
     cache_intermediate_states: bool,
@@ -2312,68 +2302,77 @@ def run_mtp_decode(
     major, _ = torch.cuda.get_device_capability(q.device)
     use_packed_fma = major >= 10  # SM100+ (Blackwell) supports packed F32x2
 
+    # B and pool_size are intentionally absent: per-batch and pool tensors are
+    # marked dynamic below, so one cubin per variant serves all batch/pool sizes.
+    cache_key = (
+        T,
+        H,
+        HV,
+        K,
+        V,
+        cache_steps,
+        disable_state_update,
+        cache_intermediate_states,
+        scale,
+        use_qk_l2norm,
+        tile_v,
+        vec_size,
+        ilp_rows,
+        use_smem_v,
+        use_packed_fma,
+    )
     if use_inline_kernel:
-        inline_cache_key = (
-            B,
-            T,
-            H,
-            HV,
-            K,
-            V,
-            pool_size,
-            cache_steps,
-            disable_state_update,
-            cache_intermediate_states,
-            scale,
-            use_qk_l2norm,
-            tile_v,
-            vec_size,
-            ilp_rows,
-            use_smem_v,
-            use_packed_fma,
-        )
-        cache = _get_compiled_mtp_kernel_inline(*inline_cache_key)
+        cache = _get_compiled_mtp_kernel_inline(*cache_key)
     else:
-        warp_cache_key = (
-            B,
-            T,
-            H,
-            HV,
-            K,
-            V,
-            pool_size,
-            cache_steps,
-            disable_state_update,
-            cache_intermediate_states,
-            scale,
-            use_qk_l2norm,
-            tile_v,
-            vec_size,
-            ilp_rows,
-            use_smem_v,
-            use_packed_fma,
-        )
-        cache = _get_compiled_mtp_kernel(*warp_cache_key)
+        cache = _get_compiled_mtp_kernel(*cache_key)
 
-    if "cu_seqlens" not in cache or cache["cu_seqlens"].device != q.device:
-        cache["cu_seqlens"] = torch.zeros(B + 1, dtype=torch.int32, device=q.device)
-    cu_seqlens = cache["cu_seqlens"]
+    # cu_seqlens is batch-sized (dummy when is_varlen=False); per-(B, device) map.
+    cu_seqlens_map = cache.setdefault("cu_seqlens", {})
+    cu_key = (B, q.device)
+    if cu_key not in cu_seqlens_map:
+        cu_seqlens_map[cu_key] = torch.zeros(B + 1, dtype=torch.int32, device=q.device)
+    cu_seqlens = cu_seqlens_map[cu_key]
 
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
-        intermediate_states_tensor = from_dlpack(intermediate_states, assumed_align=16)
+        # Mark the batch (mode 0) dim dynamic so one cubin serves all batch
+        # sizes; explicit stride_order avoids ambiguous auto-deduction at
+        # B=1/T=1. h0_source/intermediate_states are pool-scoped — their dim 0
+        # (pool_size*HV / pool_size*T*HV) is also marked dynamic since pool_size
+        # left the cache key.
+        h0_source_tensor = from_dlpack(
+            h0_source, assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
+        intermediate_states_tensor = from_dlpack(
+            intermediate_states, assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16)
+        a_tensor = from_dlpack(a, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2), divisibility=1
+        )
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16)
-        k_tensor = from_dlpack(k, assumed_align=16)
-        v_tensor = from_dlpack(v, assumed_align=16)
-        b_tensor = from_dlpack(b, assumed_align=16)
-        o_tensor = from_dlpack(output, assumed_align=16)
-        h0_indices_tensor = from_dlpack(initial_state_indices, assumed_align=16)
-        cu_seqlens_tensor = from_dlpack(cu_seqlens, assumed_align=16)
+        q_tensor = from_dlpack(q, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        k_tensor = from_dlpack(k, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        v_tensor = from_dlpack(v, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        b_tensor = from_dlpack(b, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2), divisibility=1
+        )
+        o_tensor = from_dlpack(output, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        h0_indices_tensor = from_dlpack(
+            initial_state_indices, assumed_align=16
+        ).mark_layout_dynamic()
+        cu_seqlens_tensor = from_dlpack(
+            cu_seqlens, assumed_align=16
+        ).mark_layout_dynamic()
 
         if use_inline_kernel:
             compiled = cute.compile(
@@ -2394,7 +2393,6 @@ def run_mtp_decode(
                 softplus_threshold=20.0,
                 scale=scale,
                 HV=HV,
-                B=B,
                 T=T,
                 H=H,
                 K=K,
@@ -2431,7 +2429,6 @@ def run_mtp_decode(
                 softplus_threshold=20.0,
                 scale=scale,
                 HV=HV,
-                B=B,
                 T=T,
                 H=H,
                 K=K,

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -2302,8 +2302,6 @@ def run_mtp_decode(
     major, _ = torch.cuda.get_device_capability(q.device)
     use_packed_fma = major >= 10  # SM100+ (Blackwell) supports packed F32x2
 
-    # B and pool_size are intentionally absent: per-batch and pool tensors are
-    # marked dynamic below, so one cubin per variant serves all batch/pool sizes.
     cache_key = (
         T,
         H,
@@ -2326,7 +2324,6 @@ def run_mtp_decode(
     else:
         cache = _get_compiled_mtp_kernel(*cache_key)
 
-    # cu_seqlens is batch-sized (dummy when is_varlen=False); per-(B, device) map.
     cu_seqlens_map = cache.setdefault("cu_seqlens", {})
     cu_key = (B, q.device)
     if cu_key not in cu_seqlens_map:
@@ -2336,17 +2333,12 @@ def run_mtp_decode(
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        # Mark the leading (mode 0) dim dynamic so one cubin serves all batch
-        # sizes; explicit stride_order avoids ambiguous auto-deduction at
-        # B=1/T=1. h0_source's pool-slot dim is marked too since pool_size left
-        # the cache key.
         h0_source_tensor = from_dlpack(
             h0_source, assumed_align=16
         ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
         intermediate_states_tensor = from_dlpack(intermediate_states, assumed_align=16)
         if cache_intermediate_states:
-            # Only the real cache buffer has a meaningful leading dim; the
-            # caching-off dummy ([1,1,1]) is never read by the kernel.
+            # Caching-off dummy ([1,1,1]) is never read; skip marking it.
             intermediate_states_tensor = (
                 intermediate_states_tensor.mark_compact_shape_dynamic(
                     mode=0, stride_order=(0, 1, 2), divisibility=1

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -528,7 +528,6 @@ def run_gdn_decode_kernel_small_batch_nontranspose(
     softplus_beta: cutlass.Constexpr[float],
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     HV: cutlass.Constexpr[int],
@@ -609,7 +608,6 @@ def run_gdn_decode_kernel_big_batch_nontranspose(
     softplus_beta: cutlass.Constexpr[float],
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     HV: cutlass.Constexpr[int],
@@ -679,7 +677,7 @@ def run_gdn_decode_kernel_big_batch_nontranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel_nontranspose(
-    B: int,
+    use_small_batch: bool,
     T: int,
     H: int,
     HV: int,
@@ -723,40 +721,65 @@ def run_nontranspose_decode(
         scale: Query scale factor.
         use_qk_l2norm: Whether to apply L2 normalization.
     """
-    # Compile kernel with TVM FFI (cached)
-    cache_key = (B, T, H, HV, K, V, q.dtype, scale, use_qk_l2norm)
+    # Compile kernel with TVM FFI (cached). use_small_batch selects the kernel
+    # variant and is part of the key; B is not (per-batch tensors are marked
+    # dynamic below so one cubin per variant serves all batch sizes).
+    use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
+    cache_key = (use_small_batch, T, H, HV, K, V, q.dtype, scale, use_qk_l2norm)
     cache = _get_compiled_decode_kernel_nontranspose(*cache_key)
 
-    # Get or create h0_indices and cu_seqlens (cached per config)
-    if "h0_indices" not in cache or cache["h0_indices"].device != q.device:
-        cache["h0_indices"] = torch.arange(B, dtype=torch.int32, device=q.device)
-        cache["cu_seqlens"] = torch.zeros(B + 1, dtype=torch.int32, device=q.device)
-    h0_indices = cache["h0_indices"]
-    cu_seqlens = cache["cu_seqlens"]
+    # Batch-sized aux tensors live in a per-(B, device) sub-map.
+    aux_map = cache.setdefault("aux", {})
+    aux_key = (B, q.device)
+    if aux_key not in aux_map:
+        aux_map[aux_key] = (
+            torch.arange(B, dtype=torch.int32, device=q.device),
+            torch.zeros(B + 1, dtype=torch.int32, device=q.device),
+        )
+    h0_indices, cu_seqlens = aux_map[aux_key]
 
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
         # Choose kernel based on batch size
-        use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
-
         if use_small_batch:
             run_func = run_gdn_decode_kernel_small_batch_nontranspose
         else:
             run_func = run_gdn_decode_kernel_big_batch_nontranspose
 
-        # Convert tensors to CuTe format for compilation only
-        h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
+        # Convert tensors to CuTe format for compilation only. Mark the batch
+        # (mode 0) dim dynamic so one cubin serves all batch sizes; explicit
+        # stride_order avoids ambiguous auto-deduction at B=1/T=1. h0_source is
+        # [B*HV, K, V] (dim 0 scales with batch).
+        h0_source_tensor = from_dlpack(
+            h0_source, assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16)
+        a_tensor = from_dlpack(a, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2), divisibility=1
+        )
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16)
-        k_tensor = from_dlpack(k, assumed_align=16)
-        v_tensor = from_dlpack(v, assumed_align=16)
-        b_tensor = from_dlpack(b, assumed_align=16)
-        o_tensor = from_dlpack(output, assumed_align=16)
-        h0_indices_tensor = from_dlpack(h0_indices, assumed_align=16)
-        cu_seqlens_tensor = from_dlpack(cu_seqlens, assumed_align=16)
+        q_tensor = from_dlpack(q, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        k_tensor = from_dlpack(k, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        v_tensor = from_dlpack(v, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        b_tensor = from_dlpack(b, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2), divisibility=1
+        )
+        o_tensor = from_dlpack(output, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        h0_indices_tensor = from_dlpack(
+            h0_indices, assumed_align=16
+        ).mark_layout_dynamic()
+        cu_seqlens_tensor = from_dlpack(
+            cu_seqlens, assumed_align=16
+        ).mark_layout_dynamic()
 
         # Use TVM FFI to reduce runtime overhead
         compiled = cute.compile(
@@ -775,7 +798,6 @@ def run_nontranspose_decode(
             softplus_beta=1.0,
             softplus_threshold=20.0,
             scale=scale,
-            B=B,
             T=T,
             H=H,
             HV=HV,

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -721,14 +721,10 @@ def run_nontranspose_decode(
         scale: Query scale factor.
         use_qk_l2norm: Whether to apply L2 normalization.
     """
-    # Compile kernel with TVM FFI (cached). use_small_batch selects the kernel
-    # variant and is part of the key; B is not (per-batch tensors are marked
-    # dynamic below so one cubin per variant serves all batch sizes).
     use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
     cache_key = (use_small_batch, T, H, HV, K, V, q.dtype, scale, use_qk_l2norm)
     cache = _get_compiled_decode_kernel_nontranspose(*cache_key)
 
-    # Batch-sized aux tensors live in a per-(B, device) sub-map.
     aux_map = cache.setdefault("aux", {})
     aux_key = (B, q.device)
     if aux_key not in aux_map:
@@ -747,10 +743,6 @@ def run_nontranspose_decode(
         else:
             run_func = run_gdn_decode_kernel_big_batch_nontranspose
 
-        # Convert tensors to CuTe format for compilation only. Mark the batch
-        # (mode 0) dim dynamic so one cubin serves all batch sizes; explicit
-        # stride_order avoids ambiguous auto-deduction at B=1/T=1. h0_source is
-        # [B*HV, K, V] (dim 0 scales with batch).
         h0_source_tensor = from_dlpack(
             h0_source, assumed_align=16
         ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -978,8 +978,6 @@ def run_pretranspose_decode(
     )
     cache = _get_compiled_decode_kernel(*cache_key)
 
-    # Get or create h0_indices and cu_seqlens (cached per (B, device); B is no
-    # longer in the compile cache key, so the batch-sized aux tensors live here).
     aux_map = cache.setdefault("aux", {})
     aux_key = (B, q.device)
     if aux_key not in aux_map:
@@ -1002,11 +1000,6 @@ def run_pretranspose_decode(
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        # Convert tensors to CuTe format for compilation only. Mark the batch
-        # (mode 0) dim dynamic so one cubin serves all batch sizes. Explicit
-        # stride_order avoids ambiguous auto-deduction at B=1/T=1. Pool state
-        # ([pool_size, HV, V, K]) keeps its baked layout (pool stays in the
-        # cache key); only non-pool state ([B*HV, V, K]) scales with batch.
         h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
         if not use_pool_indexing:
             h0_source_tensor = h0_source_tensor.mark_compact_shape_dynamic(

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -62,7 +62,6 @@ def gdn_decode_kernel_small_batch_pretranspose(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -383,7 +382,6 @@ def gdn_decode_kernel_big_batch_pretranspose(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -690,7 +688,6 @@ def run_gdn_decode_kernel_small_batch_pretranspose(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -712,6 +709,7 @@ def run_gdn_decode_kernel_small_batch_pretranspose(
         v_dim = h0_source.layout.shape[1]
         k_dim = h0_source.layout.shape[2]
     # Grid size: use B*HV (actual batch) not h0_source.shape[0] (which may be pool_size*HV)
+    B = cute.size(q.shape[0])
     grid_batch = B * HV
 
     # Create cp.async copy with cache-global mode (bypass L1)
@@ -768,7 +766,6 @@ def run_gdn_decode_kernel_small_batch_pretranspose(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -803,7 +800,6 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -820,6 +816,7 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
     else:
         v_dim = h0_source.layout.shape[1]
         k_dim = h0_source.layout.shape[2]
+    B = cute.size(q.shape[0])
     grid_batch = B * HV
 
     # Create cp.async copy with cache-global mode (bypass L1)
@@ -876,7 +873,6 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -900,7 +896,6 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel(
-    B: int,
     T: int,
     H: int,
     HV: int,
@@ -966,7 +961,6 @@ def run_pretranspose_decode(
     else:
         pool_size = stride0 = stride1 = stride2 = stride3 = 0
     cache_key = (
-        B,
         T,
         H,
         HV,
@@ -984,39 +978,69 @@ def run_pretranspose_decode(
     )
     cache = _get_compiled_decode_kernel(*cache_key)
 
-    # Get or create h0_indices and cu_seqlens (cached per config)
-    if "h0_indices" not in cache or cache["h0_indices"].device != q.device:
-        cache["h0_indices"] = torch.zeros(B, dtype=torch.int32, device=q.device)
-        cache["cu_seqlens"] = torch.zeros(B + 1, dtype=torch.int32, device=q.device)
+    # Get or create h0_indices and cu_seqlens (cached per (B, device); B is no
+    # longer in the compile cache key, so the batch-sized aux tensors live here).
+    aux_map = cache.setdefault("aux", {})
+    aux_key = (B, q.device)
+    if aux_key not in aux_map:
+        aux_map[aux_key] = (
+            torch.zeros(B, dtype=torch.int32, device=q.device),
+            torch.zeros(B + 1, dtype=torch.int32, device=q.device),
+        )
+    default_h0_indices, cu_seqlens = aux_map[aux_key]
 
     if use_pool_indexing and initial_state_indices is not None:
         h0_indices = initial_state_indices.to(torch.int32)
     else:
-        h0_indices = cache["h0_indices"]
+        h0_indices = default_h0_indices
     # Resolve output indices: default to same as read indices
     if use_pool_indexing and output_state_indices is not None:
         h0_out_indices = output_state_indices.to(torch.int32)
     else:
         h0_out_indices = h0_indices
-    cu_seqlens = cache["cu_seqlens"]
 
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        # Convert tensors to CuTe format for compilation only
-        # Use the actual tensor view so strided pool layouts are preserved.
+        # Convert tensors to CuTe format for compilation only. Mark the batch
+        # (mode 0) dim dynamic so one cubin serves all batch sizes. Explicit
+        # stride_order avoids ambiguous auto-deduction at B=1/T=1. Pool state
+        # ([pool_size, HV, V, K]) keeps its baked layout (pool stays in the
+        # cache key); only non-pool state ([B*HV, V, K]) scales with batch.
         h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
+        if not use_pool_indexing:
+            h0_source_tensor = h0_source_tensor.mark_compact_shape_dynamic(
+                mode=0, stride_order=(0, 1, 2), divisibility=1
+            )
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16)
+        a_tensor = from_dlpack(a, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2), divisibility=1
+        )
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16)
-        k_tensor = from_dlpack(k, assumed_align=16)
-        v_tensor = from_dlpack(v, assumed_align=16)
-        b_tensor = from_dlpack(b, assumed_align=16)
-        o_tensor = from_dlpack(output, assumed_align=16)
-        h0_indices_tensor = from_dlpack(h0_indices, assumed_align=16)
-        h0_out_indices_tensor = from_dlpack(h0_out_indices, assumed_align=16)
-        cu_seqlens_tensor = from_dlpack(cu_seqlens, assumed_align=16)
+        q_tensor = from_dlpack(q, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        k_tensor = from_dlpack(k, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        v_tensor = from_dlpack(v, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        b_tensor = from_dlpack(b, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2), divisibility=1
+        )
+        o_tensor = from_dlpack(output, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
+        )
+        h0_indices_tensor = from_dlpack(
+            h0_indices, assumed_align=16
+        ).mark_layout_dynamic()
+        h0_out_indices_tensor = from_dlpack(
+            h0_out_indices, assumed_align=16
+        ).mark_layout_dynamic()
+        cu_seqlens_tensor = from_dlpack(
+            cu_seqlens, assumed_align=16
+        ).mark_layout_dynamic()
 
         # Always use 8-CTA architecture (benchmarks show it's better for all batch sizes)
         run_func = run_gdn_decode_kernel_small_batch_pretranspose
@@ -1040,7 +1064,6 @@ def run_pretranspose_decode(
             softplus_threshold=20.0,
             scale=scale,
             HV=HV,
-            B=B,
             T=T,
             H=H,
             K=K,


### PR DESCRIPTION
## 📌 Description

Addresses part 2 of https://github.com/flashinfer-ai/flashinfer/issues/3602 , also brings over overlapping effort from @bkryu 's work in #3601 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved GPU kernel compilation and caching to better reuse compiled cubins across varying batch sizes.
  * Updated GDN decode/verify (including MTP) kernel launch behavior to derive batch sizing at runtime.
* **Robustness Improvements**
  * Enhanced support for dynamic batch-dependent tensors during compilation and execution.
  * Improved handling of per-batch auxiliary metadata and correct index/state aliasing for split-pool scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->