### PR TITLE
Remove pagesize 16/32 assertion from xqa nvfp4 sm120 

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2485,20 +2485,6 @@ def get_trtllm_gen_decode_module(*args):
     )
 
 
-def _check_xqa_nvfp4_page_size(page_size: int) -> None:
-    """Validate page_size for the XQA backend with an NVFP4 KV cache.
-
-    XQA's NVFP4 path only supports page_size 64 or 128; page_size 16/32 reach
-    the kernel but silently produce wrong results, so reject them early.
-    """
-    if page_size in (16, 32):
-        raise ValueError(
-            "NVFP4 KV cache page_size 16 and 32 are not supported by "
-            "FlashInfer XQA. Use page_size 64 or 128 instead. "
-            f"Got page_size={page_size}."
-        )
-
-
 @flashinfer_api(trace=trtllm_batch_decode_trace)
 def trtllm_batch_decode_with_kv_cache(
     query: torch.Tensor,
@@ -2642,8 +2628,6 @@ def trtllm_batch_decode_with_kv_cache(
         Per-block scale factors for NVFP4 KV cache, as a tuple of ``(k_scales, v_scales)``.
         Each scale tensor has shape ``[num_pages, num_kv_heads, page_size, head_dim // 16]``
         in HND layout, with dtype ``torch.float8_e4m3fn``.
-        NVFP4 KV cache does not support page sizes 16 or 32 in the XQA backend;
-        use page size 64 or 128 instead.
 
         **Contiguity requirements (trtllm-gen backend):**
 
@@ -2727,12 +2711,6 @@ def trtllm_batch_decode_with_kv_cache(
         )
 
     if backend == "xqa":
-        if is_nvfp4_kvcache:
-            nvfp4_page_size = (
-                k_cache.shape[-2] if kv_layout == "HND" else k_cache.shape[-3]
-            )
-            _check_xqa_nvfp4_page_size(nvfp4_page_size)
-
         # xqa backend doesn't support nvfp4 output
         if out_dtype == "nvfp4" or (out_dtype is None and isinstance(out, FP4Tensor)):
             raise ValueError("xqa backend does not support nvfp4 output")
@@ -3072,16 +3050,6 @@ def xqa_batch_decode_with_kv_cache(
         # or [num_pages, num_kv_heads, page_size, head_dim// 2] for NVFP4 KV cache with packed head dim
         num_kv_heads = k_cache.shape[1]
         page_size = k_cache.shape[2]
-
-    # NVFP4 KV cache (uint8 storage + scale factors) only supports page_size
-    # 64/128 on XQA; reject 16/32 early to avoid silently wrong results.
-    is_nvfp4_kvcache = (
-        k_cache.dtype == torch.uint8
-        and v_cache.dtype == torch.uint8
-        and k_cache_sf is not None
-    )
-    if is_nvfp4_kvcache:
-        _check_xqa_nvfp4_page_size(page_size)
 
     # query shape: [num_tokens, num_heads, head_dim]
     head_dim = query.shape[-1]

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -586,6 +586,8 @@ def test_xqa_batch_decode(
 @pytest.mark.parametrize(
     "batch_size,q_len_per_req,page_size,num_kv_heads,head_grp_size",
     [
+        (1, 1, 16, 2, 4),
+        (1, 1, 32, 2, 4),
         (4, 4, 64, 4, 2),
         (1, 1, 64, 2, 4),
         (1, 1, 64, 2, 8),


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed page-size validation for NVFP4 decoding, allowing previously blocked `page_size` values.
  * Updated the XQA decode flow so NVFP4 page-size checks no longer prevent execution for the affected configurations.
* **Tests**
  * Expanded NVFP4 batch-decode coverage to include additional configurations with `page_size` set to 16 and 32.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->