### PR TITLE
fix(moe): don't mark trtllm-gen FP4 MoE backend supported on SM120/SM121

### DIFF
--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -228,11 +228,13 @@ class TrtllmFp4Config:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        # SM100+ only: the routed runner delegates to the trtllm-gen sm100
-        # module, which core.is_trtllm_moe_supported() gates on major >= 10.
-        # Returning True on SM90 would mark the backend available on H100 and
-        # then fail at dispatch.
-        return arch >= 100
+        # SM100 family only: the routed runner delegates to the trtllm-gen sm100
+        # module, whose cubins are built for SM100/SM103/SM110. Marking the
+        # backend available outside that set — SM90 (H100), or SM120/SM121
+        # (consumer Blackwell), which have no trtllm-gen MoE cubins — makes
+        # MoELayer build a runner that then fails at dispatch (cubin-not-found)
+        # instead of raising the clean "no usable backend" error at construction.
+        return arch in (100, 103, 110)
 
     @staticmethod
     def prepare_weights(


### PR DESCRIPTION
## Description

`TrtllmFp4Config.supported()` returned `True` for all `arch >= 100`, but the routed runner (`TrtllmFp4RoutedRunner`) delegates to the trtllm-gen **sm100** module, whose cubins are SM100-family only (SM100/SM103/SM110). On SM120/SM121 (consumer/workstation Blackwell) there are no trtllm-gen MoE cubins, so `MoELayer` selected and built a `TrtllmFp4RoutedRunner` that then failed deep at dispatch (cubin-not-found) instead of raising the clean "no usable backend" error at construction.

The existing comment already reasoned about the **lower** bound (don't mark the backend available on SM90/H100 where it "fails at dispatch"). This PR extends the same reasoning to the **upper** bound: gate on `100 <= arch < 120`. SM100/SM103/SM110 behavior is unchanged.

## Related Issues

None — found while auditing SM120 MoE dispatch on an RTX PRO 6000.

## Tests

Verified on an RTX PRO 6000 Blackwell (SM120, CUDA 13.0) with a minimal `MoEConfig(QuantVariant.NVFP4)`:

| | `supported(120)` | `supported(100)` / `(110)` | MoELayer(NVFP4) on SM120 |
|---|---|---|---|
| before | `True` | `True` | selects `TrtllmFp4RoutedRunner` → SM100 cubins → dispatch cubin-miss |
| after | `False` | `True` (unchanged) | clean `RuntimeError: none of the configured backends are usable on sm120` at construction |

`pre-commit run --files` passes (ruff check, ruff format, mypy, codespell).

## Reviewer Notes

- This is a **clean-error** fix: SM120 NVFP4 MoE is served today by the dedicated `b12x_fused_moe` path; the unified `MoELayer` MVP remains SM100-family for now. Full unified-API SM120 enablement (a CUTLASS/b12x NVFP4 runner mapped into `_BACKEND_RUNNERS`) is a larger change that overlaps the NVFP4-scale plumbing in #3614.
- The sibling trtllm-gen configs (`TrtllmFp8Block/PerTensor/Bf16/MxInt4`) share the identical `arch >= 100` upper-bound gap but are unreachable in the NVFP4-only MVP; left for a focused follow-up.

>  AI-assisted: investigated and authored with Claude Code, validated on SM120 hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted Trtllm FP4 backend GPU support to SM100-family architectures only (SM100/SM103/SM110), improving detection of unsupported hardware during initialization and avoiding later dispatch-time failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->