### PR TITLE
Bug fix (gdn): Layout contract fix from 3649

### DIFF
--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -1773,32 +1773,22 @@ def gated_delta_rule_mtp_wide_vec(
             # scales with B. The dummy [1,1,1] tensor (caching off) is never read
             # and cannot be marked dynamic (no unique stride-1 dim), so skip it.
             inter_ = inter_.mark_compact_shape_dynamic(mode=0)
-        q_ = from_dlpack(
-            q, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
-        k_ = from_dlpack(
-            k, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
-        v_ = from_dlpack(
-            v, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
-        a_ = from_dlpack(
-            a, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
-        b_ = from_dlpack(
-            b, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
+        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
+        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
+        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
+        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
+        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
         o_ = from_dlpack(
             output, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
+        ).mark_layout_dynamic()
         h0_idx_ = from_dlpack(
             initial_state_indices, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
+        ).mark_layout_dynamic()
         h0_out_idx_ = from_dlpack(
             initial_state_indices, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
+        ).mark_layout_dynamic()
 
         _compiled_kernels_wide_vec[cache_key] = {
             "compiled": cute.compile(
@@ -2047,32 +2037,22 @@ def gated_delta_rule_mtp(
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
         if cache_intermediate_states:
             inter_ = inter_.mark_compact_shape_dynamic(mode=0)
-        q_ = from_dlpack(
-            q, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
-        k_ = from_dlpack(
-            k, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
-        v_ = from_dlpack(
-            v, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
-        a_ = from_dlpack(
-            a, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
-        b_ = from_dlpack(
-            b, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
+        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
+        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
+        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
+        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
+        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True).mark_layout_dynamic()
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
         o_ = from_dlpack(
             output, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
+        ).mark_layout_dynamic()
         h0_idx_ = from_dlpack(
             initial_state_indices, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
+        ).mark_layout_dynamic()
         h0_out_idx_ = from_dlpack(
             initial_state_indices, assumed_align=32, enable_tvm_ffi=True
-        ).mark_compact_shape_dynamic(mode=0)
+        ).mark_layout_dynamic()
 
         _compiled_kernels_mtp[cache_key] = {
             "compiled": cute.compile(

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -129,7 +129,6 @@ def gdn_decode_bf16state_mtp_ilp4_kernel(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -749,7 +748,6 @@ def gdn_wide_vec_kernel(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1248,7 +1246,6 @@ def run_gdn_decode_bf16state_mtp_ilp4(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1273,6 +1270,9 @@ def run_gdn_decode_bf16state_mtp_ilp4(
     )
 
     num_v_tiles = cute.ceil_div(v_dim, tile_v)
+    # Batch size is a runtime extent (q's leading dim is marked dynamic at
+    # compile time); the grid scales with B without baking B into the cubin.
+    B = cute.size(q.shape[0])
     grid_size = B * HV * num_v_tiles
 
     smem_bytes = 128
@@ -1299,7 +1299,6 @@ def run_gdn_decode_bf16state_mtp_ilp4(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -1340,7 +1339,6 @@ def _run_wide_vec(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1354,6 +1352,11 @@ def _run_wide_vec(
     stream: cuda.CUstream,
 ):
     num_v_tiles: cutlass.Constexpr[int] = V // tile_v
+    # Batch size is a *runtime* extent: when q's leading dim is marked dynamic
+    # (see gated_delta_rule_mtp_wide_vec), cute.size returns a dynamic value so
+    # the grid scales with B without baking B into the cubin. The kernel never
+    # uses B internally (it decodes i_n from block_idx), so only the grid needs it.
+    B = cute.size(q.shape[0])
     grid_size = B * HV * num_v_tiles
     smem_bytes = (
         4 * T * (K + 8)  # sQ FP32
@@ -1378,7 +1381,6 @@ def _run_wide_vec(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -1725,9 +1727,14 @@ def gated_delta_rule_mtp_wide_vec(
     # page). Include in the cache key so padded vs tight pools each get their
     # own compiled kernel — cute.compile bakes the stride into the cubin.
     pool_slot_stride = int(initial_state_source.stride(0))
+    # NOTE: ``B_val`` is deliberately NOT part of the cache key. The batch dim
+    # of every per-batch tensor (q/k/v/a/b/o/indices) is marked dynamic before
+    # ``cute.compile`` below, and the grid is derived from the runtime batch
+    # extent inside ``_run_wide_vec``. A single compiled cubin therefore serves
+    # every batch size for a given (tile_v, T, HV, ...) — eliminating the
+    # per-batch-size recompilation that previously happened at inference time.
     cache_key = (
-        "v3_mtp_bf16_tiled",
-        B_val,
+        "v3_mtp_bf16_tiled_dynB",
         T_val,
         H_val,
         HV_val,
@@ -1745,36 +1752,53 @@ def gated_delta_rule_mtp_wide_vec(
         use_packed_fma,
         same_pool,
     )
-    if cache_key not in _compiled_kernels_wide_vec:
-        default_indices = torch.arange(B_val, dtype=torch.int32, device=q.device)
-        default_output = torch.empty(
+
+    # Defaults are sized for the CURRENT batch (the dynamic-B cubin accepts any
+    # B, so we must never reuse a tensor sized for an earlier call's batch).
+    if initial_state_indices is None:
+        initial_state_indices = torch.arange(B_val, dtype=torch.int32, device=q.device)
+    if output is None:
+        output = torch.empty(
             B_val, T_val, HV_val, V_val, device=q.device, dtype=q.dtype
         )
 
-        if initial_state_indices is None:
-            initial_state_indices = default_indices
-        if output is None:
-            output = default_output
-
-        # Compile-time indices template: any [B] int32 on the right device.
-        # Both read and write index tensors share the same shape/dtype so
-        # the same dlpack handle works for both slots.
+    if cache_key not in _compiled_kernels_wide_vec:
+        # Mark the leading (batch) dim dynamic on every per-batch tensor so the
+        # compiled cubin is batch-size agnostic. h0_source / A_log / dt_bias are
+        # NOT batch-scoped (pool / per-head), so they keep static shapes.
         h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
-        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
-        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
-        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
-        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
-        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
+        if cache_intermediate_states:
+            # Real cache buffer reshaped to [B*cache_steps*HV, V, K]; leading dim
+            # scales with B. The dummy [1,1,1] tensor (caching off) is never read
+            # and cannot be marked dynamic (no unique stride-1 dim), so skip it.
+            inter_ = inter_.mark_compact_shape_dynamic(mode=0)
+        q_ = from_dlpack(
+            q, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        k_ = from_dlpack(
+            k, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        v_ = from_dlpack(
+            v, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        a_ = from_dlpack(
+            a, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        b_ = from_dlpack(
+            b, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
-        o_ = from_dlpack(output, assumed_align=32, enable_tvm_ffi=True)
+        o_ = from_dlpack(
+            output, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
         h0_idx_ = from_dlpack(
             initial_state_indices, assumed_align=32, enable_tvm_ffi=True
-        )
+        ).mark_compact_shape_dynamic(mode=0)
         h0_out_idx_ = from_dlpack(
             initial_state_indices, assumed_align=32, enable_tvm_ffi=True
-        )
+        ).mark_compact_shape_dynamic(mode=0)
 
         _compiled_kernels_wide_vec[cache_key] = {
             "compiled": cute.compile(
@@ -1795,7 +1819,6 @@ def gated_delta_rule_mtp_wide_vec(
                 softplus_threshold,
                 scale,
                 HV_val,
-                B_val,
                 T_val,
                 H_val,
                 K_val,
@@ -1809,19 +1832,13 @@ def gated_delta_rule_mtp_wide_vec(
                 stream,
                 options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
-            "default_indices": default_indices,
-            "output": default_output,
         }
 
     cache = _compiled_kernels_wide_vec[cache_key]
-    if initial_state_indices is None:
-        initial_state_indices = cache["default_indices"]
     if output_state_indices is None:
         # Single-pool: read==write. Reuse the same indices tensor — no extra
         # allocation, kernel still produces the same address for both slots.
         output_state_indices = initial_state_indices
-    if output is None:
-        output = cache["output"]
 
     cache["compiled"](
         h0_source,
@@ -1990,9 +2007,12 @@ def gated_delta_rule_mtp(
     # Slot stride may be larger than HV*V*K (vLLM's packed conv+ssm page).
     # Include in cache key — cute.compile bakes the stride into the cubin.
     pool_slot_stride = int(initial_state_source.stride(0))
+    # ``B`` is intentionally absent from the cache key: the batch dim of every
+    # per-batch tensor is marked dynamic before ``cute.compile``, and the grid
+    # is derived from the runtime batch extent in the launch wrapper. One cubin
+    # per (tile_v, T, HV, ...) serves all batch sizes (no inference-time recompile).
     cache_key = (
-        "mtp_bf16",
-        B,
+        "mtp_bf16_dynB",
         T,
         H,
         HV,
@@ -2011,29 +2031,48 @@ def gated_delta_rule_mtp(
         use_packed_fma,
         same_pool,
     )
-    if cache_key not in _compiled_kernels_mtp:
-        # First call for this shape: allocate default indices/output and do
-        # dlpack conversions once for compilation. Steady-state calls pass
-        # torch tensors straight to the compiled callable (tvm-ffi accepts
-        # either) and reuse these cached defaults when the caller doesn't
-        # provide their own.
-        default_indices = torch.arange(B, dtype=torch.int32, device=q.device)
-        default_output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
 
+    # Defaults sized for the CURRENT batch (the dynamic-B cubin accepts any B,
+    # so a tensor sized for an earlier call must never be reused).
+    if initial_state_indices is None:
+        initial_state_indices = torch.arange(B, dtype=torch.int32, device=q.device)
+    if output is None:
+        output = torch.empty(B, T, HV, V, device=q.device, dtype=q.dtype)
+
+    if cache_key not in _compiled_kernels_mtp:
+        # Mark the leading (batch) dim dynamic on every per-batch tensor so the
+        # compiled cubin is batch-size agnostic. h0_source / A_log / dt_bias are
+        # pool- / head-scoped and keep static shapes.
         h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
-        q_ = from_dlpack(q, assumed_align=32, enable_tvm_ffi=True)
-        k_ = from_dlpack(k, assumed_align=32, enable_tvm_ffi=True)
-        v_ = from_dlpack(v, assumed_align=32, enable_tvm_ffi=True)
-        a_ = from_dlpack(a, assumed_align=32, enable_tvm_ffi=True)
-        b_ = from_dlpack(b, assumed_align=32, enable_tvm_ffi=True)
+        if cache_intermediate_states:
+            inter_ = inter_.mark_compact_shape_dynamic(mode=0)
+        q_ = from_dlpack(
+            q, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        k_ = from_dlpack(
+            k, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        v_ = from_dlpack(
+            v, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        a_ = from_dlpack(
+            a, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        b_ = from_dlpack(
+            b, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
-        o_ = from_dlpack(default_output, assumed_align=32, enable_tvm_ffi=True)
-        h0_idx_ = from_dlpack(default_indices, assumed_align=32, enable_tvm_ffi=True)
+        o_ = from_dlpack(
+            output, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
+        h0_idx_ = from_dlpack(
+            initial_state_indices, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
         h0_out_idx_ = from_dlpack(
-            default_indices, assumed_align=32, enable_tvm_ffi=True
-        )
+            initial_state_indices, assumed_align=32, enable_tvm_ffi=True
+        ).mark_compact_shape_dynamic(mode=0)
 
         _compiled_kernels_mtp[cache_key] = {
             "compiled": cute.compile(
@@ -2054,7 +2093,6 @@ def gated_delta_rule_mtp(
                 softplus_threshold,
                 scale,
                 HV,
-                B,
                 T,
                 H,
                 K,
@@ -2068,16 +2106,12 @@ def gated_delta_rule_mtp(
                 stream,
                 options="--enable-tvm-ffi --generate-line-info --opt-level 3",
             ),
-            "default_indices": default_indices,
-            "output": default_output,
         }
 
     cache = _compiled_kernels_mtp[cache_key]
 
     if output_state_indices is None:
         output_state_indices = initial_state_indices
-    if output is None:
-        output = cache["output"]
 
     cache["compiled"](
         h0_source,

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -213,7 +213,6 @@ def gdn_verify_kernel_mtp(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1352,7 +1351,6 @@ def run_gdn_verify_kernel_mtp(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -1378,7 +1376,7 @@ def run_gdn_verify_kernel_mtp(
     num_v_tiles = cute.ceil_div(v_dim, tile_v)
 
     # Grid: (B * HV * num_v_tiles, 1, 1) - parallelize across V dimension
-    grid_size = B * HV * num_v_tiles
+    grid_size = q.shape[0] * HV * num_v_tiles
 
     # Shared memory for pre-computed q, k, g, beta, preloaded v data, and output
     smem_bytes = (
@@ -1411,7 +1409,6 @@ def run_gdn_verify_kernel_mtp(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -1455,7 +1452,6 @@ def gdn_verify_kernel_mtp_inline(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -2127,7 +2123,6 @@ def run_gdn_verify_kernel_mtp_inline(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -2153,7 +2148,7 @@ def run_gdn_verify_kernel_mtp_inline(
     num_v_tiles = cute.ceil_div(v_dim, tile_v)
 
     # Grid: (B * HV * num_v_tiles, 1, 1) - parallelize across V dimension
-    grid_size = B * HV * num_v_tiles
+    grid_size = q.shape[0] * HV * num_v_tiles
 
     # v10: No sQ/sK/sG/sBeta — only sVdata + sOutput
     smem_bytes = (
@@ -2182,7 +2177,6 @@ def run_gdn_verify_kernel_mtp_inline(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -2205,13 +2199,11 @@ def run_gdn_verify_kernel_mtp_inline(
 
 @functools.cache
 def _get_compiled_mtp_kernel(
-    B: int,
     T: int,
     H: int,
     HV: int,
     K: int,
     V: int,
-    pool_size: int,
     cache_steps: int,
     disable_state_update: bool,
     cache_intermediate_states: bool,
@@ -2229,13 +2221,11 @@ def _get_compiled_mtp_kernel(
 
 @functools.cache
 def _get_compiled_mtp_kernel_inline(
-    B: int,
     T: int,
     H: int,
     HV: int,
     K: int,
     V: int,
-    pool_size: int,
     cache_steps: int,
     disable_state_update: bool,
     cache_intermediate_states: bool,
@@ -2312,68 +2302,68 @@ def run_mtp_decode(
     major, _ = torch.cuda.get_device_capability(q.device)
     use_packed_fma = major >= 10  # SM100+ (Blackwell) supports packed F32x2
 
+    # B and pool_size absent from the key: per-batch and pool tensors are marked
+    # dynamic below, so one cubin per variant serves all batch/pool sizes.
+    cache_key = (
+        T,
+        H,
+        HV,
+        K,
+        V,
+        cache_steps,
+        disable_state_update,
+        cache_intermediate_states,
+        scale,
+        use_qk_l2norm,
+        tile_v,
+        vec_size,
+        ilp_rows,
+        use_smem_v,
+        use_packed_fma,
+    )
     if use_inline_kernel:
-        inline_cache_key = (
-            B,
-            T,
-            H,
-            HV,
-            K,
-            V,
-            pool_size,
-            cache_steps,
-            disable_state_update,
-            cache_intermediate_states,
-            scale,
-            use_qk_l2norm,
-            tile_v,
-            vec_size,
-            ilp_rows,
-            use_smem_v,
-            use_packed_fma,
-        )
-        cache = _get_compiled_mtp_kernel_inline(*inline_cache_key)
+        cache = _get_compiled_mtp_kernel_inline(*cache_key)
     else:
-        warp_cache_key = (
-            B,
-            T,
-            H,
-            HV,
-            K,
-            V,
-            pool_size,
-            cache_steps,
-            disable_state_update,
-            cache_intermediate_states,
-            scale,
-            use_qk_l2norm,
-            tile_v,
-            vec_size,
-            ilp_rows,
-            use_smem_v,
-            use_packed_fma,
-        )
-        cache = _get_compiled_mtp_kernel(*warp_cache_key)
+        cache = _get_compiled_mtp_kernel(*cache_key)
 
-    if "cu_seqlens" not in cache or cache["cu_seqlens"].device != q.device:
-        cache["cu_seqlens"] = torch.zeros(B + 1, dtype=torch.int32, device=q.device)
-    cu_seqlens = cache["cu_seqlens"]
+    # cu_seqlens is batch-sized; per-(B, device) map since B left the cache key.
+    cu_seqlens_map = cache.setdefault("cu_seqlens", {})
+    cu_key = (B, q.device)
+    if cu_key not in cu_seqlens_map:
+        cu_seqlens_map[cu_key] = torch.zeros(B + 1, dtype=torch.int32, device=q.device)
+    cu_seqlens = cu_seqlens_map[cu_key]
 
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
+        # Per-batch tensors (q/k/v/a/b/o, indices) use mark_layout_dynamic so one
+        # cubin serves all batch sizes AND non-compact packed views (SGLang fused
+        # QKV). Pool / intermediate-state tensors mark only mode 0 (inner dims
+        # stay static for num_v_tiles).
+        h0_source_tensor = from_dlpack(
+            h0_source, assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
         intermediate_states_tensor = from_dlpack(intermediate_states, assumed_align=16)
+        if cache_intermediate_states:
+            intermediate_states_tensor = (
+                intermediate_states_tensor.mark_compact_shape_dynamic(
+                    mode=0, stride_order=(0, 1, 2), divisibility=1
+                )
+            )
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16)
+        a_tensor = from_dlpack(a, assumed_align=16).mark_layout_dynamic()
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16)
-        k_tensor = from_dlpack(k, assumed_align=16)
-        v_tensor = from_dlpack(v, assumed_align=16)
-        b_tensor = from_dlpack(b, assumed_align=16)
-        o_tensor = from_dlpack(output, assumed_align=16)
-        h0_indices_tensor = from_dlpack(initial_state_indices, assumed_align=16)
-        cu_seqlens_tensor = from_dlpack(cu_seqlens, assumed_align=16)
+        q_tensor = from_dlpack(q, assumed_align=16).mark_layout_dynamic()
+        k_tensor = from_dlpack(k, assumed_align=16).mark_layout_dynamic()
+        v_tensor = from_dlpack(v, assumed_align=16).mark_layout_dynamic()
+        b_tensor = from_dlpack(b, assumed_align=16).mark_layout_dynamic()
+        o_tensor = from_dlpack(output, assumed_align=16).mark_layout_dynamic()
+        h0_indices_tensor = from_dlpack(
+            initial_state_indices, assumed_align=16
+        ).mark_layout_dynamic()
+        cu_seqlens_tensor = from_dlpack(
+            cu_seqlens, assumed_align=16
+        ).mark_layout_dynamic()
 
         if use_inline_kernel:
             compiled = cute.compile(
@@ -2394,7 +2384,6 @@ def run_mtp_decode(
                 softplus_threshold=20.0,
                 scale=scale,
                 HV=HV,
-                B=B,
                 T=T,
                 H=H,
                 K=K,
@@ -2431,7 +2420,6 @@ def run_mtp_decode(
                 softplus_threshold=20.0,
                 scale=scale,
                 HV=HV,
-                B=B,
                 T=T,
                 H=H,
                 K=K,

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -528,7 +528,6 @@ def run_gdn_decode_kernel_small_batch_nontranspose(
     softplus_beta: cutlass.Constexpr[float],
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     HV: cutlass.Constexpr[int],
@@ -609,7 +608,6 @@ def run_gdn_decode_kernel_big_batch_nontranspose(
     softplus_beta: cutlass.Constexpr[float],
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     HV: cutlass.Constexpr[int],
@@ -679,7 +677,7 @@ def run_gdn_decode_kernel_big_batch_nontranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel_nontranspose(
-    B: int,
+    use_small_batch: bool,
     T: int,
     H: int,
     HV: int,
@@ -723,40 +721,51 @@ def run_nontranspose_decode(
         scale: Query scale factor.
         use_qk_l2norm: Whether to apply L2 normalization.
     """
-    # Compile kernel with TVM FFI (cached)
-    cache_key = (B, T, H, HV, K, V, q.dtype, scale, use_qk_l2norm)
+    # Compile kernel with TVM FFI (cached). use_small_batch (kernel variant) is
+    # in the key; B is not (per-batch tensors are marked dynamic below).
+    use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
+    cache_key = (use_small_batch, T, H, HV, K, V, q.dtype, scale, use_qk_l2norm)
     cache = _get_compiled_decode_kernel_nontranspose(*cache_key)
 
-    # Get or create h0_indices and cu_seqlens (cached per config)
-    if "h0_indices" not in cache or cache["h0_indices"].device != q.device:
-        cache["h0_indices"] = torch.arange(B, dtype=torch.int32, device=q.device)
-        cache["cu_seqlens"] = torch.zeros(B + 1, dtype=torch.int32, device=q.device)
-    h0_indices = cache["h0_indices"]
-    cu_seqlens = cache["cu_seqlens"]
+    # Batch-sized aux tensors, keyed per (B, device) since B left the cache key.
+    aux_map = cache.setdefault("aux", {})
+    aux_key = (B, q.device)
+    if aux_key not in aux_map:
+        aux_map[aux_key] = (
+            torch.arange(B, dtype=torch.int32, device=q.device),
+            torch.zeros(B + 1, dtype=torch.int32, device=q.device),
+        )
+    h0_indices, cu_seqlens = aux_map[aux_key]
 
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
         # Choose kernel based on batch size
-        use_small_batch = B < SMALL_BATCH_THRESHOLD_NT
-
         if use_small_batch:
             run_func = run_gdn_decode_kernel_small_batch_nontranspose
         else:
             run_func = run_gdn_decode_kernel_big_batch_nontranspose
 
-        # Convert tensors to CuTe format for compilation only
-        h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
+        # Per-batch tensors (q/k/v/a/b/o, indices) use mark_layout_dynamic so one
+        # cubin serves all batch sizes AND non-compact packed views (SGLang fused
+        # QKV). h0_source ([B*HV, K, V]) marks only mode 0 (inner dims static).
+        h0_source_tensor = from_dlpack(
+            h0_source, assumed_align=16
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16)
+        a_tensor = from_dlpack(a, assumed_align=16).mark_layout_dynamic()
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16)
-        k_tensor = from_dlpack(k, assumed_align=16)
-        v_tensor = from_dlpack(v, assumed_align=16)
-        b_tensor = from_dlpack(b, assumed_align=16)
-        o_tensor = from_dlpack(output, assumed_align=16)
-        h0_indices_tensor = from_dlpack(h0_indices, assumed_align=16)
-        cu_seqlens_tensor = from_dlpack(cu_seqlens, assumed_align=16)
+        q_tensor = from_dlpack(q, assumed_align=16).mark_layout_dynamic()
+        k_tensor = from_dlpack(k, assumed_align=16).mark_layout_dynamic()
+        v_tensor = from_dlpack(v, assumed_align=16).mark_layout_dynamic()
+        b_tensor = from_dlpack(b, assumed_align=16).mark_layout_dynamic()
+        o_tensor = from_dlpack(output, assumed_align=16).mark_layout_dynamic()
+        h0_indices_tensor = from_dlpack(
+            h0_indices, assumed_align=16
+        ).mark_layout_dynamic()
+        cu_seqlens_tensor = from_dlpack(
+            cu_seqlens, assumed_align=16
+        ).mark_layout_dynamic()
 
         # Use TVM FFI to reduce runtime overhead
         compiled = cute.compile(
@@ -775,7 +784,6 @@ def run_nontranspose_decode(
             softplus_beta=1.0,
             softplus_threshold=20.0,
             scale=scale,
-            B=B,
             T=T,
             H=H,
             HV=HV,

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -62,7 +62,6 @@ def gdn_decode_kernel_small_batch_pretranspose(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -383,7 +382,6 @@ def gdn_decode_kernel_big_batch_pretranspose(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -690,7 +688,6 @@ def run_gdn_decode_kernel_small_batch_pretranspose(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -712,6 +709,7 @@ def run_gdn_decode_kernel_small_batch_pretranspose(
         v_dim = h0_source.layout.shape[1]
         k_dim = h0_source.layout.shape[2]
     # Grid size: use B*HV (actual batch) not h0_source.shape[0] (which may be pool_size*HV)
+    B = cute.size(q.shape[0])
     grid_batch = B * HV
 
     # Create cp.async copy with cache-global mode (bypass L1)
@@ -768,7 +766,6 @@ def run_gdn_decode_kernel_small_batch_pretranspose(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -803,7 +800,6 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
     softplus_threshold: cutlass.Constexpr[float],
     scale: cutlass.Constexpr[float],
     HV: cutlass.Constexpr[int],
-    B: cutlass.Constexpr[int],
     T: cutlass.Constexpr[int],
     H: cutlass.Constexpr[int],
     K: cutlass.Constexpr[int],
@@ -820,6 +816,7 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
     else:
         v_dim = h0_source.layout.shape[1]
         k_dim = h0_source.layout.shape[2]
+    B = cute.size(q.shape[0])
     grid_batch = B * HV
 
     # Create cp.async copy with cache-global mode (bypass L1)
@@ -876,7 +873,6 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
         softplus_threshold,
         scale,
         HV,
-        B,
         T,
         H,
         K,
@@ -900,7 +896,6 @@ def run_gdn_decode_kernel_big_batch_pretranspose(
 
 @functools.cache
 def _get_compiled_decode_kernel(
-    B: int,
     T: int,
     H: int,
     HV: int,
@@ -966,7 +961,6 @@ def run_pretranspose_decode(
     else:
         pool_size = stride0 = stride1 = stride2 = stride3 = 0
     cache_key = (
-        B,
         T,
         H,
         HV,
@@ -984,39 +978,55 @@ def run_pretranspose_decode(
     )
     cache = _get_compiled_decode_kernel(*cache_key)
 
-    # Get or create h0_indices and cu_seqlens (cached per config)
-    if "h0_indices" not in cache or cache["h0_indices"].device != q.device:
-        cache["h0_indices"] = torch.zeros(B, dtype=torch.int32, device=q.device)
-        cache["cu_seqlens"] = torch.zeros(B + 1, dtype=torch.int32, device=q.device)
+    # Batch-sized aux tensors, keyed per (B, device) since B left the cache key.
+    aux_map = cache.setdefault("aux", {})
+    aux_key = (B, q.device)
+    if aux_key not in aux_map:
+        aux_map[aux_key] = (
+            torch.zeros(B, dtype=torch.int32, device=q.device),
+            torch.zeros(B + 1, dtype=torch.int32, device=q.device),
+        )
+    default_h0_indices, cu_seqlens = aux_map[aux_key]
 
     if use_pool_indexing and initial_state_indices is not None:
         h0_indices = initial_state_indices.to(torch.int32)
     else:
-        h0_indices = cache["h0_indices"]
+        h0_indices = default_h0_indices
     # Resolve output indices: default to same as read indices
     if use_pool_indexing and output_state_indices is not None:
         h0_out_indices = output_state_indices.to(torch.int32)
     else:
         h0_out_indices = h0_indices
-    cu_seqlens = cache["cu_seqlens"]
 
     if "compiled" not in cache:
         stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
-        # Convert tensors to CuTe format for compilation only
-        # Use the actual tensor view so strided pool layouts are preserved.
+        # Per-batch tensors (q/k/v/a/b/o, indices) use mark_layout_dynamic so one
+        # cubin serves all batch sizes AND non-compact packed views (SGLang fused
+        # QKV). Non-pool state ([B*HV, V, K]) marks only mode 0 (inner dims stay
+        # static for num_v_tiles); a pool keeps its baked layout via the key.
         h0_source_tensor = from_dlpack(h0_source, assumed_align=16)
+        if not use_pool_indexing:
+            h0_source_tensor = h0_source_tensor.mark_compact_shape_dynamic(
+                mode=0, stride_order=(0, 1, 2), divisibility=1
+            )
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16)
+        a_tensor = from_dlpack(a, assumed_align=16).mark_layout_dynamic()
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16)
-        k_tensor = from_dlpack(k, assumed_align=16)
-        v_tensor = from_dlpack(v, assumed_align=16)
-        b_tensor = from_dlpack(b, assumed_align=16)
-        o_tensor = from_dlpack(output, assumed_align=16)
-        h0_indices_tensor = from_dlpack(h0_indices, assumed_align=16)
-        h0_out_indices_tensor = from_dlpack(h0_out_indices, assumed_align=16)
-        cu_seqlens_tensor = from_dlpack(cu_seqlens, assumed_align=16)
+        q_tensor = from_dlpack(q, assumed_align=16).mark_layout_dynamic()
+        k_tensor = from_dlpack(k, assumed_align=16).mark_layout_dynamic()
+        v_tensor = from_dlpack(v, assumed_align=16).mark_layout_dynamic()
+        b_tensor = from_dlpack(b, assumed_align=16).mark_layout_dynamic()
+        o_tensor = from_dlpack(output, assumed_align=16).mark_layout_dynamic()
+        h0_indices_tensor = from_dlpack(
+            h0_indices, assumed_align=16
+        ).mark_layout_dynamic()
+        h0_out_indices_tensor = from_dlpack(
+            h0_out_indices, assumed_align=16
+        ).mark_layout_dynamic()
+        cu_seqlens_tensor = from_dlpack(
+            cu_seqlens, assumed_align=16
+        ).mark_layout_dynamic()
 
         # Always use 8-CTA architecture (benchmarks show it's better for all batch sizes)
         run_func = run_gdn_decode_kernel_small_batch_pretranspose
@@ -1040,7 +1050,6 @@ def run_pretranspose_decode(
             softplus_threshold=20.0,
             scale=scale,
             HV=HV,
-            B=B,
             T=T,
             H=H,
             K=K,

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -750,15 +750,23 @@ __global__ void SamplingFromLogitsKernel(DType* logits, IdType* output, IdType* 
     DataAndIndex<DType, IdType> cur_data[VEC_SIZE];
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-      cur_data[j].data = (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d
-                             ? logits_vec[j] + gumbel_noise[j]
-                             : -cuda::std::numeric_limits<DType>::infinity();
-      cur_data[j].index = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+      const uint32_t token_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+      const bool valid = token_idx < d;
+      cur_data[j].data =
+          valid ? logits_vec[j] + gumbel_noise[j] : -cuda::std::numeric_limits<DType>::infinity();
+      // Padding lanes (token_idx >= d) must never carry an out-of-range index: even though their
+      // data is -inf and should never win the reduction, assigning a valid fallback (0) guarantees
+      // the returned token id stays within [0, d).
+      cur_data[j].index = valid ? token_idx : 0;
     }
 
     max_data +=
         BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage)
             .template Sum<VEC_SIZE>(cur_data);
+    // CUB BlockReduce leaves temp_storage in an undefined state; a barrier is required before it
+    // can be safely reused in the next loop iteration. Without this sync, concurrent read/write of
+    // the shared reduction storage races and can return a corrupted index.
+    __syncthreads();
   }
   if (tx == 0) {
     output[bx] = max_data.index;

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -2635,3 +2635,137 @@ def test_gdn_decode_bf16_state_mtp_pool_larger_than_batch(
             atol=0,
             rtol=0,
         )
+
+
+# ============================================================================
+# Packed (non-compact) Q/K/V coverage (regression test for PR #3649)
+#
+# SGLang feeds q/k/v as head-dim slices of a single fused mixed_qkv buffer, so
+# their batch stride is the full packed width, not the compact per-tensor
+# width. The decode kernels must accept these non-compact views and return
+# results identical to the contiguous equivalents. PR #3649 regressed this by
+# requiring a compact layout on the dynamic-batch compile path.
+# ============================================================================
+
+
+def _packed_qkv(
+    batch_size, seq_len, num_q_heads, num_k_heads, num_v_heads, head_size, device
+):
+    """q/k/v as non-compact head-dim slices of one fused [B, T, Htot, D] buffer."""
+    htot = num_q_heads + num_k_heads + num_v_heads
+    fused = torch.randn(
+        batch_size, seq_len, htot, head_size, dtype=torch.bfloat16, device=device
+    )
+    q = fused[:, :, :num_q_heads, :]
+    k = fused[:, :, num_q_heads : num_q_heads + num_k_heads, :]
+    v = fused[:, :, num_q_heads + num_k_heads :, :]
+    # The property PR #3649 mishandled: these head-dim slices are non-compact
+    # (batch stride is the packed width). Only observable for B>1; at B=1 the
+    # size-1 batch dim makes the slice trivially contiguous.
+    assert batch_size == 1 or not q.is_contiguous(), "expected a packed view"
+    return q, k, v
+
+
+def _packed_qkv_params(batch_size, seq_len, num_v_heads, head_size, device):
+    a = (
+        torch.randn(
+            batch_size, seq_len, num_v_heads, dtype=torch.bfloat16, device=device
+        )
+        * 0.1
+    )
+    b = torch.randn(
+        batch_size, seq_len, num_v_heads, dtype=torch.bfloat16, device=device
+    )
+    A_log = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+    dt_bias = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+    return a, b, A_log, dt_bias
+
+
+@pytest.mark.parametrize("state_dtype", ["bfloat16", "float32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+def test_decode_pretranspose_packed_qkv(batch_size: int, state_dtype: str):
+    """Pretranspose decode must accept packed q/k/v (bit-identical to contiguous)."""
+    _skip_if_not_sm90_or_later()
+    torch.manual_seed(0)
+    Hq = Hk = 16
+    HV = 32
+    D = 128
+    dev = torch.device("cuda")
+    scale = 1.0 / math.sqrt(D)
+    kv_dtype = getattr(torch, state_dtype)
+
+    q, k, v = _packed_qkv(batch_size, 1, Hq, Hk, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, 1, HV, D, dev)
+    state = torch.randn(batch_size, HV, D, D, dtype=kv_dtype, device=dev)
+
+    kw = dict(A_log=A_log, a=a, dt_bias=dt_bias, b=b, scale=scale, use_qk_l2norm=True)
+    o_p, s_p = gated_delta_rule_decode_pretranspose(
+        q=q, k=k, v=v, state=state.clone(), **kw
+    )
+    o_c, s_c = gated_delta_rule_decode_pretranspose(
+        q=q.contiguous(), k=k.contiguous(), v=v.contiguous(), state=state.clone(), **kw
+    )
+    torch.testing.assert_close(o_p, o_c, atol=0, rtol=0)
+    torch.testing.assert_close(s_p, s_c, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+def test_decode_nontranspose_packed_qkv(batch_size: int):
+    """Nontranspose decode must accept packed q/k/v (bit-identical to contiguous)."""
+    _skip_if_not_sm90_or_later()
+    torch.manual_seed(0)
+    Hq = Hk = 16
+    HV = 32
+    D = 128
+    dev = torch.device("cuda")
+    scale = 1.0 / math.sqrt(D)
+
+    q, k, v = _packed_qkv(batch_size, 1, Hq, Hk, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, 1, HV, D, dev)
+    state = torch.randn(batch_size, HV, D, D, dtype=torch.float32, device=dev)
+
+    kw = dict(A_log=A_log, a=a, dt_bias=dt_bias, b=b, scale=scale, use_qk_l2norm=True)
+    o_p, s_p = gated_delta_rule_decode(q=q, k=k, v=v, state=state.clone(), **kw)
+    o_c, s_c = gated_delta_rule_decode(
+        q=q.contiguous(), k=k.contiguous(), v=v.contiguous(), state=state.clone(), **kw
+    )
+    torch.testing.assert_close(o_p, o_c, atol=0, rtol=0)
+    torch.testing.assert_close(s_p, s_c, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+@pytest.mark.parametrize("seq_len", [2, 4])
+def test_mtp_packed_qkv(batch_size: int, seq_len: int):
+    """MTP decode must accept packed q/k/v (bit-identical to contiguous)."""
+    _skip_if_not_sm90_or_later()
+    torch.manual_seed(0)
+    Hq = Hk = 16
+    HV = 32
+    D = 128
+    dev = torch.device("cuda")
+    scale = 1.0 / math.sqrt(D)
+
+    q, k, v = _packed_qkv(batch_size, seq_len, Hq, Hk, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, seq_len, HV, D, dev)
+    pool = torch.randn(batch_size, HV, D, D, dtype=torch.float32, device=dev)
+    idx = torch.arange(batch_size, dtype=torch.int32, device=dev)
+
+    kw = dict(
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        b=b,
+        initial_state_indices=idx,
+        scale=scale,
+        disable_state_update=True,
+        use_qk_l2norm=True,
+    )
+    o_p, _ = gated_delta_rule_mtp(q=q, k=k, v=v, initial_state=pool.clone(), **kw)
+    o_c, _ = gated_delta_rule_mtp(
+        q=q.contiguous(),
+        k=k.contiguous(),
+        v=v.contiguous(),
+        initial_state=pool.clone(),
+        **kw,
+    )
+    torch.testing.assert_close(o_p, o_c, atol=0, rtol=0)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The merged PR #3649 made the bf16 GDN decode kernel batch-size agnostic by marking its per-batch input tensors with CuTe's mark_compact_shape_dynamic before cute.compile. That call requires the tensor to have a compact layout for the dynamic batch dimension. 

SGLang's decode q/k/v doesn't satisfy this. CuTe rejected those non-compact views with "RuntimeError: The stride_order is not consistent with the layout", which broke SGLang Qwen 3.5 GDN decode end to end. The math was never wrong; the change just tightened the compile-time layout requirement. 

This fix PR adds some more layout unit testing that repro-ed the SGLang layout error, and then the fix

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
