### PR TITLE
feat(benchmark): add MLA --mla_is_var_seq / --mla_cute_dsl_impl knobs

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -217,6 +217,33 @@ def parse_attention_args(line, parser):
             "measurement reflects the autotuned tactic."
         ),
     )
+    parser.add_argument(
+        "--mla_is_var_seq",
+        choices=["true", "false", "auto"],
+        default=None,
+        help=(
+            "MLA-only: control the is_var_seq argument passed to "
+            "trtllm_batch_decode_with_kv_cache_mla, which selects the var-seq vs. "
+            "persistent scheduler (is_persistent = not is_var_seq). "
+            "'true'/'false' force the value; 'auto' resolves to --random_actual_seq_len. "
+            "If unset (default), is_var_seq is not passed and the API default (True) "
+            "is used, preserving existing behavior and perf baselines."
+        ),
+    )
+    parser.add_argument(
+        "--mla_cute_dsl_impl",
+        choices=["auto", "modular", "monolithic"],
+        default=None,
+        help=(
+            "MLA-only: control the cute_dsl_impl argument passed to "
+            "trtllm_batch_decode_with_kv_cache_mla, selecting the CuTe DSL "
+            "decode implementation. 'auto' (API default) runs monolithic and "
+            "only promotes to modular for modular-only features (e.g. sinks); "
+            "'modular'/'monolithic' force that impl. If unset (default), "
+            "cute_dsl_impl is not passed and the API default ('auto') is used, "
+            "preserving existing behavior and perf baselines."
+        ),
+    )
 
     args = parser.parse_args(line)
 
@@ -2275,6 +2302,27 @@ def testBatchMLAPagedAttentionWrapper(args):
     causal = False  # False for MLA
     run_refcheck = args.refcheck
 
+    # Resolve the MLA is_var_seq override (selects var-seq vs. persistent
+    # scheduler). None => do not pass is_var_seq to the API, keeping its default
+    # so existing cases and perf baselines are unchanged.
+    mla_is_var_seq_arg = getattr(args, "mla_is_var_seq", None)
+    if mla_is_var_seq_arg is None:
+        resolved_is_var_seq = None
+    elif mla_is_var_seq_arg == "auto":
+        resolved_is_var_seq = args.random_actual_seq_len
+    else:
+        resolved_is_var_seq = mla_is_var_seq_arg == "true"
+    # Only forwarded to the direct trtllm API when explicitly resolved.
+    mla_api_extra_kwargs = (
+        {} if resolved_is_var_seq is None else {"is_var_seq": resolved_is_var_seq}
+    )
+    # Resolve the MLA cute_dsl_impl override (selects modular vs. monolithic
+    # CuTe DSL decode kernel). None => do not pass cute_dsl_impl, keeping the
+    # API default ('auto') so existing cases and perf baselines are unchanged.
+    mla_cute_dsl_impl_arg = getattr(args, "mla_cute_dsl_impl", None)
+    if mla_cute_dsl_impl_arg is not None:
+        mla_api_extra_kwargs["cute_dsl_impl"] = mla_cute_dsl_impl_arg
+
     backends = filter_backends_by_compute_capability(backends, args.routine, device)
     # Check for backend-specific constraints
     if "fa2" in backends:
@@ -2518,6 +2566,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 bmm2_scale=1.0,
                 backend="trtllm-gen",
                 enable_pdl=args.enable_pdl,
+                **mla_api_extra_kwargs,
             ).squeeze(1)
         elif backend == "auto":
             # Autotune dispatcher: picks between trtllm-gen and cute-dsl per
@@ -2537,6 +2586,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 bmm2_scale=1.0,
                 backend="auto",
                 enable_pdl=args.enable_pdl,
+                **mla_api_extra_kwargs,
             ).squeeze(1)
         elif backend == "cute-dsl":
             return flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla(
@@ -2553,6 +2603,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 bmm2_scale=1.0,
                 backend="cute-dsl",
                 enable_pdl=args.enable_pdl,
+                **mla_api_extra_kwargs,
             ).squeeze(1)
         else:
             print(f"[ERROR] Unsupported backend: {backend}")
@@ -2727,6 +2778,13 @@ def testBatchMLAPagedAttentionWrapper(args):
                 cur_res["kv_dtype"] = kv_dtype
                 cur_res["avg_actual_seq_len"] = avg_seq_len_kv
                 cur_res["random_actual_seq_len"] = args.random_actual_seq_len
+                # Leave empty (null) when not explicitly overridden so legacy
+                # var-seq rows keep matching historical null baselines.
+                if resolved_is_var_seq is not None:
+                    cur_res["is_var_seq"] = resolved_is_var_seq
+                # Same null-preserving rule for cute_dsl_impl.
+                if mla_cute_dsl_impl_arg is not None:
+                    cur_res["cute_dsl_impl"] = mla_cute_dsl_impl_arg
                 cur_res["case_tag"] = args.case_tag
                 res.append(cur_res)
     return res

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -2528,6 +2528,15 @@ def testBatchMLAPagedAttentionWrapper(args):
         block_tables,
         actual_seq_lens_kv,
     ):
+        """
+        Run a single MLA decode backend and return its output tensor.
+
+        Dispatches to the BatchMLAPagedAttentionWrapper for fa2/fa3/cutlass or
+        to the direct trtllm_batch_decode_with_kv_cache_mla API for
+        trtllm-native/auto/cute-dsl. The trtllm/auto/cute-dsl branches also
+        forward the resolved MLA overrides (is_var_seq / cute_dsl_impl) via
+        mla_api_extra_kwargs.
+        """
         if backend in ["fa2", "fa3"]:
             # BatchMLAPagedAttentionWrapper.run() does not accept enable_pdl;
             # the fa2/fa3 MLA wrapper has no PDL support. trtllm-native/auto/

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -2309,7 +2309,7 @@ def testBatchMLAPagedAttentionWrapper(args):
     if mla_is_var_seq_arg is None:
         resolved_is_var_seq = None
     elif mla_is_var_seq_arg == "auto":
-        resolved_is_var_seq = args.random_actual_seq_len
+        resolved_is_var_seq = getattr(args, "random_actual_seq_len", False)
     else:
         resolved_is_var_seq = mla_is_var_seq_arg == "true"
     # Only forwarded to the direct trtllm API when explicitly resolved.

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -27,6 +27,8 @@ output_column_dict = {
         "kv_dtype",
         "avg_actual_seq_len",
         "random_actual_seq_len",
+        "is_var_seq",
+        "cute_dsl_impl",
     ],
     "gemm": [
         "n",


### PR DESCRIPTION
`testBatchMLAPagedAttentionWrapper` never passes `is_var_seq` or `cute_dsl_impl` to `trtllm_batch_decode_with_kv_cache_mla`, so the MLA decode benchmark always runs the API defaults (`is_var_seq=True`, the var-seq scheduler; `cute_dsl_impl="auto"`, which runs monolithic and only promotes to modular for modular-only features). The CuTe DSL FP8 MLA decode regression fixed in #3132 lives on the *modular + persistent* path (`is_persistent = not is_var_seq`), which neither default reaches, so it could not be benchmarked or guarded. This adds explicit knobs for both.

- Add `--mla_is_var_seq {true,false,auto}` (MLA-only). **Default unset**: `is_var_seq` is not passed and the API default (`True`) is kept, so existing cases and perf baselines are unchanged. `auto` resolves to `--random_actual_seq_len`.
- Add `--mla_cute_dsl_impl {auto,modular,monolithic}` (MLA-only). **Default unset**: `cute_dsl_impl` is not passed and the API default (`auto`) is kept. `modular` is required to benchmark/guard the path #3132 regressed on.
- Forward the resolved values to the `trtllm-native` / `auto` / `cute-dsl` direct-API branches, kept consistent across all three so backend comparisons stay meaningful. `fa2`/`fa3`/`cutlass` wrapper backends are unaffected.
- Record `is_var_seq` / `cute_dsl_impl` on MLA result rows only when explicitly set, so legacy rows stay null and remain comparable to historical baselines.

- Add `is_var_seq` and `cute_dsl_impl` to `output_column_dict["attention"]` so they are emitted in the benchmark CSV (empty for rows that do not set them).

The targeted PR#3132 perf case that sets `--mla_is_var_seq false --mla_cute_dsl_impl modular` lives in the flashinfer-ci testlists, not here.

- [x] Existing benchmark suite (`benchmarks/test_flashinfer_benchmark.py`) remains green (decode/prefill/gemm; not affected by the new MLA-only flags).
- [x] Without the new flags, an existing MLA case produces the same `median_time` and empty `is_var_seq` / `cute_dsl_impl` CSV columns as before.
- [x] With `--mla_is_var_seq false --mla_cute_dsl_impl modular`, a cute-dsl FP8 MLA case runs the modular persistent scheduler on SM100 (cc 10.0 / B200) and records `is_var_seq=False`, `cute_dsl_impl=modular`.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--mla_is_var_seq` and `--mla_cute_dsl_impl` CLI options to the attention benchmark to control MLA sequence variability and CuTe implementation selection.
  * Extended benchmark output to report `is_var_seq` and `cute_dsl_impl` as new columns when those options are explicitly provided, keeping historical default output unchanged otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->