### PR TITLE
feat(comm): expose peer resource pause resume hooks

### DIFF
--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -120,6 +120,33 @@ Core Classes
     MnnvlMemory
     McastGPUBuffer
 
+CUDA graph-stable checkpoint pause/resume
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+MNNVL workspaces used by MoE all-to-all kernels are CUDA VMM allocations.
+For process checkpoint/restore, callers may release the non-checkpointable
+physical/imported MNNVL handles while keeping the CUDA virtual address
+reservations and Python workspace tensors alive.  Use
+``detach_physical_keep_va`` only after all kernels using the workspace have
+quiesced.  After restore, use ``remap_physical_same_va`` to recreate/export/
+import handles and map them at the original virtual addresses before replaying
+captured CUDA graphs.  The remap path refreshes communicator/transport state
+from the current ``MnnvlConfig`` when provided; it does not reuse stale
+cross-process handles from the checkpoint.
+
+CUDA graphs remain valid only if every graph-visible workspace tensor pointer,
+rank stride, rank count, rank id, and tensor layout validates unchanged.  The
+MNNVL APIs fail closed when this metadata changes.  Non-workspace tensors
+captured by a graph remain the caller's responsibility.
+
+.. autosummary::
+    :toctree: ../generated
+
+    MnnvlMemory.detach_physical_keep_va
+    MnnvlMemory.remap_physical_same_va
+    MnnvlMemory.get_graph_visible_addresses
+    MnnvlMemory.validate_graph_visible_addresses
+
 TensorRT-LLM MNNVL AllReduce
 ----------------------------
 

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -218,6 +218,10 @@ class TRTLLMAllReduceFusionWorkspace(AllReduceFusionWorkspace):
                 )
             detach(synchronize=synchronize, barrier=barrier)
 
+    def pause(self, *, synchronize: bool = True, barrier: bool = True) -> None:
+        """Pause graph-visible peer mappings before process checkpoint."""
+        self.detach_physical_keep_va(synchronize=synchronize, barrier=barrier)
+
     def _reset_after_remap(self, *, barrier: bool = True) -> None:
         """Reinitialize Lamport buffers and flags after physical remap."""
         lamport_dtype = (
@@ -265,6 +269,22 @@ class TRTLLMAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         if reset:
             self._reset_after_remap(barrier=barrier)
         self.validate_graph_visible_addresses()
+
+    def resume(
+        self,
+        *,
+        comm_backend: Optional[CommBackend] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        reset: bool = True,
+    ) -> None:
+        """Resume graph-visible peer mappings after process restore."""
+        self.remap_physical_same_va(
+            comm_backend=comm_backend,
+            synchronize=synchronize,
+            barrier=barrier,
+            reset=reset,
+        )
 
     def destroy(self) -> None:
         """Destroy workspace and free resources."""

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import logging
+from ctypes import c_void_p, cast as ctypes_cast
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +149,7 @@ class TRTLLMAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         self.workspace_tensor = workspace_tuple[1]
         self.mem_handles = workspace_tuple[2]
         self.metadata = workspace_tuple[3]
+        self._graph_visible_addresses = self.get_graph_visible_addresses()
 
     @property
     def backend(self) -> str:
@@ -177,6 +179,92 @@ class TRTLLMAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         except ValueError as e:
             logger.warning("Workspace is insufficient for problem size. %s", e)
             return False
+
+    def get_graph_visible_addresses(self) -> dict:
+        """Return graph-visible pointer metadata for the TRTLLM workspace."""
+        return {
+            "ipc_handles": [list(handles) for handles in self.ipc_handles],
+            "workspace_tensor": self.workspace_tensor.detach().cpu().tolist(),
+            "workspace_tensor_data_ptr": int(self.workspace_tensor.data_ptr()),
+            "workspace_tensor_dtype": str(self.workspace_tensor.dtype),
+            "workspace_tensor_shape": list(self.workspace_tensor.shape),
+            "workspace_tensor_stride": list(self.workspace_tensor.stride()),
+            "workspace_tensor_device": str(self.workspace_tensor.device),
+        }
+
+    def validate_graph_visible_addresses(self) -> None:
+        """Validate that workspace pointers captured by CUDA graphs are stable."""
+        current = self.get_graph_visible_addresses()
+        if current != self._graph_visible_addresses:
+            raise RuntimeError(
+                "TRTLLM all-reduce graph-visible workspace pointers changed "
+                "during checkpoint restore"
+            )
+        for handle in self.mem_handles:
+            if hasattr(handle, "validate_graph_visible_addresses"):
+                handle.validate_graph_visible_addresses()
+
+    def detach_physical_keep_va(
+        self, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Detach checkpointable symmetric-memory backing while preserving VAs."""
+        self.validate_graph_visible_addresses()
+        for handle in self.mem_handles:
+            detach = getattr(handle, "detach_physical_keep_va", None)
+            if detach is None:
+                raise RuntimeError(
+                    "TRTLLM all-reduce workspace handle does not support "
+                    "graph-stable checkpoint pause"
+                )
+            detach(synchronize=synchronize, barrier=barrier)
+
+    def _reset_after_remap(self, *, barrier: bool = True) -> None:
+        """Reinitialize Lamport buffers and flags after physical remap."""
+        lamport_dtype = (
+            torch.float32 if self.metadata["use_fp32_lamport"] else torch.float16
+        )
+        self.mem_handles[2].lamport_initialize(self.rank, lamport_dtype)
+
+        flag_ptr = int(self.workspace_tensor[-1].item())
+        from .cuda_ipc import cudart
+
+        cudart.cudaMemset(flag_ptr, 0, 5 * 4)
+        lamport_comm_size_bytes = self.metadata["lamport_comm_size"].to_bytes(
+            4, byteorder="little"
+        )
+        cudart.cudaMemcpy(
+            c_void_p(flag_ptr + 3 * 4),
+            ctypes_cast(lamport_comm_size_bytes, c_void_p),
+            4,
+        )
+        if barrier:
+            self.mem_handles[0].comm_backend.barrier()
+
+    def remap_physical_same_va(
+        self,
+        *,
+        comm_backend: Optional[CommBackend] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        reset: bool = True,
+    ) -> None:
+        """Remap checkpointable symmetric-memory backing at the original VAs."""
+        for handle in self.mem_handles:
+            remap = getattr(handle, "remap_physical_same_va", None)
+            if remap is None:
+                raise RuntimeError(
+                    "TRTLLM all-reduce workspace handle does not support "
+                    "graph-stable checkpoint resume"
+                )
+            remap(
+                comm_backend=comm_backend,
+                synchronize=synchronize,
+                barrier=barrier,
+                zero_local=True,
+            )
+        if reset:
+            self._reset_after_remap(barrier=barrier)
+        self.validate_graph_visible_addresses()
 
     def destroy(self) -> None:
         """Destroy workspace and free resources."""

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -1283,6 +1283,8 @@ class SymmDeviceMemory:
         self.uc_handles: List[
             int
         ] = []  # std::vector<CUmemGenericAllocationHandle> mUcHandles
+        self._graph_visible_addresses: Optional[Dict[str, Any]] = None
+        self._mapped = False
 
         # Signal pad constants
         self.SIGNAL_PAD_ALIGNMENT = 16
@@ -1310,15 +1312,9 @@ class SymmDeviceMemory:
         )
 
         # Create handle exchanger
-        if is_mnnvl_fabric_supported(device_idx):
-            self._exchanger: HandleExchanger = FabricHandleExchanger(
-                self.comm_backend, self.group_rank, self.group_size
-            )
-        else:
-            self._exchanger = PosixFDHandleExchanger(
-                self.comm_backend, self.group_rank, self.group_size
-            )
+        self._exchanger: Optional[HandleExchanger] = self._create_handle_exchanger()
         self._alloc_mn_mcast_mem(buf_size, enable_multicast)
+        self._mapped = True
 
         if allocate_signal_pads:
             # Initialize signal pads
@@ -1332,11 +1328,12 @@ class SymmDeviceMemory:
 
             self.signal_pads_dev = alloc_and_copy_to_cuda(self.signal_pads)
         self.uc_ptrs_dev = alloc_and_copy_to_cuda(self.uc_ptrs)
+        self._graph_visible_addresses = self.get_graph_visible_addresses()
 
     def __del__(self):
         """Destructor - cleanup allocated memory"""
 
-        if hasattr(self, "_exchanger"):
+        if getattr(self, "_exchanger", None) is not None:
             self._exchanger.close()
 
         # Skip cleanup during Python finalization to avoid segfaults
@@ -1354,8 +1351,10 @@ class SymmDeviceMemory:
         # Free device pointers
         if self.signal_pads_dev:
             checkCudaErrors(cuda.cuMemFree(self.signal_pads_dev))
+            self.signal_pads_dev = 0
         if self.uc_ptrs_dev:
             checkCudaErrors(cuda.cuMemFree(self.uc_ptrs_dev))
+            self.uc_ptrs_dev = 0
 
         # Unmap UC regions and release their handles
         if hasattr(self, "uc_handles") and self.uc_handles:
@@ -1383,17 +1382,314 @@ class SymmDeviceMemory:
                 checkCudaErrors(
                     cuda.cuMemAddressFree(self.uc_base_ptr, self.total_uc_size)
                 )
+                self.uc_base_ptr = 0
 
         # Release MC handle
-        if hasattr(self, "mc_handle") and self.mc_handle and self.mc_handle != 0:
+        if hasattr(self, "mc_ptr") and self.mc_ptr:
+            if hasattr(self, "mc_handle") and self.mc_handle and self.mc_handle != 0:
+                try:
+                    checkCudaErrors(cuda.cuMemUnmap(self.mc_ptr, self.allocation_size))
+                    checkCudaErrors(cuda.cuMemRelease(self.mc_handle))
+                except Exception as e:
+                    logger.warning("Destructor: Failed to release MC handle: %s", e)
             try:
-                checkCudaErrors(cuda.cuMemUnmap(self.mc_ptr, self.allocation_size))
                 checkCudaErrors(
                     cuda.cuMemAddressFree(self.mc_ptr, self.allocation_size)
                 )
-                checkCudaErrors(cuda.cuMemRelease(self.mc_handle))
             except Exception as e:
-                logger.warning("Destructor: Failed to release MC handle: %s", e)
+                logger.warning("Destructor: Failed to free MC VA: %s", e)
+            self.mc_ptr = 0
+            self.mc_handle = 0
+
+    def _create_handle_exchanger(self) -> HandleExchanger:
+        if is_mnnvl_fabric_supported(self.device_idx):
+            return FabricHandleExchanger(
+                self.comm_backend, self.group_rank, self.group_size
+            )
+        return PosixFDHandleExchanger(
+            self.comm_backend, self.group_rank, self.group_size
+        )
+
+    def _close_handle_exchanger(self) -> None:
+        exchanger = getattr(self, "_exchanger", None)
+        if exchanger is not None:
+            exchanger.close()
+            self._exchanger = None
+
+    def _validate_comm(self, comm_backend: CommBackend) -> None:
+        comm_size = comm_backend.Get_size()
+        comm_rank = comm_backend.Get_rank()
+        if comm_size != self.group_size or comm_rank != self.group_rank:
+            raise RuntimeError(
+                "Restored symmetric-memory communicator does not match the "
+                "graph-visible allocation layout: "
+                f"rank/size {comm_rank}/{comm_size} != "
+                f"{self.group_rank}/{self.group_size}"
+            )
+
+    def _collective_mapped_states(self, comm_backend: CommBackend) -> List[bool]:
+        mapped_states = comm_backend.allgather(self._mapped)
+        if len(mapped_states) != self.group_size:
+            raise RuntimeError(
+                "Symmetric-memory mapped-state allgather returned "
+                f"{len(mapped_states)} ranks, expected {self.group_size}"
+            )
+        if any(mapped_states) and not all(mapped_states):
+            raise RuntimeError("Inconsistent symmetric-memory mapped state across ranks")
+        return mapped_states
+
+    def _collective_allocation_metadata(self, comm_backend: CommBackend) -> None:
+        local_metadata = {
+            "group_rank": self.group_rank,
+            "group_size": self.group_size,
+            "buf_size": self.buf_size,
+            "allocation_size": self.allocation_size,
+            "signal_pad_offset": self.signal_pad_offset,
+            "total_uc_size": getattr(self, "total_uc_size", 0),
+            "has_multicast": bool(self.mc_ptr),
+        }
+        all_metadata = comm_backend.allgather(local_metadata)
+        if len(all_metadata) != self.group_size:
+            raise RuntimeError(
+                "Symmetric-memory metadata allgather returned "
+                f"{len(all_metadata)} ranks, expected {self.group_size}"
+            )
+        for rank, metadata in enumerate(all_metadata):
+            expected = {**local_metadata, "group_rank": rank}
+            if metadata != expected:
+                raise RuntimeError(
+                    "Inconsistent symmetric-memory allocation metadata across "
+                    f"ranks: rank {rank} has {metadata!r}, expected {expected!r}"
+                )
+
+    def get_graph_visible_addresses(self) -> Dict[str, Any]:
+        """Return the VA/layout state captured by graph-visible tensors."""
+        return {
+            "buf_size": self.buf_size,
+            "group_size": self.group_size,
+            "group_rank": self.group_rank,
+            "device_idx": self.device_idx,
+            "allocation_size": self.allocation_size,
+            "signal_pad_offset": self.signal_pad_offset,
+            "total_uc_size": getattr(self, "total_uc_size", 0),
+            "uc_base_ptr": int(getattr(self, "uc_base_ptr", 0)),
+            "uc_ptrs": list(self.uc_ptrs),
+            "uc_ptrs_dev": int(self.uc_ptrs_dev),
+            "signal_pads": list(self.signal_pads),
+            "signal_pads_dev": int(self.signal_pads_dev),
+            "mc_ptr": int(self.mc_ptr),
+            "has_multicast": bool(self.mc_ptr),
+        }
+
+    def validate_graph_visible_addresses(
+        self, expected: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Validate that graph-visible VAs and pointer arrays are stable."""
+        expected = expected or self._graph_visible_addresses
+        if expected is None:
+            raise RuntimeError("Missing captured symmetric-memory address metadata")
+        current = self.get_graph_visible_addresses()
+        for key, expected_value in expected.items():
+            if current.get(key) != expected_value:
+                raise RuntimeError(
+                    f"SymmDeviceMemory graph-visible address changed for {key}: "
+                    f"{current.get(key)!r} != {expected_value!r}"
+                )
+
+    def detach_physical_keep_va(
+        self, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Release UC/MC physical mappings while preserving graph-visible VAs."""
+        self._validate_comm(self.comm_backend)
+        mapped_states = self._collective_mapped_states(self.comm_backend)
+        if not any(mapped_states):
+            if barrier:
+                self.comm_backend.barrier()
+                self.comm_backend.barrier()
+            return
+        self._collective_allocation_metadata(self.comm_backend)
+        self.validate_graph_visible_addresses()
+        if synchronize:
+            checkCudaErrors(cuda.cuCtxSynchronize())
+        if barrier:
+            self.comm_backend.barrier()
+
+        if self.mc_handle:
+            checkCudaErrors(cuda.cuMemUnmap(self.mc_ptr, self.allocation_size))
+            checkCudaErrors(cuda.cuMemRelease(self.mc_handle))
+            self.mc_handle = 0
+
+        for peer, handle in enumerate(self.uc_handles):
+            if handle:
+                checkCudaErrors(
+                    cuda.cuMemUnmap(self.uc_ptrs[peer], self.allocation_size)
+                )
+                checkCudaErrors(cuda.cuMemRelease(handle))
+                self.uc_handles[peer] = 0
+        self._mapped = False
+        self._close_handle_exchanger()
+
+        if barrier:
+            self.comm_backend.barrier()
+
+    def remap_physical_same_va(
+        self,
+        *,
+        comm_backend: Optional[CommBackend] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        zero_local: bool = True,
+    ) -> None:
+        """Create fresh UC/MC backing and map it into the original VAs."""
+        comm_backend = comm_backend or self.comm_backend
+        self._validate_comm(comm_backend)
+        mapped_states = self._collective_mapped_states(comm_backend)
+        if comm_backend is not self.comm_backend and any(mapped_states):
+            raise RuntimeError(
+                "Cannot refresh symmetric-memory communicator while allocation "
+                "is still mapped; call detach_physical_keep_va before checkpoint "
+                "remap"
+            )
+        if all(mapped_states):
+            if barrier:
+                comm_backend.barrier()
+                comm_backend.barrier()
+            return
+        self._collective_allocation_metadata(comm_backend)
+        self.validate_graph_visible_addresses()
+        if synchronize:
+            checkCudaErrors(cuda.cuCtxSynchronize())
+        if barrier:
+            comm_backend.barrier()
+
+        enable_multicast = bool(self.mc_ptr)
+        fresh: Optional[SymmDeviceMemory] = None
+        mapped_uc_peers: List[int] = []
+        mapped_mc = False
+        try:
+            fresh = SymmDeviceMemory(
+                buf_size=self.buf_size,
+                group_size=self.group_size,
+                group_rank=self.group_rank,
+                device_idx=self.device_idx,
+                comm_backend_for_handle_transfer=comm_backend,
+                enable_multicast=enable_multicast,
+                allocate_signal_pads=False,
+            )
+            if fresh.allocation_size != self.allocation_size:
+                raise RuntimeError(
+                    "Restored symmetric-memory allocation size changed: "
+                    f"{fresh.allocation_size} != {self.allocation_size}"
+                )
+
+            for peer_ptr in fresh.uc_ptrs:
+                checkCudaErrors(cuda.cuMemUnmap(peer_ptr, fresh.allocation_size))
+            checkCudaErrors(
+                cuda.cuMemAddressFree(fresh.uc_base_ptr, fresh.total_uc_size)
+            )
+            fresh.uc_ptrs = []
+            fresh.uc_base_ptr = 0
+            fresh.total_uc_size = 0
+
+            for peer, handle in enumerate(fresh.uc_handles):
+                checkCudaErrors(
+                    cuda.cuMemMap(
+                        self.uc_ptrs[peer], self.allocation_size, 0, handle, 0
+                    )
+                )
+                mapped_uc_peers.append(peer)
+            checkCudaErrors(
+                cuda.cuMemSetAccess(
+                    self.uc_base_ptr,
+                    self.total_uc_size,
+                    [self._get_mem_access_desc()],
+                    1,
+                )
+            )
+
+            if enable_multicast:
+                checkCudaErrors(cuda.cuMemUnmap(fresh.mc_ptr, fresh.allocation_size))
+                checkCudaErrors(
+                    cuda.cuMemAddressFree(fresh.mc_ptr, fresh.allocation_size)
+                )
+                fresh.mc_ptr = 0
+                checkCudaErrors(
+                    cuda.cuMemMap(
+                        self.mc_ptr,
+                        self.allocation_size,
+                        0,
+                        fresh.mc_handle,
+                        0,
+                    )
+                )
+                mapped_mc = True
+                checkCudaErrors(
+                    cuda.cuMemSetAccess(
+                        self.mc_ptr,
+                        self.allocation_size,
+                        [self._get_mem_access_desc()],
+                        1,
+                    )
+                )
+
+            if fresh.uc_ptrs_dev:
+                checkCudaErrors(cuda.cuMemFree(fresh.uc_ptrs_dev))
+                fresh.uc_ptrs_dev = 0
+
+            if zero_local:
+                checkCudaErrors(
+                    cuda.cuMemsetD8(
+                        self.uc_ptrs[self.group_rank], 0, self.allocation_size
+                    )
+                )
+
+            self.validate_graph_visible_addresses()
+            self._close_handle_exchanger()
+            self.uc_handles = fresh.uc_handles
+            self.mc_handle = fresh.mc_handle
+            self.comm_backend = comm_backend
+            self._exchanger = fresh._exchanger
+            self._mapped = True
+
+            fresh.uc_handles = []
+            fresh.uc_ptrs = []
+            fresh.uc_base_ptr = 0
+            fresh.total_uc_size = 0
+            fresh.mc_handle = 0
+            fresh.mc_ptr = 0
+            fresh._exchanger = None
+        except Exception as exc:
+            cleanup_errors = []
+            if mapped_mc:
+                try:
+                    checkCudaErrors(cuda.cuMemUnmap(self.mc_ptr, self.allocation_size))
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            if enable_multicast and not fresh.mc_ptr and fresh.mc_handle:
+                try:
+                    checkCudaErrors(cuda.cuMemRelease(fresh.mc_handle))
+                    fresh.mc_handle = 0
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            for peer in reversed(mapped_uc_peers):
+                try:
+                    checkCudaErrors(
+                        cuda.cuMemUnmap(self.uc_ptrs[peer], self.allocation_size)
+                    )
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            if cleanup_errors:
+                raise RuntimeError(
+                    "Failed to roll back partial symmetric-memory remap after "
+                    f"{exc!r}: {cleanup_errors!r}"
+                ) from exc
+            raise
+        finally:
+            if fresh is not None:
+                del fresh
+
+        if barrier:
+            self.comm_backend.barrier()
 
     def get_signal_pad_ptrs_host(self) -> List[int]:
         """Get the raw array of signal pad pointers to all ranks (including self)"""
@@ -1530,20 +1826,27 @@ class SymmDeviceMemory:
             )
         )
 
-        # All-gather shareable handles
-        all_shareable_uc_handles = self._exchanger.allgather(local_shareable_uc_handle)
-        cuda.cuCtxSynchronize()
+        all_shareable_uc_handles = []
+        try:
+            # All-gather shareable handles
+            all_shareable_uc_handles = self._exchanger.allgather(
+                local_shareable_uc_handle
+            )
+            cuda.cuCtxSynchronize()
 
-        # Import remote handles
-        for p in range(self.group_size):
-            if p != self.group_rank:
-                self.uc_handles[p] = checkCudaErrors(
-                    cuda.cuMemImportFromShareableHandle(
-                        all_shareable_uc_handles[p],
-                        self._exchanger.handle_type,
+            # Import remote handles
+            for p in range(self.group_size):
+                if p != self.group_rank:
+                    self.uc_handles[p] = checkCudaErrors(
+                        cuda.cuMemImportFromShareableHandle(
+                            all_shareable_uc_handles[p],
+                            self._exchanger.handle_type,
+                        )
                     )
-                )
-                self._exchanger.cleanup(all_shareable_uc_handles[p])
+        finally:
+            self._exchanger.cleanup(local_shareable_uc_handle)
+            for handle in all_shareable_uc_handles:
+                self._exchanger.cleanup(handle)
 
         # Reserve address space for UC pointers
         self.uc_ptrs = [0] * self.group_size
@@ -1585,19 +1888,22 @@ class SymmDeviceMemory:
         else:
             shareable_mc_handle = None
 
-        # Broadcast multicast handle from rank 0
-        shareable_mc_handle = self._exchanger.broadcast(shareable_mc_handle, root=0)
-        cuda.cuCtxSynchronize()
+        try:
+            # Broadcast multicast handle from rank 0
+            shareable_mc_handle = self._exchanger.broadcast(shareable_mc_handle, root=0)
+            cuda.cuCtxSynchronize()
 
-        # Import multicast handle for non-root ranks
-        if self.group_rank != 0:
-            self.mc_handle = checkCudaErrors(
-                cuda.cuMemImportFromShareableHandle(
-                    shareable_mc_handle,
-                    self._exchanger.handle_type,
+            # Import multicast handle for non-root ranks
+            if self.group_rank != 0:
+                self.mc_handle = checkCudaErrors(
+                    cuda.cuMemImportFromShareableHandle(
+                        shareable_mc_handle,
+                        self._exchanger.handle_type,
+                    )
                 )
-            )
-            self._exchanger.cleanup(shareable_mc_handle)
+        finally:
+            if shareable_mc_handle is not None:
+                self._exchanger.cleanup(shareable_mc_handle)
 
         # Add device to multicast
         checkCudaErrors(cuda.cuMulticastAddDevice(self.mc_handle, self.device_idx))
@@ -1735,3 +2041,55 @@ class McastGPUBuffer:
     def get_buffer_ptrs_dev(self) -> int:
         """Get the buffer pointers device array"""
         return self.mcast_device_memory.get_buffer_ptrs_dev()
+
+    @property
+    def buffer_size(self) -> int:
+        """Return the usable local buffer size, excluding signal padding."""
+        return self.buf_size
+
+    @property
+    def buffer_ptrs(self) -> List[int]:
+        """Return host unicast pointers for all ranks."""
+        return self.mcast_device_memory.get_buffer_ptrs_host()
+
+    @property
+    def buffer_ptrs_dev(self) -> int:
+        """Return the device pointer array of unicast pointers."""
+        return self.mcast_device_memory.get_buffer_ptrs_dev()
+
+    @property
+    def multicast_ptr(self) -> int:
+        """Return the multicast pointer."""
+        return self.mcast_device_memory.get_multicast_ptr()
+
+    def get_graph_visible_addresses(self) -> Dict[str, Any]:
+        """Return graph-visible pointer metadata for this buffer."""
+        return self.mcast_device_memory.get_graph_visible_addresses()
+
+    def validate_graph_visible_addresses(self) -> None:
+        """Validate that graph-visible buffer pointers are stable."""
+        self.mcast_device_memory.validate_graph_visible_addresses()
+
+    def detach_physical_keep_va(
+        self, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Detach physical backing while preserving graph-visible VAs."""
+        self.mcast_device_memory.detach_physical_keep_va(
+            synchronize=synchronize, barrier=barrier
+        )
+
+    def remap_physical_same_va(
+        self,
+        *,
+        comm_backend: Optional[CommBackend] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        zero_local: bool = True,
+    ) -> None:
+        """Remap physical backing at the original graph-visible VAs."""
+        self.mcast_device_memory.remap_physical_same_va(
+            comm_backend=comm_backend,
+            synchronize=synchronize,
+            barrier=barrier,
+            zero_local=zero_local,
+        )

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -354,6 +354,20 @@ class MnnvlConfig:
     fabric_page_size: int = 1 << 29  # 512MB
 
 
+@dataclass
+class _MnnvlAllocationRecord:
+    mapping: Mapping
+    comm: CommBackend
+    comm_size: int
+    comm_rank: int
+    aligned_size: int
+    mem_handles: List[Any]
+    start_address: int
+    rank_stride: int
+    address_offset: int
+    mapped: bool = True
+
+
 class MnnvlMemory:  # type: ignore[no-redef]
     initialized: bool = False
 
@@ -389,7 +403,8 @@ class MnnvlMemory:  # type: ignore[no-redef]
                 MnnvlMemory.close_mnnvl_memory(self.ptr)
 
     def as_torch_strided_tensor(self, dtype):
-        num_segments = MnnvlMemory.comm.Get_size()
+        record = MnnvlMemory.allocated_map[self.ptr]
+        num_segments = record.comm.Get_size()
         return pack_strided_memory(
             self.ptr,
             self.segment_size,
@@ -398,6 +413,99 @@ class MnnvlMemory:  # type: ignore[no-redef]
             dtype,
             MnnvlMemory.dev_id,
         )
+
+    def detach_physical_keep_va(
+        self, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Release mapped MNNVL handles while keeping graph-visible VAs alive."""
+        MnnvlMemory.detach_mnnvl_memory_keep_va(
+            self.ptr, synchronize=synchronize, barrier=barrier
+        )
+
+    def remap_physical_same_va(
+        self,
+        *,
+        config: Optional[MnnvlConfig] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        zero_local: bool = True,
+    ) -> None:
+        """Recreate MNNVL handles and map them at the original virtual addresses."""
+        MnnvlMemory.remap_mnnvl_memory_same_va(
+            self.ptr,
+            config=config,
+            synchronize=synchronize,
+            barrier=barrier,
+            zero_local=zero_local,
+        )
+
+    def get_graph_visible_addresses(self) -> Dict[str, Any]:
+        """Return the VA/layout state captured by CUDA graph-visible tensors."""
+        record = MnnvlMemory.allocated_map[self.ptr]
+        return {
+            "ptr": self.ptr,
+            "segment_size": self.segment_size,
+            "rank_stride": self.rank_stride,
+            "start_address": record.start_address,
+            "address_offset": record.address_offset,
+            "aligned_size": record.aligned_size,
+            "comm_size": record.comm_size,
+            "comm_rank": record.comm_rank,
+            "rank_ptrs": [
+                record.start_address + i * record.rank_stride + record.address_offset
+                for i in range(record.comm_size)
+            ],
+        }
+
+    def validate_graph_visible_addresses(
+        self, expected: Optional[Dict[str, Any]], tensor: Optional[torch.Tensor] = None
+    ) -> None:
+        """Validate that graph-visible VAs and optional tensor metadata are stable."""
+        if expected is None:
+            raise RuntimeError("Missing captured MNNVL graph-visible address metadata")
+
+        current = self.get_graph_visible_addresses()
+        for key in (
+            "ptr",
+            "segment_size",
+            "rank_stride",
+            "start_address",
+            "address_offset",
+            "aligned_size",
+            "comm_size",
+            "comm_rank",
+            "rank_ptrs",
+        ):
+            if current[key] != expected[key]:
+                raise RuntimeError(
+                    f"MNNVL graph-visible address changed for {key}: "
+                    f"{current[key]!r} != {expected[key]!r}"
+                )
+
+        if tensor is not None:
+            element_size = tensor.element_size()
+            if tensor.data_ptr() != current["ptr"]:
+                raise RuntimeError(
+                    f"MNNVL tensor data_ptr changed: {tensor.data_ptr()} "
+                    f"!= {current['ptr']}"
+                )
+            if tensor.size(0) != current["comm_size"]:
+                raise RuntimeError(
+                    f"MNNVL tensor rank dimension changed: {tensor.size(0)} "
+                    f"!= {current['comm_size']}"
+                )
+            expected_segment_elements = current["segment_size"] // element_size
+            if tensor.size(1) != expected_segment_elements:
+                raise RuntimeError(
+                    "MNNVL tensor segment dimension changed: "
+                    f"{tensor.size(1)} != {expected_segment_elements}"
+                )
+            if tensor.stride(0) * element_size != current["rank_stride"]:
+                raise RuntimeError(
+                    "MNNVL tensor rank stride changed: "
+                    f"{tensor.stride(0) * element_size} != "
+                    f"{current['rank_stride']}"
+                )
 
     @staticmethod
     def initialize():
@@ -413,8 +521,10 @@ class MnnvlMemory:  # type: ignore[no-redef]
 
     @staticmethod
     def set_comm_from_config(mapping: Mapping, config: MnnvlConfig = None):
-        MnnvlMemory.config = config or MnnvlConfig(comm_backend=MPIBackend())  # type: ignore[attr-defined]
-        comm = config.comm_backend.Split(
+        MnnvlMemory.config = config or MnnvlConfig(comm_backend=MPIBackend())
+        if MnnvlMemory.config.comm_backend is None:
+            raise RuntimeError("MNNVL config must provide a communication backend")
+        comm = MnnvlMemory.config.comm_backend.Split(
             mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
         )
         MnnvlMemory.comm = comm  # type: ignore[assignment]
@@ -423,7 +533,27 @@ class MnnvlMemory:  # type: ignore[no-redef]
     def get_comm(mapping: Mapping):
         if MnnvlMemory.comm is not None:
             return MnnvlMemory.comm
+        if MnnvlMemory.config is not None:
+            config = MnnvlMemory.config
+            if config.comm_backend is not None:
+                comm = config.comm_backend.Split(
+                    mapping.pp_rank * mapping.cp_size + mapping.cp_rank,
+                    mapping.tp_rank,
+                )
+                MnnvlMemory.comm = comm
+                return comm
         comm = MpiComm().Split(
+            mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
+        )
+        MnnvlMemory.comm = comm
+        return comm
+
+    @staticmethod
+    def refresh_comm_from_config(mapping: Mapping, config: MnnvlConfig) -> CommBackend:
+        if config.comm_backend is None:
+            raise RuntimeError("MNNVL remap config must provide a communication backend")
+        MnnvlMemory.config = config
+        comm = config.comm_backend.Split(
             mapping.pp_rank * mapping.cp_size + mapping.cp_rank, mapping.tp_rank
         )
         MnnvlMemory.comm = comm
@@ -466,6 +596,179 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return MnnvlMemory.allocation_granularity
 
     @staticmethod
+    def _exchange_shareable_handles(
+        comm: CommBackend,
+        allocation_prop: cuda.CUmemAllocationProp,
+        allocated_mem_handle: Any,
+    ) -> List[Any]:
+        shareable_handle = checkCudaErrors(
+            cuda.cuMemExportToShareableHandle(
+                allocated_mem_handle, allocation_prop.requestedHandleTypes, 0
+            )
+        )
+        if (
+            allocation_prop.requestedHandleTypes
+            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
+        ):
+            return comm.allgather(shareable_handle.data)
+
+        remote_fds = []
+        try:
+            all_handles_data = comm.allgather(shareable_handle)
+            all_pids = comm.allgather(os.getpid())
+            libc = ctypes.CDLL(None, use_errno=True)
+            syscall = libc.syscall
+            SYS_pidfd_open = 434
+            SYS_pidfd_getfd = 438
+
+            for pid, fd in zip(all_pids, all_handles_data, strict=True):
+                pidfd = syscall(SYS_pidfd_open, pid, 0)
+                if pidfd < 0:
+                    err = ctypes.get_errno()
+                    raise RuntimeError(
+                        f"pidfd_open({pid}) failed with errno {err}: "
+                        f"{os.strerror(err)}"
+                    )
+                try:
+                    remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
+                    if remote_fd < 0:
+                        err = ctypes.get_errno()
+                        error_msg = (
+                            f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with "
+                            f"errno {err}: {os.strerror(err)}."
+                        )
+                        if err == 1:  # EPERM
+                            error_msg += (
+                                " Permission denied. If running in a container, "
+                                "try adding --cap-add=SYS_PTRACE to your docker "
+                                "run command."
+                            )
+                        else:
+                            error_msg += (
+                                " This may be due to kernel version "
+                                "(requires Linux 5.6+)."
+                            )
+                        raise RuntimeError(error_msg)
+                    remote_fds.append(remote_fd)
+                finally:
+                    os.close(pidfd)
+
+            # Keep exported fds alive until all ranks have duplicated them.
+            comm.barrier()
+            exchanged_fds = remote_fds
+            remote_fds = []
+            return exchanged_fds
+        finally:
+            for fd in remote_fds:
+                os.close(fd)
+            os.close(shareable_handle)
+
+    @staticmethod
+    def _create_and_map_mnnvl_handles(
+        mapping: Mapping,
+        aligned_size: int,
+        start_address: int,
+        rank_stride: int,
+        address_offset: int,
+        *,
+        comm: Optional[CommBackend] = None,
+        zero_local: bool = False,
+    ) -> List[Any]:
+        dev = checkCudaErrors(cuda.cuCtxGetDevice())
+        dev_id = int(dev)
+        assert dev_id == MnnvlMemory.dev_id, (
+            f"Different dev_id found dev_id={dev_id} but "
+            f"MnnvlMemory.dev_id={MnnvlMemory.dev_id}"
+        )
+        comm = comm or MnnvlMemory.get_comm(mapping)
+        comm_rank = comm.Get_rank()
+        comm_size = comm.Get_size()
+        allocation_prop = MnnvlMemory.get_allocation_prop(dev_id)
+        is_posix_fd = (
+            allocation_prop.requestedHandleTypes
+            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+        allocated_mem_handle = checkCudaErrors(
+            cuda.cuMemCreate(aligned_size, allocation_prop, flags=0)
+        )
+        created_mem_handles = [allocated_mem_handle]
+        mapped_ptrs: List[int] = []
+        posix_fds: List[Optional[int]] = []
+
+        def close_posix_fd(index: int) -> None:
+            fd = posix_fds[index]
+            if fd is not None:
+                os.close(fd)
+                posix_fds[index] = None
+
+        try:
+            all_handles_data = MnnvlMemory._exchange_shareable_handles(
+                comm, allocation_prop, allocated_mem_handle
+            )
+            posix_fds = list(all_handles_data) if is_posix_fd else []
+
+            madesc = cuda.CUmemAccessDesc()
+            madesc.location = allocation_prop.location
+            madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+
+            mem_handles = [None] * comm_size
+
+            for i, remote_handle_data in enumerate(all_handles_data):
+                rank_ptr = start_address + rank_stride * i + address_offset
+                try:
+                    if i == comm_rank:
+                        mem_handle = allocated_mem_handle
+                    else:
+                        mem_handle = checkCudaErrors(
+                            cuda.cuMemImportFromShareableHandle(
+                                remote_handle_data,
+                                allocation_prop.requestedHandleTypes,
+                            )
+                        )
+                        created_mem_handles.append(mem_handle)
+                    mem_handles[i] = mem_handle
+                    checkCudaErrors(
+                        cuda.cuMemMap(rank_ptr, aligned_size, 0, mem_handle, 0)
+                    )
+                    mapped_ptrs.append(rank_ptr)
+                finally:
+                    if is_posix_fd:
+                        close_posix_fd(i)
+
+                checkCudaErrors(
+                    cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1)
+                )
+
+            if zero_local:
+                local_ptr = start_address + rank_stride * comm_rank + address_offset
+                checkCudaErrors(cuda.cuMemsetD8(local_ptr, 0, aligned_size))
+
+            return mem_handles
+        except Exception as exc:
+            cleanup_errors = []
+            for i in range(len(posix_fds)):
+                try:
+                    close_posix_fd(i)
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            for rank_ptr in reversed(mapped_ptrs):
+                try:
+                    checkCudaErrors(cuda.cuMemUnmap(rank_ptr, aligned_size))
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            for mem_handle in reversed(created_mem_handles):
+                try:
+                    checkCudaErrors(cuda.cuMemRelease(mem_handle))
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            if cleanup_errors:
+                raise RuntimeError(
+                    "Failed to roll back partial MNNVL handle mapping after "
+                    f"{exc!r}: {cleanup_errors!r}"
+                ) from exc
+            raise
+
+    @staticmethod
     def new_mnnvl_memory_address(mapping: Mapping, size: int):
         page_count = (
             size + MnnvlMemory.fabric_page_size - 1
@@ -494,7 +797,6 @@ class MnnvlMemory:  # type: ignore[no-redef]
             f"Different dev_id found dev_id={dev_id} but MnnvlMemory.dev_id={MnnvlMemory.dev_id}"
         )
         comm = MnnvlMemory.get_comm(mapping)
-        comm_rank = comm.Get_rank()
         comm_size = comm.Get_size()
         all_rank_allocate_sizes = comm.allgather(size)
         assert len(all_rank_allocate_sizes) == comm_size
@@ -515,100 +817,27 @@ class MnnvlMemory:  # type: ignore[no-redef]
             <= MnnvlMemory.current_rank_stride
         )
 
-        allocation_prop = MnnvlMemory.get_allocation_prop(dev_id)
-        allocated_mem_handle = checkCudaErrors(
-            cuda.cuMemCreate(aligned_size, allocation_prop, flags=0)
-        )
-        exported_fabric_handle = checkCudaErrors(
-            cuda.cuMemExportToShareableHandle(
-                allocated_mem_handle, allocation_prop.requestedHandleTypes, 0
-            )
-        )
-        if (
-            allocation_prop.requestedHandleTypes
-            == cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_FABRIC
-        ):
-            all_handles_data = comm.allgather(exported_fabric_handle.data)
-        else:
-            all_handles_data = comm.allgather(exported_fabric_handle)
-            all_pids = comm.allgather(os.getpid())
-            libc = ctypes.CDLL(None, use_errno=True)
-            syscall = libc.syscall
-            SYS_pidfd_open = 434
-            SYS_pidfd_getfd = 438
-            pidfds = []
-            for pid in all_pids:
-                pidfd = syscall(SYS_pidfd_open, pid, 0)
-                if pidfd < 0:
-                    err = ctypes.get_errno()
-                    raise RuntimeError(
-                        f"pidfd_open({pid}) failed with errno {err}: {os.strerror(err)}"
-                    )
-                pidfds.append(pidfd)
-
-            remote_fds = []
-            for pidfd, fd in zip(pidfds, all_handles_data, strict=True):
-                remote_fd = syscall(SYS_pidfd_getfd, pidfd, fd, 0)
-                if remote_fd < 0:
-                    err = ctypes.get_errno()
-                    error_msg = f"pidfd_getfd(pidfd={pidfd}, fd={fd}) failed with errno {err}: {os.strerror(err)}."
-                    if err == 1:  # EPERM
-                        error_msg += (
-                            " Permission denied. If running in a container, try adding --cap-add=SYS_PTRACE "
-                            "to your docker run command."
-                        )
-                    else:
-                        error_msg += (
-                            " This may be due to kernel version (requires Linux 5.6+)."
-                        )
-                    raise RuntimeError(error_msg)
-                remote_fds.append(remote_fd)
-
-            all_handles_data = remote_fds
-        # all_handles_data like b'\x00\x00\x00 \x00\x00\x00\x00\x8f\xec\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\x00\x00\x00\x00\x00\x1d\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'  # noqa: E501
-        # can use buf = memoryview(data) to import if using plain buffer for data.
-
-        madesc = cuda.CUmemAccessDesc()
-        madesc.location = allocation_prop.location
-        madesc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
-
-        mem_handles = [None] * comm_size
-
-        for i, remote_handle_data in enumerate(all_handles_data):
-            rank_ptr = (
-                MnnvlMemory.current_start_address
-                + MnnvlMemory.current_rank_stride * i
-                + MnnvlMemory.current_mem_offset
-            )
-            if i == comm_rank:
-                # Local memory mapping
-                mem_handles[i] = allocated_mem_handle
-                checkCudaErrors(
-                    cuda.cuMemMap(rank_ptr, aligned_size, 0, allocated_mem_handle, 0)
-                )
-            else:
-                # Fabric memory mapping
-                imported_mem_handle = checkCudaErrors(
-                    cuda.cuMemImportFromShareableHandle(
-                        remote_handle_data, allocation_prop.requestedHandleTypes
-                    )
-                )
-                mem_handles[i] = imported_mem_handle
-                checkCudaErrors(
-                    cuda.cuMemMap(rank_ptr, aligned_size, 0, imported_mem_handle, 0)
-                )
-
-            checkCudaErrors(cuda.cuMemSetAccess(rank_ptr, aligned_size, [madesc], 1))
-
         ptr = MnnvlMemory.current_start_address + MnnvlMemory.current_mem_offset
         stride = MnnvlMemory.current_rank_stride
-        MnnvlMemory.allocated_map[ptr] = (
+        comm = MnnvlMemory.get_comm(mapping)
+        mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
             mapping,
             aligned_size,
-            mem_handles,
             MnnvlMemory.current_start_address,
             MnnvlMemory.current_rank_stride,
             MnnvlMemory.current_mem_offset,
+            comm=comm,
+        )
+        MnnvlMemory.allocated_map[ptr] = _MnnvlAllocationRecord(
+            mapping=mapping,
+            comm=comm,
+            comm_size=comm.Get_size(),
+            comm_rank=comm.Get_rank(),
+            aligned_size=aligned_size,
+            mem_handles=mem_handles,
+            start_address=MnnvlMemory.current_start_address,
+            rank_stride=MnnvlMemory.current_rank_stride,
+            address_offset=MnnvlMemory.current_mem_offset,
         )
         MnnvlMemory.address_refcnt[MnnvlMemory.current_start_address] = (
             MnnvlMemory.address_refcnt.get(MnnvlMemory.current_start_address, 0) + 1
@@ -618,31 +847,132 @@ class MnnvlMemory:  # type: ignore[no-redef]
         return ptr, stride
 
     @staticmethod
-    def close_mnnvl_memory(ptr: int):
-        (
-            mapping,
-            aligned_size,
-            mem_handles,
-            start_address,
-            rank_stride,
-            address_offset,
-        ) = MnnvlMemory.allocated_map.pop(ptr)
-        comm = MnnvlMemory.get_comm(mapping)
+    def _validate_remap_comm(
+        record: _MnnvlAllocationRecord, comm: CommBackend
+    ) -> None:
         comm_size = comm.Get_size()
-        for i in range(comm_size):
-            rank_ptr = start_address + i * rank_stride + address_offset
-            checkCudaErrors(cuda.cuMemUnmap(rank_ptr, aligned_size))
-            checkCudaErrors(cuda.cuMemRelease(mem_handles[i]))
-        MnnvlMemory.address_refcnt[start_address] -= 1
+        comm_rank = comm.Get_rank()
+        if comm_size != record.comm_size or comm_rank != record.comm_rank:
+            raise RuntimeError(
+                "Restored MNNVL communicator does not match the graph-visible "
+                "allocation layout: "
+                f"rank/size {comm_rank}/{comm_size} != "
+                f"{record.comm_rank}/{record.comm_size}"
+            )
 
-        if MnnvlMemory.address_refcnt[start_address] == 0:
-            MnnvlMemory.address_refcnt.pop(start_address)
-            device_ptr = cuda.CUdeviceptr(start_address)
-            checkCudaErrors(cuda.cuMemAddressFree(device_ptr, comm_size * rank_stride))
-            if start_address == MnnvlMemory.current_start_address:
+    @staticmethod
+    def close_mnnvl_memory(ptr: int):
+        record = MnnvlMemory.allocated_map.pop(ptr)
+        comm = record.comm
+        comm_size = comm.Get_size()
+        if record.mapped:
+            for i in range(comm_size):
+                rank_ptr = (
+                    record.start_address
+                    + i * record.rank_stride
+                    + record.address_offset
+                )
+                checkCudaErrors(cuda.cuMemUnmap(rank_ptr, record.aligned_size))
+                checkCudaErrors(cuda.cuMemRelease(record.mem_handles[i]))
+            record.mapped = False
+        MnnvlMemory.address_refcnt[record.start_address] -= 1
+
+        if MnnvlMemory.address_refcnt[record.start_address] == 0:
+            MnnvlMemory.address_refcnt.pop(record.start_address)
+            device_ptr = cuda.CUdeviceptr(record.start_address)
+            checkCudaErrors(
+                cuda.cuMemAddressFree(
+                    device_ptr, comm_size * record.rank_stride
+                )
+            )
+            if record.start_address == MnnvlMemory.current_start_address:
                 MnnvlMemory.current_start_address = 0
                 MnnvlMemory.current_rank_stride = 0
                 MnnvlMemory.current_mem_offset = 0
+
+    @staticmethod
+    def detach_mnnvl_memory_keep_va(
+        ptr: int, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        record = MnnvlMemory.allocated_map[ptr]
+        comm = record.comm
+        mapped_states = comm.allgather(record.mapped)
+        if any(mapped_states) and not all(mapped_states):
+            raise RuntimeError("Inconsistent MNNVL mapped state across ranks")
+        if not any(mapped_states):
+            if barrier:
+                comm.barrier()
+                comm.barrier()
+            return
+        comm_size = comm.Get_size()
+
+        if synchronize:
+            checkCudaErrors(cuda.cuCtxSynchronize())
+        if barrier:
+            comm.barrier()
+
+        for i in range(comm_size):
+            rank_ptr = (
+                record.start_address + i * record.rank_stride + record.address_offset
+            )
+            checkCudaErrors(cuda.cuMemUnmap(rank_ptr, record.aligned_size))
+            checkCudaErrors(cuda.cuMemRelease(record.mem_handles[i]))
+
+        record.mem_handles = [None] * comm_size
+        record.mapped = False
+
+        if barrier:
+            comm.barrier()
+
+    @staticmethod
+    def remap_mnnvl_memory_same_va(
+        ptr: int,
+        *,
+        config: Optional[MnnvlConfig] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        zero_local: bool = True,
+    ) -> None:
+        record = MnnvlMemory.allocated_map[ptr]
+        if config is not None and record.mapped:
+            raise RuntimeError(
+                "Cannot refresh MNNVL communicator while allocation is still mapped; "
+                "call detach_physical_keep_va before checkpoint remap"
+            )
+        if config is not None:
+            comm = MnnvlMemory.refresh_comm_from_config(record.mapping, config)
+            MnnvlMemory._validate_remap_comm(record, comm)
+            record.comm = comm
+        else:
+            comm = record.comm
+            MnnvlMemory._validate_remap_comm(record, comm)
+        mapped_states = comm.allgather(record.mapped)
+        if any(mapped_states) and not all(mapped_states):
+            raise RuntimeError("Inconsistent MNNVL mapped state across ranks")
+        if all(mapped_states):
+            if barrier:
+                comm.barrier()
+                comm.barrier()
+            return
+
+        if synchronize:
+            checkCudaErrors(cuda.cuCtxSynchronize())
+        if barrier:
+            comm.barrier()
+
+        record.mem_handles = MnnvlMemory._create_and_map_mnnvl_handles(
+            record.mapping,
+            record.aligned_size,
+            record.start_address,
+            record.rank_stride,
+            record.address_offset,
+            comm=comm,
+            zero_local=zero_local,
+        )
+        record.mapped = True
+
+        if barrier:
+            comm.barrier()
 
     @staticmethod
     def support_nvlink(need_all_up: bool = True):

--- a/flashinfer/comm/trtllm_alltoall.py
+++ b/flashinfer/comm/trtllm_alltoall.py
@@ -436,6 +436,8 @@ class MnnvlMoe:
     moe_workspace_tensor: torch.Tensor = None
     moe_prepare_workspace_tensor: torch.Tensor = None
     moe_mapping: Mapping = None
+    _graph_visible_addresses: Optional[dict] = None
+    _prepare_graph_visible_addresses: Optional[dict] = None
 
     @staticmethod
     def get_moe_workspaces(mapping: Mapping, config: Optional[MnnvlConfig] = None):
@@ -450,6 +452,9 @@ class MnnvlMoe:
         MnnvlMoe.moe_workspace = MnnvlMemory(mapping, workspace_size_per_rank)
         MnnvlMoe.moe_workspace_tensor = MnnvlMoe.moe_workspace.as_torch_strided_tensor(
             torch.uint64
+        )
+        MnnvlMoe._graph_visible_addresses = (
+            MnnvlMoe.moe_workspace.get_graph_visible_addresses()
         )
         return MnnvlMoe.moe_workspace_tensor
 
@@ -469,7 +474,72 @@ class MnnvlMoe:
         MnnvlMoe.moe_prepare_workspace_tensor = (
             MnnvlMoe.moe_prepare_workspace.as_torch_strided_tensor(torch.uint64)
         )
+        MnnvlMoe._prepare_graph_visible_addresses = (
+            MnnvlMoe.moe_prepare_workspace.get_graph_visible_addresses()
+        )
         return MnnvlMoe.moe_prepare_workspace_tensor
+
+    @staticmethod
+    def get_graph_visible_addresses():
+        """Return CUDA graph-visible MNNVL workspace VA/layout metadata."""
+        return {
+            "workspace": MnnvlMoe._graph_visible_addresses,
+            "prepare_workspace": MnnvlMoe._prepare_graph_visible_addresses,
+        }
+
+    @staticmethod
+    def validate_graph_visible_addresses():
+        """Validate that cached workspace tensors still use their original VAs."""
+        if MnnvlMoe.moe_workspace is not None:
+            MnnvlMoe.moe_workspace.validate_graph_visible_addresses(
+                MnnvlMoe._graph_visible_addresses,
+                MnnvlMoe.moe_workspace_tensor,
+            )
+        if MnnvlMoe.moe_prepare_workspace is not None:
+            MnnvlMoe.moe_prepare_workspace.validate_graph_visible_addresses(
+                MnnvlMoe._prepare_graph_visible_addresses,
+                MnnvlMoe.moe_prepare_workspace_tensor,
+            )
+
+    @staticmethod
+    def detach_physical_keep_va(
+        *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Release two-sided MoE MNNVL mappings while preserving workspace VAs."""
+        MnnvlMoe.validate_graph_visible_addresses()
+        if MnnvlMoe.moe_workspace is not None:
+            MnnvlMoe.moe_workspace.detach_physical_keep_va(
+                synchronize=synchronize, barrier=barrier
+            )
+        if MnnvlMoe.moe_prepare_workspace is not None:
+            MnnvlMoe.moe_prepare_workspace.detach_physical_keep_va(
+                synchronize=synchronize, barrier=barrier
+            )
+
+    @staticmethod
+    def remap_physical_same_va(
+        *,
+        config: Optional[MnnvlConfig] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        zero_local: bool = True,
+    ) -> None:
+        """Remap two-sided MoE MNNVL workspaces at their original VAs."""
+        if MnnvlMoe.moe_workspace is not None:
+            MnnvlMoe.moe_workspace.remap_physical_same_va(
+                config=config,
+                synchronize=synchronize,
+                barrier=barrier,
+                zero_local=zero_local,
+            )
+        if MnnvlMoe.moe_prepare_workspace is not None:
+            MnnvlMoe.moe_prepare_workspace.remap_physical_same_va(
+                config=config,
+                synchronize=synchronize,
+                barrier=barrier,
+                zero_local=zero_local,
+            )
+        MnnvlMoe.validate_graph_visible_addresses()
 
     @staticmethod
     def compute_target_rank_id(

--- a/flashinfer/comm/trtllm_alltoall.py
+++ b/flashinfer/comm/trtllm_alltoall.py
@@ -517,6 +517,13 @@ class MnnvlMoe:
             )
 
     @staticmethod
+    def pause(*, synchronize: bool = True, barrier: bool = True) -> None:
+        """Pause graph-visible peer mappings before process checkpoint."""
+        MnnvlMoe.detach_physical_keep_va(
+            synchronize=synchronize, barrier=barrier
+        )
+
+    @staticmethod
     def remap_physical_same_va(
         *,
         config: Optional[MnnvlConfig] = None,
@@ -540,6 +547,22 @@ class MnnvlMoe:
                 zero_local=zero_local,
             )
         MnnvlMoe.validate_graph_visible_addresses()
+
+    @staticmethod
+    def resume(
+        *,
+        config: Optional[MnnvlConfig] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        zero_local: bool = True,
+    ) -> None:
+        """Resume graph-visible peer mappings after process restore."""
+        MnnvlMoe.remap_physical_same_va(
+            config=config,
+            synchronize=synchronize,
+            barrier=barrier,
+            zero_local=zero_local,
+        )
 
     @staticmethod
     def compute_target_rank_id(

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -430,6 +430,28 @@ LamportTokenNumThreshold = 16
 _symm_workspace_refs: dict[int, list[torch.Tensor]] = {}
 
 
+def _alloc_symm_device_memory_buffer_bytes(
+    size_bytes: int,
+    world_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    comm_backend: CommBackend,
+    rank: int,
+) -> tuple[list[int], torch.Tensor, SymmDeviceMemory]:
+    handle = SymmDeviceMemory(
+        buf_size=size_bytes,
+        group_size=world_size,
+        group_rank=rank,
+        device_idx=device.index,
+        comm_backend_for_handle_transfer=comm_backend,
+    )
+    return (
+        handle.get_buffer_ptrs_host(),
+        torch.empty(0, dtype=dtype, device=device),
+        handle,
+    )
+
+
 @deprecated(
     "trtllm_create_ipc_workspace_for_all_reduce and trtllm_custom_all_reduce are deprecated and will be removed in the next major bump, use allreduce.py instead."
 )
@@ -655,16 +677,28 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     ]:
         aligned_size = round_up(size, 16)
 
-        ptrs, tensor, handle = _alloc_symm_buffer_bytes(
-            aligned_size,
-            tp_size,
-            dtype,
-            device,
-            group_name,
-        )
+        if use_symm_dev_mem:
+            assert comm_backend is not None
+            ptrs, tensor, handle = _alloc_symm_device_memory_buffer_bytes(
+                aligned_size,
+                tp_size,
+                dtype,
+                device,
+                comm_backend,
+                tp_rank,
+            )
+        else:
+            ptrs, tensor, handle = _alloc_symm_buffer_bytes(
+                aligned_size,
+                tp_size,
+                dtype,
+                device,
+                group_name,
+            )
         symm_refs.append((tensor, handle))
         ipc_handles.append(ptrs)
-        mem_handles.append(handle)
+        if use_symm_dev_mem:
+            mem_handles.append(handle)
 
     logger.debug(
         "rank %s allocated ipc_handles: %s",

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -284,6 +284,10 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             )
         detach(synchronize=synchronize, barrier=barrier)
 
+    def pause(self, *, synchronize: bool = True, barrier: bool = True) -> None:
+        """Pause graph-visible peer mappings before process checkpoint."""
+        self.detach_physical_keep_va(synchronize=synchronize, barrier=barrier)
+
     def remap_physical_same_va(
         self,
         *,
@@ -320,6 +324,22 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             if barrier:
                 self.comm_backend.barrier()
         self.validate_graph_visible_addresses()
+
+    def resume(
+        self,
+        *,
+        comm_backend: Optional[CommBackend] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        reset: bool = True,
+    ) -> None:
+        """Resume graph-visible peer mappings after process restore."""
+        self.remap_physical_same_va(
+            comm_backend=comm_backend,
+            synchronize=synchronize,
+            barrier=barrier,
+            reset=reset,
+        )
 
     def destroy(self) -> None:
         """Destroy workspace and free resources."""

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -14,15 +14,12 @@ import torch
 from typing_extensions import deprecated
 
 from flashinfer.comm.mapping import Mapping
-from flashinfer.comm.mnnvl import TorchDistBackend
-
 from ..jit import gen_trtllm_mnnvl_comm_module
 from ..utils import register_custom_op
 from ..fp4_quantization import _compute_swizzled_layout_sf_size
-from .mnnvl import CommBackend, MPIBackend
+from .mnnvl import CommBackend, McastGPUBuffer, MPIBackend
 from .trtllm_ar import QuantizationSFLayout
 from .workspace_base import AllReduceFusionWorkspace
-from .torch_symmetric_memory import _alloc_symm_buffer_bytes
 
 
 def mpi_barrier():
@@ -146,25 +143,19 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         # support base_gpu_id != 0 scenarios where the actual CUDA device
         # index differs from the TP rank / local_rank.
         device = torch.device("cuda", torch.cuda.current_device())
-        if isinstance(comm_backend, TorchDistBackend):
-            group = (
-                comm_backend._group
-                if comm_backend._group is not None
-                else torch.distributed.group.WORLD
-            )
-            group_name = group.group_name
-        else:
-            group_name = torch.distributed.group.WORLD.group_name
-        self.ptrs, self.tensor, self.handle = _alloc_symm_buffer_bytes(
+        self.handle = McastGPUBuffer(
             requested_workspace_size,
             mapping.tp_size,
-            torch.float32,
+            mapping.tp_rank,
             device,
-            group_name,
+            comm_backend,
         )
+        self.comm_backend = comm_backend
+        self.ptrs = self.handle.buffer_ptrs
+        self.tensor = torch.empty(0, dtype=torch.float32, device=device)
 
-        # handle.buffer_size is the usable data size. torch symmetric memory
-        # allocator places signal_pad on top of it, not carved from within.
+        # handle.buffer_size is the usable data size. SymmDeviceMemory places
+        # signal_pad on top of it, not carved from within.
         allocated_size = self.handle.buffer_size
         # We want the buffer size to be aligned to 16B which is the granularity for buffer management.
         self.buffer_size_bytes = (
@@ -177,8 +168,8 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             f"[MNNVL Allreduce] Actual allocated size: {allocated_size} bytes, Actual buffer size per lamport buffer: {self.buffer_size_bytes} bytes, total workspace: {self.workspace_size_bytes} bytes."
         )
 
-        # lamport initialize tensor to negative zero.
-        self.tensor.fill_(-0.0)
+        # Lamport initialize local workspace buffers to negative zero.
+        self.handle.lamport_initialize(self.rank, torch.float32)
         # Wait until the initialization is done
         torch.cuda.synchronize()
         comm_backend.barrier()
@@ -197,6 +188,7 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         self.uc_ptrs_dev = self.handle.buffer_ptrs_dev
         self.uc_ptr_local = self.handle.buffer_ptrs[self.rank]
         self.mc_ptr = self.handle.multicast_ptr
+        self._graph_visible_addresses = self.get_graph_visible_addresses()
 
     @functools.cache
     def is_buffer_size_sufficient(
@@ -250,6 +242,84 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
     @property
     def backend(self) -> str:
         return "mnnvl"
+
+    def get_graph_visible_addresses(self) -> dict:
+        """Return graph-visible pointer metadata for the MNNVL workspace."""
+        return {
+            "ptrs": list(self.ptrs),
+            "uc_ptrs_dev": int(self.uc_ptrs_dev),
+            "uc_ptr_local": int(self.uc_ptr_local),
+            "mc_ptr": int(self.mc_ptr),
+            "buffer_flags_data_ptr": int(self.buffer_flags.data_ptr()),
+            "buffer_flags_dtype": str(self.buffer_flags.dtype),
+            "buffer_flags_shape": list(self.buffer_flags.shape),
+            "buffer_flags_stride": list(self.buffer_flags.stride()),
+            "buffer_flags_device": str(self.buffer_flags.device),
+            "buffer_size_bytes": self.buffer_size_bytes,
+            "workspace_size_bytes": self.workspace_size_bytes,
+        }
+
+    def validate_graph_visible_addresses(self) -> None:
+        """Validate that all graph-visible workspace pointers are stable."""
+        current = self.get_graph_visible_addresses()
+        if current != self._graph_visible_addresses:
+            raise RuntimeError(
+                "MNNVL all-reduce graph-visible workspace pointers changed "
+                "during checkpoint restore"
+            )
+        validate = getattr(self.handle, "validate_graph_visible_addresses", None)
+        if validate is not None:
+            validate()
+
+    def detach_physical_keep_va(
+        self, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Detach checkpointable workspace backing while preserving VAs."""
+        self.validate_graph_visible_addresses()
+        detach = getattr(self.handle, "detach_physical_keep_va", None)
+        if detach is None:
+            raise RuntimeError(
+                "MNNVL all-reduce allocator handle does not support "
+                "graph-stable checkpoint pause"
+            )
+        detach(synchronize=synchronize, barrier=barrier)
+
+    def remap_physical_same_va(
+        self,
+        *,
+        comm_backend: Optional[CommBackend] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        reset: bool = True,
+    ) -> None:
+        """Remap checkpointable workspace backing at the original VAs."""
+        remap = getattr(self.handle, "remap_physical_same_va", None)
+        if remap is None:
+            raise RuntimeError(
+                "MNNVL all-reduce allocator handle does not support "
+                "graph-stable checkpoint resume"
+            )
+        remap(
+            comm_backend=comm_backend,
+            synchronize=synchronize,
+            barrier=barrier,
+            zero_local=True,
+        )
+        if comm_backend is not None:
+            self.comm_backend = comm_backend
+        if reset:
+            self.handle.lamport_initialize(self.rank, torch.float32)
+            self.buffer_flags.copy_(
+                torch.tensor(
+                    [0, 2, self.buffer_size_bytes, 0, 0, 0, 0, 0, 0],
+                    dtype=torch.uint32,
+                    device=self.buffer_flags.device,
+                )
+            )
+            torch.cuda.synchronize()
+            if barrier:
+                self.comm_backend.barrier()
+        self.validate_graph_visible_addresses()
 
     def destroy(self) -> None:
         """Destroy workspace and free resources."""

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -761,6 +761,10 @@ class MoeAlltoAll:
             synchronize=synchronize, barrier=barrier
         )
 
+    def pause(self, *, synchronize: bool = True, barrier: bool = True) -> None:
+        """Pause graph-visible peer mappings before process checkpoint."""
+        self.detach_physical_keep_va(synchronize=synchronize, barrier=barrier)
+
     def remap_physical_same_va(
         self,
         *,
@@ -793,6 +797,22 @@ class MoeAlltoAll:
                 MnnvlMemory.allocated_map[self.mnnvl_mem.ptr].comm.barrier()
         self.validate_graph_visible_addresses()
         self._state = _A2AState()
+
+    def resume(
+        self,
+        *,
+        config: Optional[MnnvlConfig] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        reinitialize: bool = True,
+    ) -> None:
+        """Resume graph-visible peer mappings after process restore."""
+        self.remap_physical_same_va(
+            config=config,
+            synchronize=synchronize,
+            barrier=barrier,
+            reinitialize=reinitialize,
+        )
 
     def _reset_workspace(self):
         """Reset the workspace to free up its state. This is mainly used for testing. Use this with caution. This object is no longer usable after this."""

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -568,6 +568,7 @@ class MoeAlltoAll:
                 "mnnvl_mem": mnnvl_mem,
                 "workspace": workspace,
                 "metainfo": metainfo,
+                "graph_visible_addresses": mnnvl_mem.get_graph_visible_addresses(),
             }
             return cls._WORKSPACE_CACHE[key]
 
@@ -708,6 +709,7 @@ class MoeAlltoAll:
         self.ep_rank = mapping.moe_ep_rank
         self.top_k = top_k
         self.num_experts = num_experts
+        self.mnnvl_config = mnnvl_config
 
         if not isinstance(self.top_k, int) or self.top_k <= 0:
             raise ValueError("top_k must be a positive int")
@@ -735,6 +737,61 @@ class MoeAlltoAll:
         self.mnnvl_mem = self._WORKSPACE["mnnvl_mem"]
         self.workspace = self._WORKSPACE["workspace"]
         self.metainfo = self._WORKSPACE["metainfo"]
+        self._state = _A2AState()
+
+    def get_graph_visible_addresses(self) -> dict:
+        """Return CUDA graph-visible MNNVL workspace VA/layout metadata."""
+        return self._WORKSPACE["graph_visible_addresses"]
+
+    def validate_graph_visible_addresses(self) -> None:
+        """Validate that the cached workspace tensor still uses its original VA."""
+        self.mnnvl_mem.validate_graph_visible_addresses(
+            self._WORKSPACE["graph_visible_addresses"],
+            self.workspace,
+        )
+
+    def detach_physical_keep_va(
+        self, *, synchronize: bool = True, barrier: bool = True
+    ) -> None:
+        """Release MNNVL mappings while preserving workspace tensor pointers."""
+        if self._state.phase != "idle":
+            raise RuntimeError("Cannot detach MNNVL workspace during an active A2A phase")
+        self.validate_graph_visible_addresses()
+        self.mnnvl_mem.detach_physical_keep_va(
+            synchronize=synchronize, barrier=barrier
+        )
+
+    def remap_physical_same_va(
+        self,
+        *,
+        config: Optional[MnnvlConfig] = None,
+        synchronize: bool = True,
+        barrier: bool = True,
+        reinitialize: bool = True,
+    ) -> None:
+        """Remap MNNVL workspace at the original VA and refresh local state."""
+        config = config if config is not None else self.mnnvl_config
+        self.mnnvl_mem.remap_physical_same_va(
+            config=config,
+            synchronize=synchronize,
+            barrier=barrier,
+            zero_local=False,
+        )
+        if reinitialize:
+            refreshed_metainfo = moe_a2a_initialize(
+                self.workspace,
+                self.ep_rank,
+                self.ep_size,
+                self.max_num_tokens,
+            )
+            if not torch.equal(refreshed_metainfo, self.metainfo):
+                raise RuntimeError(
+                    "MoeAlltoAll metainfo changed during MNNVL remap; "
+                    "existing CUDA graphs are not safe to replay"
+                )
+            if barrier:
+                MnnvlMemory.allocated_map[self.mnnvl_mem.ptr].comm.barrier()
+        self.validate_graph_visible_addresses()
         self._state = _A2AState()
 
     def _reset_workspace(self):

--- a/tests/comm/test_allreduce_graph_stable_checkpoint.py
+++ b/tests/comm/test_allreduce_graph_stable_checkpoint.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import pytest
+
+from flashinfer.comm import mnnvl as mnnvl_mod
+from flashinfer.comm.allreduce import TRTLLMAllReduceFusionWorkspace
+from flashinfer.comm.mnnvl import SymmDeviceMemory
+from flashinfer.comm.trtllm_mnnvl_ar import MNNVLAllReduceFusionWorkspace
+
+
+class _FakeComm:
+    def __init__(self, size=2, rank=0, mapped_states=None, metadata=None):
+        self.size = size
+        self.rank = rank
+        self.barriers = 0
+        self.mapped_states = mapped_states
+        self.metadata = metadata
+
+    def Get_size(self):
+        return self.size
+
+    def Get_rank(self):
+        return self.rank
+
+    def allgather(self, value):
+        if isinstance(value, bool):
+            if self.mapped_states is not None:
+                return self.mapped_states
+            return [value] * self.size
+        if isinstance(value, dict):
+            if self.metadata is not None:
+                return self.metadata
+            return [{**value, "group_rank": rank} for rank in range(self.size)]
+        return [value] * self.size
+
+    def barrier(self):
+        self.barriers += 1
+
+
+class _FakeCheckpointableHandle:
+    def __init__(self):
+        self.comm_backend = _FakeComm()
+        self.calls = []
+
+    def validate_graph_visible_addresses(self):
+        self.calls.append(("validate",))
+
+    def detach_physical_keep_va(self, *, synchronize=True, barrier=True):
+        self.calls.append(("detach", synchronize, barrier))
+
+    def remap_physical_same_va(
+        self, *, comm_backend=None, synchronize=True, barrier=True, zero_local=True
+    ):
+        self.calls.append(("remap", comm_backend, synchronize, barrier, zero_local))
+
+    def lamport_initialize(self, rank, dtype):
+        self.calls.append(("lamport", rank, dtype))
+
+
+def _make_trtllm_workspace():
+    workspace = object.__new__(TRTLLMAllReduceFusionWorkspace)
+    workspace.world_size = 2
+    workspace.rank = 0
+    workspace.ipc_handles = [[0x1000, 0x2000], [0x3000, 0x4000], [0x5000, 0x6000]]
+    workspace.workspace_tensor = torch.tensor(
+        [0x1000, 0x2000, 0x3000, 0x4000, 0x5000, 0x6000, 0x7000],
+        dtype=torch.int64,
+    )
+    workspace.mem_handles = [_FakeCheckpointableHandle() for _ in range(3)]
+    workspace.metadata = {
+        "use_fp32_lamport": False,
+        "lamport_comm_size": 1024,
+    }
+    workspace._graph_visible_addresses = workspace.get_graph_visible_addresses()
+    workspace._destroyed = False
+    return workspace
+
+
+def test_trtllm_allreduce_checkpoint_hooks_delegate_to_handles():
+    workspace = _make_trtllm_workspace()
+
+    workspace.detach_physical_keep_va(synchronize=False, barrier=False)
+    workspace.remap_physical_same_va(
+        comm_backend="fresh-comm",
+        synchronize=False,
+        barrier=False,
+        reset=False,
+    )
+
+    for handle in workspace.mem_handles:
+        assert ("validate",) in handle.calls
+        assert ("detach", False, False) in handle.calls
+        assert ("remap", "fresh-comm", False, False, True) in handle.calls
+
+
+def test_trtllm_allreduce_checkpoint_hooks_fail_closed_without_handle_support():
+    workspace = _make_trtllm_workspace()
+    workspace.mem_handles = [object()]
+
+    try:
+        workspace.detach_physical_keep_va()
+    except RuntimeError as exc:
+        assert "does not support" in str(exc)
+    else:
+        raise AssertionError("checkpoint pause should fail without handle support")
+
+
+def test_mnnvl_allreduce_checkpoint_hooks_delegate_to_allocator_handle():
+    workspace = object.__new__(MNNVLAllReduceFusionWorkspace)
+    workspace.world_size = 2
+    workspace.rank = 0
+    workspace.tp_size = 2
+    workspace.ptrs = [0x1000, 0x2000]
+    workspace.uc_ptrs_dev = 0x3000
+    workspace.uc_ptr_local = 0x1000
+    workspace.mc_ptr = 0x4000
+    workspace.buffer_size_bytes = 128
+    workspace.buffer_flags = torch.tensor(
+        [0, 2, workspace.buffer_size_bytes, 0, 0, 0, 0, 0, 0],
+        dtype=torch.uint32,
+    )
+    workspace.workspace_size_bytes = 384
+    workspace.handle = _FakeCheckpointableHandle()
+    workspace.comm_backend = workspace.handle.comm_backend
+    workspace._graph_visible_addresses = workspace.get_graph_visible_addresses()
+
+    workspace.detach_physical_keep_va(synchronize=False, barrier=False)
+    workspace.remap_physical_same_va(
+        comm_backend="fresh-comm",
+        synchronize=False,
+        barrier=False,
+        reset=False,
+    )
+
+    assert ("detach", False, False) in workspace.handle.calls
+    assert ("remap", "fresh-comm", False, False, True) in workspace.handle.calls
+
+
+def _make_symm_memory(comm, *, mapped=True):
+    memory = object.__new__(SymmDeviceMemory)
+    memory.device_idx = 0
+    memory.group_size = 2
+    memory.group_rank = 0
+    memory.buf_size = 128
+    memory.signal_pad_offset = 128
+    memory.allocation_size = 0x1000
+    memory.total_uc_size = 0x2000
+    memory.uc_base_ptr = 0x1000
+    memory.uc_ptrs = [0x1000, 0x2000]
+    memory.uc_ptrs_dev = 0x3000
+    memory.signal_pads = [0x1080, 0x2080]
+    memory.signal_pads_dev = 0x4000
+    memory.mc_ptr = 0x5000
+    memory.mc_handle = "old_mc_handle" if mapped else 0
+    memory.uc_handles = ["old_handle0", "old_handle1"] if mapped else [0, 0]
+    memory.comm_backend = comm
+    memory._mapped = mapped
+    memory._exchanger = None
+    memory._graph_visible_addresses = memory.get_graph_visible_addresses()
+    memory._get_mem_access_desc = lambda: "access"
+    return memory
+
+
+def test_symm_device_memory_rejects_changed_comm_layout():
+    memory = _make_symm_memory(_FakeComm(rank=1))
+
+    with pytest.raises(RuntimeError, match="communicator"):
+        memory.detach_physical_keep_va(synchronize=False, barrier=False)
+
+
+def test_symm_device_memory_rejects_inconsistent_mapped_state():
+    memory = _make_symm_memory(_FakeComm(mapped_states=[True, False]))
+
+    with pytest.raises(RuntimeError, match="mapped state"):
+        memory.detach_physical_keep_va(synchronize=False, barrier=False)
+
+
+def test_symm_device_memory_rejects_inconsistent_allocation_metadata():
+    metadata = [
+        {
+            "group_rank": 0,
+            "group_size": 2,
+            "buf_size": 128,
+            "allocation_size": 0x1000,
+            "signal_pad_offset": 128,
+            "total_uc_size": 0x2000,
+            "has_multicast": True,
+        },
+        {
+            "group_rank": 1,
+            "group_size": 2,
+            "buf_size": 256,
+            "allocation_size": 0x1000,
+            "signal_pad_offset": 128,
+            "total_uc_size": 0x2000,
+            "has_multicast": True,
+        },
+    ]
+    memory = _make_symm_memory(_FakeComm(mapped_states=[True, True], metadata=metadata))
+
+    with pytest.raises(RuntimeError, match="metadata"):
+        memory.detach_physical_keep_va(synchronize=False, barrier=False)
+
+
+def test_symm_device_memory_remap_rolls_back_partial_mappings(monkeypatch):
+    memory = _make_symm_memory(_FakeComm(mapped_states=[False, False]), mapped=False)
+    fresh = type(
+        "_FreshSymmMemory",
+        (),
+        {
+            "allocation_size": 0x1000,
+            "uc_ptrs": [0xA000, 0xB000],
+            "uc_base_ptr": 0xA000,
+            "total_uc_size": 0x2000,
+            "uc_handles": ["new_handle0", "new_handle1"],
+            "mc_ptr": 0xC000,
+            "mc_handle": "new_mc_handle",
+            "uc_ptrs_dev": 0,
+            "_exchanger": None,
+        },
+    )()
+    success = type("_Success", (), {"value": 0})()
+    calls = []
+
+    class _FakeCuda:
+        def cuCtxSynchronize(self):
+            calls.append(("sync",))
+            return (success,)
+
+        def cuMemUnmap(self, ptr, size):
+            calls.append(("unmap", ptr, size))
+            return (success,)
+
+        def cuMemAddressFree(self, ptr, size):
+            calls.append(("address_free", ptr, size))
+            return (success,)
+
+        def cuMemMap(self, ptr, size, offset, handle, flags):
+            calls.append(("map", ptr, handle))
+            if ptr == 0x2000:
+                raise RuntimeError("map failed")
+            return (success,)
+
+        def cuMemSetAccess(self, ptr, size, desc, count):
+            calls.append(("access", ptr, size))
+            return (success,)
+
+        def cuMemRelease(self, handle):
+            calls.append(("release", handle))
+            return (success,)
+
+    monkeypatch.setattr(mnnvl_mod, "cuda", _FakeCuda())
+    monkeypatch.setattr(mnnvl_mod, "SymmDeviceMemory", lambda **kwargs: fresh)
+
+    with pytest.raises(RuntimeError, match="map failed"):
+        memory.remap_physical_same_va(synchronize=False, barrier=False)
+
+    assert ("map", 0x1000, "new_handle0") in calls
+    assert ("unmap", 0x1000, 0x1000) in calls
+    assert memory.uc_handles == [0, 0]
+    assert not memory._mapped
+
+
+def test_trtllm_allreduce_validates_workspace_tensor_storage():
+    workspace = _make_trtllm_workspace()
+    workspace.workspace_tensor = workspace.workspace_tensor.clone()
+
+    with pytest.raises(RuntimeError, match="graph-visible"):
+        workspace.validate_graph_visible_addresses()
+
+
+def test_mnnvl_allreduce_validates_buffer_flags_storage():
+    workspace = object.__new__(MNNVLAllReduceFusionWorkspace)
+    workspace.world_size = 2
+    workspace.rank = 0
+    workspace.ptrs = [0x1000, 0x2000]
+    workspace.uc_ptrs_dev = 0x3000
+    workspace.uc_ptr_local = 0x1000
+    workspace.mc_ptr = 0x4000
+    workspace.buffer_size_bytes = 128
+    workspace.workspace_size_bytes = 384
+    workspace.buffer_flags = torch.tensor(
+        [0, 2, workspace.buffer_size_bytes, 0, 0, 0, 0, 0, 0],
+        dtype=torch.uint32,
+    )
+    workspace.handle = _FakeCheckpointableHandle()
+    workspace._graph_visible_addresses = workspace.get_graph_visible_addresses()
+    workspace.buffer_flags = workspace.buffer_flags.clone()
+
+    with pytest.raises(RuntimeError, match="graph-visible"):
+        workspace.validate_graph_visible_addresses()
+
+
+def test_mnnvl_allreduce_reset_barrier_uses_fresh_comm(monkeypatch):
+    workspace = object.__new__(MNNVLAllReduceFusionWorkspace)
+    workspace.world_size = 2
+    workspace.rank = 0
+    workspace.ptrs = [0x1000, 0x2000]
+    workspace.uc_ptrs_dev = 0x3000
+    workspace.uc_ptr_local = 0x1000
+    workspace.mc_ptr = 0x4000
+    workspace.buffer_size_bytes = 128
+    workspace.workspace_size_bytes = 384
+    workspace.buffer_flags = torch.tensor(
+        [0, 2, workspace.buffer_size_bytes, 0, 0, 0, 0, 0, 0],
+        dtype=torch.uint32,
+    )
+    workspace.handle = _FakeCheckpointableHandle()
+    old_comm = _FakeComm()
+    fresh_comm = _FakeComm()
+    workspace.comm_backend = old_comm
+    workspace._graph_visible_addresses = workspace.get_graph_visible_addresses()
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    workspace.remap_physical_same_va(
+        comm_backend=fresh_comm,
+        synchronize=False,
+        barrier=True,
+        reset=True,
+    )
+
+    assert workspace.comm_backend is fresh_comm
+    assert old_comm.barriers == 0
+    assert fresh_comm.barriers == 1
+
+
+def test_mnnvl_allreduce_reset_respects_barrier_false(monkeypatch):
+    workspace = object.__new__(MNNVLAllReduceFusionWorkspace)
+    workspace.world_size = 2
+    workspace.rank = 0
+    workspace.ptrs = [0x1000, 0x2000]
+    workspace.uc_ptrs_dev = 0x3000
+    workspace.uc_ptr_local = 0x1000
+    workspace.mc_ptr = 0x4000
+    workspace.buffer_size_bytes = 128
+    workspace.workspace_size_bytes = 384
+    workspace.buffer_flags = torch.tensor(
+        [0, 2, workspace.buffer_size_bytes, 0, 0, 0, 0, 0, 0],
+        dtype=torch.uint32,
+    )
+    workspace.handle = _FakeCheckpointableHandle()
+    fresh_comm = _FakeComm()
+    workspace.comm_backend = _FakeComm()
+    workspace._graph_visible_addresses = workspace.get_graph_visible_addresses()
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    workspace.remap_physical_same_va(
+        comm_backend=fresh_comm,
+        synchronize=False,
+        barrier=False,
+        reset=True,
+    )
+
+    assert fresh_comm.barriers == 0

--- a/tests/comm/test_mnnvl_graph_stable_checkpoint.py
+++ b/tests/comm/test_mnnvl_graph_stable_checkpoint.py
@@ -1,0 +1,501 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from flashinfer.comm import mnnvl as mnnvl_mod
+from flashinfer.comm import trtllm_moe_alltoall as moe_a2a_mod
+from flashinfer.comm.mnnvl import MnnvlConfig, MnnvlMemory, _MnnvlAllocationRecord
+from flashinfer.comm.trtllm_moe_alltoall import MoeAlltoAll
+
+
+class _FakeComm:
+    def __init__(self, size: int = 2, rank: int = 0, values=None):
+        self.size = size
+        self.rank = rank
+        self.barriers = 0
+        self.values = values
+
+    def Get_size(self):
+        return self.size
+
+    def Get_rank(self):
+        return self.rank
+
+    def allgather(self, value):
+        if self.values is not None:
+            return self.values
+        return [value] * self.size
+
+    def barrier(self):
+        self.barriers += 1
+
+
+class _FakeTensor:
+    def __init__(
+        self,
+        data_ptr: int,
+        element_size: int,
+        size: tuple[int, int],
+        stride: tuple[int, int],
+    ):
+        self._data_ptr = data_ptr
+        self._element_size = element_size
+        self._size = size
+        self._stride = stride
+
+    def data_ptr(self):
+        return self._data_ptr
+
+    def element_size(self):
+        return self._element_size
+
+    def size(self, dim: int):
+        return self._size[dim]
+
+    def stride(self, dim: int):
+        return self._stride[dim]
+
+
+@pytest.fixture
+def fake_mnnvl_state():
+    old_comm = MnnvlMemory.comm
+    old_allocated_map = MnnvlMemory.allocated_map
+    old_address_refcnt = MnnvlMemory.address_refcnt
+    try:
+        fake_comm = _FakeComm()
+        MnnvlMemory.comm = fake_comm
+        MnnvlMemory.allocated_map = {
+            0x1000: _MnnvlAllocationRecord(
+                mapping=object(),
+                comm=fake_comm,
+                comm_size=2,
+                comm_rank=0,
+                aligned_size=0x1000,
+                mem_handles=["handle0", "handle1"],
+                start_address=0x1000,
+                rank_stride=0x4000,
+                address_offset=0,
+            )
+        }
+        MnnvlMemory.address_refcnt = {0x1000: 1}
+        yield fake_comm
+    finally:
+        MnnvlMemory.comm = old_comm
+        MnnvlMemory.allocated_map = old_allocated_map
+        MnnvlMemory.address_refcnt = old_address_refcnt
+
+
+def _make_memory():
+    mem = object.__new__(MnnvlMemory)
+    mem.ptr = 0x1000
+    mem.segment_size = 0x400
+    mem.rank_stride = 0x4000
+    return mem
+
+
+@pytest.mark.usefixtures("fake_mnnvl_state")
+def test_graph_visible_address_validation():
+    mem = _make_memory()
+    expected = mem.get_graph_visible_addresses()
+    tensor = _FakeTensor(
+        data_ptr=0x1000,
+        element_size=4,
+        size=(2, 0x100),
+        stride=(0x1000, 1),
+    )
+
+    mem.validate_graph_visible_addresses(expected, tensor)
+
+    changed_expected = {**expected, "rank_stride": 0x8000}
+    with pytest.raises(RuntimeError, match="rank_stride"):
+        mem.validate_graph_visible_addresses(changed_expected, tensor)
+
+    changed_tensor = _FakeTensor(
+        data_ptr=0x2000,
+        element_size=4,
+        size=(2, 0x100),
+        stride=(0x1000, 1),
+    )
+    with pytest.raises(RuntimeError, match="data_ptr"):
+        mem.validate_graph_visible_addresses(expected, changed_tensor)
+
+    changed_rank = {**expected, "comm_rank": 1}
+    with pytest.raises(RuntimeError, match="comm_rank"):
+        mem.validate_graph_visible_addresses(changed_rank, tensor)
+
+
+def test_detach_and_remap_preserve_va_metadata(monkeypatch, fake_mnnvl_state):
+    calls = []
+
+    success = SimpleNamespace(value=0)
+
+    def _record(name, *args):
+        calls.append((name, *args))
+        return (success,)
+
+    fake_cuda = SimpleNamespace(
+        cuCtxSynchronize=lambda: _record("sync"),
+        cuMemUnmap=lambda ptr, size: _record("unmap", ptr, size),
+        cuMemRelease=lambda handle: _record("release", handle),
+    )
+    monkeypatch.setattr(mnnvl_mod, "cuda", fake_cuda)
+
+    MnnvlMemory.detach_mnnvl_memory_keep_va(0x1000)
+
+    record = MnnvlMemory.allocated_map[0x1000]
+    assert not record.mapped
+    assert record.mem_handles == [None, None]
+    assert ("unmap", 0x1000, 0x1000) in calls
+    assert ("unmap", 0x5000, 0x1000) in calls
+    assert not any(call[0] == "address_free" for call in calls)
+    assert fake_mnnvl_state.barriers == 2
+
+    remap_args = None
+
+    def _remap(*args, **kwargs):
+        nonlocal remap_args
+        remap_args = (args, kwargs)
+        return ["new_handle0", "new_handle1"]
+
+    monkeypatch.setattr(MnnvlMemory, "_create_and_map_mnnvl_handles", _remap)
+    MnnvlMemory.remap_mnnvl_memory_same_va(0x1000)
+
+    record = MnnvlMemory.allocated_map[0x1000]
+    assert record.mapped
+    assert record.mem_handles == ["new_handle0", "new_handle1"]
+    assert remap_args == (
+        (record.mapping, 0x1000, 0x1000, 0x4000, 0),
+        {"comm": fake_mnnvl_state, "zero_local": True},
+    )
+
+
+def test_remap_refreshes_comm_from_current_config(monkeypatch, fake_mnnvl_state):
+    record = MnnvlMemory.allocated_map[0x1000]
+    record.mapped = False
+    record.mem_handles = [None, None]
+
+    new_comm = _FakeComm(size=2, rank=0)
+    config = MnnvlConfig(comm_backend=SimpleNamespace())
+
+    def _refresh(mapping, refresh_config):
+        assert mapping is record.mapping
+        assert refresh_config is config
+        return new_comm
+
+    remap_args = None
+
+    def _remap(*args, **kwargs):
+        nonlocal remap_args
+        remap_args = (args, kwargs)
+        return ["new_handle0", "new_handle1"]
+
+    success = SimpleNamespace(value=0)
+    fake_cuda = SimpleNamespace(cuCtxSynchronize=lambda: (success,))
+    monkeypatch.setattr(mnnvl_mod, "cuda", fake_cuda)
+    monkeypatch.setattr(MnnvlMemory, "refresh_comm_from_config", _refresh)
+    monkeypatch.setattr(MnnvlMemory, "_create_and_map_mnnvl_handles", _remap)
+
+    MnnvlMemory.remap_mnnvl_memory_same_va(0x1000, config=config)
+
+    assert record.comm is new_comm
+    assert record.mapped
+    assert record.mem_handles == ["new_handle0", "new_handle1"]
+    assert remap_args == (
+        (record.mapping, 0x1000, 0x1000, 0x4000, 0),
+        {"comm": new_comm, "zero_local": True},
+    )
+
+
+def test_remap_rejects_changed_comm_before_mapping(monkeypatch, fake_mnnvl_state):
+    record = MnnvlMemory.allocated_map[0x1000]
+    record.mapped = False
+    record.mem_handles = [None, None]
+    config = MnnvlConfig(comm_backend=SimpleNamespace())
+
+    def _refresh(mapping, refresh_config):
+        return _FakeComm(size=3, rank=0)
+
+    def _remap(*args, **kwargs):
+        raise AssertionError("remap should not run with changed communicator")
+
+    monkeypatch.setattr(MnnvlMemory, "refresh_comm_from_config", _refresh)
+    monkeypatch.setattr(MnnvlMemory, "_create_and_map_mnnvl_handles", _remap)
+
+    with pytest.raises(RuntimeError, match="does not match"):
+        MnnvlMemory.remap_mnnvl_memory_same_va(0x1000, config=config)
+
+
+def test_remap_config_requires_detached_allocation(fake_mnnvl_state):
+    config = MnnvlConfig(comm_backend=SimpleNamespace())
+
+    with pytest.raises(RuntimeError, match="still mapped"):
+        MnnvlMemory.remap_mnnvl_memory_same_va(0x1000, config=config)
+
+
+def test_posix_handle_exchange_closes_exported_and_pidfds(monkeypatch):
+    fake_comm = _FakeComm(values=[10, 11])
+    closed = []
+
+    class _FakeCuda:
+        class CUmemAllocationHandleType:
+            CU_MEM_HANDLE_TYPE_FABRIC = "fabric"
+            CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = "posix"
+
+        def cuMemExportToShareableHandle(
+            self, allocated_mem_handle, handle_type, flags
+        ):
+            posix_fd = (
+                self.CUmemAllocationHandleType
+                .CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+            )
+            assert handle_type == posix_fd
+            return (SimpleNamespace(value=0), 7)
+
+    syscall_results = iter([100, 200, 101, 201])
+
+    class _FakeLibc:
+        def syscall(self, number, *args):
+            return next(syscall_results)
+
+    allocation_prop = SimpleNamespace(
+        requestedHandleTypes=(
+            _FakeCuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+        )
+    )
+
+    monkeypatch.setattr(mnnvl_mod, "cuda", _FakeCuda())
+    monkeypatch.setattr(mnnvl_mod.ctypes, "CDLL", lambda *args, **kwargs: _FakeLibc())
+    monkeypatch.setattr(mnnvl_mod.os, "close", lambda fd: closed.append(fd))
+
+    remote_fds = MnnvlMemory._exchange_shareable_handles(
+        fake_comm, allocation_prop, "handle"
+    )
+
+    assert remote_fds == [200, 201]
+    assert closed == [100, 101, 7]
+    assert fake_comm.barriers == 1
+
+
+def test_create_and_map_rolls_back_unconsumed_fds_on_import_failure(monkeypatch):
+    fake_comm = _FakeComm(size=3, rank=0)
+    success = SimpleNamespace(value=0)
+    calls = []
+    closed = []
+
+    class _FakeCuda:
+        class CUmemAllocationHandleType:
+            CU_MEM_HANDLE_TYPE_FABRIC = "fabric"
+            CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = "posix"
+
+        class CUmemAccess_flags:
+            CU_MEM_ACCESS_FLAGS_PROT_READWRITE = "rw"
+
+        class CUmemAccessDesc:
+            pass
+
+        def cuCtxGetDevice(self):
+            return (success, 0)
+
+        def cuMemCreate(self, size, allocation_prop, flags):
+            calls.append(("create", size))
+            return (success, "local_handle")
+
+        def cuMemImportFromShareableHandle(self, fd, handle_type):
+            calls.append(("import", fd, handle_type))
+            raise RuntimeError("import failed")
+
+        def cuMemMap(self, ptr, size, offset, handle, flags):
+            calls.append(("map", ptr, handle))
+            return (success,)
+
+        def cuMemSetAccess(self, ptr, size, desc, count):
+            calls.append(("access", ptr))
+            return (success,)
+
+        def cuMemUnmap(self, ptr, size):
+            calls.append(("unmap", ptr, size))
+            return (success,)
+
+        def cuMemRelease(self, handle):
+            calls.append(("release", handle))
+            return (success,)
+
+    monkeypatch.setattr(mnnvl_mod, "cuda", _FakeCuda())
+    monkeypatch.setattr(MnnvlMemory, "dev_id", 0)
+    monkeypatch.setattr(
+        MnnvlMemory,
+        "get_allocation_prop",
+        lambda dev_id: SimpleNamespace(
+            requestedHandleTypes="posix",
+            location="device0",
+        ),
+    )
+    monkeypatch.setattr(
+        MnnvlMemory,
+        "_exchange_shareable_handles",
+        lambda *args: [10, 11, 12],
+    )
+    monkeypatch.setattr(mnnvl_mod.os, "close", lambda fd: closed.append(fd))
+
+    with pytest.raises(RuntimeError, match="import failed"):
+        MnnvlMemory._create_and_map_mnnvl_handles(
+            object(),
+            0x1000,
+            0x1000,
+            0x4000,
+            0,
+            comm=fake_comm,
+        )
+
+    assert closed == [10, 11, 12]
+    assert ("unmap", 0x1000, 0x1000) in calls
+    assert ("release", "local_handle") in calls
+
+
+def test_create_and_map_rolls_back_partial_mappings_on_access_failure(monkeypatch):
+    fake_comm = _FakeComm(size=2, rank=0)
+    success = SimpleNamespace(value=0)
+    calls = []
+    closed = []
+
+    class _FakeCuda:
+        class CUmemAllocationHandleType:
+            CU_MEM_HANDLE_TYPE_FABRIC = "fabric"
+            CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = "posix"
+
+        class CUmemAccess_flags:
+            CU_MEM_ACCESS_FLAGS_PROT_READWRITE = "rw"
+
+        class CUmemAccessDesc:
+            pass
+
+        def cuCtxGetDevice(self):
+            return (success, 0)
+
+        def cuMemCreate(self, size, allocation_prop, flags):
+            calls.append(("create", size))
+            return (success, "local_handle")
+
+        def cuMemImportFromShareableHandle(self, fd, handle_type):
+            calls.append(("import", fd, handle_type))
+            return (success, f"remote_handle_{fd}")
+
+        def cuMemMap(self, ptr, size, offset, handle, flags):
+            calls.append(("map", ptr, handle))
+            return (success,)
+
+        def cuMemSetAccess(self, ptr, size, desc, count):
+            calls.append(("access", ptr))
+            if ptr == 0x5000:
+                raise RuntimeError("set access failed")
+            return (success,)
+
+        def cuMemUnmap(self, ptr, size):
+            calls.append(("unmap", ptr, size))
+            return (success,)
+
+        def cuMemRelease(self, handle):
+            calls.append(("release", handle))
+            return (success,)
+
+    monkeypatch.setattr(mnnvl_mod, "cuda", _FakeCuda())
+    monkeypatch.setattr(MnnvlMemory, "dev_id", 0)
+    monkeypatch.setattr(
+        MnnvlMemory,
+        "get_allocation_prop",
+        lambda dev_id: SimpleNamespace(
+            requestedHandleTypes="posix",
+            location="device0",
+        ),
+    )
+    monkeypatch.setattr(
+        MnnvlMemory,
+        "_exchange_shareable_handles",
+        lambda *args: [10, 11],
+    )
+    monkeypatch.setattr(mnnvl_mod.os, "close", lambda fd: closed.append(fd))
+
+    with pytest.raises(RuntimeError, match="set access failed"):
+        MnnvlMemory._create_and_map_mnnvl_handles(
+            object(),
+            0x1000,
+            0x1000,
+            0x4000,
+            0,
+            comm=fake_comm,
+        )
+
+    assert closed == [10, 11]
+    assert ("unmap", 0x5000, 0x1000) in calls
+    assert ("unmap", 0x1000, 0x1000) in calls
+    assert ("release", "remote_handle_11") in calls
+    assert ("release", "local_handle") in calls
+
+
+def test_moe_alltoall_remap_uses_allocation_record_comm(monkeypatch):
+    class _FakeMnnvlMemory:
+        ptr = 0x1000
+        mapping = object()
+
+        def __init__(self):
+            self.remap_kwargs = None
+
+        def remap_physical_same_va(self, **kwargs):
+            self.remap_kwargs = kwargs
+
+        def validate_graph_visible_addresses(self, expected, tensor):
+            assert expected == "graph"
+            assert tensor == "workspace"
+
+    record_comm = _FakeComm()
+    fake_mnnvl_mem = _FakeMnnvlMemory()
+    moe = object.__new__(MoeAlltoAll)
+    moe.mnnvl_config = "config"
+    moe.mnnvl_mem = fake_mnnvl_mem
+    moe.workspace = "workspace"
+    moe.metainfo = "metainfo"
+    moe.ep_rank = 0
+    moe.ep_size = 2
+    moe.max_num_tokens = 8
+    moe._WORKSPACE = {"graph_visible_addresses": "graph"}
+
+    monkeypatch.setattr(
+        MnnvlMemory,
+        "allocated_map",
+        {fake_mnnvl_mem.ptr: SimpleNamespace(comm=record_comm)},
+    )
+    monkeypatch.setattr(
+        MnnvlMemory,
+        "get_comm",
+        lambda mapping: (_ for _ in ()).throw(AssertionError("used global comm")),
+    )
+    monkeypatch.setattr(
+        moe_a2a_mod,
+        "moe_a2a_initialize",
+        lambda workspace, ep_rank, ep_size, max_num_tokens: "new_metainfo",
+    )
+    monkeypatch.setattr(moe_a2a_mod.torch, "equal", lambda lhs, rhs: True)
+
+    moe.remap_physical_same_va(synchronize=False)
+
+    assert fake_mnnvl_mem.remap_kwargs == {
+        "config": "config",
+        "synchronize": False,
+        "barrier": True,
+        "zero_local": False,
+    }
+    assert record_comm.barriers == 1


### PR DESCRIPTION
## Summary

- Add high-level `pause()` / `resume()` aliases for all graph-stable checkpoint-capable communication resources in the stack.
- Keep this layer intentionally thin so integrations can call a stable lifecycle API without reaching into lower-level detach/remap method names.
- This now sits on top of both the MNNVL/MoE mechanics and the allreduce/symmetric-memory mechanics.

Stack note: this is PR 3 in the logical stack, even though its PR number is #3728:

1. #3727 — MNNVL/MoE graph-stable checkpoint support.
2. #3729 — allreduce / `SymmDeviceMemory` / `McastGPUBuffer` graph-stable checkpoint support.
3. #3728 — this PR, high-level `pause()` / `resume()` API aliases for all supported resources.

Because I only have fork branches and read-only permission on upstream, this draft PR targets `main`; reviewers should review the incremental diff from `schwinns/allreduce-graph-stable-checkpoint` to `schwinns/comm-pause-resume-api`.

## Validation

- `git diff --check schwinns/allreduce-graph-stable-checkpoint..schwinns/comm-pause-resume-api`
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile flashinfer/comm/allreduce.py flashinfer/comm/trtllm_alltoall.py flashinfer/comm/trtllm_mnnvl_ar.py flashinfer/comm/trtllm_moe_alltoall.py`

Not run:

- Targeted pytest was attempted for the full stack but this local session lacks `pytest` (`No module named pytest`).
