### PR TITLE
Enable SwapAB in `mm_fp4` `cute-dsl` backend when M is not a multiple of 8.

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4433,7 +4433,6 @@ def _get_sm100_block_scaled_tactics(
     )
 
     batch_size = 1
-    m_aligned = m % 8 == 0
     n_aligned = n % 8 == 0
 
     valid_tactics = []
@@ -4442,7 +4441,7 @@ def _get_sm100_block_scaled_tactics(
             for swap_ab in (False, True):
                 if not swap_ab and not n_aligned:
                     continue
-                if swap_ab and not m_aligned:
+                if swap_ab and not n_aligned:
                     continue
 
                 if swap_ab:
@@ -5645,15 +5644,7 @@ def _cute_dsl_gemm_fp4_runner(
                 a.device,
             )
 
-            if m == 1:
-                if n <= 1024:
-                    allowed_tiles = {(256, 64)}
-                elif n >= 8192:
-                    allowed_tiles = {(128, 128)}
-                else:
-                    allowed_tiles = {(128, 64)}
-                sm100_base = [t for t in sm100_base if t[0] in allowed_tiles]
-            elif m in (8, 16):
+            if m <= 32:
                 allowed_tiles = {
                     (128, 8),
                     (128, 16),
@@ -5743,6 +5734,9 @@ def _cute_dsl_gemm_fp4_runner(
             sf_vec_size = 16 if use_nvfp4 else 32
             sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
             batch_size = 1
+
+            if n % 8 != 0:
+                raise ValueError(f"CuTe-DSL FP4 GEMM requires N % 8 == 0, got n={n}")
 
             if tactic is None or tactic == -1:
                 # Use analytical heuristic to pick the best tactic based on
@@ -6133,6 +6127,8 @@ def _mxfp8_swizzled_scale_len(m: int, k: int, swizzle_layout: SfLayout) -> int:
 
 
 _MM_FP4_TUNING_CONFIG_8x4 = TuningConfig(
+    use_cuda_graph=True,
+    use_cold_l2_cache=True,
     dynamic_tensor_specs=(
         DynamicTensorSpec(
             (0,),  # a_tensor_index
@@ -6162,6 +6158,8 @@ _MM_FP4_TUNING_CONFIG_8x4 = TuningConfig(
 
 
 _MM_FP4_TUNING_CONFIG_128x4 = TuningConfig(
+    use_cuda_graph=True,
+    use_cold_l2_cache=True,
     dynamic_tensor_specs=(
         DynamicTensorSpec(
             (0,),  # a_tensor_index

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -5488,7 +5488,7 @@ def _cutlass_gemm_fp4_requirement(
 @supported_compute_capability([100, 103])
 def _cute_dsl_gemm_fp4_requirement(
     a: torch.Tensor,  # unused
-    b: torch.Tensor,  # unused
+    b: torch.Tensor,
     a_descale: torch.Tensor,  # unused
     b_descale: torch.Tensor,  # unused
     alpha: Optional[torch.Tensor] = None,  # unused
@@ -5496,9 +5496,7 @@ def _cute_dsl_gemm_fp4_requirement(
     out: Optional[torch.Tensor] = None,  # unused
     block_size: int = 16,  # unused
     use_8x4_sf_layout: bool = False,
-    backend: Literal[
-        "cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"
-    ] = "auto",  # unused
+    backend: Literal["cudnn", "trtllm", "cutlass", "cute-dsl", "b12x", "auto"] = "auto",
     use_nvfp4: bool = True,
     enable_pdl: bool = True,  # unused
 ):
@@ -5508,6 +5506,11 @@ def _cute_dsl_gemm_fp4_requirement(
     # preparation for 128x4 layout.
     if use_8x4_sf_layout:
         raise ValueError("cute_dsl FP4 GEMM only supports 128x4 scale factor layout.")
+    # N must be 8-aligned; raise only for explicit cute-dsl (never auto-selected).
+    if b.shape[1] % 8 != 0:
+        if backend != "cute-dsl":
+            return False
+        raise ValueError(f"CuTe-DSL FP4 GEMM requires N % 8 == 0, got n={b.shape[1]}")
     _check_cute_dsl_availability()
     return True
 
@@ -5732,9 +5735,6 @@ def _cute_dsl_gemm_fp4_runner(
             sf_vec_size = 16 if use_nvfp4 else 32
             sf_dtype = cutlass.Float8E4M3FN if use_nvfp4 else cutlass.Float8E8M0FNU
             batch_size = 1
-
-            if n % 8 != 0:
-                raise ValueError(f"CuTe-DSL FP4 GEMM requires N % 8 == 0, got n={n}")
 
             if tactic is None or tactic == -1:
                 # Use analytical heuristic to pick the best tactic based on

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4439,9 +4439,7 @@ def _get_sm100_block_scaled_tactics(
     for mma_tiler_mn in _SM100_MMA_TILER_MN_CANDIDATES:
         for cluster_shape_mn in _SM100_CLUSTER_SHAPE_MN_CANDIDATES:
             for swap_ab in (False, True):
-                if not swap_ab and not n_aligned:
-                    continue
-                if swap_ab and not n_aligned:
+                if not n_aligned:
                     continue
 
                 if swap_ab:

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
@@ -168,6 +168,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -178,6 +179,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -373,6 +375,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -383,6 +386,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -1364,7 +1368,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             # Threads/warps participating in tma store pipeline
             c_producer_group = pipeline.CooperativeGroup(
                 pipeline.Agent.Thread,
-                32 * len(self.epilog_warp_id),
                 32 * len(self.epilog_warp_id),
             )
             c_pipeline = pipeline.PipelineTmaStore.create(

--- a/flashinfer/gemm/kernels/utils.py
+++ b/flashinfer/gemm/kernels/utils.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from ...fused_moe.utils import last_positive_power_of_2
+from ...fused_moe.utils import next_positive_power_of_2
 
 _SM100_MMA_TILER_MN_CANDIDATES = [
     (128, 8),
@@ -46,10 +46,9 @@ def _compute_tactic_for_m(rep_m, n, real_k, sm_count, m_aligned):
 
     Selects swap_ab, tile shape, and cluster shape sequentially:
 
-    1. **swap_ab**: Swap A and B operands when M is small (8-16) and
+    1. **swap_ab**: Swap A and B operands when M is small (1-32) and N is
        8-aligned, putting the larger N dimension on the M-axis to increase
-       the number of CTAs.  Also swaps when N is not 8-aligned (required
-       for memory alignment).
+       the number of CTAs.
 
     2. **Tile shape**: Scores all 8 candidates from _SM100_MMA_TILER_MN_CANDIDATES.
        The score balances three factors:
@@ -71,9 +70,7 @@ def _compute_tactic_for_m(rep_m, n, real_k, sm_count, m_aligned):
     n_aligned = n % 8 == 0
 
     swap_ab = False
-    if m_aligned and 8 <= rep_m <= 16 and n > rep_m:
-        swap_ab = True
-    if not swap_ab and not n_aligned and m_aligned:
+    if n_aligned and 1 <= rep_m <= 32 and n > rep_m:
         swap_ab = True
 
     prob_m = n if swap_ab else rep_m
@@ -170,5 +167,5 @@ def _select_sm100_mm_fp4_cute_dsl_tactic(m, n, real_k, sm_count):
                 )
         _SM100_MM_FP4_TACTIC_CACHE[cache_key] = bucket_tactics
 
-    bucket = min(last_positive_power_of_2(m), _M_BUCKETS[-1])
+    bucket = min(next_positive_power_of_2(m), _M_BUCKETS[-1])
     return bucket_tactics[(bucket, m % 8 == 0)]

--- a/flashinfer/gemm/kernels/utils.py
+++ b/flashinfer/gemm/kernels/utils.py
@@ -30,18 +30,16 @@ _SM100_MMA_TILER_MN_CANDIDATES = [
     (256, 256),
 ]
 
-# Tactic cache: (n, real_k, sm_count) -> dict[(m_bucket, is_8_aligned) -> tactic_tuple]
+# Tactic cache: (n, real_k, sm_count) -> dict[m_bucket -> tactic_tuple]
 # Bounded by the number of unique (N, K) pairs in the model (typically < 50).
 _SM100_MM_FP4_TACTIC_CACHE: dict[tuple, dict] = {}
 
 # M bucket boundaries — powers of 2 for fast bucketing via
-# last_positive_power_of_2 (imported from flashinfer.fused_moe.utils).
-# Each bucket is precomputed for both 8-aligned and non-8-aligned M,
-# keyed as (bucket, is_8_aligned).
+# next_positive_power_of_2 (imported from flashinfer.fused_moe.utils).
 _M_BUCKETS = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096)
 
 
-def _compute_tactic_for_m(rep_m, n, real_k, sm_count, m_aligned):
+def _compute_tactic_for_m(rep_m, n, real_k, sm_count):
     """Compute the best tactic for a specific (M, N, K) on a GPU with sm_count SMs.
 
     Selects swap_ab, tile shape, and cluster shape sequentially:
@@ -161,11 +159,8 @@ def _select_sm100_mm_fp4_cute_dsl_tactic(m, n, real_k, sm_count):
     if bucket_tactics is None:
         bucket_tactics = {}
         for rep_m in _M_BUCKETS:
-            for aligned in (True, False):
-                bucket_tactics[(rep_m, aligned)] = _compute_tactic_for_m(
-                    rep_m, n, real_k, sm_count, aligned
-                )
+            bucket_tactics[rep_m] = _compute_tactic_for_m(rep_m, n, real_k, sm_count)
         _SM100_MM_FP4_TACTIC_CACHE[cache_key] = bucket_tactics
 
     bucket = min(next_positive_power_of_2(m), _M_BUCKETS[-1])
-    return bucket_tactics[(bucket, m % 8 == 0)]
+    return bucket_tactics[bucket]

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -202,5 +202,38 @@ def test_mm_fp4_b12x_misaligned_k_raises():
         )
 
 
+def test_mm_fp4_cute_dsl_misaligned_n_raises():
+    device = torch.device("cuda")
+    if get_compute_capability(device)[0] != 10:
+        pytest.skip("cute_dsl backend only supports SM100/SM103 GPUs.")
+    m, n, k = 16, 130, 128  # n % 8 == 2
+    a = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
+    b = torch.randn([n, k], device="cuda", dtype=torch.bfloat16)
+    g_in = (448 * 6) / a.float().abs().nan_to_num().max()
+    g_w = (448 * 6) / b.float().abs().nan_to_num().max()
+    a_fp4, a_s = nvfp4_quantize(
+        a, g_in, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    b_fp4, b_s = nvfp4_quantize(
+        b, g_w, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    res = torch.empty([m, n], device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="N % 8 == 0"):
+        mm_fp4(
+            a_fp4,
+            b_fp4.T,
+            a_s,
+            b_s.T,
+            1.0 / (g_in * g_w),
+            torch.bfloat16,
+            res,
+            block_size=16,
+            use_8x4_sf_layout=False,
+            backend="cute-dsl",
+            use_nvfp4=True,
+            skip_check=False,
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -114,7 +114,9 @@ def _test_mm_fp4(
 
 
 # TODO: Consdier splitting this function up for the various backends
-@pytest.mark.parametrize("m", [1, 2, 4, 8, 16, 32, 48, 64, 128, 256, 512])
+@pytest.mark.parametrize(
+    "m", [1, 2, 4, 8, 9, 12, 15, 16, 17, 20, 24, 31, 32, 48, 64, 128, 256, 512]
+)
 @pytest.mark.parametrize("n", [128, 256, 512])
 @pytest.mark.parametrize("k", [128, 256, 512])
 @pytest.mark.parametrize("res_dtype", [torch.bfloat16, torch.float16])

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -115,7 +115,8 @@ def _test_mm_fp4(
 
 # TODO: Consdier splitting this function up for the various backends
 @pytest.mark.parametrize(
-    "m", [1, 2, 4, 8, 9, 12, 15, 16, 17, 20, 24, 31, 32, 48, 64, 128, 256, 512]
+    "m",
+    [1, 2, 3, 4, 5, 7, 8, 9, 12, 13, 15, 16, 17, 20, 24, 31, 32, 48, 64, 128, 256, 512],
 )
 @pytest.mark.parametrize("n", [128, 256, 512])
 @pytest.mark.parametrize("k", [128, 256, 512])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Enable SwapAB in `mm_fp4` `cute-dsl` backend when M is not a multiple of 8, and through offline tuning, use M <= 32 as a heuristic for SwapAB (typically, this is the point where there is no benefit).

Note: it's very similar to https://github.com/flashinfer-ai/flashinfer/pull/3464, except add the cuda-graph and cold-L2 mode, since otherwise the autotuner will fail to profile the correct timings. (Note: this is currently already used in `trtllm_fp*_block_scale_moe` autotuning. This also fixes https://github.com/flashinfer-ai/flashinfer/issues/3648, where the autotuner fails to pick the fastest tile on Llama 3.3 70B FP4 shapes

As well, fix some warnings emitted from the DSL, with 4.5.0

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

For example, here are the speedups in the M = 1 case in DSV3 shapes:

| K    | N    | Before — Tile Size | Before — Cluster Shape | Before — Swap AB | Before (µs) | After — Tile Size | After — Cluster Shape | After — Swap AB | After (µs) | Speedup |
|-----:|-----:|:------------------:|:----------------------:|:----------------:|------------:|:-----------------:|:---------------------:|:---------------:|-----------:|:-------:|
| 256  | 7168 | 128 × 64           | 1 × 2                  | No               | 3.81        | 128 × 32          | 1 × 1                 | Yes             | 3.26       | 1.17×   |
| 2048 | 7168 | 128 × 64           | 1 × 4                  | No               | 6.02        | 128 × 16          | 1 × 1                 | Yes             | 5.47       | 1.10×   |
| 2304 | 7168 | 128 × 64           | 1 × 4                  | No               | 6.16        | 128 × 16          | 1 × 1                 | Yes             | 5.57       | 1.11×   |
| 3584 | 1024 | 256 × 64           | 4 × 4                  | No               | 5.82        | 128 × 8           | 1 × 1                 | Yes             | 4.90       | 1.19×   |
| 3584 | 9216 | 128 × 128          | 1 × 4                  | No               | 9.06        | 128 × 16          | 1 × 1                 | Yes             | 7.20       | 1.26×   |

In the E2E framework speedup, it could be around 135 -> 140 TPS in BS = 1 decoding.

Here are the cases for Llama 3.3 70B FP4 + TP4:

| Shape (M × K) × (K × N)  | Before — Tile Size | Before — Cluster Shape | Before — Swap AB | Before (µs) | After — Tile Size | After — Cluster Shape | After — Swap AB | After (µs) | Speedup |
|:------------------------:|:------------------:|:----------------------:|:----------------:|------------:|:-----------------:|:---------------------:|:---------------:|-----------:|:-------:|
| (1, 1024) × (1024, 8192) | 128 × 64           | 1 × 4                  | No               | 4.99        | 128 × 8           | 1 × 1                 | Yes             | 4.32       | 1.16×   |
| (1, 3584) × (3584, 8192) | 128 × 64           | 1 × 4                  | No               | 7.90        | 128 × 16          | 1 × 1                 | Yes             | 6.94       | 1.14×   |


### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

```
pytest tests/gemm/test_mm_fp4.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: anyio-4.13.0, typeguard-4.5.2
collected 23957 items  
...
============================================================================================================ warnings summary =============================================================================================================
tests/conftest.py:16
tests/conftest.py:16
  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================= 6336 passed, 17621 skipped, 2 warnings in 797.85s (0:13:17) =======================================================================================
```

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SM100 block-scaled GEMM setup to consistently respect the B operand dtype.
  * Improved FP4 (SM100, cute-dsl) tactic selection and swap handling, with updated validity rules based on N alignment and broader small-M support.
  * Added/strengthened FP4 validation so the cute-dsl backend is only used when N is 8-aligned (otherwise it errors/falls back).

* **Performance**
  * Improved FP4 autotuning defaults by enabling CUDA Graphs and cold L2 caching.

* **Tests**
  * Expanded FP4 coverage and added a negative test for misaligned N behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->