### PR TITLE
feat(moe): enable DSFp8 + LoRA delta path

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -582,6 +582,9 @@ class FusedMoeLauncher {
   // | false | false | [gemm2_output, expert_weights, expanded_idx_to_permuted_idx]               |
   // | false | true  | [gemm2_output, expert_weights, expanded_idx_to_permuted_idx, gemm1_output] |
   //
+  // The `gemm1_output` slot carries the post-activation FC1 output with shape
+  // [num_padded_tokens, intermediate_size].
+  //
   // `expanded_idx_to_permuted_idx` is appended whenever a permuted-layout
   // tensor (`gemm2_output` or `gemm1_output`) is returned, so the caller can
   // always unpermute back to (token, slot) order.
@@ -1450,7 +1453,12 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
       result.push_back(expanded_idx_to_permuted_idx);
     }
     if (return_activation_output) {
-      result.push_back(gemm1_output);
+      // For DSFp8, gemm1_output is the pre-activation FC1 output (shape [M, 2*I])
+      // and the post-activation tensor lives in activation_output (shape [M, I]).
+      // MxFp8 fuses SwiGLU into FC1 so gemm1_output IS already post-activation.
+      result.push_back(quantization_type == Fp8QuantizationType::DeepSeekFp8
+                           ? activation_output
+                           : gemm1_output);
     }
     return result;
   }

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -528,8 +528,7 @@ class FusedMoeLauncher {
     // path and numerics. DSFp8 + biasMn routes through the unified constructor below
     // (which accepts gemm1_bias_type).
     if (this->mDtypeAct == btg::Dtype::E4m3 && this->mDtypeWeights == btg::Dtype::E4m3 &&
-        args->mUseDeepSeekFp8 &&
-        args->gemm1_bias_type == batchedGemm::gemm::BiasType::None) {
+        args->mUseDeepSeekFp8 && args->gemm1_bias_type == batchedGemm::gemm::BiasType::None) {
       moe_runner = std::make_unique<RunnerType>(this->mDtypeWeights, args->mUseDeepSeekFp8,
                                                 (int32_t)tile_tokens_dim, this->use_shuffled_weight,
                                                 this->weight_layout, usePerTokenScalingGemm1,
@@ -1456,9 +1455,8 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
       // For DSFp8, gemm1_output is the pre-activation FC1 output (shape [M, 2*I])
       // and the post-activation tensor lives in activation_output (shape [M, I]).
       // MxFp8 fuses SwiGLU into FC1 so gemm1_output IS already post-activation.
-      result.push_back(quantization_type == Fp8QuantizationType::DeepSeekFp8
-                           ? activation_output
-                           : gemm1_output);
+      result.push_back(quantization_type == Fp8QuantizationType::DeepSeekFp8 ? activation_output
+                                                                             : gemm1_output);
     }
     return result;
   }

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -523,12 +523,13 @@ class FusedMoeLauncher {
         ;
     // FIXME(siyuan): currently only nvfp4 x nvfp4 uses per-token scaling in both FC1 and FC2
     bool usePerTokenScalingGemm2 = per_token_scales.has_value() && mDtypeAct == btg::Dtype::E2m1;
-    // For FP8 block-scale (E4m3 activations, E4m3 weights) with DeepSeek FP8, use the
-    // weights-only Runner constructor to match the original kernel path and numerics.
+    // For FP8 block-scale (E4m3 activations, E4m3 weights) with DeepSeek FP8 and no
+    // gemm1 bias, use the weights-only Runner constructor to match the original kernel
+    // path and numerics. DSFp8 + biasMn routes through the unified constructor below
+    // (which accepts gemm1_bias_type).
     if (this->mDtypeAct == btg::Dtype::E4m3 && this->mDtypeWeights == btg::Dtype::E4m3 &&
-        args->mUseDeepSeekFp8) {
-      TVM_FFI_ICHECK(args->gemm1_bias_type == batchedGemm::gemm::BiasType::None)
-          << "DeepSeek FP8 MoE does not support a gemm1_bias_type other than None";
+        args->mUseDeepSeekFp8 &&
+        args->gemm1_bias_type == batchedGemm::gemm::BiasType::None) {
       moe_runner = std::make_unique<RunnerType>(this->mDtypeWeights, args->mUseDeepSeekFp8,
                                                 (int32_t)tile_tokens_dim, this->use_shuffled_weight,
                                                 this->weight_layout, usePerTokenScalingGemm1,
@@ -1398,10 +1399,6 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
   Array<Tensor> run(int64_t moe_tactic, bool enable_pdl = true,
                     bool use_routing_scales_on_input = false, bool use_deep_seek_fp8 = false,
                     bool return_activation_output = false) override {
-    if (return_activation_output) {
-      TVM_FFI_ICHECK(quantization_type == Fp8QuantizationType::MxFp8)
-          << "return_activation_output is only supported for MxFp8 block-scale MoE";
-    }
     check_routing();
     prepare_routing();
 
@@ -1473,9 +1470,11 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
     for (int32_t tile_N : selected_tile_nums) {
       std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner> moe_runner;
       // Keep getValidConfigs constructor path aligned with runtime prepare_moe_common().
-      // This branch is for DeepSeek FP8 (E4m3 activations + E4m3 weights).
+      // DSFp8 without bias uses the weights-only constructor;
+      // DSFp8 + biasMn routes through the unified constructor below.
       if (quantization_type == Fp8QuantizationType::DeepSeekFp8 && dtype_act == btg::Dtype::E4m3 &&
-          dtype_weights == btg::Dtype::E4m3) {
+          dtype_weights == btg::Dtype::E4m3 &&
+          gemm1_bias_type == batchedGemm::gemm::BiasType::None) {
         TVM_FFI_ICHECK(static_cast<int>(activation_type) ==
                        static_cast<int>(ActivationType::Swiglu))
             << "DeepSeekFp8 only supports ActivationType::Swiglu, got "
@@ -2319,10 +2318,6 @@ Array<Tensor> trtllm_fp8_block_scale_moe(
   auto const gemm1_bias_type_enum = gemm1_lora_delta.has_value()
                                         ? batchedGemm::gemm::BiasType::Mn
                                         : batchedGemm::gemm::BiasType::None;
-  if (gemm1_lora_delta.has_value() && quantization_type != Fp8QuantizationType::MxFp8) {
-    TVM_FFI_LOG_AND_THROW(NotImplementedError)
-        << "FP8 block-scale MoE only supports lora delta for MxFp8.";
-  }
   auto const dtype_act =
       quantization_type == Fp8QuantizationType::DeepSeekFp8 ? btg::Dtype::E4m3 : btg::Dtype::MxE4m3;
   auto const dtype_weights =
@@ -2654,9 +2649,6 @@ Array<Array<int64_t>> trtllm_get_valid_moe_configs(
 
   } else if (fp8_quantization_type == Fp8QuantizationType::DeepSeekFp8 &&
              dtype_act == btg::Dtype::E4m3 && dtype_weights == btg::Dtype::E4m3) {
-    if (has_gemm1_lora_delta) {
-      TVM_FFI_LOG_AND_THROW(NotImplementedError) << "DeepSeek FP8 MoE does not support lora delta";
-    }
     if (activation_type != ActivationType::Swiglu) {
       TVM_FFI_LOG_AND_THROW(NotImplementedError)
           << "DeepSeekFp8 only supports ActivationType::Swiglu, "

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -1492,7 +1492,8 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
             static_cast<batchedGemm::gemm::MatrixLayout>(weight_layout));
       } else {
         // Under current trtllm_get_valid_moe_configs() dispatch rules, this else-path is
-        // reached only by FP8 block-scale MXFP8 (dtype_act=dtype_weights=MxE4m3).
+        // reached by FP8 block-scale MXFP8 (dtype_act=dtype_weights=MxE4m3) and by
+        // DeepSeek FP8 with a gemm1 bias (BiasType::Mn).
         moe_runner = std::make_unique<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner>(
             dtype_act,                                              // dtypeAct
             dtype_weights,                                          // dtypeWeights

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -361,15 +361,17 @@ tensorrt_llm::kernels::TrtllmGenBatchedGemmRunnerOptions getOptions(
       "Unknown activation type", serializeActivationType(activationType), "of enum", actTypeInt);
   bool isGatedAct = isGatedActivation(activationType);
   bool useBiasMn = biasType == batchedGemm::gemm::BiasType::Mn;
-  auto fusedBiasShuffleMode = useBiasMn ? batchedGemm::gemm::FusedBiasShuffleMode::ReorderAndShuffle
-                                        : batchedGemm::gemm::FusedBiasShuffleMode::None;
+  // ReorderAndShuffle is only supported on fused-act (gated) paths in trtllm-gen.
+  // DSFp8 uses non-fused activation, so it must use Shuffle mode for biasMn.
+  auto fusedBiasShuffleMode =
+      useBiasMn ? (useDeepSeekFp8 ? batchedGemm::gemm::FusedBiasShuffleMode::Shuffle
+                                  : batchedGemm::gemm::FusedBiasShuffleMode::ReorderAndShuffle)
+                : batchedGemm::gemm::FusedBiasShuffleMode::None;
   auto const biasDtype = batchedGemm::trtllm::gen::Dtype::Bfloat16;
   if (useBiasMn) {
     // These checks are because trtllm-gen only exports a subset of the bias types and modes
     FLASHINFER_CHECK(isGatedAct,
                      "PermuteGemm1 BiasType::Mn requires a gated activation (SwiGlu/GeGlu)");
-    FLASHINFER_CHECK(!useDeepSeekFp8,
-                     "PermuteGemm1 BiasType::Mn requires fusedAct=true (not DeepSeek FP8)");
     FLASHINFER_CHECK(useShuffledMatrix,
                      "PermuteGemm1 BiasType::Mn requires useShuffledMatrix=true");
   }

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -137,7 +137,7 @@ class ArtifactPath:
 
     TRTLLM_GEN_FMHA: str = "158f6fa11ef139a098cfddcdddce73ca99d164ad/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
-        "d2c5915bf45ae64308a947824c14966c2718a292/batched_gemm-91e0ba0-896b90b/"
+        "481dce07c89a216cbfd18cf39de49a82d40739a8/batched_gemm-dd6d23e-721ae60/"
     )
     TRTLLM_GEN_GEMM: str = (
         "10f64528a1172dae8e29601a3b99ab9dc78d37be/gemm-91e0ba0-2710384/"
@@ -160,7 +160,7 @@ class CheckSumHash:
         "c2d9399b2537be785882354a4f9902ed6c03136c0ea341e201eac40c3923e1dc"
     )
     TRTLLM_GEN_BMM: str = (
-        "ffc4f52df6ff901000ab4cd80fa1ae24dcf5fe5739c6e5c0b3bb9b8e4802084e"
+        "aa19cf2a37eed029eee5b3f96b37e069e4ab40f419b25ed7a3fd9526d8833bfb"
     )
     DEEPGEMM: str = "1a2a166839042dbd2a57f48051c82cd1ad032815927c753db269a4ed10d0ffbf"
     TRTLLM_GEN_GEMM: str = (

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2093,13 +2093,6 @@ def get_trtllm_moe_sm100_module():
             if fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8
             else DtypeTrtllmGen.MxE4m3
         )  # FP8 weights
-        if (
-            gemm1_lora_delta is not None
-            and fp8_quantization_type != Fp8QuantizationType.MxFp8
-        ):
-            raise NotImplementedError(
-                "LoRA delta is only supported for MxFp8 block-scale MoE."
-            )
         _validate_fp8_block_scale_gemm1_activation_params(
             fp8_quantization_type,
             activation_type,

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -1921,6 +1921,10 @@ def test_mxfp8_block_scale_moe_swiglu_oa_activation_params(cache_permute_indices
             FP8BlockScaleMoe(fp8_quantization_type=QuantMode.FP8_BLOCK_SCALE_MXFP8),
             id="MxFp8",
         ),
+        pytest.param(
+            FP8BlockScaleMoe(fp8_quantization_type=QuantMode.FP8_BLOCK_SCALE_DEEPSEEK),
+            id="DSFp8",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -1955,7 +1959,11 @@ def test_mxfp8_block_scale_moe_swiglu_oa_activation_params(cache_permute_indices
             {
                 "use_shuffled_weight": True,
                 "layout": WeightLayout.BlockMajorK,
-                "compatible_moe_impls": [BF16Moe, MxInt4BlockScaleMoe],
+                "compatible_moe_impls": [
+                    BF16Moe,
+                    MxInt4BlockScaleMoe,
+                    FP8BlockScaleMoe,
+                ],
             },
             id="Shuffled_BlockMajorK",
         ),
@@ -1965,7 +1973,7 @@ def test_mxfp8_block_scale_moe_swiglu_oa_activation_params(cache_permute_indices
                 "layout": WeightLayout.MajorK,
                 "compatible_moe_impls": [FP8BlockScaleMoe],
             },
-            id="Shuffled_MajorK_MxFp8",
+            id="Shuffled_MajorK",
         ),
     ],
 )

--- a/tests/moe/trtllm_gen_fused_moe_utils.py
+++ b/tests/moe/trtllm_gen_fused_moe_utils.py
@@ -308,6 +308,30 @@ class Moe(ABC):
         """Unified actual computation that delegates to implementation-specific methods."""
         return _compute_moe_actual_unified(self, args_dequant, args, **kwargs)
 
+    def check_intermediate_output(self, raw_kernel_output, reference_args):
+        """Validate the kernel's exposed post-activation FC1 output.
+
+        This base implementation checks only the shape. Quant-specific subclasses may override
+        to add a numerical comparison in their own block-scale format.
+
+        ``reference_args`` is the dequantized-reference args object that carries ``intermediate_size``,
+        the reference ``activation_output``, and ``permute_info``).
+        """
+        assert isinstance(raw_kernel_output, list) and len(raw_kernel_output) >= 3, (
+            f"Expected the kernel to return [output, "
+            f"expanded_idx_to_permuted_idx, gemm1_output]; got "
+            f"{type(raw_kernel_output).__name__} of length "
+            f"{len(raw_kernel_output) if isinstance(raw_kernel_output, list) else 'n/a'}"
+        )
+        intermediate = raw_kernel_output[2]
+        assert intermediate.shape[-1] == reference_args.intermediate_size, (
+            f"Expected the post-activation FC1 output to have last-dim "
+            f"{reference_args.intermediate_size}; got shape "
+            f"{tuple(intermediate.shape)}. The kernel may have returned the "
+            f"pre-activation gemm1_output buffer (shape [M, 2*intermediate_size]) "
+            f"instead of the post-activation activation_output buffer."
+        )
+
     @abstractmethod
     def get_tolerances(self):
         """Get accuracy tolerances for this quantization mode."""
@@ -916,7 +940,11 @@ class MxInt4BlockScaleMoe(Moe):
                     tune_max_num_tokens=TUNE_MAX_NUM_TOKENS,
                     norm_topk_prob=norm_topk_prob,
                 )
-        return output[0].to(torch.float)
+        if isinstance(output, list):
+            if kwargs.get("return_full_output", False):
+                return output
+            return output[0].to(torch.float)
+        return output.to(torch.float)
 
     def compute_reference(self, args):
         return run_moe_reference_mxint4(args)
@@ -1207,7 +1235,7 @@ class FP8BlockScaleMoe(Moe):
     ):
         """Call MoE with runtime block scale generation + kernel execution.
 
-        When a ``gemm1_lora_delta`` is set for MXFP8, routing has to happen
+        When a ``gemm1_lora_delta`` is set, routing has to happen
         outside the MoE kernel so the caller's LoRA backbone and the MoE share
         the same top-k routing. We therefore switch to the routed entry point
         and reuse ``permute_info["topKIndices"]`` / ``permute_info["topKLogits"]``
@@ -1252,10 +1280,6 @@ class FP8BlockScaleMoe(Moe):
         # Use autotuner for optimal kernel selection
         with autotune(enable_autotune):
             if gemm1_lora_delta is not None:
-                if self.fp8_quantization_type != QuantMode.FP8_BLOCK_SCALE_MXFP8:
-                    raise NotImplementedError(
-                        "LoRA delta is only supported for MXFP8 in FP8BlockScaleMoe tests."
-                    )
                 packed_topk_ids = pack_topk_for_routed_moe(
                     permute_info["topKIndices"], permute_info["topKLogits"]
                 )
@@ -1319,6 +1343,8 @@ class FP8BlockScaleMoe(Moe):
                     gemm1_clamp_limit=gemm1_clamp_limit,
                 )
         if isinstance(output, list):
+            if kwargs.get("return_full_output", False):
+                return output
             return output[0].to(torch.float)
         return output.to(torch.float)
 
@@ -1336,6 +1362,67 @@ class FP8BlockScaleMoe(Moe):
     def get_tolerances(self):
         """Get FP8 block-scale accuracy tolerances."""
         return {"atol": 0.1, "rtol": 0.85, "percent": 0.79}
+
+    def check_intermediate_output(self, raw_kernel_output, reference_args):
+        """Shape check (base) plus a value comparison of the post-activation
+        FC1 output against the reference fp32.
+        """
+        super().check_intermediate_output(raw_kernel_output, reference_args)
+
+        # Gather both sides into canonical expanded-index order.
+        # We index each by its own expanded->permuted map (each exactly
+        # [num_tokens * top_k] long).
+        kernel_codes = raw_kernel_output[2]
+        kernel_expanded_to_permuted = raw_kernel_output[1].to(torch.int64).cpu()
+        ref_expanded_to_permuted = (
+            reference_args.permute_info["expandedTokenIdxToPermutedIdx"]
+            .to(torch.int64)
+            .cpu()
+        )
+        kernel_routed = kernel_codes[kernel_expanded_to_permuted]
+        ref_routed = reference_args.activation_output[ref_expanded_to_permuted].to(
+            torch.float32
+        )
+        n_rows, intermediate_size = ref_routed.shape
+
+        if self.fp8_quantization_type == QuantMode.FP8_BLOCK_SCALE_DEEPSEEK:
+            # Per-(1, 128) linear block scale derived from the reference.
+            finfo = torch.finfo(torch.float8_e4m3fn)
+            n_blocks = intermediate_size // 128
+            scale = (
+                ref_routed.view(n_rows, n_blocks, 128)
+                .abs()
+                .amax(dim=-1, keepdim=True)
+                .clamp(min=1e-12)
+                / finfo.max
+            )
+            kernel_dequant = (
+                kernel_routed.view(torch.float8_e4m3fn)
+                .to(torch.float32)
+                .view(n_rows, n_blocks, 128)
+                * scale
+            ).view(n_rows, intermediate_size)
+        else:  # FP8_BLOCK_SCALE_MXFP8
+            # mx-format scale via the mx quantizer;
+            # keep only the scale to decode the kernel's codes.
+            _, ref_scale = mxfp8_quantize(ref_routed.to(torch.bfloat16), True)
+            ref_scale_bytes = ref_scale.view(torch.uint8).reshape(-1).cpu()
+            kernel_dequant = (
+                mxfp8_dequantize_host(
+                    kernel_routed.cpu().view(torch.uint8), ref_scale_bytes
+                )
+                .to(ref_routed.device)
+                .to(torch.float32)
+            )
+
+        tolerances = self.get_tolerances()
+        check_accuracy(
+            ref_routed,
+            kernel_dequant,
+            atol=tolerances["atol"],
+            rtol=tolerances["rtol"],
+            percent=tolerances["percent"],
+        )
 
 
 # ====================================================================================
@@ -1724,6 +1811,8 @@ class BF16Moe(Moe):
                     gemm1_clamp_limit=gemm1_clamp_limit,
                 )
         if isinstance(output, list):
+            if kwargs.get("return_full_output", False):
+                return output
             return output[0].to(torch.float)
         return output.to(torch.float)
 
@@ -2482,6 +2571,10 @@ def run_moe_dequant(args, quant_mode: QuantMode):
         i += my_num_tokens
         i = (i + args.padding - 1) // args.padding * args.padding
 
+    # Stash the fp32 post-activation FC1 output so callers can compare against
+    # the kernel's return_activation_output slot.
+    args.activation_output = activation_output.clone()
+
     if quant_mode == QuantMode.FP4_NVFP4_NVFP4:
         # Use centralized function for activation quantization
         activation_output, c_global_sf = quant_dequant_fp4(
@@ -2727,6 +2820,7 @@ def run_moe_reference_dsfp8(args):
         gemm1_alpha=args.gemm1_alpha,
         gemm1_beta=args.gemm1_beta,
         gemm1_clamp_limit=args.gemm1_clamp_limit,
+        gemm1_lora_delta=args.gemm1_lora_delta,
     )
 
     return run_moe_dequant(
@@ -2910,6 +3004,7 @@ def _compute_moe_actual_unified(moe_impl, args_dequant, args, **kwargs):
         "gemm1_clamp_limit": args.gemm1_clamp_limit,
         "permute_info": args.permute_info,
         "norm_topk_prob": kwargs.get("norm_topk_prob", True),
+        "return_full_output": kwargs.get("return_full_output", False),
     }
 
     return moe_impl.call_moe(
@@ -3161,8 +3256,12 @@ def run_moe_test(
     routing_bias_dtype=None,
     norm_topk_prob=True,
     check_reference=True,
+    check_intermediate_output=False,
 ):
     """Common test logic for all routing methods."""
+    if gemm1_lora_delta is not None:
+        check_intermediate_output = True
+
     skip_checks(
         moe_impl,
         routing_config,
@@ -3360,7 +3459,14 @@ def run_moe_test(
         hidden_states_quant=inputs_data["hidden_states"],
         enable_autotune=enable_autotune,
         norm_topk_prob=norm_topk_prob,
+        return_full_output=check_intermediate_output,
     )
+
+    # When a lora delta is set, the kernel returns the post-activation FC1 output
+    # exposed as the third element. Validate it.
+    if check_intermediate_output:
+        moe_impl.check_intermediate_output(output_dequant_actual, args_dequant)
+        output_dequant_actual = output_dequant_actual[0].to(torch.float)
 
     # Compare outputs
     if check_reference:


### PR DESCRIPTION
## 📌 Description

Enables the DeepSeek FP8 path of `trtllm_fp8_block_scale_routed_moe` to accept a `gemm1_lora_delta` argument (`BiasType::Mn`). 

## 🔍 Related Issues

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

Validated on B200 against the live public cubin mirror.

```
$ pytest tests/moe/test_trtllm_gen_fused_moe.py::test_moe_lora_delta -k "MxFp8 or DSFp8"

test_moe_lora_delta[Swiglu-Shuffled_BlockMajorK-Renorm-MxFp8-1024-1024-8]   SKIPPED   (MxFp8 requires MajorK)
test_moe_lora_delta[Swiglu-Shuffled_BlockMajorK-Renorm-MxFp8-1024-1024-128] SKIPPED   (MxFp8 requires MajorK)
test_moe_lora_delta[Swiglu-Shuffled_BlockMajorK-Renorm-DSFp8-1024-1024-8]   PASSED    (new)
test_moe_lora_delta[Swiglu-Shuffled_BlockMajorK-Renorm-DSFp8-1024-1024-128] PASSED    (new)
test_moe_lora_delta[Swiglu-Shuffled_MajorK-Renorm-MxFp8-1024-1024-8]        PASSED    (baseline)
test_moe_lora_delta[Swiglu-Shuffled_MajorK-Renorm-MxFp8-1024-1024-128]      PASSED    (baseline)
test_moe_lora_delta[Swiglu-Shuffled_MajorK-Renorm-DSFp8-1024-1024-8]        PASSED    (new)
test_moe_lora_delta[Swiglu-Shuffled_MajorK-Renorm-DSFp8-1024-1024-128]      PASSED    (new)

6 passed, 2 skipped, 8 deselected, 2 warnings in 750.74s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Expanded LoRA-delta support for FP8 Block-Scale MoE, including DeepSeek FP8 variants, and improved configuration generation for additional bias cases.
* **Bug Fixes**
  * Corrected DeepSeek FP8 bias/shuffle handling for bias type **Mn**.
  * Fixed activation-output selection when returning intermediate activations for DeepSeek FP8.
  * Relaxed prior validation/restrictions so FP8 block-scale MoE accepts LoRA-delta where applicable.
* **Tests**
  * Extended MoE LoRA-delta coverage with verification of a post-activation FC1 intermediate output.
* **Chores**
  * Updated BMM artifact download path and checksum manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->