### PR TITLE
Only some redundancies have been optimized, and the main improvement is in TTFT

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -1956,20 +1956,14 @@ class MoEDynamicKernel:
                                 csB_p[None, None, k_next],
                                 crB[None, None, k_next],
                             )
-                            fz_csSFA_cur = cute.filter_zeros(
-                                csSFA[None, None, None, cons_state.index]
-                            )
-                            fz_csSFB_cur = cute.filter_zeros(
-                                csSFB[None, None, None, cons_state.index]
-                            )
                             cute.copy(
                                 smem_copy_SFA,
-                                fz_csSFA_cur[None, None, k_next],
+                                fz_csSFA_p[None, None, k_next],
                                 fz_crSFA[None, None, k_next],
                             )
                             cute.copy(
                                 smem_copy_SFB,
-                                fz_csSFB_cur[None, None, k_next],
+                                fz_csSFB_p[None, None, k_next],
                                 fz_crSFB[None, None, k_next],
                             )
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -2345,9 +2339,9 @@ class MoEDynamicKernel:
                         cute.copy(
                             smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0]
                         )
-                        f2 = cute.filter_zeros(csSFB_phase2)
-                        f4 = cute.filter_zeros(crSFB)
-                        cute.copy(smem_copy_SFB, f2[None, None, 0], f4[None, None, 0])
+                        f2_hoist = cute.filter_zeros(csSFB_phase2)
+                        f4_hoist = cute.filter_zeros(crSFB)
+                        cute.copy(smem_copy_SFB, f2_hoist[None, None, 0], f4_hoist[None, None, 0])
 
                         down_acc.fill(0.0)
                         for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -2366,12 +2360,10 @@ class MoEDynamicKernel:
                                     csB_phase2[None, None, k_next],
                                     crB[None, None, k_next],
                                 )
-                                f2 = cute.filter_zeros(csSFB_phase2)
-                                f4 = cute.filter_zeros(crSFB)
                                 cute.copy(
                                     smem_copy_SFB,
-                                    f2[None, None, k_next],
-                                    f4[None, None, k_next],
+                                    f2_hoist[None, None, k_next],
+                                    f4_hoist[None, None, k_next],
                                 )
                             for _mt in cutlass.range_constexpr(fc2_m_tiles):
                                 for _nt in cutlass.range_constexpr(fc2_n_tiles):

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -1016,9 +1016,15 @@ class MoEMicroKernel:
                 i += flat_stride
         scatter_total = num_tokens * cols
         j = flat_tid
+        row = flat_tid // cols
+        col = flat_tid - row * cols
         while j < scatter_total:
-            scatter_output[j // cols, j % cols] = cutlass.BFloat16(0.0)
+            scatter_output[row, col] = cutlass.BFloat16(0.0)
             j += flat_stride
+            col += flat_stride
+            while col >= cols:
+                col -= cols
+                row += Int32(1)
         cute.arch.sync_threads()
         # When the quantized input is shared across experts, only pair 0
         # writes to packed storage; there is no expert-parallel routing to
@@ -1631,20 +1637,14 @@ class MoEMicroKernel:
                             csB_p[None, None, k_next],
                             crB[None, None, k_next],
                         )
-                        fz_csSFA_cur = cute.filter_zeros(
-                            csSFA_tile[None, None, None, cons_state.index]
-                        )
-                        fz_csSFB_cur = cute.filter_zeros(
-                            csSFB_tile[None, None, None, cons_state.index]
-                        )
                         cute.copy(
                             smem_copy_SFA,
-                            fz_csSFA_cur[None, None, k_next],
+                            fz_csSFA_p[None, None, k_next],
                             fz_crSFA[None, None, k_next],
                         )
                         cute.copy(
                             smem_copy_SFB,
-                            fz_csSFB_cur[None, None, k_next],
+                            fz_csSFB_p[None, None, k_next],
                             fz_crSFB[None, None, k_next],
                         )
                 for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -2034,9 +2034,9 @@ class MoEMicroKernel:
                     cute.copy(
                         smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0]
                     )
-                    f2 = cute.filter_zeros(csSFB_phase2)
-                    f4 = cute.filter_zeros(crSFB_phase2)
-                    cute.copy(smem_copy_SFB, f2[None, None, 0], f4[None, None, 0])
+                    f2_hoist = cute.filter_zeros(csSFB_phase2)
+                    f4_hoist = cute.filter_zeros(crSFB_phase2)
+                    cute.copy(smem_copy_SFB, f2_hoist[None, None, 0], f4_hoist[None, None, 0])
 
                     down_acc.fill(0.0)
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -2053,12 +2053,10 @@ class MoEMicroKernel:
                                 csB_phase2[None, None, k_next],
                                 crB[None, None, k_next],
                             )
-                            f2 = cute.filter_zeros(csSFB_phase2)
-                            f4 = cute.filter_zeros(crSFB_phase2)
                             cute.copy(
                                 smem_copy_SFB,
-                                f2[None, None, k_next],
-                                f4[None, None, k_next],
+                                f2_hoist[None, None, k_next],
+                                f4_hoist[None, None, k_next],
                             )
                         for _mt in range(self.num_m_tiles):
                             for _nt in range(self.num_n_tiles):

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -985,9 +985,15 @@ class MoEStaticKernel:
             active_expert_count[Int32(0)] = Int32(0)
         scatter_total = num_tokens * cols
         j = flat_tid
+        row = flat_tid // cols
+        col = flat_tid - row * cols
         while j < scatter_total:
-            scatter_output[j // cols, j % cols] = cutlass.BFloat16(0.0)
+            scatter_output[row, col] = cutlass.BFloat16(0.0)
             j += flat_stride
+            col += flat_stride
+            while col >= cols:
+                col -= cols
+                row += Int32(1)
         cute.arch.sync_threads()
         self._resident_grid_barrier(
             barrier_count,
@@ -1553,20 +1559,14 @@ class MoEStaticKernel:
                             csB_p[None, None, k_next],
                             crB[None, None, k_next],
                         )
-                        fz_csSFA_cur = cute.filter_zeros(
-                            csSFA_tile[None, None, None, cons_state.index]
-                        )
-                        fz_csSFB_cur = cute.filter_zeros(
-                            csSFB_tile[None, None, None, cons_state.index]
-                        )
                         cute.copy(
                             smem_copy_SFA,
-                            fz_csSFA_cur[None, None, k_next],
+                            fz_csSFA_p[None, None, k_next],
                             fz_crSFA[None, None, k_next],
                         )
                         cute.copy(
                             smem_copy_SFB,
-                            fz_csSFB_cur[None, None, k_next],
+                            fz_csSFB_p[None, None, k_next],
                             fz_crSFB[None, None, k_next],
                         )
                 for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -1951,9 +1951,9 @@ class MoEStaticKernel:
                     cute.copy(
                         smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0]
                     )
-                    f2 = cute.filter_zeros(csSFB_phase2)
-                    f4 = cute.filter_zeros(crSFB_phase2)
-                    cute.copy(smem_copy_SFB, f2[None, None, 0], f4[None, None, 0])
+                    f2_hoist = cute.filter_zeros(csSFB_phase2)
+                    f4_hoist = cute.filter_zeros(crSFB_phase2)
+                    cute.copy(smem_copy_SFB, f2_hoist[None, None, 0], f4_hoist[None, None, 0])
 
                     down_acc.fill(0.0)
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
@@ -1970,12 +1970,10 @@ class MoEStaticKernel:
                                 csB_phase2[None, None, k_next],
                                 crB[None, None, k_next],
                             )
-                            f2 = cute.filter_zeros(csSFB_phase2)
-                            f4 = cute.filter_zeros(crSFB_phase2)
                             cute.copy(
                                 smem_copy_SFB,
-                                f2[None, None, k_next],
-                                f4[None, None, k_next],
+                                f2_hoist[None, None, k_next],
+                                f4_hoist[None, None, k_next],
                             )
                         for _mt in range(self.num_m_tiles):
                             for _nt in range(self.num_n_tiles):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Performance:
Optimize the static path overhead of the MoE kernel to improve NVFP4 inference TTFT
Blackwell SM120 architecture, using b12x backend for inference, with TP = 4, and the model being Qwen3.6-35B-A3B-NVFP4
```
  --dataset-name random \
  --random-input-len 1024 \
  --random-output-len 4096 \
  --num-prompts 256 \
  --max-concurrency 64 \
````
Average TTFT improved by 43.6%, from the baseline of 1722ms to 971ms

Modification Details:
It involves 3 files: moe_static_kernel. py, moe_dynamic_kernel. py, and moe_micro_kernel. py.
1. Scatter Initialization: Eliminate Integer Division in Inner Loops
`scatter_output[j // cols, j % cols]` in Phase 0 triggers a GPU software division routine (approximately 30 cycles per iteration) in every loop iteration. Replace this with incremental `row/col` tracking, using subtraction `(while col >= cols: col -= cols; row += 1)` instead of division. The division will only be executed once during thread initialization, and will no longer be repeated inside the loop.
2. Gated GEMM: Reuse `fz_csSFA_p/fz_csSFB_p` and remove the duplicate `filter_zeros`
Within the main loop of the FC1 k-block, after each pipeline stage advance, the `filter_zeros` result has already been captured via `fz_csSFA_p/fz_csSFB_p`, yet at the end of the loop, `filter_zeros (csSFA_tile[. .., cons_state. index])` is recalculated for the same tensor. Remove this redundant call and directly reuse the existing variable.
3. FC2 Sweep: Lift filter_zeros from inside the k-block loop to the outer layer
The filter_zeros of both csSFB_phase2 and crSFB_phase2 are repeatedly invoked in every k-block iteration of the FC2 output tile loop. Since the tensor shape remains unchanged across k-blocks, the computation result can be hoisted to execute only once per output tile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Mixture of Experts kernel implementations to eliminate redundant tensor filtering operations. Precomputed filtered tensors are now reused within inner loops, reducing computational overhead in both forward-pass and output-processing phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->