### PR TITLE
Enables CUDA Graphs and Cold L2 cache in MLA Decode Autotuning

### DIFF
--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2211,6 +2211,8 @@ def _build_mla_decode_tuning_config(
                 tensor_initializers=[None, init_block_tables, init_seq_lens, None],
             ),
         ),
+        use_cuda_graph=True,
+        use_cold_l2_cache=True,
     )
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The MLA decode autotuner was not using CUDA graphs during autotuning. This biases the autotuner to the trtllm-gen backend, since it has less launch overhead. Using CUDA graphs during autotune is the standard in flashinfer (for GEMM and MoE autotuning we enable CUDA graphs).

## 🔍 Related Issues

<!-- Link any related issues here -->

#2891 - @b8zhong was seeing incorrect autotuner selections when integrating with SGLang

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MLA decode behavior with updated tuning settings, which may boost performance and better handle cache-related conditions during generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->