### PR TITLE
Fix cudart library resolution when stubs are loaded

### DIFF
--- a/flashinfer/comm/cuda_ipc.py
+++ b/flashinfer/comm/cuda_ipc.py
@@ -119,24 +119,53 @@ class CudaRTLibrary:
     #  to the corresponding dictionary
     path_to_dict_mapping: Dict[str, Dict[str, Any]] = {}
 
+    @staticmethod
+    def _load_exported_functions(so_file: str) -> Dict[str, Any]:
+        """Load cudart and bind every runtime symbol required by this wrapper."""
+        lib = CudaRTLibrary.path_to_library_cache.get(so_file)
+        if lib is None:
+            lib = ctypes.CDLL(so_file)
+        _funcs = {}
+        for func in CudaRTLibrary.exported_functions:
+            f = getattr(lib, func.name)
+            f.restype = func.restype
+            f.argtypes = func.argtypes
+            _funcs[func.name] = f
+        CudaRTLibrary.path_to_library_cache[so_file] = lib
+        CudaRTLibrary.path_to_dict_mapping[so_file] = _funcs
+        return _funcs
+
+    @staticmethod
+    def _find_loadable_cudart() -> str:
+        """Return the first loaded libcudart candidate that exports required symbols."""
+        candidates = []
+        with open("/proc/self/maps") as f:
+            for line in f:
+                if "libcudart" not in line or "/" not in line:
+                    continue
+                path = line[line.index("/") :].strip()
+                filename = path.split("/")[-1]
+                if not filename.rpartition(".so")[0].startswith("libcudart"):
+                    continue
+                if path not in candidates:
+                    candidates.append(path)
+        for path in candidates:
+            try:
+                CudaRTLibrary._load_exported_functions(path)
+            except (AttributeError, OSError):
+                continue
+            return path
+        raise AssertionError("libcudart is not loaded in the current process")
+
     def __init__(self, so_file: Optional[str] = None):
         if so_file is None:
-            so_file = find_loaded_library("libcudart")
-            assert so_file is not None, "libcudart is not loaded in the current process"
-        if so_file not in CudaRTLibrary.path_to_library_cache:
-            lib = ctypes.CDLL(so_file)
-            CudaRTLibrary.path_to_library_cache[so_file] = lib
-        self.lib = CudaRTLibrary.path_to_library_cache[so_file]
+            so_file = self._find_loadable_cudart()
 
         if so_file not in CudaRTLibrary.path_to_dict_mapping:
-            _funcs = {}
-            for func in CudaRTLibrary.exported_functions:
-                f = getattr(self.lib, func.name)
-                f.restype = func.restype
-                f.argtypes = func.argtypes
-                _funcs[func.name] = f
-            CudaRTLibrary.path_to_dict_mapping[so_file] = _funcs
-        self.funcs = CudaRTLibrary.path_to_dict_mapping[so_file]
+            self.funcs = self._load_exported_functions(so_file)
+        else:
+            self.funcs = CudaRTLibrary.path_to_dict_mapping[so_file]
+        self.lib = CudaRTLibrary.path_to_library_cache[so_file]
 
     def CUDART_CHECK(self, result: cudaError_t) -> None:
         if result != 0:

--- a/tests/comm/test_cuda_ipc_cudart_resolution.py
+++ b/tests/comm/test_cuda_ipc_cudart_resolution.py
@@ -1,0 +1,89 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+def _load_cuda_ipc_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "flashinfer" / "comm" / "cuda_ipc.py"
+    spec = importlib.util.spec_from_file_location("_cuda_ipc_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+CudaRTLibrary = _load_cuda_ipc_module().CudaRTLibrary
+
+
+class _FakeFunction:
+    restype = None
+    argtypes = None
+
+    def __call__(self, *args):
+        return 0
+
+
+class _FakeCudart:
+    def __getattr__(self, name):
+        if name == "cudaDeviceReset":
+            raise AttributeError(name)
+        return _FakeFunction()
+
+
+class _FakeFullCudart:
+    def __getattr__(self, name):
+        return _FakeFunction()
+
+
+def _clear_cudart_cache():
+    CudaRTLibrary.path_to_library_cache.clear()
+    CudaRTLibrary.path_to_dict_mapping.clear()
+
+
+def test_auto_cudart_resolution_skips_stub_without_required_symbols():
+    _clear_cudart_cache()
+    maps = "\n".join(
+        [
+            "7f000000-7f001000 r-xp 00000000 00:00 0 /pkg/tilelang/lib/libcudart_stub.so",
+            "7f010000-7f011000 r-xp 00000000 00:00 0 /usr/local/cuda/lib64/libcudart.so.13",
+        ]
+    )
+    libraries = {
+        "/pkg/tilelang/lib/libcudart_stub.so": _FakeCudart(),
+        "/usr/local/cuda/lib64/libcudart.so.13": _FakeFullCudart(),
+    }
+
+    with (
+        mock.patch("builtins.open", mock.mock_open(read_data=maps)),
+        mock.patch("ctypes.CDLL", side_effect=lambda path: libraries[path]) as cdll,
+    ):
+        cudart = CudaRTLibrary()
+
+    assert cudart.lib is libraries["/usr/local/cuda/lib64/libcudart.so.13"]
+    assert [call.args[0] for call in cdll.call_args_list] == [
+        "/pkg/tilelang/lib/libcudart_stub.so",
+        "/usr/local/cuda/lib64/libcudart.so.13",
+    ]
+    assert (
+        "/pkg/tilelang/lib/libcudart_stub.so" not in CudaRTLibrary.path_to_library_cache
+    )
+    assert (
+        "/pkg/tilelang/lib/libcudart_stub.so" not in CudaRTLibrary.path_to_dict_mapping
+    )
+
+
+def test_explicit_cudart_path_still_requires_exported_symbols():
+    _clear_cudart_cache()
+    stub_path = "/pkg/tilelang/lib/libcudart_stub.so"
+    with (
+        mock.patch("ctypes.CDLL", return_value=_FakeCudart()),
+        pytest.raises(AttributeError, match="cudaDeviceReset"),
+    ):
+        CudaRTLibrary(stub_path)
+
+    assert stub_path not in CudaRTLibrary.path_to_library_cache
+    assert stub_path not in CudaRTLibrary.path_to_dict_mapping


### PR DESCRIPTION
## Summary

Fixes #3676.

`CudaRTLibrary()` previously resolved `libcudart` by taking the first `/proc/self/maps` entry whose filename matched `libcudart*`. That can select a co-loaded stub such as `tilelang/lib/libcudart_stub.so`, which has the right filename shape but does not export the CUDA runtime symbols FlashInfer needs. Importing or constructing `flashinfer.comm.CudaRTLibrary` then fails before it can reach the real CUDA runtime.

This change keeps explicit `so_file` handling strict, but makes automatic discovery try every loaded `libcudart*` candidate and accept the first one that exports the required CUDA runtime functions.

## Tests

- `PYTHONPYCACHEPREFIX=/private/tmp/flashinfer-pycache /usr/bin/python3 -m py_compile flashinfer/comm/cuda_ipc.py tests/comm/test_cuda_ipc_cudart_resolution.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/flashinfer-pycache /usr/bin/python3 -m pytest --noconftest -q tests/comm/test_cuda_ipc_cudart_resolution.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-flashinfer UV_TOOL_DIR=/private/tmp/uv-tools-flashinfer uvx ruff check flashinfer/comm/cuda_ipc.py tests/comm/test_cuda_ipc_cudart_resolution.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-flashinfer UV_TOOL_DIR=/private/tmp/uv-tools-flashinfer uvx ruff format --check flashinfer/comm/cuda_ipc.py tests/comm/test_cuda_ipc_cudart_resolution.py`
- `git diff --check`

Note: the focused pytest uses `--noconftest` locally because this machine does not have `tvm_ffi`, and the repository-wide `tests/conftest.py` imports the full FlashInfer JIT stack. The added test directly loads `flashinfer/comm/cuda_ipc.py` and only exercises the host-side cudart resolution logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved CUDA runtime library discovery and dynamic loading to reliably pick a compatible `cudart` when multiple candidates exist, ensuring required exports are present before use.

* **Tests**
  * Added automated coverage for CUDA runtime resolution, verifying that auto-selection prefers a valid library over stubs missing required symbols, and that explicit paths fail when symbols are absent (without caching incompatible results).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->