### PR TITLE
fix(trace): handle combined paged KV cache tensor in _get_tensor (#3685)

### DIFF
--- a/flashinfer/fi_trace.py
+++ b/flashinfer/fi_trace.py
@@ -144,7 +144,7 @@ def build_fi_trace_fn(spec: Any) -> Callable[..., Dict[str, Any]]:
                 # a (k_cache, v_cache) tuple; the k/v split lives on dim 1.
                 # Recover the per-cache view so dtype/shape extraction matches
                 # the template's dim_names.
-                val = val[:, tuple_idx]
+                val = val[:, tuple_idx] if tuple_idx < val.shape[1] else None
             else:
                 return None
         return val if isinstance(val, torch.Tensor) else None

--- a/flashinfer/fi_trace.py
+++ b/flashinfer/fi_trace.py
@@ -136,8 +136,15 @@ def build_fi_trace_fn(spec: Any) -> Callable[..., Dict[str, Any]]:
         if val is None:
             return None
         if tuple_idx is not None:
-            if isinstance(val, (tuple, list)) and len(val) > tuple_idx:
-                val = val[tuple_idx]
+            if isinstance(val, (tuple, list)):
+                val = val[tuple_idx] if len(val) > tuple_idx else None
+            elif isinstance(val, torch.Tensor) and val.dim() >= 2 and val.shape[1] == 2:
+                # vLLM passes the paged KV cache as a single combined tensor
+                # [num_pages, 2, page_size, num_kv_heads, head_dim] rather than
+                # a (k_cache, v_cache) tuple; the k/v split lives on dim 1.
+                # Recover the per-cache view so dtype/shape extraction matches
+                # the template's dim_names.
+                val = val[:, tuple_idx]
             else:
                 return None
         return val if isinstance(val, torch.Tensor) else None

--- a/flashinfer/trace/template.py
+++ b/flashinfer/trace/template.py
@@ -257,7 +257,7 @@ def _get_tensor(
             # (k_cache, v_cache) tuple; the k/v split lives on dim 1. Recover
             # the per-cache view so dtype/shape extraction matches the
             # template's dim_names.
-            val = val[:, tuple_idx]
+            val = val[:, tuple_idx] if tuple_idx < val.shape[1] else None
         else:
             return None
     return val if isinstance(val, torch.Tensor) else None

--- a/flashinfer/trace/template.py
+++ b/flashinfer/trace/template.py
@@ -249,8 +249,15 @@ def _get_tensor(
     if val is None:
         return None
     if tuple_idx is not None:
-        if isinstance(val, (tuple, list)) and len(val) > tuple_idx:
-            val = val[tuple_idx]
+        if isinstance(val, (tuple, list)):
+            val = val[tuple_idx] if len(val) > tuple_idx else None
+        elif isinstance(val, torch.Tensor) and val.dim() >= 2 and val.shape[1] == 2:
+            # vLLM passes the paged KV cache as a single combined tensor
+            # [num_pages, 2, page_size, num_kv_heads, head_dim] rather than a
+            # (k_cache, v_cache) tuple; the k/v split lives on dim 1. Recover
+            # the per-cache view so dtype/shape extraction matches the
+            # template's dim_names.
+            val = val[:, tuple_idx]
         else:
             return None
     return val if isinstance(val, torch.Tensor) else None

--- a/tests/trace/test_fi_trace.py
+++ b/tests/trace/test_fi_trace.py
@@ -332,6 +332,40 @@ def test_gqa_paged_decode_fi_trace():
     ]
 
 
+def test_gqa_paged_decode_fi_trace_combined_kv_cache():
+    # vLLM passes the paged KV cache as a single combined tensor
+    # [num_pages, 2, page_size, num_kv_heads, head_dim] instead of a
+    # (k_cache, v_cache) tuple. The trace must still recover per-cache
+    # dtype/shape from the k/v split on dim 1 (regression for #3685).
+    from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper
+
+    batch_size = 32
+    num_qo_heads = 32
+    num_kv_heads = 8
+    head_dim = 128
+    num_pages = 512
+    page_size = 16
+
+    q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=torch.bfloat16)
+    paged_kv_cache = torch.randn(
+        num_pages, 2, page_size, num_kv_heads, head_dim, dtype=torch.bfloat16
+    )
+
+    defn = BatchDecodeWithPagedKVCacheWrapper.run.fi_trace(
+        q=q, paged_kv_cache=paged_kv_cache
+    )
+    _check_defn(defn, "gqa_paged", "BatchDecodeWithPagedKVCacheWrapper")
+    axes = defn["axes"]
+    # Axes that are only sourced from the KV cache must still resolve.
+    assert axes["num_kv_heads"]["value"] == num_kv_heads
+    assert axes["head_dim"]["value"] == head_dim
+    assert axes["page_size"]["value"] == page_size
+
+    # The combined tensor must not be skipped: dtype is recovered, not "unknown".
+    assert defn["inputs"]["k_cache"]["dtype"] == "bfloat16"
+    assert defn["inputs"]["v_cache"]["dtype"] == "bfloat16"
+
+
 # ---------------------------------------------------------------------------
 # GQA ragged prefill
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The trace `_get_tensor` helper only accepted a `(k_cache, v_cache)` tuple/list
for parameters declared with a `tuple_idx` (the `paged_kv_cache` k/v split).
When vLLM calls FlashInfer it passes the paged KV cache as a **single combined
tensor** `[num_pages, 2, page_size, num_kv_heads, head_dim]` rather than a
tuple, so `_get_tensor` returned `None` and the trace **silently skipped** that
input — KV-only axes (`num_kv_heads`, `page_size`) lost their value and the
k/v cache `dtype` came out as `"unknown"`.

This recovers the per-cache view by splitting the combined tensor on **dim 1**
(the k/v axis) when a bare tensor is passed for a tuple parameter:

```python
elif isinstance(val, torch.Tensor) and val.dim() >= 2 and val.shape[1] == 2:
    val = val[:, tuple_idx]
```

The k/v axis sits at dim 1 for both `NHD` and `HND` combined layouts
(`decode.py`, `cascade.py`, `prefill.py` docstrings), so the split is
layout-agnostic and yields a rank-4 view matching the template `dim_names`.
The guard only triggers for the combined-cache form; every `tuple_idx=` call
site in `flashinfer/trace/templates/` is the `paged_kv_cache` split, so there
is no false-positive risk on other parameters.

The same helper exists in two places (the standalone
`flashinfer/trace/template.py` module and the nested copy in
`flashinfer/fi_trace.py`); both are fixed identically.

## Related Issues

Fixes #3685

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually and fixed any reported issues (`ruff format` / `ruff check` clean).

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing.

Added `test_gqa_paged_decode_fi_trace_combined_kv_cache`, which traces with a
combined `paged_kv_cache` tensor and asserts the KV-sourced axes and k/v dtype
are recovered. Full trace suite (`tests/trace/test_fi_trace.py`,
`tests/trace/test_fi_trace_template_consistency.py`) passes — 412 passed.

## Reviewer Notes

The fix targets the combined `dim1 == 2` form that vLLM uses. The shared-KV
`dim1 == 1` variant some docstrings mention is intentionally left alone:
`tuple_idx=1` (v_cache) is not meaningful there and the upstream combined cache
is always 2-wide.

AI-assisted (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced KV cache handling to support vLLM’s paged cache format when k/v are provided as a single combined tensor, ensuring correct trace recovery of KV-related dimensions and types.

* **Tests**
  * Added unit test coverage for trace generation with combined paged KV cache tensors, verifying recovered axes and that k/v cache inputs retain the expected dtype.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->