### PR TITLE
fix(comm): resolve the real libcudart, not a co-loaded look-alike (e.g. tilelang libcudart_stub.so)

### DIFF
--- a/flashinfer/comm/cuda_ipc.py
+++ b/flashinfer/comm/cuda_ipc.py
@@ -47,24 +47,20 @@ def find_loaded_library(lib_name) -> Optional[str]:
     shared libraries loaded by the process. We can use this file to find the path of the
     a loaded library.
     """  # noqa
-    found = False
+    # `lib_name` can substring-match another library legitimately loaded in the
+    # same process (e.g. tilelang's `libcudart_stub.so`, which lacks `cudaDeviceReset`).
+    # Accept only the real runtime (`libcudart.so[.N]`) or a hash-suffixed copy
+    # (`libcudart-<hash>.so.N`, as PyTorch ships); skip look-alikes.
     with open("/proc/self/maps") as f:
         for line in f:
-            if lib_name in line:
-                found = True
-                break
-    if not found:
-        # the library is not loaded in the current process
-        return None
-    # if lib_name is libcudart, we need to match a line with:
-    # address /path/to/libcudart-hash.so.11.0
-    start = line.index("/")
-    path = line[start:].strip()
-    filename = path.split("/")[-1]
-    assert filename.rpartition(".so")[0].startswith(lib_name), (
-        f"Unexpected filename: {filename} for library {lib_name}"
-    )
-    return path
+            if lib_name not in line or "/" not in line:
+                continue
+            path = line[line.index("/"):].strip()
+            stem = path.split("/")[-1].rpartition(".so")[0]
+            if stem == lib_name or stem.startswith(lib_name + "-"):
+                return path
+    # the library is not loaded in the current process
+    return None
 
 
 class CudaRTLibrary:


### PR DESCRIPTION
## Summary

`import flashinfer.comm` can fail at **import time** with `AttributeError: undefined symbol: cudaDeviceReset` when another package legitimately loaded in the same process provides a shared object whose filename contains `libcudart` but which is not the full CUDA runtime.

At import, `cuda_ipc.py` constructs a module-level `CudaRTLibrary()`. With no explicit path it calls `find_loaded_library("libcudart")`, which returns the **first** `/proc/self/maps` line containing the substring `libcudart` (lowest base address), guarded only by `rpartition(".so")[0].startswith(lib_name)` — which also accepts `libcudart_stub`. [tilelang](https://github.com/tile-ai/tilelang) ships `tilelang/lib/libcudart_stub.so` (no `cudaDeviceReset`); when it maps below the real runtime it is selected, and `CudaRTLibrary.__init__` raises.

Fixes #3676.

## Reproduction (arch-independent; verified on H100)

```bash
# one env with flashinfer-python, tilelang, torch
python3 -c "import torch; import tilelang; import flashinfer.comm"
# AttributeError: .../tilelang/lib/libcudart_stub.so: undefined symbol: cudaDeviceReset
```

## Fix

Scan all `libcudart`-matching mappings and accept only the real runtime (`libcudart.so[.N]`) or a hash-suffixed copy (`libcudart-<hash>.so.N`, as PyTorch ships), skipping look-alikes.

## Verification

- **Before:** import raises as above.
- **After (this patch):** `import flashinfer.comm` succeeds; `find_loaded_library("libcudart")` returns the real `.../libcudart.so.13`. Verified on H100 with the repro above.
- Also confirmed it still accepts the hash-suffixed runtime (not over-skipped) and returns `None` when only a non-runtime look-alike is present (no false positive).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision when detecting loaded CUDA shared libraries.
  * Avoids false positives from partial/substring matches by requiring exact library name alignment and supporting common variant naming (e.g., suffixed `lib*` files).
  * Ensures more reliable CUDA IPC library path resolution, reducing sporadic detection failures or incorrect matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->