### PR TITLE
feat(mnnvl): preserve MoE all-to-all graph VAs across checkpoint restore

### DIFF
--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -130,7 +130,15 @@ reservations and Python workspace tensors alive.  Use
 ``detach_handles`` only after all kernels using the workspace have
 quiesced.  After restore, use ``reattach_handles`` to recreate/export/
 import handles and map them at the original virtual addresses before replaying
-captured CUDA graphs.  The reattach path refreshes communicator/transport state
+captured CUDA graphs.  CUDA synchronization needed for safe unmap/remap is
+performed internally:
+
+.. code-block:: python
+
+    workspace.detach_handles()
+    workspace.reattach_handles()
+
+The reattach path refreshes communicator/transport state
 from the current ``MnnvlConfig`` when provided; it does not reuse stale
 cross-process handles from the checkpoint.  ``reattach_handles`` maps fresh
 physical handles back into the preserved graph-visible virtual addresses and

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -120,6 +120,35 @@ Core Classes
     MnnvlMemory
     McastGPUBuffer
 
+CUDA graph-stable checkpoint detach/reattach
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MNNVL workspaces used by MoE all-to-all kernels are CUDA VMM allocations.
+For process checkpoint/restore, callers may release the non-checkpointable
+physical/imported MNNVL handles while keeping the CUDA virtual address
+reservations and Python workspace tensors alive.  Use
+``detach_handles`` only after all kernels using the workspace have
+quiesced.  After restore, use ``reattach_handles`` to recreate/export/
+import handles and map them at the original virtual addresses before replaying
+captured CUDA graphs.  The reattach path refreshes communicator/transport state
+from the current ``MnnvlConfig`` when provided; it does not reuse stale
+cross-process handles from the checkpoint.  ``reattach_handles`` maps fresh
+physical handles back into the preserved graph-visible virtual addresses and
+never reserves fresh graph-visible VA.
+
+CUDA graphs remain valid only if every graph-visible workspace tensor pointer,
+rank stride, rank count, rank id, and tensor layout validates unchanged.  The
+MNNVL APIs fail closed when this metadata changes.  Non-workspace tensors
+captured by a graph remain the caller's responsibility.
+
+.. autosummary::
+    :toctree: ../generated
+
+    MnnvlMemory.detach_handles
+    MnnvlMemory.reattach_handles
+    MnnvlMemory.get_graph_visible_addresses
+    MnnvlMemory.validate_graph_visible_addresses
+
 TensorRT-LLM MNNVL AllReduce
 ----------------------------
 

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -120,43 +120,6 @@ Core Classes
     MnnvlMemory
     McastGPUBuffer
 
-CUDA graph-stable checkpoint detach/reattach
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-MNNVL workspaces used by MoE all-to-all kernels are CUDA VMM allocations.
-For process checkpoint/restore, callers may release the non-checkpointable
-physical/imported MNNVL handles while keeping the CUDA virtual address
-reservations and Python workspace tensors alive.  Use
-``detach_handles`` only after all kernels using the workspace have
-quiesced.  After restore, use ``reattach_handles`` to recreate/export/
-import handles and map them at the original virtual addresses before replaying
-captured CUDA graphs.  CUDA synchronization needed for safe unmap/remap is
-performed internally:
-
-.. code-block:: python
-
-    workspace.detach_handles()
-    workspace.reattach_handles()
-
-The reattach path refreshes communicator/transport state
-from the current ``MnnvlConfig`` when provided; it does not reuse stale
-cross-process handles from the checkpoint.  ``reattach_handles`` maps fresh
-physical handles back into the preserved graph-visible virtual addresses and
-never reserves fresh graph-visible VA.
-
-CUDA graphs remain valid only if every graph-visible workspace tensor pointer,
-rank stride, rank count, rank id, and tensor layout validates unchanged.  The
-MNNVL APIs fail closed when this metadata changes.  Non-workspace tensors
-captured by a graph remain the caller's responsibility.
-
-.. autosummary::
-    :toctree: ../generated
-
-    MnnvlMemory.detach_handles
-    MnnvlMemory.reattach_handles
-    MnnvlMemory.get_graph_visible_addresses
-    MnnvlMemory.validate_graph_visible_addresses
-
 TensorRT-LLM MNNVL AllReduce
 ----------------------------
 
@@ -193,6 +156,29 @@ MNNVL A2A (Throughput Backend)
     :show-inheritance:
 
     .. automethod:: __init__
+
+``MoeAlltoAll`` preserves its CUDA virtual addresses across process
+checkpoint/restore.  After quiescing all work, call ``checkpoint_prepare`` to
+release the non-checkpointable physical MNNVL handles.  Then call
+``checkpoint_restore`` with a fresh communication backend before replaying a
+captured CUDA graph:
+
+.. code-block:: python
+
+    moe_alltoall.checkpoint_prepare()
+    moe_alltoall.checkpoint_restore(comm_backend)
+
+Both methods are collective.  Every rank must call them in the same order, and
+``comm_backend`` must reproduce the original rank and world size.
+Repeated calls are no-ops after the workspace reaches the requested state.
+If an exception occurs after a physical detach or reattach begins, do not retry
+or reuse the workspace; restart the affected rank.
+
+.. autosummary::
+    :toctree: ../generated
+
+    MoeAlltoAll.checkpoint_prepare
+    MoeAlltoAll.checkpoint_restore
 
 DCP All-to-All (Context-Parallel Attention Reduction)
 -----------------------------------------------------

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -158,27 +158,27 @@ MNNVL A2A (Throughput Backend)
     .. automethod:: __init__
 
 ``MoeAlltoAll`` preserves its CUDA virtual addresses across process
-checkpoint/restore.  After quiescing all work, call ``checkpoint_prepare`` to
+checkpoint/restore.  After quiescing all work, call ``detach_handles`` to
 release the non-checkpointable physical MNNVL handles.  Then call
-``checkpoint_restore`` with a fresh communication backend before replaying a
+``attach_handles`` with a fresh communication backend before replaying a
 captured CUDA graph:
 
 .. code-block:: python
 
-    moe_alltoall.checkpoint_prepare()
-    moe_alltoall.checkpoint_restore(comm_backend)
+    moe_alltoall.detach_handles()
+    moe_alltoall.attach_handles(comm_backend)
 
 Both methods are collective.  Every rank must call them in the same order, and
 ``comm_backend`` must reproduce the original rank and world size.
 Repeated calls are no-ops after the workspace reaches the requested state.
-If an exception occurs after a physical detach or reattach begins, do not retry
-or reuse the workspace; restart the affected rank.
+If an exception occurs after physical handle detachment or attachment begins,
+do not retry or reuse the workspace; restart the affected rank.
 
 .. autosummary::
     :toctree: ../generated
 
-    MoeAlltoAll.checkpoint_prepare
-    MoeAlltoAll.checkpoint_restore
+    MoeAlltoAll.detach_handles
+    MoeAlltoAll.attach_handles
 
 DCP All-to-All (Context-Parallel Attention Reduction)
 -----------------------------------------------------

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -158,27 +158,27 @@ MNNVL A2A (Throughput Backend)
     .. automethod:: __init__
 
 ``MoeAlltoAll`` preserves its CUDA virtual addresses across process
-checkpoint/restore.  After quiescing all work, call ``detach_handles`` to
+checkpoint/restore.  After quiescing all work, call ``checkpoint_prepare`` to
 release the non-checkpointable physical MNNVL handles.  Then call
-``attach_handles`` with a fresh communication backend before replaying a
+``checkpoint_restore`` with a fresh communication backend before replaying a
 captured CUDA graph:
 
 .. code-block:: python
 
-    moe_alltoall.detach_handles()
-    moe_alltoall.attach_handles(comm_backend)
+    moe_alltoall.checkpoint_prepare()
+    moe_alltoall.checkpoint_restore(comm_backend)
 
 Both methods are collective.  Every rank must call them in the same order, and
 ``comm_backend`` must reproduce the original rank and world size.
 Repeated calls are no-ops after the workspace reaches the requested state.
-If an exception occurs after physical handle detachment or attachment begins,
+If an exception occurs after physical handle unmapping or remapping begins,
 do not retry or reuse the workspace; restart the affected rank.
 
 .. autosummary::
     :toctree: ../generated
 
-    MoeAlltoAll.detach_handles
-    MoeAlltoAll.attach_handles
+    MoeAlltoAll.checkpoint_prepare
+    MoeAlltoAll.checkpoint_restore
 
 DCP All-to-All (Context-Parallel Attention Reduction)
 -----------------------------------------------------

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -556,19 +556,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return comm
 
     @staticmethod
-    def refresh_comm_from_config(mapping: Mapping, config: MnnvlConfig) -> CommBackend:
-        if config.comm_backend is None:
-            raise RuntimeError(
-                "MNNVL reattach config must provide a communication backend"
-            )
-        MnnvlMemory.config = config
-        comm = config.comm_backend.Split(
-            mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
-        )
-        MnnvlMemory.comm = comm
-        return comm
-
-    @staticmethod
     def get_allocation_prop(dev_id: int):
         location = cuda.CUmemLocation()
         location.type = cuda.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
@@ -795,20 +782,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return ptr, stride
 
     @staticmethod
-    def _validate_remap_comm(
-        record: _MnnvlAllocationRecord, comm: CommBackend
-    ) -> None:
-        comm_size = comm.Get_size()
-        comm_rank = comm.Get_rank()
-        if comm_size != record.comm_size or comm_rank != record.comm_rank:
-            raise RuntimeError(
-                "Restored MNNVL communicator does not match the graph-visible "
-                "allocation layout: "
-                f"rank/size {comm_rank}/{comm_size} != "
-                f"{record.comm_rank}/{record.comm_size}"
-            )
-
-    @staticmethod
     def _unmap_and_release_mnnvl_handles(record: _MnnvlAllocationRecord) -> None:
         for i in range(record.comm_size):
             rank_ptr = (
@@ -886,10 +859,28 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 "call detach_handles before checkpoint reattach"
             )
         if config is not None:
-            comm = MnnvlMemory.refresh_comm_from_config(record.mapping, config)
+            if config.comm_backend is None:
+                raise RuntimeError(
+                    "MNNVL reattach config must provide a communication backend"
+                )
+            MnnvlMemory.config = config
+            comm = config.comm_backend.Split(
+                record.mapping.pp_rank * record.mapping.cp_size
+                + record.mapping.cp_rank,
+                record.mapping.tp_rank,
+            )
+            MnnvlMemory.comm = comm
         else:
             comm = comm or record.comm
-        MnnvlMemory._validate_remap_comm(record, comm)
+        comm_size = comm.Get_size()
+        comm_rank = comm.Get_rank()
+        if comm_size != record.comm_size or comm_rank != record.comm_rank:
+            raise RuntimeError(
+                "Restored MNNVL communicator does not match the graph-visible "
+                "allocation layout: "
+                f"rank/size {comm_rank}/{comm_size} != "
+                f"{record.comm_rank}/{record.comm_size}"
+            )
         record.comm = comm
         mapped_states = comm.allgather(record.mapped)
         if any(mapped_states) and not all(mapped_states):

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -406,12 +406,12 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return MnnvlMemory.allocated_map[self.ptr].mapped
 
     def as_torch_strided_tensor(self, dtype):
-        record = MnnvlMemory.allocated_map[self.ptr]
+        num_segments = MnnvlMemory.comm.Get_size()
         return pack_strided_memory(
             self.ptr,
             self.segment_size,
             self.rank_stride,
-            record.comm_size,
+            num_segments,
             dtype,
             MnnvlMemory.dev_id,
         )
@@ -483,75 +483,7 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return MnnvlMemory.allocation_granularity
 
     @staticmethod
-    def _exchange_shareable_handles(
-        comm: CommBackend,
-        allocation_prop: cuda.CUmemAllocationProp,
-        allocated_mem_handle: Any,
-    ) -> List[Any]:
-        exported_fabric_handle = checkCudaErrors(
-            cuda.cuMemExportToShareableHandle(
-                allocated_mem_handle, allocation_prop.requestedHandleTypes, 0
-            )
-        )
-        if (
-            allocation_prop.requestedHandleTypes
-            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
-        ):
-            return comm.allgather(exported_fabric_handle.data)
-
-        exported_fd = int(exported_fabric_handle)
-        remote_fds = []
-        try:
-            all_handles_data = comm.allgather(exported_fd)
-            all_pids = comm.allgather(os.getpid())
-            libc = ctypes.CDLL(None, use_errno=True)
-            syscall = libc.syscall
-            SYS_pidfd_open = 434
-            SYS_pidfd_getfd = 438
-
-            for pid, fd in zip(all_pids, all_handles_data, strict=True):
-                pidfd = syscall(SYS_pidfd_open, pid, 0)
-                if pidfd < 0:
-                    err = ctypes.get_errno()
-                    raise RuntimeError(
-                        f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
-                    )
-                try:
-                    remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
-                    if remote_fd < 0:
-                        err = ctypes.get_errno()
-                        error_msg = (
-                            f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with "
-                            f"errno {err}: {os.strerror(err)}."
-                        )
-                        if err == 1:  # EPERM
-                            error_msg += (
-                                " Permission denied. If running in a container, "
-                                "try adding --cap-add=SYS_PTRACE to your docker "
-                                "run command."
-                            )
-                        else:
-                            error_msg += (
-                                " This may be due to kernel version "
-                                "(requires Linux 5.6+)."
-                            )
-                        raise RuntimeError(error_msg)
-                    remote_fds.append(remote_fd)
-                finally:
-                    os.close(pidfd)
-
-            # Every rank must duplicate every exported FD before its owner closes it.
-            comm.barrier()
-            return remote_fds
-        except BaseException:
-            for remote_fd in remote_fds:
-                os.close(remote_fd)
-            raise
-        finally:
-            os.close(exported_fd)
-
-    @staticmethod
-    def _create_and_map_mnnvl_handles(
+    def _create_and_map_handles(
         comm: CommBackend,
         aligned_size: int,
         start_address: int,
@@ -570,30 +502,94 @@ class MnnvlMemory:  # type: ignore[no-redef]
         allocated_mem_handle = checkCudaErrors(
             cuda.cuMemCreate(aligned_size, allocation_prop, flags=0)
         )
-        all_handles_data = MnnvlMemory._exchange_shareable_handles(
-            comm, allocation_prop, allocated_mem_handle
+        exported_fabric_handle = checkCudaErrors(
+            cuda.cuMemExportToShareableHandle(
+                allocated_mem_handle, allocation_prop.requestedHandleTypes, 0
+            )
         )
+        if (
+            allocation_prop.requestedHandleTypes
+            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+        ):
+            all_handles_data = comm.allgather(exported_fabric_handle.data)
+        else:
+            exported_fd = int(exported_fabric_handle)
+            pidfds = []
+            remote_fds = []
+            try:
+                all_handles_data = comm.allgather(exported_fd)
+                all_pids = comm.allgather(os.getpid())
+                libc = ctypes.CDLL(None, use_errno=True)
+                syscall = libc.syscall
+                SYS_pidfd_open = 434
+                SYS_pidfd_getfd = 438
+
+                for pid in all_pids:
+                    pidfd = syscall(SYS_pidfd_open, pid, 0)
+                    if pidfd < 0:
+                        err = ctypes.get_errno()
+                        raise RuntimeError(
+                            f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
+                        )
+                    pidfds.append(pidfd)
+
+                for pidfd, fd in zip(pidfds, all_handles_data, strict=True):
+                    remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
+                    if remote_fd < 0:
+                        err = ctypes.get_errno()
+                        error_msg = f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno {err}: {os.strerror(err)}."
+                        if err == 1:  # EPERM
+                            error_msg += (
+                                " Permission denied. If running in a container, try adding --cap-add=SYS_PTRACE "
+                                "to your docker run command."
+                            )
+                        else:
+                            error_msg += " This may be due to kernel version (requires Linux 5.6+)."
+                        raise RuntimeError(error_msg)
+                    remote_fds.append(remote_fd)
+
+                # Every rank must duplicate every exported FD before its owner closes it.
+                comm.barrier()
+                all_handles_data = remote_fds
+            except BaseException:
+                for remote_fd in remote_fds:
+                    os.close(remote_fd)
+                raise
+            finally:
+                for pidfd in pidfds:
+                    os.close(pidfd)
+                os.close(exported_fd)
+        # all_handles_data like b'\x00\x00\x00 \x00\x00\x00\x00\x8f\xec\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00\x00\x00\x1d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # noqa: E501
+        # can use buf = memoryview(data) to import if using plain buffer for data.
+
+        madesc = cuda.CUmemAccessDesc()
+        madesc.location = allocation_prop.location
+        madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
 
         mem_handles = [None] * comm_size
         try:
-            madesc = cuda.CUmemAccessDesc()
-            madesc.location = allocation_prop.location
-            madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
-
             for i, remote_handle_data in enumerate(all_handles_data):
                 rank_ptr = start_address + rank_stride * i + address_offset
                 if i == comm_rank:
+                    # Local memory mapping
                     mem_handles[i] = allocated_mem_handle
+                    checkCudaErrors(
+                        cuda.cuMemMap(
+                            rank_ptr, aligned_size, 0, allocated_mem_handle, 0
+                        )
+                    )
                 else:
+                    # Fabric memory mapping
                     imported_mem_handle = checkCudaErrors(
                         cuda.cuMemImportFromShareableHandle(
                             remote_handle_data, allocation_prop.requestedHandleTypes
                         )
                     )
                     mem_handles[i] = imported_mem_handle
-                checkCudaErrors(
-                    cuda.cuMemMap(rank_ptr, aligned_size, 0, mem_handles[i], 0)
-                )
+                    checkCudaErrors(
+                        cuda.cuMemMap(rank_ptr, aligned_size, 0, imported_mem_handle, 0)
+                    )
+
                 checkCudaErrors(
                     cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1)
                 )
@@ -636,6 +632,7 @@ class MnnvlMemory:  # type: ignore[no-redef]
             f"Different dev_id found dev_id={dev_id} but MnnvlMemory.dev_id={MnnvlMemory.dev_id}"
         )
         comm = MnnvlMemory.get_comm(mapping)
+        comm_rank = comm.Get_rank()
         comm_size = comm.Get_size()
         all_rank_allocate_sizes = comm.allgather(size)
         assert len(all_rank_allocate_sizes) == comm_size
@@ -656,20 +653,19 @@ class MnnvlMemory:  # type: ignore[no-redef]
             <= MnnvlMemory.current_rank_stride
         )
 
-        ptr = MnnvlMemory.current_start_address + MnnvlMemory.current_mem_offset
-        stride = MnnvlMemory.current_rank_stride
-        comm = MnnvlMemory.get_comm(mapping)
-        mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
+        mem_handles = MnnvlMemory._create_and_map_handles(
             comm,
             aligned_size,
             MnnvlMemory.current_start_address,
             MnnvlMemory.current_rank_stride,
             MnnvlMemory.current_mem_offset,
         )
+        ptr = MnnvlMemory.current_start_address + MnnvlMemory.current_mem_offset
+        stride = MnnvlMemory.current_rank_stride
         MnnvlMemory.allocated_map[ptr] = _MnnvlAllocationRecord(
             comm=comm,
-            comm_size=comm.Get_size(),
-            comm_rank=comm.Get_rank(),
+            comm_size=comm_size,
+            comm_rank=comm_rank,
             aligned_size=aligned_size,
             mem_handles=mem_handles,
             start_address=MnnvlMemory.current_start_address,
@@ -684,7 +680,7 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return ptr, stride
 
     @staticmethod
-    def _unmap_and_release_mnnvl_handles(record: _MnnvlAllocationRecord) -> None:
+    def _unmap_and_release_handles(record: _MnnvlAllocationRecord) -> None:
         for i in range(record.comm_size):
             rank_ptr = (
                 record.start_address + i * record.rank_stride + record.address_offset
@@ -696,8 +692,7 @@ class MnnvlMemory:  # type: ignore[no-redef]
     def close_mnnvl_memory(ptr: int):
         record = MnnvlMemory.allocated_map.pop(ptr)
         if record.mapped:
-            MnnvlMemory._unmap_and_release_mnnvl_handles(record)
-            record.mapped = False
+            MnnvlMemory._unmap_and_release_handles(record)
         MnnvlMemory.address_refcnt[record.start_address] -= 1
 
         if MnnvlMemory.address_refcnt[record.start_address] == 0:

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -414,28 +414,26 @@ class MnnvlMemory:  # type: ignore[no-redef]
             MnnvlMemory.dev_id,
         )
 
-    def detach_handles(
-        self, *, synchronize: bool = True, barrier: bool = True
-    ) -> None:
-        """Release mapped MNNVL handles while keeping graph-visible VAs alive."""
-        MnnvlMemory._detach_mnnvl_handles(
-            self.ptr, synchronize=synchronize, barrier=barrier
-        )
+    def detach_handles(self) -> None:
+        """Release mapped MNNVL handles while keeping graph-visible VAs alive.
+
+        CUDA synchronization is performed internally before unmapping.
+        """
+        MnnvlMemory._detach_mnnvl_handles(self.ptr)
 
     def reattach_handles(
         self,
         *,
         comm: Optional[CommBackend] = None,
-        synchronize: bool = True,
-        barrier: bool = True,
         zero_local: bool = True,
     ) -> None:
-        """Recreate MNNVL handles and map them at the original virtual addresses."""
+        """Map fresh MNNVL handles at the preserved virtual addresses.
+
+        CUDA synchronization is performed internally before remapping.
+        """
         MnnvlMemory._reattach_mnnvl_handles(
             self.ptr,
             comm=comm,
-            synchronize=synchronize,
-            barrier=barrier,
             zero_local=zero_local,
         )
 
@@ -812,31 +810,19 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 MnnvlMemory.current_mem_offset = 0
 
     @staticmethod
-    def _detach_mnnvl_handles(
-        ptr: int, *, synchronize: bool = True, barrier: bool = True
-    ) -> None:
+    def _detach_mnnvl_handles(ptr: int) -> None:
         record = MnnvlMemory.allocated_map[ptr]
         comm = record.comm
         mapped_states = comm.allgather(record.mapped)
         if any(mapped_states) and not all(mapped_states):
             raise RuntimeError("Inconsistent MNNVL mapped state across ranks")
         if not any(mapped_states):
-            if barrier:
-                comm.barrier()
-                comm.barrier()
             return
 
-        if synchronize:
-            checkCudaErrors(cuda.cuCtxSynchronize())
-        if barrier:
-            comm.barrier()
-
+        checkCudaErrors(cuda.cuCtxSynchronize())
         MnnvlMemory._unmap_and_release_mnnvl_handles(record)
         record.mem_handles = [None] * record.comm_size
         record.mapped = False
-
-        if barrier:
-            comm.barrier()
 
     @staticmethod
     def _reattach_mnnvl_handles(
@@ -844,8 +830,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
         *,
         comm: Optional[CommBackend] = None,
         config: Optional[MnnvlConfig] = None,
-        synchronize: bool = True,
-        barrier: bool = True,
         zero_local: bool = True,
     ) -> None:
         record = MnnvlMemory.allocated_map[ptr]
@@ -886,16 +870,9 @@ class MnnvlMemory:  # type: ignore[no-redef]
         if any(mapped_states) and not all(mapped_states):
             raise RuntimeError("Inconsistent MNNVL mapped state across ranks")
         if all(mapped_states):
-            if barrier:
-                comm.barrier()
-                comm.barrier()
             return
 
-        if synchronize:
-            checkCudaErrors(cuda.cuCtxSynchronize())
-        if barrier:
-            comm.barrier()
-
+        checkCudaErrors(cuda.cuCtxSynchronize())
         record.mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
             record.mapping,
             record.aligned_size,
@@ -906,9 +883,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
             zero_local=zero_local,
         )
         record.mapped = True
-
-        if barrier:
-            comm.barrier()
 
     @staticmethod
     def support_nvlink(need_all_up: bool = True):

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -712,57 +712,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 MnnvlMemory.current_mem_offset = 0
 
     @staticmethod
-    def _detach_mnnvl_handles(ptr: int) -> bool:
-        record = MnnvlMemory.allocated_map[ptr]
-        if not record.mapped:
-            return False
-        comm_rank = record.comm.Get_rank()
-        comm_size = record.comm.Get_size()
-        if comm_rank != record.comm_rank or comm_size != record.comm_size:
-            raise RuntimeError(
-                "MNNVL communicator does not match the allocation layout: "
-                f"rank/size {comm_rank}/{comm_size} != "
-                f"{record.comm_rank}/{record.comm_size}"
-            )
-
-        checkCudaErrors(cuda.cuCtxSynchronize())
-        record.comm.barrier()
-        MnnvlMemory._unmap_and_release_mnnvl_handles(record)
-        record.mem_handles = [None] * record.comm_size
-        record.mapped = False
-        return True
-
-    @staticmethod
-    def _reattach_mnnvl_handles(
-        ptr: int,
-        comm_backend: CommBackend,
-    ) -> bool:
-        record = MnnvlMemory.allocated_map[ptr]
-        if record.mapped:
-            return False
-        comm_size = comm_backend.Get_size()
-        comm_rank = comm_backend.Get_rank()
-        if comm_size != record.comm_size or comm_rank != record.comm_rank:
-            raise RuntimeError(
-                "Restored MNNVL communicator does not match the graph-visible "
-                "allocation layout: "
-                f"rank/size {comm_rank}/{comm_size} != "
-                f"{record.comm_rank}/{record.comm_size}"
-            )
-        checkCudaErrors(cuda.cuCtxSynchronize())
-        record.mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
-            comm_backend,
-            record.aligned_size,
-            record.start_address,
-            record.rank_stride,
-            record.address_offset,
-        )
-        record.comm = comm_backend
-        MnnvlMemory.comm = comm_backend
-        record.mapped = True
-        return True
-
-    @staticmethod
     def support_nvlink(need_all_up: bool = True):
         dev_id = torch.cuda.current_device()
         handle = pynvml.nvmlDeviceGetHandleByIndex(dev_id)

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -425,7 +425,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
         self,
         *,
         comm: Optional[CommBackend] = None,
-        zero_local: bool = True,
     ) -> None:
         """Map fresh MNNVL handles at the preserved virtual addresses.
 
@@ -434,7 +433,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
         MnnvlMemory._reattach_mnnvl_handles(
             self.ptr,
             comm=comm,
-            zero_local=zero_local,
         )
 
     def get_graph_visible_addresses(self) -> Dict[str, Any]:
@@ -654,7 +652,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
         address_offset: int,
         *,
         comm: Optional[CommBackend] = None,
-        zero_local: bool = False,
     ) -> List[Any]:
         dev = checkCudaErrors(cuda.cuCtxGetDevice())
         dev_id = int(dev)
@@ -694,10 +691,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 cuda.cuMemMap(rank_ptr, aligned_size, 0, mem_handles[i], 0)
             )
             checkCudaErrors(cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1))
-
-        if zero_local:
-            local_ptr = start_address + rank_stride * comm_rank + address_offset
-            checkCudaErrors(cuda.cuMemsetD8(local_ptr, 0, aligned_size))
 
         return mem_handles
 
@@ -830,7 +823,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
         *,
         comm: Optional[CommBackend] = None,
         config: Optional[MnnvlConfig] = None,
-        zero_local: bool = True,
     ) -> None:
         record = MnnvlMemory.allocated_map[ptr]
         if config is not None and comm is not None:
@@ -880,7 +872,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
             record.rank_stride,
             record.address_offset,
             comm=comm,
-            zero_local=zero_local,
         )
         record.mapped = True
 

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -354,6 +354,20 @@ class MnnvlConfig:
     fabric_page_size: int = 1 << 29  # 512MB
 
 
+@dataclass
+class _MnnvlAllocationRecord:
+    mapping: Mapping
+    comm: CommBackend
+    comm_size: int
+    comm_rank: int
+    aligned_size: int
+    mem_handles: List[Any]
+    start_address: int
+    rank_stride: int
+    address_offset: int
+    mapped: bool = True
+
+
 class MnnvlMemory:  # type: ignore[no-redef]
     initialized: bool = False
 
@@ -389,7 +403,8 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 MnnvlMemory.close_mnnvl_memory(self.ptr)
 
     def as_torch_strided_tensor(self, dtype):
-        num_segments = MnnvlMemory.comm.Get_size()
+        record = MnnvlMemory.allocated_map[self.ptr]
+        num_segments = record.comm.Get_size()
         return pack_strided_memory(
             self.ptr,
             self.segment_size,
@@ -398,6 +413,106 @@ class MnnvlMemory:  # type: ignore[no-redef]
             dtype,
             MnnvlMemory.dev_id,
         )
+
+    def detach_handles(
+        self, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Release mapped MNNVL handles while keeping graph-visible VAs alive."""
+        MnnvlMemory._detach_mnnvl_handles(
+            self.ptr, synchronize=synchronize, barrier=barrier
+        )
+
+    def reattach_handles(
+        self,
+        *,
+        comm: Optional[CommBackend] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        zero_local: bool = True,
+    ) -> None:
+        """Recreate MNNVL handles and map them at the original virtual addresses."""
+        MnnvlMemory._reattach_mnnvl_handles(
+            self.ptr,
+            comm=comm,
+            synchronize=synchronize,
+            barrier=barrier,
+            zero_local=zero_local,
+        )
+
+    def get_graph_visible_addresses(self) -> Dict[str, Any]:
+        """Return the VA/layout state captured by CUDA graph-visible tensors."""
+        record = MnnvlMemory.allocated_map[self.ptr]
+        return {
+            "ptr": self.ptr,
+            "segment_size": self.segment_size,
+            "rank_stride": self.rank_stride,
+            "start_address": record.start_address,
+            "address_offset": record.address_offset,
+            "aligned_size": record.aligned_size,
+            "comm_size": record.comm_size,
+            "comm_rank": record.comm_rank,
+            "rank_ptrs": [
+                record.start_address + i * record.rank_stride + record.address_offset
+                for i in range(record.comm_size)
+            ],
+        }
+
+    def validate_graph_visible_addresses(
+        self,
+        expected: Optional[Dict[str, Any]],
+        tensor: Optional[torch.Tensor] = None,
+    ) -> None:
+        """Validate that graph-visible VAs and optional tensor metadata are stable."""
+        if expected is None:
+            raise RuntimeError("Missing captured MNNVL graph-visible address metadata")
+
+        current = self.get_graph_visible_addresses()
+        expected_keys = set(expected)
+        current_keys = set(current)
+        missing = expected_keys - current_keys
+        if missing:
+            field = sorted(missing)[0]
+            raise RuntimeError(
+                f"MNNVL graph-visible address metadata missing field {field!r}"
+            )
+        extra = current_keys - expected_keys
+        if extra:
+            field = sorted(extra)[0]
+            raise RuntimeError(
+                f"MNNVL graph-visible address metadata has extra field {field!r}"
+            )
+        for key, expected_value in expected.items():
+            current_value = current[key]
+            if current_value != expected_value:
+                raise RuntimeError(
+                    f"MNNVL graph-visible address field {key} changed: "
+                    f"{current_value!r} != {expected_value!r}"
+                )
+
+        if tensor is not None:
+            element_size = tensor.element_size()
+            if tensor.data_ptr() != current["ptr"]:
+                raise RuntimeError(
+                    f"MNNVL tensor data_ptr changed: {tensor.data_ptr()} "
+                    f"!= {current['ptr']}"
+                )
+            if tensor.size(0) != current["comm_size"]:
+                raise RuntimeError(
+                    f"MNNVL tensor rank dimension changed: {tensor.size(0)} "
+                    f"!= {current['comm_size']}"
+                )
+            expected_segment_elements = current["segment_size"] // element_size
+            if tensor.size(1) != expected_segment_elements:
+                raise RuntimeError(
+                    "MNNVL tensor segment dimension changed: "
+                    f"{tensor.size(1)} != {expected_segment_elements}"
+                )
+            if tensor.stride(0) * element_size != current["rank_stride"]:
+                raise RuntimeError(
+                    "MNNVL tensor rank stride changed: "
+                    f"{tensor.stride(0) * element_size} != "
+                    f"{current['rank_stride']}"
+                )
 
     @staticmethod
     def initialize():
@@ -413,8 +528,10 @@ class MnnvlMemory:  # type: ignore[no-redef]
 
     @staticmethod
     def set_comm_from_config(mapping: Mapping, config: MnnvlConfig = None):
-        MnnvlMemory.config = config or MnnvlConfig(comm_backend=MPIBackend())  # type: ignore[attr-defined]
-        comm = config.comm_backend.Split(
+        MnnvlMemory.config = config or MnnvlConfig(comm_backend=MPIBackend())
+        if MnnvlMemory.config.comm_backend is None:
+            raise RuntimeError("MNNVL config must provide a communication backend")
+        comm = MnnvlMemory.config.comm_backend.Split(
             mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
         )
         MnnvlMemory.comm = comm  # type: ignore[assignment]
@@ -423,7 +540,29 @@ class MnnvlMemory:  # type: ignore[no-redef]
     def get_comm(mapping: Mapping):
         if MnnvlMemory.comm is not None:
             return MnnvlMemory.comm
+        if MnnvlMemory.config is not None:
+            config = MnnvlMemory.config
+            if config.comm_backend is not None:
+                comm = config.comm_backend.Split(
+                    mapping.pp_rank * mapping.cp_size + mapping.cp_rank,
+                    mapping.tp_rank,
+                )
+                MnnvlMemory.comm = comm
+                return comm
         comm = MpiComm().Split(
+            mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
+        )
+        MnnvlMemory.comm = comm
+        return comm
+
+    @staticmethod
+    def refresh_comm_from_config(mapping: Mapping, config: MnnvlConfig) -> CommBackend:
+        if config.comm_backend is None:
+            raise RuntimeError(
+                "MNNVL reattach config must provide a communication backend"
+            )
+        MnnvlMemory.config = config
+        comm = config.comm_backend.Split(
             mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
         )
         MnnvlMemory.comm = comm
@@ -466,6 +605,118 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return MnnvlMemory.allocation_granularity
 
     @staticmethod
+    def _exchange_shareable_handles(
+        comm: CommBackend,
+        allocation_prop: cuda.CUmemAllocationProp,
+        allocated_mem_handle: Any,
+    ) -> List[Any]:
+        exported_fabric_handle = checkCudaErrors(
+            cuda.cuMemExportToShareableHandle(
+                allocated_mem_handle, allocation_prop.requestedHandleTypes, 0
+            )
+        )
+        if (
+            allocation_prop.requestedHandleTypes
+            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+        ):
+            return comm.allgather(exported_fabric_handle.data)
+
+        all_handles_data = comm.allgather(exported_fabric_handle)
+        all_pids = comm.allgather(os.getpid())
+        libc = ctypes.CDLL(None, use_errno=True)
+        syscall = libc.syscall
+        SYS_pidfd_open = 434
+        SYS_pidfd_getfd = 438
+        pidfds = []
+        for pid in all_pids:
+            pidfd = syscall(SYS_pidfd_open, pid, 0)
+            if pidfd < 0:
+                err = ctypes.get_errno()
+                raise RuntimeError(
+                    f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
+                )
+            pidfds.append(pidfd)
+
+        remote_fds = []
+        for pidfd, fd in zip(pidfds, all_handles_data, strict=True):
+            remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
+            if remote_fd < 0:
+                err = ctypes.get_errno()
+                error_msg = (
+                    f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno "
+                    f"{err}: {os.strerror(err)}."
+                )
+                if err == 1:  # EPERM
+                    error_msg += (
+                        " Permission denied. If running in a container, try "
+                        "adding --cap-add=SYS_PTRACE to your docker run command."
+                    )
+                else:
+                    error_msg += (
+                        " This may be due to kernel version (requires Linux 5.6+)."
+                    )
+                raise RuntimeError(error_msg)
+            remote_fds.append(remote_fd)
+
+        return remote_fds
+
+    @staticmethod
+    def _create_and_map_mnnvl_handles(
+        mapping: Mapping,
+        aligned_size: int,
+        start_address: int,
+        rank_stride: int,
+        address_offset: int,
+        *,
+        comm: Optional[CommBackend] = None,
+        zero_local: bool = False,
+    ) -> List[Any]:
+        dev = checkCudaErrors(cuda.cuCtxGetDevice())
+        dev_id = int(dev)
+        assert dev_id == MnnvlMemory.dev_id, (
+            f"Different dev_id found dev_id={dev_id} but "
+            f"MnnvlMemory.dev_id={MnnvlMemory.dev_id}"
+        )
+        comm = comm or MnnvlMemory.get_comm(mapping)
+        comm_rank = comm.Get_rank()
+        comm_size = comm.Get_size()
+        allocation_prop = MnnvlMemory.get_allocation_prop(dev_id)
+        allocated_mem_handle = checkCudaErrors(
+            cuda.cuMemCreate(aligned_size, allocation_prop, flags=0)
+        )
+        all_handles_data = MnnvlMemory._exchange_shareable_handles(
+            comm, allocation_prop, allocated_mem_handle
+        )
+
+        madesc = cuda.CUmemAccessDesc()
+        madesc.location = allocation_prop.location
+        madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+
+        mem_handles = [None] * comm_size
+
+        for i, remote_handle_data in enumerate(all_handles_data):
+            rank_ptr = start_address + rank_stride * i + address_offset
+            if i == comm_rank:
+                mem_handles[i] = allocated_mem_handle
+            else:
+                imported_mem_handle = checkCudaErrors(
+                    cuda.cuMemImportFromShareableHandle(
+                        remote_handle_data, allocation_prop.requestedHandleTypes
+                    )
+                )
+                mem_handles[i] = imported_mem_handle
+            checkCudaErrors(
+                cuda.cuMemMap(rank_ptr, aligned_size, 0, mem_handles[i], 0)
+            )
+            checkCudaErrors(cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1))
+
+        if zero_local:
+            local_ptr = start_address + rank_stride * comm_rank + address_offset
+            checkCudaErrors(cuda.cuMemsetD8(local_ptr, 0, aligned_size))
+
+        return mem_handles
+
+    @staticmethod
     def new_mnnvl_memory_address(mapping: Mapping, size: int):
         page_count = (
             size + MnnvlMemory.fabric_page_size - 1
@@ -494,7 +745,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
             f"Different dev_id found dev_id={dev_id} but MnnvlMemory.dev_id={MnnvlMemory.dev_id}"
         )
         comm = MnnvlMemory.get_comm(mapping)
-        comm_rank = comm.Get_rank()
         comm_size = comm.Get_size()
         all_rank_allocate_sizes = comm.allgather(size)
         assert len(all_rank_allocate_sizes) == comm_size
@@ -515,100 +765,27 @@ class MnnvlMemory:  # type: ignore[no-redef]
             <= MnnvlMemory.current_rank_stride
         )
 
-        allocation_prop = MnnvlMemory.get_allocation_prop(dev_id)
-        allocated_mem_handle = checkCudaErrors(
-            cuda.cuMemCreate(aligned_size, allocation_prop, flags=0)
-        )
-        exported_fabric_handle = checkCudaErrors(
-            cuda.cuMemExportToShareableHandle(
-                allocated_mem_handle, allocation_prop.requestedHandleTypes, 0
-            )
-        )
-        if (
-            allocation_prop.requestedHandleTypes
-            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
-        ):
-            all_handles_data = comm.allgather(exported_fabric_handle.data)
-        else:
-            all_handles_data = comm.allgather(exported_fabric_handle)
-            all_pids = comm.allgather(os.getpid())
-            libc = ctypes.CDLL(None, use_errno=True)
-            syscall = libc.syscall
-            SYS_pidfd_open = 434
-            SYS_pidfd_getfd = 438
-            pidfds = []
-            for pid in all_pids:
-                pidfd = syscall(SYS_pidfd_open, pid, 0)
-                if pidfd < 0:
-                    err = ctypes.get_errno()
-                    raise RuntimeError(
-                        f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
-                    )
-                pidfds.append(pidfd)
-
-            remote_fds = []
-            for pidfd, fd in zip(pidfds, all_handles_data, strict=True):
-                remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
-                if remote_fd < 0:
-                    err = ctypes.get_errno()
-                    error_msg = f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno {err}: {os.strerror(err)}."
-                    if err == 1:  # EPERM
-                        error_msg += (
-                            " Permission denied. If running in a container, try adding --cap-add=SYS_PTRACE "
-                            "to your docker run command."
-                        )
-                    else:
-                        error_msg += (
-                            " This may be due to kernel version (requires Linux 5.6+)."
-                        )
-                    raise RuntimeError(error_msg)
-                remote_fds.append(remote_fd)
-
-            all_handles_data = remote_fds
-        # all_handles_data like b'\x00\x00\x00 \x00\x00\x00\x00\x8f\xec\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00\x00\x00\x1d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # noqa: E501
-        # can use buf = memoryview(data) to import if using plain buffer for data.
-
-        madesc = cuda.CUmemAccessDesc()
-        madesc.location = allocation_prop.location
-        madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
-
-        mem_handles = [None] * comm_size
-
-        for i, remote_handle_data in enumerate(all_handles_data):
-            rank_ptr = (
-                MnnvlMemory.current_start_address
-                + MnnvlMemory.current_rank_stride * i
-                + MnnvlMemory.current_mem_offset
-            )
-            if i == comm_rank:
-                # Local memory mapping
-                mem_handles[i] = allocated_mem_handle
-                checkCudaErrors(
-                    cuda.cuMemMap(rank_ptr, aligned_size, 0, allocated_mem_handle, 0)
-                )
-            else:
-                # Fabric memory mapping
-                imported_mem_handle = checkCudaErrors(
-                    cuda.cuMemImportFromShareableHandle(
-                        remote_handle_data, allocation_prop.requestedHandleTypes
-                    )
-                )
-                mem_handles[i] = imported_mem_handle
-                checkCudaErrors(
-                    cuda.cuMemMap(rank_ptr, aligned_size, 0, imported_mem_handle, 0)
-                )
-
-            checkCudaErrors(cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1))
-
         ptr = MnnvlMemory.current_start_address + MnnvlMemory.current_mem_offset
         stride = MnnvlMemory.current_rank_stride
-        MnnvlMemory.allocated_map[ptr] = (
+        comm = MnnvlMemory.get_comm(mapping)
+        mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
             mapping,
             aligned_size,
-            mem_handles,
             MnnvlMemory.current_start_address,
             MnnvlMemory.current_rank_stride,
             MnnvlMemory.current_mem_offset,
+            comm=comm,
+        )
+        MnnvlMemory.allocated_map[ptr] = _MnnvlAllocationRecord(
+            mapping=mapping,
+            comm=comm,
+            comm_size=comm.Get_size(),
+            comm_rank=comm.Get_rank(),
+            aligned_size=aligned_size,
+            mem_handles=mem_handles,
+            start_address=MnnvlMemory.current_start_address,
+            rank_stride=MnnvlMemory.current_rank_stride,
+            address_offset=MnnvlMemory.current_mem_offset,
         )
         MnnvlMemory.address_refcnt[MnnvlMemory.current_start_address] = (
             MnnvlMemory.address_refcnt.get(MnnvlMemory.current_start_address, 0) + 1
@@ -618,31 +795,129 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return ptr, stride
 
     @staticmethod
-    def close_mnnvl_memory(ptr: int):
-        (
-            mapping,
-            aligned_size,
-            mem_handles,
-            start_address,
-            rank_stride,
-            address_offset,
-        ) = MnnvlMemory.allocated_map.pop(ptr)
-        comm = MnnvlMemory.get_comm(mapping)
+    def _validate_remap_comm(
+        record: _MnnvlAllocationRecord, comm: CommBackend
+    ) -> None:
         comm_size = comm.Get_size()
-        for i in range(comm_size):
-            rank_ptr = start_address + i * rank_stride + address_offset
-            checkCudaErrors(cuda.cuMemUnmap(rank_ptr, aligned_size))
-            checkCudaErrors(cuda.cuMemRelease(mem_handles[i]))
-        MnnvlMemory.address_refcnt[start_address] -= 1
+        comm_rank = comm.Get_rank()
+        if comm_size != record.comm_size or comm_rank != record.comm_rank:
+            raise RuntimeError(
+                "Restored MNNVL communicator does not match the graph-visible "
+                "allocation layout: "
+                f"rank/size {comm_rank}/{comm_size} != "
+                f"{record.comm_rank}/{record.comm_size}"
+            )
 
-        if MnnvlMemory.address_refcnt[start_address] == 0:
-            MnnvlMemory.address_refcnt.pop(start_address)
-            device_ptr = cuda.CUdeviceptr(start_address)
-            checkCudaErrors(cuda.cuMemAddressFree(device_ptr, comm_size * rank_stride))
-            if start_address == MnnvlMemory.current_start_address:
+    @staticmethod
+    def _unmap_and_release_mnnvl_handles(record: _MnnvlAllocationRecord) -> None:
+        for i in range(record.comm_size):
+            rank_ptr = (
+                record.start_address + i * record.rank_stride + record.address_offset
+            )
+            checkCudaErrors(cuda.cuMemUnmap(rank_ptr, record.aligned_size))
+            checkCudaErrors(cuda.cuMemRelease(record.mem_handles[i]))
+
+    @staticmethod
+    def close_mnnvl_memory(ptr: int):
+        record = MnnvlMemory.allocated_map.pop(ptr)
+        if record.mapped:
+            MnnvlMemory._unmap_and_release_mnnvl_handles(record)
+            record.mapped = False
+        MnnvlMemory.address_refcnt[record.start_address] -= 1
+
+        if MnnvlMemory.address_refcnt[record.start_address] == 0:
+            MnnvlMemory.address_refcnt.pop(record.start_address)
+            device_ptr = cuda.CUdeviceptr(record.start_address)
+            checkCudaErrors(
+                cuda.cuMemAddressFree(
+                    device_ptr, record.comm_size * record.rank_stride
+                )
+            )
+            if record.start_address == MnnvlMemory.current_start_address:
                 MnnvlMemory.current_start_address = 0
                 MnnvlMemory.current_rank_stride = 0
                 MnnvlMemory.current_mem_offset = 0
+
+    @staticmethod
+    def _detach_mnnvl_handles(
+        ptr: int, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        record = MnnvlMemory.allocated_map[ptr]
+        comm = record.comm
+        mapped_states = comm.allgather(record.mapped)
+        if any(mapped_states) and not all(mapped_states):
+            raise RuntimeError("Inconsistent MNNVL mapped state across ranks")
+        if not any(mapped_states):
+            if barrier:
+                comm.barrier()
+                comm.barrier()
+            return
+
+        if synchronize:
+            checkCudaErrors(cuda.cuCtxSynchronize())
+        if barrier:
+            comm.barrier()
+
+        MnnvlMemory._unmap_and_release_mnnvl_handles(record)
+        record.mem_handles = [None] * record.comm_size
+        record.mapped = False
+
+        if barrier:
+            comm.barrier()
+
+    @staticmethod
+    def _reattach_mnnvl_handles(
+        ptr: int,
+        *,
+        comm: Optional[CommBackend] = None,
+        config: Optional[MnnvlConfig] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        zero_local: bool = True,
+    ) -> None:
+        record = MnnvlMemory.allocated_map[ptr]
+        if config is not None and comm is not None:
+            raise RuntimeError("Pass either comm or config when reattaching MNNVL")
+        if (config is not None or (comm is not None and comm is not record.comm)) and (
+            record.mapped
+        ):
+            raise RuntimeError(
+                "Cannot refresh MNNVL communicator while allocation is still mapped; "
+                "call detach_handles before checkpoint reattach"
+            )
+        if config is not None:
+            comm = MnnvlMemory.refresh_comm_from_config(record.mapping, config)
+        else:
+            comm = comm or record.comm
+        MnnvlMemory._validate_remap_comm(record, comm)
+        record.comm = comm
+        mapped_states = comm.allgather(record.mapped)
+        if any(mapped_states) and not all(mapped_states):
+            raise RuntimeError("Inconsistent MNNVL mapped state across ranks")
+        if all(mapped_states):
+            if barrier:
+                comm.barrier()
+                comm.barrier()
+            return
+
+        if synchronize:
+            checkCudaErrors(cuda.cuCtxSynchronize())
+        if barrier:
+            comm.barrier()
+
+        record.mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
+            record.mapping,
+            record.aligned_size,
+            record.start_address,
+            record.rank_stride,
+            record.address_offset,
+            comm=comm,
+            zero_local=zero_local,
+        )
+        record.mapped = True
+
+        if barrier:
+            comm.barrier()
 
     @staticmethod
     def support_nvlink(need_all_up: bool = True):

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -356,7 +356,6 @@ class MnnvlConfig:
 
 @dataclass
 class _MnnvlAllocationRecord:
-    mapping: Mapping
     comm: CommBackend
     comm_size: int
     comm_rank: int
@@ -402,113 +401,20 @@ class MnnvlMemory:  # type: ignore[no-redef]
             if hasattr(self, "ptr"):
                 MnnvlMemory.close_mnnvl_memory(self.ptr)
 
+    @property
+    def mapped(self) -> bool:
+        return MnnvlMemory.allocated_map[self.ptr].mapped
+
     def as_torch_strided_tensor(self, dtype):
         record = MnnvlMemory.allocated_map[self.ptr]
-        num_segments = record.comm.Get_size()
         return pack_strided_memory(
             self.ptr,
             self.segment_size,
             self.rank_stride,
-            num_segments,
+            record.comm_size,
             dtype,
             MnnvlMemory.dev_id,
         )
-
-    def detach_handles(self) -> None:
-        """Release mapped MNNVL handles while keeping graph-visible VAs alive.
-
-        CUDA synchronization is performed internally before unmapping.
-        """
-        MnnvlMemory._detach_mnnvl_handles(self.ptr)
-
-    def reattach_handles(
-        self,
-        *,
-        comm: Optional[CommBackend] = None,
-    ) -> None:
-        """Map fresh MNNVL handles at the preserved virtual addresses.
-
-        CUDA synchronization is performed internally before remapping.
-        """
-        MnnvlMemory._reattach_mnnvl_handles(
-            self.ptr,
-            comm=comm,
-        )
-
-    def get_graph_visible_addresses(self) -> Dict[str, Any]:
-        """Return the VA/layout state captured by CUDA graph-visible tensors."""
-        record = MnnvlMemory.allocated_map[self.ptr]
-        return {
-            "ptr": self.ptr,
-            "segment_size": self.segment_size,
-            "rank_stride": self.rank_stride,
-            "start_address": record.start_address,
-            "address_offset": record.address_offset,
-            "aligned_size": record.aligned_size,
-            "comm_size": record.comm_size,
-            "comm_rank": record.comm_rank,
-            "rank_ptrs": [
-                record.start_address + i * record.rank_stride + record.address_offset
-                for i in range(record.comm_size)
-            ],
-        }
-
-    def validate_graph_visible_addresses(
-        self,
-        expected: Optional[Dict[str, Any]],
-        tensor: Optional[torch.Tensor] = None,
-    ) -> None:
-        """Validate that graph-visible VAs and optional tensor metadata are stable."""
-        if expected is None:
-            raise RuntimeError("Missing captured MNNVL graph-visible address metadata")
-
-        current = self.get_graph_visible_addresses()
-        expected_keys = set(expected)
-        current_keys = set(current)
-        missing = expected_keys - current_keys
-        if missing:
-            field = sorted(missing)[0]
-            raise RuntimeError(
-                f"MNNVL graph-visible address metadata missing field {field!r}"
-            )
-        extra = current_keys - expected_keys
-        if extra:
-            field = sorted(extra)[0]
-            raise RuntimeError(
-                f"MNNVL graph-visible address metadata has extra field {field!r}"
-            )
-        for key, expected_value in expected.items():
-            current_value = current[key]
-            if current_value != expected_value:
-                raise RuntimeError(
-                    f"MNNVL graph-visible address field {key} changed: "
-                    f"{current_value!r} != {expected_value!r}"
-                )
-
-        if tensor is not None:
-            element_size = tensor.element_size()
-            if tensor.data_ptr() != current["ptr"]:
-                raise RuntimeError(
-                    f"MNNVL tensor data_ptr changed: {tensor.data_ptr()} "
-                    f"!= {current['ptr']}"
-                )
-            if tensor.size(0) != current["comm_size"]:
-                raise RuntimeError(
-                    f"MNNVL tensor rank dimension changed: {tensor.size(0)} "
-                    f"!= {current['comm_size']}"
-                )
-            expected_segment_elements = current["segment_size"] // element_size
-            if tensor.size(1) != expected_segment_elements:
-                raise RuntimeError(
-                    "MNNVL tensor segment dimension changed: "
-                    f"{tensor.size(1)} != {expected_segment_elements}"
-                )
-            if tensor.stride(0) * element_size != current["rank_stride"]:
-                raise RuntimeError(
-                    "MNNVL tensor rank stride changed: "
-                    f"{tensor.stride(0) * element_size} != "
-                    f"{current['rank_stride']}"
-                )
 
     @staticmethod
     def initialize():
@@ -524,10 +430,8 @@ class MnnvlMemory:  # type: ignore[no-redef]
 
     @staticmethod
     def set_comm_from_config(mapping: Mapping, config: MnnvlConfig = None):
-        MnnvlMemory.config = config or MnnvlConfig(comm_backend=MPIBackend())
-        if MnnvlMemory.config.comm_backend is None:
-            raise RuntimeError("MNNVL config must provide a communication backend")
-        comm = MnnvlMemory.config.comm_backend.Split(
+        MnnvlMemory.config = config or MnnvlConfig(comm_backend=MPIBackend())  # type: ignore[attr-defined]
+        comm = config.comm_backend.Split(
             mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
         )
         MnnvlMemory.comm = comm  # type: ignore[assignment]
@@ -536,15 +440,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
     def get_comm(mapping: Mapping):
         if MnnvlMemory.comm is not None:
             return MnnvlMemory.comm
-        if MnnvlMemory.config is not None:
-            config = MnnvlMemory.config
-            if config.comm_backend is not None:
-                comm = config.comm_backend.Split(
-                    mapping.pp_rank * mapping.cp_size + mapping.cp_rank,
-                    mapping.tp_rank,
-                )
-                MnnvlMemory.comm = comm
-                return comm
         comm = MpiComm().Split(
             mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
         )
@@ -604,54 +499,64 @@ class MnnvlMemory:  # type: ignore[no-redef]
         ):
             return comm.allgather(exported_fabric_handle.data)
 
-        all_handles_data = comm.allgather(exported_fabric_handle)
-        all_pids = comm.allgather(os.getpid())
-        libc = ctypes.CDLL(None, use_errno=True)
-        syscall = libc.syscall
-        SYS_pidfd_open = 434
-        SYS_pidfd_getfd = 438
-        pidfds = []
-        for pid in all_pids:
-            pidfd = syscall(SYS_pidfd_open, pid, 0)
-            if pidfd < 0:
-                err = ctypes.get_errno()
-                raise RuntimeError(
-                    f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
-                )
-            pidfds.append(pidfd)
-
+        exported_fd = int(exported_fabric_handle)
         remote_fds = []
-        for pidfd, fd in zip(pidfds, all_handles_data, strict=True):
-            remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
-            if remote_fd < 0:
-                err = ctypes.get_errno()
-                error_msg = (
-                    f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno "
-                    f"{err}: {os.strerror(err)}."
-                )
-                if err == 1:  # EPERM
-                    error_msg += (
-                        " Permission denied. If running in a container, try "
-                        "adding --cap-add=SYS_PTRACE to your docker run command."
-                    )
-                else:
-                    error_msg += (
-                        " This may be due to kernel version (requires Linux 5.6+)."
-                    )
-                raise RuntimeError(error_msg)
-            remote_fds.append(remote_fd)
+        try:
+            all_handles_data = comm.allgather(exported_fd)
+            all_pids = comm.allgather(os.getpid())
+            libc = ctypes.CDLL(None, use_errno=True)
+            syscall = libc.syscall
+            SYS_pidfd_open = 434
+            SYS_pidfd_getfd = 438
 
-        return remote_fds
+            for pid, fd in zip(all_pids, all_handles_data, strict=True):
+                pidfd = syscall(SYS_pidfd_open, pid, 0)
+                if pidfd < 0:
+                    err = ctypes.get_errno()
+                    raise RuntimeError(
+                        f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
+                    )
+                try:
+                    remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
+                    if remote_fd < 0:
+                        err = ctypes.get_errno()
+                        error_msg = (
+                            f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with "
+                            f"errno {err}: {os.strerror(err)}."
+                        )
+                        if err == 1:  # EPERM
+                            error_msg += (
+                                " Permission denied. If running in a container, "
+                                "try adding --cap-add=SYS_PTRACE to your docker "
+                                "run command."
+                            )
+                        else:
+                            error_msg += (
+                                " This may be due to kernel version "
+                                "(requires Linux 5.6+)."
+                            )
+                        raise RuntimeError(error_msg)
+                    remote_fds.append(remote_fd)
+                finally:
+                    os.close(pidfd)
+
+            # Every rank must duplicate every exported FD before its owner closes it.
+            comm.barrier()
+            return remote_fds
+        except BaseException:
+            for remote_fd in remote_fds:
+                os.close(remote_fd)
+            raise
+        finally:
+            os.close(exported_fd)
 
     @staticmethod
     def _create_and_map_mnnvl_handles(
-        mapping: Mapping,
+        comm: CommBackend,
         aligned_size: int,
         start_address: int,
         rank_stride: int,
         address_offset: int,
-        *,
-        comm: Optional[CommBackend] = None,
     ) -> List[Any]:
         dev = checkCudaErrors(cuda.cuCtxGetDevice())
         dev_id = int(dev)
@@ -659,7 +564,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
             f"Different dev_id found dev_id={dev_id} but "
             f"MnnvlMemory.dev_id={MnnvlMemory.dev_id}"
         )
-        comm = comm or MnnvlMemory.get_comm(mapping)
         comm_rank = comm.Get_rank()
         comm_size = comm.Get_size()
         allocation_prop = MnnvlMemory.get_allocation_prop(dev_id)
@@ -670,27 +574,36 @@ class MnnvlMemory:  # type: ignore[no-redef]
             comm, allocation_prop, allocated_mem_handle
         )
 
-        madesc = cuda.CUmemAccessDesc()
-        madesc.location = allocation_prop.location
-        madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
-
         mem_handles = [None] * comm_size
+        try:
+            madesc = cuda.CUmemAccessDesc()
+            madesc.location = allocation_prop.location
+            madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
 
-        for i, remote_handle_data in enumerate(all_handles_data):
-            rank_ptr = start_address + rank_stride * i + address_offset
-            if i == comm_rank:
-                mem_handles[i] = allocated_mem_handle
-            else:
-                imported_mem_handle = checkCudaErrors(
-                    cuda.cuMemImportFromShareableHandle(
-                        remote_handle_data, allocation_prop.requestedHandleTypes
+            for i, remote_handle_data in enumerate(all_handles_data):
+                rank_ptr = start_address + rank_stride * i + address_offset
+                if i == comm_rank:
+                    mem_handles[i] = allocated_mem_handle
+                else:
+                    imported_mem_handle = checkCudaErrors(
+                        cuda.cuMemImportFromShareableHandle(
+                            remote_handle_data, allocation_prop.requestedHandleTypes
+                        )
                     )
+                    mem_handles[i] = imported_mem_handle
+                checkCudaErrors(
+                    cuda.cuMemMap(rank_ptr, aligned_size, 0, mem_handles[i], 0)
                 )
-                mem_handles[i] = imported_mem_handle
-            checkCudaErrors(
-                cuda.cuMemMap(rank_ptr, aligned_size, 0, mem_handles[i], 0)
-            )
-            checkCudaErrors(cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1))
+                checkCudaErrors(
+                    cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1)
+                )
+        finally:
+            if (
+                allocation_prop.requestedHandleTypes
+                == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+            ):
+                for shareable_fd in all_handles_data:
+                    os.close(int(shareable_fd))
 
         return mem_handles
 
@@ -747,15 +660,13 @@ class MnnvlMemory:  # type: ignore[no-redef]
         stride = MnnvlMemory.current_rank_stride
         comm = MnnvlMemory.get_comm(mapping)
         mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
-            mapping,
+            comm,
             aligned_size,
             MnnvlMemory.current_start_address,
             MnnvlMemory.current_rank_stride,
             MnnvlMemory.current_mem_offset,
-            comm=comm,
         )
         MnnvlMemory.allocated_map[ptr] = _MnnvlAllocationRecord(
-            mapping=mapping,
             comm=comm,
             comm_size=comm.Get_size(),
             comm_rank=comm.Get_rank(),
@@ -793,9 +704,7 @@ class MnnvlMemory:  # type: ignore[no-redef]
             MnnvlMemory.address_refcnt.pop(record.start_address)
             device_ptr = cuda.CUdeviceptr(record.start_address)
             checkCudaErrors(
-                cuda.cuMemAddressFree(
-                    device_ptr, record.comm_size * record.rank_stride
-                )
+                cuda.cuMemAddressFree(device_ptr, record.comm_size * record.rank_stride)
             )
             if record.start_address == MnnvlMemory.current_start_address:
                 MnnvlMemory.current_start_address = 0
@@ -803,53 +712,36 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 MnnvlMemory.current_mem_offset = 0
 
     @staticmethod
-    def _detach_mnnvl_handles(ptr: int) -> None:
+    def _detach_mnnvl_handles(ptr: int) -> bool:
         record = MnnvlMemory.allocated_map[ptr]
-        comm = record.comm
-        mapped_states = comm.allgather(record.mapped)
-        if any(mapped_states) and not all(mapped_states):
-            raise RuntimeError("Inconsistent MNNVL mapped state across ranks")
-        if not any(mapped_states):
-            return
+        if not record.mapped:
+            return False
+        comm_rank = record.comm.Get_rank()
+        comm_size = record.comm.Get_size()
+        if comm_rank != record.comm_rank or comm_size != record.comm_size:
+            raise RuntimeError(
+                "MNNVL communicator does not match the allocation layout: "
+                f"rank/size {comm_rank}/{comm_size} != "
+                f"{record.comm_rank}/{record.comm_size}"
+            )
 
         checkCudaErrors(cuda.cuCtxSynchronize())
+        record.comm.barrier()
         MnnvlMemory._unmap_and_release_mnnvl_handles(record)
         record.mem_handles = [None] * record.comm_size
         record.mapped = False
+        return True
 
     @staticmethod
     def _reattach_mnnvl_handles(
         ptr: int,
-        *,
-        comm: Optional[CommBackend] = None,
-        config: Optional[MnnvlConfig] = None,
-    ) -> None:
+        comm_backend: CommBackend,
+    ) -> bool:
         record = MnnvlMemory.allocated_map[ptr]
-        if config is not None and comm is not None:
-            raise RuntimeError("Pass either comm or config when reattaching MNNVL")
-        if (config is not None or (comm is not None and comm is not record.comm)) and (
-            record.mapped
-        ):
-            raise RuntimeError(
-                "Cannot refresh MNNVL communicator while allocation is still mapped; "
-                "call detach_handles before checkpoint reattach"
-            )
-        if config is not None:
-            if config.comm_backend is None:
-                raise RuntimeError(
-                    "MNNVL reattach config must provide a communication backend"
-                )
-            MnnvlMemory.config = config
-            comm = config.comm_backend.Split(
-                record.mapping.pp_rank * record.mapping.cp_size
-                + record.mapping.cp_rank,
-                record.mapping.tp_rank,
-            )
-            MnnvlMemory.comm = comm
-        else:
-            comm = comm or record.comm
-        comm_size = comm.Get_size()
-        comm_rank = comm.Get_rank()
+        if record.mapped:
+            return False
+        comm_size = comm_backend.Get_size()
+        comm_rank = comm_backend.Get_rank()
         if comm_size != record.comm_size or comm_rank != record.comm_rank:
             raise RuntimeError(
                 "Restored MNNVL communicator does not match the graph-visible "
@@ -857,23 +749,18 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 f"rank/size {comm_rank}/{comm_size} != "
                 f"{record.comm_rank}/{record.comm_size}"
             )
-        record.comm = comm
-        mapped_states = comm.allgather(record.mapped)
-        if any(mapped_states) and not all(mapped_states):
-            raise RuntimeError("Inconsistent MNNVL mapped state across ranks")
-        if all(mapped_states):
-            return
-
         checkCudaErrors(cuda.cuCtxSynchronize())
         record.mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
-            record.mapping,
+            comm_backend,
             record.aligned_size,
             record.start_address,
             record.rank_stride,
             record.address_offset,
-            comm=comm,
         )
+        record.comm = comm_backend
+        MnnvlMemory.comm = comm_backend
         record.mapped = True
+        return True
 
     @staticmethod
     def support_nvlink(need_all_up: bool = True):

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -772,9 +772,11 @@ class MoeAlltoAll:
         # Every rank must stop using the workspace before releasing its backing.
         torch.cuda.synchronize()
         record.comm.barrier()
-        MnnvlMemory._unmap_and_release_mnnvl_handles(record)
+        MnnvlMemory._unmap_and_release_handles(record)
         record.mem_handles = [None] * record.comm_size
         record.mapped = False
+        # Do not return until every rank has released its handles.
+        record.comm.barrier()
 
     @flashinfer_api
     def checkpoint_restore(
@@ -797,7 +799,7 @@ class MoeAlltoAll:
             )
         # CUDA work must quiesce before the workspace is remapped.
         torch.cuda.synchronize()
-        record.mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
+        record.mem_handles = MnnvlMemory._create_and_map_handles(
             comm_backend,
             record.aligned_size,
             record.start_address,
@@ -980,6 +982,7 @@ class MoeAlltoAll:
             sf_layout,
         )
 
+        # Reset state for next round
         self._state = _A2AState()
 
         return output

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -14,7 +14,7 @@ import functools
 
 from ..api_logging import flashinfer_api
 
-from .mnnvl import MnnvlMemory, MnnvlConfig
+from .mnnvl import CommBackend, MnnvlMemory, MnnvlConfig
 from .mapping import Mapping
 from ..jit.comm import gen_moe_alltoall_module
 from ..utils import register_custom_op
@@ -589,6 +589,7 @@ class MoeAlltoAll:
                 "mnnvl_mem": mnnvl_mem,
                 "workspace": workspace,
                 "metainfo": metainfo,
+                "graph_visible_addresses": mnnvl_mem.get_graph_visible_addresses(),
             }
             return cls._WORKSPACE_CACHE[key]
 
@@ -729,6 +730,7 @@ class MoeAlltoAll:
         self.ep_rank = mapping.moe_ep_rank
         self.top_k = top_k
         self.num_experts = num_experts
+        self.mnnvl_config = mnnvl_config
 
         if not isinstance(self.top_k, int) or self.top_k <= 0:
             raise ValueError("top_k must be a positive int")
@@ -756,6 +758,57 @@ class MoeAlltoAll:
         self.mnnvl_mem = self._WORKSPACE["mnnvl_mem"]
         self.workspace = self._WORKSPACE["workspace"]
         self.metainfo = self._WORKSPACE["metainfo"]
+        self._state = _A2AState()
+
+    def get_graph_visible_addresses(self) -> dict:
+        """Return CUDA graph-visible MNNVL workspace VA/layout metadata."""
+        return dict(self._WORKSPACE["graph_visible_addresses"])
+
+    def validate_graph_visible_addresses(self) -> None:
+        """Validate that the cached workspace tensor still uses its original VA."""
+        self.mnnvl_mem.validate_graph_visible_addresses(
+            self._WORKSPACE["graph_visible_addresses"], self.workspace
+        )
+
+    def detach_handles(
+        self, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Release MNNVL mappings while preserving workspace tensor pointers."""
+        if self._state.phase != "idle":
+            raise RuntimeError("Cannot detach MNNVL workspace during an active A2A phase")
+        self.validate_graph_visible_addresses()
+        self.mnnvl_mem.detach_handles(synchronize=synchronize, barrier=barrier)
+
+    def reattach_handles(
+        self,
+        *,
+        comm: Optional[CommBackend] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+    ) -> None:
+        """Reattach MNNVL workspace at the original VA and refresh local state."""
+        MnnvlMemory._reattach_mnnvl_handles(
+            self.mnnvl_mem.ptr,
+            comm=comm,
+            config=None if comm is not None else self.mnnvl_config,
+            synchronize=synchronize,
+            barrier=barrier,
+            zero_local=False,
+        )
+        refreshed_metainfo = moe_a2a_initialize(
+            self.workspace,
+            self.ep_rank,
+            self.ep_size,
+            self.max_num_tokens,
+        )
+        if not torch.equal(refreshed_metainfo, self.metainfo):
+            raise RuntimeError(
+                "MoeAlltoAll metainfo changed during MNNVL reattach; "
+                "existing CUDA graphs are not safe to replay"
+            )
+        if barrier:
+            MnnvlMemory.allocated_map[self.mnnvl_mem.ptr].comm.barrier()
+        self.validate_graph_visible_addresses()
         self._state = _A2AState()
 
     def _reset_workspace(self):

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -589,7 +589,6 @@ class MoeAlltoAll:
                 "mnnvl_mem": mnnvl_mem,
                 "workspace": workspace,
                 "metainfo": metainfo,
-                "graph_visible_addresses": mnnvl_mem.get_graph_visible_addresses(),
             }
             return cls._WORKSPACE_CACHE[key]
 
@@ -730,7 +729,6 @@ class MoeAlltoAll:
         self.ep_rank = mapping.moe_ep_rank
         self.top_k = top_k
         self.num_experts = num_experts
-        self.mnnvl_config = mnnvl_config
 
         if not isinstance(self.top_k, int) or self.top_k <= 0:
             raise ValueError("top_k must be a positive int")
@@ -760,34 +758,41 @@ class MoeAlltoAll:
         self.metainfo = self._WORKSPACE["metainfo"]
         self._state = _A2AState()
 
-    def get_graph_visible_addresses(self) -> dict:
-        """Return CUDA graph-visible MNNVL workspace VA/layout metadata."""
-        return dict(self._WORKSPACE["graph_visible_addresses"])
+    def _require_handles_attached(self) -> None:
+        if not self.mnnvl_mem.mapped:
+            raise RuntimeError("MNNVL handles are not attached")
 
-    def validate_graph_visible_addresses(self) -> None:
-        """Validate that the cached workspace tensor still uses its original VA."""
-        self.mnnvl_mem.validate_graph_visible_addresses(
-            self._WORKSPACE["graph_visible_addresses"], self.workspace
-        )
-
-    def detach_handles(self) -> None:
-        """Release MNNVL mappings while preserving workspace tensor pointers."""
+    @flashinfer_api
+    def checkpoint_prepare(self) -> None:
+        """Detach MNNVL backing; repeated successful calls are no-ops."""
+        if not self.mnnvl_mem.mapped:
+            return
         if self._state.phase != "idle":
-            raise RuntimeError("Cannot detach MNNVL workspace during an active A2A phase")
-        self.validate_graph_visible_addresses()
-        self.mnnvl_mem.detach_handles()
+            raise RuntimeError(
+                "Cannot prepare a checkpoint during an active all-to-all phase"
+            )
 
-    def reattach_handles(
+        if not MnnvlMemory._detach_mnnvl_handles(self.mnnvl_mem.ptr):
+            raise RuntimeError(
+                "MNNVL allocation state disagrees with its checkpoint lifecycle"
+            )
+
+    @flashinfer_api
+    def checkpoint_restore(
         self,
-        *,
-        comm: Optional[CommBackend] = None,
+        comm_backend: CommBackend,
     ) -> None:
-        """Reattach MNNVL workspace at the original VA and refresh local state."""
-        MnnvlMemory._reattach_mnnvl_handles(
+        """Restore MNNVL backing; repeated successful calls are no-ops."""
+        if self.mnnvl_mem.mapped:
+            return
+
+        if not MnnvlMemory._reattach_mnnvl_handles(
             self.mnnvl_mem.ptr,
-            comm=comm,
-            config=None if comm is not None else self.mnnvl_config,
-        )
+            comm_backend,
+        ):
+            raise RuntimeError(
+                "MNNVL allocation state disagrees with its checkpoint lifecycle"
+            )
         refreshed_metainfo = moe_a2a_initialize(
             self.workspace,
             self.ep_rank,
@@ -798,12 +803,14 @@ class MoeAlltoAll:
             raise RuntimeError(
                 "MoeAlltoAll metainfo changed during MNNVL reattach; "
                 "existing CUDA graphs are not safe to replay"
-            )
-        self.validate_graph_visible_addresses()
+        )
+        torch.cuda.synchronize()
+        comm_backend.barrier()
         self._state = _A2AState()
 
     def _reset_workspace(self):
         """Reset the workspace to free up its state. This is mainly used for testing. Use this with caution. This object is no longer usable after this."""
+        self._require_handles_attached()
         torch.cuda.synchronize()
         del self._WORKSPACE
         del self._WORKSPACE_CACHE[
@@ -850,6 +857,7 @@ class MoeAlltoAll:
             Workspace-backed receive tensors, one per ``input_payloads``
             entry, each shaped ``[ep_size, runtime_max_tokens_per_rank, *]``.
         """
+        self._require_handles_attached()
         assert self._state.phase == "idle", "dispatch called twice without combine"
         assert runtime_max_tokens_per_rank <= self.max_num_tokens, (
             "runtime_max_tokens_per_rank exceeds max_num_tokens"
@@ -930,6 +938,7 @@ class MoeAlltoAll:
         torch.Tensor
             ``[local_num_tokens, elements_per_token]`` combined tensor.
         """
+        self._require_handles_attached()
         assert self._state.phase == "dispatched", (
             "combine called before successful dispatch"
         )
@@ -954,7 +963,6 @@ class MoeAlltoAll:
             sf_layout,
         )
 
-        # Reset state for next round
         self._state = _A2AState()
 
         return output
@@ -993,6 +1001,7 @@ class MoeAlltoAll:
         RuntimeError
             If called before a successful :meth:`dispatch`.
         """
+        self._require_handles_attached()
         if self._state.phase != "dispatched":
             raise RuntimeError(
                 "get_combine_payload_tensor_in_workspace called before successful dispatch"

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -763,36 +763,62 @@ class MoeAlltoAll:
             raise RuntimeError("MNNVL handles are not attached")
 
     @flashinfer_api
-    def checkpoint_prepare(self) -> None:
-        """Detach MNNVL backing; repeated successful calls are no-ops."""
-        if not self.mnnvl_mem.mapped:
+    def detach_handles(self) -> None:
+        """Detach MNNVL handles; repeated successful calls are no-ops."""
+        record = MnnvlMemory.allocated_map[self.mnnvl_mem.ptr]
+        if not record.mapped:
             return
         if self._state.phase != "idle":
             raise RuntimeError(
-                "Cannot prepare a checkpoint during an active all-to-all phase"
+                "Cannot detach MNNVL handles during an active all-to-all phase"
             )
 
-        if not MnnvlMemory._detach_mnnvl_handles(self.mnnvl_mem.ptr):
+        comm_rank = record.comm.Get_rank()
+        comm_size = record.comm.Get_size()
+        if comm_rank != record.comm_rank or comm_size != record.comm_size:
             raise RuntimeError(
-                "MNNVL allocation state disagrees with its checkpoint lifecycle"
+                "MNNVL communicator does not match the allocation layout: "
+                f"rank/size {comm_rank}/{comm_size} != "
+                f"{record.comm_rank}/{record.comm_size}"
             )
+        # Every rank must stop using the workspace before releasing its backing.
+        torch.cuda.synchronize()
+        record.comm.barrier()
+        MnnvlMemory._unmap_and_release_mnnvl_handles(record)
+        record.mem_handles = [None] * record.comm_size
+        record.mapped = False
 
     @flashinfer_api
-    def checkpoint_restore(
+    def attach_handles(
         self,
         comm_backend: CommBackend,
     ) -> None:
-        """Restore MNNVL backing; repeated successful calls are no-ops."""
-        if self.mnnvl_mem.mapped:
+        """Attach MNNVL handles; repeated successful calls are no-ops."""
+        record = MnnvlMemory.allocated_map[self.mnnvl_mem.ptr]
+        if record.mapped:
             return
 
-        if not MnnvlMemory._reattach_mnnvl_handles(
-            self.mnnvl_mem.ptr,
-            comm_backend,
-        ):
+        comm_size = comm_backend.Get_size()
+        comm_rank = comm_backend.Get_rank()
+        if comm_size != record.comm_size or comm_rank != record.comm_rank:
             raise RuntimeError(
-                "MNNVL allocation state disagrees with its checkpoint lifecycle"
+                "MNNVL communicator does not match the graph-visible "
+                "allocation layout: "
+                f"rank/size {comm_rank}/{comm_size} != "
+                f"{record.comm_rank}/{record.comm_size}"
             )
+        # CUDA work must quiesce before the workspace is remapped.
+        torch.cuda.synchronize()
+        record.mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
+            comm_backend,
+            record.aligned_size,
+            record.start_address,
+            record.rank_stride,
+            record.address_offset,
+        )
+        record.comm = comm_backend
+        MnnvlMemory.comm = comm_backend
+        record.mapped = True
         refreshed_metainfo = moe_a2a_initialize(
             self.workspace,
             self.ep_rank,
@@ -801,9 +827,9 @@ class MoeAlltoAll:
         )
         if not torch.equal(refreshed_metainfo, self.metainfo):
             raise RuntimeError(
-                "MoeAlltoAll metainfo changed during MNNVL reattach; "
+                "MoeAlltoAll metainfo changed after attaching MNNVL handles; "
                 "existing CUDA graphs are not safe to replay"
-        )
+            )
         torch.cuda.synchronize()
         comm_backend.barrier()
         self._state = _A2AState()

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -758,29 +758,17 @@ class MoeAlltoAll:
         self.metainfo = self._WORKSPACE["metainfo"]
         self._state = _A2AState()
 
-    def _require_handles_attached(self) -> None:
-        if not self.mnnvl_mem.mapped:
-            raise RuntimeError("MNNVL handles are not attached")
-
     @flashinfer_api
-    def detach_handles(self) -> None:
-        """Detach MNNVL handles; repeated successful calls are no-ops."""
+    def checkpoint_prepare(self) -> None:
+        """Unmap MNNVL handles for checkpointing; repeated calls are no-ops."""
         record = MnnvlMemory.allocated_map[self.mnnvl_mem.ptr]
         if not record.mapped:
             return
         if self._state.phase != "idle":
             raise RuntimeError(
-                "Cannot detach MNNVL handles during an active all-to-all phase"
+                "Cannot unmap MNNVL handles during an active all-to-all phase"
             )
 
-        comm_rank = record.comm.Get_rank()
-        comm_size = record.comm.Get_size()
-        if comm_rank != record.comm_rank or comm_size != record.comm_size:
-            raise RuntimeError(
-                "MNNVL communicator does not match the allocation layout: "
-                f"rank/size {comm_rank}/{comm_size} != "
-                f"{record.comm_rank}/{record.comm_size}"
-            )
         # Every rank must stop using the workspace before releasing its backing.
         torch.cuda.synchronize()
         record.comm.barrier()
@@ -789,11 +777,11 @@ class MoeAlltoAll:
         record.mapped = False
 
     @flashinfer_api
-    def attach_handles(
+    def checkpoint_restore(
         self,
         comm_backend: CommBackend,
     ) -> None:
-        """Attach MNNVL handles; repeated successful calls are no-ops."""
+        """Remap MNNVL handles after restore; repeated calls are no-ops."""
         record = MnnvlMemory.allocated_map[self.mnnvl_mem.ptr]
         if record.mapped:
             return
@@ -802,8 +790,8 @@ class MoeAlltoAll:
         comm_rank = comm_backend.Get_rank()
         if comm_size != record.comm_size or comm_rank != record.comm_rank:
             raise RuntimeError(
-                "MNNVL communicator does not match the graph-visible "
-                "allocation layout: "
+                "Cannot remap MNNVL handles because the communicator does not "
+                "match the graph-visible allocation layout: "
                 f"rank/size {comm_rank}/{comm_size} != "
                 f"{record.comm_rank}/{record.comm_size}"
             )
@@ -827,7 +815,7 @@ class MoeAlltoAll:
         )
         if not torch.equal(refreshed_metainfo, self.metainfo):
             raise RuntimeError(
-                "MoeAlltoAll metainfo changed after attaching MNNVL handles; "
+                "MoeAlltoAll metainfo changed during MNNVL handle remap; "
                 "existing CUDA graphs are not safe to replay"
             )
         torch.cuda.synchronize()
@@ -836,7 +824,8 @@ class MoeAlltoAll:
 
     def _reset_workspace(self):
         """Reset the workspace to free up its state. This is mainly used for testing. Use this with caution. This object is no longer usable after this."""
-        self._require_handles_attached()
+        if not self.mnnvl_mem.mapped:
+            raise RuntimeError("MNNVL handles are unmapped")
         torch.cuda.synchronize()
         del self._WORKSPACE
         del self._WORKSPACE_CACHE[
@@ -883,7 +872,8 @@ class MoeAlltoAll:
             Workspace-backed receive tensors, one per ``input_payloads``
             entry, each shaped ``[ep_size, runtime_max_tokens_per_rank, *]``.
         """
-        self._require_handles_attached()
+        if not self.mnnvl_mem.mapped:
+            raise RuntimeError("MNNVL handles are unmapped")
         assert self._state.phase == "idle", "dispatch called twice without combine"
         assert runtime_max_tokens_per_rank <= self.max_num_tokens, (
             "runtime_max_tokens_per_rank exceeds max_num_tokens"
@@ -964,7 +954,8 @@ class MoeAlltoAll:
         torch.Tensor
             ``[local_num_tokens, elements_per_token]`` combined tensor.
         """
-        self._require_handles_attached()
+        if not self.mnnvl_mem.mapped:
+            raise RuntimeError("MNNVL handles are unmapped")
         assert self._state.phase == "dispatched", (
             "combine called before successful dispatch"
         )
@@ -1027,7 +1018,8 @@ class MoeAlltoAll:
         RuntimeError
             If called before a successful :meth:`dispatch`.
         """
-        self._require_handles_attached()
+        if not self.mnnvl_mem.mapped:
+            raise RuntimeError("MNNVL handles are unmapped")
         if self._state.phase != "dispatched":
             raise RuntimeError(
                 "get_combine_payload_tensor_in_workspace called before successful dispatch"

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -770,29 +770,23 @@ class MoeAlltoAll:
             self._WORKSPACE["graph_visible_addresses"], self.workspace
         )
 
-    def detach_handles(
-        self, *, synchronize: bool = True, barrier: bool = True
-    ) -> None:
+    def detach_handles(self) -> None:
         """Release MNNVL mappings while preserving workspace tensor pointers."""
         if self._state.phase != "idle":
             raise RuntimeError("Cannot detach MNNVL workspace during an active A2A phase")
         self.validate_graph_visible_addresses()
-        self.mnnvl_mem.detach_handles(synchronize=synchronize, barrier=barrier)
+        self.mnnvl_mem.detach_handles()
 
     def reattach_handles(
         self,
         *,
         comm: Optional[CommBackend] = None,
-        synchronize: bool = True,
-        barrier: bool = True,
     ) -> None:
         """Reattach MNNVL workspace at the original VA and refresh local state."""
         MnnvlMemory._reattach_mnnvl_handles(
             self.mnnvl_mem.ptr,
             comm=comm,
             config=None if comm is not None else self.mnnvl_config,
-            synchronize=synchronize,
-            barrier=barrier,
             zero_local=False,
         )
         refreshed_metainfo = moe_a2a_initialize(
@@ -806,8 +800,6 @@ class MoeAlltoAll:
                 "MoeAlltoAll metainfo changed during MNNVL reattach; "
                 "existing CUDA graphs are not safe to replay"
             )
-        if barrier:
-            MnnvlMemory.allocated_map[self.mnnvl_mem.ptr].comm.barrier()
         self.validate_graph_visible_addresses()
         self._state = _A2AState()
 

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -787,7 +787,6 @@ class MoeAlltoAll:
             self.mnnvl_mem.ptr,
             comm=comm,
             config=None if comm is not None else self.mnnvl_config,
-            zero_local=False,
         )
         refreshed_metainfo = moe_a2a_initialize(
             self.workspace,


### PR DESCRIPTION
## Summary

- Preserve the existing MNNVL CUDA virtual-address reservation while releasing and recreating its physical/imported handles across process checkpoint/restore.
- Expose the lifecycle only at the owning `MoeAlltoAll` workspace as `checkpoint_prepare()` and `checkpoint_restore(comm_backend)`.
- Require the restored rank-group backend to preserve the original rank and size, then remap fresh handles at the existing virtual addresses and reinitialize the MoE all-to-all workspace.
- Keep handle detach/reattach private.
- Treat repeated calls as successful no-ops once the workspace is already in the requested state.
- Keep dispatch/combine state in each `_A2AState` and read handle attachment from the shared `MnnvlMemory.mapped` state.
- Reject data operations while the MNNVL handles are detached.
- Close exported, duplicated, and pidfd descriptors in the POSIX handle-exchange path.

## Scope

This PR is independent of the symmetric-memory/all-reduce work in #3745. It covers the MNNVL MoE all-to-all DEP/EP path and does not add retry semantics or a second public memory-level checkpoint API.

## Usage

```python
moe_alltoall.checkpoint_prepare()
moe_alltoall.checkpoint_restore(comm_backend)
```

Successful transitions are idempotent. A transition that raises is terminal for that workspace; callers should abort the restored worker rather than retrying the failed operation.

Both methods are collective: every rank must call them in the same order, and `comm_backend` must reproduce the original rank and world size.

## Validation

Rebased onto `flashinfer-ai/main` at `2b150b39a7554fe73b5e1e8864b9f93030ebe2be`.

- `ruff format --check flashinfer/comm/mnnvl.py flashinfer/comm/trtllm_moe_alltoall.py`
- `ruff check flashinfer/comm/mnnvl.py flashinfer/comm/trtllm_moe_alltoall.py`
- `python -m py_compile flashinfer/comm/mnnvl.py flashinfer/comm/trtllm_moe_alltoall.py`
- `git diff --check`

No GPU/MNNVL runtime test was run in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checkpoint lifecycle APIs for MoE all-to-all: `checkpoint_prepare()` and `checkpoint_restore(comm_backend)` to support CUDA checkpoint/restore with correct handle remapping, address preservation, and metadata refresh.

* **Bug Fixes**
  * Improved MNNVL handle lifecycle management during checkpoint transitions, including safer workspace cleanup and stricter state handling.
  * Enforced fail-fast checks when required handles are not currently mapped.

* **Documentation**
  * Expanded API documentation with collective call ordering, communicator matching requirements, idempotency behavior, and restart guidance after exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->