### PR TITLE
fix(jit): cap ninja jobs by available memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,6 +508,12 @@ export FLASHINFER_CUDA_ARCH_LIST="8.0 9.0a"  # Target architectures
 export FLASHINFER_WORKSPACE_BASE="/scratch"   # Custom cache directory
 ```
 
+When `MAX_JOBS` is unset, nvcc JIT builds cap ninja at one worker per 10 GiB of
+available memory if that is lower than the CPU-count default. On Linux, the
+estimate also honors inherited cgroup memory limits and CPU affinity. Set
+`MAX_JOBS` to a positive integer to override the cap. Zero and invalid values
+use the automatic limits and never request ninja's unlimited `-j 0` mode.
+
 #### Full Environment Variable Reference
 
 Already covered above (Quick Reference / Debugging): `FLASHINFER_LOGLEVEL`,

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -372,24 +372,121 @@ def _get_total_memory_gib() -> Optional[float]:
     return pages * page_size / (1024**3)
 
 
+def _get_cgroup_memory_paths() -> List[tuple[str, str]]:
+    """Return limit and usage files from the current cgroup to its root."""
+    cgroup_files = []
+
+    def add_hierarchy(
+        root: Path, cgroup_path: str, limit_name: str, usage_name: str
+    ) -> None:
+        relative_parts = [part for part in cgroup_path.split("/") if part]
+        if ".." in relative_parts:
+            return
+
+        current = root.joinpath(*relative_parts)
+        while True:
+            cgroup_files.append((str(current / limit_name), str(current / usage_name)))
+            if current == root:
+                break
+            current = current.parent
+
+    try:
+        with open("/proc/self/cgroup") as f:
+            for line in f:
+                _hierarchy, controllers, cgroup_path = line.strip().split(":", 2)
+                if not controllers:
+                    add_hierarchy(
+                        Path("/sys/fs/cgroup"),
+                        cgroup_path,
+                        "memory.max",
+                        "memory.current",
+                    )
+                elif "memory" in controllers.split(","):
+                    add_hierarchy(
+                        Path("/sys/fs/cgroup/memory"),
+                        cgroup_path,
+                        "memory.limit_in_bytes",
+                        "memory.usage_in_bytes",
+                    )
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+
+    cgroup_files.extend(
+        (
+            ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"),
+            (
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+                "/sys/fs/cgroup/memory/memory.usage_in_bytes",
+            ),
+        )
+    )
+
+    return list(dict.fromkeys(cgroup_files))
+
+
+def _get_cgroup_memory_available_gib() -> Optional[float]:
+    """Return the tightest available-memory estimate in the cgroup hierarchy."""
+    available_estimates = []
+    for limit_path, usage_path in _get_cgroup_memory_paths():
+        try:
+            with open(limit_path) as f:
+                limit = f.read().strip()
+            if limit == "max":
+                continue
+            with open(usage_path) as f:
+                usage = f.read().strip()
+            available_bytes = max(0, int(limit) - int(usage))
+            available_estimates.append(available_bytes / (1024**3))
+        except (FileNotFoundError, OSError, ValueError):
+            continue
+
+    return min(available_estimates) if available_estimates else None
+
+
 def _get_available_memory_gib() -> Optional[float]:
     """Return the best memory estimate for choosing ninja parallelism."""
-    mem_available_gib = _get_linux_mem_available_gib()
-    if mem_available_gib is not None:
-        return mem_available_gib
-    return _get_total_memory_gib()
+    system_available_gib = _get_linux_mem_available_gib()
+    if system_available_gib is None:
+        system_available_gib = _get_total_memory_gib()
+
+    cgroup_available_gib = _get_cgroup_memory_available_gib()
+    estimates = [
+        value
+        for value in (system_available_gib, cgroup_available_gib)
+        if value is not None
+    ]
+    return min(estimates) if estimates else None
+
+
+def _get_available_cpu_count() -> Optional[int]:
+    """Return the process CPU allowance, accounting for affinity when available."""
+    try:
+        affinity_count = len(os.sched_getaffinity(0))
+        if affinity_count > 0:
+            return affinity_count
+    except (AttributeError, OSError):
+        pass
+
+    return os.cpu_count()
 
 
 def _get_num_workers() -> Optional[int]:
     """Return a ninja worker cap, or None to use ninja's default."""
     max_jobs = os.environ.get("MAX_JOBS")
     if max_jobs is not None:
-        if max_jobs.isdigit():
-            return int(max_jobs)
-        logger.warning("Ignoring invalid MAX_JOBS=%r; using ninja default.", max_jobs)
-        return None
+        try:
+            max_jobs_value = int(max_jobs)
+        except ValueError:
+            max_jobs_value = 0
+        if max_jobs_value >= 1:
+            return max_jobs_value
+        logger.warning(
+            "Ignoring invalid MAX_JOBS=%r; value must be a positive integer. "
+            "Applying automatic parallelism limits.",
+            max_jobs,
+        )
 
-    cpu_count = os.cpu_count()
+    cpu_count = _get_available_cpu_count()
     available_gib = _get_available_memory_gib()
     if cpu_count is None or available_gib is None:
         return None

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -19,6 +19,8 @@ from ..compilation_context import CompilationContext
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_NINJA_MEMORY_GIB_PER_JOB = 10
+
 
 def parse_env_flags(env_var_name) -> List[str]:
     env_flags = os.environ.get(env_var_name)
@@ -343,10 +345,65 @@ def generate_ninja_build_for_op(
     return "\n".join(lines)
 
 
+def _get_linux_mem_available_gib() -> Optional[float]:
+    """Return Linux MemAvailable in GiB, including reclaimable cache."""
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) / (1024**2)
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+
+    return None
+
+
+def _get_total_memory_gib() -> Optional[float]:
+    """Return total physical memory in GiB when available."""
+    try:
+        pages = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+    except (AttributeError, OSError, ValueError):
+        return None
+
+    if pages <= 0 or page_size <= 0:
+        return None
+
+    return pages * page_size / (1024**3)
+
+
+def _get_available_memory_gib() -> Optional[float]:
+    """Return the best memory estimate for choosing ninja parallelism."""
+    mem_available_gib = _get_linux_mem_available_gib()
+    if mem_available_gib is not None:
+        return mem_available_gib
+    return _get_total_memory_gib()
+
+
 def _get_num_workers() -> Optional[int]:
+    """Return a ninja worker cap, or None to use ninja's default."""
     max_jobs = os.environ.get("MAX_JOBS")
-    if max_jobs is not None and max_jobs.isdigit():
-        return int(max_jobs)
+    if max_jobs is not None:
+        if max_jobs.isdigit():
+            return int(max_jobs)
+        logger.warning("Ignoring invalid MAX_JOBS=%r; using ninja default.", max_jobs)
+        return None
+
+    cpu_count = os.cpu_count()
+    available_gib = _get_available_memory_gib()
+    if cpu_count is None or available_gib is None:
+        return None
+
+    memory_safe_jobs = max(1, int(available_gib // _DEFAULT_NINJA_MEMORY_GIB_PER_JOB))
+    if memory_safe_jobs < cpu_count:
+        logger.info(
+            "Limiting ninja parallelism to %s jobs based on %.1f GiB available "
+            "memory. Set MAX_JOBS to override.",
+            memory_safe_jobs,
+            available_gib,
+        )
+        return memory_safe_jobs
+
     return None
 
 

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -1,3 +1,4 @@
+import io
 import subprocess
 from types import SimpleNamespace
 
@@ -127,6 +128,107 @@ def test_run_ninja_uses_max_jobs(monkeypatch, tmp_path):
             "8",
         ]
     ]
+
+
+def test_run_ninja_uses_ninja_default_when_max_jobs_is_invalid(monkeypatch, tmp_path):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setenv("MAX_JOBS", "auto")
+    monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: 31.0)
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 20)
+    monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
+
+    cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
+
+    assert "-j" not in commands[0]
+
+
+def test_get_available_memory_prefers_linux_mem_available(monkeypatch):
+    meminfo = io.StringIO(
+        "MemTotal:       131072000 kB\n"
+        "MemFree:          1024000 kB\n"
+        "MemAvailable:   104857600 kB\n"
+    )
+
+    monkeypatch.setattr("builtins.open", lambda *_args, **_kwargs: meminfo)
+    monkeypatch.setattr(cpp_ext, "_get_total_memory_gib", lambda: 1.0)
+
+    assert cpp_ext._get_available_memory_gib() == 100.0
+
+
+def test_get_available_memory_falls_back_to_total_memory(monkeypatch):
+    monkeypatch.setattr(cpp_ext, "_get_linux_mem_available_gib", lambda: None)
+    monkeypatch.setattr(cpp_ext, "_get_total_memory_gib", lambda: 64.0)
+
+    assert cpp_ext._get_available_memory_gib() == 64.0
+
+
+def test_run_ninja_limits_jobs_when_available_memory_is_low(monkeypatch, tmp_path):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: 31.0)
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 20)
+    monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
+
+    cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
+
+    assert commands == [
+        [
+            "ninja",
+            "-v",
+            "-C",
+            str(tmp_path.resolve()),
+            "-f",
+            str((tmp_path / "build.ninja").resolve()),
+            "-j",
+            "3",
+        ]
+    ]
+
+
+def test_run_ninja_uses_ninja_default_when_memory_is_unknown(monkeypatch, tmp_path):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: None)
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 20)
+    monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
+
+    cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
+
+    assert "-j" not in commands[0]
+
+
+def test_run_ninja_uses_ninja_default_when_memory_supports_all_cpus(
+    monkeypatch, tmp_path
+):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: 128.0)
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
+
+    cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
+
+    assert "-j" not in commands[0]
 
 
 def test_jit_spec_build_rewrites_ninja_before_build(monkeypatch):

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -130,21 +130,24 @@ def test_run_ninja_uses_max_jobs(monkeypatch, tmp_path):
     ]
 
 
-def test_run_ninja_uses_ninja_default_when_max_jobs_is_invalid(monkeypatch, tmp_path):
+@pytest.mark.parametrize("max_jobs", ["auto", "0", "-1"])
+def test_run_ninja_applies_memory_cap_when_max_jobs_is_invalid(
+    monkeypatch, tmp_path, max_jobs
+):
     commands = []
 
     def fake_run(command, **kwargs):
         commands.append(command)
         return subprocess.CompletedProcess(command, 0)
 
-    monkeypatch.setenv("MAX_JOBS", "auto")
+    monkeypatch.setenv("MAX_JOBS", max_jobs)
     monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: 31.0)
-    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 20)
+    monkeypatch.setattr(cpp_ext, "_get_available_cpu_count", lambda: 20)
     monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
 
     cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
 
-    assert "-j" not in commands[0]
+    assert commands[0][-2:] == ["-j", "3"]
 
 
 def test_get_available_memory_prefers_linux_mem_available(monkeypatch):
@@ -156,6 +159,7 @@ def test_get_available_memory_prefers_linux_mem_available(monkeypatch):
 
     monkeypatch.setattr("builtins.open", lambda *_args, **_kwargs: meminfo)
     monkeypatch.setattr(cpp_ext, "_get_total_memory_gib", lambda: 1.0)
+    monkeypatch.setattr(cpp_ext, "_get_cgroup_memory_available_gib", lambda: None)
 
     assert cpp_ext._get_available_memory_gib() == 100.0
 
@@ -163,8 +167,88 @@ def test_get_available_memory_prefers_linux_mem_available(monkeypatch):
 def test_get_available_memory_falls_back_to_total_memory(monkeypatch):
     monkeypatch.setattr(cpp_ext, "_get_linux_mem_available_gib", lambda: None)
     monkeypatch.setattr(cpp_ext, "_get_total_memory_gib", lambda: 64.0)
+    monkeypatch.setattr(cpp_ext, "_get_cgroup_memory_available_gib", lambda: None)
 
     assert cpp_ext._get_available_memory_gib() == 64.0
+
+
+def test_get_cgroup_memory_available_v2(monkeypatch):
+    values = {
+        "/sys/fs/cgroup/memory.max": "21474836480\n",
+        "/sys/fs/cgroup/memory.current": "5368709120\n",
+    }
+
+    monkeypatch.setattr(
+        cpp_ext,
+        "_get_cgroup_memory_paths",
+        lambda: [("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current")],
+    )
+    monkeypatch.setattr("builtins.open", lambda path: io.StringIO(values[str(path)]))
+
+    assert cpp_ext._get_cgroup_memory_available_gib() == 15.0
+
+
+def test_get_cgroup_memory_available_uses_inherited_v2_limit(monkeypatch):
+    paths = [
+        (
+            "/sys/fs/cgroup/workload/leaf/memory.max",
+            "/sys/fs/cgroup/workload/leaf/memory.current",
+        ),
+        (
+            "/sys/fs/cgroup/workload/memory.max",
+            "/sys/fs/cgroup/workload/memory.current",
+        ),
+        ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"),
+    ]
+    values = {
+        paths[0][0]: "max\n",
+        paths[1][0]: "21474836480\n",
+        paths[1][1]: "5368709120\n",
+        paths[2][0]: "max\n",
+    }
+
+    monkeypatch.setattr(cpp_ext, "_get_cgroup_memory_paths", lambda: paths)
+    monkeypatch.setattr("builtins.open", lambda path: io.StringIO(values[str(path)]))
+
+    assert cpp_ext._get_cgroup_memory_available_gib() == 15.0
+
+
+def test_get_cgroup_memory_paths_include_v2_ancestors(monkeypatch):
+    cgroup = io.StringIO("0::/workload/leaf\n")
+    monkeypatch.setattr("builtins.open", lambda *_args, **_kwargs: cgroup)
+
+    assert cpp_ext._get_cgroup_memory_paths()[:3] == [
+        (
+            "/sys/fs/cgroup/workload/leaf/memory.max",
+            "/sys/fs/cgroup/workload/leaf/memory.current",
+        ),
+        (
+            "/sys/fs/cgroup/workload/memory.max",
+            "/sys/fs/cgroup/workload/memory.current",
+        ),
+        ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current"),
+    ]
+
+
+def test_get_cgroup_memory_available_v1_and_clamps_usage(monkeypatch):
+    paths = (
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+        "/sys/fs/cgroup/memory/memory.usage_in_bytes",
+    )
+    values = {paths[0]: "10737418240\n", paths[1]: "11811160064\n"}
+
+    monkeypatch.setattr(cpp_ext, "_get_cgroup_memory_paths", lambda: [paths])
+    monkeypatch.setattr("builtins.open", lambda path: io.StringIO(values[str(path)]))
+
+    assert cpp_ext._get_cgroup_memory_available_gib() == 0.0
+
+
+def test_get_available_memory_honors_cgroup_limit(monkeypatch):
+    monkeypatch.setattr(cpp_ext, "_get_linux_mem_available_gib", lambda: 100.0)
+    monkeypatch.setattr(cpp_ext, "_get_total_memory_gib", lambda: 128.0)
+    monkeypatch.setattr(cpp_ext, "_get_cgroup_memory_available_gib", lambda: 15.0)
+
+    assert cpp_ext._get_available_memory_gib() == 15.0
 
 
 def test_run_ninja_limits_jobs_when_available_memory_is_low(monkeypatch, tmp_path):
@@ -176,7 +260,7 @@ def test_run_ninja_limits_jobs_when_available_memory_is_low(monkeypatch, tmp_pat
 
     monkeypatch.delenv("MAX_JOBS", raising=False)
     monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: 31.0)
-    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 20)
+    monkeypatch.setattr(cpp_ext, "_get_available_cpu_count", lambda: 20)
     monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
 
     cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
@@ -204,7 +288,7 @@ def test_run_ninja_uses_ninja_default_when_memory_is_unknown(monkeypatch, tmp_pa
 
     monkeypatch.delenv("MAX_JOBS", raising=False)
     monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: None)
-    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 20)
+    monkeypatch.setattr(cpp_ext, "_get_available_cpu_count", lambda: 20)
     monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
 
     cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
@@ -223,7 +307,27 @@ def test_run_ninja_uses_ninja_default_when_memory_supports_all_cpus(
 
     monkeypatch.delenv("MAX_JOBS", raising=False)
     monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: 128.0)
-    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(cpp_ext, "_get_available_cpu_count", lambda: 8)
+    monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
+
+    cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)
+
+    assert "-j" not in commands[0]
+
+
+def test_run_ninja_respects_cpu_affinity_when_memory_supports_more_jobs(
+    monkeypatch, tmp_path
+):
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.delenv("MAX_JOBS", raising=False)
+    monkeypatch.setattr(cpp_ext, "_get_available_memory_gib", lambda: 31.0)
+    monkeypatch.setattr(cpp_ext.os, "sched_getaffinity", lambda _pid: {2, 3})
+    monkeypatch.setattr(cpp_ext.os, "cpu_count", lambda: 20)
     monkeypatch.setattr(cpp_ext.subprocess, "run", fake_run)
 
     cpp_ext.run_ninja(tmp_path, tmp_path / "build.ninja", verbose=False)


### PR DESCRIPTION
## Summary

Fixes #3634.

- keeps explicit `MAX_JOBS` behavior unchanged
- estimates available host memory when `MAX_JOBS` is unset
- passes `-j` to ninja only when the CPU-count default appears unsafe for large CUTLASS JIT builds
- preserves existing ninja default behavior when memory cannot be detected or appears sufficient

This prevents first-run SM120/SM121 FP4 JIT builds from launching too many parallel `nvcc` workers on memory-constrained or unified-memory systems.

## Tests

- `python -m pytest tests/test_jit_cpp_ext.py -q`
- `python -m ruff check flashinfer/jit/cpp_ext.py tests/test_jit_cpp_ext.py`
- `python -m ruff format --check flashinfer/jit/cpp_ext.py tests/test_jit_cpp_ext.py`

Hardware available for follow-up validation: RTX 5090, sm_120, 32GB, driver 580.159.03.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically limits Ninja build parallelism based on available memory, container limits, and CPU affinity.
  * Supports explicit positive `MAX_JOBS` values to override automatic limits.
* **Bug Fixes**
  * Prevents invalid or zero `MAX_JOBS` values from enabling unbounded parallel builds.
  * Improves resource detection across Linux memory and cgroup configurations.
* **Documentation**
  * Documented automatic worker limits and `MAX_JOBS` behavior for nvcc JIT builds.
* **Tests**
  * Added coverage for memory limits, CPU affinity, cgroup configurations, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->