### PR TITLE
Yanqinz/autotuner tactic

### DIFF
--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -487,8 +487,8 @@ class FakeTensor:
 class TunableRunner(ABC):
     @abstractmethod
     def get_valid_tactics(
-        self, inputs: list[torch.Tensor], profile: OptimizationProfile
-    ) -> list[int]:
+        self, inputs: List[torch.Tensor], profile: OptimizationProfile
+    ) -> List[Any]:
         """One tactic corresponding to one cuda kernel normally, but how to interpret the meaning
         of tactic is pure internal details of the runner.
 
@@ -527,8 +527,8 @@ class TunableRunner(ABC):
     @abstractmethod
     def forward(
         self,
-        inputs: list[torch.Tensor],
-        tactic: int = -1,
+        inputs: List[torch.Tensor],
+        tactic: Any = -1,
         do_preparation: bool = False,
         **kwargs,  # all others are keyword args only
     ) -> Any:
@@ -1314,7 +1314,7 @@ class AutoTuner:
         tuning_config: TuningConfig,
         inputs: list[torch.Tensor],
         **kwargs,
-    ) -> tuple[TunableRunner, int]:
+    ) -> Tuple[TunableRunner, Any]:
         """Choose the best runner and tactic combination through performance profiling.
 
         Args:
@@ -1325,9 +1325,9 @@ class AutoTuner:
             **kwargs: Arbitrary keyword arguments, will be passed to get_valid_tactics and forward method of each runner
 
         Returns:
-            Tuple[TunableRunner, int]: A tuple containing:
+            Tuple[TunableRunner, Any]: A tuple containing:
                 - The selected runner implementation
-                - The best tactic ID for that runner (-1 if using fallback)
+                - The best tactic for that runner (-1 if using fallback)
 
         Note:
             The method profiles different implementations and tactics to find the

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -2168,13 +2168,31 @@ class AutoTuner:
                 )
                 return False
 
+        skipped_legacy_cudnn_tactics = 0
         with self._lock:
             for key, value in configs.items():
                 runner_name = value[0]
                 tactic = _json_to_tactic(value[1])
+                if (
+                    runner_name.startswith("Cudnn")
+                    and isinstance(tactic, int)
+                    and tactic >= 0
+                ):
+                    skipped_legacy_cudnn_tactics += 1
+                    continue
                 self._file_configs[key] = (runner_name, tactic)
 
-        logger.info(f"[Autotuner]: Loaded {len(configs)} configs from {path}")
+        if skipped_legacy_cudnn_tactics:
+            logger.warning(
+                f"[Autotuner]: Skipped {skipped_legacy_cudnn_tactics} legacy "
+                "cuDNN config(s) using integer plan-index tactics. They will "
+                "be re-tuned when autotuning is enabled."
+            )
+
+        logger.info(
+            f"[Autotuner]: Loaded {len(configs) - skipped_legacy_cudnn_tactics} "
+            f"configs from {path}"
+        )
         return True
 
     def _prepare_input_tensors_with_batches(

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -487,8 +487,8 @@ class FakeTensor:
 class TunableRunner(ABC):
     @abstractmethod
     def get_valid_tactics(
-        self, inputs: List[torch.Tensor], profile: OptimizationProfile
-    ) -> List[Any]:
+        self, inputs: list[torch.Tensor], profile: OptimizationProfile
+    ) -> list[Any]:
         """One tactic corresponding to one cuda kernel normally, but how to interpret the meaning
         of tactic is pure internal details of the runner.
 
@@ -527,7 +527,7 @@ class TunableRunner(ABC):
     @abstractmethod
     def forward(
         self,
-        inputs: List[torch.Tensor],
+        inputs: list[torch.Tensor],
         tactic: Any = -1,
         do_preparation: bool = False,
         **kwargs,  # all others are keyword args only
@@ -1314,7 +1314,7 @@ class AutoTuner:
         tuning_config: TuningConfig,
         inputs: list[torch.Tensor],
         **kwargs,
-    ) -> Tuple[TunableRunner, Any]:
+    ) -> tuple[TunableRunner, Any]:
         """Choose the best runner and tactic combination through performance profiling.
 
         Args:

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2300,8 +2300,6 @@ def _cudnn_bf16_gemm_usable_or_skip(
 
 def _is_cublas_fp4_available_in_cudnn():
     """Check if cuBLAS backend for FP4 GEMM is available in cuDNN."""
-
-    # Check cuDNN backend version for FP4 support (requires cudnn_version == 9.11.1 or cudnn_version >= 9.13)
     backend_version = cudnn.backend_version()
     CUDNN_VERSION_9_11_1 = 91101
     CUDNN_VERSION_9_13_0 = 91300
@@ -2315,71 +2313,49 @@ def _check_cudnn_override_shape_availability():
     """Raise if the installed cuDNN backend does not support is_override_shape_enabled."""
     _check_cudnn_availability()
     backend_version = cudnn.backend_version()
-    if backend_version < 92100:
+    if backend_version < 92301:
         raise RuntimeError(
-            f"cuDNN override-shape GEMM requires backend version >= 92100 (9.21.0), "
+            f"cuDNN override-shape GEMM requires backend version >= 92301 (9.23.1), "
             f"found {backend_version}. "
             f"Please upgrade cuDNN: pip install --upgrade nvidia-cudnn-cu12 nvidia-cudnn-frontend"
         )
-    try:
-        version_str = cudnn.__version__
-        major, minor = map(int, version_str.split(".")[:2])
-        required_frontend_version = (1, 24) if backend_version >= 92300 else (1, 20)
-        if (major, minor) < required_frontend_version:
-            raise RuntimeError(
-                f"cuDNN override-shape GEMM requires cudnn-frontend version >= "
-                f"{required_frontend_version[0]}.{required_frontend_version[1]}, found {version_str}. "
-                f"Please upgrade: pip install --upgrade nvidia-cudnn-frontend"
-            )
-    except (AttributeError, ValueError, IndexError) as e:
-        raise RuntimeError(
-            "Unable to determine cudnn-frontend version. "
-            "Override-shape GEMM requires cudnn-frontend >= 1.20, or >= 1.24 with cuDNN backend >= 9.23.0"
-        ) from e
 
 
 def _is_cudnn_override_shape_available() -> bool:
     """Return True if the installed cuDNN backend supports is_override_shape_enabled."""
     if not CUDNN_AVAILABLE:
         return False
-    try:
-        backend_version = cudnn.backend_version()
-        if backend_version < 92100:
-            return False
-        version_str = cudnn.__version__
-        major, minor = map(int, version_str.split(".")[:2])
-        required_frontend_version = (1, 24) if backend_version >= 92300 else (1, 20)
-        return (major, minor) >= required_frontend_version
-    except Exception:
+    if cudnn.backend_version() < 92301:
         return False
+    return True
 
 
-def _get_cudnn_workspace_size(graph, tactic: int) -> int:
-    if tactic < 0:
+def _get_cudnn_workspace_size(graph, plan_index: int) -> int:
+    if plan_index < 0:
         return graph.get_workspace_size()
-    return graph.get_workspace_size_plan_at_index(tactic)
+    return graph.get_workspace_size_plan_at_index(plan_index)
 
 
 def _get_cudnn_override_shape_workspace_size(
     graph,
-    tactic: int,
+    plan_index: int,
     cudnn_handle,
     override_uids,
     override_shapes,
     override_strides,
 ) -> int:
     if cudnn.backend_version() >= 92300:
-        if tactic < 0:
+        if plan_index < 0:
             return graph.get_workspace_size(
                 cudnn_handle, override_uids, override_shapes, override_strides
             )
         return graph.get_workspace_size_plan_at_index(
-            tactic, cudnn_handle, override_uids, override_shapes, override_strides
+            plan_index, cudnn_handle, override_uids, override_shapes, override_strides
         )
     else:
-        if tactic < 0:
+        if plan_index < 0:
             return graph.get_workspace_size()
-        return graph.get_workspace_size_plan_at_index(tactic)
+        return graph.get_workspace_size_plan_at_index(plan_index)
 
 
 def _cudnn_graph_engine_knob_tactics(graph) -> List[tuple]:

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -3728,11 +3728,9 @@ def build_cudnn_gemm_bf16_graph(
     bias_is_not_none,
     bias_shape,
     bias_stride,
-    policy=None,
+    tactic=-1,
 ):
     _check_cudnn_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     stream = torch.cuda.current_stream(device)
     with cudnn.graph(_get_cudnn_handle(device, stream)) as (graph, _):
@@ -3774,16 +3772,29 @@ def build_cudnn_gemm_bf16_graph(
 
         graph.validate()
         graph.build_operation_graph()
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        if _is_cudnn_engine_knob_tactic(tactic):
+            engine_id, knob_items = tactic
+            graph.create_execution_plan(
+                int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+            )
+            policy = None
+        else:
+            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+            policy = (
+                cudnn.build_plan_policy.HEURISTICS_CHOICE
+                if tactic < 0
+                else cudnn.build_plan_policy.ALL
+            )
         graph.check_support()
-        graph.build_plans(policy)
+        if policy is None:
+            graph.build_plans()
+        else:
+            graph.build_plans(policy)
 
         return graph
 
 
-def execute_cudnn_gemm_bf16_graph(
-    graph, a, b, bias, c_final, workspace, tactic: int = -1
-):
+def execute_cudnn_gemm_bf16_graph(graph, a, b, bias, c_final, workspace, tactic=-1):
     if bias is not None:
         variant_pack = {
             UIDs.A_UID.value: a,
@@ -3801,15 +3812,55 @@ def execute_cudnn_gemm_bf16_graph(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    workspace_size = _get_cudnn_workspace_size(graph, tactic)
+    if _is_cudnn_engine_knob_tactic(tactic):
+        target_engine_id, target_knob_items = tactic
+        target_tactic = (
+            int(target_engine_id),
+            tuple(
+                (int(knob_type), int(value)) for knob_type, value in target_knob_items
+            ),
+        )
+        plan_index = -1
+        for candidate_plan_index in range(graph.get_execution_plan_count()):
+            try:
+                engine_id, knobs = graph.get_engine_and_knobs_at_index(
+                    candidate_plan_index
+                )
+            except (AttributeError, RuntimeError):
+                continue
+            candidate_tactic = (
+                int(engine_id),
+                tuple(
+                    sorted(
+                        (int(knob_type), int(value))
+                        for knob_type, value in knobs.items()
+                    )
+                ),
+            )
+            if candidate_tactic == target_tactic:
+                plan_index = candidate_plan_index
+                break
+        if plan_index < 0:
+            warnings.warn(
+                "cuDNN bf16 GEMM engine/knob tactic did not match any built "
+                "execution plan; falling back to default tactic=-1.",
+                stacklevel=2,
+            )
+    else:
+        plan_index = tactic
+
+    if plan_index >= graph.get_execution_plan_count():
+        plan_index = -1
+
+    workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace.numel() < workspace_size:
         workspace.resize_(workspace_size)
 
-    if tactic == -1:
+    if plan_index < 0:
         graph.execute(variant_pack, workspace, handle=cudnn_handle)
     else:
         graph.execute_plan_at_index(
-            variant_pack, workspace, tactic, handle=cudnn_handle
+            variant_pack, workspace, plan_index, handle=cudnn_handle
         )
 
 
@@ -3829,7 +3880,7 @@ def build_cudnn_gemm_bf16_graph_override_shape(
     cache_m: int = _OVERRIDE_SHAPE_CACHE_M,
     is_a_k_major: bool = True,
     is_b_k_major: bool = True,
-    policy=None,
+    tactic=-1,
 ):
     """Build a cuDNN BF16 GEMM graph with override-shape support.
 
@@ -3845,8 +3896,6 @@ def build_cudnn_gemm_bf16_graph_override_shape(
             If False, B is row-major with K-contiguous layout (stride along K is 1).
     """
     _check_cudnn_override_shape_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     a_shape = (batch, cache_m, k)
     a_stride = (cache_m * k, k, 1) if is_a_k_major else (cache_m * k, 1, cache_m)
@@ -3908,9 +3957,24 @@ def build_cudnn_gemm_bf16_graph_override_shape(
 
     graph.validate()
     graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+    if _is_cudnn_engine_knob_tactic(tactic):
+        engine_id, knob_items = tactic
+        graph.create_execution_plan(
+            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+        )
+        policy = None
+    else:
+        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        policy = (
+            cudnn.build_plan_policy.HEURISTICS_CHOICE
+            if tactic < 0
+            else cudnn.build_plan_policy.ALL
+        )
     graph.check_support()
-    graph.build_plans(policy)
+    if policy is None:
+        graph.build_plans()
+    else:
+        graph.build_plans(policy)
 
     return graph
 
@@ -3918,7 +3982,7 @@ def build_cudnn_gemm_bf16_graph_override_shape(
 # Internal helper called from mm_bf16; the user-facing mm_bf16 is already
 # decorated, so decorating here would double-log the same invocation.
 def execute_cudnn_gemm_bf16_graph_override_shape(
-    graph, a, b, bias, c_final, workspace, tactic: int = 0
+    graph, a, b, bias, c_final, workspace, tactic=-1
 ):
     """Execute a BF16 GEMM cuDNN graph built with override-shape enabled.
 
@@ -3972,21 +4036,76 @@ def execute_cudnn_gemm_bf16_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
+    if _is_cudnn_engine_knob_tactic(tactic):
+        target_engine_id, target_knob_items = tactic
+        target_tactic = (
+            int(target_engine_id),
+            tuple(
+                (int(knob_type), int(value)) for knob_type, value in target_knob_items
+            ),
+        )
+        plan_index = -1
+        for candidate_plan_index in range(graph.get_execution_plan_count()):
+            try:
+                engine_id, knobs = graph.get_engine_and_knobs_at_index(
+                    candidate_plan_index
+                )
+            except (AttributeError, RuntimeError):
+                continue
+            candidate_tactic = (
+                int(engine_id),
+                tuple(
+                    sorted(
+                        (int(knob_type), int(value))
+                        for knob_type, value in knobs.items()
+                    )
+                ),
+            )
+            if candidate_tactic == target_tactic:
+                plan_index = candidate_plan_index
+                break
+        if plan_index < 0:
+            warnings.warn(
+                "cuDNN bf16 GEMM engine/knob tactic did not match any built "
+                "override-shape execution plan; falling back to default tactic=-1.",
+                stacklevel=2,
+            )
+    else:
+        plan_index = tactic
+
+    if plan_index >= graph.get_execution_plan_count():
+        plan_index = -1
+
     workspace_size = _get_cudnn_override_shape_workspace_size(
-        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+        graph,
+        plan_index,
+        cudnn_handle,
+        override_uids,
+        override_shapes,
+        override_strides,
     )
     if workspace.numel() < workspace_size:
         workspace.resize_(workspace_size)
 
-    graph.execute_plan_at_index(
-        variant_pack,
-        workspace,
-        tactic,
-        handle=cudnn_handle,
-        override_uids=override_uids,
-        override_shapes=override_shapes,
-        override_strides=override_strides,
-    )
+    if plan_index < 0:
+        graph.execute(
+            variant_pack,
+            workspace,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
+    else:
+        graph.execute_plan_at_index(
+            variant_pack,
+            workspace,
+            plan_index,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
 
 
 def _cudnn_gemm_bf16(
@@ -3995,7 +4114,7 @@ def _cudnn_gemm_bf16(
     b: torch.Tensor,
     bias: torch.Tensor,
     out: torch.Tensor,
-    tactic: int = -1,
+    tactic=-1,
 ):
     _check_cudnn_availability()
 
@@ -4009,11 +4128,6 @@ def _cudnn_gemm_bf16(
         bias_shape = (1, 1, 1)
         bias_stride = (1, 1, 1)
 
-    if tactic == -1:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
-    else:
-        policy = cudnn.build_plan_policy.ALL
-
     graph = build_cudnn_gemm_bf16_graph(
         a_shape,
         a_stride,
@@ -4024,7 +4138,7 @@ def _cudnn_gemm_bf16(
         bias is not None,
         bias_shape,
         bias_stride,
-        policy=policy,
+        tactic=tactic,
     )
 
     execute_cudnn_gemm_bf16_graph(graph, a, b, bias, out, workspace, tactic=tactic)
@@ -4077,7 +4191,7 @@ def _cudnn_gemm_bf16_runner(
             self._is_b_k_major = True if is_b_k_major is None else is_b_k_major
             self._use_override_shape = _is_cudnn_override_shape_available()
 
-        def _get_override_graph(self, a, b, bias, out):
+        def _get_override_graph(self, a, b, bias, out, tactic=-1):
             a_shape, _ = _get_bf16_3d_shape_stride(a)
             b_shape, _ = _get_bf16_3d_shape_stride(b)
 
@@ -4109,7 +4223,10 @@ def _cudnn_gemm_bf16_runner(
                 cache_m=cache_m,
                 is_a_k_major=self._is_a_k_major,
                 is_b_k_major=self._is_b_k_major,
-                policy=cudnn.build_plan_policy.ALL,
+                # tactic value only be 0 or -1 to hit the graph cache
+                tactic=(
+                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
+                ),
             )
             return graph
 
@@ -4123,11 +4240,11 @@ def _cudnn_gemm_bf16_runner(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> List[tuple]:
             a, b, bias, _, out, _ = inputs
 
             if self._use_override_shape:
-                graph = self._get_override_graph(a, b, bias, out)
+                graph = self._get_override_graph(a, b, bias, out, tactic=0)
             else:
                 a_shape, a_stride = _get_bf16_3d_shape_stride(a)
                 b_shape, b_stride = _get_bf16_3d_shape_stride(b)
@@ -4148,33 +4265,41 @@ def _cudnn_gemm_bf16_runner(
                     bias is not None,
                     bias_shape,
                     bias_stride,
-                    policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
+                    tactic=0,
                 )
 
-            return list(range(graph.get_execution_plan_count()))
+            return _cudnn_graph_engine_knob_tactics(graph)
 
         def forward(
             self,
             inputs: List[torch.Tensor],
-            tactic: int = -1,
+            tactic=-1,
             do_preparation: bool = False,
             **kwargs,
         ) -> torch.Tensor:
             a, b, bias, _, out, workspace_buffer = inputs
 
-            if self._use_override_shape:
-                graph = self._get_override_graph(a, b, bias, out)
+            try:
+                if self._use_override_shape:
+                    graph = self._get_override_graph(a, b, bias, out, tactic=tactic)
 
-                execute_cudnn_gemm_bf16_graph_override_shape(
-                    graph,
-                    a,
-                    b,
-                    bias,
-                    out,
-                    workspace_buffer,
-                    tactic=max(tactic, 0),
+                    execute_cudnn_gemm_bf16_graph_override_shape(
+                        graph,
+                        a,
+                        b,
+                        bias,
+                        out,
+                        workspace_buffer,
+                        tactic=tactic,
+                    )
+                else:
+                    _cudnn_gemm_bf16(workspace_buffer, a, b, bias, out, tactic=tactic)
+            except Exception as exc:
+                warnings.warn(
+                    "cuDNN bf16 GEMM tactic failed; falling back to default "
+                    f"tactic=-1. ({exc})",
+                    stacklevel=2,
                 )
-            else:
                 _cudnn_gemm_bf16(workspace_buffer, a, b, bias, out, tactic=-1)
 
             return out

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2452,6 +2452,35 @@ def _get_cudnn_plan_index_for_tactic(graph, tactic) -> int:
     return plan_index
 
 
+def _finalize_cudnn_graph_for_tactic(
+    graph, tactic, heur_modes, deselect_eng0: bool = False
+) -> None:
+    graph.validate()
+    graph.build_operation_graph()
+
+    if _is_cudnn_engine_knob_tactic(tactic):
+        engine_id, knob_items = tactic
+        graph.create_execution_plan(
+            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+        )
+        policy = None
+    else:
+        graph.create_execution_plans(heur_modes)
+        policy = (
+            cudnn.build_plan_policy.HEURISTICS_CHOICE
+            if tactic < 0
+            else cudnn.build_plan_policy.ALL
+        )
+        if deselect_eng0:
+            graph.deselect_engines(["eng0"])
+
+    graph.check_support()
+    if policy is None:
+        graph.build_plans()
+    else:
+        graph.build_plans(policy)
+
+
 def clear_cudnn_graph_cache() -> None:
     """Invalidate all process-local cuDNN GEMM graph caches **and** the
     AutoTuner profiling cache.
@@ -2652,32 +2681,12 @@ def build_cudnn_gemm_fp4_graph(
         block_descale_b_cudnn_tensor.set_uid(UIDs.BLOCK_DESCALE_B_UID.value)
         c_final_cudnn_tensor.set_uid(UIDs.O_UID.value)
 
-        graph.validate()
-        graph.build_operation_graph()
-        if _is_cudnn_engine_knob_tactic(tactic):
-            engine_id, knob_items = tactic
-            graph.create_execution_plan(
-                int(engine_id), _cudnn_knob_items_to_dict(knob_items)
-            )
-            policy = None
-        else:
-            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-            policy = (
-                cudnn.build_plan_policy.HEURISTICS_CHOICE
-                if tactic < 0
-                else cudnn.build_plan_policy.ALL
-            )
-
-        # WAR: The alpha (contains the global scale) is not supported by the cuBLAS backend (eng0)
-        # in older cuDNN versions, so we deselect it.
-        if (alpha_is_not_none) and (not _is_cublas_fp4_available_in_cudnn()):
-            graph.deselect_engines(["eng0"])
-
-        graph.check_support()
-        if policy is None:
-            graph.build_plans()
-        else:
-            graph.build_plans(policy)
+        _finalize_cudnn_graph_for_tactic(
+            graph,
+            tactic,
+            [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK],
+            deselect_eng0=alpha_is_not_none and not _is_cublas_fp4_available_in_cudnn(),
+        )
 
         return graph
 
@@ -2856,27 +2865,9 @@ def build_cudnn_gemm_fp4_graph_override_shape(
     block_descale_b_cudnn_tensor.set_uid(UIDs.BLOCK_DESCALE_B_UID.value)
     c_final_cudnn_tensor.set_uid(UIDs.O_UID.value)
 
-    graph.validate()
-    graph.build_operation_graph()
-    if _is_cudnn_engine_knob_tactic(tactic):
-        engine_id, knob_items = tactic
-        graph.create_execution_plan(
-            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
-        )
-        policy = None
-    else:
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-        policy = (
-            cudnn.build_plan_policy.HEURISTICS_CHOICE
-            if tactic < 0
-            else cudnn.build_plan_policy.ALL
-        )
-
-    graph.check_support()
-    if policy is None:
-        graph.build_plans()
-    else:
-        graph.build_plans(policy)
+    _finalize_cudnn_graph_for_tactic(
+        graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+    )
 
     return graph
 
@@ -3126,26 +3117,9 @@ def build_cudnn_gemm_mxfp8_graph_override_shape(
     block_descale_b_cudnn_tensor.set_uid(UIDs.BLOCK_DESCALE_B_UID.value)
     c_tensor.set_uid(UIDs.O_UID.value)
 
-    graph.validate()
-    graph.build_operation_graph()
-    if _is_cudnn_engine_knob_tactic(tactic):
-        engine_id, knob_items = tactic
-        graph.create_execution_plan(
-            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
-        )
-        policy = None
-    else:
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-        policy = (
-            cudnn.build_plan_policy.HEURISTICS_CHOICE
-            if tactic < 0
-            else cudnn.build_plan_policy.ALL
-        )
-    graph.check_support()
-    if policy is None:
-        graph.build_plans()
-    else:
-        graph.build_plans(policy)
+    _finalize_cudnn_graph_for_tactic(
+        graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+    )
 
     return graph
 
@@ -3334,26 +3308,9 @@ def build_cudnn_gemm_fp8_graph(
         b_scale_cudnn_tensor.set_uid(UIDs.B_SCALE_UID.value)
         c_after_scale_b_cudnn_tensor.set_uid(UIDs.O_UID.value)
 
-        graph.validate()
-        graph.build_operation_graph()
-        if _is_cudnn_engine_knob_tactic(tactic):
-            engine_id, knob_items = tactic
-            graph.create_execution_plan(
-                int(engine_id), _cudnn_knob_items_to_dict(knob_items)
-            )
-            policy = None
-        else:
-            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-            policy = (
-                cudnn.build_plan_policy.HEURISTICS_CHOICE
-                if tactic < 0
-                else cudnn.build_plan_policy.ALL
-            )
-        graph.check_support()
-        if policy is None:
-            graph.build_plans()
-        else:
-            graph.build_plans(policy)
+        _finalize_cudnn_graph_for_tactic(
+            graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+        )
 
         return graph
 
@@ -3471,26 +3428,9 @@ def build_cudnn_gemm_fp8_graph_override_shape(
     b_scale_cudnn_tensor.set_uid(UIDs.B_SCALE_UID.value)
     c_after_scale_b.set_uid(UIDs.O_UID.value)
 
-    graph.validate()
-    graph.build_operation_graph()
-    if _is_cudnn_engine_knob_tactic(tactic):
-        engine_id, knob_items = tactic
-        graph.create_execution_plan(
-            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
-        )
-        policy = None
-    else:
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-        policy = (
-            cudnn.build_plan_policy.HEURISTICS_CHOICE
-            if tactic < 0
-            else cudnn.build_plan_policy.ALL
-        )
-    graph.check_support()
-    if policy is None:
-        graph.build_plans()
-    else:
-        graph.build_plans(policy)
+    _finalize_cudnn_graph_for_tactic(
+        graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+    )
 
     return graph
 
@@ -3807,26 +3747,9 @@ def build_cudnn_gemm_bf16_graph(
         b_cudnn_tensor.set_uid(UIDs.B_UID.value)
         c_final_cudnn_tensor.set_uid(UIDs.O_UID.value)
 
-        graph.validate()
-        graph.build_operation_graph()
-        if _is_cudnn_engine_knob_tactic(tactic):
-            engine_id, knob_items = tactic
-            graph.create_execution_plan(
-                int(engine_id), _cudnn_knob_items_to_dict(knob_items)
-            )
-            policy = None
-        else:
-            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-            policy = (
-                cudnn.build_plan_policy.HEURISTICS_CHOICE
-                if tactic < 0
-                else cudnn.build_plan_policy.ALL
-            )
-        graph.check_support()
-        if policy is None:
-            graph.build_plans()
-        else:
-            graph.build_plans(policy)
+        _finalize_cudnn_graph_for_tactic(
+            graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+        )
 
         return graph
 
@@ -3954,26 +3877,9 @@ def build_cudnn_gemm_bf16_graph_override_shape(
     b_cudnn_tensor.set_uid(UIDs.B_UID.value)
     c_final_cudnn_tensor.set_uid(UIDs.O_UID.value)
 
-    graph.validate()
-    graph.build_operation_graph()
-    if _is_cudnn_engine_knob_tactic(tactic):
-        engine_id, knob_items = tactic
-        graph.create_execution_plan(
-            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
-        )
-        policy = None
-    else:
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-        policy = (
-            cudnn.build_plan_policy.HEURISTICS_CHOICE
-            if tactic < 0
-            else cudnn.build_plan_policy.ALL
-        )
-    graph.check_support()
-    if policy is None:
-        graph.build_plans()
-    else:
-        graph.build_plans(policy)
+    _finalize_cudnn_graph_for_tactic(
+        graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+    )
 
     return graph
 
@@ -9010,26 +8916,9 @@ def build_cudnn_gemm_mxfp8_graph(
         block_descale_b_cudnn_tensor.set_uid(UIDs.BLOCK_DESCALE_B_UID.value)
         c_final_cudnn_tensor.set_uid(UIDs.O_UID.value)
 
-        graph.validate()
-        graph.build_operation_graph()
-        if _is_cudnn_engine_knob_tactic(tactic):
-            engine_id, knob_items = tactic
-            graph.create_execution_plan(
-                int(engine_id), _cudnn_knob_items_to_dict(knob_items)
-            )
-            policy = None
-        else:
-            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-            policy = (
-                cudnn.build_plan_policy.HEURISTICS_CHOICE
-                if tactic < 0
-                else cudnn.build_plan_policy.ALL
-            )
-        graph.check_support()
-        if policy is None:
-            graph.build_plans()
-        else:
-            graph.build_plans(policy)
+        _finalize_cudnn_graph_for_tactic(
+            graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+        )
 
         return graph
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2406,6 +2406,52 @@ def _cudnn_knob_items_to_dict(knob_items) -> dict:
     }
 
 
+def _get_cudnn_plan_index_for_tactic(graph, tactic) -> int:
+    if _is_cudnn_engine_knob_tactic(tactic):
+        target_engine_id, target_knob_items = tactic
+        target_tactic = (
+            int(target_engine_id),
+            tuple(
+                sorted(
+                    (int(knob_type), int(value))
+                    for knob_type, value in target_knob_items
+                )
+            ),
+        )
+        plan_index = -1
+        for candidate_plan_index in range(graph.get_execution_plan_count()):
+            try:
+                engine_id, knobs = graph.get_engine_and_knobs_at_index(
+                    candidate_plan_index
+                )
+            except (AttributeError, RuntimeError):
+                continue
+            candidate_tactic = (
+                int(engine_id),
+                tuple(
+                    sorted(
+                        (int(knob_type), int(value))
+                        for knob_type, value in knobs.items()
+                    )
+                ),
+            )
+            if candidate_tactic == target_tactic:
+                plan_index = candidate_plan_index
+                break
+        if plan_index < 0:
+            warnings.warn(
+                "cuDNN GEMM engine/knob tactic did not match any built execution "
+                "plan; falling back to default tactic=-1.",
+                stacklevel=3,
+            )
+    else:
+        plan_index = tactic
+
+    if plan_index >= graph.get_execution_plan_count():
+        plan_index = -1
+    return plan_index
+
+
 def clear_cudnn_graph_cache() -> None:
     """Invalidate all process-local cuDNN GEMM graph caches **and** the
     AutoTuner profiling cache.
@@ -2530,11 +2576,9 @@ def build_cudnn_gemm_fp4_graph(
     device,
     alpha_is_not_none,
     use_nvfp4,
-    policy=None,
+    tactic=-1,
 ):
     _check_cudnn_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     stream = torch.cuda.current_stream(device)
     with cudnn.graph(_get_cudnn_handle(device, stream)) as (graph, _):
@@ -2610,15 +2654,25 @@ def build_cudnn_gemm_fp4_graph(
 
         graph.validate()
         graph.build_operation_graph()
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.B])
-
-        # WAR: The alpha (contains the global scale) is not supported by the cuBLAS backend (eng0)
-        # in older cuDNN versions, so we deselect it.
-        if (alpha_is_not_none) and (not _is_cublas_fp4_available_in_cudnn()):
-            graph.deselect_engines(["eng0"])
+        if _is_cudnn_engine_knob_tactic(tactic):
+            engine_id, knob_items = tactic
+            graph.create_execution_plan(
+                int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+            )
+            policy = None
+        else:
+            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+            policy = (
+                cudnn.build_plan_policy.HEURISTICS_CHOICE
+                if tactic < 0
+                else cudnn.build_plan_policy.ALL
+            )
 
         graph.check_support()
-        graph.build_plans(policy)
+        if policy is None:
+            graph.build_plans()
+        else:
+            graph.build_plans(policy)
 
         return graph
 
@@ -2632,7 +2686,7 @@ def execute_cudnn_gemm_fp4_graph(
     alpha,
     c_final,
     workspace_buffer,
-    tactic: int = -1,
+    tactic=-1,
 ):
     variant_pack = {
         UIDs.A_UID.value: a.view(get_native_fp4_dtype()),
@@ -2645,20 +2699,15 @@ def execute_cudnn_gemm_fp4_graph(
     if alpha is not None:
         variant_pack[UIDs.ALPHA_UID.value] = alpha.view(torch.float)
 
-    # This (non-override) graph is built at the real shape, whereas the tactic
-    # was tuned against a possibly different (bucketed) M whose plan list can
-    # differ in length. If the index is out of range, fall back to the
-    # heuristic default rather than letting execute_plan_at_index raise.
-    if tactic >= graph.get_execution_plan_count():
-        tactic = -1
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
 
-    workspace_size = _get_cudnn_workspace_size(graph, tactic)
+    workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace_buffer.numel() < workspace_size:
         workspace_buffer.resize_(workspace_size)
 
     stream = torch.cuda.current_stream(a.device)
 
-    if tactic == -1:
+    if plan_index < 0:
         graph.execute(
             variant_pack, workspace_buffer, handle=_get_cudnn_handle(a.device, stream)
         )
@@ -2666,7 +2715,7 @@ def execute_cudnn_gemm_fp4_graph(
         graph.execute_plan_at_index(
             variant_pack,
             workspace_buffer,
-            tactic,
+            plan_index,
             handle=_get_cudnn_handle(a.device, stream),
         )
 
@@ -2693,7 +2742,7 @@ def build_cudnn_gemm_fp4_graph_override_shape(
     alpha_is_not_none,
     use_nvfp4,
     cache_m: int = _OVERRIDE_SHAPE_CACHE_M,
-    policy=None,
+    tactic=-1,
 ):
     """Build a cuDNN FP4 GEMM graph with override-shape support.
 
@@ -2706,8 +2755,6 @@ def build_cudnn_gemm_fp4_graph_override_shape(
     """
 
     _check_cudnn_override_shape_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     scale_type = cudnn.data_type.FP8_E4M3 if use_nvfp4 else cudnn.data_type.FP8_E8M0
 
@@ -2806,13 +2853,25 @@ def build_cudnn_gemm_fp4_graph_override_shape(
 
     graph.validate()
     graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.B])
-
-    if alpha_is_not_none and not _is_cublas_fp4_available_in_cudnn():
-        graph.deselect_engines(["eng0"])
+    if _is_cudnn_engine_knob_tactic(tactic):
+        engine_id, knob_items = tactic
+        graph.create_execution_plan(
+            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+        )
+        policy = None
+    else:
+        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        policy = (
+            cudnn.build_plan_policy.HEURISTICS_CHOICE
+            if tactic < 0
+            else cudnn.build_plan_policy.ALL
+        )
 
     graph.check_support()
-    graph.build_plans(policy)
+    if policy is None:
+        graph.build_plans()
+    else:
+        graph.build_plans(policy)
 
     return graph
 
@@ -2828,7 +2887,7 @@ def execute_cudnn_gemm_fp4_graph_override_shape(
     alpha,
     c_final,
     workspace,
-    tactic: int = 0,
+    tactic=-1,
 ):
     """Execute FP4 GEMM cuDNN graph with dynamic-shape overrides."""
 
@@ -2886,21 +2945,38 @@ def execute_cudnn_gemm_fp4_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
+
     workspace_size = _get_cudnn_override_shape_workspace_size(
-        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+        graph,
+        plan_index,
+        cudnn_handle,
+        override_uids,
+        override_shapes,
+        override_strides,
     )
     if workspace.numel() < workspace_size:
         workspace.resize_(workspace_size)
 
-    graph.execute_plan_at_index(
-        variant_pack,
-        workspace,
-        tactic,
-        handle=cudnn_handle,
-        override_uids=override_uids,
-        override_shapes=override_shapes,
-        override_strides=override_strides,
-    )
+    if plan_index < 0:
+        graph.execute(
+            variant_pack,
+            workspace,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
+    else:
+        graph.execute_plan_at_index(
+            variant_pack,
+            workspace,
+            plan_index,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
 
 
 def execute_cudnn_gemm_mxfp8_graph(
@@ -3266,45 +3342,7 @@ def execute_cudnn_gemm_fp8_graph(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    if _is_cudnn_engine_knob_tactic(tactic):
-        target_engine_id, target_knob_items = tactic
-        target_tactic = (
-            int(target_engine_id),
-            tuple(
-                (int(knob_type), int(value)) for knob_type, value in target_knob_items
-            ),
-        )
-        plan_index = -1
-        for candidate_plan_index in range(graph.get_execution_plan_count()):
-            try:
-                engine_id, knobs = graph.get_engine_and_knobs_at_index(
-                    candidate_plan_index
-                )
-            except (AttributeError, RuntimeError):
-                continue
-            candidate_tactic = (
-                int(engine_id),
-                tuple(
-                    sorted(
-                        (int(knob_type), int(value))
-                        for knob_type, value in knobs.items()
-                    )
-                ),
-            )
-            if candidate_tactic == target_tactic:
-                plan_index = candidate_plan_index
-                break
-        if plan_index < 0:
-            warnings.warn(
-                "cuDNN fp8 GEMM engine/knob tactic did not match any built "
-                "execution plan; falling back to default tactic=-1.",
-                stacklevel=2,
-            )
-    else:
-        plan_index = tactic
-
-    if plan_index >= graph.get_execution_plan_count():
-        plan_index = -1
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace.numel() < workspace_size:
@@ -3453,45 +3491,7 @@ def execute_cudnn_gemm_fp8_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    if _is_cudnn_engine_knob_tactic(tactic):
-        target_engine_id, target_knob_items = tactic
-        target_tactic = (
-            int(target_engine_id),
-            tuple(
-                (int(knob_type), int(value)) for knob_type, value in target_knob_items
-            ),
-        )
-        plan_index = -1
-        for candidate_plan_index in range(graph.get_execution_plan_count()):
-            try:
-                engine_id, knobs = graph.get_engine_and_knobs_at_index(
-                    candidate_plan_index
-                )
-            except (AttributeError, RuntimeError):
-                continue
-            candidate_tactic = (
-                int(engine_id),
-                tuple(
-                    sorted(
-                        (int(knob_type), int(value))
-                        for knob_type, value in knobs.items()
-                    )
-                ),
-            )
-            if candidate_tactic == target_tactic:
-                plan_index = candidate_plan_index
-                break
-        if plan_index < 0:
-            warnings.warn(
-                "cuDNN fp8 GEMM engine/knob tactic did not match any built "
-                "override-shape execution plan; falling back to default tactic=-1.",
-                stacklevel=2,
-            )
-    else:
-        plan_index = tactic
-
-    if plan_index >= graph.get_execution_plan_count():
-        plan_index = -1
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
 
     workspace_size = _get_cudnn_override_shape_workspace_size(
         graph,
@@ -3812,45 +3812,7 @@ def execute_cudnn_gemm_bf16_graph(graph, a, b, bias, c_final, workspace, tactic=
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    if _is_cudnn_engine_knob_tactic(tactic):
-        target_engine_id, target_knob_items = tactic
-        target_tactic = (
-            int(target_engine_id),
-            tuple(
-                (int(knob_type), int(value)) for knob_type, value in target_knob_items
-            ),
-        )
-        plan_index = -1
-        for candidate_plan_index in range(graph.get_execution_plan_count()):
-            try:
-                engine_id, knobs = graph.get_engine_and_knobs_at_index(
-                    candidate_plan_index
-                )
-            except (AttributeError, RuntimeError):
-                continue
-            candidate_tactic = (
-                int(engine_id),
-                tuple(
-                    sorted(
-                        (int(knob_type), int(value))
-                        for knob_type, value in knobs.items()
-                    )
-                ),
-            )
-            if candidate_tactic == target_tactic:
-                plan_index = candidate_plan_index
-                break
-        if plan_index < 0:
-            warnings.warn(
-                "cuDNN bf16 GEMM engine/knob tactic did not match any built "
-                "execution plan; falling back to default tactic=-1.",
-                stacklevel=2,
-            )
-    else:
-        plan_index = tactic
-
-    if plan_index >= graph.get_execution_plan_count():
-        plan_index = -1
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
 
     workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace.numel() < workspace_size:
@@ -4036,45 +3998,7 @@ def execute_cudnn_gemm_bf16_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    if _is_cudnn_engine_knob_tactic(tactic):
-        target_engine_id, target_knob_items = tactic
-        target_tactic = (
-            int(target_engine_id),
-            tuple(
-                (int(knob_type), int(value)) for knob_type, value in target_knob_items
-            ),
-        )
-        plan_index = -1
-        for candidate_plan_index in range(graph.get_execution_plan_count()):
-            try:
-                engine_id, knobs = graph.get_engine_and_knobs_at_index(
-                    candidate_plan_index
-                )
-            except (AttributeError, RuntimeError):
-                continue
-            candidate_tactic = (
-                int(engine_id),
-                tuple(
-                    sorted(
-                        (int(knob_type), int(value))
-                        for knob_type, value in knobs.items()
-                    )
-                ),
-            )
-            if candidate_tactic == target_tactic:
-                plan_index = candidate_plan_index
-                break
-        if plan_index < 0:
-            warnings.warn(
-                "cuDNN bf16 GEMM engine/knob tactic did not match any built "
-                "override-shape execution plan; falling back to default tactic=-1.",
-                stacklevel=2,
-            )
-    else:
-        plan_index = tactic
-
-    if plan_index >= graph.get_execution_plan_count():
-        plan_index = -1
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
 
     workspace_size = _get_cudnn_override_shape_workspace_size(
         graph,
@@ -4282,7 +4206,6 @@ def _cudnn_gemm_bf16_runner(
             try:
                 if self._use_override_shape:
                     graph = self._get_override_graph(a, b, bias, out, tactic=tactic)
-
                     execute_cudnn_gemm_bf16_graph_override_shape(
                         graph,
                         a,
@@ -5552,7 +5475,7 @@ def _cudnn_gemm_fp4(
     block_size: int = 16,
     use_nvfp4: bool = True,
     workspace_buffer: torch.Tensor = None,
-    tactic: int = -1,
+    tactic=-1,
 ):
     _check_cudnn_availability()
 
@@ -5568,11 +5491,6 @@ def _cudnn_gemm_fp4(
     expanded_b_descale_shape, expanded_b_descale_stride = (
         _expand_block_scale_tensor_shape(b_descale, batch)
     )
-
-    if tactic == -1:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
-    else:
-        policy = cudnn.build_plan_policy.ALL
 
     # build the fp4 cudnn graph
     # Constructed graph is cached, via @functools.lru_cache decorator.
@@ -5591,7 +5509,7 @@ def _cudnn_gemm_fp4(
         a.device,
         alpha is not None,
         use_nvfp4,
-        policy=policy,
+        tactic=tactic,
     )
 
     # execute the fp4 cudnn graph
@@ -5640,7 +5558,9 @@ def _cudnn_gemm_fp4_runner(tuning_config):
             self._m_bucket_mapper = m_bucket_mapper
             self._use_override_shape = _is_cudnn_override_shape_available()
 
-        def _get_override_graph(self, a, b, alpha, out_dtype, block_size, use_nvfp4):
+        def _get_override_graph(
+            self, a, b, alpha, out_dtype, block_size, use_nvfp4, tactic=-1
+        ):
             real_a_shape, _ = _get_real_fp4_shape_from_packed_uint8(a)
             real_b_shape, _ = _get_real_fp4_shape_from_packed_uint8(b)
 
@@ -5671,7 +5591,10 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                 alpha_is_not_none=alpha is not None,
                 use_nvfp4=use_nvfp4,
                 cache_m=cache_m,
-                policy=cudnn.build_plan_policy.ALL,
+                # tactic value only be 0 or -1 to hit the graph cache
+                tactic=(
+                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
+                ),
             )
             return graph
 
@@ -5686,7 +5609,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> List[tuple]:
             (
                 a,
                 b,
@@ -5702,7 +5625,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
 
             if self._use_override_shape:
                 graph = self._get_override_graph(
-                    a, b, alpha, out_dtype, block_size, use_nvfp4
+                    a, b, alpha, out_dtype, block_size, use_nvfp4, tactic=0
                 )
             else:
                 real_a_shape, real_a_stride = _get_real_fp4_shape_from_packed_uint8(a)
@@ -5733,15 +5656,15 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                     a.device,
                     alpha is not None,
                     use_nvfp4,
-                    policy=cudnn.build_plan_policy.ALL,
+                    tactic=0,
                 )
 
-            return list(range(graph.get_execution_plan_count()))
+            return _cudnn_graph_engine_knob_tactics(graph)
 
         def forward(
             self,
             inputs: List[torch.Tensor],
-            tactic: int = -1,
+            tactic=-1,
             do_preparation: bool = False,
             **kwargs,
         ) -> torch.Tensor:
@@ -5758,25 +5681,43 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                 workspace_buffer,
             ) = inputs
 
-            if self._use_override_shape:
-                graph = self._get_override_graph(
-                    a, b, alpha, out_dtype, block_size, use_nvfp4
-                )
+            try:
+                if self._use_override_shape:
+                    graph = self._get_override_graph(
+                        a, b, alpha, out_dtype, block_size, use_nvfp4, tactic=tactic
+                    )
 
-                execute_cudnn_gemm_fp4_graph_override_shape(
-                    graph,
-                    a,
-                    b,
-                    a_descale,
-                    b_descale,
-                    alpha,
-                    out,
-                    workspace_buffer,
-                    tactic=max(tactic, 0),
+                    execute_cudnn_gemm_fp4_graph_override_shape(
+                        graph,
+                        a,
+                        b,
+                        a_descale,
+                        b_descale,
+                        alpha,
+                        out,
+                        workspace_buffer,
+                        tactic=tactic,
+                    )
+                else:
+                    _cudnn_gemm_fp4(
+                        a,
+                        b,
+                        a_descale,
+                        b_descale,
+                        alpha,
+                        out_dtype,
+                        out,
+                        block_size,
+                        use_nvfp4,
+                        workspace_buffer,
+                        tactic=tactic,
+                    )
+            except Exception as exc:
+                warnings.warn(
+                    "cuDNN fp4 GEMM tactic failed; falling back to default "
+                    f"tactic=-1. ({exc})",
+                    stacklevel=2,
                 )
-            else:
-                # Apply the tuned tactic. tactic>=0 -> specific plan
-                # (policy=ALL); tactic==-1 -> cheap HEURISTICS_CHOICE default.
                 _cudnn_gemm_fp4(
                     a,
                     b,
@@ -5788,7 +5729,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                     block_size,
                     use_nvfp4,
                     workspace_buffer,
-                    tactic=tactic,
+                    tactic=-1,
                 )
 
             return out

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -15,7 +15,11 @@ limitations under the License.
 """
 
 import functools
+<<<<<<< HEAD
 from collections import defaultdict
+=======
+import logging
+>>>>>>> 1990cae7 (fix_comments)
 from dataclasses import replace
 import warnings
 from enum import Enum
@@ -88,6 +92,8 @@ from ..jit.gemm import gen_fp8_blockscale_gemm_sm90_module
 from ..tllm_enums import DtypeTrtllmGen, SfLayout
 from .routergemm import get_tinygemm2_module
 
+
+logger = logging.getLogger(__name__)
 
 CUDNN_AVAILABLE = False
 try:
@@ -2364,7 +2370,12 @@ def _cudnn_graph_engine_knob_tactics(graph) -> List[tuple]:
     for plan_idx in range(graph.get_execution_plan_count()):
         try:
             engine_id, knobs = graph.get_engine_and_knobs_at_index(plan_idx)
-        except (AttributeError, RuntimeError):
+        except (AttributeError, RuntimeError) as exc:
+            logger.debug(
+                "Skipping plan index %d in cuDNN engine/knob tactic enumeration: %s",
+                plan_idx,
+                exc,
+            )
             continue
         knob_items = tuple(
             sorted((int(knob_type), int(value)) for knob_type, value in knobs.items())
@@ -2374,7 +2385,11 @@ def _cudnn_graph_engine_knob_tactics(graph) -> List[tuple]:
 
 
 def _is_cudnn_engine_knob_tactic(tactic) -> bool:
-    return isinstance(tactic, (tuple, list)) and len(tactic) == 2
+    return isinstance(tactic, tuple) and len(tactic) == 2
+
+
+def _tactic_for_graph_cache(tactic) -> int:
+    return 0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
 
 
 def _cudnn_knob_items_to_dict(knob_items) -> dict:
@@ -2425,6 +2440,12 @@ def _get_cudnn_plan_index_for_tactic(graph, tactic) -> int:
         plan_index = tactic
 
     if plan_index >= graph.get_execution_plan_count():
+        warnings.warn(
+            f"cuDNN GEMM plan index {plan_index} is out of range "
+            f"(execution plan count: {graph.get_execution_plan_count()}); "
+            "falling back to default tactic=-1.",
+            stacklevel=3,
+        )
         plan_index = -1
     return plan_index
 
@@ -2466,7 +2487,7 @@ def clear_cudnn_graph_cache() -> None:
         **Internal / debug-only helper** -- not part of FlashInfer's
         public API.  Production callers should never need this:
         every ``build_cudnn_gemm_*`` helper is wrapped with
-        ``functools.lru_cache(maxsize=1024)``, which auto-evicts cold
+        ``functools.lru_cache(maxsize=2048)``, which auto-evicts cold
         shapes and keeps hot shapes resident, capping GPU memory
         growth on its own.
 
@@ -2566,7 +2587,7 @@ def _validate_bf16_output_dtype(dtype: torch.dtype):
         )
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_fp4_graph(
     a_shape,
     a_stride,
@@ -2721,7 +2742,7 @@ def execute_cudnn_gemm_fp4_graph(
 _OVERRIDE_SHAPE_CACHE_M = 8192
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_fp4_graph_override_shape(
     batch,
     n,
@@ -2992,7 +3013,7 @@ def execute_cudnn_gemm_mxfp8_graph(
         )
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_mxfp8_graph_override_shape(
     batch,
     n,
@@ -3221,7 +3242,7 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
         )
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_fp8_graph(
     a_shape,
     a_stride,
@@ -3332,7 +3353,7 @@ def execute_cudnn_gemm_fp8_graph(
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_fp8_graph_override_shape(
     batch,
     n,
@@ -3563,9 +3584,7 @@ def _cudnn_gemm_fp8_runner():
                 o_type=_torch_data_type_to_cudnn_data_type(out.dtype),
                 device=a.device,
                 cache_m=cache_m,
-                tactic=(
-                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
-                ),
+                tactic=_tactic_for_graph_cache(tactic),
             )
 
         def get_valid_tactics(
@@ -3671,7 +3690,7 @@ def _get_bf16_3d_shape_stride(tensor: torch.Tensor):
     return (tuple(shape), tuple(stride))
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_bf16_graph(
     a_shape,
     a_stride,
@@ -3768,7 +3787,7 @@ def execute_cudnn_gemm_bf16_graph(graph, a, b, bias, c_final, workspace, tactic=
 # ---------------------------------------------------------------------------
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_bf16_graph_override_shape(
     batch,
     n,
@@ -4067,10 +4086,7 @@ def _cudnn_gemm_bf16_runner(
                 cache_m=cache_m,
                 is_a_k_major=self._is_a_k_major,
                 is_b_k_major=self._is_b_k_major,
-                # tactic value only be 0 or -1 to hit the graph cache
-                tactic=(
-                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
-                ),
+                tactic=_tactic_for_graph_cache(tactic),
             )
             return graph
 
@@ -5117,10 +5133,7 @@ def _cudnn_mm_mxfp8_runner():
                 block_size=32,
                 device=a.device,
                 cache_m=cache_m,
-                # tactic value only be 0 or -1 to hit the graph cache
-                tactic=(
-                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
-                ),
+                tactic=_tactic_for_graph_cache(tactic),
             )
 
         def get_valid_tactics(
@@ -5536,10 +5549,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
                 alpha_is_not_none=alpha is not None,
                 use_nvfp4=use_nvfp4,
                 cache_m=cache_m,
-                # tactic value only be 0 or -1 to hit the graph cache
-                tactic=(
-                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
-                ),
+                tactic=_tactic_for_graph_cache(tactic),
             )
             return graph
 
@@ -8775,7 +8785,7 @@ def _calculate_block_scale_dims(
     return block_scale_dim_m, block_scale_dim_n, block_scale_dim_k
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_gemm_mxfp8_graph(
     a_shape,
     a_stride,
@@ -8975,10 +8985,7 @@ def _cudnn_gemm_mxfp8_runner():
                 block_size=32,
                 device=a.device,
                 cache_m=cache_m,
-                # tactic value only be 0 or -1 to hit the graph cache
-                tactic=(
-                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
-                ),
+                tactic=_tactic_for_graph_cache(tactic),
             )
 
         def get_valid_tactics(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -15,11 +15,8 @@ limitations under the License.
 """
 
 import functools
-<<<<<<< HEAD
 from collections import defaultdict
-=======
 import logging
->>>>>>> 1990cae7 (fix_comments)
 from dataclasses import replace
 import warnings
 from enum import Enum

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -15,10 +15,10 @@ limitations under the License.
 """
 
 import functools
-from collections import defaultdict
 import logging
-from dataclasses import replace
 import warnings
+from collections import defaultdict
+from dataclasses import replace
 from enum import Enum
 from types import SimpleNamespace
 from typing import Callable, List, Literal, Optional, Tuple

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -17,6 +17,7 @@ limitations under the License.
 import functools
 from collections import defaultdict
 from dataclasses import replace
+import warnings
 from enum import Enum
 from types import SimpleNamespace
 from typing import Callable, List, Literal, Optional, Tuple
@@ -2381,6 +2382,30 @@ def _get_cudnn_override_shape_workspace_size(
         return graph.get_workspace_size_plan_at_index(tactic)
 
 
+def _cudnn_graph_engine_knob_tactics(graph) -> List[tuple]:
+    tactics: List[tuple] = []
+    for plan_idx in range(graph.get_execution_plan_count()):
+        try:
+            engine_id, knobs = graph.get_engine_and_knobs_at_index(plan_idx)
+        except (AttributeError, RuntimeError):
+            continue
+        knob_items = tuple(
+            sorted((int(knob_type), int(value)) for knob_type, value in knobs.items())
+        )
+        tactics.append((int(engine_id), knob_items))
+    return tactics
+
+
+def _is_cudnn_engine_knob_tactic(tactic) -> bool:
+    return isinstance(tactic, (tuple, list)) and len(tactic) == 2
+
+
+def _cudnn_knob_items_to_dict(knob_items) -> dict:
+    return {
+        cudnn.knob_type(int(knob_type)): int(value) for knob_type, value in knob_items
+    }
+
+
 def clear_cudnn_graph_cache() -> None:
     """Invalidate all process-local cuDNN GEMM graph caches **and** the
     AutoTuner profiling cache.
@@ -3142,29 +3167,9 @@ def build_cudnn_gemm_fp8_graph(
     b_type,
     o_type,
     device,
-    policy=None,
+    tactic=-1,
 ):
-    """Build a cuDNN graph for GEMM with per-tensor quantization.
-
-    This function is cached to avoid rebuilding identical graphs.
-
-    Args:
-        a_shape: Shape of tensor A
-        a_stride: Stride of tensor A
-        b_shape: Shape of tensor B
-        b_stride: Stride of tensor B
-        a_type: Data type for input tensor A
-        b_type: Data type for input tensor B
-        o_type: Data type for output tensor
-        policy: cuDNN build plan policy. None defaults to HEURISTICS_CHOICE.
-                Use ALL to enumerate all execution plans for autotuning.
-
-    Returns:
-        cuDNN graph object
-    """
     _check_cudnn_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     stream = torch.cuda.current_stream(device)
     with cudnn.graph(_get_cudnn_handle(device, stream)) as (graph, _):
@@ -3218,9 +3223,24 @@ def build_cudnn_gemm_fp8_graph(
 
         graph.validate()
         graph.build_operation_graph()
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        if _is_cudnn_engine_knob_tactic(tactic):
+            engine_id, knob_items = tactic
+            graph.create_execution_plan(
+                int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+            )
+            policy = None
+        else:
+            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+            policy = (
+                cudnn.build_plan_policy.HEURISTICS_CHOICE
+                if tactic < 0
+                else cudnn.build_plan_policy.ALL
+            )
         graph.check_support()
-        graph.build_plans(policy)
+        if policy is None:
+            graph.build_plans()
+        else:
+            graph.build_plans(policy)
 
         return graph
 
@@ -3233,7 +3253,7 @@ def execute_cudnn_gemm_fp8_graph(
     b_scale,
     c_final,
     workspace,
-    tactic: int = -1,
+    tactic=-1,
 ):
     variant_pack = {
         UIDs.A_UID.value: a,
@@ -3246,22 +3266,23 @@ def execute_cudnn_gemm_fp8_graph(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
-    # This (non-override) graph is built at the real shape, whereas the tactic
-    # was tuned against a possibly different (bucketed) M whose plan list can
-    # differ in length. If the index is out of range, fall back to the
-    # heuristic default rather than letting execute_plan_at_index raise.
-    if tactic >= graph.get_execution_plan_count():
-        tactic = -1
+    if _is_cudnn_engine_knob_tactic(tactic):
+        plan_index = -1
+    else:
+        plan_index = tactic
 
-    workspace_size = _get_cudnn_workspace_size(graph, tactic)
+    if plan_index >= graph.get_execution_plan_count():
+        plan_index = -1
+
+    workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace.numel() < workspace_size:
         workspace.resize_(workspace_size)
 
-    if tactic == -1:
+    if plan_index < 0:
         graph.execute(variant_pack, workspace, handle=cudnn_handle)
     else:
         graph.execute_plan_at_index(
-            variant_pack, workspace, tactic, handle=cudnn_handle
+            variant_pack, workspace, plan_index, handle=cudnn_handle
         )
 
 
@@ -3434,14 +3455,9 @@ def _cudnn_gemm_fp8(
     b_scale: torch.Tensor,
     out: Optional[torch.Tensor],
     torch_out_dtype: torch.dtype,
-    tactic: int = -1,
+    tactic=-1,
 ):
     _check_cudnn_availability()
-
-    if tactic == -1:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
-    else:
-        policy = cudnn.build_plan_policy.ALL
 
     graph = build_cudnn_gemm_fp8_graph(
         a.shape,
@@ -3452,7 +3468,7 @@ def _cudnn_gemm_fp8(
         _torch_data_type_to_cudnn_data_type(b.dtype),
         _torch_data_type_to_cudnn_data_type(torch_out_dtype),
         a.device,
-        policy=policy,
+        tactic=tactic,
     )
 
     execute_cudnn_gemm_fp8_graph(
@@ -3506,14 +3522,11 @@ def _cudnn_gemm_fp8_runner():
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> List[tuple]:
             a, b, _, _, out, _ = inputs
             if self._use_override_shape:
                 graph = self._get_override_graph(a, b, out)
             else:
-                # ALL exposes every heuristic plan to the autotuner;
-                # HEURISTICS_CHOICE would collapse to a single plan. Graph
-                # is @lru_cache'd, so all plans are built once per shape.
                 graph = build_cudnn_gemm_fp8_graph(
                     a_shape=a.shape,
                     a_stride=a.stride(),
@@ -3523,34 +3536,48 @@ def _cudnn_gemm_fp8_runner():
                     b_type=_torch_data_type_to_cudnn_data_type(b.dtype),
                     o_type=_torch_data_type_to_cudnn_data_type(out.dtype),
                     device=a.device,
-                    policy=cudnn.build_plan_policy.ALL,
+                    tactic=0,
                 )
-
-            return list(range(graph.get_execution_plan_count()))
+            return _cudnn_graph_engine_knob_tactics(graph)
 
         def forward(
             self,
             inputs: List[torch.Tensor],
-            tactic: int = -1,
+            tactic=-1,
             do_preparation: bool = False,
             **kwargs,
         ) -> torch.Tensor:
             a, b, scale_a, scale_b, out, workspace_buffer = inputs
-            if self._use_override_shape:
-                graph = self._get_override_graph(a, b, out)
-                execute_cudnn_gemm_fp8_graph_override_shape(
-                    graph,
-                    a,
-                    b,
-                    scale_a,
-                    scale_b,
-                    out,
-                    workspace_buffer,
-                    tactic=max(tactic, 0),
+            try:
+                if self._use_override_shape:
+                    graph = self._get_override_graph(a, b, out)
+                    execute_cudnn_gemm_fp8_graph_override_shape(
+                        graph,
+                        a,
+                        b,
+                        scale_a,
+                        scale_b,
+                        out,
+                        workspace_buffer,
+                        tactic=max(tactic, 0),
+                    )
+                else:
+                    _cudnn_gemm_fp8(
+                        workspace_buffer,
+                        a,
+                        b,
+                        scale_a,
+                        scale_b,
+                        out,
+                        out.dtype,
+                        tactic=tactic,
+                    )
+            except Exception as exc:
+                warnings.warn(
+                    "cuDNN fp8 GEMM tactic failed; falling back to default "
+                    f"tactic=-1. ({exc})",
+                    stacklevel=2,
                 )
-            else:
-                # Apply the tuned tactic. tactic>=0 -> specific plan
-                # (policy=ALL); tactic==-1 -> cheap HEURISTICS_CHOICE default.
                 _cudnn_gemm_fp8(
                     workspace_buffer,
                     a,
@@ -3559,7 +3586,7 @@ def _cudnn_gemm_fp8_runner():
                     scale_b,
                     out,
                     out.dtype,
-                    tactic=tactic,
+                    tactic=-1,
                 )
             return out
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -3157,7 +3157,7 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
     )
 
 
-@functools.lru_cache(maxsize=2048)
+@functools.lru_cache(maxsize=1024)
 def build_cudnn_gemm_fp8_graph(
     a_shape,
     a_stride,
@@ -3267,7 +3267,39 @@ def execute_cudnn_gemm_fp8_graph(
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
     if _is_cudnn_engine_knob_tactic(tactic):
+        target_engine_id, target_knob_items = tactic
+        target_tactic = (
+            int(target_engine_id),
+            tuple(
+                (int(knob_type), int(value)) for knob_type, value in target_knob_items
+            ),
+        )
         plan_index = -1
+        for candidate_plan_index in range(graph.get_execution_plan_count()):
+            try:
+                engine_id, knobs = graph.get_engine_and_knobs_at_index(
+                    candidate_plan_index
+                )
+            except (AttributeError, RuntimeError):
+                continue
+            candidate_tactic = (
+                int(engine_id),
+                tuple(
+                    sorted(
+                        (int(knob_type), int(value))
+                        for knob_type, value in knobs.items()
+                    )
+                ),
+            )
+            if candidate_tactic == target_tactic:
+                plan_index = candidate_plan_index
+                break
+        if plan_index < 0:
+            warnings.warn(
+                "cuDNN fp8 GEMM engine/knob tactic did not match any built "
+                "execution plan; falling back to default tactic=-1.",
+                stacklevel=2,
+            )
     else:
         plan_index = tactic
 
@@ -3301,16 +3333,9 @@ def build_cudnn_gemm_fp8_graph_override_shape(
     o_type,
     device,
     cache_m: int = _OVERRIDE_SHAPE_CACHE_M,
-    policy=None,
+    tactic=-1,
 ):
-    """Build an FP8 per-tensor-quantized GEMM cuDNN graph with override-shape.
-
-    Compiled once with ``cache_m`` as M; at execution time the actual M is
-    supplied through ``override_shapes`` / ``override_strides``.
-    """
     _check_cudnn_override_shape_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     a_shape = [batch, cache_m, k]
     a_stride = [cache_m * k, k, 1]
@@ -3373,17 +3398,30 @@ def build_cudnn_gemm_fp8_graph_override_shape(
 
     graph.validate()
     graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+    if _is_cudnn_engine_knob_tactic(tactic):
+        engine_id, knob_items = tactic
+        graph.create_execution_plan(
+            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+        )
+        policy = None
+    else:
+        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        policy = (
+            cudnn.build_plan_policy.HEURISTICS_CHOICE
+            if tactic < 0
+            else cudnn.build_plan_policy.ALL
+        )
     graph.check_support()
-    graph.build_plans(policy)
+    if policy is None:
+        graph.build_plans()
+    else:
+        graph.build_plans(policy)
 
     return graph
 
 
-# Internal helper called from mm_fp8 per-tensor path; the user-facing mm_fp8
-# is already decorated, so decorating here would double-log the same invocation.
 def execute_cudnn_gemm_fp8_graph_override_shape(
-    graph, a, b, a_scale, b_scale, c_final, workspace, tactic: int = 0
+    graph, a, b, a_scale, b_scale, c_final, workspace, tactic=-1
 ):
     """Execute FP8 per-tensor GEMM graph with dynamic-shape overrides."""
     # Override-shape graphs require the runtime strides to match the profiled layout.
@@ -3415,21 +3453,76 @@ def execute_cudnn_gemm_fp8_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
+    if _is_cudnn_engine_knob_tactic(tactic):
+        target_engine_id, target_knob_items = tactic
+        target_tactic = (
+            int(target_engine_id),
+            tuple(
+                (int(knob_type), int(value)) for knob_type, value in target_knob_items
+            ),
+        )
+        plan_index = -1
+        for candidate_plan_index in range(graph.get_execution_plan_count()):
+            try:
+                engine_id, knobs = graph.get_engine_and_knobs_at_index(
+                    candidate_plan_index
+                )
+            except (AttributeError, RuntimeError):
+                continue
+            candidate_tactic = (
+                int(engine_id),
+                tuple(
+                    sorted(
+                        (int(knob_type), int(value))
+                        for knob_type, value in knobs.items()
+                    )
+                ),
+            )
+            if candidate_tactic == target_tactic:
+                plan_index = candidate_plan_index
+                break
+        if plan_index < 0:
+            warnings.warn(
+                "cuDNN fp8 GEMM engine/knob tactic did not match any built "
+                "override-shape execution plan; falling back to default tactic=-1.",
+                stacklevel=2,
+            )
+    else:
+        plan_index = tactic
+
+    if plan_index >= graph.get_execution_plan_count():
+        plan_index = -1
+
     workspace_size = _get_cudnn_override_shape_workspace_size(
-        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+        graph,
+        plan_index,
+        cudnn_handle,
+        override_uids,
+        override_shapes,
+        override_strides,
     )
     if workspace.numel() < workspace_size:
         workspace.resize_(workspace_size)
 
-    graph.execute_plan_at_index(
-        variant_pack,
-        workspace,
-        tactic,
-        handle=cudnn_handle,
-        override_uids=override_uids,
-        override_shapes=override_shapes,
-        override_strides=override_strides,
-    )
+    if plan_index < 0:
+        graph.execute(
+            variant_pack,
+            workspace,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
+    else:
+        graph.execute_plan_at_index(
+            variant_pack,
+            workspace,
+            plan_index,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
 
 
 def _torch_data_type_to_cudnn_data_type(dtype: torch.dtype):
@@ -3499,13 +3592,14 @@ def _cudnn_gemm_fp8_runner():
             a, b, _, _, out, _ = inputs
             return (a.dtype, b.dtype, out.dtype)
 
-        def _get_override_graph(self, a, b, out):
+        def _get_override_graph(self, a, b, out, tactic=-1):
             batch = a.shape[0]
             actual_m = a.shape[-2]
             k = a.shape[-1]
             n = b.shape[-1]
             cache_m = self._m_bucket_mapper(actual_m)
 
+            # tactic value only be 0 or -1 to hit the graph cache
             return build_cudnn_gemm_fp8_graph_override_shape(
                 batch=batch,
                 n=n,
@@ -3515,7 +3609,9 @@ def _cudnn_gemm_fp8_runner():
                 o_type=_torch_data_type_to_cudnn_data_type(out.dtype),
                 device=a.device,
                 cache_m=cache_m,
-                policy=cudnn.build_plan_policy.ALL,
+                tactic=(
+                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
+                ),
             )
 
         def get_valid_tactics(
@@ -3524,8 +3620,9 @@ def _cudnn_gemm_fp8_runner():
             profile: OptimizationProfile,
         ) -> List[tuple]:
             a, b, _, _, out, _ = inputs
+            # build all plans by setting tactic=0
             if self._use_override_shape:
-                graph = self._get_override_graph(a, b, out)
+                graph = self._get_override_graph(a, b, out, tactic=0)
             else:
                 graph = build_cudnn_gemm_fp8_graph(
                     a_shape=a.shape,
@@ -3550,7 +3647,7 @@ def _cudnn_gemm_fp8_runner():
             a, b, scale_a, scale_b, out, workspace_buffer = inputs
             try:
                 if self._use_override_shape:
-                    graph = self._get_override_graph(a, b, out)
+                    graph = self._get_override_graph(a, b, out, tactic=tactic)
                     execute_cudnn_gemm_fp8_graph_override_shape(
                         graph,
                         a,
@@ -3559,7 +3656,7 @@ def _cudnn_gemm_fp8_runner():
                         scale_b,
                         out,
                         workspace_buffer,
-                        tactic=max(tactic, 0),
+                        tactic=tactic,
                     )
                 else:
                     _cudnn_gemm_fp8(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -350,8 +350,6 @@ def _cudnn_mm_bf16_requirement(
     ] = "cudnn",
 ):
     _validate_bf16_output_dtype(out_dtype)
-    if not _cudnn_bf16_gemm_usable_or_skip(a, out_dtype, backend):
-        return False
     return _cudnn_available_or_raise_for_backend(backend)
 
 
@@ -697,8 +695,6 @@ def _cudnn_bmm_bf16_requirement(
     backend: Literal["cudnn", "cutlass", "cutile", "tgv", "auto"] = "cudnn",
 ):
     _validate_bf16_output_dtype(out_dtype)
-    if not _cudnn_bf16_gemm_usable_or_skip(A, out_dtype, backend):
-        return False
     return _cudnn_available_or_raise_for_backend(backend)
 
 
@@ -2272,33 +2268,6 @@ def _cudnn_available_or_raise_for_backend(backend):
     if backend == "cudnn":
         _check_cudnn_availability()
     return False
-
-
-def _cudnn_bf16_gemm_usable_or_skip(
-    a: torch.Tensor, out_dtype: torch.dtype, backend: str
-) -> bool:
-    """Precise ban for the cuDNN 9.23.0.x bf16-GEMM bug. cuDNN 9.23.0 (backend_version 92300)
-    miscomputes bf16 GEMM/BMM with **fp16 output on SM90/Hopper** for non-power-of-2 M: the split-k
-    partial-reduce kernel assumes row-major output, but Hopper swaps A<->B so the output is
-    column-major -> wrong reduce dims -> garbage (ratio ~1). bf16 OUTPUT, SM80/89/100, and the
-    non-bf16 dtype paths are all UNAFFECTED, and it's fixed in 9.23.1 (92301). So disable exactly
-    {SM90, fp16-out, 9.23.0.x}: auto falls back to cutlass/cublas, explicit cudnn raises a clear,
-    skippable error. (Envelope deliberately drops the non-pow2-M condition -- the actual trigger --
-    for robustness against the split-k tile heuristic; the over-restriction is only pow2-M
-    bf16->fp16 on SM90/9.23.0, which simply falls back.)"""
-    if (
-        CUDNN_AVAILABLE
-        and out_dtype == torch.float16
-        and cudnn.backend_version() == 92300
-        and get_compute_capability(a.device)[0] == 9
-    ):
-        if backend == "cudnn":
-            raise RuntimeError(
-                "cuDNN 9.23.0 miscomputes bf16->fp16 GEMM/BMM on SM90/Hopper (non-power-of-2 M); "
-                "not supported. Use bf16 output, another backend, or upgrade to cuDNN >= 9.23.1."
-            )
-        return False
-    return True
 
 
 def _is_cublas_fp4_available_in_cudnn():

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2317,18 +2317,13 @@ def _get_cudnn_override_shape_workspace_size(
     override_shapes,
     override_strides,
 ) -> int:
-    if cudnn.backend_version() >= 92300:
-        if plan_index < 0:
-            return graph.get_workspace_size(
-                cudnn_handle, override_uids, override_shapes, override_strides
-            )
-        return graph.get_workspace_size_plan_at_index(
-            plan_index, cudnn_handle, override_uids, override_shapes, override_strides
+    if plan_index < 0:
+        return graph.get_workspace_size(
+            cudnn_handle, override_uids, override_shapes, override_strides
         )
-    else:
-        if plan_index < 0:
-            return graph.get_workspace_size()
-        return graph.get_workspace_size_plan_at_index(plan_index)
+    return graph.get_workspace_size_plan_at_index(
+        plan_index, cudnn_handle, override_uids, override_shapes, override_strides
+    )
 
 
 def _cudnn_graph_engine_knob_tactics(graph) -> List[tuple]:

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2338,7 +2338,7 @@ def _check_cudnn_override_shape_availability():
         ) from e
 
 
-def is_cudnn_override_shape_available() -> bool:
+def _is_cudnn_override_shape_available() -> bool:
     """Return True if the installed cuDNN backend supports is_override_shape_enabled."""
     if not CUDNN_AVAILABLE:
         return False
@@ -3586,7 +3586,7 @@ def _cudnn_gemm_fp8_runner():
         def __init__(self):
             super().__init__()
             self._m_bucket_mapper = m_bucket_mapper
-            self._use_override_shape = is_cudnn_override_shape_available()
+            self._use_override_shape = _is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
             a, b, _, _, out, _ = inputs
@@ -4075,7 +4075,7 @@ def _cudnn_gemm_bf16_runner(
             # profile tensors use) when caller didn't specify.
             self._is_a_k_major = True if is_a_k_major is None else is_a_k_major
             self._is_b_k_major = True if is_b_k_major is None else is_b_k_major
-            self._use_override_shape = is_cudnn_override_shape_available()
+            self._use_override_shape = _is_cudnn_override_shape_available()
 
         def _get_override_graph(self, a, b, bias, out):
             a_shape, _ = _get_bf16_3d_shape_stride(a)
@@ -5122,7 +5122,7 @@ def _cudnn_mm_mxfp8_runner():
         def __init__(self):
             super().__init__()
             self._m_bucket_mapper = m_bucket_mapper
-            self._use_override_shape = is_cudnn_override_shape_available()
+            self._use_override_shape = _is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
             a, b, _, _, _, out, _ = inputs
@@ -5513,7 +5513,7 @@ def _cudnn_gemm_fp4_runner(tuning_config):
         def __init__(self):
             super().__init__()
             self._m_bucket_mapper = m_bucket_mapper
-            self._use_override_shape = is_cudnn_override_shape_available()
+            self._use_override_shape = _is_cudnn_override_shape_available()
 
         def _get_override_graph(self, a, b, alpha, out_dtype, block_size, use_nvfp4):
             real_a_shape, _ = _get_real_fp4_shape_from_packed_uint8(a)
@@ -8951,7 +8951,7 @@ def _cudnn_gemm_mxfp8_runner():
         def __init__(self):
             super().__init__()
             self._m_bucket_mapper = m_bucket_mapper
-            self._use_override_shape = is_cudnn_override_shape_available()
+            self._use_override_shape = _is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
             a, b, _, _, out, _ = inputs

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2992,7 +2992,7 @@ def execute_cudnn_gemm_mxfp8_graph(
     b_descale,
     c_final,
     workspace_buffer,
-    tactic: int = -1,
+    tactic=-1,
 ):
     variant_pack = {
         UIDs.A_UID.value: a,
@@ -3002,14 +3002,16 @@ def execute_cudnn_gemm_mxfp8_graph(
         UIDs.O_UID.value: c_final,
     }
 
-    workspace_size = _get_cudnn_workspace_size(graph, tactic)
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
+
+    workspace_size = _get_cudnn_workspace_size(graph, plan_index)
 
     if workspace_buffer.numel() < workspace_size:
         workspace_buffer.resize_(workspace_size)
 
     stream = torch.cuda.current_stream(a.device)
 
-    if tactic == -1:
+    if plan_index < 0:
         graph.execute(
             variant_pack, workspace_buffer, handle=_get_cudnn_handle(a.device, stream)
         )
@@ -3017,7 +3019,7 @@ def execute_cudnn_gemm_mxfp8_graph(
         graph.execute_plan_at_index(
             variant_pack,
             workspace_buffer,
-            tactic,
+            plan_index,
             handle=_get_cudnn_handle(a.device, stream),
         )
 
@@ -3033,7 +3035,7 @@ def build_cudnn_gemm_mxfp8_graph_override_shape(
     block_size,
     device,
     cache_m: int = _OVERRIDE_SHAPE_CACHE_M,
-    policy=None,
+    tactic=-1,
 ):
     """Build a cuDNN MXFP8 GEMM graph with override-shape support.
 
@@ -3041,8 +3043,6 @@ def build_cudnn_gemm_mxfp8_graph_override_shape(
     provided through ``override_shapes`` / ``override_strides``.
     """
     _check_cudnn_override_shape_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     if a_type not in [cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2]:
         raise ValueError(f"A type must be FP8_E4M3 or FP8_E5M2, got {a_type}")
@@ -3128,9 +3128,24 @@ def build_cudnn_gemm_mxfp8_graph_override_shape(
 
     graph.validate()
     graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.B])
+    if _is_cudnn_engine_knob_tactic(tactic):
+        engine_id, knob_items = tactic
+        graph.create_execution_plan(
+            int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+        )
+        policy = None
+    else:
+        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+        policy = (
+            cudnn.build_plan_policy.HEURISTICS_CHOICE
+            if tactic < 0
+            else cudnn.build_plan_policy.ALL
+        )
     graph.check_support()
-    graph.build_plans(policy)
+    if policy is None:
+        graph.build_plans()
+    else:
+        graph.build_plans(policy)
 
     return graph
 
@@ -3145,7 +3160,7 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
     b_descale,
     c_final,
     workspace,
-    tactic: int = 0,
+    tactic=-1,
 ):
     """Execute MXFP8 GEMM cuDNN graph with dynamic-shape overrides."""
     # Override-shape graphs require the runtime strides to match the profiled layout.
@@ -3221,21 +3236,38 @@ def execute_cudnn_gemm_mxfp8_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
+
     workspace_size = _get_cudnn_override_shape_workspace_size(
-        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+        graph,
+        plan_index,
+        cudnn_handle,
+        override_uids,
+        override_shapes,
+        override_strides,
     )
     if workspace.numel() < workspace_size:
         workspace.resize_(workspace_size)
 
-    graph.execute_plan_at_index(
-        variant_pack,
-        workspace,
-        tactic,
-        handle=cudnn_handle,
-        override_uids=override_uids,
-        override_shapes=override_shapes,
-        override_strides=override_strides,
-    )
+    if plan_index < 0:
+        graph.execute(
+            variant_pack,
+            workspace,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
+    else:
+        graph.execute_plan_at_index(
+            variant_pack,
+            workspace,
+            plan_index,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
 
 
 @functools.lru_cache(maxsize=1024)
@@ -5181,7 +5213,7 @@ def _cudnn_mm_mxfp8_runner():
             a, b, _, _, _, out, _ = inputs
             return (a.dtype, b.dtype, out.dtype)
 
-        def _get_override_graph(self, a, b, out):
+        def _get_override_graph(self, a, b, out, tactic=-1):
             # a is [m, k], b is [k, n] (2D mm promoted to batch-size-1 bmm).
             actual_m = a.shape[0]
             k = a.shape[1]
@@ -5197,17 +5229,20 @@ def _cudnn_mm_mxfp8_runner():
                 block_size=32,
                 device=a.device,
                 cache_m=cache_m,
-                policy=cudnn.build_plan_policy.ALL,
+                # tactic value only be 0 or -1 to hit the graph cache
+                tactic=(
+                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
+                ),
             )
 
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> List[tuple]:
             a, b, _, _, _, out, _ = inputs
             if self._use_override_shape:
-                graph = self._get_override_graph(a, b, out)
+                graph = self._get_override_graph(a, b, out, tactic=0)
             else:
                 a3 = a.unsqueeze(0)
                 b3 = b.unsqueeze(0)
@@ -5221,33 +5256,50 @@ def _cudnn_mm_mxfp8_runner():
                     o_type=_torch_data_type_to_cudnn_data_type(out.dtype),
                     block_size=32,
                     device=a.device,
-                    policy=cudnn.build_plan_policy.ALL,
+                    tactic=0,
                 )
-            return list(range(graph.get_execution_plan_count()))
+            return _cudnn_graph_engine_knob_tactics(graph)
 
         def forward(
             self,
             inputs: List[torch.Tensor],
-            tactic: int = -1,
+            tactic=-1,
             do_preparation: bool = False,
             **kwargs,
         ) -> torch.Tensor:
             a, b, a_descale, b_descale, _out_dtype, out, workspace_buffer = inputs
             # unsqueeze(0) returns views sharing storage, so writes to the 3D
             # output view land in the user-provided 2D ``out`` tensor.
-            if self._use_override_shape:
-                graph = self._get_override_graph(a, b, out)
-                execute_cudnn_gemm_mxfp8_graph_override_shape(
-                    graph=graph,
-                    a=a.unsqueeze(0),
-                    b=b.unsqueeze(0),
-                    a_descale=a_descale,
-                    b_descale=b_descale,
-                    c_final=out.unsqueeze(0),
-                    workspace=workspace_buffer,
-                    tactic=max(tactic, 0),
+            try:
+                if self._use_override_shape:
+                    graph = self._get_override_graph(a, b, out, tactic=tactic)
+                    execute_cudnn_gemm_mxfp8_graph_override_shape(
+                        graph=graph,
+                        a=a.unsqueeze(0),
+                        b=b.unsqueeze(0),
+                        a_descale=a_descale,
+                        b_descale=b_descale,
+                        c_final=out.unsqueeze(0),
+                        workspace=workspace_buffer,
+                        tactic=tactic,
+                    )
+                else:
+                    _cudnn_gemm_mxfp8(
+                        a=a.unsqueeze(0),
+                        b=b.unsqueeze(0),
+                        a_descale=a_descale,
+                        b_descale=b_descale,
+                        out=out.unsqueeze(0),
+                        out_dtype=out.dtype,
+                        workspace_buffer=workspace_buffer,
+                        tactic=tactic,
+                    )
+            except Exception as exc:
+                warnings.warn(
+                    "cuDNN mxfp8 GEMM tactic failed; falling back to default "
+                    f"tactic=-1. ({exc})",
+                    stacklevel=2,
                 )
-            else:
                 _cudnn_gemm_mxfp8(
                     a=a.unsqueeze(0),
                     b=b.unsqueeze(0),
@@ -5256,7 +5308,7 @@ def _cudnn_mm_mxfp8_runner():
                     out=out.unsqueeze(0),
                     out_dtype=out.dtype,
                     workspace_buffer=workspace_buffer,
-                    tactic=tactic,
+                    tactic=-1,
                 )
             return out
 
@@ -8846,11 +8898,8 @@ def build_cudnn_gemm_mxfp8_graph(
     block_size,
     o_type,  # cudnn.data_type, BF16 or FP16
     device,
-    policy=None,
+    tactic=-1,
 ):
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
-
     if len(a_shape) != 3:
         raise ValueError(f"A shape must be 3D, got {a_shape}")
     if len(b_shape) != 3:
@@ -8963,9 +9012,24 @@ def build_cudnn_gemm_mxfp8_graph(
 
         graph.validate()
         graph.build_operation_graph()
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.B])
+        if _is_cudnn_engine_knob_tactic(tactic):
+            engine_id, knob_items = tactic
+            graph.create_execution_plan(
+                int(engine_id), _cudnn_knob_items_to_dict(knob_items)
+            )
+            policy = None
+        else:
+            graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
+            policy = (
+                cudnn.build_plan_policy.HEURISTICS_CHOICE
+                if tactic < 0
+                else cudnn.build_plan_policy.ALL
+            )
         graph.check_support()
-        graph.build_plans(policy)
+        if policy is None:
+            graph.build_plans()
+        else:
+            graph.build_plans(policy)
 
         return graph
 
@@ -8978,15 +9042,10 @@ def _cudnn_gemm_mxfp8(
     out_dtype: torch.dtype = torch.bfloat16,
     out: Optional[torch.Tensor] = None,
     workspace_buffer: torch.Tensor = None,
-    tactic: int = -1,
+    tactic=-1,
 ):
     # mxfp8 block size is 32
     block_size = 32
-
-    if tactic == -1:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
-    else:
-        policy = cudnn.build_plan_policy.ALL
 
     graph = build_cudnn_gemm_mxfp8_graph(
         a_shape=a.shape,
@@ -8998,7 +9057,7 @@ def _cudnn_gemm_mxfp8(
         o_type=_torch_data_type_to_cudnn_data_type(out_dtype),
         block_size=block_size,
         device=a.device,
-        policy=policy,
+        tactic=tactic,
     )
     # execute the mxfp8 cudnn graph
     execute_cudnn_gemm_mxfp8_graph(
@@ -9028,7 +9087,7 @@ def _cudnn_gemm_mxfp8_runner():
             a, b, _, _, out, _ = inputs
             return (a.dtype, b.dtype, out.dtype)
 
-        def _get_override_graph(self, a, b, out):
+        def _get_override_graph(self, a, b, out, tactic=-1):
             batch = a.shape[0]
             actual_m = a.shape[-2]
             k = a.shape[-1]
@@ -9045,17 +9104,20 @@ def _cudnn_gemm_mxfp8_runner():
                 block_size=32,
                 device=a.device,
                 cache_m=cache_m,
-                policy=cudnn.build_plan_policy.ALL,
+                # tactic value only be 0 or -1 to hit the graph cache
+                tactic=(
+                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
+                ),
             )
 
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> List[tuple]:
             a, b, _, _, out, _ = inputs
             if self._use_override_shape:
-                graph = self._get_override_graph(a, b, out)
+                graph = self._get_override_graph(a, b, out, tactic=0)
             else:
                 graph = build_cudnn_gemm_mxfp8_graph(
                     a_shape=a.shape,
@@ -9067,32 +9129,49 @@ def _cudnn_gemm_mxfp8_runner():
                     o_type=_torch_data_type_to_cudnn_data_type(out.dtype),
                     block_size=32,
                     device=a.device,
-                    policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
+                    tactic=0,
                 )
 
-            return list(range(graph.get_execution_plan_count()))
+            return _cudnn_graph_engine_knob_tactics(graph)
 
         def forward(
             self,
             inputs: List[torch.Tensor],
-            tactic: int = -1,
+            tactic=-1,
             do_preparation: bool = False,
             **kwargs,
         ) -> torch.Tensor:
             a, b, scale_a, scale_b, out, workspace_buffer = inputs
-            if self._use_override_shape:
-                graph = self._get_override_graph(a, b, out)
-                execute_cudnn_gemm_mxfp8_graph_override_shape(
-                    graph=graph,
-                    a=a,
-                    b=b,
-                    a_descale=scale_a,
-                    b_descale=scale_b,
-                    c_final=out,
-                    workspace=workspace_buffer,
-                    tactic=max(tactic, 0),
+            try:
+                if self._use_override_shape:
+                    graph = self._get_override_graph(a, b, out, tactic=tactic)
+                    execute_cudnn_gemm_mxfp8_graph_override_shape(
+                        graph=graph,
+                        a=a,
+                        b=b,
+                        a_descale=scale_a,
+                        b_descale=scale_b,
+                        c_final=out,
+                        workspace=workspace_buffer,
+                        tactic=tactic,
+                    )
+                else:
+                    _cudnn_gemm_mxfp8(
+                        a=a,
+                        b=b,
+                        a_descale=scale_a,
+                        b_descale=scale_b,
+                        out=out,
+                        out_dtype=out.dtype,
+                        workspace_buffer=workspace_buffer,
+                        tactic=tactic,
+                    )
+            except Exception as exc:
+                warnings.warn(
+                    "cuDNN mxfp8 GEMM tactic failed; falling back to default "
+                    f"tactic=-1. ({exc})",
+                    stacklevel=2,
                 )
-            else:
                 _cudnn_gemm_mxfp8(
                     a=a,
                     b=b,

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2668,6 +2668,11 @@ def build_cudnn_gemm_fp4_graph(
                 else cudnn.build_plan_policy.ALL
             )
 
+        # WAR: The alpha (contains the global scale) is not supported by the cuBLAS backend (eng0)
+        # in older cuDNN versions, so we deselect it.
+        if (alpha_is_not_none) and (not _is_cublas_fp4_available_in_cudnn()):
+            graph.deselect_engines(["eng0"])
+
         graph.check_support()
         if policy is None:
             graph.build_plans()

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -2325,9 +2325,10 @@ def _is_cudnn_override_shape_available() -> bool:
     """Return True if the installed cuDNN backend supports is_override_shape_enabled."""
     if not CUDNN_AVAILABLE:
         return False
-    if cudnn.backend_version() < 92301:
+    try:
+        return cudnn.backend_version() >= 92301
+    except (AttributeError, RuntimeError, TypeError):
         return False
-    return True
 
 
 def _get_cudnn_workspace_size(graph, plan_index: int) -> int:

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4078,7 +4078,12 @@ def _cudnn_gemm_bf16_runner(
             # inputs layout: a, b, bias, pdl, out, workspace_buffer
             # out.dtype distinguishes bfloat16 / float16 / float32 output graphs
             _, _, bias, _, out, _ = inputs
-            return (out.dtype, bias is not None)
+            return (
+                out.dtype,
+                bias is not None,
+                self._is_a_k_major,
+                self._is_b_k_major,
+            )
 
         def get_valid_tactics(
             self,

--- a/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
@@ -30,7 +30,7 @@ from .gemm_base import (
     _get_cudnn_override_shape_workspace_size,
     _get_cudnn_workspace_size,
     _torch_data_type_to_cudnn_data_type,
-    is_cudnn_override_shape_available,
+    _is_cudnn_override_shape_available,
 )
 from .gemm_bf16_fp4 import _unswizzle_sf_128x4
 
@@ -365,7 +365,7 @@ def _cudnn_bf16_fp4_runner(tuning_config):
         def __init__(self):
             super().__init__()
             self._m_bucket_mapper = m_bucket_mapper
-            self._use_override_shape = is_cudnn_override_shape_available()
+            self._use_override_shape = _is_cudnn_override_shape_available()
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
             _, _, _, alpha, out_dtype, _, block_size, use_nvfp4, _ = inputs

--- a/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
@@ -33,7 +33,7 @@ from .gemm_base import (
     _get_cudnn_workspace_size,
     _cudnn_graph_engine_knob_tactics,
     _finalize_cudnn_graph_for_tactic,
-    _is_cudnn_engine_knob_tactic,
+    _tactic_for_graph_cache,
     _torch_data_type_to_cudnn_data_type,
     _is_cudnn_override_shape_available,
     _check_cudnn_override_shape_availability,
@@ -109,7 +109,7 @@ def _build_bf16_fp4_graph_common(
     return c_final_cudnn_tensor
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_bf16_fp4_graph(
     batch,
     m,
@@ -170,7 +170,7 @@ def build_cudnn_bf16_fp4_graph(
         return graph
 
 
-@functools.lru_cache(maxsize=1024)
+@functools.lru_cache(maxsize=2048)
 def build_cudnn_bf16_fp4_graph_override_shape(
     batch,
     n,
@@ -407,10 +407,7 @@ def _cudnn_bf16_fp4_runner(tuning_config):
                 alpha_is_not_none=alpha is not None,
                 use_nvfp4=use_nvfp4,
                 cache_m=cache_m,
-                # tactic value only be 0 or -1 to hit the graph cache
-                tactic=(
-                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
-                ),
+                tactic=_tactic_for_graph_cache(tactic),
             )
 
         def get_valid_tactics(

--- a/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
@@ -36,6 +36,7 @@ from .gemm_base import (
     _is_cudnn_engine_knob_tactic,
     _torch_data_type_to_cudnn_data_type,
     _is_cudnn_override_shape_available,
+    _check_cudnn_override_shape_availability,
 )
 from .gemm_bf16_fp4 import _unswizzle_sf_128x4
 
@@ -185,6 +186,8 @@ def build_cudnn_bf16_fp4_graph_override_shape(
 ):
     """Build a cuDNN bf16 x fp4 GEMM graph with override-shape support."""
     _check_cudnn_fp4_availability()
+
+    _check_cudnn_override_shape_availability()
 
     scale_type = cudnn.data_type.FP8_E4M3 if use_nvfp4 else cudnn.data_type.FP8_E8M0
 

--- a/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
@@ -3,6 +3,7 @@
 """cuDNN backend for the bf16 x fp4 GEMM (graph build / execute / runner)."""
 
 import functools
+import warnings
 from typing import List, Optional, Tuple
 
 import torch
@@ -28,7 +29,11 @@ from .gemm_base import (
     _check_cudnn_fp4_availability,
     _get_cudnn_handle,
     _get_cudnn_override_shape_workspace_size,
+    _get_cudnn_plan_index_for_tactic,
     _get_cudnn_workspace_size,
+    _cudnn_graph_engine_knob_tactics,
+    _finalize_cudnn_graph_for_tactic,
+    _is_cudnn_engine_knob_tactic,
     _torch_data_type_to_cudnn_data_type,
     _is_cudnn_override_shape_available,
 )
@@ -115,12 +120,10 @@ def build_cudnn_bf16_fp4_graph(
     device,
     alpha_is_not_none,
     use_nvfp4,
-    policy=None,
+    tactic=-1,
 ):
     """Build a fixed-shape cuDNN bf16 x fp4 GEMM graph (no override-shape)."""
     _check_cudnn_fp4_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     scale_type = cudnn.data_type.FP8_E4M3 if use_nvfp4 else cudnn.data_type.FP8_E8M0
 
@@ -160,11 +163,9 @@ def build_cudnn_bf16_fp4_graph(
             alpha_is_not_none,
         )
 
-        graph.validate()
-        graph.build_operation_graph()
-        graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-        graph.check_support()
-        graph.build_plans(policy)
+        _finalize_cudnn_graph_for_tactic(
+            graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+        )
         return graph
 
 
@@ -180,12 +181,10 @@ def build_cudnn_bf16_fp4_graph_override_shape(
     alpha_is_not_none,
     use_nvfp4,
     cache_m: int = _OVERRIDE_SHAPE_CACHE_M,
-    policy=None,
+    tactic=-1,
 ):
     """Build a cuDNN bf16 x fp4 GEMM graph with override-shape support."""
     _check_cudnn_fp4_availability()
-    if policy is None:
-        policy = cudnn.build_plan_policy.HEURISTICS_CHOICE
 
     scale_type = cudnn.data_type.FP8_E4M3 if use_nvfp4 else cudnn.data_type.FP8_E8M0
 
@@ -231,11 +230,9 @@ def build_cudnn_bf16_fp4_graph_override_shape(
         alpha_is_not_none,
     )
 
-    graph.validate()
-    graph.build_operation_graph()
-    graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-    graph.check_support()
-    graph.build_plans(policy)
+    _finalize_cudnn_graph_for_tactic(
+        graph, tactic, [cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK]
+    )
     return graph
 
 
@@ -260,21 +257,23 @@ def execute_cudnn_bf16_fp4_graph(
     alpha,
     out,
     workspace_buffer,
-    tactic: int = -1,
+    tactic=-1,
 ):
     variant_pack = _bf16_fp4_variant_pack(a, b, b_descale, alpha, out)
 
-    workspace_size = _get_cudnn_workspace_size(graph, tactic)
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
+
+    workspace_size = _get_cudnn_workspace_size(graph, plan_index)
     if workspace_buffer.numel() < workspace_size:
         workspace_buffer.resize_(workspace_size)
 
     stream = torch.cuda.current_stream(a.device)
     handle = _get_cudnn_handle(a.device, stream)
-    if tactic == -1:
+    if plan_index < 0:
         graph.execute(variant_pack, workspace_buffer, handle=handle)
     else:
         graph.execute_plan_at_index(
-            variant_pack, workspace_buffer, tactic, handle=handle
+            variant_pack, workspace_buffer, plan_index, handle=handle
         )
 
 
@@ -287,7 +286,7 @@ def execute_cudnn_bf16_fp4_graph_override_shape(
     out,
     workspace_buffer,
     block_size: int = 16,
-    tactic: int = 0,
+    tactic=-1,
 ):
     """Execute the bf16 x fp4 graph, overriding A / output to the real M."""
     m, k = int(a.shape[0]), int(a.shape[1])
@@ -318,21 +317,38 @@ def execute_cudnn_bf16_fp4_graph_override_shape(
     stream = torch.cuda.current_stream(a.device)
     cudnn_handle = _get_cudnn_handle(a.device, stream)
 
+    plan_index = _get_cudnn_plan_index_for_tactic(graph, tactic)
+
     workspace_size = _get_cudnn_override_shape_workspace_size(
-        graph, tactic, cudnn_handle, override_uids, override_shapes, override_strides
+        graph,
+        plan_index,
+        cudnn_handle,
+        override_uids,
+        override_shapes,
+        override_strides,
     )
     if workspace_buffer.numel() < workspace_size:
         workspace_buffer.resize_(workspace_size)
 
-    graph.execute_plan_at_index(
-        variant_pack,
-        workspace_buffer,
-        tactic,
-        handle=cudnn_handle,
-        override_uids=override_uids,
-        override_shapes=override_shapes,
-        override_strides=override_strides,
-    )
+    if plan_index < 0:
+        graph.execute(
+            variant_pack,
+            workspace_buffer,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
+    else:
+        graph.execute_plan_at_index(
+            variant_pack,
+            workspace_buffer,
+            plan_index,
+            handle=cudnn_handle,
+            override_uids=override_uids,
+            override_shapes=override_shapes,
+            override_strides=override_strides,
+        )
 
 
 # Autotuner sweeps M (token count) of the bf16 activation ``a``
@@ -371,7 +387,9 @@ def _cudnn_bf16_fp4_runner(tuning_config):
             _, _, _, alpha, out_dtype, _, block_size, use_nvfp4, _ = inputs
             return (out_dtype, block_size, use_nvfp4, alpha is not None)
 
-        def _get_override_graph(self, a, b, alpha, out_dtype, block_size, use_nvfp4):
+        def _get_override_graph(
+            self, a, b, alpha, out_dtype, block_size, use_nvfp4, tactic=-1
+        ):
             actual_m, k = int(a.shape[0]), int(a.shape[1])
             n = int(b.shape[0])
             cache_m = self._m_bucket_mapper(actual_m)
@@ -386,14 +404,17 @@ def _cudnn_bf16_fp4_runner(tuning_config):
                 alpha_is_not_none=alpha is not None,
                 use_nvfp4=use_nvfp4,
                 cache_m=cache_m,
-                policy=cudnn.build_plan_policy.ALL,
+                # tactic value only be 0 or -1 to hit the graph cache
+                tactic=(
+                    0 if _is_cudnn_engine_knob_tactic(tactic) or tactic >= 0 else -1
+                ),
             )
 
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
-        ) -> List[int]:
+        ) -> List[tuple]:
             (
                 a,
                 b,
@@ -407,7 +428,7 @@ def _cudnn_bf16_fp4_runner(tuning_config):
             ) = inputs
             if self._use_override_shape:
                 graph = self._get_override_graph(
-                    a, b, alpha, out_dtype, block_size, use_nvfp4
+                    a, b, alpha, out_dtype, block_size, use_nvfp4, tactic=0
                 )
             else:
                 graph = build_cudnn_bf16_fp4_graph(
@@ -421,14 +442,14 @@ def _cudnn_bf16_fp4_runner(tuning_config):
                     device=a.device,
                     alpha_is_not_none=alpha is not None,
                     use_nvfp4=use_nvfp4,
-                    policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
+                    tactic=0,
                 )
-            return list(range(graph.get_execution_plan_count()))
+            return _cudnn_graph_engine_knob_tactics(graph)
 
         def forward(
             self,
             inputs: List[torch.Tensor],
-            tactic: int = -1,
+            tactic=-1,
             do_preparation: bool = False,
             **kwargs,
         ) -> torch.Tensor:
@@ -443,22 +464,52 @@ def _cudnn_bf16_fp4_runner(tuning_config):
                 use_nvfp4,
                 workspace_buffer,
             ) = inputs
-            if self._use_override_shape:
-                graph = self._get_override_graph(
-                    a, b, alpha, out_dtype, block_size, use_nvfp4
+            try:
+                if self._use_override_shape:
+                    graph = self._get_override_graph(
+                        a, b, alpha, out_dtype, block_size, use_nvfp4, tactic=tactic
+                    )
+                    execute_cudnn_bf16_fp4_graph_override_shape(
+                        graph,
+                        a,
+                        b,
+                        b_descale,
+                        alpha,
+                        out,
+                        workspace_buffer,
+                        block_size=block_size,
+                        tactic=tactic,
+                    )
+                else:
+                    graph = build_cudnn_bf16_fp4_graph(
+                        batch=1,
+                        m=int(a.shape[0]),
+                        n=int(b.shape[0]),
+                        k=int(a.shape[1]),
+                        a_type=_torch_data_type_to_cudnn_data_type(a.dtype),
+                        o_type=_torch_data_type_to_cudnn_data_type(out_dtype),
+                        block_size=block_size,
+                        device=a.device,
+                        alpha_is_not_none=alpha is not None,
+                        use_nvfp4=use_nvfp4,
+                        tactic=tactic,
+                    )
+                    execute_cudnn_bf16_fp4_graph(
+                        graph,
+                        a,
+                        b,
+                        b_descale,
+                        alpha,
+                        out,
+                        workspace_buffer,
+                        tactic=tactic,
+                    )
+            except Exception as exc:
+                warnings.warn(
+                    "cuDNN bf16-fp4 GEMM tactic failed; falling back to default "
+                    f"tactic=-1. ({exc})",
+                    stacklevel=2,
                 )
-                execute_cudnn_bf16_fp4_graph_override_shape(
-                    graph,
-                    a,
-                    b,
-                    b_descale,
-                    alpha,
-                    out,
-                    workspace_buffer,
-                    block_size=block_size,
-                    tactic=max(tactic, 0),
-                )
-            else:
                 graph = build_cudnn_bf16_fp4_graph(
                     batch=1,
                     m=int(a.shape[0]),
@@ -470,7 +521,7 @@ def _cudnn_bf16_fp4_runner(tuning_config):
                     device=a.device,
                     alpha_is_not_none=alpha is not None,
                     use_nvfp4=use_nvfp4,
-                    policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
+                    tactic=-1,
                 )
                 execute_cudnn_bf16_fp4_graph(
                     graph,

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ einops
 nccl4py>=0.3.1
 ninja
 numpy
-nvidia-cudnn-frontend>=1.13.0
+nvidia-cudnn-frontend>=1.25.0
 nvidia-cutlass-dsl>=4.5.0
 nvidia-ml-py
 packaging>=24.2

--- a/tests/autotuner/test_autotuner_bmm_fp8.py
+++ b/tests/autotuner/test_autotuner_bmm_fp8.py
@@ -6,13 +6,19 @@ from flashinfer.autotuner import AutoTuner
 from flashinfer.gemm.gemm_base import (
     _FP8_GEMM_SM100_TUNING_CONFIG,
     _cudnn_gemm_fp8_runner,
-    _is_cudnn_engine_knob_tactic,
     _get_cache_buf,
     get_gemm_module,
     DEFAULT_WORKSPACE_SIZE,
 )
 from flashinfer.utils import get_compute_capability
 from tests.utils_fp8 import to_float8
+
+
+def _assert_engine_knob_tactic(tactic):
+    """cuDNN tactics are stable (engine_id, knob_items) descriptors, not plan indices."""
+    engine_id, knob_items = tactic
+    assert isinstance(engine_id, int)
+    assert all(len(item) == 2 for item in knob_items)
 
 
 @pytest.mark.parametrize(
@@ -121,8 +127,7 @@ def test_autotuner_gemm(pre_tune, tune_mode, expected_cache_hit, m, n, k):
     assert is_cache_hit == expected_cache_hit
     if is_cache_hit:
         assert runner_id == 0
-        # cuDNN tactics are stable engine/knob descriptors, not plan indices.
-        assert _is_cudnn_engine_knob_tactic(tactic)
+        _assert_engine_knob_tactic(tactic)
         assert stored_profile is not None
 
 
@@ -199,7 +204,7 @@ def test_autotuner_gemm_cross_bucket_m(backend):
     )
     assert is_cache_hit
     if backend == "cudnn":
-        assert _is_cudnn_engine_knob_tactic(tactic)
+        _assert_engine_knob_tactic(tactic)
     else:
         assert tactic >= 0
     assert stored_profile is not None

--- a/tests/autotuner/test_autotuner_bmm_fp8.py
+++ b/tests/autotuner/test_autotuner_bmm_fp8.py
@@ -6,6 +6,7 @@ from flashinfer.autotuner import AutoTuner
 from flashinfer.gemm.gemm_base import (
     _FP8_GEMM_SM100_TUNING_CONFIG,
     _cudnn_gemm_fp8_runner,
+    _is_cudnn_engine_knob_tactic,
     _get_cache_buf,
     get_gemm_module,
     DEFAULT_WORKSPACE_SIZE,
@@ -120,10 +121,8 @@ def test_autotuner_gemm(pre_tune, tune_mode, expected_cache_hit, m, n, k):
     assert is_cache_hit == expected_cache_hit
     if is_cache_hit:
         assert runner_id == 0
-        # cuDNN FP8 runner now enumerates multiple execution plans, so the
-        # autotuner can pick any valid plan index (>= 0). Tactic == -1 would
-        # mean the fallback path was chosen (no hit), which contradicts the hit.
-        assert tactic >= 0
+        # cuDNN tactics are stable engine/knob descriptors, not plan indices.
+        assert _is_cudnn_engine_knob_tactic(tactic)
         assert stored_profile is not None
 
 
@@ -131,12 +130,12 @@ def test_autotuner_gemm(pre_tune, tune_mode, expected_cache_hit, m, n, k):
 def test_autotuner_gemm_cross_bucket_m(backend):
     """Tune at one M bucket, then run inference at a non-bucket M.
 
-    The non-override cuDNN graph (and the cuBLASLt algo list) is enumerated at
-    the *real* shape, so a tactic tuned against a different (bucketed) M may be
-    out of range for the runtime plan/algo list. This must NOT raise (the
-    runner clamps an out-of-range index back to the heuristic default), and the
-    autotuner must still reuse the tuned bucket entry for the non-bucket M
-    (i.e. the workspace scratch size does not leak into the cache key).
+    The cuBLASLt algo list is enumerated at the *real* shape, so an integer
+    tactic tuned against a different (bucketed) M may be out of range at
+    runtime. cuDNN tactics are stable engine/knob descriptors and are resolved
+    against the runtime graph. Both paths must reuse the tuned bucket entry for
+    the non-bucket M (i.e. the workspace scratch size does not leak into the
+    cache key) and produce finite output.
     """
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     cc = compute_capability[0] * 10 + compute_capability[1]
@@ -199,5 +198,8 @@ def test_autotuner_gemm_cross_bucket_m(backend):
         inputs=[a8, b8, a_s, b_s, res, workspace_buffer],
     )
     assert is_cache_hit
-    assert tactic >= 0
+    if backend == "cudnn":
+        assert _is_cudnn_engine_knob_tactic(tactic)
+    else:
+        assert tactic >= 0
     assert stored_profile is not None

--- a/tests/gemm/test_bmm_mxfp8.py
+++ b/tests/gemm/test_bmm_mxfp8.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -37,31 +39,40 @@ def test_bmm_mxfp8(
     # Block size is 32 in MXFP8
     assert input_mxfp8.numel() == (input_scale.numel() * 32)
 
-    mat2 = (
-        torch.randn([b, n, k], device="cuda", dtype=input_dtype)
-        .transpose(-2, -1)
-        .contiguous()
-    )
-    mat2_mxfp8, mat2_scale = mxfp8_quantize(mat2, is_sf_swizzled_layout)
+    weight = torch.randn([b, n, k], device="cuda", dtype=input_dtype)
+    weight_mxfp8, weight_scale = mxfp8_quantize(weight, is_sf_swizzled_layout)
+    mat2_mxfp8 = weight_mxfp8.transpose(-2, -1)
 
-    assert mat2_mxfp8.numel() == (mat2_scale.numel() * 32)
+    assert mat2_mxfp8.shape == (b, k, n)
+    assert mat2_mxfp8.stride(-2) == 1
+
+    assert weight_mxfp8.numel() == (weight_scale.numel() * 32)
 
     # Compute reference result
-    reference = torch.bmm(input_mat, mat2)
+    reference = torch.bmm(input_mat, weight.transpose(-2, -1))
 
     # Create output tensor
     res = torch.empty([b, m, n], device="cuda", dtype=res_dtype)
 
-    with autotune(auto_tuning):
-        bmm_mxfp8(
-            input_mxfp8,
-            mat2_mxfp8,
-            input_scale,
-            mat2_scale,
-            res_dtype,
-            res,
-            backend=backend,
-        )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with autotune(auto_tuning):
+            bmm_mxfp8(
+                input_mxfp8,
+                mat2_mxfp8,
+                input_scale,
+                weight_scale,
+                res_dtype,
+                res,
+                backend=backend,
+            )
+
+    fallback_warnings = [
+        warning
+        for warning in caught
+        if "falling back to default tactic=-1" in str(warning.message)
+    ]
+    assert not fallback_warnings
 
     # Verify output properties
     assert res.shape == (b, m, n), f"Expected shape {(b, m, n)}, got {res.shape}"

--- a/tests/gemm/test_unified_gemm_fuzz.py
+++ b/tests/gemm/test_unified_gemm_fuzz.py
@@ -122,9 +122,6 @@ pytestmark = [
     pytest.mark.skipif(_SKIP is not None, reason=str(_SKIP)),
 ]
 _SM = _CC[0] * 10 + _CC[1]
-_CUDNN_VER = (
-    torch.backends.cudnn.version() or 0
-)  # e.g. 92300 == 9.23.0, 92301 == 9.23.1
 
 # A clean rejection ("not supported on this shape/arch/dtype") must SKIP, never fail; a crash
 # (CUDA error / illegal access / device assert) is always a finding and re-raises.
@@ -433,12 +430,6 @@ _CONVENTION_DIVERGENCES = [
 
 # Tracked findings the fuzzer surfaced (xfail-but-RUN: the case still executes, a correctness
 # failure is tolerated to keep the suite green, and an unexpected PASS warns "fixed -> remove it").
-#
-# NOTE: the cuDNN-9.23.0 bf16-mm/bmm fp16-out SM90 garbage finding used to live here as an xfail.
-# It's gone because flashinfer now precisely bans that envelope ({SM90, bf16->fp16, 9.23.0.x} in
-# gemm_base.py _cudnn_bf16_gemm_usable_or_skip) -> the cuDNN path is skipped there (auto falls
-# back), and 9.23.1+ has it fixed, so the broken path is unreachable. No workaround needed.
-#
 # Each entry is (predicate, reason, crash_capable). crash_capable=True entries are xfailed UP FRONT
 # (the kernel is never launched): the same root cause that yields garbage on one library stack can
 # be an out-of-bounds access on another, and one IMA poisons the CUDA context for every later test
@@ -461,31 +452,6 @@ _KNOWN_FAILURES = [
         "b=16 m=7 n=512 k=2688). To probe fixed-ness, run the REPRO with this entry removed. "
         "See HANDOFF_SM120_MXFP8_BMM_VERIFY.md.",
         True,  # crash-capable: IMA'd on GB200/cu129
-    ),
-    (
-        lambda cfg: (
-            cfg.adapter.quant_mode == "bf16"
-            and cfg.backend == "cudnn"
-            and _CC[0] == 9
-            and _CUDNN_VER == 92300
-        ),
-        "cuDNN 9.23.0 SM90 bf16 GEMM: the AUTOTUNER-selected (non-default) tactic returns garbage "
-        "for bf16->bf16 too (found by the autotune-ON winner validation: mm_bf16 m63_n32_k2688 "
-        "seed 1834712400, ratio 0.98 vs 0.0022 at the default tactic). Root-caused by per-plan "
-        "enumeration: of the graph's 15 plans exactly the five 'eng7_k17=4_*' ones (engine 7 with "
-        "CUDNN_KNOB_TYPE_SPLIT_K_SLC=4) miscompute; eng7 WITHOUT split-k is correct, and the tuner "
-        "picks the broken one because split-k wins the timing race on tall-K shapes. Same 9.23.0 "
-        "split-k family as the bf16->fp16 bug that gemm_base.py hard-bans, but bf16-out escapes "
-        "that ban because its DEFAULT tactic is correct -- only autotune(True) reaches the broken "
-        "plan. NOT tactic-index drift: the index was profiled and executed against the same graph "
-        "in the same process. Banning the whole {SM90, bf16-out, 9.23.0} envelope would kill a "
-        "working default path and the requirement layer cannot exclude a single plan, so it is "
-        "ledgered (numeric-only) instead; a tactics-blocklist entry (FLASHINFER_TACTICS_BLOCKLIST) "
-        "is the product-side mitigation for users pinned on 9.23.0. VERIFIED fixed in 9.23.1: the "
-        "same per-plan matrix on 9.23.1.3 and 9.23.2.1 shows all 15 plans (incl. the five "
-        "eng7_k17=4 ones) correct -- so the ==92300 gate is exact. Unreachable in CI (containers "
-        "pin newer cuDNN).",
-        False,  # numeric-only: default tactic is fine; still run, xfail at compare
     ),
 ]
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

This PR contains a series of changes to make cudnn GEMM backend stable during autotuning.
1. Bump flashinfer dependency requirement of cudnn frontend version from v1.13.0 to v1.25.0
2. Replace fixed plan index cached in autotuner with explicit cudnn engine/knob combination
3. Add a fallback plan for cudnn backend when cached execution plan is not available to avoid abrupt crash

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified cuDNN GEMM execution around a **tactic → plan_index** workflow, including discovery of engine/knob tactics, consistent plan selection, and plan-specific workspace sizing (covers FP4/BF16 and related paths).
* **Bug Fixes**
  * Added resilience for tactic-based execution: if a tactic fails, the system warns and automatically falls back to the default tactic.
* **Tests**
  * Updated autotuner tests to validate cuDNN engine/knob tactics and to verify expected warning behavior; expanded MXFP8 bmm warning assertions.
* **Dependencies**
  * Increased minimum `nvidia-cudnn-frontend` to **≥ 1.25.0**.
* **Chores**
  * Broadened autotuner tactic handling to support non-integer representations; skipped legacy cuDNN integer tactic cache entries when autotuning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->