### PR TITLE
feat: allow using NVL a2a kernels without MNNVL as long as all peers are within the same node / intra-node NVL domain

### DIFF
--- a/flashinfer/comm/abstractions.py
+++ b/flashinfer/comm/abstractions.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lightweight interface for the comm package for convenient implementation-agnostic references."""
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class CommBackend(Protocol):
+    """Structural interface for a collective communication backend."""
+
+    def Get_rank(self) -> int:
+        """Return the caller's rank within the group."""
+        ...
+
+    def Get_size(self) -> int:
+        """Return the number of ranks in the group."""
+        ...
+
+    def allgather(self, data: Any) -> tuple[Any, ...]:
+        """Gather ``data`` from every rank into a per-rank tuple (indexed by rank)."""
+        ...
+
+    def bcast(self, data: Any, root: int) -> Any:
+        """Broadcast ``data`` from ``root`` to every rank and return it."""
+        ...
+
+    def barrier(self) -> None:
+        """Block until every rank has reached this barrier."""
+        ...
+
+    def Split(self, color: int, key: int) -> "CommBackend":
+        """Partition the group into sub-groups by ``color``, ranked by ``key``."""
+        ...

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -70,7 +70,12 @@ from .trtllm_ar import trtllm_moe_finalize_allreduce_fusion
 
 from .mapping import Mapping
 
-from .mnnvl import CommBackend, SymmDeviceMemory
+from .mnnvl import (
+    CommBackend,
+    SymmDeviceMemory,
+    all_ranks_support_mnnvl,
+    is_multicast_supported,
+)
 
 # Note: AllReduceFusionPattern and QuantizationSFLayout are pseudo-types (classes with int constants)
 # Import them for runtime use but type hint as int for mypy compatibility
@@ -274,22 +279,6 @@ def _trtllm_workspace_check(
     return world_size <= 16
 
 
-def _mnnvl_workspace_check(
-    backend: str,
-    world_size: int,
-    rank: int,
-    max_token_num: int,
-    hidden_dim: int,
-    dtype: torch.dtype,
-) -> bool:
-    """
-    Check if mnnvl backend CAN be used for workspace creation.
-
-    """
-
-    return True
-
-
 # ============================================================================
 # HEURISTIC - Performance-based backend selection
 # ============================================================================
@@ -461,13 +450,9 @@ def create_allreduce_fusion_workspace(
             dtype=dtype,
         ):
             suitable_backends.append("trtllm")
-        if _mnnvl_workspace_check(
-            backend=backend,
-            world_size=world_size,
-            rank=rank,
-            max_token_num=max_token_num,
-            hidden_dim=hidden_dim,
-            dtype=dtype,
+        local_mnnvl_supported = is_multicast_supported(torch.cuda.current_device())
+        if all_ranks_support_mnnvl(
+            local_mnnvl_supported, world_size, comm_backend, group
         ):
             suitable_backends.append("mnnvl")
 

--- a/flashinfer/comm/comm_backend.py
+++ b/flashinfer/comm/comm_backend.py
@@ -20,6 +20,7 @@ so any object exposing the same methods (rank/size/allgather/bcast/barrier/
 Split) is a valid backend. Nothing here depends on CUDA.
 """
 
+from collections.abc import Sequence
 from typing import Any
 
 
@@ -83,6 +84,25 @@ class MPIBackend:
         split = MPIBackend()
         split._mpicomm = self._mpicomm.Split(color, key)
         return split
+
+
+def _split_partition(all_info: Sequence[tuple[int, int, int]]) -> list[list[int]]:
+    """Full color partition for an MPI-style ``Split``.
+
+    ``all_info`` is the allgathered ``(color, key, global_rank)`` from every rank.
+    Returns one rank-list per color (colors sorted ascending); within each color,
+    ranks are ordered by ``(key, global_rank)`` -- lower key first, ties broken by
+    rank, matching ``MPI_Comm_split``. The result is independent of the calling
+    rank: every rank must build the *same* partition, because
+    ``torch.distributed.new_group`` names each sub-group by a global counter (not
+    by its member ranks), so ranks that create only their own sub-group get
+    colliding rendezvous keys and deadlock.
+    """
+    colors = sorted({c for c, _, _ in all_info})
+    return [
+        [r for _, r in sorted((k, r) for c, k, r in all_info if c == col)]
+        for col in colors
+    ]
 
 
 class TorchDistBackend:
@@ -152,21 +172,11 @@ class TorchDistBackend:
         Returns:
             New TorchDistBackend with the split process group
         """
-        # Gather (color, key, global_rank) from every process.
-        global_rank = self.Get_rank()
-        all_info = self.allgather((color, key, global_rank))
-
-        # Only our own sub-group is needed, so skip bucketing every color: take
-        # the ranks sharing my color, ordered by key (lower key = lower rank).
-        # Kept as a list -- new_group() iterates `ranks` twice (membership check,
-        # then sort), so a lazy generator won't do, and its parameter is list[int].
-        my_group_ranks = [
-            r
-            for _, r in sorted(
-                ((k, r) for c, k, r in all_info if c == color),
-                key=lambda kr: kr[0],
-            )
-        ]
-
-        new_group = self._dist.new_group(ranks=my_group_ranks)  # pyright: ignore
-        return TorchDistBackend(group=new_group)  # pyright: ignore
+        # Gather (color, key, global_rank) from every rank, then create the full
+        # color partition on *every* rank (see _split_partition) and let
+        # new_subgroups_by_enumeration hand back the sub-group this rank is in.
+        all_info = self.allgather((color, key, self.Get_rank()))
+        cur_group, _ = self._dist.new_subgroups_by_enumeration(
+            _split_partition(all_info)
+        )  # pyright: ignore
+        return TorchDistBackend(group=cur_group)  # pyright: ignore

--- a/flashinfer/comm/comm_backend.py
+++ b/flashinfer/comm/comm_backend.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Concrete ``CommBackend`` adapters.
+
+``MPIBackend`` and ``TorchDistBackend`` are adapters that satisfy the
+``CommBackend`` structural interface (see ``abstractions``) without inheritance,
+so any object exposing the same methods (rank/size/allgather/bcast/barrier/
+Split) is a valid backend. Nothing here depends on CUDA.
+"""
+
+from typing import Any
+
+
+def lazy_import_mpi() -> Any:
+    """Lazy import for mpi4py."""
+    try:
+        from mpi4py import MPI
+
+        return MPI
+    except ImportError as err:
+        raise ImportError("mpi4py is not installed") from err  # type: ignore[no-redef]
+
+
+class MpiComm:  # type: ignore[no-redef]
+    _comm: Any = None
+    _MPI: Any = None
+
+    @classmethod
+    def _get_mpi(cls):
+        if cls._MPI is None:
+            cls._MPI = lazy_import_mpi()
+            cls._comm = cls._MPI.COMM_WORLD
+        return cls._MPI
+
+    @classmethod
+    def set_mpi_comm(cls, new_comm: Any):
+        cls._get_mpi()
+        # Optional: add type checking here
+        cls._comm = new_comm
+
+    def __getattr__(self, name: str) -> Any:
+        if self._comm is None:
+            self._get_mpi()
+        return getattr(self._comm, name)
+
+
+class MPIBackend:
+    """``CommBackend`` adapter over mpi4py."""
+
+    def __init__(self):
+        self._mpicomm = MpiComm()
+
+    def Get_rank(self) -> int:
+        return self._mpicomm.Get_rank()
+
+    def Get_size(self) -> int:
+        return self._mpicomm.Get_size()
+
+    def allgather(self, data: Any) -> tuple[Any, ...]:
+        return tuple(self._mpicomm.allgather(data))
+
+    def bcast(self, data: Any, root: int) -> Any:
+        return self._mpicomm.bcast(data, root)
+
+    def barrier(self) -> None:
+        self._mpicomm.Barrier()
+
+    def Split(self, color: int, key: int) -> "MPIBackend":
+        # Return the sub-group as a new adapter and leave self unchanged,
+        # consistent with TorchDistBackend.Split.
+        split = MPIBackend()
+        split._mpicomm = self._mpicomm.Split(color, key)
+        return split
+
+
+class TorchDistBackend:
+    """``CommBackend`` adapter over torch.distributed."""
+
+    def __init__(self, group: Any | None = None):
+        """
+        Initialize TorchDistBackend.
+
+        Args:
+            group: Optional process group. If None, uses the default process group.
+        """
+        import torch.distributed as dist
+
+        if not dist.is_initialized():
+            raise RuntimeError(
+                "torch.distributed is not initialized. "
+                "Please call torch.distributed.init_process_group() first."
+            )
+        self._group = group
+        self._dist = dist
+
+    def Get_rank(self) -> int:
+        return self._dist.get_rank(self._group)
+
+    def Get_size(self) -> int:
+        return self._dist.get_world_size(self._group)
+
+    def allgather(self, data: Any) -> tuple[Any, ...]:
+        """All-gather arbitrary Python objects across all ranks."""
+        output_list = [None] * self.Get_size()
+        self._dist.all_gather_object(output_list, data, group=self._group)  # pyright: ignore[reportUnknownMemberType]
+        return tuple(output_list)
+
+    def bcast(self, data: Any, root: int) -> Any:
+        """Broadcast a Python object from root to all ranks.
+
+        Args:
+            data: object to broadcast (only used on the root rank).
+            root: group-local rank of the sender (consistent with MPI).
+        """
+        object_list = [data]
+        global_root = (
+            self._dist.get_global_rank(self._group, root)
+            if self._group is not None
+            else root
+        )
+        self._dist.broadcast_object_list(
+            object_list, src=global_root, group=self._group
+        )
+        return object_list[0]
+
+    def barrier(self) -> None:
+        self._dist.barrier(group=self._group)  # pyright: ignore[reportUnknownMemberType]
+
+    def Split(self, color: int, key: int) -> "TorchDistBackend":
+        """
+        Split the communicator into sub-groups based on color.
+
+        All processes with the same color will be in the same new group.
+        The key determines the rank ordering within the new group.
+
+        Args:
+            color: Processes with the same color are placed in the same group
+            key: Determines rank ordering within the new group (lower key = lower rank)
+
+        Returns:
+            New TorchDistBackend with the split process group
+        """
+        # Gather (color, key, global_rank) from every process.
+        global_rank = self.Get_rank()
+        all_info = self.allgather((color, key, global_rank))
+
+        # Only our own sub-group is needed, so skip bucketing every color: take
+        # the ranks sharing my color, ordered by key (lower key = lower rank).
+        # Kept as a list -- new_group() iterates `ranks` twice (membership check,
+        # then sort), so a lazy generator won't do, and its parameter is list[int].
+        my_group_ranks = [
+            r
+            for _, r in sorted(
+                ((k, r) for c, k, r in all_info if c == color),
+                key=lambda kr: kr[0],
+            )
+        ]
+
+        new_group = self._dist.new_group(ranks=my_group_ranks)  # pyright: ignore
+        return TorchDistBackend(group=new_group)  # pyright: ignore

--- a/flashinfer/comm/fd_exchange.py
+++ b/flashinfer/comm/fd_exchange.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""File-descriptor exchange across ranks over AF_UNIX sockets (SCM_RIGHTS).
+
+Pure OS-level fd passing — no CUDA. The kernel installs a fresh entry in the
+receiver's descriptor table, so no ``CAP_SYS_PTRACE`` (as ``pidfd_getfd`` would
+need) is required. Two collective helpers are built on a ``CommBackend``:
+
+* :func:`exchange_fds` — all-to-all (every rank ends up with every rank's fd).
+* :func:`broadcast_fd` — one-to-all (root's fd to every rank).
+
+plus the low-level SCM_RIGHTS send/recv primitives shared by connectionless
+(SOCK_DGRAM) callers.
+"""
+
+import array
+import contextlib
+import logging
+import os
+import socket
+import tempfile
+import threading
+import time
+from collections.abc import Iterable
+
+from .abstractions import CommBackend
+
+logger = logging.getLogger(__name__)
+
+_FD_ITEMSIZE = array.array("i").itemsize
+_TIMEOUT_S = 30.0
+
+# One control message as delivered by socket.recvmsg():
+# (cmsg_level, cmsg_type, cmsg_data), where cmsg_data is always ``bytes``.
+CmsgTriple = tuple[int, int, bytes]
+
+
+# ============================================================================
+# Low-level SCM_RIGHTS primitives
+# ============================================================================
+
+
+def _fd_ancillary(fd: int) -> tuple[tuple[int, int, array.array[int]]]:
+    """Ancillary-data payload carrying a single fd via SCM_RIGHTS."""
+    return ((socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [fd])),)
+
+
+def _extract_fd(ancdata: Iterable[CmsgTriple]) -> int | None:
+    """Return the first fd found in received ancillary data, or None."""
+    fds = array.array("i")
+    for cmsg_level, cmsg_type, cmsg_data in ancdata:
+        if cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS:
+            trim = len(cmsg_data) - (len(cmsg_data) % fds.itemsize)
+            fds.frombytes(cmsg_data[:trim])
+    return fds[0] if fds else None
+
+
+def send_fd_dgram(sock: socket.socket, fd: int, dest_path: str) -> None:
+    """Send one fd over a bound AF_UNIX/SOCK_DGRAM socket to ``dest_path``."""
+    sock.sendmsg([b"\x00"], _fd_ancillary(fd), 0, dest_path)
+
+
+def recv_fd_dgram(sock: socket.socket) -> int:
+    """Receive one fd from a bound AF_UNIX/SOCK_DGRAM socket."""
+    _, ancdata, _, _ = sock.recvmsg(1, socket.CMSG_SPACE(_FD_ITEMSIZE))
+    fd = _extract_fd(ancdata)
+    if fd is None:
+        raise RuntimeError("[fd_exchange] no file descriptor in received message")
+    return fd
+
+
+def _send_fd_stream(sock: socket.socket, fd: int) -> None:
+    sock.sendmsg([b"\x00"], _fd_ancillary(fd))
+
+
+def _recv_fd_stream(conn: socket.socket) -> int | None:
+    _, ancdata, _, _ = conn.recvmsg(1, socket.CMSG_SPACE(_FD_ITEMSIZE))
+    return _extract_fd(ancdata)
+
+
+def _connect_with_retry(path: str, timeout: float) -> socket.socket:
+    """Connect to a listening AF_UNIX socket, retrying until it is bound."""
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            sock.connect(path)
+            return sock
+        except (ConnectionRefusedError, FileNotFoundError):
+            if time.monotonic() > deadline:
+                sock.close()
+                raise RuntimeError(
+                    f"[fd_exchange] timed out connecting to {path}"
+                ) from None
+            time.sleep(0.01)
+
+
+# ============================================================================
+# Collective fd exchange over a CommBackend
+# ============================================================================
+
+
+def exchange_fds(comm: CommBackend, local_fd: int) -> list[int]:
+    """All-to-all fd exchange over AF_UNIX/SOCK_STREAM sockets.
+
+    Returns a list of length ``comm.Get_size()`` where entry ``[rank]`` is the
+    fd received from that rank. Entry ``[own_rank]`` is ``local_fd`` itself
+    (not a dup). The caller owns every returned fd and must close each exactly
+    once; closing ``entry[own_rank]`` closes ``local_fd``. ``local_fd`` is never
+    closed by this function, so on error the caller still owns it.
+    """
+    comm_rank = comm.Get_rank()
+    comm_size = comm.Get_size()
+
+    # Private temp dir per rank prevents path collisions between concurrent groups.
+    with tempfile.TemporaryDirectory(
+        prefix=f"cuda_fd_xchg_{os.getpid()}_{comm_rank}_",
+        ignore_cleanup_errors=True,
+    ) as xchg_dir:
+        sock_path = os.path.join(xchg_dir, "fd.sock")
+        all_sock_paths = comm.allgather(sock_path)
+
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(sock_path)
+            server.listen(comm_size)
+            server.settimeout(_TIMEOUT_S)
+
+            received_fds: list[int | None] = [None] * comm_size
+            received_fds[comm_rank] = local_fd
+            accept_errors: list[Exception] = []
+
+            def accept_loop():
+                for _ in range(comm_size - 1):
+                    try:
+                        conn, _ = server.accept()
+                        try:
+                            rank_bytes = b""
+                            while len(rank_bytes) < 4:
+                                chunk = conn.recv(4 - len(rank_bytes))
+                                if not chunk:
+                                    break
+                                rank_bytes += chunk
+                            sender_rank = int.from_bytes(rank_bytes, "little")
+                            fd = _recv_fd_stream(conn)
+                            if fd is not None:
+                                received_fds[sender_rank] = fd
+                        finally:
+                            conn.close()
+                    except Exception as exc:
+                        accept_errors.append(exc)
+
+            t = threading.Thread(target=accept_loop, daemon=True)
+            t.start()
+
+            for target_rank in range(comm_size):
+                if target_rank == comm_rank:
+                    continue
+                sock = _connect_with_retry(all_sock_paths[target_rank], _TIMEOUT_S)
+                try:
+                    sock.sendall(comm_rank.to_bytes(4, "little"))
+                    _send_fd_stream(sock, local_fd)
+                finally:
+                    sock.close()
+
+            t.join(timeout=_TIMEOUT_S)
+
+            if accept_errors:
+                _close_fds(
+                    fd for fd in received_fds if fd is not None and fd != local_fd
+                )
+                raise RuntimeError(
+                    f"[fd_exchange] SCM_RIGHTS accept errors: {accept_errors}"
+                )
+            missing = [i for i, fd in enumerate(received_fds) if fd is None]
+            if missing:
+                _close_fds(
+                    fd for fd in received_fds if fd is not None and fd != local_fd
+                )
+                raise RuntimeError(
+                    f"[fd_exchange] did not receive file descriptors from ranks: {missing}"
+                )
+            return received_fds  # type: ignore[return-value]
+        finally:
+            server.close()
+
+
+def broadcast_fd(comm: CommBackend, local_fd: int | None, root: int) -> int:
+    """Broadcast one fd from ``root`` to all ranks over AF_UNIX/SOCK_STREAM.
+
+    ``root`` passes its fd as ``local_fd`` and gets the same fd back; every
+    other rank passes ``None`` and receives root's fd (a fresh local dup). The
+    caller closes the returned fd exactly once.
+    """
+    comm_rank = comm.Get_rank()
+    comm_size = comm.Get_size()
+    if comm_size <= 1:
+        assert local_fd is not None
+        return local_fd
+
+    with tempfile.TemporaryDirectory(
+        prefix=f"cuda_fd_bcast_{os.getpid()}_{comm_rank}_",
+        ignore_cleanup_errors=True,
+    ) as xchg_dir:
+        sock_path = os.path.join(xchg_dir, "fd.sock")
+        all_sock_paths = comm.allgather(sock_path)
+
+        if comm_rank == root:
+            assert local_fd is not None, "root must supply the fd to broadcast"
+            for target_rank in range(comm_size):
+                if target_rank == root:
+                    continue
+                sock = _connect_with_retry(all_sock_paths[target_rank], _TIMEOUT_S)
+                try:
+                    _send_fd_stream(sock, local_fd)
+                finally:
+                    sock.close()
+            return local_fd
+
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(sock_path)
+            server.listen(1)
+            server.settimeout(_TIMEOUT_S)
+            conn, _ = server.accept()
+            try:
+                fd = _recv_fd_stream(conn)
+            finally:
+                conn.close()
+            if fd is None:
+                raise RuntimeError(
+                    f"[fd_exchange] rank {comm_rank} received no fd from root {root}"
+                )
+            return fd
+        finally:
+            server.close()
+
+
+def _close_fds(fds: Iterable[int]) -> None:
+    for fd in fds:
+        with contextlib.suppress(OSError):
+            os.close(fd)

--- a/flashinfer/comm/mixed_comm.py
+++ b/flashinfer/comm/mixed_comm.py
@@ -22,7 +22,6 @@ import os
 import pathlib
 import socket
 import statistics
-import struct
 import tempfile
 from itertools import product
 from typing import Dict, List
@@ -45,6 +44,7 @@ except ImportError:
 
 from ..api_logging import flashinfer_api
 from ..cuda_utils import checkCudaErrors
+from .fd_exchange import recv_fd_dgram, send_fd_dgram
 from ..jit.comm import gen_mixed_comm_module
 from ..testing.utils import bench_gpu_time
 from ..utils import backend_requirement, supported_compute_capability
@@ -654,24 +654,11 @@ class MixedCommHandler:
 
         def send_fd(sock, fd, rank):
             """Send a file descriptor to the specified rank via Unix socket."""
-            sock.sendmsg(
-                [b"\x00"],
-                [(socket.SOL_SOCKET, socket.SCM_RIGHTS, struct.pack("i", fd))],
-                0,
-                get_socket_path(rank),
-            )
+            send_fd_dgram(sock, fd, get_socket_path(rank))
 
         def recv_fd(sock):
             """Receive a file descriptor from a Unix socket."""
-            ancdata = sock.recvmsg(
-                1,
-                socket.CMSG_SPACE(struct.calcsize("i")),
-            )[1]
-            for cmsg_level, cmsg_type, cmsg_data in ancdata:
-                if cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS:
-                    fd = struct.unpack("i", cmsg_data)[0]
-                    return fd
-            raise RuntimeError("Failed to receive file descriptor")
+            return recv_fd_dgram(sock)
 
         def create_and_allgather_uc_handle(sock, uc_prop):
             """Create a unicast memory handle and exchange it with all local ranks."""

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -17,16 +17,10 @@ import ctypes
 import logging
 import os
 import socket
-import array
-import random
 
-import contextlib
-
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
-import platform
 import sys
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING
 import pynvml
 
 logger = logging.getLogger(__name__)
@@ -50,6 +44,17 @@ except ImportError:
 from ..cuda_utils import checkCudaErrors
 from .dlpack_utils import create_dlpack_capsule, pack_strided_memory
 from .mapping import Mapping
+
+from .abstractions import CommBackend
+from .comm_backend import (  # noqa: F401
+    MPIBackend,
+    MpiComm,
+    TorchDistBackend,
+)
+from .fd_exchange import broadcast_fd, exchange_fds
+
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
 
 # mpi4py only exports MPI_COMM_TYPE_SHARED, so we define OMPI_COMM_TYPE_HOST here
 OMPI_COMM_TYPE_HOST = 9
@@ -170,181 +175,6 @@ def alloc_and_copy_to_cuda(host_ptr_array: List[int]) -> Optional[int]:
     return int(device_ptr)
 
 
-class CommBackend(ABC):
-    """Abstract communication backend interface"""
-
-    @abstractmethod
-    def Get_rank(self) -> int: ...
-
-    @abstractmethod
-    def Get_size(self) -> int: ...
-
-    @abstractmethod
-    def allgather(self, data: int) -> List[int]: ...
-
-    @abstractmethod
-    def bcast(self, data: Any, root: int) -> Any: ...
-
-    @abstractmethod
-    def barrier(self) -> None: ...
-
-    @abstractmethod
-    def Split(self, color: int, key: int) -> "CommBackend": ...
-
-
-if TYPE_CHECKING:
-    from mpi4py import MPI  # noqa: F401
-
-
-def lazy_import_mpi():
-    """Lazy import for mpi4py"""
-    try:
-        from mpi4py import MPI
-
-        return MPI
-    except ImportError as err:
-        raise ImportError("mpi4py is not installed") from err  # type: ignore[no-redef]
-
-
-class MpiComm:  # type: ignore[no-redef]
-    _comm: Any = None
-    _MPI: Any = None
-
-    @classmethod
-    def _get_mpi(cls):
-        if cls._MPI is None:
-            cls._MPI = lazy_import_mpi()
-            cls._comm = cls._MPI.COMM_WORLD
-        return cls._MPI
-
-    @classmethod
-    def set_mpi_comm(cls, new_comm: Any):
-        cls._get_mpi()
-        # Optional: add type checking here
-        cls._comm = new_comm
-
-    def __getattr__(self, name):
-        if self._comm is None:
-            self._get_mpi()
-        return getattr(self._comm, name)
-
-
-class MPIBackend(CommBackend):
-    def __init__(self):
-        self._mpicomm = MpiComm()
-
-    def Get_rank(self) -> int:
-        return self._mpicomm.Get_rank()
-
-    def Get_size(self) -> int:
-        return self._mpicomm.Get_size()
-
-    def allgather(self, data: int) -> List[int]:
-        return self._mpicomm.allgather(data)
-
-    def bcast(self, data: Any, root: int) -> Any:
-        return self._mpicomm.bcast(data, root)
-
-    def barrier(self):
-        self._mpicomm.Barrier()
-
-    def Split(self, color: int, key: int) -> CommBackend:
-        self._mpicomm = self._mpicomm.Split(color, key)
-        return MPIBackend()  # Returns new adapter
-
-
-class TorchDistBackend(CommBackend):
-    """Communication backend using torch.distributed"""
-
-    def __init__(self, group: Optional[Any] = None):
-        """
-        Initialize TorchDistBackend.
-
-        Args:
-            group: Optional process group. If None, uses the default process group.
-        """
-        import torch.distributed as dist
-
-        if not dist.is_initialized():
-            raise RuntimeError(
-                "torch.distributed is not initialized. "
-                "Please call torch.distributed.init_process_group() first."
-            )
-        self._group = group
-        self._dist = dist
-
-    def Get_rank(self) -> int:
-        return self._dist.get_rank(self._group)
-
-    def Get_size(self) -> int:
-        return self._dist.get_world_size(self._group)
-
-    def allgather(self, data: Any) -> List[Any]:
-        """All-gather arbitrary Python objects across all ranks."""
-        output_list = [None] * self.Get_size()
-        self._dist.all_gather_object(output_list, data, group=self._group)
-        return output_list
-
-    def bcast(self, data: Any, root: int) -> Any:
-        """Broadcast a Python object from root to all ranks.
-
-        Args:
-            data: object to broadcast (only used on the root rank).
-            root: group-local rank of the sender (consistent with MPI).
-        """
-        object_list = [data]
-        global_root = (
-            self._dist.get_global_rank(self._group, root)
-            if self._group is not None
-            else root
-        )
-        self._dist.broadcast_object_list(
-            object_list, src=global_root, group=self._group
-        )
-        return object_list[0]
-
-    def barrier(self) -> None:
-        self._dist.barrier(group=self._group)
-
-    def Split(self, color: int, key: int) -> "TorchDistBackend":
-        """
-        Split the communicator into sub-groups based on color.
-
-        All processes with the same color will be in the same new group.
-        The key determines the rank ordering within the new group.
-
-        Args:
-            color: Processes with the same color are placed in the same group
-            key: Determines rank ordering within the new group (lower key = lower rank)
-
-        Returns:
-            New TorchDistBackend with the split process group
-        """
-        # Gather (color, key, global_rank) from all processes
-        global_rank = self.Get_rank()
-
-        all_info = self.allgather((color, key, global_rank))
-
-        # Group ranks by color, sort by key within each group
-        color_groups: Dict[int, List[tuple]] = {}
-        for c, k, r in all_info:
-            if c not in color_groups:
-                color_groups[c] = []
-            color_groups[c].append((k, r))
-
-        # Sort each group by key to determine rank ordering
-        for c in color_groups:
-            color_groups[c].sort(key=lambda x: x[0])
-
-        # Find my new group's ranks (in sorted order by key)
-        my_group_ranks = [r for _, r in color_groups[color]]
-
-        # Create new process group with the ranks in my color group
-        new_group = self._dist.new_group(ranks=my_group_ranks)
-
-        return TorchDistBackend(group=new_group)
-
-
 @dataclass
 class MnnvlConfig:
     """Configuration for MNNVL memory management"""
@@ -446,6 +276,39 @@ class MnnvlMemory:  # type: ignore[no-redef]
         MnnvlMemory.comm = comm
         return comm
 
+    _fabric_supported: bool | None = None
+
+    @staticmethod
+    def _probe_fabric_supported(dev_id: int) -> bool:
+        """Return True if this rank's GPU supports FABRIC handles and is part of a fabric cluster."""
+        try:
+            return is_mnnvl_fabric_supported(dev_id)
+        except Exception:
+            return False
+
+    @staticmethod
+    def _resolve_fabric_support(comm: CommBackend, dev_id: int) -> bool:
+        """AND-reduce per-rank FABRIC support and cache the result.
+
+        All ranks must take the same handle-exchange path or the collective deadlocks.
+        """
+        if MnnvlMemory._fabric_supported is not None:
+            return MnnvlMemory._fabric_supported
+
+        local_supported = MnnvlMemory._probe_fabric_supported(dev_id)
+        agreed = all_ranks_agree(comm, local_supported)
+
+        if agreed != local_supported:
+            logger.warning(
+                "[MnnvlMemory] FABRIC support probe disagrees across ranks "
+                f"(local={local_supported}); falling back to "
+                f"{'FABRIC' if agreed else 'POSIX fd'} on all ranks to keep the "
+                "handle-exchange path consistent."
+            )
+
+        MnnvlMemory._fabric_supported = agreed
+        return agreed
+
     @staticmethod
     def get_allocation_prop(dev_id: int):
         location = cuda.CUmemLocation()
@@ -453,11 +316,15 @@ class MnnvlMemory:  # type: ignore[no-redef]
         location.id = dev_id
         allocation_prop = cuda.CUmemAllocationProp()
         allocation_prop.type = cuda.CUmemAllocationType.CU_MEM_ALLOCATION_TYPE_PINNED
-        # TODO: We differentiate FABRIC for GB200 (aarch64) and POSIX_FILE_DESCRIPTOR for B200 (x86_64).
-        # May need to find a better way to handle this.
-        arch = platform.machine().lower()
-        is_on_aarch64 = "aarch64" in arch
-        if is_on_aarch64:
+        allocation_prop.location = location
+
+        use_fabric = (
+            MnnvlMemory._fabric_supported
+            if MnnvlMemory._fabric_supported is not None
+            else MnnvlMemory._probe_fabric_supported(dev_id)
+        )
+
+        if use_fabric:
             allocation_prop.requestedHandleTypes = (
                 cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
             )
@@ -465,7 +332,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
             allocation_prop.requestedHandleTypes = (
                 cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
             )
-        allocation_prop.location = location
         return allocation_prop
 
     @staticmethod
@@ -511,54 +377,28 @@ class MnnvlMemory:  # type: ignore[no-redef]
             allocation_prop.requestedHandleTypes
             == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
         ):
-            all_handles_data = comm.allgather(exported_fabric_handle.data)
+            # tuple (FABRIC) here, list[int] (POSIX fds) below -- widen to Sequence.
+            all_handles_data: Sequence[Any] = comm.allgather(
+                exported_fabric_handle.data
+            )
         else:
+            # The exchange returns our own exported_fd (not a dup) at our rank's
+            # slot; the mapping loop's finally closes it along with received fds.
             exported_fd = int(exported_fabric_handle)
-            pidfds = []
-            remote_fds = []
             try:
-                all_handles_data = comm.allgather(exported_fd)
-                all_pids = comm.allgather(os.getpid())
-                libc = ctypes.CDLL(None, use_errno=True)
-                syscall = libc.syscall
-                SYS_pidfd_open = 434
-                SYS_pidfd_getfd = 438
-
-                for pid in all_pids:
-                    pidfd = syscall(SYS_pidfd_open, pid, 0)
-                    if pidfd < 0:
-                        err = ctypes.get_errno()
-                        raise RuntimeError(
-                            f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
-                        )
-                    pidfds.append(pidfd)
-
-                for pidfd, fd in zip(pidfds, all_handles_data, strict=True):
-                    remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
-                    if remote_fd < 0:
-                        err = ctypes.get_errno()
-                        error_msg = f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno {err}: {os.strerror(err)}."
-                        if err == 1:  # EPERM
-                            error_msg += (
-                                " Permission denied. If running in a container, try adding --cap-add=SYS_PTRACE "
-                                "to your docker run command."
-                            )
-                        else:
-                            error_msg += " This may be due to kernel version (requires Linux 5.6+)."
-                        raise RuntimeError(error_msg)
-                    remote_fds.append(remote_fd)
-
-                # Every rank must duplicate every exported FD before its owner closes it.
-                comm.barrier()
-                all_handles_data = remote_fds
+                local_host = socket.gethostname()
+                all_hosts = comm.allgather(local_host)
+                if len(set(all_hosts)) != 1:
+                    raise RuntimeError(
+                        "[MnnvlMemory] POSIX fd exchange via SCM_RIGHTS requires all "
+                        "ranks to share the same host, but got differing hostnames: "
+                        f"{all_hosts}. Multi-node MNNVL requires a fabric-capable GPU "
+                        "setup (CU_MEM_HANDLE_TYPE_FABRIC)."
+                    )
+                all_handles_data = exchange_fds(comm, exported_fd)
             except BaseException:
-                for remote_fd in remote_fds:
-                    os.close(remote_fd)
-                raise
-            finally:
-                for pidfd in pidfds:
-                    os.close(pidfd)
                 os.close(exported_fd)
+                raise
         # all_handles_data like b'\x00\x00\x00 \x00\x00\x00\x00\x8f\xec\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00\x00\x00\x1d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # noqa: E501
         # can use buf = memoryview(data) to import if using plain buffer for data.
 
@@ -639,6 +479,7 @@ class MnnvlMemory:  # type: ignore[no-redef]
         assert all(x == size for x in all_rank_allocate_sizes), (
             "Not all rank allocating same size."
         )
+        MnnvlMemory._resolve_fabric_support(comm, dev_id)
         granularity = MnnvlMemory.get_allocation_granularity(dev_id)
         aligned_size = (size + granularity - 1) // granularity * granularity
 
@@ -722,7 +563,9 @@ class MnnvlMemory:  # type: ignore[no-redef]
                     is_active = pynvml.nvmlDeviceGetNvLinkState(handle, link_idx)
                     if is_active:
                         active_links += 1
-            except pynvml.NVMLError_NotSupported:
+            except (pynvml.NVMLError_NotSupported, pynvml.NVMLError_InvalidArgument):
+                # Link indices beyond the device's link count raise
+                # InvalidArgument on some platforms (e.g. B200).
                 continue
         return (
             active_links == available_links and available_links > 0
@@ -738,207 +581,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
         # May need better support check.
         support_nvlink_and_all_up = MnnvlMemory.support_nvlink(True)
         return support_nvlink_and_all_up
-
-
-# The helper class for passing the FD handle over the socket.
-class IpcSocket:
-    """Unix Domain Socket for IPC file descriptor passing"""
-
-    def __init__(self, rank: int, op_id: int, use_abstract=True):
-        """
-        Initialize IPC socket
-
-        Args:
-            rank: Process rank
-            op_id: Unique operation ID (hash)
-            use_abstract: Use Linux abstract socket namespace
-        """
-        self.rank = rank
-        self.op_id = op_id
-        self.use_abstract = use_abstract
-
-        # Create Unix domain socket (DGRAM for compatibility with C code)
-        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-
-        # Create unique socket name
-        socket_name = f"/tmp/mcastmem-socket-{rank}-{op_id:x}"
-
-        if use_abstract:
-            # Linux abstract socket: prepend null byte
-            self.socket_path = "\0" + socket_name
-        else:
-            self.socket_path = socket_name
-            # Remove existing socket file if it exists
-            with contextlib.suppress(FileNotFoundError):
-                os.unlink(socket_name)
-
-        # Bind socket
-        self.sock.bind(self.socket_path)
-
-    def send_fd(self, fd: int, dest_rank: int, dest_op_id: Optional[int] = None):
-        """
-        Send a file descriptor to another process
-
-        Args:
-            fd: File descriptor to send
-            dest_rank: Destination process rank
-            dest_op_id: Destination operation ID
-        """
-        # Construct destination socket path
-        dest_op_id = dest_op_id or self.op_id
-        dest_socket_name = f"/tmp/mcastmem-socket-{dest_rank}-{dest_op_id:x}"
-
-        if self.use_abstract:
-            dest_path = "\0" + dest_socket_name
-        else:
-            dest_path = dest_socket_name
-
-        # Prepare message with file descriptor
-        # Send dummy byte as data (required)
-        dummy_data = b"\x00"
-
-        # Pack file descriptor in ancillary data (SCM_RIGHTS)
-        fds = array.array("i", [fd])
-        ancillary = [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds.tobytes())]
-
-        # Send message with file descriptor
-        self.sock.sendmsg([dummy_data], ancillary, 0, dest_path)
-
-    def recv_fd(self):
-        """
-        Receive a file descriptor from another process
-
-        Returns:
-            int: Received file descriptor
-        """
-        # Receive message with ancillary data
-        # Maximum size for ancillary data containing one fd
-        fds = array.array("i")
-        msg, ancdata, flags, addr = self.sock.recvmsg(
-            1,
-            socket.CMSG_SPACE(
-                fds.itemsize
-            ),  # Buffer size for dummy data  # Ancillary data size
-        )
-
-        # Extract file descriptor from ancillary data
-        for cmsg_level, cmsg_type, cmsg_data in ancdata:
-            if cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS:
-                fds = array.array("i")
-                fds.frombytes(
-                    cmsg_data[: len(cmsg_data) - (len(cmsg_data) % fds.itemsize)]
-                )
-                return fds[0]
-
-        raise RuntimeError("No file descriptor received")
-
-    def close(self):
-        """Close the socket"""
-        self.sock.close()
-        if not self.use_abstract and self.socket_path:
-            with contextlib.suppress(FileNotFoundError):
-                os.unlink(self.socket_path)
-
-
-class HandleExchanger(ABC):
-    """Abstract interface for exchanging CUDA shareable handles across ranks."""
-
-    def __init__(self, comm_backend: "CommBackend", group_rank: int, group_size: int):
-        self.comm = comm_backend
-        self.rank = group_rank
-        self.size = group_size
-
-    @property
-    @abstractmethod
-    def handle_type(self) -> cuda.CUmemAllocationHandleType:
-        """The CUDA handle type this exchanger works with."""
-        ...
-
-    @abstractmethod
-    def allgather(self, local_handle) -> List:
-        """All-gather shareable handles from all ranks."""
-        ...
-
-    @abstractmethod
-    def broadcast(self, handle, root: int):
-        """Broadcast a handle from root to all ranks."""
-        ...
-
-    @abstractmethod
-    def cleanup(self, handle) -> None: ...
-
-    @abstractmethod
-    def close(self) -> None: ...
-
-
-class FabricHandleExchanger(HandleExchanger):
-    """Handle exchange using CUDA Fabric handles via MPI/collective backend."""
-
-    @property
-    def handle_type(self) -> cuda.CUmemAllocationHandleType:
-        return cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
-
-    def allgather(self, local_handle) -> List:
-        return self.comm.allgather(local_handle.data)
-
-    def broadcast(self, handle, root: int):
-        return self.comm.bcast(handle.data if handle else None, root=root)
-
-    def cleanup(self, handle) -> None:
-        pass  # No cleanup needed for Fabric handles.
-
-    def close(self) -> None:
-        pass  # No close needed for Fabric handles.
-
-
-class PosixFDHandleExchanger(HandleExchanger):
-    """Handle exchange using POSIX file descriptors via IPC sockets."""
-
-    def __init__(self, comm_backend: "CommBackend", group_rank: int, group_size: int):
-        super().__init__(comm_backend, group_rank, group_size)
-        self._socket = self._init_ipc_socket()
-
-    def _init_ipc_socket(self) -> IpcSocket:
-        if self.rank == 0:
-            opId = random.Random().randint(0, 2**64 - 1)
-        else:
-            opId = None
-        opId = self.comm.bcast(opId, root=0)
-        return IpcSocket(self.rank, opId)
-
-    @property
-    def handle_type(self) -> cuda.CUmemAllocationHandleType:
-        return cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
-
-    def allgather(self, local_handle) -> List:
-        result = [None] * self.size
-        for i in range(self.size):
-            self.comm.barrier()
-            self._socket.send_fd(local_handle, (self.rank + i) % self.size)
-            src = (self.rank + self.size - i) % self.size
-            result[src] = self._socket.recv_fd()
-        return result
-
-    def broadcast(self, handle, root: int):
-        if self.rank == root:
-            for p in range(1, self.size):
-                self.comm.barrier()
-                self._socket.send_fd(handle, p)
-            return handle
-        else:
-            # Ordered receive to avoid race condition
-            for _ in range(self.rank):
-                self.comm.barrier()
-            result = self._socket.recv_fd()
-            for _ in range(self.size - self.rank - 1):
-                self.comm.barrier()
-            return result
-
-    def cleanup(self, handle) -> None:
-        os.close(handle)
-
-    def close(self) -> None:
-        self._socket.close()
 
 
 def is_mnnvl_fabric_supported(device_idx: int) -> bool:
@@ -963,6 +605,124 @@ def is_mnnvl_fabric_supported(device_idx: int) -> bool:
         )
     finally:
         pynvml.nvmlShutdown()
+
+
+def is_multicast_supported(device_idx: int) -> bool:
+    """Return True if the device supports NVLink multicast (cuMulticastCreate; SM90+ NVLink)."""
+    try:
+        multicast_supported = checkCudaErrors(
+            cuda.cuDeviceGetAttribute(
+                cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED,
+                device_idx,
+            )
+        )
+        return multicast_supported != 0
+    except Exception:
+        return False
+
+
+def all_ranks_agree(comm: CommBackend, local: bool) -> bool:
+    """AND-reduce a per-rank boolean over the group (True iff every rank is True)."""
+    return all(comm.allgather(local))
+
+
+def all_ranks_support_mnnvl(
+    local_supported: bool,
+    world_size: int,
+    comm_backend: CommBackend | None = None,
+    group: "ProcessGroup | None" = None,
+) -> bool:
+    """Return True only if every rank supports MNNVL.
+
+    All ranks must build the same workspace type or the collective rendezvous
+    deadlocks, so we AND-reduce the per-rank probe. Must be called on every rank
+    unconditionally.
+    """
+    if world_size <= 1:
+        return local_supported
+
+    comm = comm_backend
+    if comm is None:
+        import torch.distributed as dist
+
+        comm = TorchDistBackend(group=group) if dist.is_initialized() else MPIBackend()
+
+    comm_size = comm.Get_size()
+    if comm_size != world_size:
+        logger.warning(
+            "[MNNVL] capability-vote comm size %d != world_size %d; disabling "
+            "MNNVL auto-selection. Pass a comm_backend/group scoped to the "
+            "workspace ranks to enable it.",
+            comm_size,
+            world_size,
+        )
+        return False
+
+    return all_ranks_agree(comm, local_supported)
+
+
+@dataclass(frozen=True)
+class HandleExchanger:
+    """Exchanges CUDA shareable memory handles across ranks.
+
+    ``handle_type`` is the tag that selects the transport: FABRIC handles ride
+    the ``CommBackend`` object collectives; POSIX file descriptors ride AF_UNIX
+    SCM_RIGHTS sockets (see :mod:`.fd_exchange`).
+    """
+
+    comm: CommBackend
+    rank: int
+    size: int
+    handle_type: "cuda.CUmemAllocationHandleType"
+
+
+def make_handle_exchanger(
+    comm: CommBackend, rank: int, size: int, dev_id: int
+) -> HandleExchanger:
+    """Pick FABRIC vs POSIX-fd handles based on the device's fabric support."""
+    if is_mnnvl_fabric_supported(dev_id):
+        handle_type = cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+    else:
+        handle_type = (
+            cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+    return HandleExchanger(comm=comm, rank=rank, size=size, handle_type=handle_type)
+
+
+def _handle_is_fabric(ex: HandleExchanger) -> bool:
+    return ex.handle_type == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+
+
+def handle_allgather(ex: HandleExchanger, local_handle) -> Sequence[Any]:
+    """All-gather shareable handles from every rank (indexed by rank).
+
+    Returns a tuple for FABRIC handles and a list for POSIX fds; callers only
+    index and iterate. For POSIX fds the returned sequence owns real
+    descriptors (``entry[own_rank]`` is the caller's own fd); close each
+    returned fd exactly once (see :func:`.fd_exchange.exchange_fds`).
+    """
+    if _handle_is_fabric(ex):
+        return ex.comm.allgather(local_handle.data)
+    return exchange_fds(ex.comm, int(local_handle))
+
+
+def handle_broadcast(ex: HandleExchanger, handle, root: int):
+    """Broadcast one shareable handle from ``root`` to every rank."""
+    if _handle_is_fabric(ex):
+        return ex.comm.bcast(handle.data if handle else None, root=root)
+    return broadcast_fd(ex.comm, int(handle) if handle is not None else None, root)
+
+
+def handle_cleanup(ex: HandleExchanger, handle) -> None:
+    """Release a shareable handle: FABRIC needs none; a POSIX fd is closed."""
+    if not _handle_is_fabric(ex) and handle is not None:
+        os.close(int(handle))
+
+
+def handle_close(ex: HandleExchanger | None) -> None:
+    """Release transport resources. Sockets are self-managed per exchange, so
+    this is a no-op kept for symmetry with the previous interface."""
+    return None
 
 
 # TODO: This class follows similar logic with MnnvlMemory, but the latter use single instance mode to manage the memory allocation.
@@ -1023,17 +783,10 @@ class SymmDeviceMemory:
         self.SIGNAL_PAD_SIZE = SIGNAL_PAD_SIZE
 
         # Check if device supports multicasting
-        if self._enable_multicast:
-            multicast_supported = checkCudaErrors(
-                cuda.cuDeviceGetAttribute(
-                    cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED,
-                    device_idx,
-                )
+        if self._enable_multicast and not is_multicast_supported(device_idx):
+            raise RuntimeError(
+                "[SymmDeviceMemory] Device does not support multicasting."
             )
-            if multicast_supported == 0:
-                raise RuntimeError(
-                    "[SymmDeviceMemory] Device does not support multicasting."
-                )
 
         # Calculate signal pad offset with alignment (matching C++ exactly)
         self.signal_pad_offset = round_up(buf_size, self.SIGNAL_PAD_ALIGNMENT)
@@ -1064,7 +817,7 @@ class SymmDeviceMemory:
         """Destructor - cleanup allocated memory"""
 
         if hasattr(self, "_exchanger") and self._exchanger is not None:
-            self._exchanger.close()
+            handle_close(self._exchanger)
 
         # Skip cleanup during Python finalization to avoid segfaults
         # Especially cause the CUDA context could be destroyed at this point.
@@ -1179,14 +932,9 @@ class SymmDeviceMemory:
     def _create_and_map_handles(self, comm: CommBackend) -> None:
         """Create physical backing and map it at the reserved addresses."""
         # Create handle exchanger
-        if is_mnnvl_fabric_supported(self.device_idx):
-            self._exchanger = FabricHandleExchanger(
-                comm, self.group_rank, self.group_size
-            )
-        else:
-            self._exchanger = PosixFDHandleExchanger(
-                comm, self.group_rank, self.group_size
-            )
+        self._exchanger = make_handle_exchanger(
+            comm, self.group_rank, self.group_size, self.device_idx
+        )
 
         self._verify_cuda_context()
 
@@ -1226,7 +974,7 @@ class SymmDeviceMemory:
         for handle in self.uc_handles:
             checkCudaErrors(cuda.cuMemRelease(handle))
 
-        self._exchanger.close()
+        handle_close(self._exchanger)
         self.uc_handles = [0] * self.group_size
         self._exchanger = None
         self._mapped = False
@@ -1307,8 +1055,12 @@ class SymmDeviceMemory:
             )
         )
 
-        # All-gather shareable handles
-        all_shareable_uc_handles = self._exchanger.allgather(local_shareable_uc_handle)
+        # All-gather shareable handles. For POSIX fds, entry[group_rank] is our
+        # own local_shareable_uc_handle (not a dup), so the cleanup loop below
+        # closes it exactly once — no separate cleanup of local_shareable_uc_handle.
+        all_shareable_uc_handles = handle_allgather(
+            self._exchanger, local_shareable_uc_handle
+        )
         cuda.cuCtxSynchronize()
 
         # Import remote handles
@@ -1320,8 +1072,7 @@ class SymmDeviceMemory:
                         self._exchanger.handle_type,
                     )
                 )
-            self._exchanger.cleanup(all_shareable_uc_handles[p])
-        self._exchanger.cleanup(local_shareable_uc_handle)
+            handle_cleanup(self._exchanger, all_shareable_uc_handles[p])
 
         # Reserve address space for UC pointers
         if not self.uc_ptrs:
@@ -1366,7 +1117,9 @@ class SymmDeviceMemory:
             shareable_mc_handle = None
 
         # Broadcast multicast handle from rank 0
-        shareable_mc_handle = self._exchanger.broadcast(shareable_mc_handle, root=0)
+        shareable_mc_handle = handle_broadcast(
+            self._exchanger, shareable_mc_handle, root=0
+        )
         cuda.cuCtxSynchronize()
 
         # Import multicast handle for non-root ranks
@@ -1377,7 +1130,7 @@ class SymmDeviceMemory:
                     self._exchanger.handle_type,
                 )
             )
-        self._exchanger.cleanup(shareable_mc_handle)
+        handle_cleanup(self._exchanger, shareable_mc_handle)
 
         # Add device to multicast
         checkCudaErrors(cuda.cuMulticastAddDevice(self.mc_handle, self.device_idx))

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -185,6 +185,13 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         self.uc_ptrs_dev = self.handle.get_buffer_ptrs_dev()
         self.uc_ptr_local = self.handle.get_unicast_ptr(self.rank)
         self.mc_ptr = self.handle.get_multicast_ptr()
+        if not self.mc_ptr:
+            self.destroy()
+            raise RuntimeError(
+                "[MNNVLAllReduceFusionWorkspace] Multicast pointer is null after rendezvous. "
+                "This requires NVLink multicast (SM90+ with NVLink, e.g. H100 SXM). "
+                "Use backend='trtllm' or backend='auto' on unsupported hardware."
+            )
 
     @functools.cache
     def is_buffer_size_sufficient(

--- a/tests/comm/conftest.py
+++ b/tests/comm/conftest.py
@@ -29,51 +29,16 @@ def pytest_sessionfinish(session, exitstatus):
 Shared test utilities for comm tests.
 """
 
-import ctypes
-import os
-
 from flashinfer.comm.mnnvl import MnnvlMemory
 
 
-def _check_pidfd_permissions() -> bool:
-    """Check if pidfd_getfd syscall is available and permitted.
-
-    This is required for MNNVL in containers - the SYS_PTRACE capability
-    must be available for cross-process file descriptor sharing.
-    """
-    try:
-        libc = ctypes.CDLL(None, use_errno=True)
-        syscall = libc.syscall
-        SYS_pidfd_open = 434
-        SYS_pidfd_getfd = 438
-
-        # Try to open our own process and get our own fd
-        my_pid = os.getpid()
-        pidfd = syscall(SYS_pidfd_open, my_pid, 0)
-        if pidfd < 0:
-            return False
-
-        # Try pidfd_getfd on stdin (fd=0) - this tests the permission
-        # We don't actually need the result, just checking if it's permitted
-        test_fd = syscall(SYS_pidfd_getfd, pidfd, 0, 0)
-        os.close(pidfd)
-
-        if test_fd < 0:
-            err = ctypes.get_errno()
-            if err == 1:  # EPERM - permission denied (container issue)
-                return False
-            # Other errors (like EBADF) are OK - permission check passed
-        else:
-            os.close(test_fd)
-
-        return True
-    except Exception:
-        return False
-
-
 def mnnvl_available() -> bool:
-    """Check if MNNVL is fully available (hardware + container permissions)."""
-    return MnnvlMemory.supports_mnnvl() and _check_pidfd_permissions()
+    """Check if MNNVL memory is available (all NVLink links up).
+
+    Handle exchange uses either FABRIC handles or POSIX fds over SCM_RIGHTS
+    sockets, so no extra container capability (e.g. SYS_PTRACE) is required.
+    """
+    return MnnvlMemory.supports_mnnvl()
 
 
 def pytest_addoption(parser):

--- a/tests/comm/conftest.py
+++ b/tests/comm/conftest.py
@@ -11,6 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import sys
+
+# Multiprocessing workers (spawn/forkserver) in this directory re-import their
+# test module by dotted path (e.g. ``tests.comm.test_comm_backend``) to unpickle
+# their target, which needs the repo root on ``sys.path``. This repo runs pytest
+# with ``--import-mode=importlib`` (pytest.ini), which does not add it, and plain
+# ``pytest`` (unlike ``python -m pytest``) doesn't put CWD there either -- so the
+# workers fail with ``ModuleNotFoundError: No module named 'tests'``. Put the repo
+# root on the parent's path here; spawn/forkserver capture the parent's sys.path
+# and restore it in the child before unpickling.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
 import pytest
 import torch.distributed as dist
 

--- a/tests/comm/test_all_gather_matmul.py
+++ b/tests/comm/test_all_gather_matmul.py
@@ -84,17 +84,6 @@ def unit_test(rank: int, world_size: int, port: int, dtype: torch.dtype):
 )
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_all_gather_matmul(dtype: torch.dtype):
-    import os
-    import sys
-
-    # mp.spawn starts fresh interpreters that need to re-import this module;
-    # ensure the repo root is on sys.path so 'tests.comm' is findable.
-    repo_root = os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    )
-    if repo_root not in sys.path:
-        sys.path.insert(0, repo_root)
-
     port = random.randint(30000, 60000)
     world_size = torch.cuda.device_count()
     mp.spawn(unit_test, args=(world_size, port, dtype), nprocs=world_size, join=True)

--- a/tests/comm/test_comm_backend.py
+++ b/tests/comm/test_comm_backend.py
@@ -29,7 +29,11 @@ from typing import Any
 import pytest
 import torch.distributed as dist
 
-from flashinfer.comm.comm_backend import MPIBackend, TorchDistBackend
+from flashinfer.comm.comm_backend import (
+    MPIBackend,
+    TorchDistBackend,
+    _split_partition,  # pyright: ignore[reportPrivateUsage]
+)
 
 _TIMEOUT_S = 120.0
 
@@ -112,7 +116,7 @@ _gloo_unavailable = not dist.is_available() or not dist.is_gloo_available()
 
 
 @pytest.mark.skipif(_gloo_unavailable, reason="torch.distributed gloo backend required")
-@pytest.mark.parametrize("world_size", [2])
+@pytest.mark.parametrize("world_size", [2, 4])
 def test_torch_dist_backend_collectives(world_size: int) -> None:
     results = _run_dist(world_size)
 
@@ -133,6 +137,104 @@ def test_torch_dist_backend_collectives(world_size: int) -> None:
         assert res["sub_type"] == "TorchDistBackend"
         assert res["sub_size"] == len(peers)
         assert res["sub_rank"] == peers.index(rank)
+
+
+class _FakeGroup:
+    def __init__(self, ranks: tuple[int, ...]) -> None:
+        self.ranks = ranks
+
+
+class _FakeDist:
+    """Single-process stand-in for torch.distributed, driving one logical rank."""
+
+    def __init__(
+        self, rank: int, world_size: int, all_info: list[tuple[int, int, int]]
+    ) -> None:
+        self._rank = rank
+        self._world = world_size
+        self._all_info = all_info
+        self.created: list[tuple[int, ...]] = []  # sub-groups created, in order
+
+    def get_rank(self, group: Any = None) -> int:
+        return self._rank if group is None else group.ranks.index(self._rank)
+
+    def get_world_size(self, group: Any = None) -> int:
+        return self._world if group is None else len(group.ranks)
+
+    def all_gather_object(
+        self, out_list: list[Any], data: Any, group: Any = None
+    ) -> None:
+        # Simulate the collective: every rank observes all ranks' contributions,
+        # and its own slot must match what it put in.
+        assert data == self._all_info[self._rank]
+        for i, info in enumerate(self._all_info):
+            out_list[i] = info
+
+    def new_subgroups_by_enumeration(
+        self, ranks_per_subgroup_list: list[list[int]]
+    ) -> tuple[Any, list[Any]]:
+        subs = [_FakeGroup(tuple(r)) for r in ranks_per_subgroup_list]
+        self.created.extend(g.ranks for g in subs)
+        cur = next((g for g in subs if self._rank in g.ranks), None)
+        return cur, subs
+
+    def new_group(self, ranks: list[int]) -> Any:
+        # Unused by the fixed Split, but recorded so a regression to the buggy
+        # "create only my own color" implementation is caught by the same
+        # created-sequence assertion below.
+        g = _FakeGroup(tuple(ranks))
+        self.created.append(g.ranks)
+        return g
+
+
+def _drive_split(
+    colors_keys: list[tuple[int, int]],
+) -> list[tuple[_FakeDist, TorchDistBackend]]:
+    """Run Split once per logical rank against a fake torch.distributed.
+
+    Caller must stub ``dist.is_initialized`` -- the child TorchDistBackend that
+    Split constructs goes through the real ``__init__`` guard.
+    """
+    world_size = len(colors_keys)
+    all_info = [(c, k, r) for r, (c, k) in enumerate(colors_keys)]
+    out: list[tuple[_FakeDist, TorchDistBackend]] = []
+    for rank, (color, key) in enumerate(colors_keys):
+        fake = _FakeDist(rank, world_size, all_info)
+        b = object.__new__(TorchDistBackend)
+        b._group = None  # pyright: ignore[reportPrivateUsage]
+        b._dist = fake  # pyright: ignore[reportPrivateUsage, reportAttributeAccessIssue]
+        out.append((fake, b.Split(color, key)))
+    return out
+
+
+def test_torch_dist_backend_split_creates_every_subgroup_on_every_rank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 4 ranks, 2 colors, 2 ranks each
+    monkeypatch.setattr(dist, "is_initialized", lambda: True)
+    driven = _drive_split([(r % 2, r) for r in range(4)])
+
+    # Full color partition, ranks ordered by (key, rank) within each color.
+    expected = [(0, 2), (1, 3)]
+    for rank, (fake, sub) in enumerate(driven):
+        # Every rank creates the SAME sequence of sub-groups (all colors, in
+        # order) -- the invariant new_group requires; "own color only" breaks it.
+        assert fake.created == expected, f"rank {rank}: {fake.created}"
+        # ...and gets back a backend scoped to its own color's sub-group.
+        assert sub._group.ranks == expected[rank % 2]  # pyright: ignore[reportPrivateUsage, reportOptionalMemberAccess]
+
+
+def test_split_partition_covers_all_colors_ordered_by_key() -> None:
+    # The rank-independent core of Split, tested directly (no dist needed).
+    # allgathered (color, key, global_rank) from 4 ranks, 2 colors.
+    all_info = [(0, 0, 0), (1, 1, 1), (0, 2, 2), (1, 3, 3)]
+    # Full partition, colors ascending; within a color, ranks by (key, rank).
+    assert _split_partition(all_info) == [[0, 2], [1, 3]]
+
+    # Single color, keys reverse the natural order: lower key -> lower rank,
+    # ties broken by global rank -- matching MPI_Comm_split.
+    reversed_keys = [(0, 10, 0), (0, 5, 1), (0, 20, 2), (0, 0, 3)]
+    assert _split_partition(reversed_keys) == [[3, 1, 0, 2]]
 
 
 class _FakeMpiComm:

--- a/tests/comm/test_comm_backend.py
+++ b/tests/comm/test_comm_backend.py
@@ -34,10 +34,11 @@ from flashinfer.comm.comm_backend import MPIBackend, TorchDistBackend
 _TIMEOUT_S = 120.0
 
 
-def _backend_checks(rank: int, world_size: int) -> dict[str, Any]:
+def _backend_checks(rank: int) -> dict[str, Any]:
     """Run every CommBackend method once and return the observed results.
 
     All ranks issue the same sequence of collectives, so the calls stay matched.
+    The world size is read from the process group, not passed in.
     """
     b = TorchDistBackend()
     res: dict[str, Any] = {}
@@ -72,7 +73,7 @@ def _dist_entry(rank: int, world_size: int, store_path: str, q: Any) -> None:
         world_size=world_size,
     )
     try:
-        q.put((rank, _backend_checks(rank, world_size)))
+        q.put((rank, _backend_checks(rank)))
     finally:
         dist.destroy_process_group()
 
@@ -111,7 +112,7 @@ _gloo_unavailable = not dist.is_available() or not dist.is_gloo_available()
 
 
 @pytest.mark.skipif(_gloo_unavailable, reason="torch.distributed gloo backend required")
-@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("world_size", [2])
 def test_torch_dist_backend_collectives(world_size: int) -> None:
     results = _run_dist(world_size)
 

--- a/tests/comm/test_comm_backend.py
+++ b/tests/comm/test_comm_backend.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the CommBackend adapters (MPIBackend, TorchDistBackend).
+
+TorchDistBackend is exercised for real over the gloo backend across processes
+(CPU only, no GPU). MPIBackend needs an MPI runtime for real use, so its adapter
+logic is unit-tested against an injected fake mpi4py communicator.
+"""
+
+import importlib.util
+import multiprocessing as mp
+import os
+import shutil
+import tempfile
+from typing import Any
+
+import pytest
+import torch.distributed as dist
+
+from flashinfer.comm.comm_backend import MPIBackend, TorchDistBackend
+
+_TIMEOUT_S = 120.0
+
+
+def _backend_checks(rank: int, world_size: int) -> dict[str, Any]:
+    """Run every CommBackend method once and return the observed results.
+
+    All ranks issue the same sequence of collectives, so the calls stay matched.
+    """
+    b = TorchDistBackend()
+    res: dict[str, Any] = {}
+    res["rank"] = b.Get_rank()
+    res["size"] = b.Get_size()
+
+    gathered = b.allgather(rank)
+    res["allgather"] = gathered
+    res["allgather_type"] = type(gathered).__name__
+
+    # Only the root supplies a value; every rank must receive it.
+    res["bcast"] = b.bcast(12345 if rank == 0 else None, root=0)
+
+    b.barrier()
+
+    # Split by parity, ordered within each sub-group by key=rank.
+    sub = b.Split(rank % 2, key=rank)
+    res["sub_type"] = type(sub).__name__
+    res["sub_rank"] = sub.Get_rank()
+    res["sub_size"] = sub.Get_size()
+    return res
+
+
+def _dist_entry(rank: int, world_size: int, store_path: str, q: Any) -> None:
+    # Pin gloo to loopback; otherwise it may pick a real NIC and fail to connect
+    # the full mesh between local processes.
+    os.environ.setdefault("GLOO_SOCKET_IFNAME", "lo")
+    dist.init_process_group(
+        backend="gloo",
+        init_method=f"file://{store_path}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        q.put((rank, _backend_checks(rank, world_size)))
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_dist(world_size: int) -> dict[int, dict[str, Any]]:
+    # spawn (not fork/forkserver): starts fresh interpreters, so it stays safe
+    # even if an MPI test in the same session has already called MPI_Init.
+    ctx = mp.get_context("spawn")
+    tmpdir = tempfile.mkdtemp(prefix="tdb_store_")
+    store_path = os.path.join(tmpdir, "store")
+    q = ctx.Queue()
+    procs = [
+        ctx.Process(target=_dist_entry, args=(r, world_size, store_path, q))
+        for r in range(world_size)
+    ]
+    try:
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=_TIMEOUT_S)
+        for p in procs:
+            assert p.exitcode == 0, f"worker pid={p.pid} exited with {p.exitcode}"
+        results: dict[int, dict[str, Any]] = {}
+        while not q.empty():
+            rank, res = q.get()
+            results[rank] = res
+        assert len(results) == world_size, (
+            f"expected {world_size} results, got {sorted(results)}"
+        )
+        return results
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+_gloo_unavailable = not dist.is_available() or not dist.is_gloo_available()
+
+
+@pytest.mark.skipif(_gloo_unavailable, reason="torch.distributed gloo backend required")
+@pytest.mark.parametrize("world_size", [2, 4])
+def test_torch_dist_backend_collectives(world_size: int) -> None:
+    results = _run_dist(world_size)
+
+    for rank in range(world_size):
+        res = results[rank]
+        assert res["rank"] == rank
+        assert res["size"] == world_size
+
+        # allgather returns a per-rank tuple, indexed by rank.
+        assert res["allgather"] == tuple(range(world_size))
+        assert res["allgather_type"] == "tuple"
+
+        # every rank received the root's value.
+        assert res["bcast"] == 12345
+
+        # Split by parity: same-parity ranks form a sub-group, ordered by rank.
+        peers = [r for r in range(world_size) if r % 2 == rank % 2]
+        assert res["sub_type"] == "TorchDistBackend"
+        assert res["sub_size"] == len(peers)
+        assert res["sub_rank"] == peers.index(rank)
+
+
+class _FakeMpiComm:
+    """Records calls and returns canned values, standing in for mpi4py's comm."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+
+    def Get_rank(self) -> int:
+        self.calls.append(("Get_rank",))
+        return 3
+
+    def Get_size(self) -> int:
+        self.calls.append(("Get_size",))
+        return 8
+
+    def allgather(self, data: Any) -> list[Any]:
+        self.calls.append(("allgather", data))
+        return [data, data]  # a list -- the adapter must freeze it to a tuple
+
+    def bcast(self, data: Any, root: int) -> Any:
+        self.calls.append(("bcast", data, root))
+        return data
+
+    def Barrier(self) -> None:
+        self.calls.append(("Barrier",))
+
+    def Split(self, color: int, key: int) -> "_FakeMpiComm":
+        self.calls.append(("Split", color, key))
+        return _FakeMpiComm()
+
+
+def _fake_backend() -> tuple[MPIBackend, _FakeMpiComm]:
+    b = MPIBackend()  # MpiComm() is created but mpi4py is only imported on use
+    fake = _FakeMpiComm()
+    b._mpicomm = fake  # pyright: ignore[reportPrivateUsage, reportAttributeAccessIssue]
+    return b, fake
+
+
+def test_mpi_backend_rank_and_size_delegate() -> None:
+    b, fake = _fake_backend()
+    assert b.Get_rank() == 3
+    assert b.Get_size() == 8
+    assert ("Get_rank",) in fake.calls and ("Get_size",) in fake.calls
+
+
+def test_mpi_backend_allgather_returns_tuple() -> None:
+    b, fake = _fake_backend()
+    result = b.allgather(7)
+    assert result == (7, 7)
+    assert isinstance(result, tuple)  # adapter freezes mpi4py's list
+    assert ("allgather", 7) in fake.calls
+
+
+def test_mpi_backend_bcast_forwards_data_and_root() -> None:
+    b, fake = _fake_backend()
+    assert b.bcast("payload", root=2) == "payload"
+    assert ("bcast", "payload", 2) in fake.calls
+
+
+def test_mpi_backend_barrier_calls_uppercase_Barrier() -> None:
+    b, fake = _fake_backend()
+    b.barrier()
+    assert ("Barrier",) in fake.calls
+
+
+def test_mpi_backend_split_returns_subgroup_without_mutating_self() -> None:
+    b, fake = _fake_backend()
+    b2 = b.Split(1, 5)
+    assert ("Split", 1, 5) in fake.calls
+    assert isinstance(b2, MPIBackend) and b2 is not b
+    # self must be left unchanged (still delegating to the original comm),
+    # mirroring TorchDistBackend.Split. A regression to "mutate self into the
+    # sub-group" would route this call to the split child instead.
+    fake.calls.clear()
+    b.Get_rank()
+    assert ("Get_rank",) in fake.calls
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("mpi4py") is None, reason="mpi4py required"
+)
+def test_mpi_backend_real_collectives() -> None:
+    """Real mpi4py collectives over COMM_WORLD.
+
+    Runs at world_size 1 under plain pytest (real delegation + tuple wrapping)
+    and at world_size N under ``mpirun -np N pytest <this file>``.
+    """
+    b = MPIBackend()
+    world_size = b.Get_size()
+    rank = b.Get_rank()
+    assert 0 <= rank < world_size
+
+    gathered = b.allgather(rank)
+    assert isinstance(gathered, tuple)
+    assert gathered == tuple(range(world_size))
+
+    assert b.bcast(12345 if rank == 0 else None, root=0) == 12345
+
+    b.barrier()
+
+    # Split by parity, ordered within each sub-group by key=rank.
+    sub = b.Split(rank % 2, key=rank)
+    assert isinstance(sub, MPIBackend)
+    peers = [r for r in range(world_size) if r % 2 == rank % 2]
+    assert sub.Get_size() == len(peers)
+    assert sub.Get_rank() == peers.index(rank)
+    # Split must not mutate the parent communicator.
+    assert b.Get_size() == world_size

--- a/tests/comm/test_fd_exchange.py
+++ b/tests/comm/test_fd_exchange.py
@@ -86,8 +86,7 @@ def _make_file(rank: int) -> tuple[int, str]:
 
 
 def _read_fd(fd: int) -> str:
-    os.lseek(fd, 0, 0)
-    return os.read(fd, 128).decode()
+    return os.pread(fd, 128, 0).decode()
 
 
 def _worker_exchange(rank: int, size: int, barrier: Any, shared: Any, q: Any) -> None:

--- a/tests/comm/test_fd_exchange.py
+++ b/tests/comm/test_fd_exchange.py
@@ -1,0 +1,238 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Correctness tests for flashinfer.comm.fd_exchange."""
+
+import array
+import multiprocessing as mp
+import os
+import socket
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from flashinfer.comm.abstractions import CommBackend
+from flashinfer.comm.fd_exchange import (
+    _extract_fd,  # pyright: ignore[reportPrivateUsage]
+    _fd_ancillary,  # pyright: ignore[reportPrivateUsage]
+    broadcast_fd,
+    exchange_fds,
+    recv_fd_dgram,
+    send_fd_dgram,
+)
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX") or not hasattr(socket, "CMSG_SPACE"),
+    reason="fd_exchange requires AF_UNIX sockets with SCM_RIGHTS (POSIX only)",
+)
+
+_TIMEOUT_S = 60.0
+
+
+class _MPComm:
+    """A minimal CommBackend test double over multiprocessing sync primitives.
+
+    ``barrier``/``shared`` are multiprocessing proxies (dynamically typed), hence
+    ``Any``. ``bcast``/``Split`` are unused by the fd helpers and only exist to
+    satisfy the CommBackend protocol.
+    """
+
+    def __init__(self, rank: int, size: int, barrier: Any, shared: Any):
+        self.rank, self.size = rank, size
+        self._barrier, self._shared = barrier, shared
+
+    def Get_rank(self) -> int:
+        return self.rank
+
+    def Get_size(self) -> int:
+        return self.size
+
+    def allgather(self, data: Any) -> tuple[Any, ...]:
+        self._shared[self.rank] = data
+        self._barrier.wait()
+        result = tuple(self._shared)
+        self._barrier.wait()
+        return result
+
+    def bcast(self, data: Any, root: int) -> Any:
+        raise NotImplementedError
+
+    def barrier(self) -> None:
+        self._barrier.wait()
+
+    def Split(self, color: int, key: int) -> CommBackend:
+        raise NotImplementedError
+
+
+def _make_file(rank: int) -> tuple[int, str]:
+    """A fresh temp file whose contents uniquely identify ``rank``."""
+    fd, path = tempfile.mkstemp(prefix=f"fdx_{rank}_")
+    os.write(fd, f"rank-{rank}".encode())
+    return fd, path
+
+
+def _read_fd(fd: int) -> str:
+    os.lseek(fd, 0, 0)
+    return os.read(fd, 128).decode()
+
+
+def _worker_exchange(rank: int, size: int, barrier: Any, shared: Any, q: Any) -> None:
+    comm = _MPComm(rank, size, barrier, shared)
+    fd, path = _make_file(rank)
+    try:
+        fds = exchange_fds(comm, fd)
+        # Own slot must be the original fd (not a dup), per the documented contract.
+        own_slot_is_original = fds[rank] == fd
+        contents = [_read_fd(f) for f in fds]
+        # Caller owns every returned fd and closes each exactly once.
+        for f in fds:
+            os.close(f)
+        q.put((rank, (contents, own_slot_is_original)))
+    finally:
+        os.unlink(path)
+
+
+def _worker_broadcast(
+    rank: int, size: int, barrier: Any, shared: Any, q: Any, root: int
+) -> None:
+    comm = _MPComm(rank, size, barrier, shared)
+    fd, path = _make_file(rank)
+    try:
+        rfd = broadcast_fd(comm, fd if rank == root else None, root)
+        content = _read_fd(rfd)
+        os.close(rfd)
+        if rank != root:
+            os.close(fd)  # our own file fd is not handed back to us
+        q.put((rank, content))
+    finally:
+        os.unlink(path)
+
+
+def _run_workers(target: Callable[..., None], size: int, *extra: Any) -> dict[int, Any]:
+    # forkserver forks workers from a clean single-threaded server, avoiding the
+    # "fork() in a multi-threaded process" hazard (torch/cuda leave threads live).
+    ctx = mp.get_context("forkserver")
+    barrier = ctx.Barrier(size)
+    shared = ctx.Manager().list([None] * size)
+    q = ctx.Queue()
+    procs = [
+        ctx.Process(target=target, args=(r, size, barrier, shared, q, *extra))
+        for r in range(size)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=_TIMEOUT_S)
+    for p in procs:
+        assert p.exitcode == 0, f"worker pid={p.pid} exited with {p.exitcode}"
+    results: dict[int, Any] = {}
+    while not q.empty():
+        rank, payload = q.get()
+        results[rank] = payload
+    assert len(results) == size, f"expected {size} results, got {sorted(results)}"
+    return results
+
+
+@pytest.mark.parametrize("size", [1, 2, 3, 4])
+def test_exchange_fds_all_to_all(size: int) -> None:
+    results = _run_workers(_worker_exchange, size)
+    expected = [f"rank-{i}" for i in range(size)]
+    for rank in range(size):
+        contents, own_slot_is_original = results[rank]
+        # Every rank can read every rank's file through the exchanged fds.
+        assert contents == expected, f"rank {rank} read {contents}, expected {expected}"
+        assert own_slot_is_original, f"rank {rank} own slot was not its original fd"
+
+
+@pytest.mark.parametrize(
+    "size,root",
+    [(2, 0), (2, 1), (3, 0), (3, 2), (4, 0), (4, 3)],
+)
+def test_broadcast_fd(size: int, root: int) -> None:
+    results = _run_workers(_worker_broadcast, size, root)
+    expected = f"rank-{root}"
+    for rank in range(size):
+        assert results[rank] == expected, (
+            f"rank {rank} read {results[rank]}, expected root's content {expected}"
+        )
+
+
+def test_broadcast_fd_single_rank_returns_local() -> None:
+    comm = _MPComm(0, 1, None, None)  # size==1 short-circuits before any sync
+    fd, path = _make_file(0)
+    try:
+        assert broadcast_fd(comm, fd, root=0) == fd
+    finally:
+        os.close(fd)
+        os.unlink(path)
+
+
+def test_dgram_send_recv_roundtrip(tmp_path: Path) -> None:
+    recv_path = str(tmp_path / "recv.sock")
+    send_path = str(tmp_path / "send.sock")
+    recv_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    send_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    recv_sock.bind(recv_path)
+    send_sock.bind(send_path)
+    recv_sock.settimeout(_TIMEOUT_S)
+    fd, path = _make_file(0)
+    try:
+        send_fd_dgram(send_sock, fd, recv_path)
+        got_fd = recv_fd_dgram(recv_sock)
+        try:
+            assert got_fd != fd  # a distinct descriptor referring to the same file
+            assert _read_fd(got_fd) == "rank-0"
+        finally:
+            os.close(got_fd)
+    finally:
+        os.close(fd)
+        os.unlink(path)
+        recv_sock.close()
+        send_sock.close()
+
+
+def test_recv_fd_dgram_without_fd_raises(tmp_path: Path) -> None:
+    recv_path = str(tmp_path / "recv.sock")
+    send_path = str(tmp_path / "send.sock")
+    recv_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    send_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    recv_sock.bind(recv_path)
+    send_sock.bind(send_path)
+    recv_sock.settimeout(_TIMEOUT_S)
+    try:
+        send_sock.sendto(b"\x00", recv_path)  # payload but no ancillary fd
+        with pytest.raises(RuntimeError, match="no file descriptor"):
+            recv_fd_dgram(recv_sock)
+    finally:
+        recv_sock.close()
+        send_sock.close()
+
+
+def test_fd_ancillary_extract_roundtrip() -> None:
+    anc = _fd_ancillary(7)
+    assert isinstance(anc, tuple) and len(anc) == 1
+    level, cmsg_type, buf = anc[0]
+    assert level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS
+    assert list(buf) == [7]
+    # _extract_fd decodes the received-side form, where cmsg_data is bytes.
+    assert _extract_fd([(socket.SOL_SOCKET, socket.SCM_RIGHTS, buf.tobytes())]) == 7
+
+
+def test_extract_fd_ignores_unrelated_control_messages() -> None:
+    assert _extract_fd([]) is None
+    wrong = array.array("i", [123]).tobytes()
+    assert _extract_fd([(socket.IPPROTO_IP, 0, wrong)]) is None

--- a/tests/comm/test_mixed_comm.py
+++ b/tests/comm/test_mixed_comm.py
@@ -1,8 +1,6 @@
 import math
 import multiprocessing as mp
-import sys
 from itertools import product
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -15,11 +13,6 @@ from flashinfer.comm.mixed_comm import (
     MixedCommOp,
     run_mixed_comm,
 )
-
-
-_project_root = Path(__file__).parent.parent.parent
-if str(_project_root) not in sys.path:
-    sys.path.append(str(_project_root))
 
 
 def prepare_data(max_local_bs, hidden_size, world_size, dtype, device):

--- a/tests/comm/test_mnnvl_dcp_alltoall.py
+++ b/tests/comm/test_mnnvl_dcp_alltoall.py
@@ -75,7 +75,7 @@ pytestmark = [
     ),
     pytest.mark.skipif(
         not mnnvl_available(),
-        reason="MNNVL not supported on this platform or container lacks SYS_PTRACE",
+        reason="MNNVL not supported on this platform",
     ),
     pytest.mark.skipif(
         not _mpi4py_available(),
@@ -114,7 +114,7 @@ def _setup_rank():
 
 # Guard module-level allocation: pytestmark skipif conditions are not
 # enforced during module import (collection phase). If we allocate
-# unconditionally, CI environments without SYS_PTRACE will fail at
+# unconditionally, CI environments without MNNVL will fail at
 # collection time instead of gracefully skipping.
 if _dcp_alltoall_supported() and mnnvl_available() and _mpi4py_available():
     _rank, _cp_size, _comm = _setup_rank()

--- a/tests/comm/test_mnnvl_memory.py
+++ b/tests/comm/test_mnnvl_memory.py
@@ -29,7 +29,7 @@ pynvml.nvmlInit()
 
 @pytest.mark.skipif(
     not mnnvl_available(),
-    reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
+    reason="Mnnvl memory is not supported on this platform",
 )
 class TestMnnvlMemory:
     @pytest.fixture(autouse=True)
@@ -63,7 +63,7 @@ class TestMnnvlMemory:
 
     @pytest.mark.skipif(
         not mnnvl_available(),
-        reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
+        reason="Mnnvl memory is not supported on this platform",
     )
     def test_mnnvl_memory(self):
         # allocate un-aligned memory
@@ -121,7 +121,7 @@ class TestMnnvlMemory:
 
     @pytest.mark.skipif(
         not mnnvl_available(),
-        reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
+        reason="Mnnvl memory is not supported on this platform",
     )
     def test_moe_alltoall_multi_rank_single_gpu(self):
         torch.cuda.set_device(self.local_rank)

--- a/tests/comm/test_mnnvl_moe_alltoall.py
+++ b/tests/comm/test_mnnvl_moe_alltoall.py
@@ -626,9 +626,7 @@ def moe_a2a_dispatch_test_impl(distribution, top_k, use_lora=False):
     try:
         MnnvlMemory.initialize()
         if not mnnvl_available():
-            pytest.skip(
-                "MNNVL not supported on this system or container lacks SYS_PTRACE capability"
-            )
+            pytest.skip("MNNVL not supported on this system")
     except Exception:
         pytest.skip("MNNVL not supported on this system")
 
@@ -746,9 +744,7 @@ def moe_a2a_dispatch_moe_combine_test_impl(distribution, top_k, use_lora=False):
     try:
         MnnvlMemory.initialize()
         if not mnnvl_available():
-            pytest.skip(
-                "MNNVL not supported on this system or container lacks SYS_PTRACE capability"
-            )
+            pytest.skip("MNNVL not supported on this system")
     except Exception:
         pytest.skip("MNNVL not supported on this system")
 

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -250,7 +250,7 @@ def test_moe_a2a_combine_rejects_noncontiguous_output_before_jit(monkeypatch):
 @pytest.mark.parametrize("use_output_buffer", [False, True])
 @pytest.mark.skipif(
     not mnnvl_available(),
-    reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
+    reason="Mnnvl memory is not supported on this platform",
 )
 def test_moe_alltoall_single_gpu(
     num_tokens,
@@ -1012,7 +1012,7 @@ def test_moe_combine_multi_rank_single_gpu(
 
 @pytest.mark.skipif(
     not mnnvl_available(),
-    reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
+    reason="Mnnvl memory is not supported on this platform",
 )
 def test_moe_workspace_size_per_rank():
     """Test the workspace size per rank for the MoeAlltoAll operation."""


### PR DESCRIPTION
## 📌 Description

**What:** Let the NVLink all-to-all / MNNVL allreduce-fusion kernels run on a **single
node without multi-node NVLink fabric (IMEX)**, as long as every peer shares the same
intra-node NVLink domain — previously these paths required full MNNVL fabric support and
were unusable otherwise.

**How:** `MnnvlMemory` now probes CUDA **FABRIC** handle support per rank and AND-reduces
it across the group (all ranks must pick the same handle path or the rendezvous
deadlocks). When fabric is unavailable, it exports the shareable memory as
`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` and exchanges the fds over **AF_UNIX
`SCM_RIGHTS`** instead of fabric handles. `MNNVLAllReduceFusionWorkspace` also fails fast
with an actionable error when the multicast pointer is null (hardware without NVLink
multicast) instead of proceeding silently.

This PR also carries the **comm-backend refactor** that makes the above clean:

- New `flashinfer/comm/abstractions.py` — `CommBackend` as a structural `typing.Protocol`
  (leaf module, no inheritance).
- New `flashinfer/comm/comm_backend.py` — `MPIBackend` / `TorchDistBackend` adapters;
  fixes an inverted `MPIBackend.Split` (it mutated `self` into the sub-group and returned
  a fresh `COMM_WORLD` adapter, so `set_comm_from_config` got the wrong communicator).
- New `flashinfer/comm/fd_exchange.py` — the single home for fd passing (AF_UNIX
  `SCM_RIGHTS`, no `CAP_SYS_PTRACE`), deduplicating three prior copies of the logic.
- `flashinfer/comm/mnnvl.py` — handle exchange rewritten from an ABC hierarchy to a frozen
  dataclass + free functions; MNNVL capability probes (`is_multicast_supported`,
  `all_ranks_agree`, `all_ranks_support_mnnvl`) consolidated out of `allreduce.py`;
  `CommBackend.allgather` now returns a tuple.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

New CPU-only unit tests (no GPU required):

- `tests/comm/test_fd_exchange.py` — `exchange_fds` / `broadcast_fd` + the low-level
  `SCM_RIGHTS` primitives (15 tests, forkserver multiprocess).
- `tests/comm/test_comm_backend.py` — `TorchDistBackend` over real gloo across processes,
  fake-comm `MPIBackend` adapter tests, and a real mpi4py test (`mpirun -np N`). Gated to
  **skip** cleanly when gloo / mpi4py are absent.

## Reviewer Notes

- The AND-reduce of FABRIC support in `MnnvlMemory._resolve_fabric_support`: correctness
  hinges on **every** rank calling it unconditionally and agreeing on FABRIC vs POSIX-fd,
  or the handle-exchange rendezvous deadlocks.
- The `MPIBackend.Split` semantics fix (returns the sub-group, leaves `self` unchanged).
- The multiprocess gloo test is intentionally kept at `world_size=2` with the `spawn`
  start method; larger fork/forkserver meshes are unsafe here because the eager
  `import flashinfer` starts native threads that poison a fork.
