### PR TITLE
fix(mla): make cute-dsl decode eligibility gate impl-aware

### DIFF
--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2139,7 +2139,7 @@ def _cute_dsl_incompatibility_reason(
     try:
         from ..cute_dsl.attention.mla_dispatch import _resolve_impl
         resolved_impl = _resolve_impl(requested=cute_dsl_impl, kwargs={"sinks": sinks})
-    except ValueError as e:
+    except (ValueError, ImportError) as e:
         return f"cute-dsl backend (MLA decode kernel): {e}"
 
     try:

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2089,17 +2089,10 @@ def _cute_dsl_incompatibility_reason(
     Used by both the explicit ``backend="cute-dsl"`` path (raises the reason
     as a ``ValueError``) and the ``backend="auto"`` filter (silently drops
     cute-dsl from the runners list).
-
-    ``cute_dsl_impl`` mirrors the dispatcher's impl selection so the
-    eligibility check validates against the constraints of the impl that will
-    actually run (modular vs monolithic).
     """
     cc = get_compute_capability(query.device)
-    if cc[0] not in (10, 11):
-        return (
-            "cute-dsl backend (MLA decode kernel) uses tcgen05 2-SM instructions, "
-            f"supported only on SM100-SM110 (datacenter Blackwell); got SM{cc[0]}{cc[1]}"
-        )
+    if cc[0] < 10:
+        return f"cute-dsl backend (MLA decode kernel) requires SM100+, got SM{cc[0]}{cc[1]}"
     if isinstance(bmm1_scale, torch.Tensor):
         return (
             "cute-dsl backend (MLA decode kernel) does not support tensor bmm1_scale, "

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2082,12 +2082,17 @@ def _cute_dsl_incompatibility_reason(
     is_var_seq: bool,
     return_lse: bool,
     lse: Optional[torch.Tensor],
+    cute_dsl_impl: str = "auto",
 ) -> Optional[str]:
     """Return None if cute-dsl can handle this call, else a human-readable reason.
 
     Used by both the explicit ``backend="cute-dsl"`` path (raises the reason
     as a ``ValueError``) and the ``backend="auto"`` filter (silently drops
     cute-dsl from the runners list).
+
+    ``cute_dsl_impl`` mirrors the dispatcher's impl selection so the
+    eligibility check validates against the constraints of the impl that will
+    actually run (modular vs monolithic).
     """
     cc = get_compute_capability(query.device)
     if cc[0] < 10:
@@ -2132,7 +2137,16 @@ def _cute_dsl_incompatibility_reason(
 
     _, q_len, num_heads, _ = query.shape
     try:
-        from ..cute_dsl.attention.wrappers.batch_mla import _check_can_implement
+        from ..cute_dsl.attention.mla_dispatch import _resolve_impl
+        resolved_impl = _resolve_impl(requested=cute_dsl_impl, kwargs={"sinks": sinks})
+    except ValueError as e:
+        return f"cute-dsl backend (MLA decode kernel): {e}"
+
+    try:
+        if resolved_impl == "monolithic":
+            from ..cute_dsl.attention.monolithic.mla_decode import _check_can_implement
+        else:
+            from ..cute_dsl.attention.wrappers.batch_mla import _check_can_implement
 
         _check_can_implement(
             torch_dtype=query.dtype,
@@ -3043,6 +3057,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
         is_var_seq,
         return_lse,
         lse,
+        cute_dsl_impl,
     )
     if backend == "cute-dsl":
         if cute_dsl_reason is not None:

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2682,8 +2682,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
         ``cute-dsl``, and ``sparse`` backends. When True, the function
         returns ``(out, lse)``.
     cute_dsl_impl : str = "auto"
-        Which cute-dsl implementation to use.  Honored only when
-        ``backend="cute-dsl"``; ignored for other backends.
+        Which cute-dsl implementation to use. Honored when
+        ``backend="cute-dsl"`` and when ``backend="auto"`` considers the
+        cute-dsl candidate; ignored for non-cute-dsl backends.
 
         * ``"auto"`` (default) — picks monolithic by default, automatically
           promoted to modular when the call uses a feature monolithic

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2095,8 +2095,11 @@ def _cute_dsl_incompatibility_reason(
     actually run (modular vs monolithic).
     """
     cc = get_compute_capability(query.device)
-    if cc[0] < 10:
-        return f"cute-dsl backend (MLA decode kernel) requires SM100+, got SM{cc[0]}{cc[1]}"
+    if cc[0] not in (10, 11):
+        return (
+            "cute-dsl backend (MLA decode kernel) uses tcgen05 2-SM instructions, "
+            f"supported only on SM100-SM110 (datacenter Blackwell); got SM{cc[0]}{cc[1]}"
+        )
     if isinstance(bmm1_scale, torch.Tensor):
         return (
             "cute-dsl backend (MLA decode kernel) does not support tensor bmm1_scale, "

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2134,6 +2134,7 @@ def _cute_dsl_incompatibility_reason(
     _, q_len, num_heads, _ = query.shape
     try:
         from ..cute_dsl.attention.mla_dispatch import _resolve_impl
+
         resolved_impl = _resolve_impl(requested=cute_dsl_impl, kwargs={"sinks": sinks})
     except (ValueError, ImportError) as e:
         return f"cute-dsl backend (MLA decode kernel): {e}"


### PR DESCRIPTION
## Problem

`trtllm_batch_decode_with_kv_cache_mla(backend="cute-dsl")` (or `backend="auto"`) raises for valid MLA-decode configs that the kernel can actually run, e.g.:

```
ValueError: cute-dsl backend (MLA decode kernel) cannot implement this configuration:
cute_dsl_mla_decode: unsupported configuration (q_len=8, num_heads=16, page_size=64,
in_dtype=torch.bfloat16, out_dtype=torch.bfloat16)
```

`q_len=8, num_heads=16` is well within the monolithic kernel's `fold_sq` limit (`num_heads * F <= 128`, here `F=8` → `16*8=128`).

q_len=8 is a case for DFlash https://www.lmsys.org/blog/2026-06-15-next-generation-speculative-decoding-dflash-v2/

## Root cause

The eligibility gate `_cute_dsl_incompatibility_reason` always validated against the **modular** kernel's constraints (`MLAConfig.can_implement`: hard-caps `seq_len_q <= 4`, no folding), **even when the call resolves to the monolithic impl** (the default, `_DEFAULT_IMPL="monolithic"`). The monolithic kernel folds `seq_len_q` into the 128-wide MMA-M tile, so `q_len > 4` is supported there — but the gate rejected it before dispatch using the wrong impl's rules.

## Fix

Resolve the impl the same way the dispatcher does (`mla_dispatch._resolve_impl`), then validate against the matching `_check_can_implement` (monolithic vs modular). Also:
- Surfaces the `monolithic` + `sinks` conflict as a clean reason string instead of a late forward-time crash.
- Keeps `ImportError` handling around the cute-dsl import so `backend="auto"` still degrades gracefully (drops cute-dsl, falls back to trtllm-gen) when cute-dsl deps are absent.

## Validation

On B200, `q_len=8, num_heads=16, bf16, page_size=64` (bs=10) vs an fp32 torch MTP reference on byte-identical inputs:

| seq | backend | SNR (dB) | cos | time (µs) |
|---|---|---|---|---|
| 2,048 | cute-dsl | 54.84 | 0.999998 | 18.2 |
| 2,048 | trtllm-gen | 54.64 | 0.999998 | 37.0 |
| 50,000 | cute-dsl | 55.44 | 0.999999 | 127.3 |
| 50,000 | trtllm-gen | 55.41 | 0.999999 | 803.6 |

The monolithic cute-dsl kernel computes the previously-rejected config correctly (matches trtllm-gen and the torch reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved CuteDSL compatibility checking by determining the effective CuteDSL implementation and using the right eligibility logic for compatibility decisions.
  * When using automatic backend selection, the `cute_dsl_impl` preference is now honored, and incompatibility reasons are presented more clearly if requirements can’t be met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->