### PR TITLE
docs: document scale_major_mode param and FLASHINFER_AUTOTUNE_DIR env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -529,6 +529,7 @@ Used by `flashinfer.trace` / `fi_trace`.
 |----------|---------|---------|--------|
 | `FLASHINFER_VALIDATE_INPUTS` | `0` | `flashinfer/mla/_core.py` (MLA wrapper) | Non-zero / non-empty value enables defensive input validation inside the MLA wrapper. Adds host-side overhead; intended for debugging. |
 | `FLASHINFER_AUTOTUNER_LOAD_FROM_FILE` | `0` | `flashinfer/autotuner.py` | `1` loads previously serialized autotune results from disk instead of re-running the search. |
+| `FLASHINFER_AUTOTUNE_DIR` | unset | `flashinfer/mla/_sparse_mla_sm120.py` | Override the disk path for MLA AutoTuner cache files. Falls back to `FLASHINFER_WORKSPACE_DIR` when unset. |
 | `FLASHINFER_TOPK_ALGO` | unset | `flashinfer/topk.py` | Force a specific top-k algorithm (otherwise the dispatcher chooses based on shape). Used for benchmarking / regression bisection. |
 | `FLASHINFER_USE_CUDA_NORM` | `0` | `flashinfer/norm/__init__.py` | `1` switches the norm path from the default backend to the legacy CUDA-only kernels. Diagnostic toggle. |
 | `FLASHINFER_ROUTING_FORCE_BLOCK_PER_TOKEN` | unset | `csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu` | Forces the TRT-LLM MoE custom-routing kernel into "one-block-per-token" mode regardless of the active routing policy. Mainly used to reproduce specific perf points. |

--- a/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
+++ b/flashinfer/grouped_mm/cute_sm120_mxfp8_groupwise/core.py
@@ -146,6 +146,11 @@ def moe_gemm_mxfp8_nt_groupwise(
         ``1`` (per-token scaling along M and N); ``k_granularity`` must be ``32`` or ``128``.
         Anything else raises ``ValueError``.
 
+    scale_major_mode: Literal["MN"]
+        The layout mode of scale tensors.  Currently only ``"MN"`` (MN-major,
+        per-token INT32-packed UE8M0 scales in TMA-aligned layout) is supported.
+        Defaults to ``"MN"``.
+
     backend: Literal["cute"]
         Backend selector. Currently only ``"cute"`` is implemented.
 


### PR DESCRIPTION
## Summary

- `moe_gemm_mxfp8_nt_groupwise`: add missing `scale_major_mode` parameter documentation to the docstring (currently only `"MN"` is supported).
- `CLAUDE.md`: add `FLASHINFER_AUTOTUNE_DIR` to the Validation / Autotuning env var table (read in `flashinfer/mla/_sparse_mla_sm120.py` to override MLA AutoTuner cache path).

## Test plan

- [x] `pre-commit run -a` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added environment variable documentation for configuring MLA AutoTuner cache storage location with automatic fallback to the default workspace directory when unset.
  * Clarified supported parameter options and defaults in kernel function documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->