### PR TITLE
fix(mamba): reject SM120/SM121 in SSDCombined with a clear error

### DIFF
--- a/flashinfer/mamba/ssd_combined.py
+++ b/flashinfer/mamba/ssd_combined.py
@@ -285,10 +285,14 @@ class SSDCombined:
         from ..utils import get_compute_capability
 
         major, minor = get_compute_capability(torch.device("cuda"))
-        if major < 10:
+        # The SSD CuTe-DSL kernel uses tcgen05 MMA (MmaF16BF16Op), which is only
+        # available on datacenter Blackwell (SM100/SM103/SM110). Consumer/workstation
+        # Blackwell (SM120/SM121) lacks tcgen05, so reject it here with a clear message
+        # instead of a cryptic cute-dsl "expects ... sm_100a ... got sm_120a" OpError.
+        if major not in (10, 11):
             raise ValueError(
-                f"SSDCombined requires SM100+ (Blackwell or newer). "
-                f"Got SM{major}{minor}."
+                f"SSDCombined requires SM100-SM110 (tcgen05): Blackwell datacenter "
+                f"GPUs (SM100/SM103/SM110). Got SM{major}{minor}."
             )
 
         self.chunk_size = chunk_size


### PR DESCRIPTION
## Description

`SSDCombined.__init__` only rejected `major < 10`, so consumer/workstation Blackwell (SM120/SM121) passed the guard and reached the SSD CuTe-DSL kernel, which uses tcgen05 MMA (`MmaF16BF16Op`) — available only on datacenter Blackwell (SM100/SM103/SM110). On an RTX PRO 6000 (SM120) this surfaces as a cryptic cute-dsl error at construction:

```
cutlass.cute.nvgpu.common.OpError: expects arch to be one of
[sm_100a, sm_100f, sm_101a, sm_101f, sm_103a, sm_103f, sm_110a, sm_110f], but got sm_120a
   Error Code: MmaF16BF16Op error
    Suggestions: Ensure env CUTE_DSL_ARCH matches your GPU architecture
```

The `CUTE_DSL_ARCH` hint is misleading — it's a hardware capability gap (no tcgen05 on consumer Blackwell), not an env issue.

This tightens the guard to `major not in (10, 11)` (the op's own supported arch set) and corrects the message to name the actual supported range (SM100–SM110, tcgen05). **No SM120 SSD kernel exists, so this is a clean-error change, not an enablement change.**

## Related Issues

None — found while auditing SM120 dispatch on an RTX PRO 6000.

## Tests

Verified on an RTX PRO 6000 Blackwell (SM120, CUDA 13.0) with `SSDCombined(chunk_size=128, nheads=8, headdim=64, dstate=128, ngroups=8)`:

- **Before:** `OpError: ... but got sm_120a (MmaF16BF16Op error)` (cryptic, deep in cute-dsl).
- **After:** `ValueError: SSDCombined requires SM100-SM110 (tcgen05): Blackwell datacenter GPUs (SM100/SM103/SM110). Got SM120.`

`tests/mamba/test_chunk_scan_combined.py` is `skipif not is_sm100a_supported`, so SM100 behavior is unchanged. `pre-commit run --files` passes (ruff check, ruff format, mypy, codespell).

## Reviewer Notes

Supported-arch set (majors 10, 11) is taken directly from the tcgen05 `MmaF16BF16Op` error's own arch list (`sm_100/101/103/110`). Happy to add a negative-path unit test (mocking `get_compute_capability`) if preferred.

>  AI-assisted: investigated and authored with Claude Code, validated on SM120 hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU compatibility detection with more specific hardware requirement checks and clearer error messaging for unsupported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->