### PR TITLE
Build dcp_alltoall with logger and stringUtils

### DIFF
--- a/flashinfer/jit/comm.py
+++ b/flashinfer/jit/comm.py
@@ -276,6 +276,16 @@ def gen_dcp_alltoall_module() -> JitSpec:
             / "cpp"
             / "common"
             / "tllmException.cpp",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "nv_internal"
+            / "cpp"
+            / "common"
+            / "logger.cpp",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "nv_internal"
+            / "cpp"
+            / "common"
+            / "stringUtils.cpp",
         ],
         extra_include_paths=[
             str(jit_env.FLASHINFER_CSRC_DIR / "nv_internal"),


### PR DESCRIPTION
## 📌 Description

The `dcp_alltoall` module uses `Logger::getLogger` and `fmtstr` symbols. Add dependencies to `logger.cpp` and `stringUtils.cpp` to include the symbols in the shared library, matching the fix applied to `mnnvl_moe_alltoall` in #2807.

Without this, `dcp_alltoall.so` fails with undefined symbols in environments that do not ship `libtensorrt_llm.so`:

```
undefined/missing symbols [
  ('_ZN12tensorrt_llm6common6Logger9getLoggerEv', None),
  ('_ZN12tensorrt_llm6common7fmtstr_EPKcPFPcPvmES4_P13__va_list_tag', None)
]
```

## 🔍 Related Issues

#2804

## 🚀 Pull Request Checklist

- [x] I have installed `pre-commit` by running `pip install pre-commit`
- [x] I have installed the hooks with `pre-commit install`
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal C++ compilation dependencies to enhance build process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->