### PR TITLE
fix(mla): don't recommend backend='cutlass' on SM120/SM121 MLA fallback

### DIFF
--- a/flashinfer/mla/_batch_mla/_wrapper.py
+++ b/flashinfer/mla/_batch_mla/_wrapper.py
@@ -133,14 +133,18 @@ class BatchMLAPagedAttentionWrapper:
         if major < 10:
             return
         cls._blackwell_auto_fallback_warned = True
+        cutlass_hint = (
+            "; backend='cutlass' is the closest in-wrapper alternative but may be "
+            "slower than this fallback for decode shapes."
+            if major in (10, 11)
+            else "."
+        )
         warnings.warn(
             f"BatchMLAPagedAttentionWrapper: backend='auto' selected "
             f"'{selected_backend}' on SM{major}{minor}, which is not Blackwell-native "
             f"and gives poor MLA decode performance. For decode, use "
             f"flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla "
-            f"(Blackwell-native trtllm-gen); backend='cutlass' is the closest "
-            f"in-wrapper alternative but may be slower than this fallback for "
-            f"decode shapes.",
+            f"(Blackwell-native trtllm-gen){cutlass_hint}",
             UserWarning,
             stacklevel=3,
         )

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1436,15 +1436,22 @@ class BatchMLAPagedAttentionWrapper:
         if major < 10:
             return
         cls._blackwell_auto_fallback_warned = True
+        # The in-wrapper "cutlass" MLA backend builds via gen_mla_module([10, 11]),
+        # so it only exists on SM100/SM110; on SM120/SM121 it raises at build time
+        # ("No supported CUDA architectures found"). Only suggest it where it works.
+        cutlass_hint = (
+            "; backend='cutlass' is the closest in-wrapper alternative but may be "
+            "slower than this fallback for decode shapes."
+            if major in (10, 11)
+            else "."
+        )
         warnings.warn(
             f"BatchMLAPagedAttentionWrapper: backend='auto' selected "
             f"'{selected_backend}' on SM{major}{minor}, which is not Blackwell-native "
             f"and gives poor MLA decode performance. "
             f"For decode, use "
             f"flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla "
-            f"(Blackwell-native trtllm-gen); backend='cutlass' is the closest "
-            f"in-wrapper alternative but may be slower than this fallback for "
-            f"decode shapes.",
+            f"(Blackwell-native trtllm-gen){cutlass_hint}",
             UserWarning,
             stacklevel=3,
         )

--- a/tests/attention/test_mla_auto_backend_warning.py
+++ b/tests/attention/test_mla_auto_backend_warning.py
@@ -60,3 +60,23 @@ def test_explicit_backend_does_not_warn(_cc, buf):
 )
 def test_no_warn_on_hopper(_cc, buf):
     assert _make(buf, "auto") == []
+
+
+@pytest.mark.parametrize("compute_capability", [(12, 0), (12, 1)])
+def test_auto_warns_without_cutlass_hint_on_sm12x(compute_capability):
+    _fresh_state()
+    with (
+        patch(
+            "flashinfer.mla._batch_mla._wrapper._get_compute_capability",
+            return_value=compute_capability,
+        ),
+        warnings.catch_warnings(record=True) as w,
+    ):
+        warnings.simplefilter("always")
+        BatchMLAPagedAttentionWrapper._maybe_warn_blackwell_auto_fallback(
+            torch.device("cpu"), "fa2"
+        )
+    messages = [str(x.message) for x in w if WARN_TAG in str(x.message)]
+    assert len(messages) == 1
+    assert "flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla" in messages[0]
+    assert "backend='cutlass'" not in messages[0]


### PR DESCRIPTION
## Description

`BatchMLAPagedAttentionWrapper._maybe_warn_blackwell_auto_fallback` fires for all Blackwell GPUs (`major >= 10`) when `backend="auto"` falls back to a non-native MLA backend, and recommended `backend='cutlass'` as "the closest in-wrapper alternative".

But the in-wrapper cutlass MLA backend builds via `gen_mla_module(supported_major_versions=[10, 11])`, so on SM120/SM121 it raises at build time:

```
RuntimeError: No supported CUDA architectures found for major versions [10, 11].
```

So on consumer/workstation Blackwell the warning steered users toward a backend that cannot run. This makes the cutlass suggestion conditional on `major in (10, 11)`; SM120/SM121 now get only the working recommendation (`trtllm_batch_decode_with_kv_cache_mla`). SM100/SM110 text is unchanged.

## Related Issues

None — found while auditing SM120 MLA dispatch on an RTX PRO 6000.

## Tests

Verified on an RTX PRO 6000 Blackwell (SM120, CUDA 13.0):

- `gen_mla_module().build_and_load()` → `RuntimeError: No supported CUDA architectures found for major versions [10, 11].` (cutlass MLA can't build on SM120).
- Warning text **before**: `... (Blackwell-native trtllm-gen); backend='cutlass' is the closest in-wrapper alternative ...`
- Warning text **after**: `... (Blackwell-native trtllm-gen).` (no cutlass suggestion on SM12x).

`pre-commit run --files` passes (ruff check, ruff format, mypy, codespell). Pure messaging change; no kernel/behavior impact.

>  AI-assisted: investigated and authored with Claude Code, validated on SM120 hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Blackwell fallback warnings with more accurate backend guidance.
  * Avoided suggesting the CUTLASS backend for compute capabilities where it is not an appropriate alternative, including newer Blackwell variants.

* **Tests**
  * Added coverage for newer Blackwell compute capabilities.
  * Verified fallback warnings reference the appropriate MLA implementation, appear only once, and omit unsupported backend suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->