### PR TITLE
Bug fix (gdn): Layout contract fix from #3649

### DIFF
--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -64,6 +64,15 @@ def _mark_slot_dynamic(torch_t: torch.Tensor, *, assumed_align: int = 32):
     ).mark_compact_shape_dynamic(mode=0, stride_order=stride_order, divisibility=1)
 
 
+def _mark_index_dynamic(torch_t: torch.Tensor, *, assumed_align: int = 32):
+    # Batch-dynamic compact marking for contiguous index/step tensors; explicit
+    # stride_order disambiguates size-1 dims that mark_layout_dynamic cannot.
+    stride_order = tuple(sorted(range(torch_t.dim()), key=lambda d: -torch_t.stride(d)))
+    return from_dlpack(
+        torch_t, assumed_align=assumed_align, enable_tvm_ffi=True
+    ).mark_compact_shape_dynamic(mode=0, stride_order=stride_order, divisibility=1)
+
+
 # ==============================================================================
 # FMA WRAPPER FUNCTIONS (SM90 Compatibility)
 # ==============================================================================
@@ -3176,18 +3185,18 @@ def gated_delta_rule_mtp_wide_vec(
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
         o_ = _mark_batch_dynamic(output if output is not None else _placeholder_output)
-        h0_idx_ = _mark_batch_dynamic(
+        h0_idx_ = _mark_index_dynamic(
             initial_state_indices
             if initial_state_indices is not None
             else _placeholder_indices
         )
         h0_out_idx_ = h0_idx_
-        acc_steps_ = _mark_batch_dynamic(
+        acc_steps_ = _mark_index_dynamic(
             accepted_steps
             if accepted_steps is not None
             else _placeholder_accepted_steps
         )
-        ssm_idx_ = _mark_batch_dynamic(
+        ssm_idx_ = _mark_index_dynamic(
             ssm_state_indices
             if ssm_state_indices is not None
             else _placeholder_ssm_state_indices
@@ -3447,7 +3456,7 @@ def gated_delta_rule_t1_wide_vec(
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
         o_ = _mark_batch_dynamic(output if output is not None else _placeholder_output)
-        h0_idx_ = _mark_batch_dynamic(
+        h0_idx_ = _mark_index_dynamic(
             initial_state_indices
             if initial_state_indices is not None
             else _placeholder_indices
@@ -3820,18 +3829,18 @@ def gated_delta_rule_mtp(
         A_log_ = from_dlpack(A_log, assumed_align=32, enable_tvm_ffi=True)
         dt_bias_ = from_dlpack(dt_bias, assumed_align=32, enable_tvm_ffi=True)
         o_ = _mark_batch_dynamic(output if output is not None else _placeholder_output)
-        h0_idx_ = _mark_batch_dynamic(
+        h0_idx_ = _mark_index_dynamic(
             initial_state_indices
             if initial_state_indices is not None
             else _placeholder_indices
         )
         h0_out_idx_ = h0_idx_
-        acc_steps_ = _mark_batch_dynamic(
+        acc_steps_ = _mark_index_dynamic(
             accepted_steps
             if accepted_steps is not None
             else _placeholder_accepted_steps
         )
-        ssm_idx_ = _mark_batch_dynamic(
+        ssm_idx_ = _mark_index_dynamic(
             ssm_state_indices
             if ssm_state_indices is not None
             else _placeholder_ssm_state_indices

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -52,11 +52,19 @@ from flashinfer.cute_dsl.utils import get_num_sm
 
 
 def _mark_batch_dynamic(torch_t: torch.Tensor, *, assumed_align: int = 32):
-    # explicit stride_order: auto-deduction is ambiguous at B=1/T=1.
-    stride_order = tuple(sorted(range(torch_t.dim()), key=lambda d: -torch_t.stride(d)))
+    # mark_layout_dynamic accepts non-compact packed q/k/v (SGLang fused QKV).
     return from_dlpack(
         torch_t, assumed_align=assumed_align, enable_tvm_ffi=True
-    ).mark_compact_shape_dynamic(mode=0, stride_order=stride_order)
+    ).mark_layout_dynamic()
+
+
+def _mark_slot_dynamic(torch_t: torch.Tensor, *, assumed_align: int = 32):
+    # Only the leading (mode 0) dim dynamic; inner dims stay static so launchers
+    # can derive constexpr tile counts (num_v_tiles) from the pool/cache shape.
+    stride_order = tuple(range(torch_t.dim()))
+    return from_dlpack(
+        torch_t, assumed_align=assumed_align, enable_tvm_ffi=True
+    ).mark_compact_shape_dynamic(mode=0, stride_order=stride_order, divisibility=1)
 
 
 # ==============================================================================
@@ -1764,13 +1772,13 @@ def gated_delta_rule_mtp_wide_vec(
 
     if cache_key not in _compiled_kernels_wide_vec:
         if contiguous_pool:
-            h_ = _mark_batch_dynamic(h0_source)
+            h_ = _mark_slot_dynamic(h0_source)
         else:
             h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
         if cache_intermediate_states:
             # Dummy [1,1,1] tensor (caching off) has no unique stride-1 dim.
-            inter_ = _mark_batch_dynamic(intermediate_states)
+            inter_ = _mark_slot_dynamic(intermediate_states)
         q_ = _mark_batch_dynamic(q)
         k_ = _mark_batch_dynamic(k)
         v_ = _mark_batch_dynamic(v)
@@ -2023,12 +2031,12 @@ def gated_delta_rule_mtp(
 
     if cache_key not in _compiled_kernels_mtp:
         if contiguous_pool:
-            h_ = _mark_batch_dynamic(h0_source)
+            h_ = _mark_slot_dynamic(h0_source)
         else:
             h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
         inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
         if cache_intermediate_states:
-            inter_ = _mark_batch_dynamic(intermediate_states)
+            inter_ = _mark_slot_dynamic(intermediate_states)
         q_ = _mark_batch_dynamic(q)
         k_ = _mark_batch_dynamic(k)
         v_ = _mark_batch_dynamic(v)

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -1775,10 +1775,13 @@ def gated_delta_rule_mtp_wide_vec(
             h_ = _mark_slot_dynamic(h0_source)
         else:
             h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
-        inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
         if cache_intermediate_states:
-            # Dummy [1,1,1] tensor (caching off) has no unique stride-1 dim.
             inter_ = _mark_slot_dynamic(intermediate_states)
+        else:
+            # Caching-off dummy ([1,1,1]) is never read; don't mark it.
+            inter_ = from_dlpack(
+                intermediate_states, assumed_align=32, enable_tvm_ffi=True
+            )
         q_ = _mark_batch_dynamic(q)
         k_ = _mark_batch_dynamic(k)
         v_ = _mark_batch_dynamic(v)
@@ -2034,9 +2037,12 @@ def gated_delta_rule_mtp(
             h_ = _mark_slot_dynamic(h0_source)
         else:
             h_ = from_dlpack(h0_source, assumed_align=32, enable_tvm_ffi=True)
-        inter_ = from_dlpack(intermediate_states, assumed_align=32, enable_tvm_ffi=True)
         if cache_intermediate_states:
             inter_ = _mark_slot_dynamic(intermediate_states)
+        else:
+            inter_ = from_dlpack(
+                intermediate_states, assumed_align=32, enable_tvm_ffi=True
+            )
         q_ = _mark_batch_dynamic(q)
         k_ = _mark_batch_dynamic(k)
         v_ = _mark_batch_dynamic(v)

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -2345,25 +2345,14 @@ def run_mtp_decode(
                 )
             )
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2), divisibility=1
-        )
+        # mark_layout_dynamic accepts non-compact packed q/k/v (SGLang fused QKV).
+        a_tensor = from_dlpack(a, assumed_align=16).mark_layout_dynamic()
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        k_tensor = from_dlpack(k, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        v_tensor = from_dlpack(v, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        b_tensor = from_dlpack(b, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2), divisibility=1
-        )
-        o_tensor = from_dlpack(output, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
+        q_tensor = from_dlpack(q, assumed_align=16).mark_layout_dynamic()
+        k_tensor = from_dlpack(k, assumed_align=16).mark_layout_dynamic()
+        v_tensor = from_dlpack(v, assumed_align=16).mark_layout_dynamic()
+        b_tensor = from_dlpack(b, assumed_align=16).mark_layout_dynamic()
+        o_tensor = from_dlpack(output, assumed_align=16).mark_layout_dynamic()
         h0_indices_tensor = from_dlpack(
             initial_state_indices, assumed_align=16
         ).mark_layout_dynamic()

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -747,25 +747,14 @@ def run_nontranspose_decode(
             h0_source, assumed_align=16
         ).mark_compact_shape_dynamic(mode=0, stride_order=(0, 1, 2), divisibility=1)
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2), divisibility=1
-        )
+        # mark_layout_dynamic accepts non-compact packed q/k/v (SGLang fused QKV).
+        a_tensor = from_dlpack(a, assumed_align=16).mark_layout_dynamic()
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        k_tensor = from_dlpack(k, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        v_tensor = from_dlpack(v, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        b_tensor = from_dlpack(b, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2), divisibility=1
-        )
-        o_tensor = from_dlpack(output, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
+        q_tensor = from_dlpack(q, assumed_align=16).mark_layout_dynamic()
+        k_tensor = from_dlpack(k, assumed_align=16).mark_layout_dynamic()
+        v_tensor = from_dlpack(v, assumed_align=16).mark_layout_dynamic()
+        b_tensor = from_dlpack(b, assumed_align=16).mark_layout_dynamic()
+        o_tensor = from_dlpack(output, assumed_align=16).mark_layout_dynamic()
         h0_indices_tensor = from_dlpack(
             h0_indices, assumed_align=16
         ).mark_layout_dynamic()

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -1006,25 +1006,14 @@ def run_pretranspose_decode(
                 mode=0, stride_order=(0, 1, 2), divisibility=1
             )
         A_log_tensor = from_dlpack(A_log, assumed_align=16)
-        a_tensor = from_dlpack(a, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2), divisibility=1
-        )
+        # mark_layout_dynamic accepts non-compact packed q/k/v (SGLang fused QKV).
+        a_tensor = from_dlpack(a, assumed_align=16).mark_layout_dynamic()
         dt_bias_tensor = from_dlpack(dt_bias, assumed_align=16)
-        q_tensor = from_dlpack(q, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        k_tensor = from_dlpack(k, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        v_tensor = from_dlpack(v, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
-        b_tensor = from_dlpack(b, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2), divisibility=1
-        )
-        o_tensor = from_dlpack(output, assumed_align=16).mark_compact_shape_dynamic(
-            mode=0, stride_order=(0, 1, 2, 3), divisibility=1
-        )
+        q_tensor = from_dlpack(q, assumed_align=16).mark_layout_dynamic()
+        k_tensor = from_dlpack(k, assumed_align=16).mark_layout_dynamic()
+        v_tensor = from_dlpack(v, assumed_align=16).mark_layout_dynamic()
+        b_tensor = from_dlpack(b, assumed_align=16).mark_layout_dynamic()
+        o_tensor = from_dlpack(output, assumed_align=16).mark_layout_dynamic()
         h0_indices_tensor = from_dlpack(
             h0_indices, assumed_align=16
         ).mark_layout_dynamic()

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -2654,12 +2654,11 @@ def _packed_qkv(
     q = fused[:, :, :num_q_heads, :]
     k = fused[:, :, num_q_heads : num_q_heads + num_k_heads, :]
     v = fused[:, :, num_q_heads + num_k_heads :, :]
-    # Non-compact only for B>1; at B=1 the size-1 batch dim is trivially contiguous.
-    assert batch_size == 1 or not q.is_contiguous(), "expected a packed view"
+    assert not q.is_contiguous(), "expected a non-compact (packed) view"
     return q, k, v
 
 
-def _packed_qkv_params(batch_size, seq_len, num_v_heads, head_size, device):
+def _packed_qkv_params(batch_size, seq_len, num_v_heads, device):
     a = (
         torch.randn(
             batch_size, seq_len, num_v_heads, dtype=torch.bfloat16, device=device
@@ -2675,7 +2674,7 @@ def _packed_qkv_params(batch_size, seq_len, num_v_heads, head_size, device):
 
 
 @pytest.mark.parametrize("state_dtype", ["bfloat16", "float32"])
-@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+@pytest.mark.parametrize("batch_size", [2, 8, 64])
 def test_decode_pretranspose_packed_qkv(batch_size: int, state_dtype: str):
     """Pretranspose decode must accept packed q/k/v (bit-identical to contiguous)."""
     _skip_if_not_sm90_or_later()
@@ -2688,7 +2687,7 @@ def test_decode_pretranspose_packed_qkv(batch_size: int, state_dtype: str):
     kv_dtype = getattr(torch, state_dtype)
 
     q, k, v = _packed_qkv(batch_size, 1, Hq, Hk, HV, D, dev)
-    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, 1, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, 1, HV, dev)
     state = torch.randn(batch_size, HV, D, D, dtype=kv_dtype, device=dev)
 
     kw = dict(A_log=A_log, a=a, dt_bias=dt_bias, b=b, scale=scale, use_qk_l2norm=True)
@@ -2702,7 +2701,7 @@ def test_decode_pretranspose_packed_qkv(batch_size: int, state_dtype: str):
     torch.testing.assert_close(s_p, s_c, atol=0, rtol=0)
 
 
-@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+@pytest.mark.parametrize("batch_size", [2, 8, 64])
 def test_decode_nontranspose_packed_qkv(batch_size: int):
     """Nontranspose decode must accept packed q/k/v (bit-identical to contiguous)."""
     _skip_if_not_sm90_or_later()
@@ -2714,7 +2713,7 @@ def test_decode_nontranspose_packed_qkv(batch_size: int):
     scale = 1.0 / math.sqrt(D)
 
     q, k, v = _packed_qkv(batch_size, 1, Hq, Hk, HV, D, dev)
-    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, 1, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, 1, HV, dev)
     state = torch.randn(batch_size, HV, D, D, dtype=torch.float32, device=dev)
 
     kw = dict(A_log=A_log, a=a, dt_bias=dt_bias, b=b, scale=scale, use_qk_l2norm=True)
@@ -2726,7 +2725,7 @@ def test_decode_nontranspose_packed_qkv(batch_size: int):
     torch.testing.assert_close(s_p, s_c, atol=0, rtol=0)
 
 
-@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+@pytest.mark.parametrize("batch_size", [2, 8, 64])
 @pytest.mark.parametrize("seq_len", [2, 4])
 def test_mtp_packed_qkv(batch_size: int, seq_len: int):
     """MTP decode must accept packed q/k/v (bit-identical to contiguous)."""
@@ -2739,7 +2738,7 @@ def test_mtp_packed_qkv(batch_size: int, seq_len: int):
     scale = 1.0 / math.sqrt(D)
 
     q, k, v = _packed_qkv(batch_size, seq_len, Hq, Hk, HV, D, dev)
-    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, seq_len, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, seq_len, HV, dev)
     pool = torch.randn(batch_size, HV, D, D, dtype=torch.float32, device=dev)
     idx = torch.arange(batch_size, dtype=torch.int32, device=dev)
 

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -2635,3 +2635,130 @@ def test_gdn_decode_bf16_state_mtp_pool_larger_than_batch(
             atol=0,
             rtol=0,
         )
+
+
+# ============================================================================
+# Packed (non-compact) Q/K/V coverage (regression test for PR #3649): q/k/v as
+# head-dim slices of a fused QKV buffer (SGLang layout) must match contiguous.
+# ============================================================================
+
+
+def _packed_qkv(
+    batch_size, seq_len, num_q_heads, num_k_heads, num_v_heads, head_size, device
+):
+    """q/k/v as non-compact head-dim slices of one fused [B, T, Htot, D] buffer."""
+    htot = num_q_heads + num_k_heads + num_v_heads
+    fused = torch.randn(
+        batch_size, seq_len, htot, head_size, dtype=torch.bfloat16, device=device
+    )
+    q = fused[:, :, :num_q_heads, :]
+    k = fused[:, :, num_q_heads : num_q_heads + num_k_heads, :]
+    v = fused[:, :, num_q_heads + num_k_heads :, :]
+    # Non-compact only for B>1; at B=1 the size-1 batch dim is trivially contiguous.
+    assert batch_size == 1 or not q.is_contiguous(), "expected a packed view"
+    return q, k, v
+
+
+def _packed_qkv_params(batch_size, seq_len, num_v_heads, head_size, device):
+    a = (
+        torch.randn(
+            batch_size, seq_len, num_v_heads, dtype=torch.bfloat16, device=device
+        )
+        * 0.1
+    )
+    b = torch.randn(
+        batch_size, seq_len, num_v_heads, dtype=torch.bfloat16, device=device
+    )
+    A_log = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+    dt_bias = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+    return a, b, A_log, dt_bias
+
+
+@pytest.mark.parametrize("state_dtype", ["bfloat16", "float32"])
+@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+def test_decode_pretranspose_packed_qkv(batch_size: int, state_dtype: str):
+    """Pretranspose decode must accept packed q/k/v (bit-identical to contiguous)."""
+    _skip_if_not_sm90_or_later()
+    torch.manual_seed(0)
+    Hq = Hk = 16
+    HV = 32
+    D = 128
+    dev = torch.device("cuda")
+    scale = 1.0 / math.sqrt(D)
+    kv_dtype = getattr(torch, state_dtype)
+
+    q, k, v = _packed_qkv(batch_size, 1, Hq, Hk, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, 1, HV, D, dev)
+    state = torch.randn(batch_size, HV, D, D, dtype=kv_dtype, device=dev)
+
+    kw = dict(A_log=A_log, a=a, dt_bias=dt_bias, b=b, scale=scale, use_qk_l2norm=True)
+    o_p, s_p = gated_delta_rule_decode_pretranspose(
+        q=q, k=k, v=v, state=state.clone(), **kw
+    )
+    o_c, s_c = gated_delta_rule_decode_pretranspose(
+        q=q.contiguous(), k=k.contiguous(), v=v.contiguous(), state=state.clone(), **kw
+    )
+    torch.testing.assert_close(o_p, o_c, atol=0, rtol=0)
+    torch.testing.assert_close(s_p, s_c, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+def test_decode_nontranspose_packed_qkv(batch_size: int):
+    """Nontranspose decode must accept packed q/k/v (bit-identical to contiguous)."""
+    _skip_if_not_sm90_or_later()
+    torch.manual_seed(0)
+    Hq = Hk = 16
+    HV = 32
+    D = 128
+    dev = torch.device("cuda")
+    scale = 1.0 / math.sqrt(D)
+
+    q, k, v = _packed_qkv(batch_size, 1, Hq, Hk, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, 1, HV, D, dev)
+    state = torch.randn(batch_size, HV, D, D, dtype=torch.float32, device=dev)
+
+    kw = dict(A_log=A_log, a=a, dt_bias=dt_bias, b=b, scale=scale, use_qk_l2norm=True)
+    o_p, s_p = gated_delta_rule_decode(q=q, k=k, v=v, state=state.clone(), **kw)
+    o_c, s_c = gated_delta_rule_decode(
+        q=q.contiguous(), k=k.contiguous(), v=v.contiguous(), state=state.clone(), **kw
+    )
+    torch.testing.assert_close(o_p, o_c, atol=0, rtol=0)
+    torch.testing.assert_close(s_p, s_c, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 8, 64])
+@pytest.mark.parametrize("seq_len", [2, 4])
+def test_mtp_packed_qkv(batch_size: int, seq_len: int):
+    """MTP decode must accept packed q/k/v (bit-identical to contiguous)."""
+    _skip_if_not_sm90_or_later()
+    torch.manual_seed(0)
+    Hq = Hk = 16
+    HV = 32
+    D = 128
+    dev = torch.device("cuda")
+    scale = 1.0 / math.sqrt(D)
+
+    q, k, v = _packed_qkv(batch_size, seq_len, Hq, Hk, HV, D, dev)
+    a, b, A_log, dt_bias = _packed_qkv_params(batch_size, seq_len, HV, D, dev)
+    pool = torch.randn(batch_size, HV, D, D, dtype=torch.float32, device=dev)
+    idx = torch.arange(batch_size, dtype=torch.int32, device=dev)
+
+    kw = dict(
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        b=b,
+        initial_state_indices=idx,
+        scale=scale,
+        disable_state_update=True,
+        use_qk_l2norm=True,
+    )
+    o_p, _ = gated_delta_rule_mtp(q=q, k=k, v=v, initial_state=pool.clone(), **kw)
+    o_c, _ = gated_delta_rule_mtp(
+        q=q.contiguous(),
+        k=k.contiguous(),
+        v=v.contiguous(),
+        initial_state=pool.clone(),
+        **kw,
+    )
+    torch.testing.assert_close(o_p, o_c, atol=0, rtol=0)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

#3649 made the GDN decode kernels batch-size agnostic by marking the per-batch tensors (q/k/v/a/b/o) with CuTe's `mark_compact_shape_dynamic`, which requires a compact layout. This was a functional layout coverage regression, and flagged as being incompatible with an e2e sglang test. 

The fix is to mark the per-batch tensors with `mark_layout_dynamic` instead of `mark_compact_shape_dynamic`.

To verify this fix, this PR adds packed-QKV coverage for unit tests: q/k/v built as head-dim slices of a fused buffer (the SGLang layout), asserting results to the contiguous equivalents. These fail on current main (reproducing the regression) and pass with the fix.

## 🔍 Related Issues

none

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved dynamic-shape/layout annotations used for cached and compiled decoding kernels across pretranspose, nontranspose, and MTP paths, better aligning with fused/packed QKV layouts and ensuring consistent handling of cached intermediates.

* **Bug Fixes**
  * Fixed decoding behavior for packed, non-contiguous Q/K/V tensor views to produce consistent results (including bit-identical outputs vs contiguous tensors).

* **Tests**
  * Added regression tests covering pretranspose, nontranspose, and MTP decode with packed/non-contiguous Q/K/V views, including output/state equivalence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->