### PR TITLE
docs(gemm): add missing .rst entries for mm_bf16_fp4 and prepare_bf16_fp4_weights

### DIFF
--- a/docs/api/gemm.rst
+++ b/docs/api/gemm.rst
@@ -24,8 +24,8 @@ FP4 GEMM
 
     mm_fp4
 
-BF16×FP4 GEMM (W4A16)
-----------------------
+BF16 x FP4 GEMM (W4A16)
+-----------------------
 
 .. autosummary::
     :toctree: ../generated

--- a/docs/api/gemm.rst
+++ b/docs/api/gemm.rst
@@ -24,6 +24,15 @@ FP4 GEMM
 
     mm_fp4
 
+BF16×FP4 GEMM (W4A16)
+----------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    prepare_bf16_fp4_weights
+    mm_bf16_fp4
+
 MXFP8 GEMM
 ----------
 


### PR DESCRIPTION
## Summary

-  and  were introduced in #3597 (BF16×FP4 GEMM with cuDNN and CuTe-DSL backends for SM120/121, W4A16 workloads)
- Both are decorated with  but were absent from , causing API-coverage alerts
- Adds a new **BF16×FP4 GEMM (W4A16)** section in  listing both functions under 

## Changes

- : new section inserted after *FP4 GEMM* with  and 

## Test plan

- [ ] Verify  picks up both symbols without error
- [ ] Confirm API-coverage alert clears on next daily run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new API documentation subsection for **BF16×FP4 GEMM (W4A16)**, including generated reference pages for the weight preparation and matrix multiplication operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->