### PR TITLE
[GDN] sm100: support more state dtype

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -2947,7 +2947,7 @@ class GatedDeltaNetChunkedKernel:
         """Load S_init from GMEM into state TMEM (fp32).
 
         Two steps:
-          1. GMEM fp32 -> registers
+          1. GMEM state dtype -> registers
           2. registers -> state TMEM (fp32), signal kv_acc so MMA can start GEMM 7
         """
         num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
@@ -2983,7 +2983,7 @@ class GatedDeltaNetChunkedKernel:
         tGR_tCgState = thr_state_r2t.partition_S(gS_init)
         kv_acc_handle = kv_acc_producer.acquire_and_advance()
         for sub in cutlass.range(tRT_tCrState.shape[2]):
-            # 1. Load S_init fp32 GMEM -> fp32 registers
+            # 1. Load S_init GMEM -> state dtype registers
             cute.autovec_copy(
                 tGR_tCgState[None, 0, sub],
                 tGR_tCrState[None, 0, sub],
@@ -2991,7 +2991,7 @@ class GatedDeltaNetChunkedKernel:
             )
             if cutlass.const_expr(self.state_dtype != self.acc_dtype):
                 tRT_tCrState[None, 0, sub].store(
-                    tGR_tCrState[None, 0, sub].load().to(self.state_dtype)
+                    tGR_tCrState[None, 0, sub].load().to(self.acc_dtype)
                 )
             else:
                 tRT_tCrState = tGR_tCrState

--- a/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gdn_prefill.py
@@ -78,9 +78,16 @@ def _cutlass_state_dtype(torch_dtype: torch.dtype):
         return cutlass.Float32
     elif torch_dtype == torch.bfloat16:
         return cutlass.BFloat16
+    elif torch_dtype == torch.float16:
+        return cutlass.Float16
+    elif torch_dtype == torch.float8_e4m3fn:
+        return cutlass.Float8E4M3FN
+    elif torch_dtype == torch.float8_e5m2:
+        return cutlass.Float8E5M2
     else:
         raise ValueError(
-            f"Unsupported state dtype {torch_dtype}, expected float32 or bfloat16"
+            f"Unsupported state dtype {torch_dtype}, expected float32, bfloat16, "
+            "float16, float8_e4m3fn, or float8_e5m2"
         )
 
 
@@ -116,12 +123,12 @@ def chunk_gated_delta_rule_sm100(
         beta: ``(total_tokens, HO)`` float32, update gate
         output: ``(total_tokens, HO, DK)`` float16/bfloat16, pre-allocated
         cu_seqlens: ``(num_seqs + 1,)`` int32
-        initial_state: ``(num_seqs, HO, DK, DK)`` float32/bfloat16, or None
-        output_state: ``(num_seqs, HO, DK, DK)`` float32/bfloat16, or None
+        initial_state: ``(num_seqs, HO, DK, DK)`` float32/bfloat16/float16/fp8, or None
+        output_state: ``(num_seqs, HO, DK, DK)`` float32/bfloat16/float16/fp8, or None
         scale: attention scale factor (must not be 0)
         checkpoint_every_n_tokens: store intermediate state every N tokens (0 = disabled)
         cu_checkpoints: ``(num_seqs + 1,)`` int32, cumulative checkpoint counts
-        output_checkpoints: ``(total_checkpoints, HO, DK, DK)`` float32/bfloat16, or None
+        output_checkpoints: ``(total_checkpoints, HO, DK, DK)`` float32/bfloat16/float16/fp8, or None
     """
     HQ = q.size(1)
     HV = v.size(1)

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -30,6 +30,19 @@ from .gdn_kernels import (
 )
 
 
+_SM100_STATE_DTYPES: tuple[torch.dtype, ...] = (
+    torch.float32,
+    torch.bfloat16,
+    torch.float16,
+    torch.float8_e4m3fn,
+    torch.float8_e5m2,
+)
+
+
+def _format_dtype_list(dtypes: tuple[torch.dtype, ...]) -> str:
+    return ", ".join(str(dtype).removeprefix("torch.") for dtype in dtypes)
+
+
 def _cp_delta_rule_rejection_reason(
     *,
     arch_major: int,
@@ -129,7 +142,9 @@ def chunk_gated_delta_rule(
     initial_state : torch.Tensor, optional
         Initial KV state of shape
         ``[num_seqs, num_sab_heads, head_size, head_size]``.  Must be
-        float32.  Starts from zero state when ``None``.
+        float32 on SM90/SM120.  The SM100 path also accepts bfloat16,
+        float16, float8_e4m3fn, and float8_e5m2.  Starts from zero state
+        when ``None``.
     output_final_state : bool
         Whether to output the final state.  Default: ``False``.
     cu_seqlens : torch.Tensor
@@ -149,11 +164,15 @@ def chunk_gated_delta_rule(
         ``None``.
     output_state : torch.Tensor, optional
         Pre-allocated output state tensor of shape ``[num_seqs,
-        num_sab_heads, head_size, head_size]``, float32.  Required when
+        num_sab_heads, head_size, head_size]``.  Must be float32 on
+        SM90/SM120.  The SM100 path also accepts bfloat16, float16,
+        float8_e4m3fn, and float8_e5m2.  Required when
         ``output_final_state=True``.
     state_checkpoints : torch.Tensor, optional
         Pre-allocated checkpoint tensor of shape ``[total_checkpoints,
-        num_sab_heads, head_size, head_size]``, float32.  Required when
+        num_sab_heads, head_size, head_size]``.  Must be float32 on
+        SM90/SM120.  The SM100 path also accepts bfloat16, float16,
+        float8_e4m3fn, and float8_e5m2.  Required when
         ``checkpoint_every_n_tokens > 0``.
     checkpoint_cu_starts : torch.Tensor, optional
         Cumulative checkpoint counts of shape ``[num_seqs + 1]``, int64.
@@ -227,9 +246,14 @@ def chunk_gated_delta_rule(
 
     if checkpoint_every_n_tokens > 0:
         assert state_checkpoints is not None and checkpoint_cu_starts is not None
-        if state_checkpoints.dtype != torch.float32:
+        state_checkpoint_dtypes: tuple[torch.dtype, ...] = (torch.float32,)
+        if q.is_cuda and get_compute_capability(q.device)[0] == 10:
+            state_checkpoint_dtypes = _SM100_STATE_DTYPES
+        if state_checkpoints.dtype not in state_checkpoint_dtypes:
             raise ValueError(
-                f"state_checkpoints must be float32, got {state_checkpoints.dtype}"
+                "state_checkpoints must have dtype "
+                f"{_format_dtype_list(state_checkpoint_dtypes)}, "
+                f"got {state_checkpoints.dtype}"
             )
         if state_checkpoints.ndim != 4:
             raise ValueError(

--- a/tests/attention/test_cute_dsl_mla_decode.py
+++ b/tests/attention/test_cute_dsl_mla_decode.py
@@ -626,40 +626,13 @@ def test_cute_dsl_vs_trtllm_gen(
     )
 
 
-@pytest.mark.parametrize(
-    (
-        "batch_size, seq_len_k, page_size, num_heads, enable_pdl, "
-        "cute_dsl_impl, is_persistent"
-    ),
-    [
-        (batch_size, seq_len_k, page_size, num_heads, False, cute_dsl_impl, False)
-        for batch_size in [1, 4]
-        for seq_len_k in [128, 512, 2048]
-        for page_size in [64, 128]
-        for num_heads in [128, 64]
-        for cute_dsl_impl in ["modular", "monolithic"]
-    ]
-    + [
-        pytest.param(
-            128,
-            160,
-            128,
-            128,
-            False,
-            "monolithic",
-            True,
-            id="monolithic-persistent-s160-b128",
-        )
-    ],
-)
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("seq_len_k", [128, 512, 2048])
+@pytest.mark.parametrize("page_size", [64, 128])
+@pytest.mark.parametrize("num_heads", [128, 64])
+@pytest.mark.parametrize("enable_pdl", [False])
 def test_cute_dsl_mla_decode_fp8(
-    batch_size,
-    seq_len_k,
-    page_size,
-    num_heads,
-    enable_pdl,
-    cute_dsl_impl,
-    is_persistent,
+    batch_size, seq_len_k, page_size, num_heads, enable_pdl, cute_dsl_impl
 ):
     """Test FP8 MLA decode kernel against FP32 reference."""
     skip_if_unsupported()
@@ -721,7 +694,6 @@ def test_cute_dsl_mla_decode_fp8(
         max_seq_len=seq_len_k,
         softmax_scale=softmax_scale,
         output_scale=output_scale,
-        is_var_seq=not is_persistent,
         enable_pdl=enable_pdl,
         cute_dsl_impl=cute_dsl_impl,
         lse=lse_buf,
@@ -743,33 +715,19 @@ def test_cute_dsl_mla_decode_fp8(
     assert torch.isfinite(out).all(), "FP8 cute-dsl MLA decode produced non-finite"
 
     # Reference: compute in FP32 using FP8 values dequantized to FP32
-    if is_persistent:
-        check_indices = torch.tensor(
-            [0, 1, batch_size - 1], dtype=torch.long, device=device
-        )
-        query_ref = query[check_indices]
-        block_tables_ref = block_tables[check_indices]
-        seq_lens_ref = seq_lens[check_indices]
-        out_to_check = out[check_indices]
-    else:
-        query_ref = query
-        block_tables_ref = block_tables
-        seq_lens_ref = seq_lens
-        out_to_check = out
-
     kv_flat = kv_cache.reshape(-1, D_qk).to(torch.float32)
     c_latent_ref = kv_flat[:, :latent_dim]
     c_rope_ref = kv_flat[:, latent_dim:]
-    q_nope = query_ref[..., :latent_dim].to(torch.float32)
-    q_rope_tensor = query_ref[..., latent_dim:].to(torch.float32)
+    q_nope = query[..., :latent_dim].to(torch.float32)
+    q_rope_tensor = query[..., latent_dim:].to(torch.float32)
 
     ref = torch_reference_mla(
         q_nope,
         q_rope_tensor,
         c_latent_ref,
         c_rope_ref,
-        block_tables_ref,
-        seq_lens_ref,
+        block_tables,
+        seq_lens,
         softmax_scale,
         output_scale,
         page_size,
@@ -782,22 +740,13 @@ def test_cute_dsl_mla_decode_fp8(
         ref_lse = None
     # Compare outputs in FP32; FP8 has limited precision so use wider tolerance
     torch.testing.assert_close(
-        out_to_check.to(torch.float32),
-        ref_out.to(torch.float32),
-        atol=0.1,
-        rtol=0.1,
+        out.to(torch.float32), ref_out.to(torch.float32), atol=0.1, rtol=0.1
     )
     if cute_dsl_impl == "monolithic":
         # LSE reshaped back to native shape for comparison.  FP8 quantization
         # noise propagates into LSE so use the same wide tolerance as `out`.
-        lse_to_check = lse.view(batch_size, q_len, num_heads)
-        if is_persistent:
-            lse_to_check = lse_to_check[check_indices]
         torch.testing.assert_close(
-            lse_to_check,
-            ref_lse,
-            atol=0.1,
-            rtol=0.1,
+            lse.view(batch_size, q_len, num_heads), ref_lse, atol=0.1, rtol=0.1
         )
 
 

--- a/tests/attention/test_cute_dsl_mla_decode.py
+++ b/tests/attention/test_cute_dsl_mla_decode.py
@@ -626,13 +626,40 @@ def test_cute_dsl_vs_trtllm_gen(
     )
 
 
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("seq_len_k", [128, 512, 2048])
-@pytest.mark.parametrize("page_size", [64, 128])
-@pytest.mark.parametrize("num_heads", [128, 64])
-@pytest.mark.parametrize("enable_pdl", [False])
+@pytest.mark.parametrize(
+    (
+        "batch_size, seq_len_k, page_size, num_heads, enable_pdl, "
+        "cute_dsl_impl, is_persistent"
+    ),
+    [
+        (batch_size, seq_len_k, page_size, num_heads, False, cute_dsl_impl, False)
+        for batch_size in [1, 4]
+        for seq_len_k in [128, 512, 2048]
+        for page_size in [64, 128]
+        for num_heads in [128, 64]
+        for cute_dsl_impl in ["modular", "monolithic"]
+    ]
+    + [
+        pytest.param(
+            128,
+            160,
+            128,
+            128,
+            False,
+            "monolithic",
+            True,
+            id="monolithic-persistent-s160-b128",
+        )
+    ],
+)
 def test_cute_dsl_mla_decode_fp8(
-    batch_size, seq_len_k, page_size, num_heads, enable_pdl, cute_dsl_impl
+    batch_size,
+    seq_len_k,
+    page_size,
+    num_heads,
+    enable_pdl,
+    cute_dsl_impl,
+    is_persistent,
 ):
     """Test FP8 MLA decode kernel against FP32 reference."""
     skip_if_unsupported()
@@ -694,6 +721,7 @@ def test_cute_dsl_mla_decode_fp8(
         max_seq_len=seq_len_k,
         softmax_scale=softmax_scale,
         output_scale=output_scale,
+        is_var_seq=not is_persistent,
         enable_pdl=enable_pdl,
         cute_dsl_impl=cute_dsl_impl,
         lse=lse_buf,
@@ -715,19 +743,33 @@ def test_cute_dsl_mla_decode_fp8(
     assert torch.isfinite(out).all(), "FP8 cute-dsl MLA decode produced non-finite"
 
     # Reference: compute in FP32 using FP8 values dequantized to FP32
+    if is_persistent:
+        check_indices = torch.tensor(
+            [0, 1, batch_size - 1], dtype=torch.long, device=device
+        )
+        query_ref = query[check_indices]
+        block_tables_ref = block_tables[check_indices]
+        seq_lens_ref = seq_lens[check_indices]
+        out_to_check = out[check_indices]
+    else:
+        query_ref = query
+        block_tables_ref = block_tables
+        seq_lens_ref = seq_lens
+        out_to_check = out
+
     kv_flat = kv_cache.reshape(-1, D_qk).to(torch.float32)
     c_latent_ref = kv_flat[:, :latent_dim]
     c_rope_ref = kv_flat[:, latent_dim:]
-    q_nope = query[..., :latent_dim].to(torch.float32)
-    q_rope_tensor = query[..., latent_dim:].to(torch.float32)
+    q_nope = query_ref[..., :latent_dim].to(torch.float32)
+    q_rope_tensor = query_ref[..., latent_dim:].to(torch.float32)
 
     ref = torch_reference_mla(
         q_nope,
         q_rope_tensor,
         c_latent_ref,
         c_rope_ref,
-        block_tables,
-        seq_lens,
+        block_tables_ref,
+        seq_lens_ref,
         softmax_scale,
         output_scale,
         page_size,
@@ -740,13 +782,22 @@ def test_cute_dsl_mla_decode_fp8(
         ref_lse = None
     # Compare outputs in FP32; FP8 has limited precision so use wider tolerance
     torch.testing.assert_close(
-        out.to(torch.float32), ref_out.to(torch.float32), atol=0.1, rtol=0.1
+        out_to_check.to(torch.float32),
+        ref_out.to(torch.float32),
+        atol=0.1,
+        rtol=0.1,
     )
     if cute_dsl_impl == "monolithic":
         # LSE reshaped back to native shape for comparison.  FP8 quantization
         # noise propagates into LSE so use the same wide tolerance as `out`.
+        lse_to_check = lse.view(batch_size, q_len, num_heads)
+        if is_persistent:
+            lse_to_check = lse_to_check[check_indices]
         torch.testing.assert_close(
-            lse.view(batch_size, q_len, num_heads), ref_lse, atol=0.1, rtol=0.1
+            lse_to_check,
+            ref_lse,
+            atol=0.1,
+            rtol=0.1,
         )
 
 

--- a/tests/gdn/reference_delta_rule.py
+++ b/tests/gdn/reference_delta_rule.py
@@ -863,6 +863,7 @@ def blockwise_delta_rule(
     block_size: int = 32,
     scale_factor=1.0,
     state_dtype: torch.dtype = torch.float32,
+    initial_state: torch.Tensor | None = None,
     # intermediate_outputs = None,  # debug output
 ) -> torch.Tensor:
     total_seqlen = q.size(0)
@@ -895,15 +896,16 @@ def blockwise_delta_rule(
         dtype=state_dtype,
         device=q.device,
     )
+    if initial_state is not None:
+        assert tuple(initial_state.shape) == tuple(kv.shape)
+        kv.copy_(initial_state.to(state_dtype))
     output = torch.zeros_like(q)
 
     seq_offset = exclusive_cumsum(seq_lens)
     for seq_idx, seq_start in enumerate(seq_offset[:-1]):
         seq_end = seq_offset[seq_idx + 1]
         blk_offset = seq_start
-        state_HKV = torch.zeros(
-            (num_sab_heads, head_size, head_size), dtype=state_dtype, device=q.device
-        )
+        state_HKV = kv[seq_idx].clone()
         while blk_offset < seq_end:
             is_full_block = seq_end - blk_offset >= block_size
             valid_len = block_size if is_full_block else seq_end - blk_offset

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -880,14 +880,14 @@ def test_checkpoint_wrong_dtype(qkv_factory):
     """Verify error when state_checkpoints has wrong dtype."""
     _skip_if_unsupported()
     device = torch.device("cuda")
-    with pytest.raises(ValueError, match="float32"):
+    with pytest.raises(ValueError, match="state_checkpoints must have dtype"):
         chunk_gated_delta_rule(
             torch.empty(64, 1, 128, dtype=torch.float16, device=device),
             torch.empty(64, 1, 128, dtype=torch.float16, device=device),
             torch.empty(64, 1, 128, dtype=torch.float16, device=device),
             cu_seqlens=torch.tensor([0, 64], dtype=torch.int64, device=device),
             state_checkpoints=torch.empty(
-                1, 1, 128, 128, dtype=torch.float16, device=device
+                1, 1, 128, 128, dtype=torch.int32, device=device
             ),
             checkpoint_cu_starts=torch.tensor([0, 1], dtype=torch.int64, device=device),
             checkpoint_every_n_tokens=64,
@@ -915,13 +915,14 @@ def test_checkpoint_wrong_cu_starts_size(qkv_factory):
 
 
 # ---------------------------------------------------------------------------
-# BFloat16 state tests (SM100 only)
+# State dtype tests (SM100 only)
 # ---------------------------------------------------------------------------
 
 
-def _test_prefill_kernel_bf16_state(
+def _test_prefill_kernel_state_dtype(
     qkv_factory,
     dtype: str,
+    state_dtype: torch.dtype,
     num_q_heads: int,
     num_k_heads: int,
     num_v_heads: int,
@@ -951,17 +952,28 @@ def _test_prefill_kernel_bf16_state(
         cu_seq_lens = torch.tensor(exclusive_cumsum(seq_lens), dtype=torch.int64)
         alpha = torch.rand(total_seqlen, num_sab_heads)
         beta = torch.rand(total_seqlen, num_sab_heads)
+        initial_state_ref = (
+            torch.randn(
+                num_seqs,
+                num_sab_heads,
+                head_size,
+                head_size,
+                dtype=torch.float32,
+            )
+            * 0.01
+        ).to(state_dtype)
+        initial_state = initial_state_ref.transpose(-1, -2).contiguous()
 
     our_o = torch.empty(
         [total_seqlen, num_o_heads, head_size], dtype=dtype, device=device
     )
     our_state = torch.empty(
         (num_seqs, num_sab_heads, head_size, head_size),
-        dtype=torch.bfloat16,
+        dtype=state_dtype,
         device=device,
     )
     our_o.fill_(float("nan"))
-    our_state.fill_(float("nan"))
+    our_state.zero_()
 
     chunk_gated_delta_rule(
         q,
@@ -970,7 +982,7 @@ def _test_prefill_kernel_bf16_state(
         alpha,
         beta,
         scale,
-        None,
+        initial_state,
         True,
         cu_seq_lens,
         True,
@@ -992,13 +1004,14 @@ def _test_prefill_kernel_bf16_state(
         scale_factor=scale,
         alpha=alpha,
         beta=beta,
-        state_dtype=torch.bfloat16,
+        state_dtype=state_dtype,
+        initial_state=initial_state_ref,
     )
     ref_o = ref_o.to(dtype)
-    ref_state = ref_state.to(torch.bfloat16)
+    ref_state = ref_state.to(state_dtype).float()
+    our_state = our_state.float()
 
-    # BF16 state has lower precision
-    atol_o = 1e-1 if dtype == torch.bfloat16 else 5e-2
+    atol_o = 1e-1 if state_dtype != torch.float32 else 5e-2
     rtol_o = 5e-2
     atol_kv = 1e-1
     rtol_kv = 5e-2
@@ -1007,21 +1020,23 @@ def _test_prefill_kernel_bf16_state(
     torch.testing.assert_close(our_state, ref_state, atol=atol_kv, rtol=rtol_kv)
 
 
-@pytest.mark.parametrize("scale", [1.0, "auto"])
+@pytest.mark.parametrize("scale", ["auto"])
 @pytest.mark.parametrize("head_size", [128])
 @pytest.mark.parametrize(
     "num_q_heads, num_k_heads, num_v_heads",
     [
         (1, 1, 1),
-        (4, 1, 1),
         (6, 2, 2),
-        (2, 2, 4),
         (16, 16, 32),
     ],
 )
-@pytest.mark.parametrize("seq_lens", [[64], [128], [256], [256, 256], [64, 128, 512]])
-@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
-def test_prefill_kernel_bf16_state(
+@pytest.mark.parametrize("seq_lens", [[64], [256], [256, 256], [64, 128, 512]])
+@pytest.mark.parametrize("dtype", ["bfloat16"])
+@pytest.mark.parametrize(
+    "state_dtype",
+    [torch.bfloat16, torch.float16, torch.float8_e4m3fn, torch.float8_e5m2],
+)
+def test_prefill_kernel_state_dtype(
     qkv_factory,
     dtype: str,
     num_q_heads: int,
@@ -1030,17 +1045,19 @@ def test_prefill_kernel_bf16_state(
     head_size: int,
     seq_lens: list[int],
     scale: float | str,
+    state_dtype: torch.dtype,
     seed: int = int(os.environ.get("SEED", "0")),
 ):
     scale = 1.0 / math.sqrt(head_size) if scale == "auto" else scale
-    _test_prefill_kernel_bf16_state(
+    _test_prefill_kernel_state_dtype(
         qkv_factory,
         dtype,
+        state_dtype,
         num_q_heads,
         num_k_heads,
         num_v_heads,
         head_size,
         seq_lens,
         scale,
-        seed,
+        seed=seed,
     )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional state tensor dtypes, including float8 formats on supported hardware.
  * State checkpoint handling now accepts a wider range of dtypes on newer GPU architectures.

* **Bug Fixes**
  * Improved state loading and writing behavior for mixed dtype scenarios, helping preserve correct results across precision formats.
  * Updated validation messages to better reflect the supported dtype options.

* **Documentation**
  * Updated public guidance to match the newly supported state dtype combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->