### PR TITLE
docs(gdn): document missing ssm_state_indices param in gated_delta_rule_mtp

### DIFF
--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -678,6 +678,17 @@ def gated_delta_rule_mtp(
         (first dim is indexed per-batch, not per-pool-slot — buffer must
         be at least ``B`` rows and contiguous; must be float32 when
         provided). When ``None``, intermediate states are not cached.
+        Mutually exclusive with ``ssm_state_indices``.
+    ssm_state_indices : torch.Tensor, optional
+        Per-token pool scatter indices of shape ``[B, T]`` and dtype
+        ``torch.int32``.  When provided, the kernel writes each intermediate
+        hidden state ``h_{t+1}`` directly to
+        ``initial_state[ssm_state_indices[i, t]]`` instead of accumulating
+        into a dense ``intermediate_states_buffer``.  Useful for FLA-style
+        speculative-decoding flows where each draft token needs its own pool
+        slot.  Constraints: ``T >= 2``, ``disable_state_update=False``,
+        mutually exclusive with ``intermediate_states_buffer``.
+        Default: ``None``.
     disable_state_update : bool, optional
         If ``True``, the initial state is not updated.  Currently defaults
         to ``True``; pass this argument explicitly to silence the


### PR DESCRIPTION
## Summary

- `flashinfer.gdn_decode.gated_delta_rule_mtp` had `ssm_state_indices` present in the function signature but entirely absent from the NumPy-style docstring, causing API-diff alerts.
- Add a full parameter entry describing: shape `[B, T]` / dtype `int32`, per-token pool-scatter semantics (FLA-style speculative decoding), and constraints (`T >= 2`, `disable_state_update=False`, mutually exclusive with `intermediate_states_buffer`).
- Cross-link `intermediate_states_buffer` entry to note the mutual exclusivity.

## Test plan

- [ ] Read the rendered docstring (`help(flashinfer.gdn_decode.gated_delta_rule_mtp)`) and verify the new entry appears correctly between `intermediate_states_buffer` and `disable_state_update`.
- [ ] Run existing GDN decode tests to confirm no regressions: `pytest tests/gdn/test_decode_delta_rule.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the `gated_delta_rule_mtp` parameter documentation.
  * Added detailed guidance for `ssm_state_indices`, including expected shape (`[B, T]`), dtype (`torch.int32`), default behavior, and key constraints (e.g., `T >= 2`, `disable_state_update=False`).
  * Documented compatibility rules, including mutual exclusivity with intermediate state buffers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->