### PR TITLE
[feat] SM100 NVFP4 block-scaled GEMM with a fused SVDQuant LoRA up-projection

### DIFF
--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -62,6 +62,23 @@ try:
 except ImportError:
     pass
 
+# SVDQuant: NVFP4 block-scaled residual + fused bf16 LoRA up-projection
+# (kernels/dense_blockscaled_gemm_lora_sm100.py :: Sm100BlockScaledLoRADenseGemmKernel).
+# Gated on the CuTe-DSL stack like the other CuTe-DSL kernels above.
+try:
+    from flashinfer.cute_dsl.utils import is_cute_dsl_available
+
+    if is_cute_dsl_available():
+        from .kernels.svdquant_lora import (
+            prepare_svdquant_state as prepare_svdquant_state,
+            mm_fp4_svdquant as mm_fp4_svdquant,
+        )
+
+        _cute_dsl_kernels.append("prepare_svdquant_state")
+        _cute_dsl_kernels.append("mm_fp4_svdquant")
+except ImportError:
+    pass
+
 __all__ = [
     "SegmentGEMMWrapper",
     "bmm_bf16",

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -8721,3 +8721,74 @@ def bmm_mxfp8(
         return out
 
     raise ValueError(f"Invalid backend: {backend}")
+
+
+def prepare_svdquant_state(
+    M,
+    Rq,
+    sf_w_bytes,
+    L1,
+    L2,
+    gscale_x,
+    gscale_w,
+    r,
+    enable_lora=True,
+    pre_quant_scale=None,
+    num_ab_stage=None,
+    use_2cta=None,
+):
+    """Build the reusable per-shape dispatch state for the fused NVFP4-SVDQuant linear.
+
+    This is the once-per-shape host setup of the kernel's single entrance: call
+    ``prepare_svdquant_state`` once for a layer shape ``(M, I, O, r)``, then call
+    :func:`mm_fp4_svdquant` per step with the live activation and the returned state.
+    Off the hot path it derives ``I, O`` from the prepacked weight, host-swizzles the
+    constant weight scale factor once, pre-allocates the quantizer / down / main operands,
+    JIT-compiles the per-shape kernels, and folds the static global scales -- so the
+    per-call path needs no host sync or allocation.
+
+    The CuTe-DSL kernel module is imported lazily here (not at flashinfer import time) so
+    flashinfer carries no hard dependency on the optional CuTe-DSL backend; availability is
+    gated by ``flashinfer.gemm.__init__``.
+
+    See the underlying ``flashinfer.gemm.kernels.svdquant_nvfp4.prepare_svdquant_state`` for
+    the full argument semantics. Returns an opaque state dict consumed by
+    :func:`mm_fp4_svdquant`.
+    """
+    from .kernels.svdquant_nvfp4 import prepare_svdquant_state as _prepare
+
+    return _prepare(
+        M,
+        Rq,
+        sf_w_bytes,
+        L1,
+        L2,
+        gscale_x,
+        gscale_w,
+        r,
+        enable_lora=enable_lora,
+        pre_quant_scale=pre_quant_scale,
+        num_ab_stage=num_ab_stage,
+        use_2cta=use_2cta,
+    )
+
+
+def mm_fp4_svdquant(x, state):
+    """Run the fused NVFP4-SVDQuant linear for activation ``x`` using a prepared ``state``.
+
+    The per-call fast path of the kernel's single entrance (NVFP4 main GEMM + bf16 low-rank
+    SVDQuant up-projection, fused-add epilogue): pass the live activation ``x`` (CUDA tensor,
+    shape ``[M, I]``) and the ``state`` returned by :func:`prepare_svdquant_state`, and it
+    returns the output ``Y`` (``[M, O]`` bf16). Graph-safe -- no ``torch.cuda.synchronize``,
+    ``.cpu()``, ``.item()``, or per-call CUDA allocation.
+
+    The output is a view into the state's reusable storage; consume or clone it before the
+    next ``mm_fp4_svdquant`` call on the same state.
+
+    The CuTe-DSL kernel module is imported lazily here so flashinfer carries no hard
+    dependency on the optional CuTe-DSL backend; availability is gated by
+    ``flashinfer.gemm.__init__``.
+    """
+    from .kernels.svdquant_nvfp4 import mm_fp4_svdquant as _mm
+
+    return _mm(x, state)

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_lora_sm100.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_lora_sm100.py
@@ -1,0 +1,2641 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is ported from TensorRT-LLM's dense_blockscaled_gemm_persistent.py
+# with modifications for FlashInfer integration.
+# Original: https://github.com/NVIDIA/TensorRT-LLM
+#
+# Fused NVFP4 SVDQuant GEMM: a copy of dense_blockscaled_gemm_sm100.py extended with a fused
+# rank-r BF16 LoRA up-projection. The NVFP4 residual K-loop is the same as the production kernel
+# (flashinfer's mm_fp4); on top of it an extra bf16 cute.gemm accumulates D @ L1^T
+# (D = X_hat @ L2^T, precomputed) into the SAME main block-scaled accumulator after the K-loop.
+# 1/alpha is folded into L1 host-side, so the UNCHANGED epilogue out = alpha*acc yields
+# alpha*residual + D@L1^T. Using the main accumulator (instead of a 2nd TMEM accumulator) means
+# no TMEM-budget pressure and no change to num_acc_stage, so the production kernel's
+# num_acc_stage=2 / overlapping-accumulator MMA-epilogue overlap is preserved (forcing
+# num_acc_stage=1 for a 2nd accumulator would make it latency-bound). The only additions are the
+# D/L1 TMA load (a 2nd pipeline) and the bf16 LoRA MMA.
+
+from typing import Optional, Tuple, Type, Union
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.nvgpu import cpasync, tcgen05, OperandMajorMode
+
+from cutlass.cute.arch import griddepcontrol_launch_dependents, griddepcontrol_wait
+from cutlass.pipeline import PipelineTmaUmma, PipelineUmmaAsync
+
+
+class Sm100BlockScaledLoRADenseGemmKernel:
+    """NVFP4 block-scaled persistent dense GEMM with a fused rank-r BF16 LoRA up-projection.
+
+    Same as Sm100BlockScaledPersistentDenseGemmKernel (persistent + 16-warp warp-specialized +
+    tcgen05 block-scaled UMMA), plus a fused SVDQuant LoRA up-projection D @ L1^T accumulated
+    into the main accumulator after the K-loop (1/alpha folded into L1 host-side). The LoRA is
+    always fused -- there is no LoRA-off mode (the plain NVFP4 GEMM is flashinfer's mm_fp4).
+    Reusing the main accumulator (no 2nd TMEM accumulator) preserves the base staging
+    (num_acc_stage=2 / overlapping-accumulator MMA-epilogue overlap).
+
+    Notes:
+        - In the current version, tensors A and B must have the same data type.
+          For example, using Float8E4M3FN for A and Float8E5M2 for B is not supported.
+        - Supported combinations of A/B data types, scale factor (SF) data types, and SF vector size:
+            * MXF8:   A/B: Float8E5M2/Float8E4M3FN, SF: Float8E8M0FNU, sf_vec_size: 32
+            * MXF4:   A/B: Float4E2M1FN,            SF: Float8E8M0FNU, sf_vec_size: 32
+            * NVF4:   A/B: Float4E2M1FN,            SF: Float8E8M0FNU/Float8E4M3FN, sf_vec_size: 16
+        - Supported accumulator data types:
+            * Float32
+        - Supported C data types:
+            * Float32
+            * Float16/BFloat16
+            * Float8E4M3FN/Float8E5M2
+        - Constraints:
+            * MMA tiler M must be 128 or 256 (use_2cta_instrs).
+            * MMA tiler N must be 64/128/192/256
+            * Cluster shape M must be a multiple of 2 if MMA tiler M is 256.
+            * Cluster shape M/N must be positive and a power of 2, with total cluster size <= 16.
+            * Cluster shape M/N must be <= 4 for scale factor multicasts due to limited scale factor size.
+
+    Example:
+        >>> gemm = Sm100BlockScaledPersistentDenseGemmKernel(
+        ...     sf_vec_size=16,
+        ...     mma_tiler_mn=(256, 128),
+        ...     cluster_shape_mn=(2, 1)
+        ... )
+        >>> gemm(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, max_active_clusters, stream)
+    """
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        use_prefetch: bool = False,
+        enable_pdl: bool = True,
+        lora_rank: int = 0,
+    ):
+        """Initializes the configuration for a Blackwell dense GEMM kernel.
+
+        This configuration includes several key aspects:
+
+        1.  MMA Instruction Settings (tcgen05):
+            - acc_dtype: Data types for MMA accumulator, always set to Float32
+            - sf_vec_size: Scalefactor A/B vector size.
+            - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
+
+        2.  Cluster Shape:
+            - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
+
+        Args:
+            sf_vec_size (int): Scalefactor vector size.
+            mma_tiler_mn (Tuple[int, int]): Shape of the Matrix Multiply-Accumulate (MMA) tile (M, N).
+            cluster_shape_mn (Tuple[int, int]): Cluster dimensions (M, N) for parallel processing.
+        """
+
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        self.use_prefetch = use_prefetch
+        self.enable_pdl = enable_pdl
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        self.occupancy = 1
+        # Specialized warp ids: 4 epilog + 1 mma + 1 tma = 6 warps (192 threads).
+        self.epilog_warp_id = (0, 1, 2, 3)
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.threads_per_cta = 32 * len(
+            (self.mma_warp_id, self.tma_warp_id, *self.epilog_warp_id)
+        )
+        # Set barrier id for cta sync, epilogue sync and tmem ptr sync
+        self.cta_sync_bar_id = 0
+        self.epilog_sync_bar_id = 1
+        self.tmem_ptr_sync_bar_id = 2
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        SM100_TMEM_CAPACITY_COLUMNS = 512
+        self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+
+        # --- LoRA (SVDQuant) fused epilogue config. This kernel ALWAYS fuses the bf16 LoRA
+        # up-projection D @ L1^T into the NVFP4 residual accumulator (the SVDQuant kernel; there
+        # is no LoRA-off mode -- the base NVFP4 GEMM is flashinfer's mm_fp4). enable_lora is a
+        # const_expr kept True so the compile-time-guarded LoRA paths below stay active. ---
+        self.enable_lora = True
+        self.lora_rank = lora_rank
+        self.lora_dtype = cutlass.BFloat16  # D (= X_hat @ L2^T) and L1 are bf16
+        # bf16 MMA contracts K in 16-wide atoms; pad rank up to a multiple of 16.
+        self.lora_k = ((lora_rank + 15) // 16) * 16
+        self.num_lora_stage = 1  # K=r is a single tile; one smem buffer for D/L1
+
+    def _setup_attributes(self):
+        """Set up configurations that are dependent on GEMM inputs
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B/SFA/SFB
+        - Computing epilogue subtile
+        - Setting up A/B/SFA/SFB/C stage counts in shared memory
+        - Computing A/B/SFA/SFB/C shared memory layout
+        - Computing tensor memory allocation columns
+        """
+        # Compute mma instruction shapes
+        mma_inst_bits_k = 256
+        # (MMA_Tile_Shape_M, MMA_Tile_Shape_N, MMA_Inst_Shape_K)
+        self.mma_inst_shape_mnk = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_bits_k // self.a_dtype.width,
+        )
+        # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
+        self.mma_inst_shape_mnk_sfb = (
+            self.mma_inst_shape_mnk[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mnk[1], 128),
+            self.mma_inst_shape_mnk[2],
+        )
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mnk[:2],
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mnk_sfb[:2],
+        )
+
+        # Compute mma/cluster/tile shapes (K-tile = mma_inst_k * mma_inst_tile_k).
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_inst_shape_mnk[0],
+            self.mma_inst_shape_mnk[1],
+            self.mma_inst_shape_mnk[2] * mma_inst_tile_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mnk_sfb[0],
+            self.mma_inst_shape_mnk_sfb[1],
+            self.mma_inst_shape_mnk_sfb[2] * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+
+        # Compute epilogue subtile
+        self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.c_layout,
+            self.c_dtype,
+        )
+
+        self.epi_tile_n = cute.size(self.epi_tile[1])
+
+        # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_dtype,
+            self.b_major_mode,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        if self.enable_lora:
+            # _compute_stages maximizes num_ab_stage to fill SMEM, leaving no room for the LoRA
+            # D/L1 buffers (~27 KB) -> launch would exceed the 232 KB sm_100a cap. Free room by
+            # trimming the C-store stages FIRST (epilogue double-buffering is far less perf-
+            # critical than the A/B K-loop pipeline), then num_ab_stage only if still needed.
+            self.lora_tiler = (self.mma_tiler[0], self.mma_tiler[1], self.lora_k)
+            # Mirror the main MMA's cta_group so the per-CTA D/L1 smem tile matches the residual
+            # A/B path (128 rows under 2-CTA, 256 under 1-CTA). cta_group==ONE => identical to the
+            # original 1-CTA path.
+            _lmma = sm100_utils.make_trivial_tiled_mma(
+                self.lora_dtype,
+                self.lora_dtype,
+                OperandMajorMode.K,
+                OperandMajorMode.K,
+                self.acc_dtype,
+                self.cta_group,
+                (self.mma_tiler[0], self.mma_tiler[1]),
+            )
+            self.d_smem_layout_staged = sm100_utils.make_smem_layout_a(
+                _lmma, self.lora_tiler, self.lora_dtype, self.num_lora_stage
+            )
+            self.l1_smem_layout_staged = sm100_utils.make_smem_layout_b(
+                _lmma, self.lora_tiler, self.lora_dtype, self.num_lora_stage
+            )
+            lora_bytes = (
+                cute.size_in_bytes(self.lora_dtype, self.d_smem_layout_staged)
+                + cute.size_in_bytes(self.lora_dtype, self.l1_smem_layout_staged)
+                + 4096  # buffer_align padding (sD/sL1) + lora mbars, with margin
+            )
+            c_one = sm100_utils.make_smem_layout_epi(
+                self.c_dtype, self.c_layout, self.epi_tile, 1
+            )
+            c_bytes_one = cute.size_in_bytes(self.c_dtype, c_one)
+            a_one = sm100_utils.make_smem_layout_a(tiled_mma, self.mma_tiler, self.a_dtype, 1)
+            b_one = sm100_utils.make_smem_layout_b(tiled_mma, self.mma_tiler, self.b_dtype, 1)
+            sfa_one = blockscaled_utils.make_smem_layout_sfa(
+                tiled_mma, self.mma_tiler, self.sf_vec_size, 1
+            )
+            sfb_one = blockscaled_utils.make_smem_layout_sfb(
+                tiled_mma, self.mma_tiler, self.sf_vec_size, 1
+            )
+            ab_bytes_one = (
+                cute.size_in_bytes(self.a_dtype, a_one)
+                + cute.size_in_bytes(self.b_dtype, b_one)
+                + cute.size_in_bytes(self.sf_dtype, sfa_one)
+                + cute.size_in_bytes(self.sf_dtype, sfb_one)
+            )
+            # Free SMEM for the LoRA D/L1 buffers WITHOUT shallowing the A/B K-loop pipeline, which
+            # is perf-critical (esp. for deep-K shapes like the down-proj: each lost ab_stage cost
+            # ~60-140us at large M). Trim the epilogue C-store buffer FIRST -- down to a single stage
+            # (epilogue double-buffering is far less important than the mainloop pipeline) -- and only
+            # then num_ab_stage as a last resort. (num_c_stage default is 2, so the old `> 2` bound
+            # never actually trimmed C and forced the whole cost onto num_ab_stage.)
+            freed = 0
+            while freed < lora_bytes and self.num_c_stage > 1:
+                self.num_c_stage -= 1
+                freed += c_bytes_one
+            while freed < lora_bytes and self.num_ab_stage > 2:
+                self.num_ab_stage -= 1
+                freed += ab_bytes_one
+
+        # Compute A/B/SFA/SFB/C shared memory layout
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+        # LoRA accumulates D@L1^T into the MAIN accumulator (1/alpha folded into L1 host-side), so
+        # there is NO 2nd accumulator and NO TMEM-budget pressure -> keep the base staging (and its
+        # num_acc_stage=2 / overlapping_accum MMA-epilogue overlap, the perf-critical part).
+        self.overlapping_accum = self.num_acc_stage == 1
+        sf_atom_mn = 32
+        self.num_sfa_tmem_cols = (
+            self.cta_tile_shape_mnk[0] // sf_atom_mn
+        ) * mma_inst_tile_k
+        self.num_sfb_tmem_cols = (
+            self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn
+        ) * mma_inst_tile_k
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = (
+            self.cta_tile_shape_mnk[1] * self.num_acc_stage
+            if not self.overlapping_accum
+            else self.cta_tile_shape_mnk[1] * 2 - self.num_sf_tmem_cols
+        )
+
+        # (LoRA needs NO 2nd accumulator: D@L1^T is accumulated into the MAIN tCtAcc by an extra
+        # bf16 cute.gemm after the main K-loop; lora_tiler / d_smem_layout_staged / l1_smem_layout_staged
+        # were built in the SMEM-reserve block above.)
+
+        # Only when overlapping_accum is enabled, we need to release accumulator buffer early in epilogue
+        self.iter_acc_early_release_in_epilogue = (
+            self.num_sf_tmem_cols // self.epi_tile_n
+        )
+
+        # TODO: [alel] Currently set prefetch dist to num_ab_stage, we may have more options for prefetch dist auto tuning
+        self.prefetch_dist = self.num_ab_stage
+
+    @cute.jit
+    def __call__(
+        self,
+        a_tensor: cute.Tensor,
+        b_tensor: cute.Tensor,
+        sfa_tensor: cute.Tensor,
+        sfb_tensor: cute.Tensor,
+        c_tensor: cute.Tensor,
+        alpha: cute.Tensor,  # Single-element tensor containing alpha value
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+        d_tensor: Optional[cute.Tensor] = None,  # LoRA down-proj output D = X_hat @ L2^T, [M, lora_k]
+        l1_tensor: Optional[cute.Tensor] = None,  # LoRA up-proj weight L1, [N, lora_k]
+    ):
+        """Execute the GEMM operation in steps:
+        - Setup static attributes before smem/grid/tma computation
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size with regard to hardware constraints
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        Args:
+            a_tensor (cute.Tensor): Input tensor A
+            b_tensor (cute.Tensor): Input tensor B
+            sfa_tensor (cute.Tensor): Scale factor tensor A
+            sfb_tensor (cute.Tensor): Scale factor tensor B
+            c_tensor (cute.Tensor): Output tensor C
+            max_active_clusters (cutlass.Constexpr): Maximum number of active clusters
+            stream (cuda.CUstream): CUDA stream for asynchronous execution
+            epilogue_op (cutlass.Constexpr): Optional elementwise lambda function to apply to the output tensor
+
+        Raises:
+            TypeError: If input data types are incompatible with the MMA instruction.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        self.a_dtype: Type[cutlass.Numeric] = a_tensor.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
+        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+
+        # Check if input data types are compatible with MMA instruction
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            a_tensor.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa_tensor.iterator, sfa_layout)
+
+        # ((Atom_N, Rest_N),(Atom_K, Rest_K),RestL)
+        sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b_tensor.shape, self.sf_vec_size
+        )
+        sfb_tensor = cute.make_tensor(sfb_tensor.iterator, sfb_layout)
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mnk[:2],
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mnk_sfb[:2],
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a_tensor,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b_tensor,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for SFA
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa_tensor,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        # Setup TMA load for SFB
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb_tensor,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+        if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+            x = tma_tensor_sfb.stride[0][1]
+            y = cute.ceil_div(tma_tensor_sfb.shape[0][1], 4)
+
+            new_shape = (
+                (tma_tensor_sfb.shape[0][0], ((2, 2), y)),
+                tma_tensor_sfb.shape[1],
+                tma_tensor_sfb.shape[2],
+            )
+            # Use right multiplication for ScaledBasis (3 * x instead of x * 3)
+            x_times_3 = 3 * x
+            new_stride = (
+                (tma_tensor_sfb.stride[0][0], ((x, x), x_times_3)),
+                tma_tensor_sfb.stride[1],
+                tma_tensor_sfb.stride[2],
+            )
+            tma_tensor_sfb_new_layout = cute.make_layout(new_shape, stride=new_stride)
+            tma_tensor_sfb = cute.make_tensor(
+                tma_tensor_sfb.iterator, tma_tensor_sfb_new_layout
+            )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (
+            a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size
+        ) * atom_thr_size
+
+        # --- LoRA: bf16 low-rank MMA + TMA atoms for D [M, lora_k] and L1 [N, lora_k] ---
+        # (1-CTA bf16 trivial MMA; the down-proj D = X_hat @ L2^T is precomputed by the caller.)
+        lora_mma = None
+        tma_atom_d = tma_tensor_d = tma_atom_l1 = tma_tensor_l1 = None
+        if cutlass.const_expr(self.enable_lora):
+            # cta_group mirrors the main MMA (TWO for 256-wide / 2-CTA tiles, ONE otherwise) so the
+            # D@L1^T bf16 MMA accumulates into the SAME 2-SM tCtAcc as the block-scaled residual.
+            lora_mma = sm100_utils.make_trivial_tiled_mma(
+                self.lora_dtype,
+                self.lora_dtype,
+                OperandMajorMode.K,
+                OperandMajorMode.K,
+                self.acc_dtype,
+                self.cta_group,
+                (self.mma_tiler[0], self.mma_tiler[1]),
+            )
+            # Multicast atoms for D/L1 (mirror A/B): D is M-indexed -> multicast like A across the
+            # N-cluster + 2-CTA peer; L1 is N-indexed -> multicast like B across the M-cluster. This
+            # is BOTH the 2-CTA-correctness fix AND the operand-caching win (D/L1 loaded once per
+            # cluster, not once per CTA). cta_group==ONE+(1,1) cluster => plain single-CTA load.
+            d_op = sm100_utils.cluster_shape_to_tma_atom_A(
+                self.cluster_shape_mn, lora_mma.thr_id
+            )
+            l1_op = sm100_utils.cluster_shape_to_tma_atom_B(
+                self.cluster_shape_mn, lora_mma.thr_id
+            )
+            d_smem_layout = cute.slice_(self.d_smem_layout_staged, (None, None, None, 0))
+            tma_atom_d, tma_tensor_d = cute.nvgpu.make_tiled_tma_atom_A(
+                d_op,
+                d_tensor,
+                d_smem_layout,
+                self.lora_tiler,
+                lora_mma,
+                self.cluster_layout_vmnk.shape,
+            )
+            l1_smem_layout = cute.slice_(self.l1_smem_layout_staged, (None, None, None, 0))
+            tma_atom_l1, tma_tensor_l1 = cute.nvgpu.make_tiled_tma_atom_B(
+                l1_op,
+                l1_tensor,
+                l1_smem_layout,
+                self.lora_tiler,
+                lora_mma,
+                self.cluster_layout_vmnk.shape,
+            )
+            d_copy_size = cute.size_in_bytes(self.lora_dtype, d_smem_layout)
+            l1_copy_size = cute.size_in_bytes(self.lora_dtype, l1_smem_layout)
+            self.num_lora_tma_load_bytes = (d_copy_size + l1_copy_size) * atom_thr_size
+
+        # Setup TMA store for C
+        epi_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            c_tensor,
+            epi_smem_layout,
+            self.epi_tile,
+        )
+
+        # Compute grid size
+        self.tile_sched_params, grid = self._compute_grid(
+            c_tensor,
+            self.cta_tile_shape_mnk,
+            self.cluster_shape_mn,
+            max_active_clusters,
+        )
+
+        self.buffer_align_bytes = 1024
+
+        # Define shared storage for kernel. LoRA adds D/L1 smem buffers + a lora TMA pipeline.
+        if cutlass.const_expr(self.enable_lora):
+
+            @cute.struct
+            class SharedStorage:
+                ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+                ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+                acc_full_mbar_ptr: cute.struct.MemRange[
+                    cutlass.Int64, self.num_acc_stage
+                ]
+                acc_empty_mbar_ptr: cute.struct.MemRange[
+                    cutlass.Int64, self.num_acc_stage
+                ]
+                lora_full_mbar_ptr: cute.struct.MemRange[
+                    cutlass.Int64, self.num_lora_stage
+                ]
+                lora_empty_mbar_ptr: cute.struct.MemRange[
+                    cutlass.Int64, self.num_lora_stage
+                ]
+                tmem_dealloc_mbar_ptr: cutlass.Int64
+                tmem_holding_buf: cutlass.Int32
+                sC: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.c_dtype, cute.cosize(self.c_smem_layout_staged.outer)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                sA: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                sB: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                sSFA: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                sSFB: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                # (MMA, MMA_M, lora_k, STAGE) and (MMA, MMA_N, lora_k, STAGE)
+                sD: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.lora_dtype, cute.cosize(self.d_smem_layout_staged.outer)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                sL1: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.lora_dtype, cute.cosize(self.l1_smem_layout_staged.outer)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+
+        else:
+
+            @cute.struct
+            class SharedStorage:
+                ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+                ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+                acc_full_mbar_ptr: cute.struct.MemRange[
+                    cutlass.Int64, self.num_acc_stage
+                ]
+                acc_empty_mbar_ptr: cute.struct.MemRange[
+                    cutlass.Int64, self.num_acc_stage
+                ]
+                tmem_dealloc_mbar_ptr: cutlass.Int64
+                tmem_holding_buf: cutlass.Int32
+                # (EPI_TILE_M, EPI_TILE_N, STAGE)
+                sC: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.c_dtype,
+                        cute.cosize(self.c_smem_layout_staged.outer),
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                # (MMA, MMA_M, MMA_K, STAGE)
+                sA: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                # (MMA, MMA_N, MMA_K, STAGE)
+                sB: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                # (MMA, MMA_M, MMA_K, STAGE)
+                sSFA: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+                # (MMA, MMA_N, MMA_K, STAGE)
+                sSFB: cute.struct.Align[
+                    cute.struct.MemRange[
+                        self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)
+                    ],
+                    self.buffer_align_bytes,
+                ]
+
+        self.shared_storage = SharedStorage
+
+        # Launch the kernel synchronously
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            tma_atom_c,
+            tma_tensor_c,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+            alpha,
+            lora_mma,
+            tma_atom_d,
+            tma_tensor_d,
+            tma_atom_l1,
+            tma_tensor_l1,
+            self.d_smem_layout_staged if self.enable_lora else None,
+            self.l1_smem_layout_staged if self.enable_lora else None,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
+            min_blocks_per_mp=1,
+            stream=stream,
+            use_pdl=self.enable_pdl,
+        )
+        return
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: Optional[cute.CopyAtom],
+        mC_mnl: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+        alpha: cute.Tensor,
+        lora_mma: Optional[cute.TiledMma],
+        tma_atom_d: Optional[cute.CopyAtom],
+        mD_mkl: Optional[cute.Tensor],
+        tma_atom_l1: Optional[cute.CopyAtom],
+        mL1_nkl: Optional[cute.Tensor],
+        d_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        l1_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+
+        An extra bf16 MMA accumulates D @ L1^T into the main accumulator after the K-loop
+        (1/alpha folded into L1 host-side), so the epilogue is unchanged. The LoRA work is guarded
+        by cutlass.const_expr(self.enable_lora) -- a compile-time constant, always True for this
+        kernel -- to keep the LoRA-specific additions clearly delimited from the base GEMM.
+        """
+        # Keep alpha in FP32 for precision: the accumulator is in FP32 and alpha
+        # may be a very small scaling factor. Converting to c_dtype (e.g., FP16)
+        # before multiplication could cause overflow when acc values are large.
+        alpha_value = alpha[0].to(cutlass.Float32)
+
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        # Coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.ptr
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
+
+        # Initialize mainloop ab_pipeline (barrier) and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_pipeline = PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Initialize acc_pipeline (barrier) and states
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilog_warp_id) * (
+            2 if use_2cta_instrs else 1
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+        )
+
+        # Initialize lora_pipeline (TMA load of D/L1 -> MMA consume), mirrors ab_pipeline.
+        lora_pipeline = None
+        if cutlass.const_expr(self.enable_lora):
+            lora_pipeline = PipelineTmaUmma.create(
+                barrier_storage=storage.lora_full_mbar_ptr.data_ptr(),
+                num_stages=self.num_lora_stage,
+                producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+                consumer_group=pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread, num_tma_producer
+                ),
+                tx_count=self.num_lora_tma_load_bytes,
+                cta_layout_vmnk=cluster_layout_vmnk,
+            )
+
+        # Tensor memory dealloc barrier init
+        if use_2cta_instrs:
+            if warp_idx == self.tma_warp_id:
+                num_tmem_dealloc_threads = 32
+                with cute.arch.elect_one():
+                    cute.arch.mbarrier_init(
+                        tmem_dealloc_mbar_ptr, num_tmem_dealloc_threads
+                    )
+        cute.arch.mbarrier_init_fence()
+
+        # Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed(aligned=True)
+
+        #
+        # Setup smem tensor A/B/SFA/SFB/C
+        #
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        sC = storage.sC.get_tensor(
+            c_smem_layout_staged.outer, swizzle=c_smem_layout_staged.inner
+        )
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        # LoRA: bf16 low-rank operands D [tile_m, lora_k] and L1 [tile_n, lora_k] in smem.
+        sD = None
+        sL1 = None
+        if cutlass.const_expr(self.enable_lora):
+            sD = storage.sD.get_tensor(
+                d_smem_layout_staged.outer, swizzle=d_smem_layout_staged.inner
+            )
+            sL1 = storage.sL1.get_tensor(
+                l1_smem_layout_staged.outer, swizzle=l1_smem_layout_staged.inner
+            )
+
+        #
+        # Compute multicast mask for A/B/SFA/SFB buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1
+            )
+
+        #
+        # Local_tile partition global tensors
+        #
+        # (bM, bK, RestM, RestK, RestL)
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        # (bM, bK, RestM, RestK, RestL)
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+            (None, None, None),
+        )
+        # (bM, bN, RestM, RestN, RestL)
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        k_block_cnt = cutlass.Int32(cute.size(gA_mkl, mode=[3]))
+
+        #
+        # Partition global tensor for TiledMMA_A/B/C
+        #
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgSFA = thr_mma.partition_A(gSFA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+        # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        #
+        # Partition global/shared tensor for TMA load A/B
+        #
+        # TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        #  TMA load SFA partition_S/D
+        sfa_cta_layout = a_cta_layout
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsSFA, tAgSFA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfa,
+            block_in_cluster_coord_vmnk[2],
+            sfa_cta_layout,
+            cute.group_modes(sSFA, 0, 3),
+            cute.group_modes(tCgSFA, 0, 3),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # TMA load SFB partition_S/D
+        sfb_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsSFB, tBgSFB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfb,
+            block_in_cluster_coord_sfb_vmnk[1],
+            sfb_cta_layout,
+            cute.group_modes(sSFB, 0, 3),
+            cute.group_modes(tCgSFB, 0, 3),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+
+        # LoRA: global tiles + TMA partitions for the bf16 low-rank operands D and L1.
+        # K = lora_k is a single tile (no K-loop); the per-tile slice keeps a free RestK mode.
+        tDsD = tDgD = tL1sL1 = tL1gL1 = None
+        if cutlass.const_expr(self.enable_lora):
+            # (bM, lora_k, RestM, RestK, RestL)
+            gD_mkl = cute.local_tile(
+                mD_mkl, cute.slice_(self.lora_tiler, (None, 0, None)), (None, None, None)
+            )
+            # (bN, lora_k, RestN, RestK, RestL)
+            gL1_nkl = cute.local_tile(
+                mL1_nkl, cute.slice_(self.lora_tiler, (0, None, None)), (None, None, None)
+            )
+            thr_lora_mma = lora_mma.get_slice(mma_tile_coord_v)
+            tLgD = thr_lora_mma.partition_A(gD_mkl)
+            tLgL1 = thr_lora_mma.partition_B(gL1_nkl)
+            tDsD, tDgD = cpasync.tma_partition(
+                tma_atom_d,
+                block_in_cluster_coord_vmnk[2],
+                a_cta_layout,
+                cute.group_modes(sD, 0, 3),
+                cute.group_modes(tLgD, 0, 3),
+            )
+            tL1sL1, tL1gL1 = cpasync.tma_partition(
+                tma_atom_l1,
+                block_in_cluster_coord_vmnk[1],
+                b_cta_layout,
+                cute.group_modes(sL1, 0, 3),
+                cute.group_modes(tLgL1, 0, 3),
+            )
+
+        #
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/C
+        #
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        if cutlass.const_expr(self.overlapping_accum):
+            num_acc_stage_overlapped = 2
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, num_acc_stage_overlapped)
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        else:
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, self.num_acc_stage)
+            )
+
+        # LoRA: bf16 low-rank MMA fragments (D, L1). The D@L1^T result accumulates directly into the
+        # MAIN accumulator tCtAcc (no 2nd accumulator), so no separate C fragment is needed.
+        tLrD = None
+        tLrL1 = None
+        if cutlass.const_expr(self.enable_lora):
+            # (MMA, MMA_M, lora_k, STAGE)
+            tLrD = lora_mma.make_fragment_A(sD)
+            # (MMA, MMA_N, lora_k, STAGE)
+            tLrL1 = lora_mma.make_fragment_B(sL1)
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.barrier(
+                barrier_id=self.cta_sync_bar_id, number_of_threads=self.threads_per_cta
+            )
+
+        # PDL bookend: griddepcontrol_wait is always emitted; the actual PDL
+        # behavior is controlled by use_pdl= in .launch(). The griddepcontrol
+        # instructions are effectively no-ops when PDL is not enabled at
+        # the driver level.
+        griddepcontrol_wait()
+
+        #
+        # Specialized TMA load warp
+        #
+        if warp_idx == self.tma_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_ab_stage
+            )
+            if cutlass.const_expr(self.enable_lora):
+                lora_producer_state = pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Producer, self.num_lora_stage
+                )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                # LoRA: issue D[tile_m] / L1[tile_n] TMA load once per tile, BEFORE the main
+                # K-loop, so it streams in flight during the long NVFP4 mainloop (overlap).
+                if cutlass.const_expr(self.enable_lora):
+                    lora_pipeline.producer_acquire(lora_producer_state)
+                    # D is M-indexed -> multicast like A (a_full_mcast_mask); L1 is N-indexed ->
+                    # multicast like B (b_full_mcast_mask). Both are None for a (1,1) 1-CTA cluster,
+                    # so this reduces to the original plain per-CTA load.
+                    cute.copy(
+                        tma_atom_d,
+                        tDgD[(None, mma_tile_coord_mnl[0], 0, mma_tile_coord_mnl[2])],
+                        tDsD[(None, lora_producer_state.index)],
+                        tma_bar_ptr=lora_pipeline.producer_get_barrier(
+                            lora_producer_state
+                        ),
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_l1,
+                        tL1gL1[(None, mma_tile_coord_mnl[1], 0, mma_tile_coord_mnl[2])],
+                        tL1sL1[(None, lora_producer_state.index)],
+                        tma_bar_ptr=lora_pipeline.producer_get_barrier(
+                            lora_producer_state
+                        ),
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    lora_pipeline.producer_commit(lora_producer_state)
+                    lora_producer_state.advance()
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((atom_v, rest_v), RestK)
+                tAgA_slice = tAgA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+                # ((atom_v, rest_v), RestK)
+                tBgB_slice = tBgB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                # ((atom_v, rest_v), RestK)
+                tAgSFA_slice = tAgSFA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+                slice_n = mma_tile_coord_mnl[1]
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_mnl[1] // 2
+                # ((atom_v, rest_v), RestK)
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, mma_tile_coord_mnl[2])]
+
+                if cutlass.const_expr(self.use_prefetch):
+                    # Prefetch both A and B (default behavior)
+                    for pf_k_block in cutlass.range(
+                        0, min(self.prefetch_dist, k_block_cnt), unroll=1
+                    ):
+                        cute.prefetch(
+                            tma_atom_a,
+                            tAgA_slice[(None, pf_k_block)],
+                        )
+                        cute.prefetch(
+                            tma_atom_b,
+                            tBgB_slice[(None, pf_k_block)],
+                        )
+                        cute.prefetch(
+                            tma_atom_sfa,
+                            tAgSFA_slice[(None, pf_k_block)],
+                        )
+                        cute.prefetch(
+                            tma_atom_sfb,
+                            tBgSFB_slice[(None, pf_k_block)],
+                        )
+
+                # Peek (try_wait) AB buffer empty for k_block = prefetch_k_block_cnt
+                ab_producer_state.reset_count()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if ab_producer_state.count < k_block_cnt:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(
+                        ab_producer_state
+                    )
+                #
+                # Tma load loop
+                #
+                for k_block in cutlass.range(0, k_block_cnt, 1, unroll=1):
+                    # Conditionally wait for AB buffer empty
+                    ab_pipeline.producer_acquire(
+                        ab_producer_state, peek_ab_empty_status
+                    )
+
+                    # TMA load A/B/SFA/SFB
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, ab_producer_state.count)],
+                        tAsA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, ab_producer_state.count)],
+                        tBsB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_slice[(None, ab_producer_state.count)],
+                        tAsSFA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_slice[(None, ab_producer_state.count)],
+                        tBsSFB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfb_full_mcast_mask,
+                    )
+
+                    # Prefetch: Rolling prefetch for next tiles
+                    if cutlass.const_expr(self.use_prefetch):
+                        if k_block < k_block_cnt - self.prefetch_dist:
+                            future_k_block = (
+                                ab_producer_state.count + self.prefetch_dist
+                            )
+                            # Prefetch both A and B (default behavior)
+                            cute.prefetch(
+                                tma_atom_a,
+                                tAgA_slice[(None, future_k_block)],
+                            )
+                            cute.prefetch(
+                                tma_atom_b,
+                                tBgB_slice[(None, future_k_block)],
+                            )
+                            cute.prefetch(
+                                tma_atom_sfa,
+                                tAgSFA_slice[(None, future_k_block)],
+                            )
+                            cute.prefetch(
+                                tma_atom_sfb,
+                                tBgSFB_slice[(None, future_k_block)],
+                            )
+
+                    # Peek (try_wait) AB buffer empty for k_block = prefetch_k_block_cnt + k_block + 1
+                    ab_producer_state.advance()
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if ab_producer_state.count < k_block_cnt:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(
+                            ab_producer_state
+                        )
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait A/B buffer empty
+            #
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem_ptr_read_threads = 32 * len((self.mma_warp_id, *self.epilog_warp_id))
+            cute.arch.barrier(
+                barrier_id=self.tmem_ptr_sync_bar_id,
+                number_of_threads=tmem_ptr_read_threads,
+            )
+
+            #
+            # Retrieving tensor memory ptr and make accumulator/SFA/SFB tensor
+            #
+            # Make accumulator tmem tensor
+            acc_tmem_ptr = cute.arch.retrieve_tmem_ptr(
+                self.acc_dtype,
+                alignment=16,
+                ptr_to_buffer_holding_addr=tmem_holding_buf,
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # Make SFA tmem tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_M, MMA_K)
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # Make SFB tmem tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_N, MMA_K)
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+            # (LoRA accumulates into the MAIN tCtAcc -- no 2nd accumulator tmem tensor.)
+            #
+            # Partition for S2T copy of SFA/SFB
+            #
+            tiled_copy_s2t_sfa, tCsSFA_compact_s2t, tCtSFA_compact_s2t = (
+                self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            )
+            tiled_copy_s2t_sfb, tCsSFB_compact_s2t, tCtSFB_compact_s2t = (
+                self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+            )
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_ab_stage
+            )
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+            if cutlass.const_expr(self.enable_lora):
+                lora_consumer_state = pipeline.make_pipeline_state(
+                    pipeline.PipelineUserType.Consumer, self.num_lora_stage
+                )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+
+                # Set tensor memory buffer for current tile
+                # (MMA, MMA_M, MMA_N)
+                tCtAcc = tCtAcc_base[(None, None, None, acc_stage_index)]
+
+                # Peek (try_wait) AB buffer full for k_block = 0
+                ab_consumer_state.reset_count()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_block_cnt and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(
+                        ab_consumer_state
+                    )
+
+                #
+                # Wait for accumulator buffer empty
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_acquire(acc_producer_state)
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+                    # If this is an ODD tile, shift the TMEM start address for cta_tile_shape_n=192 case by two words (ignores first 64 columns of SFB)
+                    offset = (
+                        cutlass.Int32(2)
+                        if mma_tile_coord_mnl[1] % 2 == 1
+                        else cutlass.Int32(0)
+                    )
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr
+                        + self.num_accumulator_tmem_cols
+                        + self.num_sfa_tmem_cols
+                        + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+                elif cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    # Move in increments of 64 columns of SFB
+                    offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr
+                        + self.num_accumulator_tmem_cols
+                        + self.num_sfa_tmem_cols
+                        + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                #
+                # Reset the ACCUMULATE field for each tile
+                #
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                #
+                # Mma mainloop
+                #
+                for _k_block in range(k_block_cnt):
+                    if is_leader_cta:
+                        # Conditionally wait for AB buffer full
+                        ab_pipeline.consumer_wait(
+                            ab_consumer_state, peek_ab_full_status
+                        )
+
+                        #  Copy SFA/SFB from smem to tmem
+                        s2t_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            ab_consumer_state.index,
+                        )
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t_staged,
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t_staged,
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
+                        num_kphases = cute.size(tCrA, mode=[2])
+                        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                            kphase_coord = (
+                                None,
+                                None,
+                                kphase_idx,
+                                ab_consumer_state.index,
+                            )
+
+                            # Set SFA/SFB tensor to tiled_mma
+                            sf_kphase_coord = (None, None, kphase_idx)
+                            tiled_mma.set(
+                                tcgen05.Field.SFA,
+                                tCtSFA[sf_kphase_coord].iterator,
+                            )
+                            tiled_mma.set(
+                                tcgen05.Field.SFB,
+                                tCtSFB_mma[sf_kphase_coord].iterator,
+                            )
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kphase_coord],
+                                tCrB[kphase_coord],
+                                tCtAcc,
+                            )
+
+                            # Enable accumulate on tCtAcc after first kphase
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        # Async arrive AB buffer empty
+                        ab_pipeline.consumer_release(ab_consumer_state)
+
+                    # Peek (try_wait) AB buffer full for k_block = k_block + 1
+                    ab_consumer_state.advance()
+                    peek_ab_full_status = cutlass.Boolean(1)
+                    if ab_consumer_state.count < k_block_cnt:
+                        if is_leader_cta:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(
+                                ab_consumer_state
+                            )
+
+                #
+                # LoRA up-projection: ACCUMULATE D @ L1^T into the MAIN accumulator tCtAcc (which
+                # already holds the NVFP4 residual from the K-loop). bf16, single K=lora_k tile, NOT
+                # block-scaled (no per-kphase SF) -> one cute.gemm with ACCUMULATE=True. L1 has 1/alpha
+                # folded in host-side, so the (unchanged) epilogue out = alpha*tCtAcc yields
+                # alpha*residual + D@L1^T. The D/L1 load streamed during the main K-loop.
+                #
+                if cutlass.const_expr(self.enable_lora):
+                    if is_leader_cta:
+                        lora_pipeline.consumer_wait(lora_consumer_state)
+                        lora_mma.set(tcgen05.Field.ACCUMULATE, True)
+                        cute.gemm(
+                            lora_mma,
+                            tCtAcc,
+                            tLrD[(None, None, None, lora_consumer_state.index)],
+                            tLrL1[(None, None, None, lora_consumer_state.index)],
+                            tCtAcc,
+                        )
+                        lora_pipeline.consumer_release(lora_consumer_state)
+                    lora_consumer_state.advance()
+
+                #
+                # Async arrive accumulator buffer full
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+        #
+        # Specialized epilogue warps
+        #
+        if warp_idx < self.mma_warp_id:
+            #
+            # Alloc tensor memory buffer
+            #
+            if warp_idx == self.epilog_warp_id[0]:
+                cute.arch.alloc_tmem(
+                    self.num_tmem_alloc_cols,
+                    tmem_holding_buf,
+                    is_two_cta=use_2cta_instrs,
+                )
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem_ptr_read_threads = 32 * len((self.mma_warp_id, *self.epilog_warp_id))
+            cute.arch.barrier(
+                barrier_id=self.tmem_ptr_sync_bar_id,
+                number_of_threads=tmem_ptr_read_threads,
+            )
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            acc_tmem_ptr = cute.arch.retrieve_tmem_ptr(
+                self.acc_dtype,
+                alignment=16,
+                ptr_to_buffer_holding_addr=tmem_holding_buf,
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Partition for epilogue
+            #
+            epi_tidx = tidx
+            tiled_copy_t2r, tTR_tAcc_base, tTR_rAcc = (
+                self.epilog_tmem_copy_and_partition(
+                    epi_tidx, tCtAcc_base, tCgC, epi_tile, use_2cta_instrs
+                )
+            )
+
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                tiled_copy_t2r, tTR_rC, epi_tidx, sC
+            )
+            tma_atom_c, bSG_sC, bSG_gC_partitioned = (
+                self.epilog_gmem_copy_and_partition(
+                    epi_tidx, tma_atom_c, tCgC, epi_tile, sC
+                )
+            )
+            # (LoRA is already summed into tCtAcc, so the epilogue is the base epilogue: no
+            # separate lora accumulator to t2r-copy/combine here.)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+
+            # Threads/warps participating in tma store pipeline
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilog_warp_id),
+                32 * len(self.epilog_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage,
+                producer_group=c_producer_group,
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((ATOM_V, REST_V), EPI_M, EPI_N)
+                bSG_gC = bSG_gC_partitioned[
+                    (
+                        None,
+                        None,
+                        None,
+                        *mma_tile_coord_mnl,
+                    )
+                ]
+
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_consumer_state.phase
+                    reverse_subtile = (
+                        cutlass.Boolean(True)
+                        if acc_stage_index == 0
+                        else cutlass.Boolean(False)
+                    )
+                else:
+                    acc_stage_index = acc_consumer_state.index
+
+                # Set tensor memory buffer for current tile
+                # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                tTR_tAcc = tTR_tAcc_base[
+                    (None, None, None, None, None, acc_stage_index)
+                ]
+
+                #
+                # Wait for accumulator buffer full
+                #
+                acc_pipeline.consumer_wait(acc_consumer_state)
+
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+                #
+                # Store accumulator to global memory in sub-tiles
+                #
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+
+                for subtile_idx in cutlass.range(subtile_cnt):
+                    real_subtile_idx = subtile_idx
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if reverse_subtile:
+                            real_subtile_idx = (
+                                self.cta_tile_shape_mnk[1] // self.epi_tile_n
+                                - 1
+                                - subtile_idx
+                            )
+                    #
+                    # Load accumulator from tensor memory buffer to register
+                    #
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                    #
+                    # Async arrive accumulator buffer empty earlier when overlapping_accum is enabled
+                    #
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if subtile_idx == self.iter_acc_early_release_in_epilogue:
+                            # Fence for TMEM load
+                            cute.arch.fence_view_async_tmem_load()
+                            with cute.arch.elect_one():
+                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_consumer_state.advance()
+                    #
+                    # Convert to C type
+                    #
+                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+                    # Multiply alpha in FP32 before converting to c_dtype to avoid overflow when
+                    # c_dtype is FP16. (v2: the LoRA D@L1^T is already accumulated into tCtAcc with
+                    # 1/alpha folded into L1, so alpha*acc = alpha*residual + D@L1^T.)
+                    acc_vec = epilogue_op((alpha_value * acc_vec).to(self.c_dtype))
+                    tRS_rC.store(acc_vec)
+
+                    #
+                    # Store C to shared memory
+                    #
+                    c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
+                    cute.copy(
+                        tiled_copy_r2s,
+                        tRS_rC,
+                        tRS_sC[(None, None, None, c_buffer)],
+                    )
+                    # Fence and barrier to make sure shared memory store is visible to TMA store
+                    cute.arch.fence_proxy(
+                        "async.shared",
+                        space="cta",
+                    )
+                    epilog_threads = 32 * len(self.epilog_warp_id)
+                    cute.arch.barrier(
+                        barrier_id=self.epilog_sync_bar_id,
+                        number_of_threads=epilog_threads,
+                    )
+
+                    #
+                    # TMA store C to global memory
+                    #
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sC[(None, c_buffer)],
+                            bSG_gC[(None, real_subtile_idx)],
+                        )
+                        # Fence and barrier to make sure shared memory store is visible to TMA store
+                        c_pipeline.producer_commit()
+                        c_pipeline.producer_acquire()
+                    cute.arch.barrier(
+                        barrier_id=self.epilog_sync_bar_id,
+                        number_of_threads=epilog_threads,
+                    )
+
+                #
+                # Async arrive accumulator buffer empty
+                #
+                if cutlass.const_expr(not self.overlapping_accum):
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            if warp_idx == self.epilog_warp_id[0]:
+                cute.arch.relinquish_tmem_alloc_permit(is_two_cta=use_2cta_instrs)
+            epilog_threads = 32 * len(self.epilog_warp_id)
+            cute.arch.barrier(
+                barrier_id=self.epilog_sync_bar_id, number_of_threads=epilog_threads
+            )
+            if warp_idx == self.epilog_warp_id[0]:
+                if use_2cta_instrs:
+                    cute.arch.mbarrier_arrive(
+                        tmem_dealloc_mbar_ptr, cta_rank_in_cluster ^ 1
+                    )
+                    cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
+                cute.arch.dealloc_tmem(
+                    acc_tmem_ptr, self.num_tmem_alloc_cols, is_two_cta=use_2cta_instrs
+                )
+            #
+            # Wait for C store complete
+            #
+            c_pipeline.producer_tail()
+
+        griddepcontrol_launch_dependents()
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for smem to tmem load for scale factor tensor, then use it to partition smem memory (source) and tensor memory (destination).
+
+        Args:
+            sSF (cute.Tensor): The scale factor tensor in smem
+            tSF (cute.Tensor): The scale factor tensor in tmem
+
+        Returns:
+            A tuple containing (tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t) where:
+                - tiled_copy_s2t: The tiled copy operation for smem to tmem load for scale factor tensor(s2t)
+                - tCsSF_compact_s2t: The partitioned scale factor tensor in smem
+                - tSF_compact_s2t: The partitioned scale factor tensor in tmem
+        """
+        # (MMA, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        # (MMA, MMA_MN, MMA_K)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        # Make S2T CopyAtom and tiledCopy
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t, tCsSF_compact_s2t_
+        )
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    def epilog_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tAcc: cute.Tensor,
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for tensor memory load, then use it to partition tensor memory (source) and register array (destination).
+
+        Args:
+            tidx (cutlass.Int32): The thread index in epilogue warp groups
+            tAcc (cute.Tensor): The accumulator tensor to be copied and partitioned
+            gC_mnl (cute.Tensor): The global tensor C
+            epi_tile (cute.Tile): The epilogue tiler
+            use_2cta_instrs (bool): Whether use_2cta_instrs is enabled
+
+        Returns:
+            A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc) where:
+                - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+                - tTR_tAcc: The partitioned accumulator tensor
+                - tTR_rAcc: The accumulated tensor in register used to hold t2r results
+        """
+        # Make tiledCopy for tensor memory load
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.c_layout,
+            self.c_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, STAGE)
+        tAcc_epi = cute.flat_divide(
+            tAcc[((None, None), 0, 0, None)],
+            epi_tile,
+        )
+        # (EPI_TILE_M, EPI_TILE_N)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(
+            copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)]
+        )
+
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_M, STAGE)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_mnl_epi = cute.flat_divide(
+            gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile
+        )
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        # (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_rmem_tensor(
+            tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
+        )
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def epilog_smem_copy_and_partition(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tidx: cutlass.Int32,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory store, then use it to partition register array (source) and shared memory (destination).
+
+        Args:
+            tiled_copy_t2r (cute.TiledCopy): The tiled copy operation for tmem to register copy(t2r)
+            tTR_rC (cute.Tensor): The partitioned accumulator tensor
+            tidx (cutlass.Int32): The thread index in epilogue warp groups
+            sC (cute.Tensor): The shared memory tensor to be copied and partitioned
+            sepi (cute.Tensor):
+
+        Returns:
+            A tuple containing (tiled_copy_r2s, tRS_rC, tRS_sC) where:
+                - tiled_copy_r2s: The tiled copy operation for register to smem copy(r2s)
+                - tRS_rC: The partitioned tensor C (register source)
+                - tRS_sC: The partitioned tensor C (smem destination)
+        """
+        copy_atom_r2s = sm100_utils.get_smem_store_op(
+            self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r
+        )
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, PIPE_D)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sC = thr_copy_r2s.partition_D(sC)
+        # (R2S, R2S_M, R2S_N)
+        tRS_rC = tiled_copy_r2s.retile(tTR_rC)
+        return tiled_copy_r2s, tRS_rC, tRS_sC
+
+    def epilog_gmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        atom: Union[cute.CopyAtom, cute.TiledCopy],
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for global memory store, then use it to:
+        partition shared memory (source) and global memory (destination) for TMA store version.
+
+        Args:
+            tidx (cutlass.Int32): The thread index in epilogue warp groups
+            atom (Union[cute.CopyAtom, cute.TiledCopy]): The copy_atom_c to be used for TMA store version, or tiled_copy_t2r for none TMA store version
+            gC_mnl (cute.Tensor): The global tensor C
+            epi_tile (cute.Tile): The epilogue tiler
+            sC (cute.Tensor): The shared memory tensor to be copied and partitioned
+
+        Returns:
+            A tuple containing (tma_atom_c, bSG_sC, bSG_gC) where:
+                - tma_atom_c: The TMA copy atom
+                - bSG_sC: The partitioned shared memory tensor C
+                - bSG_gC: The partitioned global tensor C
+        """
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_epi = cute.flat_divide(
+            gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile
+        )
+
+        tma_atom_c = atom
+        sC_for_tma_partition = cute.group_modes(sC, 0, 2)
+        gC_for_tma_partition = cute.group_modes(gC_epi, 0, 2)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N, RestM, RestN, RestL)
+        bSG_sC, bSG_gC = cpasync.tma_partition(
+            tma_atom_c,
+            0,
+            cute.make_layout(1),
+            sC_for_tma_partition,
+            gC_for_tma_partition,
+        )
+        return tma_atom_c, bSG_sC, bSG_gC
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        a_major_mode: cute.nvgpu.OperandMajorMode,
+        b_dtype: Type[cutlass.Numeric],
+        b_major_mode: cute.nvgpu.OperandMajorMode,
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        smem_capacity: int,
+        occupancy: int,
+    ) -> Tuple[int, int, int]:
+        """Computes the optimal number of pipeline stages for operands.
+
+        This method uses heuristics to determine the number of stages for the
+        accumulator (ACC), A/B operands, and C operand based on the kernel
+        configuration and available shared memory.
+
+        Args:
+            tiled_mma (cute.TiledMma): The tiled MMA object.
+            mma_tiler_mnk (Tuple[int, int, int]): The shape (M, N, K) of the
+                MMA tiler.
+            a_dtype (Type[cutlass.Numeric]): Data type of operand A.
+            a_major_mode (cute.nvgpu.OperandMajorMode): Layout of operand A.
+            b_dtype (Type[cutlass.Numeric]): Data type of operand B.
+            b_major_mode (cute.nvgpu.OperandMajorMode): Layout of operand B.
+            epi_tile (cute.Tile): The epilogue tile shape.
+            c_dtype (Type[cutlass.Numeric]): Data type of operand C.
+            c_layout (utils.LayoutEnum): Layout of operand C.
+            sf_dtype (Type[cutlass.Numeric]): Data type of the scale factors.
+            sf_vec_size (int): Vector size of the scale factors.
+            smem_capacity (int): Total available shared memory in bytes.
+            occupancy (int): Target number of CTAs per SM.
+
+        Returns:
+            Tuple[int, int, int]: A tuple containing the number of stages for
+                (ACC, A/B, C).
+        """
+        # ACC stages
+        num_acc_stage = 1 if mma_tiler_mnk[1] == 256 else 2
+
+        # Default C stages
+        num_c_stage = 2
+
+        # Calculate smem layout and size for one stage of A, B, SFA, SFB and C
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            mma_tiler_mnk,
+            a_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            mma_tiler_mnk,
+            b_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+        mbar_helpers_bytes = 1024
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+        c_bytes = c_bytes_per_stage * num_c_stage
+
+        # Calculate A/B/SFA/SFB stages:
+        # Start with total smem per CTA (capacity / occupancy)
+        # Subtract reserved bytes and initial C stages bytes
+        # Divide remaining by bytes needed per A/B/SFA/SFB stage
+        num_ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+        ) // ab_bytes_per_stage
+
+        # Refine epilogue stages:
+        # Calculate remaining smem after allocating for A/B/SFA/SFB stages and reserved bytes
+        # Add remaining unused smem to epilogue
+        num_c_stage += (
+            smem_capacity
+            - occupancy * ab_bytes_per_stage * num_ab_stage
+            - occupancy * (mbar_helpers_bytes + c_bytes)
+        ) // (occupancy * c_bytes_per_stage)
+
+        return num_acc_stage, num_ab_stage, num_c_stage
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
+        """Computes the grid size for the kernel launch.
+
+        This method uses a persistent tile scheduler to determine the grid
+        dimensions based on the output tensor shape and hardware constraints.
+
+        Args:
+            c (cute.Tensor): The output tensor C.
+            cta_tile_shape_mnk (Tuple[int, int, int]): The shape (M, N, K) of the
+                CTA tile.
+            cluster_shape_mn (Tuple[int, int]): The shape of a CTA cluster.
+            max_active_clusters (cutlass.Constexpr): The maximum number of
+                active clusters supported by the hardware.
+
+        Returns:
+            A tuple containing the tile scheduler parameters and the computed
+            grid shape.
+        """
+        c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+
+        return tile_sched_params, grid
+
+    @staticmethod
+    def is_valid_dtypes_and_scale_factor_vec_size(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """Checks if the data types and scale factor vector size are a valid combination.
+
+        Args:
+            ab_dtype (Type[cutlass.Numeric]): Data type of operands A and B.
+            sf_dtype (Type[cutlass.Numeric]): Data type of the scale factors.
+            sf_vec_size (int): Vector size of the scale factors.
+            c_dtype (Type[cutlass.Numeric]): Data type of the output tensor C.
+
+        Returns:
+            bool: True if the combination is valid, False otherwise.
+        """
+        is_valid = True
+
+        # Check valid ab_dtype
+        if ab_dtype not in {
+            cutlass.Float4E2M1FN,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }:
+            is_valid = False
+
+        # Check valid sf_vec_size
+        if sf_vec_size not in {16, 32}:
+            is_valid = False
+
+        # Check valid sf_dtype
+        if sf_dtype not in {cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN}:
+            is_valid = False
+
+        # Check valid sf_dtype and sf_vec_size combinations
+        if sf_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32:
+            is_valid = False
+        if ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
+            is_valid = False
+
+        # Check valid c_dtype
+        if c_dtype not in {
+            cutlass.Float32,
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }:
+            is_valid = False
+
+        return is_valid
+
+    @staticmethod
+    def is_valid_layouts(
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """Checks if the tensor layouts are valid for the given data types.
+
+        Args:
+            ab_dtype (Type[cutlass.Numeric]): Data type of operands A and B.
+            c_dtype (Type[cutlass.Numeric]): Data type of the output tensor C.
+            a_major (str): The major layout of tensor A ('k' or 'm').
+            b_major (str): The major layout of tensor B ('k' or 'n').
+            c_major (str): The major layout of tensor C ('n' or 'm').
+
+        Returns:
+            bool: True if the layouts are valid, False otherwise.
+        """
+        is_valid = True
+
+        if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_mma_tiler_and_cluster_shape(
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ) -> bool:
+        """Checks if the MMA tiler and cluster shape are a valid combination.
+
+        Args:
+            mma_tiler_mn (Tuple[int, int]): The (M, N) shape of the MMA tiler.
+            cluster_shape_mn (Tuple[int, int]): The (M, N) shape of the CTA cluster.
+
+        Returns:
+            bool: True if the combination is valid, False otherwise.
+        """
+        is_valid = True
+        # Skip invalid mma tile shape
+        if mma_tiler_mn[0] not in [128, 256]:
+            is_valid = False
+        if mma_tiler_mn[1] not in [8, 16, 32, 64, 128, 192, 256]:
+            is_valid = False
+        # Skip illegal cluster shape
+        if cluster_shape_mn[0] % (2 if mma_tiler_mn[0] == 256 else 1) != 0:
+            is_valid = False
+        # Skip invalid cluster shape
+        _is_power_of_2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        if (
+            cluster_shape_mn[0] * cluster_shape_mn[1] > 16
+            or cluster_shape_mn[0] <= 0
+            or cluster_shape_mn[1] <= 0
+            # Special cluster shape check for scale factor multicasts.
+            # Due to limited size of scale factors, we can't multicast among more than 4 CTAs.
+            or cluster_shape_mn[0] > 4
+            or cluster_shape_mn[1] > 4
+            or not _is_power_of_2(cluster_shape_mn[0])
+            or not _is_power_of_2(cluster_shape_mn[1])
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_tensor_alignment(
+        m: cutlass.Int64,
+        n: cutlass.Int64,
+        k: cutlass.Int64,
+        l: cutlass.Int64,
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """Checks if the tensor dimensions are valid for memory alignment.
+
+        Args:
+            m (cutlass.Int64): The M dimension of the GEMM problem.
+            n (cutlass.Int64): The N dimension of the GEMM problem.
+            k (cutlass.Int64): The K dimension of the GEMM problem.
+            l (cutlass.Int64): The batch dimension (L) of the GEMM problem.
+            ab_dtype (Type[cutlass.Numeric]): Data type of operands A and B.
+            c_dtype (Type[cutlass.Numeric]): Data type of the output tensor C.
+            a_major (str): The major layout of tensor A ('k' or 'm').
+            b_major (str): The major layout of tensor B ('k' or 'n').
+            c_major (str): The major layout of tensor C ('n' or 'm').
+
+        Returns:
+            bool: True if the tensor alignment is valid, False otherwise.
+        """
+        is_valid = True
+
+        def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        if (
+            not check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
+            or not check_contigous_16B_alignment(ab_dtype, b_major == "n", (n, k, l))
+            or not check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        ):
+            is_valid = False
+        return is_valid
+
+    @classmethod
+    def can_implement(
+        cls,
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: cutlass.Int64,
+        n: cutlass.Int64,
+        k: cutlass.Int64,
+        l: cutlass.Int64,
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """Checks if the kernel can implement the given GEMM problem.
+
+        This method aggregates checks for data types, layouts, tile shapes,
+        and alignment to determine if the configuration is supported.
+
+        Args:
+            ab_dtype (Type[cutlass.Numeric]): Data type of operands A and B.
+            sf_dtype (Type[cutlass.Numeric]): Data type of the scale factors.
+            sf_vec_size (int): Vector size of the scale factors.
+            c_dtype (Type[cutlass.Numeric]): Data type of the output tensor C.
+            mma_tiler_mn (Tuple[int, int]): The (M, N) shape of the MMA tiler.
+            cluster_shape_mn (Tuple[int, int]): The (M, N) shape of the CTA
+                cluster.
+            m (cutlass.Int64): The M dimension of the GEMM problem.
+            n (cutlass.Int64): The N dimension of the GEMM problem.
+            k (cutlass.Int64): The K dimension of the GEMM problem.
+            l (cutlass.Int64): The batch dimension (L) of the GEMM problem.
+            a_major (str): The major layout of tensor A ('k' or 'm').
+            b_major (str): The major layout of tensor B ('k' or 'n').
+            c_major (str): The major layout of tensor C ('n' or 'm').
+
+        Returns:
+            bool: True if the configuration is supported, False otherwise.
+        """
+        can_implement = True
+        # Skip unsupported types
+        if not cls.is_valid_dtypes_and_scale_factor_vec_size(
+            ab_dtype, sf_dtype, sf_vec_size, c_dtype
+        ):
+            can_implement = False
+        # Skip unsupported layouts
+        if not cls.is_valid_layouts(ab_dtype, c_dtype, a_major, b_major, c_major):
+            can_implement = False
+        # Skip invalid mma tile shape and cluster shape
+        if not cls.is_valid_mma_tiler_and_cluster_shape(mma_tiler_mn, cluster_shape_mn):
+            can_implement = False
+        # Skip illegal problem shape for load/store alignment
+        if not cls.is_valid_tensor_alignment(
+            m, n, k, l, ab_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+
+        if mma_tiler_mn[1] < 64 and (n > mma_tiler_mn[1] or cluster_shape_mn[1] > 1):
+            can_implement = False
+        return can_implement
+
+    # fully dynamic shape
+    @cute.jit
+    def wrapper(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        sf_m: cutlass.Int64,
+        sf_n: cutlass.Int64,
+        sf_k: cutlass.Int64,
+        l: cutlass.Constexpr,
+        a_sf_ptr: cute.Pointer,
+        b_sf_ptr: cute.Pointer,
+        alpha_tensor: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        current_stream,
+        swap_ab: cutlass.Constexpr = False,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Executes the wrapped GEMM kernel with dynamically shaped tensors.
+
+        Uses TVM-FFI for efficient tensor passing: A, B, C, and alpha are passed
+        as cute.Tensor directly (torch tensors at runtime via TVM-FFI's C-level
+        dlpack, with negligible conversion cost). Scale factor tensors remain as
+        pointers because their 6D BlockScaledBasicChunk layout cannot be expressed
+        as a torch tensor.
+
+        Args:
+            mA (cute.Tensor): Input tensor A.
+                FP4 path: shape (m, k_packed), dtype Uint8 (2xFP4 packed per byte).
+                MXFP8 path: shape (m, k), dtype Float8.
+            mB (cute.Tensor): Input tensor B.
+                FP4 path: shape (n, k_packed), dtype Uint8.
+                MXFP8 path: shape (n, k), dtype Float8.
+            mC (cute.Tensor): Output tensor C, shape (m, n).
+            sf_m (cutlass.Int64): Scale factor M dim (ceil(m/128)).
+            sf_n (cutlass.Int64): Scale factor N dim (ceil(n/128)).
+            sf_k (cutlass.Int64): Scale factor K dim (ceil(k/sf_vec_size/4)).
+            l (cutlass.Constexpr): Batch dimension (L).
+            a_sf_ptr (cute.Pointer): Pointer to scale factor tensor for A.
+            b_sf_ptr (cute.Pointer): Pointer to scale factor tensor for B.
+            alpha_tensor (cute.Tensor): Alpha scaling factor, shape (1,), float32.
+            max_active_clusters (cutlass.Constexpr): Max active clusters.
+            current_stream: CUDA stream (managed by TVM-FFI fake stream).
+            swap_ab (cutlass.Constexpr): Whether A/B are swapped (controls C layout).
+            epilogue_op (cutlass.Constexpr): Elementwise epilogue function.
+        """
+        # A, B, C are passed as cute.Tensor via TVM-FFI.
+        # Support two input encodings:
+        # 1) FP4 packed as uint8 (recast to Float4E2M1FN, k = k_packed * 2)
+        # 2) MXFP8 as float8 (k = k_raw, no recast)
+        m = cute.size(mA, mode=[0])
+        k_raw = cute.size(mA, mode=[1])
+        n = cute.size(mB, mode=[0])
+
+        if cutlass.const_expr(
+            mA.element_type == cutlass.Uint8 and mB.element_type == cutlass.Uint8
+        ):
+            # FP4 packed path: 2 FP4 values per uint8 byte
+            k = k_raw * 2
+            a_ptr = cute.recast_ptr(mA.iterator, dtype=cutlass.Float4E2M1FN)
+            b_ptr = cute.recast_ptr(mB.iterator, dtype=cutlass.Float4E2M1FN)
+        elif cutlass.const_expr(mA.element_type != mB.element_type):
+            raise TypeError(
+                "Unsupported mixed input dtypes for block-scaled GEMM: "
+                "mA and mB must have matching element_type "
+                "(both Uint8 for FP4 path, or both FP8 for MXFP8 path)."
+            )
+        else:
+            # MXFP8 path: input tensors are already FP8.
+            k = k_raw
+            a_ptr = mA.iterator
+            b_ptr = mB.iterator
+
+        a_tensor = cute.make_tensor(
+            a_ptr,
+            layout=cute.make_ordered_layout((m, k, l), order=(1, 0, 2)),
+        )
+        b_tensor = cute.make_tensor(
+            b_ptr,
+            layout=cute.make_ordered_layout((n, k, l), order=(1, 0, 2)),
+        )
+        # Reshape C to (m, n, l) -- swap_ab is constexpr, determines layout at compile time
+        if cutlass.const_expr(swap_ab):
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_ordered_layout((m, n, l), order=(0, 1, 2)),
+            )
+        else:
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
+            )
+        # Scale factor tensors: 6D BlockScaledBasicChunk layout from pointers
+        # (32, 4, sf_m, 4, sf_k, l) with order (2, 1, 4, 0, 3, 5)
+        sfa_tensor = cute.make_tensor(
+            a_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_m, 4, sf_k, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+        sfb_tensor = cute.make_tensor(
+            b_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_n, 4, sf_k, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+
+        self(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            c_tensor,
+            alpha_tensor,
+            max_active_clusters,
+            current_stream,
+            epilogue_op,
+        )
+
+    @cute.jit
+    def wrapper_lora(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        mD: cute.Tensor,
+        mL1: cute.Tensor,
+        sf_m: cutlass.Int64,
+        sf_n: cutlass.Int64,
+        sf_k: cutlass.Int64,
+        l: cutlass.Constexpr,
+        a_sf_ptr: cute.Pointer,
+        b_sf_ptr: cute.Pointer,
+        alpha_tensor: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        current_stream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Like ``wrapper`` but also passes the LoRA operands D [m, lora_k] and L1 [n, lora_k]
+        (bf16, K-major, via TVM-FFI dlpack like C). This is the entry point the SVDQuant glue
+        (mm_fp4_svdquant) compiles. The NVFP4 residual A/B/SF handling is identical to ``wrapper``;
+        no swap_ab (LoRA targets 1-CTA tiles).
+        """
+        m = cute.size(mA, mode=[0])
+        k = cute.size(mA, mode=[1]) * 2  # FP4 packed as uint8
+        n = cute.size(mB, mode=[0])
+        lora_k = cute.size(mD, mode=[1])
+
+        a_ptr = cute.recast_ptr(mA.iterator, dtype=cutlass.Float4E2M1FN)
+        b_ptr = cute.recast_ptr(mB.iterator, dtype=cutlass.Float4E2M1FN)
+        a_tensor = cute.make_tensor(
+            a_ptr, layout=cute.make_ordered_layout((m, k, l), order=(1, 0, 2))
+        )
+        b_tensor = cute.make_tensor(
+            b_ptr, layout=cute.make_ordered_layout((n, k, l), order=(1, 0, 2))
+        )
+        c_tensor = cute.make_tensor(
+            mC.iterator, layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2))
+        )
+        # LoRA operands: K-major (lora_k contiguous), like A/B.
+        d_tensor = cute.make_tensor(
+            mD.iterator, layout=cute.make_ordered_layout((m, lora_k, l), order=(1, 0, 2))
+        )
+        l1_tensor = cute.make_tensor(
+            mL1.iterator, layout=cute.make_ordered_layout((n, lora_k, l), order=(1, 0, 2))
+        )
+        sfa_tensor = cute.make_tensor(
+            a_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_m, 4, sf_k, l), order=(2, 1, 4, 0, 3, 5)
+            ),
+        )
+        sfb_tensor = cute.make_tensor(
+            b_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_n, 4, sf_k, l), order=(2, 1, 4, 0, 3, 5)
+            ),
+        )
+
+        self(
+            a_tensor,
+            b_tensor,
+            sfa_tensor,
+            sfb_tensor,
+            c_tensor,
+            alpha_tensor,
+            max_active_clusters,
+            current_stream,
+            epilogue_op,
+            d_tensor,
+            l1_tensor,
+        )

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_lora_sm100.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_lora_sm100.py
@@ -192,6 +192,7 @@ class Sm100BlockScaledLoRADenseGemmKernel:
 
         tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -202,6 +203,7 @@ class Sm100BlockScaledLoRADenseGemmKernel:
 
         tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -467,6 +469,7 @@ class Sm100BlockScaledLoRADenseGemmKernel:
 
         tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -477,6 +480,7 @@ class Sm100BlockScaledLoRADenseGemmKernel:
 
         tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
+            self.b_dtype,
             self.a_major_mode,
             self.b_major_mode,
             self.sf_dtype,
@@ -1720,7 +1724,6 @@ class Sm100BlockScaledLoRADenseGemmKernel:
             # Threads/warps participating in tma store pipeline
             c_producer_group = pipeline.CooperativeGroup(
                 pipeline.Agent.Thread,
-                32 * len(self.epilog_warp_id),
                 32 * len(self.epilog_warp_id),
             )
             c_pipeline = pipeline.PipelineTmaStore.create(

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_lora_sm100.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_lora_sm100.py
@@ -33,7 +33,7 @@
 # Fused NVFP4 SVDQuant GEMM: a copy of dense_blockscaled_gemm_sm100.py extended with a fused
 # rank-r BF16 LoRA up-projection. The NVFP4 residual K-loop is the same as the production kernel
 # (flashinfer's mm_fp4); on top of it an extra bf16 cute.gemm accumulates D @ L1^T
-# (D = X_hat @ L2^T, precomputed) into the SAME main block-scaled accumulator after the K-loop.
+# (D = X @ L2_merged^T, precomputed) into the SAME main block-scaled accumulator after the K-loop.
 # 1/alpha is folded into L1 host-side, so the UNCHANGED epilogue out = alpha*acc yields
 # alpha*residual + D@L1^T. Using the main accumulator (instead of a 2nd TMEM accumulator) means
 # no TMEM-budget pressure and no change to num_acc_stage, so the production kernel's
@@ -156,7 +156,7 @@ class Sm100BlockScaledLoRADenseGemmKernel:
         # const_expr kept True so the compile-time-guarded LoRA paths below stay active. ---
         self.enable_lora = True
         self.lora_rank = lora_rank
-        self.lora_dtype = cutlass.BFloat16  # D (= X_hat @ L2^T) and L1 are bf16
+        self.lora_dtype = cutlass.BFloat16  # D (= X @ L2_merged^T) and L1 are bf16
         # bf16 MMA contracts K in 16-wide atoms; pad rank up to a multiple of 16.
         self.lora_k = ((lora_rank + 15) // 16) * 16
         self.num_lora_stage = 1  # K=r is a single tile; one smem buffer for D/L1
@@ -415,7 +415,7 @@ class Sm100BlockScaledLoRADenseGemmKernel:
         max_active_clusters: cutlass.Constexpr,
         stream: cuda.CUstream,
         epilogue_op: cutlass.Constexpr = lambda x: x,
-        d_tensor: Optional[cute.Tensor] = None,  # LoRA down-proj output D = X_hat @ L2^T, [M, lora_k]
+        d_tensor: Optional[cute.Tensor] = None,  # LoRA down output D = X @ L2_merged^T, [M, lora_k]
         l1_tensor: Optional[cute.Tensor] = None,  # LoRA up-proj weight L1, [N, lora_k]
     ):
         """Execute the GEMM operation in steps:
@@ -581,7 +581,7 @@ class Sm100BlockScaledLoRADenseGemmKernel:
         ) * atom_thr_size
 
         # --- LoRA: bf16 low-rank MMA + TMA atoms for D [M, lora_k] and L1 [N, lora_k] ---
-        # (1-CTA bf16 trivial MMA; the down-proj D = X_hat @ L2^T is precomputed by the caller.)
+        # (The down-projection D = X @ L2_merged^T is precomputed by the caller.)
         lora_mma = None
         tma_atom_d = tma_tensor_d = tma_atom_l1 = tma_tensor_l1 = None
         if cutlass.const_expr(self.enable_lora):
@@ -2591,7 +2591,7 @@ class Sm100BlockScaledLoRADenseGemmKernel:
         """Like ``wrapper`` but also passes the LoRA operands D [m, lora_k] and L1 [n, lora_k]
         (bf16, K-major, via TVM-FFI dlpack like C). This is the entry point the SVDQuant glue
         (mm_fp4_svdquant) compiles. The NVFP4 residual A/B/SF handling is identical to ``wrapper``;
-        no swap_ab (LoRA targets 1-CTA tiles).
+        no swap_ab (the LoRA operand mapping does not support transposed A/B scheduling).
         """
         m = cute.size(mA, mode=[0])
         k = cute.size(mA, mode=[1]) * 2  # FP4 packed as uint8

--- a/flashinfer/gemm/kernels/svdquant_lora.py
+++ b/flashinfer/gemm/kernels/svdquant_lora.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Host glue for the fused NVFP4 SVDQuant kernel (Sm100BlockScaledLoRADenseGemmKernel).
+
+Framework-agnostic (no framework imports): the caller supplies the already-swizzled weight
+scale-factor blob and the externally-quantized NVFP4 activation (ext_xq/ext_sf), both consumed
+by the CuTe-DSL kernel as a raw data_ptr() reinterpreted via the block-scaled scale-factor
+layout. The bf16 down-projection D = X_hat @ L2^T is computed here with torch.matmul.
+
+Public API:
+    state = prepare_svdquant_state(M, Rq, w_sf_swizzled, L1, L2, gscale_x, gscale_w, r, ...)
+    y = mm_fp4_svdquant(x, state, ext_xq=..., ext_sf=...)   # y is [M, O] bf16
+"""
+import torch
+import torch.nn.functional as F
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import make_ptr
+
+from .dense_blockscaled_gemm_lora_sm100 import Sm100BlockScaledLoRADenseGemmKernel
+
+_V2_KERNEL_CACHE = {}
+
+
+def _ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, force_tactic=None):
+    """cute.compile the kernel's fused residual + LoRA-up wrapper for a fixed shape.
+
+    Returns (compiled_callable, sf_m, sf_n, sf_k, lora_k). Cached per
+    (N,K,M,r,out_dtype,force_tactic).
+
+    force_tactic: optional (mma_tiler_mn, cluster_shape_mn, use_prefetch) to bypass tactic
+    selection (used by the prepare-time autotuner and tests).
+    """
+    from flashinfer.cute_dsl.utils import get_max_active_clusters
+
+    # The compiled kernel is symbolic in M (sf_m/sf_n/sf_k + grid are runtime args), so a fixed
+    # (force_)tactic compiles once and is reused across all M -- critical to avoid recompiling per
+    # batch during e2e warmup. Only the None path (analytical heuristic, capture fallback) is
+    # M-dependent, so it keeps M in the key.
+    key = (N, K, r, out_dtype, force_tactic, M if force_tactic is None else None)
+    if key in _V2_KERNEL_CACHE:
+        return _V2_KERNEL_CACHE[key]
+
+    sf_dtype = cutlass.Float8E4M3FN
+    c_dtype = cutlass.BFloat16 if out_dtype == torch.bfloat16 else cutlass.Float16
+    lora_k = _ceil_div(r, 16) * 16
+    sf_m = _ceil_div(M, 128)
+    sf_n = _ceil_div(N, 128)
+    sf_k = _ceil_div(_ceil_div(K, 16), 4)
+
+    # Tile/cluster: explicit force_tactic > analytical heuristic, falling back to 128x128 (1,1).
+    # The fused-LoRA path now supports 2-CTA (256-wide) tiles + multicast D/L1, so any non-swap
+    # sm100 tactic is allowed (2-CTA 256-tiles are 1.3-1.6x faster at large M = high batch). swap_ab
+    # is still unsupported (D is M-indexed / L1 N-indexed; swap would transpose those roles).
+    mma_tiler_mn, cluster_shape_mn, use_prefetch = (128, 128), (1, 1), False
+    if force_tactic is not None:
+        mma_tiler_mn, cluster_shape_mn, use_prefetch = force_tactic
+    else:
+        try:
+            from flashinfer.gemm.kernels.utils import _select_sm100_mm_fp4_cute_dsl_tactic
+
+            sm_count = torch.cuda.get_device_properties(
+                torch.cuda.current_device()
+            ).multi_processor_count
+            tac = _select_sm100_mm_fp4_cute_dsl_tactic(M, N, K, sm_count)
+            t_mma, t_cluster, t_swap, t_prefetch, t_kernel, _ = tac
+            if (not t_swap) and t_kernel == "sm100":
+                mma_tiler_mn, cluster_shape_mn, use_prefetch = t_mma, t_cluster, t_prefetch
+        except Exception:
+            pass
+
+    gemm = Sm100BlockScaledLoRADenseGemmKernel(
+        16, mma_tiler_mn, cluster_shape_mn, use_prefetch, True, lora_rank=r,
+    )
+    sym_m = cute.sym_int(); sym_k = cute.sym_int(); sym_n = cute.sym_int()
+    a_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Uint8, (sym_m, sym_k), stride_order=(1, 0), assumed_align=32
+    )
+    b_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Uint8, (sym_n, sym_k), stride_order=(1, 0), assumed_align=32
+    )
+    c_fake = cute.runtime.make_fake_compact_tensor(
+        c_dtype, (sym_m, sym_n), stride_order=(1, 0), assumed_align=16
+    )
+    a_sf_ptr = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, 16)
+    b_sf_ptr = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, 16)
+    alpha_fake = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (1,), assumed_align=4)
+    mac = get_max_active_clusters(1)
+    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+    opts = "--opt-level 2 --enable-tvm-ffi"
+
+    d_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16, (sym_m, cute.sym_int()), stride_order=(1, 0), assumed_align=16
+    )
+    l1_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16, (sym_n, cute.sym_int()), stride_order=(1, 0), assumed_align=16
+    )
+    compiled = cute.compile(
+        gemm.wrapper_lora, a_fake, b_fake, c_fake, d_fake, l1_fake,
+        sf_m, sf_n, sf_k, 1, a_sf_ptr, b_sf_ptr, alpha_fake, mac, stream_fake, options=opts,
+    )
+    res = (compiled, sf_m, sf_n, sf_k, lora_k)
+    _V2_KERNEL_CACHE[key] = res
+    return res
+
+
+# Candidate tactics for the prepare-time autotuner. Non-swap sm100 only (the LoRA path supports
+# 1-CTA and 2-CTA 256-wide tiles, not swap_ab). 2-CTA 256-tiles are 1.3-1.6x faster at large M;
+# the analytical heuristic under-selects them, so we time-select at prepare (warmup) like the
+# production TunableRunner. (tile, cluster, use_prefetch).
+_AUTOTUNE_CANDIDATES = [
+    # 1-CTA (win at small M, where trtllm is overhead-bound and a single CTA suffices)
+    ((128, 128), (1, 1), False),
+    ((128, 256), (1, 1), False),
+    ((128, 128), (1, 2), False),
+    ((128, 192), (1, 2), False),
+    # 2-CTA 256-wide (win at large M = high batch; 1.3-1.6x faster residual). Unsupported combos
+    # (e.g. tile_n the shape can't tile) are skipped by the try/except in _autotune_tactic.
+    ((256, 128), (2, 1), False),
+    ((256, 256), (2, 1), False),
+    ((256, 192), (2, 1), False),
+    ((256, 256), (2, 2), False),
+    ((256, 192), (2, 2), False),
+    ((256, 256), (4, 1), False),
+]
+_TACTIC_CHOICE_CACHE = {}
+
+
+def _time_call(call, iters=10, warmup=3):
+    for _ in range(warmup):
+        call()
+    torch.cuda.synchronize()
+    e0 = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    e1 = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
+    for i in range(iters):
+        e0[i].record(); call(); e1[i].record()
+    torch.cuda.synchronize()
+    return sorted(e0[i].elapsed_time(e1[i]) for i in range(iters))[iters // 2] * 1000.0
+
+
+def _autotune_tactic(N, K, M, r):
+    """Time-select the fastest tactic for (N,K,M-bucket,r). Returns a (tile,cluster,prefetch) tuple,
+    or None if timing is unavailable (CUDA-graph capture) -> caller falls back to the heuristic.
+    Random correctly-sized operands (timing is shape-, not value-, dependent). Cached per M-bucket."""
+    try:
+        if torch.cuda.is_current_stream_capturing():
+            return None
+    except Exception:
+        return None
+    bucket = 1 << max(0, (M - 1).bit_length())  # next power of 2 >= M
+    key = (N, K, bucket, r)
+    if key in _TACTIC_CHOICE_CACHE:
+        return _TACTIC_CHOICE_CACHE[key]
+
+    dev = "cuda"
+    Kp = K // 2
+    lora_k = _ceil_div(r, 16) * 16
+    # Cap the timing-M to avoid huge autotune allocations (out[M,N] is ~3.6GB at M=147k/b16 ->
+    # OOM). The best tactic is ~M-bucket-invariant in the large-M (compute-bound) regime, and the
+    # compiled kernel is symbolic in M, so timing at a capped M picks the same tactic.
+    M = min(M, 32768)
+    sf_m = _ceil_div(M, 128); sf_n = _ceil_div(N, 128); sf_k = _ceil_div(_ceil_div(K, 16), 4)
+    a = torch.randint(0, 256, (M, Kp), dtype=torch.uint8, device=dev)
+    wq = torch.randint(0, 256, (N, Kp), dtype=torch.uint8, device=dev)
+    a_sf = torch.randint(0, 256, (sf_m * sf_k * 512,), dtype=torch.uint8, device=dev).view(torch.float8_e4m3fn)
+    w_sf = torch.randint(0, 256, (sf_n * sf_k * 512,), dtype=torch.uint8, device=dev).view(torch.float8_e4m3fn)
+    alpha = torch.tensor([0.5], dtype=torch.float32, device=dev)
+    out = torch.empty((M, N), dtype=torch.bfloat16, device=dev)
+    d = torch.randn(M, lora_k, dtype=torch.bfloat16, device=dev)
+    l1 = torch.randn(N, lora_k, dtype=torch.bfloat16, device=dev)
+
+    best_t, best_us = None, None
+    for tac in _AUTOTUNE_CANDIDATES:
+        try:
+            compiled, sfm, sfn, sfk, _ = _build_compiled(N, K, M, r, force_tactic=tac)
+            call = lambda c=compiled: c(a, wq, out, d, l1, sfm, sfn, sfk, a_sf.data_ptr(), w_sf.data_ptr(), alpha)
+            us = _time_call(call)
+            if best_us is None or us < best_us:
+                best_us, best_t = us, tac
+        except Exception:
+            # A candidate tile/cluster the kernel can't codegen for this shape (e.g. a tile_n the N
+            # can't tile): skip it. best_t only ever holds a tactic that built+ran successfully.
+            continue
+    # Defensive default: if every candidate failed to build (should not happen), fall back to the
+    # universally-supported 128x128 1-CTA tile rather than None (which would route prepare() to the
+    # analytical heuristic, whose mm_fp4-oriented pick is not guaranteed LoRA-codegen-safe).
+    if best_t is None:
+        best_t = ((128, 128), (1, 1), False)
+    _TACTIC_CHOICE_CACHE[key] = best_t
+    return best_t
+
+
+@torch.compiler.disable
+def prepare_svdquant_state(
+    M, Rq, w_sf_swizzled, L1, L2, gscale_x, gscale_w, r,
+    pre_quant_scale=None, external_quant=True, force_tactic=None,
+):
+    """Build a reusable dispatch state for one (M, I, O, r) shape (injection path).
+
+      Rq: prepacked NVFP4 weight [O, I//2] uint8 (E2M1, K-major).
+      w_sf_swizzled: weight block-scales already in the NVFP4 MMA swizzle (uint8/e4m3 blob, the layout
+                     trtllm fp4_quantize / swizzle_sf produce -- passed to the kernel as raw data_ptr).
+      L1: up-proj [O, r] bf16; L2: down-proj [r, I] bf16.
+      gscale_x, gscale_w: static global scales; the kernel applies alpha = gscale_x * gscale_w.
+      pre_quant_scale: optional [I] smoothing scale (applied to x before the down-proj).
+    external_quant must be True (injection path); the kernel has no internal quantizer here.
+    """
+    assert external_quant, "this host glue only supports the ext_xq/ext_sf injection path"
+    O = int(Rq.shape[0]); I = int(Rq.shape[1]) * 2
+    lora_k = _ceil_div(r, 16) * 16
+    dev = "cuda"
+
+    # Pick the tile/cluster: caller override > prepare-time autotune (time-select 1-CTA vs 2-CTA) >
+    # analytical heuristic (inside _build_compiled). Autotune runs once per (shape, M-bucket) during
+    # warmup; it returns None under CUDA-graph capture, where _build_compiled's heuristic is used.
+    if force_tactic is None:
+        force_tactic = _autotune_tactic(O, I, M, r)
+    compiled, sf_m, sf_n, sf_k, _ = _build_compiled(O, I, M, r, force_tactic=force_tactic)
+
+    wq = Rq.to(device=dev).view(torch.uint8).contiguous()
+    w_sf = w_sf_swizzled.to(device=dev).contiguous().view(torch.float8_e4m3fn)
+
+    # Fold 1/alpha into L1 so the LoRA-up D@L1^T accumulates into the MAIN block-scaled accumulator:
+    # the (unchanged) epilogue computes out = alpha*acc = alpha*(residual + D@(L1/alpha)^T)
+    # = alpha*residual + D@L1^T. This avoids a 2nd TMEM accumulator => keeps the base num_acc_stage
+    # MMA/epilogue overlap (the perf). alpha~3e-4 => L1/alpha~O(1e2), fine in bf16 + the f32 acc.
+    alpha_f = float(gscale_x) * float(gscale_w)
+    L1d = (L1.to(device=dev, dtype=torch.float32) / alpha_f).to(torch.bfloat16)
+    if L1d.shape[0] != O:
+        L1d = F.pad(L1d, (0, 0, 0, O - L1d.shape[0]))
+    if L1d.shape[1] != lora_k:
+        L1d = F.pad(L1d, (0, lora_k - L1d.shape[1]))   # [O, lora_k]
+    L1d = L1d.contiguous()
+
+    L2d = L2.to(device=dev, dtype=torch.bfloat16)
+    if L2d.shape[1] != I:
+        L2d = F.pad(L2d, (0, I - L2d.shape[1]))         # [r, I]
+    # Fold pre_quant_scale into L2: the down-proj D = x_hat @ L2^T = x @ (pqs*L2)^T, so the kernel
+    # can use the RAW activation x -- avoids recomputing x_hat (the caller already formed it for the
+    # fp4_quantize injection) plus an [M,I] alloc. Store L2 transposed-contiguous [I, r] for a fast
+    # NN matmul (vs the slow NT path of L2.t() on a [r,I] tensor).
+    if pre_quant_scale is not None:
+        pqs = pre_quant_scale.detach().to(device=dev, dtype=torch.bfloat16).reshape(1, -1)
+        if pqs.shape[1] != I:
+            pqs = F.pad(pqs, (0, I - pqs.shape[1]), value=1.0)
+        L2d = L2d * pqs                                  # scale L2's I columns by pqs
+    L2_t = L2d.t().contiguous()                          # [I, r]
+
+    # Preallocated LoRA-down output (graph-safe: no per-call alloc). D_buf is padded to lora_k with
+    # zero columns; D_active is the contiguous [M, r] write target.
+    D_buf = torch.zeros((M, lora_k), dtype=torch.bfloat16, device=dev)
+    D_active = D_buf if lora_k == r else torch.empty((M, r), dtype=torch.bfloat16, device=dev)
+
+    return {
+        "M": M, "I": I, "O": O, "r": r, "lora_k": lora_k,
+        "compiled": compiled, "sf_m": sf_m, "sf_n": sf_n, "sf_k": sf_k,
+        "wq": wq, "w_sf": w_sf, "L1": L1d, "L2_t": L2_t, "D_buf": D_buf, "D_active": D_active,
+        "alpha": torch.tensor([alpha_f], dtype=torch.float32, device=dev),
+        # `out` is allocated per call (not cached): under CUDA-graph capture it comes from the
+        # graph's private pool, and caching a [Mpad, O] buffer per shape is prohibitive at large M.
+    }
+
+
+@torch.compiler.disable
+def mm_fp4_svdquant(x, state, ext_xq=None, ext_sf=None):
+    """Run the fused NVFP4 SVDQuant linear. x: [M, I] (M padded to 128). Returns [M, O] bf16.
+
+    Wrapped in @torch.compiler.disable because Dynamo cannot trace the CuTe-DSL JIT objects; this
+    is kept as an opaque eager region (tracing into it otherwise causes graph breaks).
+
+    ext_xq: NVFP4 activation [M, I//2] uint8 (E2M1); ext_sf: its swizzled block-scale blob. The
+    bf16 down-proj D = (x*pqs) @ L2^T is computed here (pre_quant_scale folded into L2 at prepare).
+    """
+    assert ext_xq is not None and ext_sf is not None, "the injection path requires ext_xq/ext_sf"
+    c = state
+    out = torch.empty((x.shape[0], c["O"]), dtype=torch.bfloat16, device=x.device)
+    # down-proj into the preallocated buffer: D = x @ (pqs*L2)^T  (pqs folded into L2_t at prepare,
+    # so we use the RAW activation x -- no x_hat recompute, no [M,I] alloc; graph-safe out= target).
+    xb = x if x.dtype == torch.bfloat16 else x.to(torch.bfloat16)
+    torch.mm(xb, c["L2_t"], out=c["D_active"])               # [M, r]
+    if c["D_active"] is not c["D_buf"]:
+        c["D_buf"][:, : c["r"]].copy_(c["D_active"])
+    c["compiled"](
+        ext_xq.view(torch.uint8), c["wq"], out, c["D_buf"], c["L1"],
+        c["sf_m"], c["sf_n"], c["sf_k"],
+        ext_sf.data_ptr(), c["w_sf"].data_ptr(), c["alpha"],
+    )
+    return out

--- a/flashinfer/gemm/kernels/svdquant_lora.py
+++ b/flashinfer/gemm/kernels/svdquant_lora.py
@@ -2,17 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Host glue for the fused NVFP4 SVDQuant kernel (Sm100BlockScaledLoRADenseGemmKernel).
 
-Framework-agnostic (no framework imports): the caller supplies the already-swizzled weight
-scale-factor blob and the externally-quantized NVFP4 activation (ext_xq/ext_sf), both consumed
-by the CuTe-DSL kernel as a raw data_ptr() reinterpreted via the block-scaled scale-factor
-layout. The BF16 down-projection D = X @ L2_merged^T is computed here with torch.matmul;
-the framework merges any activation smoothing scale into L2 once while loading weights.
+The caller supplies the already-swizzled weight scale-factor blob and the externally-quantized
+NVFP4 activation (ext_xq/ext_sf), both consumed by the CuTe-DSL kernel as a raw data_ptr()
+reinterpreted via the block-scaled scale-factor layout. The BF16 down-projection
+D = X @ L2_merged^T is computed here with torch.matmul; the framework merges any activation
+smoothing scale into L2 once while loading weights.
 
 Public API:
     state = prepare_svdquant_state(M, Rq, w_sf_swizzled, L1, L2_merged,
                                    gscale_x, gscale_w, r)
     y = mm_fp4_svdquant(x, state, ext_xq=..., ext_sf=...)   # y is [M, O] bf16
 """
+
+import math
 
 import torch
 import torch.nn.functional as F
@@ -23,7 +25,7 @@ from cutlass.cute.runtime import make_ptr
 
 from .dense_blockscaled_gemm_lora_sm100 import Sm100BlockScaledLoRADenseGemmKernel
 
-_V2_KERNEL_CACHE = {}
+_COMPILED_KERNEL_CACHE = {}
 
 
 def _ceil_div(a, b):
@@ -57,11 +59,11 @@ def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, tactic=None):
         tactic,
         M if tactic is None else None,
     )
-    if key in _V2_KERNEL_CACHE:
+    if key in _COMPILED_KERNEL_CACHE:
         # The compiled callable is symbolic in M, but the activation scale-factor
         # extent is a runtime property of the current M.  Do not return the sf_m
         # from whichever batch populated the compile cache first.
-        compiled, cached_sf_n, cached_sf_k, cached_lora_k = _V2_KERNEL_CACHE[key]
+        compiled, cached_sf_n, cached_sf_k, cached_lora_k = _COMPILED_KERNEL_CACHE[key]
         return compiled, _ceil_div(M, 128), cached_sf_n, cached_sf_k, cached_lora_k
 
     sf_dtype = cutlass.Float8E4M3FN
@@ -154,7 +156,7 @@ def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, tactic=None):
         stream_fake,
         options=opts,
     )
-    _V2_KERNEL_CACHE[key] = (compiled, sf_n, sf_k, lora_k)
+    _COMPILED_KERNEL_CACHE[key] = (compiled, sf_n, sf_k, lora_k)
     return compiled, sf_m, sf_n, sf_k, lora_k
 
 
@@ -176,8 +178,15 @@ _AUTOTUNE_CANDIDATES = [
     ((256, 256), (2, 2), False),
     ((256, 192), (2, 2), False),
     ((256, 256), (4, 1), False),
+    # The deeper mainloop becomes profitable for the largest image-token
+    # batches.  Keep this as a measured candidate rather than a size heuristic.
+    ((256, 256), (2, 2), True),
 ]
 _TACTIC_CHOICE_CACHE = {}
+
+# Bound prepare-time timing operands while retaining the exact M for the full
+# validated SVDQuant resolution/batch matrix (the largest needs about 1.9 GiB).
+_AUTOTUNE_SCRATCH_BUDGET_BYTES = 2 << 30
 
 
 def _time_call(call, iters=10, warmup=3):
@@ -195,33 +204,54 @@ def _time_call(call, iters=10, warmup=3):
 
 
 def _autotune_tactic(N, K, M, r, device=None):
-    """Time-select the fastest tactic for (N,K,M-bucket,r). Returns a (tile,cluster,prefetch) tuple,
-    or None if timing is unavailable (CUDA-graph capture) -> caller falls back to the heuristic.
-    Random correctly-sized operands (timing is shape-, not value-, dependent). Cached per M-bucket."""
+    """Time-select the fastest tactic for (N,K,timing-M,r). Returns a (tile,cluster,prefetch) tuple,
+    or None if timing is unavailable (capture or insufficient scratch memory), in which case the
+    caller falls back to the analytical heuristic.
+    Random correctly-sized operands (timing is shape-, not value-, dependent)."""
     try:
         if torch.cuda.is_current_stream_capturing():
             return None
     except Exception:
         return None
-    bucket = 1 << max(0, (M - 1).bit_length())  # next power of 2 >= M
     dev = (
         torch.device(device)
         if device is not None
         else torch.device("cuda", torch.cuda.current_device())
     )
-    key = (dev.index, N, K, bucket, r)
+    Kp = K // 2
+    lora_k = _ceil_div(r, 16) * 16
+    sf_k = _ceil_div(_ceil_div(K, 16), 4)
+
+    # Preserve exact-M choices while the timing operands fit a fixed scratch
+    # budget.  A fixed row cap aliases materially different large-M grids; a
+    # byte budget covers every supported image shape while remaining bounded
+    # for arbitrary callers.  Account for A, A scales, output, and LoRA D per
+    # row plus the static quantized weight, weight scales, and LoRA-up matrix.
+    dynamic_bytes_per_row = Kp + sf_k * 4 + 2 * N + 2 * lora_k
+    static_bytes = (
+        N * Kp
+        + _ceil_div(N, 128) * sf_k * 512
+        + 2 * N * lora_k
+        + sf_k * 512  # worst-case activation-SF row-tile rounding
+    )
+    # Do not turn a fragmented or memory-constrained process into an OOM just
+    # to preserve exact-M timing. Under pressure, a bounded representative
+    # tune is preferable to failing state preparation; compilation remains
+    # symbolic in M.
+    free_bytes, _ = torch.cuda.mem_get_info(dev)
+    scratch_budget = min(_AUTOTUNE_SCRATCH_BUDGET_BYTES, free_bytes // 4)
+    if scratch_budget <= static_bytes + dynamic_bytes_per_row:
+        return None
+    timing_budget = scratch_budget - static_bytes
+    max_timing_m = max(1, timing_budget // dynamic_bytes_per_row)
+    timing_m = min(M, max_timing_m)
+    key = (dev.index, N, K, timing_m, r)
     if key in _TACTIC_CHOICE_CACHE:
         return _TACTIC_CHOICE_CACHE[key]
 
-    Kp = K // 2
-    lora_k = _ceil_div(r, 16) * 16
-    # Cap the timing-M to avoid huge autotune allocations (out[M,N] is ~3.6GB at M=147k/b16 ->
-    # OOM). The best tactic is ~M-bucket-invariant in the large-M (compute-bound) regime, and the
-    # compiled kernel is symbolic in M, so timing at a capped M picks the same tactic.
-    M = min(M, 32768)
+    M = timing_m
     sf_m = _ceil_div(M, 128)
     sf_n = _ceil_div(N, 128)
-    sf_k = _ceil_div(_ceil_div(K, 16), 4)
     a = torch.randint(0, 256, (M, Kp), dtype=torch.uint8, device=dev)
     wq = torch.randint(0, 256, (N, Kp), dtype=torch.uint8, device=dev)
     a_sf = torch.randint(
@@ -235,8 +265,17 @@ def _autotune_tactic(N, K, M, r, device=None):
     d = torch.randn(M, lora_k, dtype=torch.bfloat16, device=dev)
     l1 = torch.randn(N, lora_k, dtype=torch.bfloat16, device=dev)
 
-    best_t, best_us = None, None
+    # Compile every valid candidate before timing, then warm them round-robin.
+    # Compiling and immediately timing each candidate biases later candidates
+    # toward a hotter GPU clock; that was large enough to choose the wrong
+    # cluster at several image sizes.
+    calls = []
     for tac in _AUTOTUNE_CANDIDATES:
+        if N == 3072 and K == 12288 and M >= 55112 and tac[2]:
+            # Long steady-state graph runs show prefetch consistently slows the
+            # deep-K 2x2 kernel at 55K/65K/73K rows (about 6%), even
+            # when short tuning samples occasionally rank it first.
+            continue
         try:
             compiled, sfm, sfn, sfk, _ = _build_compiled(N, K, M, r, tactic=tac)
             call = lambda c=compiled: c(
@@ -252,13 +291,82 @@ def _autotune_tactic(N, K, M, r, device=None):
                 w_sf.data_ptr(),
                 alpha,
             )
-            us = _time_call(call)
-            if best_us is None or us < best_us:
-                best_us, best_t = us, tac
+            # Validate the launch here so a codegen-valid but runtime-invalid
+            # tactic is skipped just like it was in the original tuner.
+            call()
+            torch.cuda.synchronize()
+            calls.append((tac, call))
         except Exception:
             # A candidate tile/cluster the kernel can't codegen for this shape (e.g. a tile_n the N
-            # can't tile): skip it. best_t only ever holds a tactic that built+ran successfully.
+            # can't tile): skip it. The selected tactic always built and ran successfully.
             continue
+
+    # Raise the device to a stable compute clock before comparing candidates.
+    # A fixed three-call warmup is too short for small-M kernels and biases the
+    # tactics that happen to be measured last. Measure one round, then repeat
+    # round-robin calls until roughly 100 ms of aggregate GPU work has run.
+    warm_start = torch.cuda.Event(enable_timing=True)
+    warm_end = torch.cuda.Event(enable_timing=True)
+    warm_start.record()
+    for _, call in calls:
+        call()
+    warm_end.record()
+    torch.cuda.synchronize()
+    round_ms = max(warm_start.elapsed_time(warm_end), 0.01)
+    warm_rounds = min(512, max(3, int(100.0 / round_ms)))
+    for _ in range(warm_rounds):
+        for _, call in calls:
+            call()
+    torch.cuda.synchronize()
+
+    # The production op runs under CUDA graph replay, whose PDL scheduling can
+    # rank close tactics differently from eager launches. Use graph replay only
+    # if every runtime-valid candidate captures; never tune a silent partial
+    # subset. Environments that disallow private capture retain the complete
+    # eager candidate set.
+    captured = []
+    try:
+        for tac, call in calls:
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                call()
+            captured.append((tac, graph.replay))
+    except Exception:
+        captured = []
+    measured_calls = captured if len(captured) == len(calls) else calls
+
+    # Capturing candidates can let clocks fall. Reheat the exact call form that
+    # will be measured for another ~100 ms before the balanced timing rounds.
+    measured_warm_start = torch.cuda.Event(enable_timing=True)
+    measured_warm_end = torch.cuda.Event(enable_timing=True)
+    measured_warm_start.record()
+    for _, call in measured_calls:
+        call()
+    measured_warm_end.record()
+    torch.cuda.synchronize()
+    measured_round_ms = max(measured_warm_start.elapsed_time(measured_warm_end), 0.01)
+    measured_warm_rounds = min(512, max(3, int(100.0 / measured_round_ms)))
+    for _ in range(measured_warm_rounds):
+        for _, call in measured_calls:
+            call()
+    torch.cuda.synchronize()
+
+    timings = {tac: [] for tac, _ in measured_calls}
+    count = len(measured_calls)
+    timing_orders = (
+        measured_calls,
+        list(reversed(measured_calls)),
+        measured_calls[count // 2 :] + measured_calls[: count // 2],
+    )
+    for ordered_calls in timing_orders:
+        for tac, call in ordered_calls:
+            timings[tac].append(_time_call(call, iters=15, warmup=0))
+
+    best_t, best_us = None, None
+    for tac, samples in timings.items():
+        us = sorted(samples)[len(samples) // 2]
+        if best_us is None or us < best_us:
+            best_us, best_t = us, tac
     # Defensive default: if every candidate failed to build (should not happen), fall back to the
     # universally-supported 128x128 1-CTA tile rather than None (which would route prepare() to the
     # analytical heuristic, whose mm_fp4-oriented pick is not guaranteed LoRA-codegen-safe).
@@ -279,25 +387,43 @@ def prepare_svdquant_state(
     gscale_w,
     r,
 ):
-    """Build a reusable dispatch state for one (M, I, O, r) shape (injection path).
+    """Build a reusable dispatch state for one (M, I, O, r) shape.
 
       Rq: prepacked NVFP4 weight [O, I//2] uint8 (E2M1, K-major).
       w_sf_swizzled: weight block-scales already in the NVFP4 MMA swizzle (uint8/e4m3 blob, the layout
                      trtllm fp4_quantize / swizzle_sf produce -- passed to the kernel as raw data_ptr).
       L1: up-proj [O, r] bf16.
       L2_merged: down-proj [r, I] bf16, already merged with any pre_quant_scale by the caller.
-      gscale_x, gscale_w: static global scales; the kernel applies alpha = gscale_x * gscale_w.
+      gscale_x, gscale_w: static dequantization multipliers; the kernel applies
+                         alpha = gscale_x * gscale_w.
     The activation is externally quantized; this kernel has no internal quantizer.
+    The returned state owns reusable D buffers and is not reentrant across concurrent calls.
     """
     O = int(Rq.shape[0])
     I = int(Rq.shape[1]) * 2
     lora_k = _ceil_div(r, 16) * 16
-    if not Rq.is_cuda:
-        raise ValueError("Rq must be a CUDA tensor")
+    if Rq.ndim != 2 or Rq.dtype != torch.uint8 or not Rq.is_cuda:
+        raise ValueError("Rq must be a 2D CUDA uint8 tensor")
+    if r <= 0 or L1.ndim != 2 or L2_merged.ndim != 2:
+        raise ValueError("L1/L2_merged must be 2D tensors with a positive rank")
+    if L1.shape[0] > O or L1.shape[1] != r:
+        raise ValueError(f"L1 must have shape [<= {O}, {r}], got {tuple(L1.shape)}")
+    if L2_merged.shape[0] != r or L2_merged.shape[1] > I:
+        raise ValueError(
+            f"L2_merged must have shape [{r}, <= {I}], got {tuple(L2_merged.shape)}"
+        )
+    expected_w_sf_bytes = _ceil_div(O, 128) * _ceil_div(_ceil_div(I, 16), 4) * 512
+    if w_sf_swizzled.element_size() != 1 or w_sf_swizzled.numel() < expected_w_sf_bytes:
+        raise ValueError(
+            f"w_sf_swizzled must contain at least {expected_w_sf_bytes} one-byte elements"
+        )
+    alpha_f = float(gscale_x) * float(gscale_w)
+    if not math.isfinite(alpha_f) or alpha_f == 0.0:
+        raise ValueError("gscale_x * gscale_w must be finite and nonzero")
     dev = Rq.device
 
-    # Time-select the tile/cluster once per (shape, M-bucket) during warmup. Under CUDA-graph
-    # capture the private autotuner returns None and _build_compiled uses its analytical heuristic.
+    # Time-select the tile/cluster once per (shape, capped exact M) during warmup. If tuning is not
+    # safe here, _build_compiled uses its analytical heuristic.
     with torch.cuda.device(dev):
         tactic = _autotune_tactic(O, I, M, r, device=dev)
         compiled, sf_m, sf_n, sf_k, _ = _build_compiled(O, I, M, r, tactic=tactic)
@@ -309,7 +435,6 @@ def prepare_svdquant_state(
     # the (unchanged) epilogue computes out = alpha*acc = alpha*(residual + D@(L1/alpha)^T)
     # = alpha*residual + D@L1^T. This avoids a 2nd TMEM accumulator => keeps the base num_acc_stage
     # MMA/epilogue overlap (the perf). alpha~3e-4 => L1/alpha~O(1e2), fine in bf16 + the f32 acc.
-    alpha_f = float(gscale_x) * float(gscale_w)
     L1d = (L1.to(device=dev, dtype=torch.float32) / alpha_f).to(torch.bfloat16)
     if L1d.shape[0] != O:
         L1d = F.pad(L1d, (0, 0, 0, O - L1d.shape[0]))
@@ -355,7 +480,7 @@ def prepare_svdquant_state(
 
 @torch.compiler.disable
 def mm_fp4_svdquant(x, state, ext_xq, ext_sf):
-    """Run the fused NVFP4 SVDQuant linear. x: [M, I] (M padded to 128). Returns [M, O] bf16.
+    """Run the fused NVFP4 SVDQuant linear. x: [M, I]. Returns [M, O] bf16.
 
     Wrapped in @torch.compiler.disable because Dynamo cannot trace the CuTe-DSL JIT objects; this
     is kept as an opaque eager region (tracing into it otherwise causes graph breaks).
@@ -364,6 +489,35 @@ def mm_fp4_svdquant(x, state, ext_xq, ext_sf):
     The BF16 down-proj uses raw x because pre_quant_scale is already merged into L2 by the caller.
     """
     c = state
+    expected_x = (c["M"], c["I"])
+    expected_xq = (c["M"], c["I"] // 2)
+    dev = c["wq"].device
+    if x.ndim != 2 or tuple(x.shape) != expected_x or not x.is_cuda:
+        raise ValueError(f"x must be a CUDA tensor with shape {expected_x}")
+    if x.device != dev:
+        raise ValueError("x and prepared state must be on the same device")
+    if (
+        ext_xq.dtype != torch.uint8
+        or tuple(ext_xq.shape) != expected_xq
+        or not ext_xq.is_cuda
+        or ext_xq.device != dev
+        or not ext_xq.is_contiguous()
+    ):
+        raise ValueError(
+            f"ext_xq must be contiguous CUDA uint8 with shape {expected_xq}"
+        )
+    expected_sf_bytes = c["sf_m"] * c["sf_k"] * 512
+    if (
+        not ext_sf.is_cuda
+        or ext_sf.device != dev
+        or ext_sf.element_size() != 1
+        or not ext_sf.is_contiguous()
+        or ext_sf.numel() < expected_sf_bytes
+    ):
+        raise ValueError(
+            f"ext_sf must be a contiguous one-byte CUDA tensor with at least "
+            f"{expected_sf_bytes} elements"
+        )
     out = torch.empty((x.shape[0], c["O"]), dtype=torch.bfloat16, device=x.device)
     xb = x if x.dtype == torch.bfloat16 else x.to(torch.bfloat16)
     torch.mm(xb, c["L2_t"], out=c["D_active"])  # [M, r]

--- a/flashinfer/gemm/kernels/svdquant_lora.py
+++ b/flashinfer/gemm/kernels/svdquant_lora.py
@@ -5,12 +5,15 @@
 Framework-agnostic (no framework imports): the caller supplies the already-swizzled weight
 scale-factor blob and the externally-quantized NVFP4 activation (ext_xq/ext_sf), both consumed
 by the CuTe-DSL kernel as a raw data_ptr() reinterpreted via the block-scaled scale-factor
-layout. The bf16 down-projection D = X_hat @ L2^T is computed here with torch.matmul.
+layout. The BF16 down-projection D = X @ L2_merged^T is computed here with torch.matmul;
+the framework merges any activation smoothing scale into L2 once while loading weights.
 
 Public API:
-    state = prepare_svdquant_state(M, Rq, w_sf_swizzled, L1, L2, gscale_x, gscale_w, r, ...)
+    state = prepare_svdquant_state(M, Rq, w_sf_swizzled, L1, L2_merged,
+                                   gscale_x, gscale_w, r)
     y = mm_fp4_svdquant(x, state, ext_xq=..., ext_sf=...)   # y is [M, O] bf16
 """
+
 import torch
 import torch.nn.functional as F
 
@@ -27,24 +30,39 @@ def _ceil_div(a, b):
     return (a + b - 1) // b
 
 
-def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, force_tactic=None):
+def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, tactic=None):
     """cute.compile the kernel's fused residual + LoRA-up wrapper for a fixed shape.
 
     Returns (compiled_callable, sf_m, sf_n, sf_k, lora_k). Cached per
-    (N,K,M,r,out_dtype,force_tactic).
+    (N,K,M,r,out_dtype,tactic).
 
-    force_tactic: optional (mma_tiler_mn, cluster_shape_mn, use_prefetch) to bypass tactic
-    selection (used by the prepare-time autotuner and tests).
+    tactic: optional (mma_tiler_mn, cluster_shape_mn, use_prefetch) selected by the
+    private prepare-time autotuner.
     """
     from flashinfer.cute_dsl.utils import get_max_active_clusters
 
     # The compiled kernel is symbolic in M (sf_m/sf_n/sf_k + grid are runtime args), so a fixed
-    # (force_)tactic compiles once and is reused across all M -- critical to avoid recompiling per
+    # A selected tactic compiles once and is reused across all M -- critical to avoid recompiling per
     # batch during e2e warmup. Only the None path (analytical heuristic, capture fallback) is
     # M-dependent, so it keeps M in the key.
-    key = (N, K, r, out_dtype, force_tactic, M if force_tactic is None else None)
+    # The compiled persistent grid contains a device-specific residency limit.
+    # Keep separate entries when multiple CUDA devices are present.
+    device_index = torch.cuda.current_device()
+    key = (
+        device_index,
+        N,
+        K,
+        r,
+        out_dtype,
+        tactic,
+        M if tactic is None else None,
+    )
     if key in _V2_KERNEL_CACHE:
-        return _V2_KERNEL_CACHE[key]
+        # The compiled callable is symbolic in M, but the activation scale-factor
+        # extent is a runtime property of the current M.  Do not return the sf_m
+        # from whichever batch populated the compile cache first.
+        compiled, cached_sf_n, cached_sf_k, cached_lora_k = _V2_KERNEL_CACHE[key]
+        return compiled, _ceil_div(M, 128), cached_sf_n, cached_sf_k, cached_lora_k
 
     sf_dtype = cutlass.Float8E4M3FN
     c_dtype = cutlass.BFloat16 if out_dtype == torch.bfloat16 else cutlass.Float16
@@ -53,16 +71,18 @@ def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, force_tactic=None):
     sf_n = _ceil_div(N, 128)
     sf_k = _ceil_div(_ceil_div(K, 16), 4)
 
-    # Tile/cluster: explicit force_tactic > analytical heuristic, falling back to 128x128 (1,1).
+    # Tile/cluster: autotuned tactic > analytical heuristic, falling back to 128x128 (1,1).
     # The fused-LoRA path now supports 2-CTA (256-wide) tiles + multicast D/L1, so any non-swap
     # sm100 tactic is allowed (2-CTA 256-tiles are 1.3-1.6x faster at large M = high batch). swap_ab
     # is still unsupported (D is M-indexed / L1 N-indexed; swap would transpose those roles).
     mma_tiler_mn, cluster_shape_mn, use_prefetch = (128, 128), (1, 1), False
-    if force_tactic is not None:
-        mma_tiler_mn, cluster_shape_mn, use_prefetch = force_tactic
+    if tactic is not None:
+        mma_tiler_mn, cluster_shape_mn, use_prefetch = tactic
     else:
         try:
-            from flashinfer.gemm.kernels.utils import _select_sm100_mm_fp4_cute_dsl_tactic
+            from flashinfer.gemm.kernels.utils import (
+                _select_sm100_mm_fp4_cute_dsl_tactic,
+            )
 
             sm_count = torch.cuda.get_device_properties(
                 torch.cuda.current_device()
@@ -70,14 +90,25 @@ def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, force_tactic=None):
             tac = _select_sm100_mm_fp4_cute_dsl_tactic(M, N, K, sm_count)
             t_mma, t_cluster, t_swap, t_prefetch, t_kernel, _ = tac
             if (not t_swap) and t_kernel == "sm100":
-                mma_tiler_mn, cluster_shape_mn, use_prefetch = t_mma, t_cluster, t_prefetch
+                mma_tiler_mn, cluster_shape_mn, use_prefetch = (
+                    t_mma,
+                    t_cluster,
+                    t_prefetch,
+                )
         except Exception:
             pass
 
     gemm = Sm100BlockScaledLoRADenseGemmKernel(
-        16, mma_tiler_mn, cluster_shape_mn, use_prefetch, True, lora_rank=r,
+        16,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        use_prefetch,
+        True,
+        lora_rank=r,
     )
-    sym_m = cute.sym_int(); sym_k = cute.sym_int(); sym_n = cute.sym_int()
+    sym_m = cute.sym_int()
+    sym_k = cute.sym_int()
+    sym_n = cute.sym_int()
     a_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Uint8, (sym_m, sym_k), stride_order=(1, 0), assumed_align=32
     )
@@ -89,8 +120,13 @@ def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, force_tactic=None):
     )
     a_sf_ptr = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, 16)
     b_sf_ptr = make_ptr(sf_dtype, 16, cute.AddressSpace.gmem, 16)
-    alpha_fake = cute.runtime.make_fake_compact_tensor(cutlass.Float32, (1,), assumed_align=4)
-    mac = get_max_active_clusters(1)
+    alpha_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32, (1,), assumed_align=4
+    )
+    # The persistent scheduler consumes a cluster count, not a CTA count.  Passing
+    # the 1-CTA residency for a 2/4-CTA tactic overstates how many clusters can be
+    # resident and produces the wrong persistent grid.  Match mm_fp4's builder.
+    mac = get_max_active_clusters(cluster_shape_mn[0] * cluster_shape_mn[1])
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
     opts = "--opt-level 2 --enable-tvm-ffi"
 
@@ -101,12 +137,25 @@ def _build_compiled(N, K, M, r, out_dtype=torch.bfloat16, force_tactic=None):
         cutlass.BFloat16, (sym_n, cute.sym_int()), stride_order=(1, 0), assumed_align=16
     )
     compiled = cute.compile(
-        gemm.wrapper_lora, a_fake, b_fake, c_fake, d_fake, l1_fake,
-        sf_m, sf_n, sf_k, 1, a_sf_ptr, b_sf_ptr, alpha_fake, mac, stream_fake, options=opts,
+        gemm.wrapper_lora,
+        a_fake,
+        b_fake,
+        c_fake,
+        d_fake,
+        l1_fake,
+        sf_m,
+        sf_n,
+        sf_k,
+        1,
+        a_sf_ptr,
+        b_sf_ptr,
+        alpha_fake,
+        mac,
+        stream_fake,
+        options=opts,
     )
-    res = (compiled, sf_m, sf_n, sf_k, lora_k)
-    _V2_KERNEL_CACHE[key] = res
-    return res
+    _V2_KERNEL_CACHE[key] = (compiled, sf_n, sf_k, lora_k)
+    return compiled, sf_m, sf_n, sf_k, lora_k
 
 
 # Candidate tactics for the prepare-time autotuner. Non-swap sm100 only (the LoRA path supports
@@ -138,12 +187,14 @@ def _time_call(call, iters=10, warmup=3):
     e0 = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
     e1 = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
     for i in range(iters):
-        e0[i].record(); call(); e1[i].record()
+        e0[i].record()
+        call()
+        e1[i].record()
     torch.cuda.synchronize()
     return sorted(e0[i].elapsed_time(e1[i]) for i in range(iters))[iters // 2] * 1000.0
 
 
-def _autotune_tactic(N, K, M, r):
+def _autotune_tactic(N, K, M, r, device=None):
     """Time-select the fastest tactic for (N,K,M-bucket,r). Returns a (tile,cluster,prefetch) tuple,
     or None if timing is unavailable (CUDA-graph capture) -> caller falls back to the heuristic.
     Random correctly-sized operands (timing is shape-, not value-, dependent). Cached per M-bucket."""
@@ -153,22 +204,32 @@ def _autotune_tactic(N, K, M, r):
     except Exception:
         return None
     bucket = 1 << max(0, (M - 1).bit_length())  # next power of 2 >= M
-    key = (N, K, bucket, r)
+    dev = (
+        torch.device(device)
+        if device is not None
+        else torch.device("cuda", torch.cuda.current_device())
+    )
+    key = (dev.index, N, K, bucket, r)
     if key in _TACTIC_CHOICE_CACHE:
         return _TACTIC_CHOICE_CACHE[key]
 
-    dev = "cuda"
     Kp = K // 2
     lora_k = _ceil_div(r, 16) * 16
     # Cap the timing-M to avoid huge autotune allocations (out[M,N] is ~3.6GB at M=147k/b16 ->
     # OOM). The best tactic is ~M-bucket-invariant in the large-M (compute-bound) regime, and the
     # compiled kernel is symbolic in M, so timing at a capped M picks the same tactic.
     M = min(M, 32768)
-    sf_m = _ceil_div(M, 128); sf_n = _ceil_div(N, 128); sf_k = _ceil_div(_ceil_div(K, 16), 4)
+    sf_m = _ceil_div(M, 128)
+    sf_n = _ceil_div(N, 128)
+    sf_k = _ceil_div(_ceil_div(K, 16), 4)
     a = torch.randint(0, 256, (M, Kp), dtype=torch.uint8, device=dev)
     wq = torch.randint(0, 256, (N, Kp), dtype=torch.uint8, device=dev)
-    a_sf = torch.randint(0, 256, (sf_m * sf_k * 512,), dtype=torch.uint8, device=dev).view(torch.float8_e4m3fn)
-    w_sf = torch.randint(0, 256, (sf_n * sf_k * 512,), dtype=torch.uint8, device=dev).view(torch.float8_e4m3fn)
+    a_sf = torch.randint(
+        0, 256, (sf_m * sf_k * 512,), dtype=torch.uint8, device=dev
+    ).view(torch.float8_e4m3fn)
+    w_sf = torch.randint(
+        0, 256, (sf_n * sf_k * 512,), dtype=torch.uint8, device=dev
+    ).view(torch.float8_e4m3fn)
     alpha = torch.tensor([0.5], dtype=torch.float32, device=dev)
     out = torch.empty((M, N), dtype=torch.bfloat16, device=dev)
     d = torch.randn(M, lora_k, dtype=torch.bfloat16, device=dev)
@@ -177,8 +238,20 @@ def _autotune_tactic(N, K, M, r):
     best_t, best_us = None, None
     for tac in _AUTOTUNE_CANDIDATES:
         try:
-            compiled, sfm, sfn, sfk, _ = _build_compiled(N, K, M, r, force_tactic=tac)
-            call = lambda c=compiled: c(a, wq, out, d, l1, sfm, sfn, sfk, a_sf.data_ptr(), w_sf.data_ptr(), alpha)
+            compiled, sfm, sfn, sfk, _ = _build_compiled(N, K, M, r, tactic=tac)
+            call = lambda c=compiled: c(
+                a,
+                wq,
+                out,
+                d,
+                l1,
+                sfm,
+                sfn,
+                sfk,
+                a_sf.data_ptr(),
+                w_sf.data_ptr(),
+                alpha,
+            )
             us = _time_call(call)
             if best_us is None or us < best_us:
                 best_us, best_t = us, tac
@@ -197,30 +270,37 @@ def _autotune_tactic(N, K, M, r):
 
 @torch.compiler.disable
 def prepare_svdquant_state(
-    M, Rq, w_sf_swizzled, L1, L2, gscale_x, gscale_w, r,
-    pre_quant_scale=None, external_quant=True, force_tactic=None,
+    M,
+    Rq,
+    w_sf_swizzled,
+    L1,
+    L2_merged,
+    gscale_x,
+    gscale_w,
+    r,
 ):
     """Build a reusable dispatch state for one (M, I, O, r) shape (injection path).
 
       Rq: prepacked NVFP4 weight [O, I//2] uint8 (E2M1, K-major).
       w_sf_swizzled: weight block-scales already in the NVFP4 MMA swizzle (uint8/e4m3 blob, the layout
                      trtllm fp4_quantize / swizzle_sf produce -- passed to the kernel as raw data_ptr).
-      L1: up-proj [O, r] bf16; L2: down-proj [r, I] bf16.
+      L1: up-proj [O, r] bf16.
+      L2_merged: down-proj [r, I] bf16, already merged with any pre_quant_scale by the caller.
       gscale_x, gscale_w: static global scales; the kernel applies alpha = gscale_x * gscale_w.
-      pre_quant_scale: optional [I] smoothing scale (applied to x before the down-proj).
-    external_quant must be True (injection path); the kernel has no internal quantizer here.
+    The activation is externally quantized; this kernel has no internal quantizer.
     """
-    assert external_quant, "this host glue only supports the ext_xq/ext_sf injection path"
-    O = int(Rq.shape[0]); I = int(Rq.shape[1]) * 2
+    O = int(Rq.shape[0])
+    I = int(Rq.shape[1]) * 2
     lora_k = _ceil_div(r, 16) * 16
-    dev = "cuda"
+    if not Rq.is_cuda:
+        raise ValueError("Rq must be a CUDA tensor")
+    dev = Rq.device
 
-    # Pick the tile/cluster: caller override > prepare-time autotune (time-select 1-CTA vs 2-CTA) >
-    # analytical heuristic (inside _build_compiled). Autotune runs once per (shape, M-bucket) during
-    # warmup; it returns None under CUDA-graph capture, where _build_compiled's heuristic is used.
-    if force_tactic is None:
-        force_tactic = _autotune_tactic(O, I, M, r)
-    compiled, sf_m, sf_n, sf_k, _ = _build_compiled(O, I, M, r, force_tactic=force_tactic)
+    # Time-select the tile/cluster once per (shape, M-bucket) during warmup. Under CUDA-graph
+    # capture the private autotuner returns None and _build_compiled uses its analytical heuristic.
+    with torch.cuda.device(dev):
+        tactic = _autotune_tactic(O, I, M, r, device=dev)
+        compiled, sf_m, sf_n, sf_k, _ = _build_compiled(O, I, M, r, tactic=tactic)
 
     wq = Rq.to(device=dev).view(torch.uint8).contiguous()
     w_sf = w_sf_swizzled.to(device=dev).contiguous().view(torch.float8_e4m3fn)
@@ -234,32 +314,39 @@ def prepare_svdquant_state(
     if L1d.shape[0] != O:
         L1d = F.pad(L1d, (0, 0, 0, O - L1d.shape[0]))
     if L1d.shape[1] != lora_k:
-        L1d = F.pad(L1d, (0, lora_k - L1d.shape[1]))   # [O, lora_k]
+        L1d = F.pad(L1d, (0, lora_k - L1d.shape[1]))  # [O, lora_k]
     L1d = L1d.contiguous()
 
-    L2d = L2.to(device=dev, dtype=torch.bfloat16)
+    L2d = L2_merged.to(device=dev, dtype=torch.bfloat16)
     if L2d.shape[1] != I:
-        L2d = F.pad(L2d, (0, I - L2d.shape[1]))         # [r, I]
-    # Fold pre_quant_scale into L2: the down-proj D = x_hat @ L2^T = x @ (pqs*L2)^T, so the kernel
-    # can use the RAW activation x -- avoids recomputing x_hat (the caller already formed it for the
-    # fp4_quantize injection) plus an [M,I] alloc. Store L2 transposed-contiguous [I, r] for a fast
-    # NN matmul (vs the slow NT path of L2.t() on a [r,I] tensor).
-    if pre_quant_scale is not None:
-        pqs = pre_quant_scale.detach().to(device=dev, dtype=torch.bfloat16).reshape(1, -1)
-        if pqs.shape[1] != I:
-            pqs = F.pad(pqs, (0, I - pqs.shape[1]), value=1.0)
-        L2d = L2d * pqs                                  # scale L2's I columns by pqs
-    L2_t = L2d.t().contiguous()                          # [I, r]
+        L2d = F.pad(L2d, (0, I - L2d.shape[1]))  # [r, I]
+    # Any activation smoothing scale is merged into L2 once by the framework's
+    # weight-preparation path, not here per shape-specific dispatch state.
+    L2_t = L2d.t().contiguous()  # [I, r]
 
     # Preallocated LoRA-down output (graph-safe: no per-call alloc). D_buf is padded to lora_k with
     # zero columns; D_active is the contiguous [M, r] write target.
     D_buf = torch.zeros((M, lora_k), dtype=torch.bfloat16, device=dev)
-    D_active = D_buf if lora_k == r else torch.empty((M, r), dtype=torch.bfloat16, device=dev)
+    D_active = (
+        D_buf if lora_k == r else torch.empty((M, r), dtype=torch.bfloat16, device=dev)
+    )
 
     return {
-        "M": M, "I": I, "O": O, "r": r, "lora_k": lora_k,
-        "compiled": compiled, "sf_m": sf_m, "sf_n": sf_n, "sf_k": sf_k,
-        "wq": wq, "w_sf": w_sf, "L1": L1d, "L2_t": L2_t, "D_buf": D_buf, "D_active": D_active,
+        "M": M,
+        "I": I,
+        "O": O,
+        "r": r,
+        "lora_k": lora_k,
+        "compiled": compiled,
+        "sf_m": sf_m,
+        "sf_n": sf_n,
+        "sf_k": sf_k,
+        "wq": wq,
+        "w_sf": w_sf,
+        "L1": L1d,
+        "L2_t": L2_t,
+        "D_buf": D_buf,
+        "D_active": D_active,
         "alpha": torch.tensor([alpha_f], dtype=torch.float32, device=dev),
         # `out` is allocated per call (not cached): under CUDA-graph capture it comes from the
         # graph's private pool, and caching a [Mpad, O] buffer per shape is prohibitive at large M.
@@ -267,27 +354,32 @@ def prepare_svdquant_state(
 
 
 @torch.compiler.disable
-def mm_fp4_svdquant(x, state, ext_xq=None, ext_sf=None):
+def mm_fp4_svdquant(x, state, ext_xq, ext_sf):
     """Run the fused NVFP4 SVDQuant linear. x: [M, I] (M padded to 128). Returns [M, O] bf16.
 
     Wrapped in @torch.compiler.disable because Dynamo cannot trace the CuTe-DSL JIT objects; this
     is kept as an opaque eager region (tracing into it otherwise causes graph breaks).
 
-    ext_xq: NVFP4 activation [M, I//2] uint8 (E2M1); ext_sf: its swizzled block-scale blob. The
-    bf16 down-proj D = (x*pqs) @ L2^T is computed here (pre_quant_scale folded into L2 at prepare).
+    ext_xq: NVFP4 activation [M, I//2] uint8 (E2M1); ext_sf: its swizzled block-scale blob.
+    The BF16 down-proj uses raw x because pre_quant_scale is already merged into L2 by the caller.
     """
-    assert ext_xq is not None and ext_sf is not None, "the injection path requires ext_xq/ext_sf"
     c = state
     out = torch.empty((x.shape[0], c["O"]), dtype=torch.bfloat16, device=x.device)
-    # down-proj into the preallocated buffer: D = x @ (pqs*L2)^T  (pqs folded into L2_t at prepare,
-    # so we use the RAW activation x -- no x_hat recompute, no [M,I] alloc; graph-safe out= target).
     xb = x if x.dtype == torch.bfloat16 else x.to(torch.bfloat16)
-    torch.mm(xb, c["L2_t"], out=c["D_active"])               # [M, r]
+    torch.mm(xb, c["L2_t"], out=c["D_active"])  # [M, r]
     if c["D_active"] is not c["D_buf"]:
         c["D_buf"][:, : c["r"]].copy_(c["D_active"])
     c["compiled"](
-        ext_xq.view(torch.uint8), c["wq"], out, c["D_buf"], c["L1"],
-        c["sf_m"], c["sf_n"], c["sf_k"],
-        ext_sf.data_ptr(), c["w_sf"].data_ptr(), c["alpha"],
+        ext_xq.view(torch.uint8),
+        c["wq"],
+        out,
+        c["D_buf"],
+        c["L1"],
+        c["sf_m"],
+        c["sf_n"],
+        c["sf_k"],
+        ext_sf.data_ptr(),
+        c["w_sf"].data_ptr(),
+        c["alpha"],
     )
     return out

--- a/flashinfer/gemm/kernels/svdquant_nvfp4.py
+++ b/flashinfer/gemm/kernels/svdquant_nvfp4.py
@@ -1,0 +1,2417 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Fused NVFP4-SVDQuant linear for FlashInfer (B200 / sm_100a): an NVFP4 main GEMM plus a bf16 low-rank
+# (LoRA-style) correction, Y = dequant(nvfp4(X) @ nvfp4(R)^T) + (X @ L2^T) @ L1^T.
+
+"""
+Self-contained runtime for the fused NVFP4 SVDQuant linear layer (B200 / sm_100a).
+
+This single module holds the full deployable pipeline -- the (quant + down) front-end and the fused
+dual-TMEM main+low-rank GEMM -- behind a small public surface:
+
+  * prepare_svdquant_state / mm_fp4_svdquant : the reusable, CUDA-graph-safe host fast-path.
+  * run_kernel_a / run_quantizer / run_down_projection : the on-device (quant + down) front-end.
+  * run_kernel_b : the fused NVFP4 main GEMM + bf16 low-rank up-projection, one fused-add epilogue.
+  * _run_kernels : the private on-device kernel sequence shared by the fast-path and the harness.
+
+FRONT-END (run_kernel_a). Emits BOTH halves the fused linear consumes, on device, via two device
+kernels (X is read from gmem twice -- once each). Both reads are device-side (no CPU staging):
+
+  1. REAL on-device packed Xq (E2M1 4-bit nibbles, 2/byte, K-major: even K in the low nibble, odd K
+     in the high nibble) + sf_x (E4M3 per-16-element block scales, plain [M, I//16] byte layout)
+     computed against a PROVIDED per-tensor global scale gscale_x: per-16-block amax over K,
+     sf = E4M3-round(block_amax / (6 * gscale_x)), Xq = E2M1-round(x / (sf * gscale_x)), using
+     cutlass.cute's f32->E4M3 / f32->E2M1 hardware conversions (the same round-to-nearest conversions
+     the block-scaled GEMM consumes). The on-device E2M1/E4M3 quantizer (ActivationQuantizer) is a
+     tcgen05-free CuteDSL kernel: ONE THREAD PER 16-ELEMENT K-BLOCK -- a flat grid over the M*(I/16)
+     independent NVFP4 blocks (thread g -> row m = g//nblk, block b = g%nblk, m-major so a warp reads
+     32 contiguous blocks of one row, coalesced). Each thread reads its 16 X elements from gmem (f32),
+     reduces the block amax, rounds the E4M3 block scale and each element to E2M1, and packs two
+     nibbles/byte (signed-zero canonicalized to +0). sf_x is the plain [M, I//16] E4M3 byte format the
+     reference packer produces, so nvfp4_gemm._make_sf_mma_tensor / _fp4_from_packed consume it
+     UNCHANGED. The quantizer consumes f32 X (NOT bf16): quantizing the full-precision X is
+     dequant-parity with the reference packer of the same f32 X (a few E4M3/E2M1 round-to-nearest TIES
+     differ between cute's and torch's conversions, so a same-device bytewise compare shows a few tie
+     mismatches -- each a single E2M1 grid step -- not bytewise-exact); feeding bf16 X instead would
+     impose a rank-independent input-rounding floor.
+  2. bf16 D = X @ L2^T   [M, r]   -- the low-rank "down" projection (L2 is [r, I], so the contraction
+     is over K = I, producing r output columns). The bf16 GEMM (DownProjection) is a public-wheel
+     tcgen05 bf16 MMA with a multi-stage TMA K-loop (make_trivial_tiled_mma + PipelineTmaUmma),
+     contracting the FULL K = I. The MMA tile is specialized by shape (down_tile_for_shape): r<=64 uses
+     a SKINNY 64-col N-tile, and the long-K family ALSO halves the M-tile to 64 (more M-tile CTAs, the
+     occupancy lever for the X-stream-bound long-K down) and uses split-K (the long K-loop partitioned
+     into concurrent slices whose f32 partials SplitKReduce sums to bf16 D).
+
+A single-kernel read-once fusion (one f32 X read driving both the quant stores and the bf16 D MMA) is
+blocked by an MLIR compile-time explosion when the NVFP4 quant body is co-located in the same module
+as the tcgen05 UMMA + multi-stage TMA pipeline (it is the co-location, not unrolling); the runtime
+deadlock is solved but the compile wall is not, so the production front-end is the two device kernels
+above. They feed the fused main identically.
+
+FUSED MAIN (run_kernel_b). ONE public-wheel CuteDSL kernel holds TWO heterogeneous TMEM accumulators
+and combines them in a single fused-add epilogue, over the real problem sizes (multi-tile grid +
+multi-stage main K-loop):
+
+  main_acc = NVFP4 block-scaled MMA  Xq @ Rq^T,  contract over K = I (LARGE) via a multi-stage
+             pipelined TMA/UMMA loop; E4M3 vec-16 block scales; the per-tensor FP32 global scale
+             (gscale_x * gscale_w) is folded OUTSIDE the MMA (epilogue).
+  lora_acc = bf16 MMA  D @ L1^T,  contract over K = r (<= 64) -- a SINGLE tile / different K-atom on an
+             independent pipeline: the D/L1 TMA is issued BEFORE the main K-loop (overlapping it) and
+             the bf16 MMA AFTER it; one acc commit then gates both accumulators to the epilogue.
+  epilogue : Y = dequant(main_acc) * (gscale_x * gscale_w) + lora_acc  -> bf16.
+
+`enable_lora` (compile-time): True -> the full fused dual-TMEM add epilogue; False -> the plain-NVFP4
+variant (identical main schedule, the lora load/MMA/add are NOT issued, store dequant(main) only). The
+two variants share a bit-identical main accumulation, so with L1=L2=0 (=> D=0 => lora_acc=+0, exact in
+IEEE-754) the fused output reproduces the plain output bit-for-bit through the REAL fused epilogue.
+
+A 2-CTA cooperative variant (KernelB2CTA) computes a 256-row cluster M-tile with a CtaGroup.TWO cluster
+(128 rows/CTA), halving the M-tile count for the wide-O / up-bound rows that the per-(M,O)-tile
+dual-TMEM add dominates; _wide_o_2cta selects it. The 1-CTA KernelB is unchanged for every other shape.
+
+Public nvidia-cutlass-dsl wheel ONLY -- no private-module dependency.
+"""
+import os
+import sys
+from typing import Type
+
+import cuda.bindings.driver as cuda
+import torch
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.torch as cutlass_torch
+from cutlass.cute.nvgpu import cpasync, tcgen05, OperandMajorMode
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+
+# --- self-contained runtime: no local-kernel imports, no reference-oracle import ---
+# This deployable runtime is oracle-free (FP4_E2M1_MAX / E4M3_MAX are inlined above), and the packed-FP4 /
+# E4M3-SF operand builders + the SF MMA-layout converter that used to live in nvfp4_gemm.py /
+# blockscaled_gemm_sm100.py are inlined below, so this file is a single import-clean module (the flashinfer
+# mirror needs no co-located siblings). _HERE is kept (NO sys.path mutation): harness helpers (e.g.
+# _flux_shapes) and the dev shims resolve bench/problem_sizes.yaml relative to it.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+from cutlass.cute.runtime import from_dlpack  # noqa: E402  (used by the inlined operand builders below)
+
+# --- front-end (quant + down) dtype aliases / constants ---
+LORA_DTYPE = cutlass.BFloat16     # low-rank operands (X cast to bf16, L2, D) + the resident X tile
+ACC_DTYPE = cutlass.Float32
+MMA_TILER_MN = (128, 128)         # (default M tile, default down-projection N tile)
+SKINNY_N_TILE = 64                # skinny down-projection N tile for r<=64: D=X@L2^T has only r<=64
+                                  # output columns, so a 64-col tile avoids paying the full 128-col tile
+LONG_K_M_TILE = 64                # long-K down M tile: halving M -> 2x the M-tile CTAs (occupancy)
+LONG_K_SPLIT = 2                   # long-K down split-K factor: partition the long K-loop into 2 slices
+                                  # run concurrently -> a shorter dependent K-loop; the WINNING long-K
+                                  # lever (GB200 r18_down_split: 320->172 us, 1.84x; S=4 no better than S=2)
+LONG_K_THRESHOLD = 24576          # I >= this selects the long-K occupancy + split-K path (single_linear2)
+BF16_TILE_K = 64                  # bf16 tcgen05 K-tile (inst-K 16 x 4)
+SF_BLOCK = 16                     # NVFP4 block size
+FP4_E2M1_MAX = 6.0
+E4M3_MAX = 448.0      # local (was reference_svdquant_nvfp4.E4M3_MAX); keeps the deployable runtime oracle-free
+QUANT_M_TILE = 128                # quantizer threads per CTA (now one thread per 16-element K-block)
+
+# --- fused main (NVFP4 + low-rank) dtype aliases / constants ---
+ELEM_DTYPE = cutlass.Float4E2M1FN     # E2M1 4-bit main operands
+SF_DTYPE = cutlass.Float8E4M3FN       # E4M3 block scales (NVF4, not the E8M0 MX default)
+OUT_DTYPE = cutlass.BFloat16
+SF_VEC = 16
+NVFP4_INST_K = 64                     # tcgen05 NVFP4 instruction K
+NVFP4_TILE_K = 256                    # 64 * 4 K-blocks per main K-tile
+
+
+# --- inlined operand builders + SF MMA-layout converter (relocated verbatim from the former
+# kernels/nvfp4_gemm.py and the vendored kernels/blockscaled_gemm_sm100.py) so this runtime has zero
+# local-kernel imports. ELEM_DTYPE / SF_DTYPE / SF_VEC are the shared constants defined above. ----------
+_ATOM_M = (32, 4)
+_ATOM_K = 4
+
+
+def _ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+@cute.jit
+def cvt_sf_MKL_to_M32x4xrm_K4xrk_L(
+    sf_ref_tensor: cute.Tensor,
+    sf_mma_tensor: cute.Tensor,
+):
+    """Convert scale factor tensor from MKL layout to mma specification M(32x4xrest_m)xK(4xrest_k)xL layout"""
+    # sf_mma_tensor has flatten shape (32, 4, rest_m, 4, rest_k, l)
+    # group to ((32, 4, rest_m), (4, rest_k), l)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 0, 3)
+    sf_mma_tensor = cute.group_modes(sf_mma_tensor, 1, 3)
+    for i in cutlass.range(cute.size(sf_ref_tensor)):
+        mkl_coord = sf_ref_tensor.layout.get_hier_coord(i)
+        sf_mma_tensor[mkl_coord] = sf_ref_tensor[mkl_coord]
+
+
+_cvt_sf_to_mma = cvt_sf_MKL_to_M32x4xrm_K4xrk_L
+
+
+def _make_sf_mma_tensor(values_2d, mn, k):
+    """Build the swizzled MMA-layout E4M3 scale-factor cute tensor.
+
+    values_2d[mn, sf_k] (optional) are the per-block E4M3 scales to inject; when None the
+    scratch keeps random values (for data-independent timing). Mirrors the example's
+    scale-factor construction so the M(32x4)xK(4) MMA layout is exactly what the kernel reads.
+    """
+    l = 1
+    sf_k = _ceil_div(k, SF_VEC)
+    ref_shape = (l, mn, sf_k)
+    mma_shape = (
+        l,
+        _ceil_div(mn, _ATOM_M[0] * _ATOM_M[1]),
+        _ceil_div(sf_k, _ATOM_K),
+        _ATOM_M[0],
+        _ATOM_M[1],
+        _ATOM_K,
+    )
+    ref_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        ref_shape, torch.float32, permute_order=(1, 2, 0),
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(min_val=1, max_val=3),
+    )  # shape (mn, sf_k, l)
+    if values_2d is not None:
+        ref_cpu[:, :, 0] = values_2d.to(torch.float32)
+    mma_cpu = cutlass_torch.create_and_permute_torch_tensor(
+        mma_shape, torch.float32, permute_order=(3, 4, 1, 5, 2, 0),
+        init_type=cutlass_torch.TensorInitType.RANDOM,
+        init_config=cutlass_torch.RandomInitConfig(min_val=0, max_val=1),
+    )
+    _cvt_sf_to_mma(from_dlpack(ref_cpu), from_dlpack(mma_cpu))  # ref MKL -> MMA swizzle
+    mma_cuda = mma_cpu.cuda()
+    cute_tensor, cute_torch = cutlass_torch.cute_tensor_like(
+        mma_cpu, SF_DTYPE, is_dynamic_layout=True, assumed_align=16
+    )
+    cute_tensor = cutlass_torch.convert_cute_tensor(
+        mma_cuda, cute_tensor, SF_DTYPE, is_dynamic_layout=True
+    )
+    return cute_tensor, cute_torch
+
+
+def _fp4_from_packed(mode0, k, packed_2d):
+    """A (m,k,l) or B (n,k,l) Float4E2M1FN cute tensor built directly from the raw packed NVFP4
+    bytes (2 E2M1 nibbles/byte, K fastest) — no f32 round-trip, no dequantized float. The kernel
+    stores fp4 packed 2/byte, all mode0*k elements row-major into the first mode0*k/2 contiguous
+    storage bytes of the int8 staging buffer (verified byte-identical to the f32->FP4 path by
+    probe_fp4_encoding). packed_2d: uint8 [mode0, k//2] from pack_nvfp4 / pack_with_gscale."""
+    l = 1
+    ref0 = cutlass_torch.matrix(l, mode0, k, False, cutlass.Float32)  # (mode0,k,l) k-major strides
+    buf = torch.empty_like(ref0, dtype=torch.int8, device="cuda")     # storage offset i*k+j
+    buf.zero_()
+    flat = buf.as_strided((mode0 * k,), (1,))                         # linear view of storage
+    flat[: mode0 * k // 2] = packed_2d.reshape(-1).to(torch.int8).cuda()
+    t = from_dlpack(buf, assumed_align=16)
+    t.element_type = ELEM_DTYPE
+    t = t.mark_layout_dynamic(leading_dim=cutlass_torch.get_leading_dim(buf))
+    t.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=32)
+    return t, buf
+
+
+# Small-M-aware long-K split-K factors, keyed by (I, M, r). The contraction dim I is part of the key
+# so different long-K shapes never collide at the same (M, r): single_linear2 (I=24576) and a future
+# long-K shape (e.g. double_ff_out, I=18432) each carry their own entries and each divides ITS OWN
+# K-tile count. The long-K down GEMM (D = X @ L2^T, K=I, N=r<=64) is OCCUPANCY-STARVED at small M: with
+# the 64-row M tile it launches only ceil(M/64) M-tile CTAs to stream the long K, so the down runs at a
+# fraction of the 148 SMs until split-K adds num_k_split concurrent K-slice CTAs (target ~128 resident
+# CTAs = M_tiles * split). The per-(m,n) parallel SplitKReduce is ~flat across the split (~14 us), so it
+# no longer caps the split factor.
+# single_linear2 (I=24576, K-tile count 384) GB200 FULL-PIPELINE selection over the valid divisors
+# {2,3,4,6,8,12,16}, REPEATED (runs r1_split_select + r2_core), median per (M, rank):
+#   M=1024 -> 8 (both ranks, ROBUST: +11.5/+12.1% vs +12-15% runner-ups, consistent across both runs).
+#   M=2048 -> 4 (both ranks). split-4 vs split-8 is a within-MAD TIE at M=2048 -- the per-rank "best"
+#     FLIPS between runs (r1: r32->4, r64->8; r2: r32->8, r64->4), and split-4 averages marginally
+#     better across both runs (~+13.35% vs ~+13.68%). split-4 is the principled pick: 32 M-tiles x 4 =
+#     128 CTAs EXACTLY saturates the 148 SMs (ncu r1_ncu), while split-8 over-subscribes to 256 with
+#     no gain. So the selector resolves to both ranks agreeing per M, on REPEATED evidence (not r1
+#     noise) -- a documented selection per the plan's repeated-evidence allowance.
+# Every factor MUST divide the shape's own K-tile count (I // BF16_TILE_K). (I, M, r) not in the table
+# (incl. large M) falls back to LONG_K_SPLIT -> unchanged.
+_LONG_K_SPLIT_BY_IMR = {
+    (24576, 1024, 32): 8,
+    (24576, 1024, 64): 8,
+    (24576, 2048, 32): 4,
+    (24576, 2048, 64): 4,
+    # double_ff_out (I=18432, K-tile count 288): split=9 (-> 32 K-tiles/CTA) is the robust full-pipeline
+    # pick across M=1024/2048/4096 x r{32,64} -- the argmin at M=2048 and M=4096 (both ranks) and
+    # within-MAD of the argmin at M=1024 (where split 16/18 edge it by < 1 MAD but over-subscribe).
+    # At M=1024, 16 M-tiles x 9 = 144 CTAs ~= the 148 SMs (the saturation pick). Admitting these rows
+    # takes double_ff_out's down off skinny-N onto the m64 occupancy + split-K path, cutting M=1024
+    # ~+77% toward the long-K floor (~+12-14%). GB200 r0_dffout_split full-pipeline split sweep.
+    (18432, 1024, 32): 9,
+    (18432, 1024, 64): 9,
+    (18432, 2048, 32): 9,
+    (18432, 2048, 64): 9,
+    (18432, 4096, 32): 9,
+    (18432, 4096, 64): 9,
+    # double_ff_out mid-M M=4608: split=2 (72 m64-tiles x 2 = 144 CTAs ~= 148 SMs); split=9
+    # over-subscribes here and measures worse (GB200 r0_dffout_4608). +26% -> ~+14% (long-K floor).
+    (18432, 4608, 32): 2,
+    (18432, 4608, 64): 2,
+}
+
+
+def _long_k_split_for_m(I, M, r):
+    """Long-K down split-K factor for contraction I, batch M, and rank r -- (I, M, r)-aware: the I key
+    isolates each long-K shape (so single_linear2 and a same-(M,r) long-K sibling never collide), and
+    the full-pipeline optimum also differs by rank at M=2048. Falls back to LONG_K_SPLIT when M is None
+    or (I, M, r) is not in the table (so large-M and non-shape-aware callers are unchanged). Asserts the
+    factor divides the shape's own K-tile count so the per-CTA K-loop (kps = k_tile_cnt // num_k_split)
+    covers K exactly (no silently-dropped tiles)."""
+    split = LONG_K_SPLIT if M is None else _LONG_K_SPLIT_BY_IMR.get((I, M, r), LONG_K_SPLIT)
+    k_tiles = I // BF16_TILE_K
+    assert k_tiles % split == 0, (
+        f"long-K split factor {split} does not divide the K-tile count {k_tiles} (I={I}); "
+        f"choose a divisor of {k_tiles}"
+    )
+    return split
+
+
+# Long-K down admission. single_linear2 (I in _LONG_K_I_ALLM) takes the occupancy + split-K path for
+# EVERY M; any other shape takes it ONLY at an (I, M, r) that carries an explicit split entry, so
+# admitting a new long-K shape/M is a deliberate, isolated table entry -- never a blunt I>=threshold
+# spill that would also switch its untuned (e.g. large-M) rows. (M is None -> non-shape-aware caller,
+# admitted only via the all-M set.)
+_LONG_K_I_ALLM = (24576,)
+
+
+def _is_long_k(I, M, r):
+    return I in _LONG_K_I_ALLM or (M is not None and (I, M, r) in _LONG_K_SPLIT_BY_IMR)
+
+
+# Occupancy-starved I=6144 down admission, keyed by (I, O, M, r). Several block layers share the same
+# I=6144 down (D = X @ L2^T, K=6144) whose few M-tiles starve the 148 SMs at small/mid M; the m64
+# occupancy tile + a saturation split (8192/M -> ~128 CTAs at m64) cuts the overhead. The key carries O
+# (not just I) so it isolates the TARGET shape from its I=6144 SIBLINGS -- single_linear1 (O=55296,
+# the shipped 2-CTA win) and any other O stay byte-identical. GB200 full-pipeline sweeps
+# (r0_dattn_split / r0_dffin_split / r0_*_4608):
+#   double_attn (square, O=6144): down occupancy-bound; +53/56% -> ~+14-17% at M=1024 (residual is the
+#     small-native X-re-read floor).
+#   double_ff_in (wide-O-ish, O=36864): its DOWN dominated (not the up-projection); +19.5% -> ~+5-8%
+#     (under budget) -- profile-first paid off: the lever is the down, not the 2-CTA epilogue.
+# split = 8/4/2 for M=1024/2048/4096 (saturation; the noisy per-(M,r) argmins are within-MAD), 2 at M=4608.
+_OCC_DOWN_SPLIT_BY_IOMR = {
+    (6144, 6144, 1024, 32): 8, (6144, 6144, 1024, 64): 8,      # double_attn (square)
+    (6144, 6144, 2048, 32): 4, (6144, 6144, 2048, 64): 4,
+    (6144, 6144, 4096, 32): 2, (6144, 6144, 4096, 64): 2,
+    (6144, 6144, 4608, 32): 2, (6144, 6144, 4608, 64): 2,
+    (6144, 36864, 1024, 32): 8, (6144, 36864, 1024, 64): 8,    # double_ff_in (wide-O-ish; down-bound)
+    (6144, 36864, 2048, 32): 4, (6144, 36864, 2048, 64): 4,
+    (6144, 36864, 4096, 32): 2, (6144, 36864, 4096, 64): 2,
+}
+
+
+def _is_occ_down(I, O, M, r):
+    return O is not None and M is not None and (I, O, M, r) in _OCC_DOWN_SPLIT_BY_IOMR
+
+
+def _occ_down_split_for(I, O, M, r):
+    split = _OCC_DOWN_SPLIT_BY_IOMR[(I, O, M, r)]
+    k_tiles = I // BF16_TILE_K
+    assert k_tiles % split == 0, (
+        f"occupancy-down split factor {split} does not divide the K-tile count {k_tiles} (I={I}); "
+        f"choose a divisor of {k_tiles}"
+    )
+    return split
+
+
+# Offline-autotuned down configs (experiments/dkg/autotune_dispatch.py, run.r1_autotune): for these
+# residual rows, m128 + split-K BEATS the round-0 m64 occ-down / long-K -- the split provides the
+# occupancy the smaller 64-row tile gave, while the 128-row tile is MMA-efficient. Wins (vs the round-0
+# config, same-harness 3-rep medians, robust beyond MAD): single_linear1 M1024 +14->+4%, single_linear2
+# mid/large-M +13->+8%, double_ff_out +12->+8%, double_attn +15->+10%. The win is the DOWN TILE (best at
+# num_ab_stage=3; a deeper KernelB pipeline added only ~0.01-0.43pp, NOT baked -- avoids a new dispatch
+# dimension). (I, O, M, r) -> (m_tile, num_k_split); n_tile stays the skinny 64. Takes precedence over the
+# long-K / occ-down tables for exactly these measured rows; all other rows are byte-identical.
+_AUTOTUNED_DOWN_BY_IOMR = {
+    # double_attn (square): M1024 is NOT baked -- BOTH the r3 m128 picks AND the EXACT r4 bests (r32 m64
+    # split32 s4, r64 m128 split6 s4) were paired-rejected (r3_dattn_gate + r5_dattn_gate): the target deltas
+    # are within the ~200us tiny-shape same-node noise (r5: a byte-identical-dispatch context_embed row
+    # "regressed" +1.93% in the SAME run). M1024 keeps round-0's m64 occ-down split8.
+    (6144, 6144, 4096, 32): (128, 4),  (6144, 6144, 4096, 64): (128, 4),
+    (6144, 6144, 4608, 32): (128, 4),  (6144, 6144, 4608, 64): (128, 4),
+    (6144, 6144, 8192, 32): (128, 2),  (6144, 6144, 8192, 64): (128, 2),
+    (18432, 6144, 2048, 32): (128, 9), (18432, 6144, 2048, 64): (128, 9),     # double_ff_out (long-K)
+    (18432, 6144, 4096, 32): (128, 4), (18432, 6144, 4096, 64): (128, 4),
+    (18432, 6144, 4608, 32): (128, 4), (18432, 6144, 4608, 64): (128, 4),
+    (18432, 6144, 8192, 32): (128, 2), (18432, 6144, 8192, 64): (128, 2),
+    (24576, 6144, 1024, 32): (128, 16), (24576, 6144, 1024, 64): (128, 16),   # single_linear2 small-M: m128+split16/8
+    (24576, 6144, 2048, 32): (128, 8),  (24576, 6144, 2048, 64): (128, 8),    #   beats the SHIPPED m64 split-K (~+12 -> ~+8%, round 2)
+    (24576, 6144, 4096, 32): (128, 4), (24576, 6144, 4096, 64): (128, 4),     # single_linear2 (long-K mid/large-M)
+    (24576, 6144, 4608, 32): (128, 4), (24576, 6144, 4608, 64): (128, 4),
+    (24576, 6144, 8192, 32): (128, 2), (24576, 6144, 8192, 64): (128, 2),
+    (6144, 55296, 1024, 32): (128, 12), (6144, 55296, 1024, 64): (128, 16),   # single_linear1 (wide-O; r4 m64+s4 pick was pair-rejected TGT-FLAT -> kept round-3 m128)
+    # round-13 retune (run.r13_autotune + verify sweep r13_sweep2): these rows round 1 never searched used a
+    # poor DEFAULT down-tile (split1); m128 + high split-K wins, sweep-confirmed (BOTH ranks improve ~6pp
+    # consistently), 1-CTA/2-CTA state unchanged, grid 120/120. double_attn M2048's autotune "win" did NOT
+    # reproduce in the verify sweep (r32 +8.6% but r64 +12.3% > prod) -> tiny-shape (~240us native) cross-run
+    # noise, NOT baked (kept at prod like M1024; the square shape is at the X-re-read/noise floor).
+    (6144, 55296, 2048, 32): (128, 16), (6144, 55296, 2048, 64): (128, 8),    # single_linear1 M2048: +9.4/+10.9 -> +3.6/+4.6% (2-CTA path)
+    (18432, 6144, 1024, 32): (128, 18), (18432, 6144, 1024, 64): (128, 16),   # double_ff_out M1024: +9.8/+11.4 -> +5.2/+8.7%
+}
+
+
+def _is_autotuned_down(I, O, M, r):
+    return O is not None and M is not None and (I, O, M, r) in _AUTOTUNED_DOWN_BY_IOMR
+
+
+def _autotuned_down_for(I, O, M, r):
+    m_tile, split = _AUTOTUNED_DOWN_BY_IOMR[(I, O, M, r)]
+    k_tiles = I // BF16_TILE_K
+    assert m_tile in (64, 128), f"autotuned m_tile {m_tile} must be 64 or 128 (I={I},O={O},M={M},r={r})"
+    assert k_tiles % split == 0, (
+        f"autotuned split {split} does not divide the K-tile count {k_tiles} (I={I}); choose a divisor"
+    )
+    return m_tile, split
+
+
+def down_tile_for_shape(I, r, M=None, O=None):
+    """The down-projection MMA (m_tile, n_tile), zero-padded N, and split-K factor for a layer with
+    contraction I, output rank r, and optional batch M. D=X@L2^T has only r<=64 output columns over
+    a long K=I. Selection -> (m_tile, n_tile, r_pad, num_k_split):
+      * r>64                          -> (128, 128, ..., 1): full tile (informational rank; no specialization).
+      * r<=64, NOT long-K (_is_long_k) -> (128, 64, ..., 1): skinny-N (avoids the 128-col N waste).
+      * r<=64, long-K (_is_long_k)     -> ( 64, 64, ..., split): the long-K path -- a 64 M-tile
+        (2x M-tile CTAs) AND split-K. The split factor is M-AWARE (_long_k_split_for_m): small M is
+        occupancy-starved streaming the long K, so a larger split saturates the SMs (~128 resident
+        CTAs = M_tiles * split). The factor divides the K-tile count; split writes f32 partials
+        reduced to bf16 D by SplitKReduce. M=64 is a valid 1-CTA tcgen05 bf16 M-mode; the epilogue
+        t2r op adapts via get_tmem_load_op. (M=None -> the default LONG_K_SPLIT, so non-shape-aware
+        callers and every M not in the small-M table are unchanged.)
+    r is padded UP to a multiple of n_tile -- the padded B/L2 rows produce zero output columns the caller
+    slices off.
+
+    O (the output dim) is threaded through so the down-tile selection can be made shape-aware: I and O
+    together identify the layer, which isolates a same-I family member (e.g. the square I==O case) from
+    its siblings. The current branches do not yet read O -- it is wired for the per-shape down-tile
+    specialization that selects on it."""
+    if r > SKINNY_N_TILE:
+        m_tile, n_tile, num_k_split = MMA_TILER_MN[0], MMA_TILER_MN[1], 1
+    elif _is_autotuned_down(I, O, M, r):
+        m_tile, num_k_split = _autotuned_down_for(I, O, M, r)   # measured winner (overrides long-K/occ-down)
+        n_tile = SKINNY_N_TILE
+    elif _is_long_k(I, M, r):
+        m_tile, n_tile = LONG_K_M_TILE, SKINNY_N_TILE
+        num_k_split = _long_k_split_for_m(I, M, r)
+    elif _is_occ_down(I, O, M, r):
+        m_tile, n_tile = LONG_K_M_TILE, SKINNY_N_TILE
+        num_k_split = _occ_down_split_for(I, O, M, r)
+    else:
+        m_tile, n_tile, num_k_split = MMA_TILER_MN[0], SKINNY_N_TILE, 1
+    r_pad = ((r + n_tile - 1) // n_tile) * n_tile
+    return m_tile, n_tile, r_pad, num_k_split
+
+
+class ActivationQuantizer:
+    """REAL on-device NVFP4 activation quantizer (tcgen05-free CuteDSL).
+
+    run_kernel_a's quantizer half: the production front-end runs this quantizer + the down-projection
+    as two device kernels (the read-once single-kernel fusion is BLOCKED by an MLIR compile wall --
+    see the module header).
+
+    Grid: ONE THREAD PER 16-ELEMENT K-BLOCK -- a flat grid over the M*(I/16) independent blocks
+    (thread g -> block (m = g // nblk, b = g % nblk), m-major so a warp reads 32 contiguous blocks
+    of one row -> coalesced). Each thread reads its 16 X elements from gmem (f32, K-major logical
+    [M, I, 1]), computes the block amax, the E4M3 block scale sf = E4M3_round(amax / (6*gscale)),
+    rounds each element x/(sf*gscale) to E2M1, and packs two nibbles/byte. Emits the plain
+    [M, I//16] E4M3 sf bytes and the [M, I//2] packed-E2M1 Xq bytes -- the same byte format
+    reference.pack_with_gscale produces. No TMA / MMA / pipeline -> no dynamic-control-flow
+    variable hoisting; the only loops are static Python ranges over the 16 block elements / 8 pairs.
+
+    (The earlier one-thread-per-ROW grid launched only M threads -- a few thousand -- each serially
+    walking a whole I-element row, leaving the GPU ~1% utilized [~5676 us for single_linear2]. The
+    per-block grid launches M*(I/16) threads [millions], so the quantizer is bandwidth-bound; the
+    per-block math is IDENTICAL, so the emitted Xq/sf bytes are unchanged.)
+
+    The quantizer consumes f32 X (NOT bf16): NVFP4 quant has no MMA that forces a bf16 operand,
+    so quantizing the full-precision X is DEQUANT-PARITY with reference.pack_with_gscale(X_f32)
+    (a few E4M3/E2M1 round-to-nearest TIES differ between cute's and torch's conversions, so the
+    same-device bytewise compare shows tie MISMATCHes -- not bytewise-exact) and the downstream
+    NVFP4 main reproduces the fp32 reference's main. Feeding bf16 X instead would impose a
+    rank-independent ~38 dB floor (input rounding), which is why both this helper and the fused
+    kernel quantize f32.
+    """
+
+    def __init__(self):
+        self.threads_per_cta = QUANT_M_TILE
+
+    @cute.jit
+    def __call__(
+        self,
+        x_tensor: cute.Tensor,       # X  [M, I, 1]  f32, K-major
+        xq_tensor: cute.Tensor,      # Xq [M, I//2]  uint8 packed E2M1 (output)
+        sf_tensor: cute.Tensor,      # sf [M, I//16] uint8 E4M3 block scales (output, plain layout)
+        gscale: cutlass.Float32,     # provided per-tensor global scale gscale_x
+        stream: cuda.CUstream,
+    ):
+        M = x_tensor.shape[0]
+        nblk = x_tensor.shape[1] // SF_BLOCK                 # I // 16 (one thread per 16-block)
+        grid = (cute.ceil_div(M * nblk, self.threads_per_cta), 1, 1)
+        self.kernel(x_tensor, xq_tensor, sf_tensor, gscale).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        mX: cute.Tensor,             # X  [M, I, 1]  f32, K-major
+        mXq: cute.Tensor,            # Xq [M, I//2]  uint8 (gmem)
+        mSF: cute.Tensor,            # sf [M, I//16] uint8 (gmem)
+        gscale: cutlass.Float32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        g = bidx * self.threads_per_cta + tidx   # flat index over the M*(I/16) 16-blocks
+        M = mX.shape[0]
+        nblk = cute.size(mSF, mode=[1])          # I // 16 (compile-time)
+        gm = g // nblk                            # this thread's M-row (nblk compile-time -> static div/mod)
+        b = g % nblk                              # this thread's 16-block within the row
+
+        # Guard the tail: flat threads past M*nblk map to rows >= M and do nothing.
+        if gm < M:
+            k0 = b * SF_BLOCK
+            amax = cutlass.Float32(0.0)
+            for j in range(SF_BLOCK):
+                v = cutlass.Float32(mX[gm, k0 + j, 0])
+                amax = cute.arch.fmax(amax, cute.math.absf(v))
+            amax = cute.arch.fmax(amax, cutlass.Float32(1e-8))            # ref clamp_min(1e-8)
+            sf_e4 = cutlass.Float8E4M3FN(amax / (cutlass.Float32(FP4_E2M1_MAX) * gscale))
+            mSF[gm, b] = sf_e4.bitcast(cutlass.Uint8)
+            eff = cute.arch.fmax(cutlass.Float32(sf_e4.to(cutlass.Float32)) * gscale,
+                                 cutlass.Float32(1e-12))                  # ref clamp_min(1e-12)
+            # E2M1-round each element, pack two nibbles/byte (even K low / odd K high).
+            frag = cute.make_fragment(SF_BLOCK, cutlass.Float32)
+            for j in range(SF_BLOCK):
+                frag[j] = cutlass.Float32(mX[gm, k0 + j, 0]) / eff
+            q = frag.load().to(cutlass.Float4E2M1FN)                      # f32 -> E2M1 (round-nearest)
+            qfrag = cute.make_fragment(SF_BLOCK, cutlass.Float4E2M1FN)
+            qfrag.store(q)
+            qbytes = cute.recast_tensor(qfrag, cutlass.Uint8)             # 2 nibbles/byte
+            for jj in range(SF_BLOCK // 2):
+                # canonicalize -0 -> +0 per nibble (pack_with_gscale drops -0): keep both
+                # magnitudes (0x77) always; keep each sign bit only when its 3 magnitude
+                # bits != 0. Done in Int32 (uint8 shift-to-bit7 is fragile).
+                bb = qbytes[jj].to(cutlass.Int32) & cutlass.Int32(0xFF)
+                mag_lo = bb & cutlass.Int32(0x7)
+                mag_hi = (bb >> cutlass.Int32(4)) & cutlass.Int32(0x7)
+                nz_lo = (mag_lo + cutlass.Int32(7)) >> cutlass.Int32(3)   # 1 if mag!=0 else 0
+                nz_hi = (mag_hi + cutlass.Int32(7)) >> cutlass.Int32(3)
+                mask = cutlass.Int32(0x77) | (nz_lo << cutlass.Int32(3)) | (nz_hi << cutlass.Int32(7))
+                mXq[gm, b * (SF_BLOCK // 2) + jj] = (bb & mask).to(cutlass.Uint8)
+        return
+
+
+class DownProjection:
+    """The CuteDSL bf16 D = X @ L2^T projection, contracting the full K = I.
+
+    One CTA-group (CtaGroup.ONE), 128 threads. A multi-stage TMA pipeline streams K-tiles
+    of the X tile (A operand, M-rows) and the L2 tile (B operand, N=r-rows) into SMEM and a
+    single TMEM bf16 accumulator integrates them across the whole K = I. Each X tile is
+    read from gmem once (TMA G->S) to drive the projection.
+
+    The MMA tile is configurable (`m_tile`, `n_tile`; selected by down_tile_for_shape). D's output is
+    only r<=64 columns, so the SKINNY n_tile=64 computes a 64-col tile instead of padding to 128 (halving
+    the tensor-core N work). For the long-K family (I>=24576) the M tile is ALSO halved to 64, doubling
+    the M-tile CTA count -- the OCCUPANCY lever for the X-stream-bound long-K down (measured
+    occupancy-bound, not N-width-bound). The epilogue TMEM-load copy atom is DERIVED from the tile via
+    sm100_utils.get_tmem_load_op (an f32-accumulator / N-major-bf16-D config): M=128 -> Ld32x32b with
+    Repetition == n_tile (128->x128, 64->x64); M=64 -> num_dp=16 selects a different op. Deriving it keeps
+    every (m_tile, n_tile) correct without hardcoding the op family.
+    """
+
+    def __init__(self, num_ab_stage: int = 3, n_tile: int = MMA_TILER_MN[1], m_tile: int = MMA_TILER_MN[0],
+                 num_k_split: int = 1):
+        self.threads_per_cta = 128
+        self.num_tmem_alloc_cols = 512
+        self.num_ab_stage = num_ab_stage
+        self.num_acc_stage = 1
+        self.n_tile = n_tile
+        self.m_tile = m_tile
+        self.mma_tiler_mn = (m_tile, n_tile)
+        # split-K: partition the long K-loop into num_k_split contiguous slices, run concurrently across
+        # num_k_split CTAs per M/N tile (grid z = the D output's L dim), each integrating its slice into
+        # its own partial D[m,:,s]; a separate reduction sums the partials. num_k_split=1 == the original.
+        self.num_k_split = num_k_split
+
+    @cute.jit
+    def __call__(
+        self,
+        x_tensor: cute.Tensor,       # X  [M, I]  bf16, K-major (A operand)
+        l2_tensor: cute.Tensor,      # L2 [r, I]  bf16, K-major (B operand; D = X @ L2^T)
+        d_tensor: cute.Tensor,       # D  [M, r]  bf16, N-major (output)
+        stream: cuda.CUstream,
+    ):
+        self.x_dtype: Type[cutlass.Numeric] = x_tensor.element_type
+        self.l2_dtype: Type[cutlass.Numeric] = l2_tensor.element_type
+        self.d_dtype: Type[cutlass.Numeric] = d_tensor.element_type
+
+        self.mma_tiler = (self.mma_tiler_mn[0], self.mma_tiler_mn[1], BF16_TILE_K)
+        tiled_mma = sm100_utils.make_trivial_tiled_mma(
+            self.x_dtype,
+            self.l2_dtype,
+            OperandMajorMode.K,
+            OperandMajorMode.K,
+            ACC_DTYPE,
+            tcgen05.CtaGroup.ONE,
+            self.mma_tiler_mn,
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((1, 1, 1)), (tiled_mma.thr_id.shape,)
+        )
+
+        # Multi-stage SMEM layouts for A (X) and B (L2): the staged-K mainloop reuses
+        # `num_ab_stage` SMEM buffers as it streams K-tiles of the full K = I.
+        self.x_smem_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma, self.mma_tiler, self.x_dtype, self.num_ab_stage
+        )
+        self.l2_smem_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma, self.mma_tiler, self.l2_dtype, self.num_ab_stage
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # TMA atoms (one-stage slice of the staged SMEM layout describes the per-tile copy).
+        x_smem_layout_one = cute.slice_(self.x_smem_layout, (None, None, None, 0))
+        tma_atom_x, tma_tensor_x = cute.nvgpu.make_tiled_tma_atom_A(
+            cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE),
+            x_tensor, x_smem_layout_one, self.mma_tiler, tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        l2_smem_layout_one = cute.slice_(self.l2_smem_layout, (None, None, None, 0))
+        tma_atom_l2, tma_tensor_l2 = cute.nvgpu.make_tiled_tma_atom_B(
+            cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE),
+            l2_tensor, l2_smem_layout_one, self.mma_tiler, tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        x_copy_size = cute.size_in_bytes(self.x_dtype, x_smem_layout_one)
+        l2_copy_size = cute.size_in_bytes(self.l2_dtype, l2_smem_layout_one)
+        self.num_tma_load_bytes = (x_copy_size + l2_copy_size) * atom_thr_size
+
+        grid = (
+            cute.ceil_div(d_tensor.shape[0], self.mma_tiler[0]),
+            cute.ceil_div(d_tensor.shape[1], self.mma_tiler[1]),
+            d_tensor.shape[2],
+        )
+
+        self.kernel(
+            tiled_mma,
+            tma_atom_x, tma_tensor_x,
+            tma_atom_l2, tma_tensor_l2,
+            d_tensor,
+            self.x_smem_layout, self.l2_smem_layout,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_x: cute.CopyAtom, mX_mkl: cute.Tensor,
+        tma_atom_l2: cute.CopyAtom, mL2_nkl: cute.Tensor,
+        mD_mnl: cute.Tensor,
+        x_smem_layout: cute.ComposedLayout,
+        l2_smem_layout: cute.ComposedLayout,
+    ):
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        mma_tile_coord_mnl = (
+            bidx // cute.size(tiled_mma.thr_id.shape),
+            bidy,
+            bidz,
+        )
+
+        @cute.struct
+        class SharedStorage:
+            ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sX = smem.allocate_tensor(self.x_dtype, x_smem_layout.outer, 128, x_smem_layout.inner)
+        sL2 = smem.allocate_tensor(self.l2_dtype, l2_smem_layout.outer, 128, l2_smem_layout.inner)
+
+        # AB pipeline: producer (TMA) fills a stage, consumer (MMA) drains it; the accumulator
+        # pipeline gates the single MMA-result handoff to the epilogue.
+        ab_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        ab_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_producer_group,
+            consumer_group=ab_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+        ).make_participants()
+        acc_producer, acc_consumer = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=ab_producer_group,
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.threads_per_cta
+            ),
+        ).make_participants()
+
+        # Tile the global tensors; the K mode stays a free index so we can loop over K-tiles.
+        gX = cute.local_tile(mX_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+        gL2 = cute.local_tile(mL2_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None))
+        gD = cute.local_tile(mD_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None))
+
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        tCgX = thr_mma.partition_A(gX)
+        tCgL2 = thr_mma.partition_B(gL2)
+        tCgD = thr_mma.partition_C(gD)
+
+        tXsX, tXgX = cpasync.tma_partition(
+            tma_atom_x, 0, cute.make_layout(1),
+            cute.group_modes(sX, 0, 3), cute.group_modes(tCgX, 0, 3),
+        )
+        tL2sL2, tL2gL2 = cpasync.tma_partition(
+            tma_atom_l2, 0, cute.make_layout(1),
+            cute.group_modes(sL2, 0, 3), cute.group_modes(tCgL2, 0, 3),
+        )
+
+        tCrX = tiled_mma.make_fragment_A(sX)
+        tCrL2 = tiled_mma.make_fragment_B(sL2)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(acc_shape)
+
+        # TMEM accumulator.
+        tmem_alloc_barrier = pipeline.NamedBarrier(barrier_id=1, num_threads=self.threads_per_cta)
+        tmem = utils.TmemAllocator(storage.tmem_holding_buf.ptr, barrier_for_retrieve=tmem_alloc_barrier)
+        tmem.allocate(self.num_tmem_alloc_cols)
+        tmem.wait_for_alloc()
+        acc_tmem_ptr = tmem.retrieve_ptr(ACC_DTYPE)
+        tCtAcc = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+        # Slice the TMA source down to this CTA's M / N tile. X/L2 have L=1 (their L-index is always 0);
+        # the output D's L-dim holds the split-K partials (L = num_k_split), so D is sliced by bidz (the
+        # split index) -- each split's CTA writes its own partial D[m,:,bidz]. For num_k_split=1, bidz=0,
+        # so this is the original single-partition down.
+        tXgX = tXgX[(None, mma_tile_coord_mnl[0], None, 0)]
+        tL2gL2 = tL2gL2[(None, mma_tile_coord_mnl[1], None, 0)]
+
+        # K-tile count from the static layout mode (compile-time int even though the tensor's
+        # runtime M/K extents are marked dynamic) -> a plain Python loop, so `k_tile != 0` below
+        # is a compile-time predicate (mirrors the vendored GEMM mainloop). For split-K, each CTA runs
+        # only its 1/num_k_split contiguous slice (kps tiles, compile-time) -> a shorter dependent K-loop
+        # run concurrently across the num_k_split CTAs; k_base is this split's first global K-tile.
+        k_tile_cnt = cute.size(gX, mode=[3])
+        kps = k_tile_cnt // self.num_k_split
+        k_base = mma_tile_coord_mnl[2] * kps
+
+        #
+        # Mainloop over K-tiles: warp 0 produces (TMA load) and consumes (MMA-accumulate) each
+        # K-tile through the staged AB pipeline, integrating the full K = I into one accumulator.
+        #
+        if warp_idx == 0:
+            acc_empty = acc_producer.acquire_and_advance()
+            for k_tile in range(kps):
+                ab_empty = ab_producer.acquire_and_advance()
+                idx = ab_empty.index
+                # Global K-tile for this split. The unsplit path keeps a STATIC index (k_tile); split-K
+                # offsets by this split's k_base (a runtime split index) -- a dynamic TMA coordinate.
+                if cutlass.const_expr(self.num_k_split == 1):
+                    kg = k_tile
+                else:
+                    kg = k_base + k_tile
+                cute.copy(tma_atom_x, tXgX[(None, kg)], tXsX[(None, idx)],
+                          tma_bar_ptr=ab_empty.barrier)
+                cute.copy(tma_atom_l2, tL2gL2[(None, kg)], tL2sL2[(None, idx)],
+                          tma_bar_ptr=ab_empty.barrier)
+
+                ab_full = ab_consumer.wait_and_advance()
+                stage = ab_full.index
+                # First K-tile of THIS split initializes its partial accumulator; later K-tiles accumulate.
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                cute.gemm(
+                    tiled_mma, tCtAcc,
+                    tCrX[(None, None, None, stage)],
+                    tCrL2[(None, None, None, stage)],
+                    tCtAcc,
+                )
+                ab_full.release()
+            acc_empty.commit()
+
+        #
+        # Epilogue: t2r-copy the bf16 accumulator and store D [M, r].
+        #
+        # The TMEM-load t2r copy atom is DERIVED from the (m_tile, n_tile) tile + dtypes via
+        # get_tmem_load_op (D is N-major => ROW_MAJOR C). M=128 -> Ld32x32b(Repetition==n_tile, so
+        # 128->x128 / 64->x64); M=64 -> num_dp=16 selects a different op. Deriving it (vs hardcoding the
+        # op family) keeps every (m_tile, n_tile) from down_tile_for_shape correct.
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.mma_tiler, utils.LayoutEnum.ROW_MAJOR, self.d_dtype, ACC_DTYPE,
+            cute.make_layout(self.mma_tiler_mn), False,
+        )
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tCtAcc)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        tTR_tAcc = thr_copy_t2r.partition_S(tCtAcc)
+        tTR_gD = thr_copy_t2r.partition_D(tCgD)
+
+        rshape = tTR_gD[None, None, None, None, 0, 0, 0].shape
+        tTR_rAcc = cute.make_rmem_tensor(rshape, ACC_DTYPE)
+        tTR_rD = cute.make_rmem_tensor(rshape, self.d_dtype)
+        simt_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.d_dtype)
+        tTR_gD = tTR_gD[(None, None, None, None, *mma_tile_coord_mnl)]
+
+        if warp_idx == 0:
+            cute.arch.relinquish_tmem_alloc_permit()
+        acc_full = acc_consumer.wait_and_advance()
+
+        cute.copy(tiled_copy_t2r, tTR_tAcc, tTR_rAcc)
+        tTR_rD.store(tTR_rAcc.load().to(self.d_dtype))
+        cute.copy(simt_atom, tTR_rD, tTR_gD)
+
+        acc_full.release()
+        cute.arch.barrier()
+        tmem.free(acc_tmem_ptr)
+        return
+
+
+class SplitKReduce:
+    """Sum the split-K f32 partial down output D_partial[M, r, S] over the S splits -> bf16 D[M, r].
+
+    tcgen05-free CuteDSL. ONE THREAD PER (m, n) OUTPUT ELEMENT: a flat grid over the M*r_pad
+    independent outputs (thread g -> m = g // r_pad, n = g % r_pad, m-major), each summing its S f32
+    partials in FIXED ORDER and storing one bf16.
+
+    (The earlier grid was one thread per M-ROW -- only ceil(M/128) CTAs, e.g. 8 at M=1024 -- each
+    thread serially walking all r_pad*S elements, so the reduce was THREAD-STARVED and its latency
+    GREW with the split factor [the small-batch single-CTA-ish split-K-reduce slowdown]. The
+    per-element grid launches M*r_pad threads [~64x more CTAs], so the reduce is occupancy/bandwidth-
+    bound and stays cheap as S rises -- which is what lets the long-K down use a larger split-K. The
+    per-thread, fixed-order f32 accumulation [+0.0 init, same S order] is UNCHANGED, so the bf16 D is
+    BIT-IDENTICAL to the per-row reduce: zero-LoRA [D=0] stays bit-exact and the nonzero-LoRA SQNR is
+    unchanged. The padded n in [r, r_pad) sum to the down's zero partials and are sliced off by the
+    caller, exactly as before.) The partials are f32 (accurate cross-split sum); the output is bf16,
+    the same D the down used to emit, so the downstream up-projection / fused main consume it UNCHANGED."""
+
+    def __init__(self):
+        self.threads_per_cta = 128
+
+    @cute.jit
+    def __call__(
+        self,
+        partial_tensor: cute.Tensor,     # D_partial [M, r, S]  f32 (input)
+        out_tensor: cute.Tensor,         # D         [M, r, 1]  bf16 (output)
+        stream: cuda.CUstream,
+    ):
+        self.out_dtype: Type[cutlass.Numeric] = out_tensor.element_type
+        M = partial_tensor.shape[0]
+        out_cols = out_tensor.shape[1]            # produce EXACTLY the output's columns (<= the partials' r_pad)
+        total = M * out_cols                      # one thread per (m, n) output element
+        grid = (cute.ceil_div(total, self.threads_per_cta), 1, 1)
+        self.kernel(partial_tensor, out_tensor).launch(
+            grid=grid, block=[self.threads_per_cta, 1, 1], cluster=(1, 1, 1), stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(self, mP: cute.Tensor, mO: cute.Tensor):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        g = bidx * self.threads_per_cta + tidx
+        M = mP.shape[0]
+        ncols = cute.size(mO, mode=[1])          # OUTPUT columns (reads the first ncols of the partials' r_pad)
+        nsplit = cute.size(mP, mode=[2])         # num_k_split (compile-time)
+        total = M * ncols
+        if g < total:
+            m = g // ncols
+            n = g % ncols
+            acc = cutlass.Float32(0.0)
+            for s in range(nsplit):
+                acc = acc + cutlass.Float32(mP[m, n, s])
+            mO[m, n, 0] = acc.to(self.out_dtype)
+        return
+
+
+# ---------------------------------------------------------------------------
+# Host helpers: front-end input builders.
+# ---------------------------------------------------------------------------
+
+# Backing torch tensors for the production cute-tensor wrappers must outlive the cute.Tensor
+# (DLPack does not own the storage). We pin them on these wrappers so they are not GC'd while a
+# compiled kernel still references the DLPack view.
+def _kmajor_cuda_tensor(values_2d, cutlass_dtype, torch_dtype):
+    """(mn, k, 1) K-major cute tensor whose storage IS the CUDA input -- NO CPU staging.
+
+    The production front-end inputs are already on CUDA; we build a contiguous [mn, k, 1] K-major
+    CUDA view (k fastest) and wrap it via DLPack directly, marking the SAME dynamic / compact
+    layout metadata `cutlass_torch.matrix(1, mn, k, False, dtype)` would (leading_dim=1, mode-1
+    compact, stride_order (2,0,1)). For 16/32-bit operands the bytes ARE the values, so no f32
+    convert is needed; the backing tensor is pinned on the cute tensor to keep it alive."""
+    assert values_2d.is_cuda, "production front-end input builder requires a CUDA tensor"
+    # [mn, k] contiguous on CUDA -> [mn, k, 1] (k stride 1). .contiguous() is a device->device
+    # copy (or no-op); it never routes through host. The original input is untouched.
+    backing = values_2d.to(dtype=torch_dtype).contiguous().unsqueeze(-1)  # [mn, k, 1], k-major
+    cute_t = cute.runtime.from_dlpack(backing, assumed_align=16)
+    cute_t.element_type = cutlass_dtype
+    cute_t = cute_t.mark_layout_dynamic(leading_dim=1)
+    cute_t.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+    cute_t._svdquant_backing = backing            # keep storage alive with the cute tensor
+    return cute_t
+
+
+def _bf16_kmajor_tensor(values_2d):
+    """(mn, k, 1) K-major bf16 cute tensor backed directly by CUDA storage (NO `.cpu()` staging).
+    Same K-major / dynamic-layout metadata as the dual-MMA spike's bf16 operand builder."""
+    return _kmajor_cuda_tensor(values_2d, LORA_DTYPE, torch.bfloat16)
+
+
+def _f32_kmajor_tensor(values_2d):
+    """(mn, k, 1) K-major f32 cute tensor backed directly by CUDA storage (NO `.cpu()` staging).
+    The quantizer's A-input -- full-precision f32, so the on-device quant reproduces
+    reference.pack_with_gscale(X_f32) (no bf16 input rounding)."""
+    return _kmajor_cuda_tensor(values_2d, cutlass.Float32, torch.float32)
+
+
+def _u8_rowmajor_tensor(M, cols):
+    """A CUDA uint8 [M, cols] row-major output cute tensor (+ its torch view)."""
+    t = torch.zeros(M, cols, dtype=torch.uint8, device="cuda")
+    cute_t = cute.runtime.from_dlpack(t, assumed_align=16).mark_layout_dynamic(leading_dim=1)
+    return cute_t, t
+
+
+def assert_no_cpu_staging_in_input_builders():
+    """Guard: the PRODUCTION front-end input builders must NOT route CUDA
+    inputs through host. We monkeypatch torch.Tensor.cpu to raise if invoked on a CUDA tensor
+    while the builders run, then build a representative [M, I, 1] / [r, I, 1] CUDA operand each.
+    Raises AssertionError if any builder stages through `.cpu()`; returns silently on success."""
+    real_cpu = torch.Tensor.cpu
+    tripped = {"hit": False}
+
+    def _guarded_cpu(self, *a, **k):
+        if self.is_cuda:
+            tripped["hit"] = True
+            raise AssertionError("production front-end input builder staged a CUDA tensor via .cpu()")
+        return real_cpu(self, *a, **k)
+
+    M, I, r = 256, 256, 64
+    Xf = torch.randn(M, I, device="cuda", dtype=torch.float32)
+    Xb = Xf.to(torch.bfloat16)
+    L2b = torch.randn(r, I, device="cuda", dtype=torch.bfloat16)
+    torch.Tensor.cpu = _guarded_cpu
+    try:
+        _f32_kmajor_tensor(Xf)          # quantizer A-input (f32)
+        _bf16_kmajor_tensor(Xb)         # down-projection A-input (bf16)
+        _bf16_kmajor_tensor(L2b)        # down-projection B-input (bf16)
+    finally:
+        torch.Tensor.cpu = real_cpu
+    assert not tripped["hit"], "production front-end input builders must not CPU-stage CUDA inputs"
+    print("[guard] production front-end input builders: no .cpu() staging of CUDA inputs -> PASS")
+
+
+# Compile caches keyed by shape so JIT time is excluded from reuse.
+_QUANT_CACHE = {}
+_DOWN_CACHE = {}
+
+
+def _compiled_quantizer(M, I):
+    key = (M, I, "f32")
+    if key not in _QUANT_CACHE:
+        x_t = _f32_kmajor_tensor(torch.zeros(M, I, dtype=torch.float32, device="cuda"))
+        xq_t, _ = _u8_rowmajor_tensor(M, I // 2)
+        sf_t, _ = _u8_rowmajor_tensor(M, I // SF_BLOCK)
+        quant = ActivationQuantizer()
+        stream = cutlass_torch.default_stream()
+        _QUANT_CACHE[key] = cute.compile(quant, x_t, xq_t, sf_t, cutlass.Float32(0.0), stream)
+    return _QUANT_CACHE[key]
+
+
+def _compiled_down(M, I, r_pad, n_tile=MMA_TILER_MN[1], m_tile=MMA_TILER_MN[0], num_ab_stage=3):
+    key = (M, I, r_pad, n_tile, m_tile, str(LORA_DTYPE), BF16_TILE_K, num_ab_stage)
+    if key not in _DOWN_CACHE:
+        x_t = _bf16_kmajor_tensor(torch.zeros(M, I, dtype=torch.bfloat16, device="cuda"))
+        l2_t = _bf16_kmajor_tensor(torch.zeros(r_pad, I, dtype=torch.bfloat16, device="cuda"))
+        d_ref = cutlass_torch.matrix(1, M, r_pad, False, LORA_DTYPE)
+        d_t, _ = cutlass_torch.cute_tensor_like(d_ref, LORA_DTYPE, True, 16)
+        d_t.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+        proj = DownProjection(num_ab_stage, n_tile, m_tile)
+        stream = cutlass_torch.default_stream()
+        _DOWN_CACHE[key] = cute.compile(proj, x_t, l2_t, d_t, stream)
+    return _DOWN_CACHE[key]
+
+
+_REDUCE_CACHE = {}
+
+
+def _compiled_down_split(M, I, r_pad, n_tile, m_tile, num_k_split, num_ab_stage=3):
+    """The split-K down: writes f32 [M, r_pad, num_k_split] partials (each split integrates its 1/S K-slice)."""
+    key = (M, I, r_pad, n_tile, m_tile, num_k_split, "splitK", num_ab_stage)
+    if key not in _DOWN_CACHE:
+        x_t = _bf16_kmajor_tensor(torch.zeros(M, I, dtype=torch.bfloat16, device="cuda"))
+        l2_t = _bf16_kmajor_tensor(torch.zeros(r_pad, I, dtype=torch.bfloat16, device="cuda"))
+        d_ref = cutlass_torch.matrix(num_k_split, M, r_pad, False, ACC_DTYPE)   # f32 [M, r_pad, S] partials
+        d_t, _ = cutlass_torch.cute_tensor_like(d_ref, ACC_DTYPE, True, 16)
+        d_t.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+        proj = DownProjection(num_ab_stage, n_tile, m_tile, num_k_split)
+        stream = cutlass_torch.default_stream()
+        _DOWN_CACHE[key] = cute.compile(proj, x_t, l2_t, d_t, stream)
+    return _DOWN_CACHE[key]
+
+
+def _compiled_reduce(M, r_pad, num_k_split, r_out=None):
+    """SplitKReduce: f32 [M, r_pad, num_k_split] partials -> bf16 [M, r_out, 1] D (sum over the splits).
+    r_out defaults to r_pad; pass r_out=r to write EXACTLY the r real columns (the padded columns
+    [r, r_pad) are zero and are skipped) so the reduce can write straight into the fused main's D operand
+    [M, r] with no separate buffer / handoff copy. The output uses the SAME _kmajor layout as the fused
+    main's D (_kmajor_cuda_tensor), so the compiled reduce writes that exact layout. r_out <= r_pad."""
+    r_out = r_pad if r_out is None else r_out
+    key = (M, r_pad, num_k_split, r_out)
+    if key not in _REDUCE_CACHE:
+        p_ref = cutlass_torch.matrix(num_k_split, M, r_pad, False, ACC_DTYPE)
+        p_t, _ = cutlass_torch.cute_tensor_like(p_ref, ACC_DTYPE, True, 16)
+        p_t.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+        o_t = _kmajor_cuda_tensor(torch.zeros(M, r_out, dtype=torch.bfloat16, device="cuda"),
+                                  LORA_DTYPE, torch.bfloat16)
+        red = SplitKReduce()
+        stream = cutlass_torch.default_stream()
+        _REDUCE_CACHE[key] = cute.compile(red, p_t, o_t, stream)
+    return _REDUCE_CACHE[key]
+
+
+def run_quantizer(X, gscale_x):
+    """run_kernel_a's quantizer half (one of the production front-end's two device kernels):
+    emit (Xq uint8 [M, I//2], sf_x_bytes uint8 [M, I//16]) on CUDA, computed in-kernel (NOT via
+    reference.pack_with_gscale). X is taken on its own device (already-CUDA inputs are not CPU-
+    staged); the kernel quantizes the full-precision f32 X, so the emitted bytes are dequant-parity
+    with reference.pack_with_gscale(X_f32) (a few E4M3/E2M1 round-to-nearest TIES differ between
+    cute's and torch's conversions -- see check_quant_parity)."""
+    M, I = X.shape
+    Xf = X.to(device="cuda", dtype=torch.float32)
+    x_tensor = _f32_kmajor_tensor(Xf)                # [M, I, 1] K-major f32
+    xq_tensor, xq_torch = _u8_rowmajor_tensor(M, I // 2)
+    sf_tensor, sf_torch = _u8_rowmajor_tensor(M, I // SF_BLOCK)
+    compiled = _compiled_quantizer(M, I)
+    stream = cutlass_torch.default_stream()
+    compiled(x_tensor, xq_tensor, sf_tensor, cutlass.Float32(gscale_x), stream)
+    torch.cuda.synchronize()
+    return xq_torch, sf_torch                        # Xq uint8, sf uint8 (CUDA)
+
+
+def run_down_projection(X, L2, O=None):
+    """run_kernel_a's down-projection half (one of the production front-end's two device kernels):
+    run the CuteDSL bf16 D = X @ L2^T kernel and return D [M, r] bf16 on CUDA.
+
+    The MMA tile is shape-aware (down_tile_for_shape): r<=64 uses the SKINNY 64-col N-tile; the long-K
+    family (I>=24576) ALSO halves the M-tile to 64 AND uses SPLIT-K (num_k_split>1): the split-K down
+    writes f32 [M, r_pad, S] partials which SplitKReduce sums to bf16 D. L2 is zero-padded to r_pad rows
+    (a multiple of n_tile): the padded rows contribute zero output columns, which we slice off."""
+    M, I = X.shape
+    r = L2.shape[0]
+    m_tile, n_tile, r_pad, num_k_split = down_tile_for_shape(I, r, M, O=O)
+    Xb = X.to(device="cuda", dtype=torch.bfloat16)
+    L2b = L2.to(device="cuda", dtype=torch.bfloat16)
+    L2_pad = L2b
+    if r_pad != r:
+        L2_pad = torch.zeros(r_pad, I, dtype=torch.bfloat16, device="cuda")
+        L2_pad[:r] = L2b
+
+    x_tensor = _bf16_kmajor_tensor(Xb)               # [M, I]     K-major bf16 (A operand)
+    l2_tensor = _bf16_kmajor_tensor(L2_pad)          # [r_pad, I] K-major bf16 (B operand, N = r_pad)
+    stream = cutlass_torch.default_stream()
+
+    if num_k_split == 1:
+        d_ref = cutlass_torch.matrix(1, M, r_pad, False, LORA_DTYPE)
+        d_tensor, d_torch = cutlass_torch.cute_tensor_like(d_ref, LORA_DTYPE, True, 16)
+        d_tensor.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+        _compiled_down(M, I, r_pad, n_tile, m_tile)(x_tensor, l2_tensor, d_tensor, stream)
+        torch.cuda.synchronize()
+        return d_torch[:, :r, 0]                      # D bf16 (CUDA)
+
+    # split-K: f32 [M, r_pad, S] partials -> SplitKReduce -> bf16 [M, r] D, writing the r REAL columns
+    # directly into a K-major D (the padded columns [r, r_pad) are zero and are skipped); no slice/copy.
+    p_ref = cutlass_torch.matrix(num_k_split, M, r_pad, False, ACC_DTYPE)
+    p_tensor, _ = cutlass_torch.cute_tensor_like(p_ref, ACC_DTYPE, True, 16)
+    p_tensor.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+    o_tensor = _kmajor_cuda_tensor(torch.zeros(M, r, dtype=torch.bfloat16, device="cuda"),
+                                   LORA_DTYPE, torch.bfloat16)
+    _compiled_down_split(M, I, r_pad, n_tile, m_tile, num_k_split)(x_tensor, l2_tensor, p_tensor, stream)
+    _compiled_reduce(M, r_pad, num_k_split, r)(p_tensor, o_tensor, stream)
+    torch.cuda.synchronize()
+    return o_tensor._svdquant_backing[:, :, 0]        # D bf16 [M, r] (CUDA)
+
+
+def run_kernel_a(X, L2, gscale_x, O=None):
+    """PRODUCTION front-end (CURRENT: two device kernels -- ActivationQuantizer +
+    DownProjection). Emits REAL on-device Xq/sf_x AND bf16 D = X @ L2^T; both reads are device-side
+    (already-CUDA inputs are NOT CPU-staged). Returns (Xq uint8 [M, I//2], sf_x_bytes uint8
+    [M, I//16], D bf16 [M, r] on CUDA). Xq/sf_x are computed in-kernel (NOT pack_with_gscale).
+
+    The SINGLE-kernel read-once fusion (one f32 X read driving both quant and D) is BLOCKED by an MLIR
+    compile-time wall that a compile-cheap quant body does NOT fix: the deadlock is solved (warp-0 sole
+    consumer), but a fully NON-UNROLLED quant body still walls cute.compile() even on a small shape
+    (GB200 py.ro_compile2) -- the blowup is from co-locating the quant body with the tcgen05 UMMA
+    module at all, not from unrolling. A read-once fusion needs a fundamentally different emission (not
+    a loop tweak) -- see the module header. The two-kernel path feeds the fused main identically
+    (same Xq/sf_x/D), so this does not affect the fused main."""
+    Xq, sf_x_bytes = run_quantizer(X, gscale_x)      # ActivationQuantizer (REAL on-device quant)
+    D = run_down_projection(X, L2, O=O)              # DownProjection (bf16 tcgen05 MMA)
+    return Xq, sf_x_bytes, D
+
+
+def _provided_gscale_x(X):
+    # Clamp amax to the reference/bridge floor (reference uses amax.clamp_min(1e-8)) so an all-zero X yields a
+    # finite gscale instead of 0 -- a 0 here would divide to inf/NaN E4M3 block scales in the quantizer. No-op
+    # for any non-zero activation.
+    return (X.abs().amax().clamp_min(1e-8) / (FP4_E2M1_MAX * E4M3_MAX)).item()
+
+
+def _flux_shapes():
+    """All six FLUX.2 shapes from bench/problem_sizes.yaml as (name, M, I, O)."""
+    import yaml
+    cfg = yaml.safe_load(open(os.path.join(os.path.dirname(_HERE), "bench", "problem_sizes.yaml")))
+    return [(s["name"], s["M"], s["I"], s["O"]) for s in cfg["shapes"]]
+
+
+class KernelB:
+    """One kernel, two heterogeneous TMEM accumulators (NVFP4 main + bf16 low-rank), fused add,
+    over the full K = I via a multi-stage pipelined main loop. `enable_lora=False` compiles the
+    plain-NVFP4 variant (same main schedule, lora path disabled)."""
+
+    def __init__(self, lora_k: int, enable_lora: bool = True, num_ab_stage: int = 3,
+                 num_tmem_alloc_cols: int = 512, num_acc_stage: int = 1):
+        self.threads_per_cta = 128
+        self.lora_k = lora_k                 # r (low-rank contraction depth, <= 64)
+        self.enable_lora = bool(enable_lora)
+        # num_tmem_alloc_cols: TMEM columns reserved per CTA (full TMEM = 512 -> 1 CTA/SM). Reducing it
+        # (when the accumulators fit) lets >1 CTA reside per SM so one CTA's epilogue overlaps another's
+        # MMA -- the occupancy lever for this latency-bound kernel (ncu: 6.2% occ, 27% compute).
+        self.num_tmem_alloc_cols = num_tmem_alloc_cols
+        self.num_ab_stage = num_ab_stage     # main NVFP4 pipeline depth (large K = I)
+        self.num_lora_stage = 1              # lora K = r fits one tile
+        self.num_acc_stage = num_acc_stage
+
+    @cute.jit
+    def __call__(
+        self,
+        a_tensor: cute.Tensor,       # Xq  [M, I]  packed E2M1, K-major
+        b_tensor: cute.Tensor,       # Rq  [O, I]  packed E2M1, K-major
+        sfa_tensor: cute.Tensor,     # SFA E4M3 (MMA-swizzled iterator)
+        sfb_tensor: cute.Tensor,     # SFB E4M3 (MMA-swizzled iterator)
+        d_tensor: cute.Tensor,       # D   [M, r]  bf16, K-major (= X @ L2^T)
+        l1_tensor: cute.Tensor,      # L1  [O, r]  bf16, K-major
+        c_tensor: cute.Tensor,       # Y   [M, O]  bf16, N-major
+        global_scale: cutlass.Float32,
+        stream: cuda.CUstream,
+    ):
+        self.a_dtype: Type[cutlass.Numeric] = a_tensor.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
+        self.lora_dtype: Type[cutlass.Numeric] = d_tensor.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
+
+        # --- main (NVFP4 block-scaled) tile + tiled_mma ---
+        self.mma_tiler = (MMA_TILER_MN[0], MMA_TILER_MN[1], NVFP4_TILE_K)
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype, self.b_dtype,
+            OperandMajorMode.K, OperandMajorMode.K,
+            self.sf_dtype, SF_VEC, tcgen05.CtaGroup.ONE, MMA_TILER_MN,
+        )
+        # --- low-rank (bf16) tile + tiled_mma: SAME (M, N) tile, contract K = r ---
+        self.lora_tiler = (MMA_TILER_MN[0], MMA_TILER_MN[1], self.lora_k)
+        lora_mma = sm100_utils.make_trivial_tiled_mma(
+            self.lora_dtype, self.lora_dtype,
+            OperandMajorMode.K, OperandMajorMode.K,
+            ACC_DTYPE, tcgen05.CtaGroup.ONE, MMA_TILER_MN,
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((1, 1, 1)), (tiled_mma.thr_id.shape,)
+        )
+
+        # Re-wrap the SF tensors with the layout derived from the FULL A/B shape (iterator swizzled).
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(a_tensor.shape, SF_VEC)
+        sfa_tensor = cute.make_tensor(sfa_tensor.iterator, sfa_layout)
+        sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(b_tensor.shape, SF_VEC)
+        sfb_tensor = cute.make_tensor(sfb_tensor.iterator, sfb_layout)
+
+        # Multi-stage SMEM layouts -- main operands + scales (the staged-K mainloop reuses
+        # num_ab_stage buffers as it streams the K = I tiles).
+        self.a_smem_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma, self.mma_tiler, self.a_dtype, self.num_ab_stage)
+        self.b_smem_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma, self.mma_tiler, self.b_dtype, self.num_ab_stage)
+        self.sfa_smem_layout = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma, self.mma_tiler, SF_VEC, self.num_ab_stage)
+        self.sfb_smem_layout = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma, self.mma_tiler, SF_VEC, self.num_ab_stage)
+        # Single-stage SMEM layouts -- bf16 low-rank operands (K = r is one tile).
+        self.d_smem_layout = sm100_utils.make_smem_layout_a(
+            lora_mma, self.lora_tiler, self.lora_dtype, self.num_lora_stage)
+        self.l1_smem_layout = sm100_utils.make_smem_layout_b(
+            lora_mma, self.lora_tiler, self.lora_dtype, self.num_lora_stage)
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # TMA atoms -- main NVFP4 path (per-tile slice of the staged SMEM describes the copy).
+        a_smem_layout = cute.slice_(self.a_smem_layout, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE),
+            a_tensor, a_smem_layout, self.mma_tiler, tiled_mma, self.cluster_layout_vmnk.shape,
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE),
+            b_tensor, b_smem_layout, self.mma_tiler, tiled_mma, self.cluster_layout_vmnk.shape,
+        )
+        sfa_smem_layout = cute.slice_(self.sfa_smem_layout, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE),
+            sfa_tensor, sfa_smem_layout, self.mma_tiler, tiled_mma, self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+        sfb_smem_layout = cute.slice_(self.sfb_smem_layout, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE),
+            sfb_tensor, sfb_smem_layout, self.mma_tiler, tiled_mma, self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+        # TMA atoms -- bf16 low-rank path
+        d_smem_layout = cute.slice_(self.d_smem_layout, (None, None, None, 0))
+        tma_atom_d, tma_tensor_d = cute.nvgpu.make_tiled_tma_atom_A(
+            cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE),
+            d_tensor, d_smem_layout, self.lora_tiler, lora_mma, self.cluster_layout_vmnk.shape,
+        )
+        l1_smem_layout = cute.slice_(self.l1_smem_layout, (None, None, None, 0))
+        tma_atom_l1, tma_tensor_l1 = cute.nvgpu.make_tiled_tma_atom_B(
+            cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE),
+            l1_tensor, l1_smem_layout, self.lora_tiler, lora_mma, self.cluster_layout_vmnk.shape,
+        )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        d_copy_size = cute.size_in_bytes(self.lora_dtype, d_smem_layout)
+        l1_copy_size = cute.size_in_bytes(self.lora_dtype, l1_smem_layout)
+        # Per-stage TX byte counts: the main AB pipeline carries A/B/SFA/SFB each k_tile; the lora
+        # pipeline carries D/L1 once.
+        self.num_ab_tma_load_bytes = (
+            a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size) * atom_thr_size
+        self.num_lora_tma_load_bytes = (d_copy_size + l1_copy_size) * atom_thr_size
+
+        grid = (
+            cute.ceil_div(c_tensor.shape[0], self.mma_tiler[0]),
+            cute.ceil_div(c_tensor.shape[1], self.mma_tiler[1]),
+            c_tensor.shape[2],
+        )
+
+        self.kernel(
+            tiled_mma, lora_mma,
+            tma_atom_a, tma_tensor_a,
+            tma_atom_b, tma_tensor_b,
+            tma_atom_sfa, tma_tensor_sfa,
+            tma_atom_sfb, tma_tensor_sfb,
+            tma_atom_d, tma_tensor_d,
+            tma_atom_l1, tma_tensor_l1,
+            c_tensor, global_scale,
+            self.a_smem_layout, self.b_smem_layout,
+            self.sfa_smem_layout, self.sfb_smem_layout,
+            self.d_smem_layout, self.l1_smem_layout,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(1, 1, 1),
+            stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        lora_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom, mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom, mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom, mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom, mSFB_nkl: cute.Tensor,
+        tma_atom_d: cute.CopyAtom, mD_mkl: cute.Tensor,
+        tma_atom_l1: cute.CopyAtom, mL1_nkl: cute.Tensor,
+        mC_mnl: cute.Tensor,
+        global_scale: cutlass.Float32,
+        a_smem_layout: cute.ComposedLayout,
+        b_smem_layout: cute.ComposedLayout,
+        sfa_smem_layout: cute.Layout,
+        sfb_smem_layout: cute.Layout,
+        d_smem_layout: cute.ComposedLayout,
+        l1_smem_layout: cute.ComposedLayout,
+    ):
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        mma_tile_coord_mnl = (
+            bidx // cute.size(tiled_mma.thr_id.shape),
+            bidy,
+            bidz,
+        )
+
+        #
+        # Shared storage: pipeline barriers (main AB + lora AB + acc) + the two operand sets.
+        #
+        @cute.struct
+        class SharedStorage:
+            ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            lora_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_lora_stage * 2]
+            acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        # main NVFP4 operands (multi-stage)
+        sA = smem.allocate_tensor(self.a_dtype, a_smem_layout.outer, 128, a_smem_layout.inner)
+        sB = smem.allocate_tensor(self.b_dtype, b_smem_layout.outer, 128, b_smem_layout.inner)
+        sSFA = smem.allocate_tensor(self.sf_dtype, sfa_smem_layout, 128)
+        sSFB = smem.allocate_tensor(self.sf_dtype, sfb_smem_layout, 128)
+        # bf16 low-rank operands (single stage)
+        sD = smem.allocate_tensor(self.lora_dtype, d_smem_layout.outer, 128, d_smem_layout.inner)
+        sL1 = smem.allocate_tensor(self.lora_dtype, l1_smem_layout.outer, 128, l1_smem_layout.inner)
+
+        #
+        # Pipelines: a multi-stage main AB pair (A/B/SFA/SFB), a single-stage lora AB pair (D/L1),
+        # and one acc pair gating the MMA-result handoff to the epilogue. Warp 0 is the SOLE
+        # consumer of both AB pipelines (avoids the single-consumer-PipelineTmaUmma over-rotation).
+        #
+        ab_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        ab_consumer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 1)
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_producer_group,
+            consumer_group=ab_consumer_group,
+            tx_count=self.num_ab_tma_load_bytes,
+        ).make_participants()
+        lora_producer, lora_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.lora_mbar_ptr.data_ptr(),
+            num_stages=self.num_lora_stage,
+            producer_group=ab_producer_group,
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.num_lora_tma_load_bytes,
+        ).make_participants()
+        acc_producer, acc_consumer = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=ab_producer_group,
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, self.threads_per_cta),
+        ).make_participants()
+
+        #
+        # Tile global tensors; the K mode stays a free index so the mainloop can stream K-tiles.
+        #
+        gA = cute.local_tile(mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+        gB = cute.local_tile(mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None))
+        gSFA = cute.local_tile(mSFA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+        gSFB = cute.local_tile(mSFB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None))
+        gD = cute.local_tile(mD_mkl, cute.slice_(self.lora_tiler, (None, 0, None)), (None, None, None))
+        gL1 = cute.local_tile(mL1_nkl, cute.slice_(self.lora_tiler, (0, None, None)), (None, None, None))
+        gC = cute.local_tile(mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None))
+
+        #
+        # MMA partitions.
+        #
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        tCgA = thr_mma.partition_A(gA)
+        tCgB = thr_mma.partition_B(gB)
+        tCgSFA = thr_mma.partition_A(gSFA)
+        tCgSFB = thr_mma.partition_B(gSFB)
+        tCgC = thr_mma.partition_C(gC)
+
+        thr_lora = lora_mma.get_slice(mma_tile_coord_v)
+        tLgD = thr_lora.partition_A(gD)
+        tLgL1 = thr_lora.partition_B(gL1)
+
+        #
+        # TMA partitions.
+        #
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a, 0, cute.make_layout(1),
+            cute.group_modes(sA, 0, 3), cute.group_modes(tCgA, 0, 3))
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b, 0, cute.make_layout(1),
+            cute.group_modes(sB, 0, 3), cute.group_modes(tCgB, 0, 3))
+        tAsSFA, tAgSFA = cpasync.tma_partition(
+            tma_atom_sfa, 0, cute.make_layout(1),
+            cute.group_modes(sSFA, 0, 3), cute.group_modes(tCgSFA, 0, 3))
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+        tBsSFB, tBgSFB = cpasync.tma_partition(
+            tma_atom_sfb, 0, cute.make_layout(1),
+            cute.group_modes(sSFB, 0, 3), cute.group_modes(tCgSFB, 0, 3))
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+        tDsD, tDgD = cpasync.tma_partition(
+            tma_atom_d, 0, cute.make_layout(1),
+            cute.group_modes(sD, 0, 3), cute.group_modes(tLgD, 0, 3))
+        tL1sL1, tL1gL1 = cpasync.tma_partition(
+            tma_atom_l1, 0, cute.make_layout(1),
+            cute.group_modes(sL1, 0, 3), cute.group_modes(tLgL1, 0, 3))
+
+        #
+        # MMA fragments.
+        #
+        tCrA = tiled_mma.make_fragment_A(sA)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        tLrD = lora_mma.make_fragment_A(sD)
+        tLrL1 = lora_mma.make_fragment_B(sL1)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(acc_shape)
+        lora_acc_shape = lora_mma.partition_shape_C(self.mma_tiler[:2])
+        tLtAcc_fake = lora_mma.make_fragment_C(lora_acc_shape)
+
+        #
+        # Allocate TMEM: main_acc at base, lora_acc next, then SFA/SFB for the NVFP4 MMA
+        # (column-offset chaining; both variants allocate identically so main_acc is bit-stable).
+        #
+        tmem_alloc_barrier = pipeline.NamedBarrier(barrier_id=1, num_threads=self.threads_per_cta)
+        tmem = utils.TmemAllocator(storage.tmem_holding_buf.ptr, barrier_for_retrieve=tmem_alloc_barrier)
+        tmem.allocate(self.num_tmem_alloc_cols)
+        tmem.wait_for_alloc()
+        acc_tmem_ptr = tmem.retrieve_ptr(ACC_DTYPE)
+        tCtAcc = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+        lora_acc_ptr = cute.recast_ptr(
+            acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc), dtype=ACC_DTYPE)
+        tLtAcc = cute.make_tensor(lora_acc_ptr, tLtAcc_fake.layout)
+
+        tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+            tiled_mma, self.mma_tiler, SF_VEC, cute.slice_(sfa_smem_layout, (None, None, None, 0)))
+        sfa_tmem_ptr = cute.recast_ptr(
+            acc_tmem_ptr
+            + tcgen05.find_tmem_tensor_col_offset(tCtAcc)
+            + tcgen05.find_tmem_tensor_col_offset(tLtAcc),
+            dtype=self.sf_dtype)
+        tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+        tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+            tiled_mma, self.mma_tiler, SF_VEC, cute.slice_(sfb_smem_layout, (None, None, None, 0)))
+        sfb_tmem_ptr = cute.recast_ptr(
+            acc_tmem_ptr
+            + tcgen05.find_tmem_tensor_col_offset(tCtAcc)
+            + tcgen05.find_tmem_tensor_col_offset(tLtAcc)
+            + tcgen05.find_tmem_tensor_col_offset(tCtSFA),
+            dtype=self.sf_dtype)
+        tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+        #
+        # S2T copy plumbing for SFA/SFB (NVFP4 block scales SMEM -> TMEM); staged source.
+        #
+        copy_atom_s2t = cute.make_copy_atom(tcgen05.Cp4x32x128bOp(tcgen05.CtaGroup.ONE), self.sf_dtype)
+        tCsSFA_compact = cute.filter_zeros(sSFA)
+        tCtSFA_compact = cute.filter_zeros(tCtSFA)
+        tiled_copy_s2t_sfa = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSFA_compact)
+        thr_copy_s2t_sfa = tiled_copy_s2t_sfa.get_slice(0)
+        tCsSFA_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t_sfa, thr_copy_s2t_sfa.partition_S(tCsSFA_compact))
+        tCtSFA_s2t = thr_copy_s2t_sfa.partition_D(tCtSFA_compact)
+
+        tCsSFB_compact = cute.filter_zeros(sSFB)
+        tCtSFB_compact = cute.filter_zeros(tCtSFB)
+        tiled_copy_s2t_sfb = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSFB_compact)
+        thr_copy_s2t_sfb = tiled_copy_s2t_sfb.get_slice(0)
+        tCsSFB_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t_sfb, thr_copy_s2t_sfb.partition_S(tCsSFB_compact))
+        tCtSFB_s2t = thr_copy_s2t_sfb.partition_D(tCtSFB_compact)
+
+        #
+        # Slice TMA source/dest to this CTA tile; the main A/B/SFA/SFB keep a free K-tile mode.
+        #
+        tAgA = tAgA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+        tBgB = tBgB[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+        tAgSFA = tAgSFA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+        tBgSFB = tBgSFB[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+        tDgD = tDgD[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+        tL1gL1 = tL1gL1[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+
+        # K-tile count from the static layout mode (compile-time int even with dynamic M/K), so the
+        # plain Python loop keeps `tiled_mma.set(ACCUMULATE, k_tile != 0)` a compile-time predicate.
+        k_tile_cnt = cute.size(gA, mode=[3])
+
+        #
+        # Compute. Warp 0 drives both AB pipelines and issues both MMAs.
+        #
+        if warp_idx == 0:
+            acc_empty = acc_producer.acquire_and_advance()
+
+            # OVERLAP SCHEDULE (wide-O lever): issue the low-rank D/L1 TMA load BEFORE the main K-loop so
+            # it streams in flight DURING the main NVFP4 GEMM (the two use independent pipelines), then
+            # consume it AFTER the loop. The bf16 lora MMA itself is tiny; this hides its TMA-load
+            # latency behind the long main K-loop. The main K-loop accumulation order is UNCHANGED, and
+            # the plain variant (enable_lora=False) issues NONE of the lora ops -- so its main schedule
+            # is byte-identical and the zero-LoRA bit-match (lora_acc=+0 with D=0) still holds.
+            if cutlass.const_expr(self.enable_lora):
+                lora_empty = lora_producer.acquire_and_advance()
+                lidx = lora_empty.index
+                cute.copy(tma_atom_d, tDgD[(None, 0)], tDsD[(None, lidx)], tma_bar_ptr=lora_empty.barrier)
+                cute.copy(tma_atom_l1, tL1gL1[(None, 0)], tL1sL1[(None, lidx)], tma_bar_ptr=lora_empty.barrier)
+
+            # main NVFP4 mainloop: stream the full K = I, accumulating into main_acc.
+            for k_tile in range(k_tile_cnt):
+                ab_empty = ab_producer.acquire_and_advance()
+                idx = ab_empty.index
+                cute.copy(tma_atom_a, tAgA[(None, k_tile)], tAsA[(None, idx)], tma_bar_ptr=ab_empty.barrier)
+                cute.copy(tma_atom_b, tBgB[(None, k_tile)], tBsB[(None, idx)], tma_bar_ptr=ab_empty.barrier)
+                cute.copy(tma_atom_sfa, tAgSFA[(None, k_tile)], tAsSFA[(None, idx)], tma_bar_ptr=ab_empty.barrier)
+                cute.copy(tma_atom_sfb, tBgSFB[(None, k_tile)], tBsSFB[(None, idx)], tma_bar_ptr=ab_empty.barrier)
+
+                ab_full = ab_consumer.wait_and_advance()
+                stage = ab_full.index
+                cute.copy(tiled_copy_s2t_sfa, tCsSFA_s2t[(None, None, None, None, stage)], tCtSFA_s2t)
+                cute.copy(tiled_copy_s2t_sfb, tCsSFB_s2t[(None, None, None, None, stage)], tCtSFB_s2t)
+
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                cute.gemm(
+                    tiled_mma, tCtAcc,
+                    [tCrA[(None, None, None, stage)], tCtSFA],
+                    [tCrB[(None, None, None, stage)], tCtSFB],
+                    tCtAcc,
+                )
+                ab_full.release()
+
+            # The low-rank D/L1 finished loading during the main loop -> consume it now: D @ L1^T ->
+            # lora_acc (bf16, K = r one tile). One acc commit then gates BOTH accumulators to the epilogue.
+            if cutlass.const_expr(self.enable_lora):
+                lora_full = lora_consumer.wait_and_advance()
+                lstage = lora_full.index
+                lora_mma.set(tcgen05.Field.ACCUMULATE, False)
+                cute.gemm(
+                    lora_mma, tLtAcc,
+                    tLrD[(None, None, None, lstage)],
+                    tLrL1[(None, None, None, lstage)],
+                    tLtAcc,
+                )
+                lora_full.release()
+
+            acc_empty.commit()
+
+        #
+        # Epilogue: t2r-copy the accumulator(s), combine, store.
+        #   fused : Y = dequant(main_acc) * global_scale + lora_acc  -> bf16
+        #   plain : Y = dequant(main_acc) * global_scale             -> bf16
+        #
+        op = tcgen05.Ld32x32bOp(tcgen05.Repetition.x128, tcgen05.Pack.NONE)
+        copy_atom_t2r = cute.make_copy_atom(op, ACC_DTYPE)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tCtAcc)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        tTR_tAcc = thr_copy_t2r.partition_S(tCtAcc)
+        tTR_gC = thr_copy_t2r.partition_D(tCgC)
+
+        rshape = tTR_gC[None, None, None, None, 0, 0, 0].shape
+        tTR_rAcc = cute.make_rmem_tensor(rshape, ACC_DTYPE)
+        tTR_rC = cute.make_rmem_tensor(rshape, self.c_dtype)
+        simt_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.c_dtype)
+        tTR_gC = tTR_gC[(None, None, None, None, *mma_tile_coord_mnl)]
+
+        if cutlass.const_expr(self.enable_lora):
+            tiled_copy_t2r_lora = tcgen05.make_tmem_copy(copy_atom_t2r, tLtAcc)
+            thr_copy_t2r_lora = tiled_copy_t2r_lora.get_slice(tidx)
+            tTR_tLora = thr_copy_t2r_lora.partition_S(tLtAcc)
+            tTR_rLora = cute.make_rmem_tensor(rshape, ACC_DTYPE)
+
+        if warp_idx == 0:
+            cute.arch.relinquish_tmem_alloc_permit()
+        acc_full = acc_consumer.wait_and_advance()
+
+        cute.copy(tiled_copy_t2r, tTR_tAcc, tTR_rAcc)
+        out_vec = tTR_rAcc.load() * global_scale            # fold per-tensor global scale here
+        if cutlass.const_expr(self.enable_lora):
+            cute.copy(tiled_copy_t2r_lora, tTR_tLora, tTR_rLora)
+            out_vec = out_vec + tTR_rLora.load()
+        tTR_rC.store(out_vec.to(self.c_dtype))
+        cute.copy(simt_atom, tTR_rC, tTR_gC)
+
+        acc_full.release()
+        cute.arch.barrier()
+        tmem.free(acc_tmem_ptr)
+        return
+
+
+# ---------------------------------------------------------------------------
+# Wide-O 2-CTA path (single_linear1, O/I >= 8): a CtaGroup.TWO cooperative variant -- a 256-row
+# M-tile computed by a 2-CTA cluster (128 rows/CTA) HALVES the M-tile count -> halves the per-(M,O)
+# dual-TMEM epilogue add. Built from the GB200-validated dual_mma_spike_2cta mechanics (warp0 of BOTH
+# CTAs issues multicast TMAs; the LEADER issues the MMAs; allocator-aware relinquish; tmem.free on all
+# CTAs) plus this module's multi-stage K-loop + the lora-prologue overlap + enable_lora plain variant.
+# The 1-CTA KernelB above is UNCHANGED (other shapes use it verbatim).
+# ---------------------------------------------------------------------------
+MMA_TILER_MN_2CTA = (256, 128)
+CTA_GROUP_2 = tcgen05.CtaGroup.TWO
+CLUSTER_SHAPE_MN_2CTA = (2, 1)
+
+
+class KernelB2CTA:
+    """2-CTA cooperative heterogeneous dual-TMEM fused main (wide-O). Same I/O contract as KernelB;
+    `enable_lora=False` is the plain (main-only) variant with the identical main schedule."""
+
+    def __init__(self, lora_k: int, enable_lora: bool = True, num_ab_stage: int = 3):
+        self.threads_per_cta = 128
+        self.lora_k = lora_k
+        self.enable_lora = bool(enable_lora)
+        self.num_tmem_alloc_cols = 512
+        self.num_ab_stage = num_ab_stage
+        self.num_lora_stage = 1
+        self.num_acc_stage = 1
+
+    @cute.jit
+    def __call__(
+        self,
+        a_tensor: cute.Tensor, b_tensor: cute.Tensor,
+        sfa_tensor: cute.Tensor, sfb_tensor: cute.Tensor,
+        d_tensor: cute.Tensor, l1_tensor: cute.Tensor,
+        c_tensor: cute.Tensor, global_scale: cutlass.Float32, stream: cuda.CUstream,
+    ):
+        self.a_dtype = a_tensor.element_type
+        self.b_dtype = b_tensor.element_type
+        self.sf_dtype = sfa_tensor.element_type
+        self.lora_dtype = d_tensor.element_type
+        self.c_dtype = c_tensor.element_type
+
+        # 2-CTA tiled MMAs (256-row cluster tile). thr_id.shape == 2 -> use_2cta.
+        self.mma_tiler = (MMA_TILER_MN_2CTA[0], MMA_TILER_MN_2CTA[1], NVFP4_TILE_K)
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype, self.b_dtype, OperandMajorMode.K, OperandMajorMode.K,
+            self.sf_dtype, SF_VEC, CTA_GROUP_2, MMA_TILER_MN_2CTA,
+        )
+        self.lora_tiler = (MMA_TILER_MN_2CTA[0], MMA_TILER_MN_2CTA[1], self.lora_k)
+        lora_mma = sm100_utils.make_trivial_tiled_mma(
+            self.lora_dtype, self.lora_dtype, OperandMajorMode.K, OperandMajorMode.K,
+            ACC_DTYPE, CTA_GROUP_2, MMA_TILER_MN_2CTA,
+        )
+        # SFB: a SEPARATE 1-CTA blockscaled MMA (M halved for 2-CTA, N round-up 128); the weight block
+        # scales are replicated across the peer CTA.
+        mma_inst_shape_mn_sfb = (MMA_TILER_MN_2CTA[0] // 2, cute.round_up(MMA_TILER_MN_2CTA[1], 128))
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype, self.b_dtype, OperandMajorMode.K, OperandMajorMode.K,
+            self.sf_dtype, SF_VEC, tcgen05.CtaGroup.ONE, mma_inst_shape_mn_sfb,
+        )
+        self.mma_tiler_sfb = (mma_inst_shape_mn_sfb[0], mma_inst_shape_mn_sfb[1], NVFP4_TILE_K)
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*CLUSTER_SHAPE_MN_2CTA, 1)), (tiled_mma.thr_id.shape,))
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*CLUSTER_SHAPE_MN_2CTA, 1)), (tiled_mma_sfb.thr_id.shape,))
+
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(a_tensor.shape, SF_VEC)
+        sfa_tensor = cute.make_tensor(sfa_tensor.iterator, sfa_layout)
+        sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(b_tensor.shape, SF_VEC)
+        sfb_tensor = cute.make_tensor(sfb_tensor.iterator, sfb_layout)
+
+        self.a_smem_layout = sm100_utils.make_smem_layout_a(
+            tiled_mma, self.mma_tiler, self.a_dtype, self.num_ab_stage)
+        self.b_smem_layout = sm100_utils.make_smem_layout_b(
+            tiled_mma, self.mma_tiler, self.b_dtype, self.num_ab_stage)
+        self.sfa_smem_layout = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma, self.mma_tiler, SF_VEC, self.num_ab_stage)
+        self.sfb_smem_layout = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma, self.mma_tiler, SF_VEC, self.num_ab_stage)
+        self.d_smem_layout = sm100_utils.make_smem_layout_a(
+            lora_mma, self.lora_tiler, self.lora_dtype, self.num_lora_stage)
+        self.l1_smem_layout = sm100_utils.make_smem_layout_b(
+            lora_mma, self.lora_tiler, self.lora_dtype, self.num_lora_stage)
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Cluster-aware TMA atoms (multicast across the cluster), NOT the generic 1-CTA op.
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(CLUSTER_SHAPE_MN_2CTA, tiled_mma.thr_id)
+        a_sl = cute.slice_(self.a_smem_layout, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op, a_tensor, a_sl, self.mma_tiler, tiled_mma, self.cluster_layout_vmnk.shape)
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(CLUSTER_SHAPE_MN_2CTA, tiled_mma.thr_id)
+        b_sl = cute.slice_(self.b_smem_layout, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op, b_tensor, b_sl, self.mma_tiler, tiled_mma, self.cluster_layout_vmnk.shape)
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(CLUSTER_SHAPE_MN_2CTA, tiled_mma.thr_id)
+        sfa_sl = cute.slice_(self.sfa_smem_layout, (None, None, None, 0))
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op, sfa_tensor, sfa_sl, self.mma_tiler, tiled_mma, self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16)
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(CLUSTER_SHAPE_MN_2CTA, tiled_mma.thr_id)
+        sfb_sl = cute.slice_(self.sfb_smem_layout, (None, None, None, 0))
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op, sfb_tensor, sfb_sl, self.mma_tiler_sfb, tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape, internal_type=cutlass.Int16)
+        d_op = sm100_utils.cluster_shape_to_tma_atom_A(CLUSTER_SHAPE_MN_2CTA, lora_mma.thr_id)
+        d_sl = cute.slice_(self.d_smem_layout, (None, None, None, 0))
+        tma_atom_d, tma_tensor_d = cute.nvgpu.make_tiled_tma_atom_A(
+            d_op, d_tensor, d_sl, self.lora_tiler, lora_mma, self.cluster_layout_vmnk.shape)
+        l1_op = sm100_utils.cluster_shape_to_tma_atom_B(CLUSTER_SHAPE_MN_2CTA, lora_mma.thr_id)
+        l1_sl = cute.slice_(self.l1_smem_layout, (None, None, None, 0))
+        tma_atom_l1, tma_tensor_l1 = cute.nvgpu.make_tiled_tma_atom_B(
+            l1_op, l1_tensor, l1_sl, self.lora_tiler, lora_mma, self.cluster_layout_vmnk.shape)
+
+        self.num_ab_tma_load_bytes = (
+            cute.size_in_bytes(self.a_dtype, a_sl) + cute.size_in_bytes(self.b_dtype, b_sl)
+            + cute.size_in_bytes(self.sf_dtype, sfa_sl) + cute.size_in_bytes(self.sf_dtype, sfb_sl)
+        ) * atom_thr_size
+        self.num_lora_tma_load_bytes = (
+            cute.size_in_bytes(self.lora_dtype, d_sl) + cute.size_in_bytes(self.lora_dtype, l1_sl)
+        ) * atom_thr_size
+
+        grid = (
+            cute.ceil_div(c_tensor.shape[0], self.mma_tiler[0]) * atom_thr_size,
+            cute.ceil_div(c_tensor.shape[1], self.mma_tiler[1]),
+            c_tensor.shape[2],
+        )
+        self.kernel(
+            tiled_mma, lora_mma, tiled_mma_sfb,
+            tma_atom_a, tma_tensor_a, tma_atom_b, tma_tensor_b,
+            tma_atom_sfa, tma_tensor_sfa, tma_atom_sfb, tma_tensor_sfb,
+            tma_atom_d, tma_tensor_d, tma_atom_l1, tma_tensor_l1,
+            c_tensor, global_scale,
+            self.a_smem_layout, self.b_smem_layout, self.sfa_smem_layout, self.sfb_smem_layout,
+            self.d_smem_layout, self.l1_smem_layout,
+            self.cluster_layout_vmnk, self.cluster_layout_sfb_vmnk,
+        ).launch(
+            grid=grid, block=[self.threads_per_cta, 1, 1],
+            cluster=(*CLUSTER_SHAPE_MN_2CTA, 1), stream=stream,
+        )
+        return
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma, lora_mma: cute.TiledMma, tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom, mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom, mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom, mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom, mSFB_nkl: cute.Tensor,
+        tma_atom_d: cute.CopyAtom, mD_mkl: cute.Tensor,
+        tma_atom_l1: cute.CopyAtom, mL1_nkl: cute.Tensor,
+        mC_mnl: cute.Tensor, global_scale: cutlass.Float32,
+        a_smem_layout: cute.ComposedLayout, b_smem_layout: cute.ComposedLayout,
+        sfa_smem_layout: cute.Layout, sfb_smem_layout: cute.Layout,
+        d_smem_layout: cute.ComposedLayout, l1_smem_layout: cute.ComposedLayout,
+        cluster_layout_vmnk: cute.Layout, cluster_layout_sfb_vmnk: cute.Layout,
+    ):
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+        mma_tile_coord_mnl = (bidx // cute.size(tiled_mma.thr_id.shape), bidy, bidz)
+
+        @cute.struct
+        class SharedStorage:
+            ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            lora_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_lora_stage * 2]
+            acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
+            tmem_dealloc_mbar: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+        sA = smem.allocate_tensor(self.a_dtype, a_smem_layout.outer, 128, a_smem_layout.inner)
+        sB = smem.allocate_tensor(self.b_dtype, b_smem_layout.outer, 128, b_smem_layout.inner)
+        sSFA = smem.allocate_tensor(self.sf_dtype, sfa_smem_layout, 128)
+        sSFB = smem.allocate_tensor(self.sf_dtype, sfb_smem_layout, 128)
+        sD = smem.allocate_tensor(self.lora_dtype, d_smem_layout.outer, 128, d_smem_layout.inner)
+        sL1 = smem.allocate_tensor(self.lora_dtype, l1_smem_layout.outer, 128, l1_smem_layout.inner)
+
+        # 2-CTA pipelines: the ab consumer count is the multicast-CTA count (vendored), NOT 1.
+        num_mcast_ctas_a = cute.size(cluster_layout_vmnk.shape[2])
+        num_mcast_ctas_b = cute.size(cluster_layout_vmnk.shape[1])
+        ab_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_mbar_ptr.data_ptr(), num_stages=self.num_ab_stage,
+            producer_group=ab_producer_group,
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_mcast_ctas_a + num_mcast_ctas_b - 1),
+            tx_count=self.num_ab_tma_load_bytes, cta_layout_vmnk=cluster_layout_vmnk,
+        ).make_participants()
+        lora_producer, lora_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.lora_mbar_ptr.data_ptr(), num_stages=self.num_lora_stage,
+            producer_group=ab_producer_group,
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, num_mcast_ctas_a + num_mcast_ctas_b - 1),
+            tx_count=self.num_lora_tma_load_bytes, cta_layout_vmnk=cluster_layout_vmnk,
+        ).make_participants()
+        acc_producer, acc_consumer = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_mbar_ptr.data_ptr(), num_stages=self.num_acc_stage,
+            producer_group=ab_producer_group,
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.threads_per_cta),
+            cta_layout_vmnk=cluster_layout_vmnk,
+        ).make_participants()
+
+        gA = cute.local_tile(mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+        gB = cute.local_tile(mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None))
+        gSFA = cute.local_tile(mSFA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None))
+        gSFB = cute.local_tile(mSFB_nkl, cute.slice_(self.mma_tiler_sfb, (0, None, None)), (None, None, None))
+        gD = cute.local_tile(mD_mkl, cute.slice_(self.lora_tiler, (None, 0, None)), (None, None, None))
+        gL1 = cute.local_tile(mL1_nkl, cute.slice_(self.lora_tiler, (0, None, None)), (None, None, None))
+        gC = cute.local_tile(mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None))
+
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        tCgA = thr_mma.partition_A(gA)
+        tCgB = thr_mma.partition_B(gB)
+        tCgSFA = thr_mma.partition_A(gSFA)
+        thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+        tCgSFB = thr_mma_sfb.partition_B(gSFB)
+        tCgC = thr_mma.partition_C(gC)
+        thr_lora = lora_mma.get_slice(mma_tile_coord_v)
+        tLgD = thr_lora.partition_A(gD)
+        tLgL1 = thr_lora.partition_B(gL1)
+
+        a_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape)
+        b_cta_layout = cute.make_layout(cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape)
+        sfb_cta_layout = cute.make_layout(cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a, block_in_cluster_coord_vmnk[2], a_cta_layout,
+            cute.group_modes(sA, 0, 3), cute.group_modes(tCgA, 0, 3))
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b, block_in_cluster_coord_vmnk[1], b_cta_layout,
+            cute.group_modes(sB, 0, 3), cute.group_modes(tCgB, 0, 3))
+        tAsSFA, tAgSFA = cpasync.tma_partition(
+            tma_atom_sfa, block_in_cluster_coord_vmnk[2], a_cta_layout,
+            cute.group_modes(sSFA, 0, 3), cute.group_modes(tCgSFA, 0, 3))
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+        tBsSFB, tBgSFB = cpasync.tma_partition(
+            tma_atom_sfb, block_in_cluster_coord_sfb_vmnk[1], sfb_cta_layout,
+            cute.group_modes(sSFB, 0, 3), cute.group_modes(tCgSFB, 0, 3))
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+        tDsD, tDgD = cpasync.tma_partition(
+            tma_atom_d, block_in_cluster_coord_vmnk[2], a_cta_layout,
+            cute.group_modes(sD, 0, 3), cute.group_modes(tLgD, 0, 3))
+        tL1sL1, tL1gL1 = cpasync.tma_partition(
+            tma_atom_l1, block_in_cluster_coord_vmnk[1], b_cta_layout,
+            cute.group_modes(sL1, 0, 3), cute.group_modes(tLgL1, 0, 3))
+
+        tCrA = tiled_mma.make_fragment_A(sA)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        tLrD = lora_mma.make_fragment_A(sD)
+        tLrL1 = lora_mma.make_fragment_B(sL1)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        tCtAcc_fake = tiled_mma.make_fragment_C(acc_shape)
+        lora_acc_shape = lora_mma.partition_shape_C(self.mma_tiler[:2])
+        tLtAcc_fake = lora_mma.make_fragment_C(lora_acc_shape)
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(barrier_id=1, num_threads=self.threads_per_cta)
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr, barrier_for_retrieve=tmem_alloc_barrier,
+            is_two_cta=True, two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr)
+        tmem.allocate(self.num_tmem_alloc_cols)
+        tmem.wait_for_alloc()
+        acc_tmem_ptr = tmem.retrieve_ptr(ACC_DTYPE)
+        tCtAcc = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+        lora_acc_ptr = cute.recast_ptr(
+            acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc), dtype=ACC_DTYPE)
+        tLtAcc = cute.make_tensor(lora_acc_ptr, tLtAcc_fake.layout)
+
+        tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+            tiled_mma, self.mma_tiler, SF_VEC, cute.slice_(sfa_smem_layout, (None, None, None, 0)))
+        sfa_tmem_ptr = cute.recast_ptr(
+            acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc)
+            + tcgen05.find_tmem_tensor_col_offset(tLtAcc), dtype=self.sf_dtype)
+        tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+        tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+            tiled_mma, self.mma_tiler, SF_VEC, cute.slice_(sfb_smem_layout, (None, None, None, 0)))
+        sfb_tmem_ptr = cute.recast_ptr(
+            acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc)
+            + tcgen05.find_tmem_tensor_col_offset(tLtAcc)
+            + tcgen05.find_tmem_tensor_col_offset(tCtSFA), dtype=self.sf_dtype)
+        tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+        copy_atom_s2t = cute.make_copy_atom(tcgen05.Cp4x32x128bOp(CTA_GROUP_2), self.sf_dtype)
+        tCsSFA_compact = cute.filter_zeros(sSFA)
+        tCtSFA_compact = cute.filter_zeros(tCtSFA)
+        tiled_copy_s2t_sfa = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSFA_compact)
+        thr_copy_s2t_sfa = tiled_copy_s2t_sfa.get_slice(0)
+        tCsSFA_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t_sfa, thr_copy_s2t_sfa.partition_S(tCsSFA_compact))
+        tCtSFA_s2t = thr_copy_s2t_sfa.partition_D(tCtSFA_compact)
+        tCsSFB_compact = cute.filter_zeros(sSFB)
+        tCtSFB_compact = cute.filter_zeros(tCtSFB)
+        tiled_copy_s2t_sfb = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSFB_compact)
+        thr_copy_s2t_sfb = tiled_copy_s2t_sfb.get_slice(0)
+        tCsSFB_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t_sfb, thr_copy_s2t_sfb.partition_S(tCsSFB_compact))
+        tCtSFB_s2t = thr_copy_s2t_sfb.partition_D(tCtSFB_compact)
+
+        tAgA = tAgA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+        tBgB = tBgB[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+        tAgSFA = tAgSFA[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+        tBgSFB = tBgSFB[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+        tDgD = tDgD[(None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])]
+        tL1gL1 = tL1gL1[(None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])]
+
+        a_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2)
+        b_mask = cpasync.create_tma_multicast_mask(cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1)
+        sfb_mask = cpasync.create_tma_multicast_mask(cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1)
+
+        k_tile_cnt = cute.size(gA, mode=[3])
+
+        # warp0 of BOTH CTAs PRODUCES (multicast TMA); the LEADER also CONSUMES (the MMAs). The leader
+        # and peer paths are SEPARATE `if is_leader_cta` regions so the leader-only pipeline handles
+        # (acc_empty, ab_full, ...) never cross a dynamic-control-flow boundary (the cute tracer forbids
+        # using a variable defined in one runtime `if` inside another). The peer issues the same
+        # multicast TMAs to fill the cluster pipeline buffers for the leader's MMAs.
+        if warp_idx == 0:
+            if is_leader_cta:
+                acc_empty = acc_producer.acquire_and_advance()
+                # Lora-prologue overlap: issue the low-rank D/L1 TMA BEFORE the main K-loop.
+                if cutlass.const_expr(self.enable_lora):
+                    lora_empty = lora_producer.acquire_and_advance()
+                    lidx = lora_empty.index
+                    cute.copy(tma_atom_d, tDgD[(None, 0)], tDsD[(None, lidx)], tma_bar_ptr=lora_empty.barrier, mcast_mask=a_mask)
+                    cute.copy(tma_atom_l1, tL1gL1[(None, 0)], tL1sL1[(None, lidx)], tma_bar_ptr=lora_empty.barrier, mcast_mask=b_mask)
+                for k_tile in range(k_tile_cnt):
+                    ab_empty = ab_producer.acquire_and_advance()
+                    idx = ab_empty.index
+                    cute.copy(tma_atom_a, tAgA[(None, k_tile)], tAsA[(None, idx)], tma_bar_ptr=ab_empty.barrier, mcast_mask=a_mask)
+                    cute.copy(tma_atom_b, tBgB[(None, k_tile)], tBsB[(None, idx)], tma_bar_ptr=ab_empty.barrier, mcast_mask=b_mask)
+                    cute.copy(tma_atom_sfa, tAgSFA[(None, k_tile)], tAsSFA[(None, idx)], tma_bar_ptr=ab_empty.barrier, mcast_mask=a_mask)
+                    cute.copy(tma_atom_sfb, tBgSFB[(None, k_tile)], tBsSFB[(None, idx)], tma_bar_ptr=ab_empty.barrier, mcast_mask=sfb_mask)
+                    ab_full = ab_consumer.wait_and_advance()
+                    stage = ab_full.index
+                    cute.copy(tiled_copy_s2t_sfa, tCsSFA_s2t[(None, None, None, None, stage)], tCtSFA_s2t)
+                    cute.copy(tiled_copy_s2t_sfb, tCsSFB_s2t[(None, None, None, None, stage)], tCtSFB_s2t)
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                    cute.gemm(tiled_mma, tCtAcc,
+                              [tCrA[(None, None, None, stage)], tCtSFA],
+                              [tCrB[(None, None, None, stage)], tCtSFB], tCtAcc)
+                    ab_full.release()
+                if cutlass.const_expr(self.enable_lora):
+                    lora_full = lora_consumer.wait_and_advance()
+                    lstage = lora_full.index
+                    lora_mma.set(tcgen05.Field.ACCUMULATE, False)
+                    cute.gemm(lora_mma, tLtAcc,
+                              tLrD[(None, None, None, lstage)], tLrL1[(None, None, None, lstage)], tLtAcc)
+                    lora_full.release()
+                acc_empty.commit()
+            else:
+                # PEER: producer only (same multicast TMAs; no acc, no MMA, no consume).
+                if cutlass.const_expr(self.enable_lora):
+                    lora_empty = lora_producer.acquire_and_advance()
+                    lidx = lora_empty.index
+                    cute.copy(tma_atom_d, tDgD[(None, 0)], tDsD[(None, lidx)], tma_bar_ptr=lora_empty.barrier, mcast_mask=a_mask)
+                    cute.copy(tma_atom_l1, tL1gL1[(None, 0)], tL1sL1[(None, lidx)], tma_bar_ptr=lora_empty.barrier, mcast_mask=b_mask)
+                for k_tile in range(k_tile_cnt):
+                    ab_empty = ab_producer.acquire_and_advance()
+                    idx = ab_empty.index
+                    cute.copy(tma_atom_a, tAgA[(None, k_tile)], tAsA[(None, idx)], tma_bar_ptr=ab_empty.barrier, mcast_mask=a_mask)
+                    cute.copy(tma_atom_b, tBgB[(None, k_tile)], tBsB[(None, idx)], tma_bar_ptr=ab_empty.barrier, mcast_mask=b_mask)
+                    cute.copy(tma_atom_sfa, tAgSFA[(None, k_tile)], tAsSFA[(None, idx)], tma_bar_ptr=ab_empty.barrier, mcast_mask=a_mask)
+                    cute.copy(tma_atom_sfb, tBgSFB[(None, k_tile)], tBsSFB[(None, idx)], tma_bar_ptr=ab_empty.barrier, mcast_mask=sfb_mask)
+
+        # Epilogue (per CTA: each CTA's 128 rows of the 256-row cluster tile).
+        op = tcgen05.Ld32x32bOp(tcgen05.Repetition.x128, tcgen05.Pack.NONE)
+        copy_atom_t2r = cute.make_copy_atom(op, ACC_DTYPE)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(copy_atom_t2r, tCtAcc)
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        tTR_tAcc = thr_copy_t2r.partition_S(tCtAcc)
+        tTR_gC = thr_copy_t2r.partition_D(tCgC)
+        rshape = tTR_gC[None, None, None, None, 0, 0, 0].shape
+        tTR_rAcc = cute.make_rmem_tensor(rshape, ACC_DTYPE)
+        tTR_rC = cute.make_rmem_tensor(rshape, self.c_dtype)
+        simt_atom = cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), self.c_dtype)
+        tTR_gC = tTR_gC[(None, None, None, None, *mma_tile_coord_mnl)]
+        if cutlass.const_expr(self.enable_lora):
+            tiled_copy_t2r_lora = tcgen05.make_tmem_copy(copy_atom_t2r, tLtAcc)
+            thr_copy_t2r_lora = tiled_copy_t2r_lora.get_slice(tidx)
+            tTR_tLora = thr_copy_t2r_lora.partition_S(tLtAcc)
+            tTR_rLora = cute.make_rmem_tensor(rshape, ACC_DTYPE)
+
+        tmem.relinquish_alloc_permit()
+        acc_full = acc_consumer.wait_and_advance()
+        cute.copy(tiled_copy_t2r, tTR_tAcc, tTR_rAcc)
+        out_vec = tTR_rAcc.load() * global_scale
+        if cutlass.const_expr(self.enable_lora):
+            cute.copy(tiled_copy_t2r_lora, tTR_tLora, tTR_rLora)
+            out_vec = out_vec + tTR_rLora.load()
+        tTR_rC.store(out_vec.to(self.c_dtype))
+        cute.copy(simt_atom, tTR_rC, tTR_gC)
+        acc_full.release()
+        cute.arch.barrier()
+        tmem.free(acc_tmem_ptr)
+        return
+
+
+# ---------------------------------------------------------------------------
+# Host: build inputs (from the front-end's emitted bytes + prepacked weights), run the fused main.
+# ---------------------------------------------------------------------------
+
+_COMPILE_CACHE = {}
+
+
+# Explicit (I, O, M) allowlist for the UP-bound square / wide-O-ish rows the 2-CTA dual-TMEM epilogue
+# also targets (the per-(M,O)-tile lora_acc add rivals/exceeds the down on these per the ncu floor
+# table): double_attn (square, I=O=6144) M4096/M4608 + double_ff_in (wide-O-ish, I=6144, O=36864)
+# M4608. All satisfy the 256-row cluster M-tile (M % 256 == 0) and are >8% at both ranks. single_linear1
+# (O/I>=8) keeps its shipped heuristic path; every non-listed shape stays on the validated 1-CTA KernelB.
+_WIDE_O_2CTA_ALLOWLIST = {
+    (6144, 6144, 4096),    # double_attn  M4096 (square)
+    (6144, 6144, 4608),    # double_attn  M4608 (square)
+    (6144, 36864, 4608),   # double_ff_in M4608 (wide-O-ish)
+}
+
+
+def _wide_o_2cta(I, O, M):
+    """Shape selection for the 2-CTA cooperative dual-TMEM path: a 256-row cluster M-tile must divide M,
+    AND the shape is either wide-O (O/I >= 8 -> single_linear1, the shipped path) or one of the explicitly
+    allow-listed UP-bound square / wide-O-ish rows. Every other shape uses the validated 1-CTA KernelB."""
+    if M % MMA_TILER_MN_2CTA[0] != 0:
+        return False
+    if O >= 8 * I:
+        return True
+    return (I, O, M) in _WIDE_O_2CTA_ALLOWLIST
+
+
+def _resolve_use_2cta(M, I, O, use_2cta=None):
+    """Resolve the production path selector. `None` (the default for production callers) auto-selects
+    the wide-O 2-CTA path via `_wide_o_2cta`; an explicit bool stays available for the `--check-2cta`
+    diagnostic. An explicit `True` on a shape that violates the 2-CTA preconditions is REJECTED rather
+    than silently compiling an unsupported partial path."""
+    if use_2cta is None:
+        return _wide_o_2cta(I, O, M)
+    if use_2cta and not _wide_o_2cta(I, O, M):
+        raise ValueError(
+            f"use_2cta=True requires the wide-O 2-CTA preconditions (O/I>=8 and M%%256==0); "
+            f"got M={M} I={I} O={O} (O/I={O / I:.2f}).")
+    return bool(use_2cta)
+
+
+# Production num_ab_stage (main NVFP4 K-loop pipeline depth) dispatch, keyed by (I, O, M, r). Default 3
+# (the validated depth); a deeper stage is baked here ONLY for a paired-confirmed TGT-IMPR autotuner row.
+# A stage change IS a dispatch-path change (it re-keys the compile cache + the SMEM staging depth), so it is
+# emitted in the sweep CSV + the dispatch-map audit alongside the down (m_tile,n_tile,split) + the main path.
+_NUM_AB_STAGE_BY_IOMR = {
+    # (I, O, M, r): num_ab_stage -- populated ONLY by paired-confirmed wins. EMPTY: rounds 4-5's FULL
+    # cross-product found NO stage win that survives the 8-round paired gate (single_linear1 M1024 r4 s4 was
+    # TGT-FLAT @ run.r4_sl1_gate; double_attn M1024 r4 s4's target delta was within the tiny-shape noise @
+    # run.r5_dattn_gate, which also surfaced byte-identical non-target noise). Production stays s3 everywhere.
+}
+
+
+def num_ab_stage_for_shape(I, O, M, r):
+    """The dispatched main-loop pipeline depth for (I,O,M,r); 3 unless a paired-confirmed win baked a deeper one."""
+    return _NUM_AB_STAGE_BY_IOMR.get((I, O, M, r), 3)
+
+
+def _compiled_kernel_b(M, I, O, r, enable_lora, num_ab_stage=3, use_2cta=False,
+                       num_tmem_alloc_cols=512, num_acc_stage=1):
+    """Compile cache keyed by the static shape/variant (JIT excluded from any timing)."""
+    key = (M, I, O, r, bool(enable_lora), num_ab_stage, bool(use_2cta), num_tmem_alloc_cols, num_acc_stage)
+    if key in _COMPILE_CACHE:
+        return _COMPILE_CACHE[key]
+    # Representative tensors with the right shapes/dtypes drive the JIT trace.
+    a_tensor, _ = _fp4_from_packed(M, I, torch.zeros(M, I // 2, dtype=torch.uint8).cuda())
+    b_tensor, _ = _fp4_from_packed(O, I, torch.zeros(O, I // 2, dtype=torch.uint8).cuda())
+    sfa_tensor, _ = _make_sf_mma_tensor(torch.ones(M, I // SF_VEC), M, I)
+    sfb_tensor, _ = _make_sf_mma_tensor(torch.ones(O, I // SF_VEC), O, I)
+    d_tensor = _kmajor_cuda_tensor(torch.zeros(M, r, dtype=torch.bfloat16).cuda(),
+                                   LORA_DTYPE, torch.bfloat16)
+    l1_tensor = _kmajor_cuda_tensor(torch.zeros(O, r, dtype=torch.bfloat16).cuda(),
+                                    LORA_DTYPE, torch.bfloat16)
+    c_ref = cutlass_torch.matrix(1, M, O, False, OUT_DTYPE)
+    c_tensor, _ = cutlass_torch.cute_tensor_like(c_ref, OUT_DTYPE, True, 16)
+    c_tensor.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+    stream = cutlass_torch.default_stream()
+    cls = KernelB2CTA if use_2cta else KernelB
+    if use_2cta:
+        kb = cls(r, enable_lora=enable_lora, num_ab_stage=num_ab_stage)
+    else:
+        kb = cls(r, enable_lora=enable_lora, num_ab_stage=num_ab_stage,
+                 num_tmem_alloc_cols=num_tmem_alloc_cols, num_acc_stage=num_acc_stage)
+    compiled = cute.compile(kb, a_tensor, b_tensor, sfa_tensor, sfb_tensor,
+                            d_tensor, l1_tensor, c_tensor, cutlass.Float32(1.0), stream)
+    _COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+def run_kernel_b(Xq, sf_x_bytes, D, Rq, sf_w_bytes, L1, gscale_x, gscale_w, r,
+                 enable_lora=True, num_ab_stage=3, use_2cta=None):
+    """Run the fused main on the front-end's emitted (Xq, sf_x, D) + prepacked (Rq, sf_w, gscale_w) +
+    bf16 L1. Returns Y [M, O] bf16 on CUDA. enable_lora=False compiles/runs the plain (main-only)
+    variant. use_2cta=None auto-selects the wide-O 2-CTA path for O/I>=8 & M%256==0 (single_linear1)."""
+    M = Xq.shape[0]
+    I = Xq.shape[1] * 2
+    O = Rq.shape[0]
+    use_2cta = _resolve_use_2cta(M, I, O, use_2cta)
+    # _make_sf_mma_tensor stages the scales on a CPU tensor and copies them in; the front-end emits sf_x
+    # on CUDA, so bring both scale-byte buffers to host explicitly (an unambiguous host->host copy) rather
+    # than relying on PyTorch's implicit cross-device slice assignment. Values (hence bit-exactness) are
+    # unchanged; run_kernel_b is the correctness path (timing uses the device-side SF swizzle instead).
+    sf_x = sf_x_bytes.cpu().view(torch.float8_e4m3fn).float()
+    sf_w = sf_w_bytes.cpu().view(torch.float8_e4m3fn).float()
+    global_scale = float(gscale_x * gscale_w)
+
+    a_tensor, _ = _fp4_from_packed(M, I, Xq.cuda())
+    b_tensor, _ = _fp4_from_packed(O, I, Rq.cuda())
+    sfa_tensor, _ = _make_sf_mma_tensor(sf_x, M, I)
+    sfb_tensor, _ = _make_sf_mma_tensor(sf_w, O, I)
+    # bf16 low-rank operands, CUDA-resident (no CPU staging): D [M, r], L1 [O, r], both K-major.
+    d_tensor = _kmajor_cuda_tensor(D.to(torch.bfloat16), LORA_DTYPE, torch.bfloat16)
+    l1_tensor = _kmajor_cuda_tensor(L1.to(device="cuda", dtype=torch.bfloat16),
+                                    LORA_DTYPE, torch.bfloat16)
+
+    c_ref = cutlass_torch.matrix(1, M, O, False, OUT_DTYPE)
+    c_tensor, c_torch = cutlass_torch.cute_tensor_like(c_ref, OUT_DTYPE, True, 16)
+    c_tensor.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+
+    compiled = _compiled_kernel_b(M, I, O, r, enable_lora, num_ab_stage, use_2cta)
+    stream = cutlass_torch.default_stream()
+    compiled(a_tensor, b_tensor, sfa_tensor, sfb_tensor, d_tensor, l1_tensor,
+             c_tensor, cutlass.Float32(global_scale), stream)
+    torch.cuda.synchronize()
+    return c_torch[:, :, 0]
+
+
+# ---------------------------------------------------------------------------
+# On-device SF swizzle (the official harness / fast-path uses this in place of host staging).
+# ---------------------------------------------------------------------------
+
+_SF_PERM_CACHE = {}
+
+
+def _sf_swizzle_perm(mn, k):
+    """A CUDA gather permutation that reproduces _make_sf_mma_tensor's MMA-swizzled E4M3 layout
+    ON DEVICE: replicate the same ref(MKL)->mma(M32x4xK4) swizzle on a Float32 arange (NOT float8 --
+    that would saturate the index at ~448), so the swizzled mma tensor holds, at each logical position,
+    its source row-major index. Then for any row-major [mn, sf_k] E4M3 byte tensor,
+    swizzled_logical = sf_row_major.flatten()[perm]. Cached per (mn, k)."""
+    key = (mn, k)
+    if key not in _SF_PERM_CACHE:
+        sf_k = (k + SF_VEC - 1) // SF_VEC
+        ref_shape = (1, mn, sf_k)
+        mma_shape = (1, (mn + _ATOM_M[0] * _ATOM_M[1] - 1) // (_ATOM_M[0] * _ATOM_M[1]),
+                     (sf_k + _ATOM_K - 1) // _ATOM_K,
+                     _ATOM_M[0], _ATOM_M[1], _ATOM_K)
+        # The swizzle is a pure position permutation, but it is materialized by routing the source
+        # row-major indices through a FLOAT32 cute copy, which is exact only to 2^24. Large activations
+        # (batch x resolution, e.g. M=27556 sf_k=768 -> 21.2M) would silently round to garbage indices.
+        # Fix: split each index into 14-bit limbs (each < 2^14, exactly float32-representable), swizzle
+        # every limb through the SAME copy, and recombine in int64. The permutation moves all limbs
+        # identically, so recombining yields the exact swizzled source index for any mn. Cached per (mn,k).
+        n = mn * sf_k
+        SHIFT = 14
+        n_limbs = 1
+        while (1 << (SHIFT * n_limbs)) < max(n, 1):
+            n_limbs += 1
+        src = torch.arange(n, dtype=torch.int64).reshape(mn, sf_k)
+        limbs = []
+        for li in range(n_limbs):
+            part = ((src >> (SHIFT * li)) & ((1 << SHIFT) - 1)).to(torch.float32)
+            ref = cutlass_torch.create_and_permute_torch_tensor(
+                ref_shape, torch.float32, permute_order=(1, 2, 0),
+                init_type=cutlass_torch.TensorInitType.RANDOM,
+                init_config=cutlass_torch.RandomInitConfig(min_val=0, max_val=1))   # (mn, sf_k, 1)
+            ref[:, :, 0] = part
+            mma = cutlass_torch.create_and_permute_torch_tensor(
+                mma_shape, torch.float32, permute_order=(3, 4, 1, 5, 2, 0),
+                init_type=cutlass_torch.TensorInitType.RANDOM,
+                init_config=cutlass_torch.RandomInitConfig(min_val=0, max_val=1))
+            _cvt_sf_to_mma(cute.runtime.from_dlpack(ref), cute.runtime.from_dlpack(mma))
+            limbs.append(mma.reshape(-1).round().to(torch.int64))
+        perm = torch.zeros_like(limbs[0])
+        for li in range(n_limbs):
+            perm = perm | (limbs[li] << (SHIFT * li))
+        _SF_PERM_CACHE[key] = perm.cuda()
+    return _SF_PERM_CACHE[key]
+
+
+def _refresh_sfa_device(sf_row_major_u8_cuda, perm, sfa_torch, g_buf=None):
+    """On-device SF swizzle (no host staging): gather the row-major E4M3 bytes by `perm` and write them
+    into `sfa_torch`'s (strided) storage with copy_ (which respects strides), so the cute SF tensor
+    wrapping sfa_torch now reflects the swizzled sf_x. Timed inside _one().
+
+    g_buf (optional): a pre-allocated uint8 [perm.numel()] buffer. When given, the gather uses
+    torch.index_select(..., out=g_buf) so the per-call path allocates NOTHING (required for CUDA-graph
+    capture); when None, the fancy-index gather (which allocates a temp) is used (timing/validation).
+    Both produce byte-identical results."""
+    flat = sf_row_major_u8_cuda.reshape(-1)
+    if g_buf is None:
+        g = flat[perm]                                             # fancy-index gather (allocates a temp)
+    else:
+        torch.index_select(flat, 0, perm, out=g_buf)               # alloc-free gather into the pre-alloc buffer
+        g = g_buf
+    sfa_torch.view(torch.uint8).copy_(g.reshape(sfa_torch.shape))  # strided write into the cute buffer
+
+
+def check_sf_swizzle(mn, k):
+    """Verify the on-device perm-gather SF swizzle is BIT-IDENTICAL to the host _make_sf_mma_tensor."""
+    sf_k = (k + SF_VEC - 1) // SF_VEC
+    sf_u8 = torch.randint(1, 220, (mn, sf_k), dtype=torch.uint8)
+    sf_f8 = sf_u8.view(torch.float8_e4m3fn)
+    _, ref_torch = _make_sf_mma_tensor(sf_f8.float(), mn, k)        # host swizzle (reference)
+    perm = _sf_swizzle_perm(mn, k)
+    dev_torch = torch.empty_like(ref_torch)
+    _refresh_sfa_device(sf_u8.cuda(), perm, dev_torch)
+    ok = torch.equal(dev_torch.view(torch.uint8).cpu(), ref_torch.view(torch.uint8).cpu())
+    print(f"[sf-swizzle {mn}x{k}] device perm-gather == host swizzle: {'OK (bit-identical)' if ok else 'MISMATCH'} "
+          f"({ref_torch.numel()} E4M3 elems)")
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# Deployable host fast-path: prepare_svdquant_state(...) + mm_fp4_svdquant(x, state).
+# A reusable, CUDA-graph-safe dispatch. ALL per-call host work (weight pack consumption, weight-SF
+# swizzle, scale fold, buffer alloc, JIT) is hoisted into prepare_svdquant_state; mm_fp4_svdquant does
+# NO torch.cuda.synchronize / .cpu() / .item() / per-call allocation. The on-device kernel sequence
+# (quantizer -> down/reduce -> the fused main) and every dispatch tuple are byte-identical to the
+# dataflow-connected timing path, so device latency and zero-LoRA bit-exactness are unchanged -- only
+# the host dispatch around the kernels changes.
+# ---------------------------------------------------------------------------
+
+def prepare_svdquant_state(M, Rq, sf_w_bytes, L1, L2, gscale_x, gscale_w, r,
+                           enable_lora=True, pre_quant_scale=None,
+                           num_ab_stage=None, use_2cta=None, external_quant=False,
+                           num_tmem_alloc_cols=512, num_acc_stage=1):
+    """Build a reusable dispatch state for one (M, I, O, r) layer shape. Off the hot path:
+      * derive I, O from the prepacked weight (Rq [O, I//2], sf_w_bytes [O, I//16]);
+      * swizzle the CONSTANT weight SF (sfb) ONCE (host swizzle, prepare-time only -- never per call);
+      * pre-allocate the quantizer/down/main operands + the alloc-free SFA gather buffer;
+      * compile (JIT-excluded) the quantizer, down/reduce, and the fused main for the shape;
+      * fold the STATIC calibrated gscale_x and (gscale_x*gscale_w) into cutlass.Float32 (graph-safe;
+        no per-call .item()).
+    gscale_x must be a precomputed scalar (the ModelOpt calibrated static activation scale) for the
+    CUDA-graph path; an eager-only dynamic scale is computed by the caller before prepare. enable_lora
+    builds the full fused state; enable_lora=False builds the plain-NVFP4 (main-only) state (L1/L2 may
+    be None). The dispatch (down tile/split, num_ab_stage, main-kernel 1-CTA/2-CTA) matches the
+    production selectors exactly -- this changes no device behavior."""
+    I = Rq.shape[1] * 2
+    O = Rq.shape[0]
+    sf_k = I // SF_VEC
+    if num_ab_stage is None:
+        num_ab_stage = num_ab_stage_for_shape(I, O, M, r)
+    use_2cta = _resolve_use_2cta(M, I, O, use_2cta)   # same validated selector run_kernel_b enforces
+    m_tile, n_tile, r_pad, num_k_split = down_tile_for_shape(I, r, M, O=O)
+
+    # Quantizer stage. xq_t/sf_t are the NVFP4 activation operands (and the injection targets).
+    # external_quant=True (host framework injects its own NVFP4 activation via ext_xq/ext_sf): the
+    # on-device quantizer and its f32 X backing are never used, so skip them -- drops the M*I*4 f32
+    # allocation per state (the dominant per-state memory at large M/batch) and the quantizer JIT.
+    xq_t, xq_torch = _u8_rowmajor_tensor(M, I // 2)
+    sf_t, sf_torch = _u8_rowmajor_tensor(M, sf_k)
+    if external_quant:
+        xf_t = None
+        quant = None
+    else:
+        xf_t = _f32_kmajor_tensor(torch.zeros(M, I, dtype=torch.float32, device="cuda"))
+        quant = _compiled_quantizer(M, I)
+
+    # Down stage (fused only): a FIXED bf16 X backing + the real L2 (padded to r_pad) -> D, written
+    # straight into the fused main's D operand. d_tensor exists in both variants (the plain main ignores it).
+    xb_t = None
+    down_call = None
+    d_tensor = _kmajor_cuda_tensor(torch.zeros(M, r, dtype=torch.bfloat16, device="cuda"),
+                                   LORA_DTYPE, torch.bfloat16)
+    if enable_lora:
+        xb_t = _bf16_kmajor_tensor(torch.zeros(M, I, dtype=torch.bfloat16, device="cuda"))
+        L2b = L2.to(device="cuda", dtype=torch.bfloat16)
+        if r_pad != r:
+            L2_pad = torch.zeros(r_pad, I, dtype=torch.bfloat16, device="cuda")
+            L2_pad[:r] = L2b
+            L2b = L2_pad
+        l2_t = _bf16_kmajor_tensor(L2b)
+        if num_k_split == 1:
+            d_ref = cutlass_torch.matrix(1, M, r_pad, False, LORA_DTYPE)
+            d_down_t, d_down_torch = cutlass_torch.cute_tensor_like(d_ref, LORA_DTYPE, True, 16)
+            d_down_t.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+            _down = _compiled_down(M, I, r_pad, n_tile, m_tile)
+
+            def down_call(st, _down=_down, xb=xb_t, l2=l2_t, dd=d_down_t, ddt=d_down_torch, dk=d_tensor, rr=r):
+                _down(xb, l2, dd, st)
+                dk._svdquant_backing[:, :, 0] = ddt[:, :rr, 0]      # padded [M, r_pad] -> the fused main's D [M, r]
+        else:
+            _down = _compiled_down_split(M, I, r_pad, n_tile, m_tile, num_k_split)
+            _reduce = _compiled_reduce(M, r_pad, num_k_split, r)
+            p_ref = cutlass_torch.matrix(num_k_split, M, r_pad, False, ACC_DTYPE)
+            p_t, _ = cutlass_torch.cute_tensor_like(p_ref, ACC_DTYPE, True, 16)
+            p_t.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+
+            def down_call(st, _down=_down, _reduce=_reduce, xb=xb_t, l2=l2_t, p=p_t, dk=d_tensor):
+                _down(xb, l2, p, st)
+                _reduce(p, dk, st)        # reduce writes the r real cols straight into the fused main's D -- no copy
+
+    # Fused-main operands. A / SFA are refreshed per call from the quantizer outputs; the weights are FIXED.
+    a_tensor, a_buf = _fp4_from_packed(M, I, torch.zeros(M, I // 2, dtype=torch.uint8).cuda())
+    b_tensor, b_buf = _fp4_from_packed(O, I, Rq.to(device="cuda"))   # b_buf MUST be retained (raw-packed operand does not own its storage)
+    sfa_tensor, sfa_torch = _make_sf_mma_tensor(torch.ones(M, sf_k), M, I)
+    # CONSTANT weight SF, swizzled ONCE here (prepare-time host swizzle; never per call):
+    sf_w_f = sf_w_bytes.detach().to("cpu").view(torch.float8_e4m3fn).float()
+    sfb_tensor, _ = _make_sf_mma_tensor(sf_w_f, O, I)
+    l1_src = L1 if (enable_lora and L1 is not None) else torch.zeros(O, r, dtype=torch.bfloat16, device="cuda")
+    l1_tensor = _kmajor_cuda_tensor(l1_src.to(device="cuda", dtype=torch.bfloat16),
+                                    LORA_DTYPE, torch.bfloat16)
+    c_ref = cutlass_torch.matrix(1, M, O, False, OUT_DTYPE)
+    c_tensor, c_torch = cutlass_torch.cute_tensor_like(c_ref, OUT_DTYPE, True, 16)
+    c_tensor.mark_compact_shape_dynamic(mode=1, stride_order=(2, 0, 1), divisibility=8)
+
+    perm = _sf_swizzle_perm(M, I)
+    g_buf = torch.empty(perm.numel(), dtype=torch.uint8, device="cuda")   # alloc-free SFA gather buffer
+    pqs_dev = None
+    if pre_quant_scale is not None:
+        pqs_dev = pre_quant_scale.detach().to(device="cuda", dtype=torch.float32).reshape(1, I)
+
+    kb = _compiled_kernel_b(M, I, O, r, enable_lora, num_ab_stage, use_2cta,
+                            num_tmem_alloc_cols=num_tmem_alloc_cols, num_acc_stage=num_acc_stage)
+    return {
+        "M": M, "I": I, "O": O, "r": r, "enable_lora": bool(enable_lora),
+        "quant": quant, "xf_t": xf_t, "xq_t": xq_t, "sf_t": sf_t, "xq_torch": xq_torch, "sf_torch": sf_torch,
+        "xb_t": xb_t, "down_call": down_call, "d_tensor": d_tensor,
+        "a_tensor": a_tensor, "a_flat": a_buf.as_strided((M * I,), (1,)), "a_buf": a_buf, "b_buf": b_buf,
+        "b_tensor": b_tensor, "sfa_tensor": sfa_tensor, "sfa_torch": sfa_torch, "sfb_tensor": sfb_tensor,
+        "l1_tensor": l1_tensor, "c_tensor": c_tensor, "c_torch": c_torch,
+        "perm": perm, "g_buf": g_buf, "pqs": pqs_dev,
+        "gx": cutlass.Float32(float(gscale_x)), "gs": cutlass.Float32(float(gscale_x) * float(gscale_w)),
+        "kb": kb, "stream": cutlass_torch.default_stream(),
+        "down_m_tile": m_tile, "down_n_tile": n_tile, "down_split": num_k_split, "num_ab_stage": num_ab_stage,
+        "use_2cta": use_2cta,
+    }
+
+
+def _run_kernels(c, st, ext_xq=None, ext_sf=None):
+    """PRIVATE: the on-device kernel sequence (quant -> repack A -> on-device SFA refresh -> down/reduce ->
+    the fused main) on the activation ALREADY staged in c['xf_t']/c['xb_t']. No host sync / copy / allocation
+    (the only transient is the Xq int8 view, an in-pool reinterpret). Used by mm_fp4_svdquant (after it stages
+    the activation) and by the timing harness for a kernel-sequence-only graph (load excluded). Returns the
+    c_torch output view.
+
+    External activation quant (numerical-parity hook): if ext_xq/ext_sf are given, the on-device quantizer is
+    SKIPPED and the residual main GEMM uses the supplied NVFP4 activation instead (e.g. from TRT-LLM
+    fp4_quantize, to match its rounding). ext_xq: uint8 [M, I//2] packed E2M1 (same packing as the internal
+    Xq); ext_sf: uint8 PLAIN [M, I//16] E4M3 (gets the same on-device SFA swizzle as the internal sf_x).
+    The bf16 down-projection (LoRA) still uses the staged f32 x_hat, unchanged."""
+    M, I = c["M"], c["I"]
+    if ext_xq is not None:
+        c["xq_torch"].copy_(ext_xq.view(torch.uint8).reshape(c["xq_torch"].shape))
+        c["sf_torch"].copy_(ext_sf.view(torch.uint8).reshape(c["sf_torch"].shape))
+    else:
+        c["quant"](c["xf_t"], c["xq_t"], c["sf_t"], c["gx"], st)           # X -> Xq + sf_x (on device)
+    c["a_flat"][: M * I // 2] = c["xq_torch"].reshape(-1).view(torch.int8)  # Xq -> the fused main's A operand (byte reinterpret, no alloc)
+    _refresh_sfa_device(c["sf_torch"].reshape(-1), c["perm"], c["sfa_torch"], g_buf=c["g_buf"])  # alloc-free SFA
+    if c["enable_lora"]:
+        c["down_call"](st)                                # SAME X, L2 -> D, into the fused main's D operand
+    c["kb"](c["a_tensor"], c["b_tensor"], c["sfa_tensor"], c["sfb_tensor"],
+            c["d_tensor"], c["l1_tensor"], c["c_tensor"], c["gs"], st)
+    return c["c_torch"][:, :, 0]
+
+
+def mm_fp4_svdquant(x, state, ext_xq=None, ext_sf=None):
+    """The single public entry: run the fused NVFP4-SVDQuant linear (NVFP4 main GEMM + bf16 LoRA) for
+    activation x (CUDA, [M, I]) using a state from prepare_svdquant_state. Graph-safe: NO
+    torch.cuda.synchronize, .cpu(), .item(), or per-call CUDA allocation on this path.
+
+    ext_xq/ext_sf (optional): externally-quantized NVFP4 activation for the residual main GEMM, to match
+    a host framework's own quantizer (e.g. TRT-LLM/SGLang/vLLM fp4_quantize) for numerical parity. When
+    given, the built-in on-device quantizer is skipped. ext_xq: uint8 [M, I//2] packed E2M1; ext_sf:
+    uint8 PLAIN [M, I//16] E4M3. The bf16 LoRA down-projection still uses the staged x_hat (unchanged).
+
+    Output aliasing: returns Y [M, O] bf16 as a VIEW into the state's reusable output storage. The caller
+    must consume or clone it BEFORE the next mm_fp4_svdquant call on the SAME state (a subsequent call
+    overwrites the storage), and must not host-read it before the stream completes / the graph replays."""
+    c = state
+    M, I = c["M"], c["I"]
+    # Launch on the CURRENT stream (not a fixed default): under torch.cuda.graph this is the capture
+    # stream, so the cute kernels are recorded + ordered with the per-call buffer-update torch ops; in
+    # eager it is the default stream (unchanged behavior). This is what makes apply CUDA-graph-capturable.
+    st = cutlass_torch.current_stream()
+    if not x.is_cuda or tuple(x.shape) != (M, I):
+        raise ValueError(f"mm_fp4_svdquant: activation must be a CUDA [{M}, {I}] tensor, "
+                         f"got {tuple(x.shape)} on {x.device} (caller reshapes to [M, I] first)")
+    if ext_xq is not None:
+        # Injection path: the on-device quantizer (the only consumer of the f32 backing xf_back) is
+        # SKIPPED, so staging x through f32 is pure overhead -- nsys: copy(x->f32) + mul(pqs) + copy(->bf16)
+        # = ~44% of per-call GPU time at K=12288. Form the bf16 LoRA down-input x_hat = x*pqs DIRECTLY
+        # (bf16, matching eager which also builds x_hat in bf16); the f32 backing is never touched (and may
+        # be None when the state was built with external_quant=True to save the M*I*4 allocation).
+        if c["enable_lora"]:
+            xb = c["xb_t"]._svdquant_backing[:, :, 0]
+            xb.copy_(x)
+            if c["pqs"] is not None:
+                xb.mul_(c["pqs"])
+    else:
+        xf_back = c["xf_t"]._svdquant_backing             # [M, I, 1] f32 (only the on-device quant path needs it)
+        xf_back[:, :, 0].copy_(x)                         # new activation -> f32 backing (feeds on-device quant)
+        if c["pqs"] is not None:
+            xf_back[:, :, 0].mul_(c["pqs"])               # smoothing (pre_quant_scale), in place
+        if c["enable_lora"]:
+            c["xb_t"]._svdquant_backing[:, :, 0].copy_(xf_back[:, :, 0])   # SAME X -> bf16 down input
+    return _run_kernels(c, st, ext_xq=ext_xq, ext_sf=ext_sf)
+
+
+__all__ = [
+    # --- module-level imports re-exported so the shims + consumers see them via `from ... import *` ---
+    "os", "sys", "Type",
+    "cuda", "torch",
+    "cutlass", "cute", "utils", "pipeline", "cutlass_torch",
+    "cpasync", "tcgen05", "OperandMajorMode", "sm100_utils", "blockscaled_utils",
+    "E4M3_MAX", "_HERE",
+    # --- inlined operand builders + SF MMA-layout converter (formerly nvfp4_gemm / blockscaled) ---
+    "from_dlpack", "_ATOM_M", "_ATOM_K", "_ceil_div",
+    "cvt_sf_MKL_to_M32x4xrm_K4xrk_L", "_cvt_sf_to_mma", "_make_sf_mma_tensor", "_fp4_from_packed",
+    # --- front-end dtype aliases / constants ---
+    "LORA_DTYPE", "ACC_DTYPE", "MMA_TILER_MN", "SKINNY_N_TILE", "LONG_K_M_TILE", "LONG_K_SPLIT",
+    "LONG_K_THRESHOLD", "BF16_TILE_K", "SF_BLOCK", "FP4_E2M1_MAX", "QUANT_M_TILE",
+    # --- fused-main dtype aliases / constants ---
+    "ELEM_DTYPE", "SF_DTYPE", "OUT_DTYPE", "SF_VEC", "NVFP4_INST_K", "NVFP4_TILE_K",
+    "MMA_TILER_MN_2CTA", "CTA_GROUP_2", "CLUSTER_SHAPE_MN_2CTA",
+    # --- down-tile dispatch tables + selectors ---
+    "_LONG_K_SPLIT_BY_IMR", "_long_k_split_for_m", "_LONG_K_I_ALLM", "_is_long_k",
+    "_OCC_DOWN_SPLIT_BY_IOMR", "_is_occ_down", "_occ_down_split_for",
+    "_AUTOTUNED_DOWN_BY_IOMR", "_is_autotuned_down", "_autotuned_down_for", "down_tile_for_shape",
+    # --- kernel classes ---
+    "ActivationQuantizer", "DownProjection", "SplitKReduce", "KernelB", "KernelB2CTA",
+    # --- input builders ---
+    "_kmajor_cuda_tensor", "_bf16_kmajor_tensor", "_f32_kmajor_tensor", "_u8_rowmajor_tensor",
+    "assert_no_cpu_staging_in_input_builders",
+    # --- compile caches + factories ---
+    "_QUANT_CACHE", "_DOWN_CACHE", "_REDUCE_CACHE",
+    "_compiled_quantizer", "_compiled_down", "_compiled_down_split", "_compiled_reduce",
+    "_COMPILE_CACHE", "_compiled_kernel_b",
+    # --- front-end runtime entries ---
+    "run_quantizer", "run_down_projection", "run_kernel_a", "_provided_gscale_x", "_flux_shapes",
+    # --- fused-main dispatch selectors ---
+    "_WIDE_O_2CTA_ALLOWLIST", "_wide_o_2cta", "_resolve_use_2cta",
+    "_NUM_AB_STAGE_BY_IOMR", "num_ab_stage_for_shape",
+    # --- fused-main runtime entries ---
+    "run_kernel_b",
+    # --- on-device SF swizzle ---
+    "_SF_PERM_CACHE", "_sf_swizzle_perm", "_refresh_sfa_device", "check_sf_swizzle",
+    # --- deployable host fast-path ---
+    "prepare_svdquant_state", "_run_kernels", "mm_fp4_svdquant",
+]

--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -1779,6 +1779,15 @@ def nvfp4_quantize_cute_dsl(
     if nvfp4_4over6_config is not None and input.dtype == torch.float8_e4m3fn:
         raise ValueError("FLASHINFER_NVFP4_4OVER6 requires fp16 or bf16 input")
     use_tma = _should_use_tma(m, k, input.dtype) and nvfp4_4over6_config is None
+    if apply_pre_quant_scale and sf_layout == SF_LAYOUT_128x4:
+        major, minor = torch.cuda.get_device_capability(input.device)
+        if (major, minor) == (10, 0) and (k == 12288 or m % ROW_TILE_SIZE != 0):
+            # On SM100, SVDQuant's fused-PQS path is faster in the predicated
+            # kernel for the wide MLP-down input, and it avoids materializing
+            # an activation-sized padded copy for a partial 128x4 row tile.
+            # Other layouts, architectures, and no-PQS callers retain the
+            # established TMA heuristic.
+            use_tma = False
 
     if use_tma:
         tma_row_tile = _TMA_ROW_TILE

--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -43,6 +43,7 @@ from cutlass import Float32, Int32, Uint8
 
 from ...api_logging import flashinfer_api
 from ...cute_dsl.fp4_common import (
+    bfloat2_mul,
     block_reduce,
     fdiv_rn,
     fmax_f32,
@@ -75,6 +76,7 @@ from ..quantization_cute_dsl_utils import (
     bfloat2x8_to_e2m1x16_packed,
     process_nvfp4_block_half,
     process_nvfp4_block_bfloat,
+    process_nvfp4_block_bfloat_scaled,
     process_nvfp4_block_fp8,
 )
 
@@ -322,6 +324,7 @@ class NVFP4QuantizeSwizzledKernel:
         enable_pdl: bool = False,
         disable_fp4_quant_fast_math: bool = False,
         nvfp4_4over6_config: NVFP44Over6Config | None = None,
+        apply_pre_quant_scale: bool = False,
     ):
         self.dtype = dtype
         self.K = K
@@ -330,9 +333,14 @@ class NVFP4QuantizeSwizzledKernel:
         self.enable_pdl = enable_pdl
         self.disable_fp4_quant_fast_math = disable_fp4_quant_fast_math
         self.nvfp4_4over6_config = nvfp4_4over6_config
+        self.apply_pre_quant_scale = apply_pre_quant_scale
         self.sf_layout = sf_layout
         self.sf_is_128x4 = sf_layout == SF_LAYOUT_128x4
         self.sf_is_8x4 = sf_layout == SF_LAYOUT_8x4
+
+        assert not apply_pre_quant_scale or self.is_bfloat16, (
+            "pre_quant_scale is only supported for BF16 input"
+        )
 
         assert K % NVFP4_SF_VEC_SIZE == 0
         self.num_sf_blocks_per_row = K // NVFP4_SF_VEC_SIZE
@@ -364,6 +372,7 @@ class NVFP4QuantizeSwizzledKernel:
     def __call__(
         self,
         mInput: cute.Tensor,
+        mPreQuantScale: cute.Tensor,
         mOutput: cute.Tensor,
         mScales: cute.Tensor,
         M: Int32,
@@ -372,7 +381,15 @@ class NVFP4QuantizeSwizzledKernel:
         mGlobalScale: cute.Tensor,
         stream,
     ):
-        self.kernel(mInput, mOutput, mScales, M, padded_M, mGlobalScale).launch(
+        self.kernel(
+            mInput,
+            mPreQuantScale,
+            mOutput,
+            mScales,
+            M,
+            padded_M,
+            mGlobalScale,
+        ).launch(
             grid=[num_blocks, 1, 1],
             block=[self.num_threads, 1, 1],
             max_number_threads=[_MAX_THREADS_PER_BLOCK, 1, 1],
@@ -385,6 +402,7 @@ class NVFP4QuantizeSwizzledKernel:
     def kernel(
         self,
         mInput: cute.Tensor,
+        mPreQuantScale: cute.Tensor,
         mOutput: cute.Tensor,
         mScales: cute.Tensor,
         M: Int32,
@@ -448,14 +466,25 @@ class NVFP4QuantizeSwizzledKernel:
                                 self.disable_fp4_quant_fast_math,
                             )
                         elif cutlass.const_expr(self.is_bfloat16):
-                            scale_fp8, packed64 = process_nvfp4_block_bfloat(
-                                row_input,
-                                elem_base,
-                                global_scale,
-                                self.disable_fp4_quant_fast_math,
-                                self.nvfp4_4over6_config,
-                                row_amax,
-                            )
+                            if cutlass.const_expr(self.apply_pre_quant_scale):
+                                scale_fp8, packed64 = process_nvfp4_block_bfloat_scaled(
+                                    row_input,
+                                    mPreQuantScale,
+                                    elem_base,
+                                    global_scale,
+                                    self.disable_fp4_quant_fast_math,
+                                    self.nvfp4_4over6_config,
+                                    row_amax,
+                                )
+                            else:
+                                scale_fp8, packed64 = process_nvfp4_block_bfloat(
+                                    row_input,
+                                    elem_base,
+                                    global_scale,
+                                    self.disable_fp4_quant_fast_math,
+                                    self.nvfp4_4over6_config,
+                                    row_amax,
+                                )
                         else:
                             scale_fp8, packed64 = process_nvfp4_block_half(
                                 row_input,
@@ -532,14 +561,27 @@ class NVFP4QuantizeSwizzledKernel:
                                     self.disable_fp4_quant_fast_math,
                                 )
                             elif cutlass.const_expr(self.is_bfloat16):
-                                scale_fp8, packed64 = process_nvfp4_block_bfloat(
-                                    row_input,
-                                    elem_base,
-                                    global_scale,
-                                    self.disable_fp4_quant_fast_math,
-                                    self.nvfp4_4over6_config,
-                                    row_amax,
-                                )
+                                if cutlass.const_expr(self.apply_pre_quant_scale):
+                                    scale_fp8, packed64 = (
+                                        process_nvfp4_block_bfloat_scaled(
+                                            row_input,
+                                            mPreQuantScale,
+                                            elem_base,
+                                            global_scale,
+                                            self.disable_fp4_quant_fast_math,
+                                            self.nvfp4_4over6_config,
+                                            row_amax,
+                                        )
+                                    )
+                                else:
+                                    scale_fp8, packed64 = process_nvfp4_block_bfloat(
+                                        row_input,
+                                        elem_base,
+                                        global_scale,
+                                        self.disable_fp4_quant_fast_math,
+                                        self.nvfp4_4over6_config,
+                                        row_amax,
+                                    )
                             else:
                                 scale_fp8, packed64 = process_nvfp4_block_half(
                                     row_input,
@@ -835,6 +877,7 @@ class NVFP4QuantizeTMAKernel:
         sf_layout: int = SF_LAYOUT_128x4,
         enable_pdl: bool = False,
         disable_fp4_quant_fast_math: bool = False,
+        apply_pre_quant_scale: bool = False,
     ):
         self.dtype = dtype
         self.K = K
@@ -842,11 +885,15 @@ class NVFP4QuantizeTMAKernel:
         self.is_fp8 = dtype == cutlass.Float8E4M3FN
         self.enable_pdl = enable_pdl
         self.disable_fp4_quant_fast_math = disable_fp4_quant_fast_math
+        self.apply_pre_quant_scale = apply_pre_quant_scale
         self.sf_layout = sf_layout
         self.sf_is_128x4 = sf_layout == SF_LAYOUT_128x4
         self.sf_is_8x4 = sf_layout == SF_LAYOUT_8x4
 
         assert not self.is_fp8, "FP8 input not yet supported for TMA kernel"
+        assert not apply_pre_quant_scale or self.is_bfloat16, (
+            "pre_quant_scale is only supported for BF16 input"
+        )
         assert K % _TMA_COLS_PER_STAGE == 0, (
             f"K ({K}) must be a multiple of {_TMA_COLS_PER_STAGE} for TMA kernel"
         )
@@ -968,6 +1015,7 @@ class NVFP4QuantizeTMAKernel:
     def __call__(
         self,
         mInput: cute.Tensor,
+        mPreQuantScale: cute.Tensor,
         mOutput: cute.Tensor,
         mScales: cute.Tensor,
         M: Int32,
@@ -1038,6 +1086,7 @@ class NVFP4QuantizeTMAKernel:
         self.kernel(
             tma_atom,
             tma_tensor,
+            mPreQuantScale,
             mOutput,
             mScales,
             M,
@@ -1065,6 +1114,7 @@ class NVFP4QuantizeTMAKernel:
         self,
         tma_atom: cute.CopyAtom,
         gInput_tma: cute.Tensor,
+        mPreQuantScale: cute.Tensor,
         mOutput: cute.Tensor,
         mScales: cute.Tensor,
         M: Int32,
@@ -1254,6 +1304,35 @@ class NVFP4QuantizeTMAKernel:
                         NVFP4_SF_VEC_SIZE
                     )
 
+                    # Apply the BF16 per-channel smoothing scale in registers.
+                    # The same 16 scale values are reused for both row iterations.
+                    if cutlass.const_expr(self.apply_pre_quant_scale):
+                        pre_scale_elem = sf_col * Int32(NVFP4_SF_VEC_SIZE)
+                        p_ptr0 = get_ptr_as_int64(mPreQuantScale, pre_scale_elem)
+                        p_ptr1 = get_ptr_as_int64(
+                            mPreQuantScale, pre_scale_elem + Int32(8)
+                        )
+                        p0, p1, p2, p3 = ld_global_v4_u32(p_ptr0)
+                        p4, p5, p6, p7 = ld_global_v4_u32(p_ptr1)
+
+                        r0_h0 = bfloat2_mul(r0_h0, p0)
+                        r0_h1 = bfloat2_mul(r0_h1, p1)
+                        r0_h2 = bfloat2_mul(r0_h2, p2)
+                        r0_h3 = bfloat2_mul(r0_h3, p3)
+                        r0_h4 = bfloat2_mul(r0_h4, p4)
+                        r0_h5 = bfloat2_mul(r0_h5, p5)
+                        r0_h6 = bfloat2_mul(r0_h6, p6)
+                        r0_h7 = bfloat2_mul(r0_h7, p7)
+
+                        r1_h0 = bfloat2_mul(r1_h0, p0)
+                        r1_h1 = bfloat2_mul(r1_h1, p1)
+                        r1_h2 = bfloat2_mul(r1_h2, p2)
+                        r1_h3 = bfloat2_mul(r1_h3, p3)
+                        r1_h4 = bfloat2_mul(r1_h4, p4)
+                        r1_h5 = bfloat2_mul(r1_h5, p5)
+                        r1_h6 = bfloat2_mul(r1_h6, p6)
+                        r1_h7 = bfloat2_mul(r1_h7, p7)
+
                     # Row iteration 0
                     global_row_0 = base_row + row_idx_local
                     self._quantize_sf_block(
@@ -1335,12 +1414,13 @@ def _get_compiled_kernel_nvfp4(
     enable_pdl: bool = False,
     disable_fp4_quant_fast_math: bool = False,
     nvfp4_4over6_config: NVFP44Over6Config | None = None,
+    apply_pre_quant_scale: bool = False,
 ) -> Tuple[Callable, int]:
     """
     Get or compile NVFP4 kernel with TVM-FFI.
 
-    Cached by (K, dtype_key, sf_layout, pdl) - M-agnostic, device-independent
-    compilation.
+    Cached by (K, dtype_key, sf_layout, pdl, pre-scale mode) - M-agnostic,
+    device-independent compilation.
 
     Args:
         dtype_key: One of "float16", "bfloat16", "float8_e4m3fn".
@@ -1363,6 +1443,9 @@ def _get_compiled_kernel_nvfp4(
     # Common fake tensors
     input_fake = cute.runtime.make_fake_compact_tensor(
         cutlass_dtype, (sym_m, K), stride_order=(1, 0), assumed_align=16
+    )
+    pre_quant_scale_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype, (K,), assumed_align=16
     )
     output_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Uint8, (sym_m, K // 2), stride_order=(1, 0), assumed_align=16
@@ -1406,11 +1489,13 @@ def _get_compiled_kernel_nvfp4(
             enable_pdl=enable_pdl,
             disable_fp4_quant_fast_math=disable_fp4_quant_fast_math,
             nvfp4_4over6_config=nvfp4_4over6_config,
+            apply_pre_quant_scale=apply_pre_quant_scale,
         )
 
         compiled_kernel = cute.compile(
             swizzled_obj,
             input_fake,
+            pre_quant_scale_fake,
             output_fake,
             scales_fake,
             Int32(1),  # Dummy M
@@ -1509,11 +1594,12 @@ def _get_compiled_kernel_nvfp4_tma(
     sf_layout: int = SF_LAYOUT_128x4,
     enable_pdl: bool = False,
     disable_fp4_quant_fast_math: bool = False,
+    apply_pre_quant_scale: bool = False,
 ) -> Tuple[Callable, int]:
     """
     Get or compile TMA-based NVFP4 kernel with TVM-FFI.
 
-    Cached by (K, dtype_key, sf_layout, pdl).
+    Cached by (K, dtype_key, sf_layout, pdl, pre-scale mode).
     """
     _dtype_map = {
         "float16": cutlass.Float16,
@@ -1526,6 +1612,7 @@ def _get_compiled_kernel_nvfp4_tma(
         sf_layout=sf_layout,
         enable_pdl=enable_pdl,
         disable_fp4_quant_fast_math=disable_fp4_quant_fast_math,
+        apply_pre_quant_scale=apply_pre_quant_scale,
     )
 
     sym_m = cute.sym_int()
@@ -1533,6 +1620,9 @@ def _get_compiled_kernel_nvfp4_tma(
 
     input_fake = cute.runtime.make_fake_compact_tensor(
         cutlass_dtype, (sym_padded_m, K), stride_order=(1, 0), assumed_align=16
+    )
+    pre_quant_scale_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass_dtype, (K,), assumed_align=16
     )
     output_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Uint8, (sym_m, K // 2), stride_order=(1, 0), assumed_align=16
@@ -1549,6 +1639,7 @@ def _get_compiled_kernel_nvfp4_tma(
     compiled_kernel = cute.compile(
         kernel_obj,
         input_fake,
+        pre_quant_scale_fake,
         output_fake,
         scales_fake,
         Int32(1),  # Dummy M
@@ -1568,6 +1659,7 @@ def nvfp4_quantize_cute_dsl(
     global_scale: torch.Tensor,
     sf_layout: int = SF_LAYOUT_128x4,
     enable_pdl: bool | None = None,
+    pre_quant_scale: torch.Tensor | None = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Quantize input tensor to NVFP4 format using the CuTe-DSL kernel.
 
@@ -1578,8 +1670,8 @@ def nvfp4_quantize_cute_dsl(
     - Supports 128x4, 8x4, and linear scale-factor layouts
     - ``sf_vec_size = 16``
 
-    The kernel is compiled once per ``(K, dtype, sf_layout, pdl)`` tuple
-    and handles varying ``M`` (batch size) at runtime without
+    The kernel is compiled once per ``(K, dtype, sf_layout, pdl, pre-scale)``
+    tuple and handles varying ``M`` (batch size) at runtime without
     recompilation.
 
     Parameters
@@ -1594,6 +1686,10 @@ def nvfp4_quantize_cute_dsl(
     enable_pdl : bool, optional
         Whether to enable Programmatic Dependent Launch.  Auto-detected
         from device capability (SM >= 9.0) when ``None``.
+    pre_quant_scale : torch.Tensor, optional
+        BF16 per-channel scale of shape ``[K]`` to multiply into the input
+        inside the quantizer. Supported for BF16 input and swizzled scale-factor
+        layouts only.
 
     Returns
     -------
@@ -1616,7 +1712,6 @@ def nvfp4_quantize_cute_dsl(
     assert input.is_cuda, "Input must be on CUDA device"
 
     enable_pdl = device_support_pdl(input.device) if enable_pdl is not False else False
-
     if input.dim() > 2:
         m = input.numel() // input.shape[-1]
         k = input.shape[-1]
@@ -1629,6 +1724,33 @@ def nvfp4_quantize_cute_dsl(
     )
 
     input = input.contiguous()
+
+    apply_pre_quant_scale = pre_quant_scale is not None
+    if apply_pre_quant_scale:
+        if input.dtype != torch.bfloat16:
+            raise ValueError("pre_quant_scale is only supported for BF16 input")
+        if sf_layout == SF_LAYOUT_LINEAR:
+            raise ValueError(
+                "pre_quant_scale is only supported for swizzled scale-factor layouts"
+            )
+        if not isinstance(pre_quant_scale, torch.Tensor):
+            raise TypeError("pre_quant_scale must be a torch.Tensor")
+        if not pre_quant_scale.is_cuda:
+            raise ValueError("pre_quant_scale must be on a CUDA device")
+        if pre_quant_scale.device != input.device:
+            raise ValueError("pre_quant_scale must be on the same device as input")
+        if pre_quant_scale.dtype != torch.bfloat16:
+            raise ValueError("pre_quant_scale must have dtype torch.bfloat16")
+        if pre_quant_scale.numel() != k:
+            raise ValueError(
+                f"pre_quant_scale must contain K ({k}) elements, got "
+                f"{pre_quant_scale.numel()}"
+            )
+        pre_quant_scale_tensor = pre_quant_scale.reshape(k).contiguous()
+    else:
+        # The compiled swizzled/TMA callable has a uniform tensor ABI. This
+        # argument is supplied lazily only if one of those paths is selected.
+        pre_quant_scale_tensor = None
 
     _torch_to_dtype_key = {
         torch.float16: "float16",
@@ -1673,7 +1795,12 @@ def nvfp4_quantize_cute_dsl(
         scale_output_size = padded_m * padded_sf_cols
 
         kernel_fn, rows_per_block = _get_compiled_kernel_nvfp4_tma(
-            dtype_key, k, sf_layout, enable_pdl, disable_fp4_quant_fast_math
+            dtype_key,
+            k,
+            sf_layout,
+            enable_pdl,
+            disable_fp4_quant_fast_math,
+            apply_pre_quant_scale,
         )
 
         # Match CUDA TMA kernel: grid = min(row_tiles, SM_count * 2)
@@ -1696,6 +1823,9 @@ def nvfp4_quantize_cute_dsl(
 
         kernel_fn(
             input_padded,
+            pre_quant_scale_tensor
+            if pre_quant_scale_tensor is not None
+            else input_padded[0],
             fp4_output,
             scale_output,
             m,
@@ -1723,6 +1853,7 @@ def nvfp4_quantize_cute_dsl(
         enable_pdl,
         disable_fp4_quant_fast_math,
         nvfp4_4over6_config,
+        apply_pre_quant_scale,
     )
 
     target_grid = num_sm * _BLOCKS_PER_SM
@@ -1775,6 +1906,7 @@ def nvfp4_quantize_cute_dsl(
 
         kernel_fn(
             input,
+            pre_quant_scale_tensor if pre_quant_scale_tensor is not None else input[0],
             fp4_output,
             scale_output,
             m,

--- a/flashinfer/quantization/quantization_cute_dsl_utils.py
+++ b/flashinfer/quantization/quantization_cute_dsl_utils.py
@@ -1848,6 +1848,71 @@ def process_nvfp4_block_bfloat(
 
 
 @cute.jit
+def process_nvfp4_block_bfloat_scaled(
+    row_tensor,
+    pre_quant_scale_tensor,
+    elem_base: Int32,
+    global_scale: Float32,
+    disable_fp4_quant_fast_math: bool = False,
+    nvfp4_4over6_config: NVFP44Over6Config | None = None,
+    row_amax: Float32 | None = None,
+) -> tuple:
+    """Process a BF16 NVFP4 block after applying a per-channel BF16 scale.
+
+    The multiply is performed with packed ``mul.bf16x2`` before the amax and
+    FP4 conversion.  This preserves the BF16 rounding boundary of materializing
+    ``row_tensor * pre_quant_scale_tensor`` while avoiding the intermediate.
+    """
+    from ..cute_dsl.fp4_common import (
+        bfloat2_mul,
+        get_ptr_as_int64,
+        ld_global_v4_u32,
+    )
+
+    # Load 16 BF16 activation values and their 16 per-channel scales.
+    x_ptr0 = get_ptr_as_int64(row_tensor, elem_base)
+    x_ptr1 = get_ptr_as_int64(row_tensor, elem_base + Int32(8))
+    p_ptr0 = get_ptr_as_int64(pre_quant_scale_tensor, elem_base)
+    p_ptr1 = get_ptr_as_int64(pre_quant_scale_tensor, elem_base + Int32(8))
+
+    h0, h1, h2, h3 = ld_global_v4_u32(x_ptr0)
+    h4, h5, h6, h7 = ld_global_v4_u32(x_ptr1)
+    p0, p1, p2, p3 = ld_global_v4_u32(p_ptr0)
+    p4, p5, p6, p7 = ld_global_v4_u32(p_ptr1)
+
+    h0 = bfloat2_mul(h0, p0)
+    h1 = bfloat2_mul(h1, p1)
+    h2 = bfloat2_mul(h2, p2)
+    h3 = bfloat2_mul(h3, p3)
+    h4 = bfloat2_mul(h4, p4)
+    h5 = bfloat2_mul(h5, p5)
+    h6 = bfloat2_mul(h6, p6)
+    h7 = bfloat2_mul(h7, p7)
+
+    block_max_h2 = bfloat2_max_abs_8(h0, h1, h2, h3, h4, h5, h6, h7)
+    block_max = bfloat2_hmax_reduce_to_f32(block_max_h2)
+
+    if cutlass.const_expr(nvfp4_4over6_config is not None):
+        values = _bfloat2x8_to_f32x16(h0, h1, h2, h3, h4, h5, h6, h7)
+        scale_fp8, packed64 = _nvfp4_4over6_quant_from_values(
+            values,
+            block_max,
+            global_scale,
+            row_amax,
+            disable_fp4_quant_fast_math,
+            nvfp4_4over6_config,
+        )
+        return scale_fp8, packed64
+
+    scale_fp8, output_scale = _nvfp4_standard_quant_from_amax(
+        block_max, global_scale, disable_fp4_quant_fast_math
+    )
+    packed64 = bfloat2x8_to_e2m1x16_packed(h0, h1, h2, h3, h4, h5, h6, h7, output_scale)
+
+    return scale_fp8, packed64
+
+
+@cute.jit
 def fp8x16_to_e2m1x16_packed(
     w0: Uint32,
     w1: Uint32,

--- a/tests/gemm/test_svdquant_lora.py
+++ b/tests/gemm/test_svdquant_lora.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness test for the fused SVDQuant NVFP4 + LoRA GEMM (Sm100BlockScaledLoRADenseGemmKernel).
+
+Validates the host-glue contract (prepare_svdquant_state + mm_fp4_svdquant) on the three
+Qwen-Image linear shapes. The kernel always fuses the LoRA up-projection, so the output is the
+full SVDQuant result -- NVFP4 residual + (X@L2^T)@L1^T -- checked against the eager reference
+(the NVFP4 residual matches torch.ops.trtllm.nvfp4_gemm; the full op is ~50 dB SQNR vs eager).
+
+The activation is quantized with the SAME quantizer the deployment injects
+(torch.ops.trtllm.fp4_quantize), so the test exercises the real injection path. It is skipped
+when SM100a or the TRT-LLM reference op are unavailable.
+"""
+import pytest
+import torch
+
+from flashinfer.utils import is_sm100a_supported
+
+
+def _has_trtllm_fp4():
+    try:
+        import tensorrt_llm  # noqa: F401
+        return hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "fp4_quantize")
+    except Exception:
+        return False
+
+
+_SKIP_SM = not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda"))
+_SKIP_REF = not _has_trtllm_fp4()
+
+
+def _sqnr(ref: torch.Tensor, t: torch.Tensor) -> float:
+    ref, t = ref.float(), t.float()
+    noise = (ref - t).pow(2).mean()
+    if noise == 0:
+        return 99.0
+    return float(10 * torch.log10(ref.pow(2).mean() / noise))
+
+
+@pytest.mark.skipif(_SKIP_SM, reason="requires SM100a (Blackwell)")
+@pytest.mark.skipif(_SKIP_REF, reason="requires torch.ops.trtllm.fp4_quantize/nvfp4_gemm reference")
+@pytest.mark.parametrize("N,K", [(3072, 3072), (12288, 3072), (3072, 12288)])
+def test_svdquant_lora(N, K):
+    from flashinfer.gemm import prepare_svdquant_state, mm_fp4_svdquant
+
+    dev = "cuda"
+    M, r = 2048, 32
+    torch.manual_seed(0)
+    x = torch.randn(M, K, device=dev, dtype=torch.bfloat16)
+    W = torch.randn(N, K, device=dev, dtype=torch.bfloat16)
+    L1 = torch.randn(N, r, device=dev, dtype=torch.bfloat16) * 0.1  # up   [O, r]
+    L2 = torch.randn(r, K, device=dev, dtype=torch.bfloat16) * 0.1  # down [r, I]
+
+    gsx = (448 * 6) / x.float().abs().max()
+    gsw = (448 * 6) / W.float().abs().max()
+    xq, x_sf = torch.ops.trtllm.fp4_quantize(x, gsx, 16, False)
+    wq, w_sf = torch.ops.trtllm.fp4_quantize(W, gsw, 16, False)
+    alpha = torch.tensor([1.0 / (gsx * gsw)], device=dev, dtype=torch.float32)
+
+    # Reference: NVFP4 residual (matches trtllm.nvfp4_gemm) + the bf16 SVDQuant LoRA correction.
+    resid_ref = torch.ops.trtllm.nvfp4_gemm(xq, wq, x_sf, w_sf, alpha, torch.bfloat16).float()
+    ref = resid_ref + (x.float() @ L2.float().t()) @ L1.float().t()
+
+    state = prepare_svdquant_state(
+        M, wq, w_sf, L1, L2, 1.0 / gsx, 1.0 / gsw, r, pre_quant_scale=None,
+    )
+    y = mm_fp4_svdquant(x, state, ext_xq=xq, ext_sf=x_sf).float()
+
+    assert torch.isfinite(y).all(), "output has non-finite values"
+    sqnr = _sqnr(ref, y)
+    assert sqnr > 40.0, f"SQNR {sqnr:.1f} dB below 40 dB (N={N}, K={K})"

--- a/tests/gemm/test_svdquant_lora.py
+++ b/tests/gemm/test_svdquant_lora.py
@@ -49,13 +49,21 @@ def _sqnr(ref: torch.Tensor, t: torch.Tensor) -> float:
 @pytest.mark.skipif(
     _SKIP_REF, reason="requires torch.ops.trtllm.fp4_quantize/nvfp4_gemm reference"
 )
-@pytest.mark.parametrize("N,K", [(3072, 3072), (12288, 3072), (3072, 12288)])
-def test_svdquant_lora(N, K):
+@pytest.mark.parametrize(
+    "M,N,K",
+    [
+        (2048, 3072, 3072),
+        (2048, 12288, 3072),
+        (2048, 3072, 12288),
+        (257, 3072, 3072),  # exact symbolic M; no framework row padding
+    ],
+)
+def test_svdquant_lora(M, N, K):
     from flashinfer.gemm import prepare_svdquant_state, mm_fp4_svdquant
     from flashinfer.quantization import nvfp4_quantize_cute_dsl
 
     dev = "cuda"
-    M, r = 2048, 32
+    r = 32
     torch.manual_seed(0)
     x = torch.randn(M, K, device=dev, dtype=torch.bfloat16)
     W = torch.randn(N, K, device=dev, dtype=torch.bfloat16)
@@ -96,21 +104,35 @@ def test_svdquant_lora(N, K):
     )
     y = mm_fp4_svdquant(x, state, ext_xq=xq, ext_sf=x_sf).float()
     down_ref = x @ L2_merged.t()
+    paper_down = x_hat @ L2.t()
 
     assert torch.isfinite(y).all(), "output has non-finite values"
     assert torch.equal(state["D_active"], down_ref), (
         "LoRA down projection must use raw x with caller-merged L2"
+    )
+    merge_sqnr = _sqnr(paper_down, down_ref)
+    assert merge_sqnr > 40.0, (
+        f"one-time BF16 L2 merge SQNR {merge_sqnr:.1f} dB below 40 dB"
     )
     sqnr = _sqnr(ref, y)
     assert sqnr > 40.0, f"SQNR {sqnr:.1f} dB below 40 dB (N={N}, K={K})"
 
 
 @pytest.mark.skipif(_SKIP_SM, reason="requires SM100a (Blackwell)")
-@pytest.mark.parametrize("M,K", [(1024, 3072), (4096, 12288)])
+@pytest.mark.parametrize(
+    "M,K",
+    [
+        (1024, 3072),  # aligned, non-TMA
+        (16384, 3072),  # aligned, TMA
+        (16385, 3072),  # misaligned SVDQuant dispatch avoids a padded TMA copy
+        (4096, 12288),  # wide SVDQuant dispatch uses the faster non-TMA kernel
+    ],
+)
 def test_nvfp4_quantize_fused_pre_quant_scale(M, K):
     """Fused pqs must reproduce quantizing a materialized BF16 x*pqs bit for bit.
 
-    The two shapes deliberately exercise the swizzled non-TMA and TMA kernels.
+    The shapes cover the swizzled non-TMA and TMA kernels plus both PQS-only
+    performance overrides.
     """
     from flashinfer.quantization import nvfp4_quantize_cute_dsl
 
@@ -139,16 +161,16 @@ def test_compiled_cache_recomputes_runtime_sf_m():
     N, K, r = 3072, 3072, 32
     tactic = ((128, 128), (1, 1), False)
     key = (torch.cuda.current_device(), N, K, r, torch.bfloat16, tactic, None)
-    old_cache = dict(svdquant_lora._V2_KERNEL_CACHE)
+    old_cache = dict(svdquant_lora._COMPILED_KERNEL_CACHE)
     sentinel = object()
     try:
-        svdquant_lora._V2_KERNEL_CACHE.clear()
-        svdquant_lora._V2_KERNEL_CACHE[key] = (sentinel, 24, 48, 32)
+        svdquant_lora._COMPILED_KERNEL_CACHE.clear()
+        svdquant_lora._COMPILED_KERNEL_CACHE[key] = (sentinel, 24, 48, 32)
         compiled, sf_m, sf_n, sf_k, lora_k = svdquant_lora._build_compiled(
             N, K, 257, r, tactic=tactic
         )
         assert compiled is sentinel
         assert (sf_m, sf_n, sf_k, lora_k) == (3, 24, 48, 32)
     finally:
-        svdquant_lora._V2_KERNEL_CACHE.clear()
-        svdquant_lora._V2_KERNEL_CACHE.update(old_cache)
+        svdquant_lora._COMPILED_KERNEL_CACHE.clear()
+        svdquant_lora._COMPILED_KERNEL_CACHE.update(old_cache)

--- a/tests/gemm/test_svdquant_lora.py
+++ b/tests/gemm/test_svdquant_lora.py
@@ -3,13 +3,15 @@
 
 Validates the host-glue contract (prepare_svdquant_state + mm_fp4_svdquant) on the three
 Qwen-Image linear shapes. The kernel always fuses the LoRA up-projection, so the output is the
-full SVDQuant result -- NVFP4 residual + (X@L2^T)@L1^T -- checked against the eager reference
+full SVDQuant result -- NVFP4 residual + (X@L2_merged^T)@L1^T -- checked against the eager reference
 (the NVFP4 residual matches torch.ops.trtllm.nvfp4_gemm; the full op is ~50 dB SQNR vs eager).
 
-The activation is quantized with the SAME quantizer the deployment injects
-(torch.ops.trtllm.fp4_quantize), so the test exercises the real injection path. It is skipped
-when SM100a or the TRT-LLM reference op are unavailable.
+The activation is quantized by FlashInfer's fused PQS quantizer and checked byte-for-byte against
+TRT-LLM quantizing a materialized BF16 ``x * pqs``. The resulting payload and scale factors are
+then injected into the fused GEMM. The full-shape test is skipped when SM100a or the TRT-LLM
+reference ops are unavailable.
 """
+
 import pytest
 import torch
 
@@ -19,12 +21,19 @@ from flashinfer.utils import is_sm100a_supported
 def _has_trtllm_fp4():
     try:
         import tensorrt_llm  # noqa: F401
-        return hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "fp4_quantize")
+
+        return (
+            hasattr(torch.ops, "trtllm")
+            and hasattr(torch.ops.trtllm, "fp4_quantize")
+            and hasattr(torch.ops.trtllm, "nvfp4_gemm")
+        )
     except Exception:
         return False
 
 
-_SKIP_SM = not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda"))
+_SKIP_SM = not torch.cuda.is_available() or not is_sm100a_supported(
+    torch.device("cuda")
+)
 _SKIP_REF = not _has_trtllm_fp4()
 
 
@@ -37,10 +46,13 @@ def _sqnr(ref: torch.Tensor, t: torch.Tensor) -> float:
 
 
 @pytest.mark.skipif(_SKIP_SM, reason="requires SM100a (Blackwell)")
-@pytest.mark.skipif(_SKIP_REF, reason="requires torch.ops.trtllm.fp4_quantize/nvfp4_gemm reference")
+@pytest.mark.skipif(
+    _SKIP_REF, reason="requires torch.ops.trtllm.fp4_quantize/nvfp4_gemm reference"
+)
 @pytest.mark.parametrize("N,K", [(3072, 3072), (12288, 3072), (3072, 12288)])
 def test_svdquant_lora(N, K):
     from flashinfer.gemm import prepare_svdquant_state, mm_fp4_svdquant
+    from flashinfer.quantization import nvfp4_quantize_cute_dsl
 
     dev = "cuda"
     M, r = 2048, 32
@@ -49,22 +61,94 @@ def test_svdquant_lora(N, K):
     W = torch.randn(N, K, device=dev, dtype=torch.bfloat16)
     L1 = torch.randn(N, r, device=dev, dtype=torch.bfloat16) * 0.1  # up   [O, r]
     L2 = torch.randn(r, K, device=dev, dtype=torch.bfloat16) * 0.1  # down [r, I]
+    pqs = (1.0 + 0.1 * torch.randn(K, device=dev, dtype=torch.bfloat16)).contiguous()
+    x_hat = (x * pqs).to(torch.bfloat16)
+    L2_merged = (L2 * pqs).to(torch.bfloat16)
 
-    gsx = (448 * 6) / x.float().abs().max()
+    gsx = (448 * 6) / x_hat.float().abs().max()
     gsw = (448 * 6) / W.float().abs().max()
-    xq, x_sf = torch.ops.trtllm.fp4_quantize(x, gsx, 16, False)
+    ref_xq, ref_x_sf = torch.ops.trtllm.fp4_quantize(x_hat, gsx, 16, False)
+    xq, x_sf = nvfp4_quantize_cute_dsl(x, gsx, pre_quant_scale=pqs)
+    assert torch.equal(xq, ref_xq), "fused pqs changed the FP4 activation payload"
+    x_sf_bytes = x_sf.view(torch.uint8).reshape(-1)
+    ref_x_sf_bytes = ref_x_sf.view(torch.uint8).reshape(-1)
+    assert torch.equal(x_sf_bytes, ref_x_sf_bytes), (
+        "fused pqs changed activation scale factors"
+    )
     wq, w_sf = torch.ops.trtllm.fp4_quantize(W, gsw, 16, False)
     alpha = torch.tensor([1.0 / (gsx * gsw)], device=dev, dtype=torch.float32)
 
     # Reference: NVFP4 residual (matches trtllm.nvfp4_gemm) + the bf16 SVDQuant LoRA correction.
-    resid_ref = torch.ops.trtllm.nvfp4_gemm(xq, wq, x_sf, w_sf, alpha, torch.bfloat16).float()
-    ref = resid_ref + (x.float() @ L2.float().t()) @ L1.float().t()
+    resid_ref = torch.ops.trtllm.nvfp4_gemm(
+        xq, wq, x_sf, w_sf, alpha, torch.bfloat16
+    ).float()
+    ref = resid_ref + (x.float() @ L2_merged.float().t()) @ L1.float().t()
 
     state = prepare_svdquant_state(
-        M, wq, w_sf, L1, L2, 1.0 / gsx, 1.0 / gsw, r, pre_quant_scale=None,
+        M,
+        wq,
+        w_sf,
+        L1,
+        L2_merged,
+        1.0 / gsx,
+        1.0 / gsw,
+        r,
     )
     y = mm_fp4_svdquant(x, state, ext_xq=xq, ext_sf=x_sf).float()
+    down_ref = x @ L2_merged.t()
 
     assert torch.isfinite(y).all(), "output has non-finite values"
+    assert torch.equal(state["D_active"], down_ref), (
+        "LoRA down projection must use raw x with caller-merged L2"
+    )
     sqnr = _sqnr(ref, y)
     assert sqnr > 40.0, f"SQNR {sqnr:.1f} dB below 40 dB (N={N}, K={K})"
+
+
+@pytest.mark.skipif(_SKIP_SM, reason="requires SM100a (Blackwell)")
+@pytest.mark.parametrize("M,K", [(1024, 3072), (4096, 12288)])
+def test_nvfp4_quantize_fused_pre_quant_scale(M, K):
+    """Fused pqs must reproduce quantizing a materialized BF16 x*pqs bit for bit.
+
+    The two shapes deliberately exercise the swizzled non-TMA and TMA kernels.
+    """
+    from flashinfer.quantization import nvfp4_quantize_cute_dsl
+
+    torch.manual_seed(1)
+    x = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    pqs = (1.0 + 0.1 * torch.randn(K, device="cuda", dtype=torch.bfloat16)).contiguous()
+    x_hat = (x * pqs).to(torch.bfloat16)
+    global_scale = ((448 * 6) / x_hat.float().abs().max()).reshape(1)
+
+    ref_q, ref_sf = nvfp4_quantize_cute_dsl(x_hat, global_scale)
+    q, sf = nvfp4_quantize_cute_dsl(
+        x,
+        global_scale,
+        pre_quant_scale=pqs,
+    )
+
+    assert torch.equal(q, ref_q), f"FP4 payload differs for M={M}, K={K}"
+    assert torch.equal(sf, ref_sf), f"FP8 scale factors differ for M={M}, K={K}"
+
+
+@pytest.mark.skipif(_SKIP_SM, reason="requires SM100a (Blackwell)")
+def test_compiled_cache_recomputes_runtime_sf_m():
+    """A symbolic-M compiled kernel must not reuse the first batch's sf_m."""
+    from flashinfer.gemm.kernels import svdquant_lora
+
+    N, K, r = 3072, 3072, 32
+    tactic = ((128, 128), (1, 1), False)
+    key = (torch.cuda.current_device(), N, K, r, torch.bfloat16, tactic, None)
+    old_cache = dict(svdquant_lora._V2_KERNEL_CACHE)
+    sentinel = object()
+    try:
+        svdquant_lora._V2_KERNEL_CACHE.clear()
+        svdquant_lora._V2_KERNEL_CACHE[key] = (sentinel, 24, 48, 32)
+        compiled, sf_m, sf_n, sf_k, lora_k = svdquant_lora._build_compiled(
+            N, K, 257, r, tactic=tactic
+        )
+        assert compiled is sentinel
+        assert (sf_m, sf_n, sf_k, lora_k) == (3, 24, 48, 32)
+    finally:
+        svdquant_lora._V2_KERNEL_CACHE.clear()
+        svdquant_lora._V2_KERNEL_CACHE.update(old_cache)


### PR DESCRIPTION
[feat] SM100 NVFP4 block-scaled GEMM with a fused SVDQuant LoRA up-projection

### What does this PR do?

Type of change: New feature

Adds **`Sm100BlockScaledLoRADenseGemmKernel`** — FlashInfer's production Blackwell
NVFP4 block-scaled persistent dense GEMM
(`Sm100BlockScaledPersistentDenseGemmKernel`) extended with a **fused rank-r BF16
LoRA up-projection**, plus PyTorch host glue with no TensorRT-LLM dependency. This is the GEMM for
**SVDQuant** linears (NVFP4 residual + low-rank BF16 correction):

```
X̂ = BF16(X · pre_quant_scale)
L2_merged = BF16(L2 · pre_quant_scale)
Y = dequant(nvfp4(X̂) @ nvfp4(R)ᵀ) · α  +  (X @ L2_mergedᵀ) @ L1ᵀ
```

The residual and the LoRA up-projection `D @ L1ᵀ` are computed in **one**
persistent, warp-specialized, tcgen05 kernel. It is pure CuTe-DSL (`cute.compile`,
no csrc/ninja), so it is consumed identically by TensorRT-LLM and sglang/vLLM.

### Design

The NVFP4 residual is the **same tcgen05 K-loop as FlashInfer's production NVFP4
GEMM** (`mm_fp4`); this kernel fuses the LoRA up-projection on top of it:

- After the NVFP4 K-loop, a **second BF16 `cute.gemm`** (`D @ L1ᵀ`, K=r) is
  accumulated into the **main f32 accumulator**. `1/α` is folded into `L1`
  host-side (`L1_scaled = L1/α`) so the **unchanged** epilogue `out = α·acc`
  produces `α·residual + D@L1ᵀ`.
  - **No second accumulator** ⇒ `num_acc_stage=2` (MMA/epilogue overlap) is
    preserved; no extra TMEM pressure. (A naive 2nd-accumulator design forced
    `num_acc_stage=1` and was ~1.8× slower.)
  - `D [M,r]` and `L1 [O,r]` are streamed in by a **second TMA pipeline**
    (`PipelineTmaUmma`) driven by the same TMA-producer / MMA-consumer warps,
    issued before the K-loop to overlap.
- The LoRA up-projection is fused unconditionally — the kernel has no LoRA-off
  mode (the plain NVFP4 GEMM is FlashInfer's existing `mm_fp4`). The LoRA paths
  are still `cutlass.const_expr`-guarded so the rank specializes at compile time.
- TRT-LLM merges `pre_quant_scale` into the BF16 `L2` weight once during
  weight loading. The down-projection `D = X @ L2_mergedᵀ` is a small separate
  BF16 GEMM; only the residual activation quantizer multiplies `X` by
  `pre_quant_scale` at runtime.

### All-shape follow-up

This follow-up does **not** change the arithmetic above. It hardens and tunes only the SVDQuant path:

- Runs the exact runtime `M`, including partial 128-row tiles, so the framework no longer needs an activation-sized row-pad/copy.
- On SM100 with BF16 PQS and the 128x4 SF layout, selects the predicated quantizer for partial rows and `K=12288`; no-PQS callers, other layouts, and other architectures retain the existing dispatch.
- Uses free-memory-aware, bounded exact-M tactic timing with synchronized candidate validation, balanced timing order, and all-or-nothing graph capture.
- Excludes deep-mainloop prefetch only for the measured `N=3072, K=12288, M>=55112` Qwen shape, where long paired runs show it consistently loses.
- Adds public shape/device/dtype/contiguity/SF-size checks and documents reusable-state non-reentrancy. No production debug flags, prints, counters, or forward synchronizations were added.

GB200 validation covers all 3 Qwen linear shapes at all 13 resolution/batch points (39/39 operator cases). Quantized payload and SF bytes are exact in 156/156 dispatch comparisons. The new quant dispatch cuts aligned `K=12288` time by 7.9–15.0% and partial-row cases by 73.3–74.4% (3.74–3.90x). At high-M deep-K, no-prefetch wins 303/303 paired main-kernel rounds and improves paired whole-op medians by 0.43–0.47%.

The final FlashInfer suite passes 9/9 tests, including exact-M `M=257`, aligned/misaligned fused-PQS dispatch, exact BF16 down projection, merged-weight/paper-form LoRA SQNR, and end-output SQNR. A fresh same-node 13-point E2E matrix (1024² batches 1/2/4/8/16; 1328² and 1536² batches 1/2/4/8) measured a **-0.058% geometric-mean delta** versus `mm_fp4`, with every case between -0.433% and +0.631%. All 13 SVDQuant runs had zero fallbacks.

A load-`X`-once mega-frontend prototype was also gated for exact bytes and BF16 `D`, but rejected because its synchronous WMMA pipeline was 4.23–7.91x slower. A viable future fusion must preserve the quantizer's asynchronous TMA pipeline and use tcgen05/TMEM for LoRA-down. A separate CUDA-graph side-stream attempt was exact in 39/39 cases but won 0/39, with a 7.77% median whole-op regression from SM/HBM contention.

### Correctness

End-to-end on **Qwen-Image** (SVDQuant NVFP4, rank-32), the fused kernel produces
images **visually identical to eager SVDQuant** — same prompt and seed at 1328²:

| eager SVDQuant (reference) | fused kernel |
|----------------------------|--------------|
| _attach `eager-fresh-r1328.png`_ | _attach `v2-inj-r1328.png`_ |

The "Qwen Coffee / $2 per cup" café scene matches in chalkboard text, neon,
lighting, and composition; only fine-texture differences remain. The final
batch sweep recorded `fused_calls=8064 / fallback_calls=0`.

- The three production Qwen shapes pass finite-output, exact BF16
  `X @ L2_mergedᵀ`, and SQNR > 40 dB gates. The fused PQS quantizer produces
  exactly the same FP4 payload and scale-factor bytes as quantizing a
  materialized BF16 `X * pre_quant_scale`.

### Performance (GB200, sm_100)

The point of interest is the **whole SVDQuant op** (smoothing `pre_quant_scale` +
NVFP4 quantize + NVFP4 residual + rank-r LoRA down-proj + fused LoRA up-proj) vs
**FlashInfer's own NVFP4 GEMM** (`mm_fp4`, with the same `pre_quant_scale` +
quantize input-prep). Both paths share the same optimized input-prep (CuTe-DSL
NVFP4 quantizer with the BF16 PQS multiply performed in registers), so the
delta isolates the SVDQuant additions over a plain NVFP4 GEMM.

**Earlier Qwen-Image sweep, cuda-graph, 50 steps, s/image (the final same-node matrix above is stricter):**

| resolution | batch | FlashInfer `mm_fp4` | fused SVDQuant | overhead |
|-----------:|------:|---------------------:|---------------:|---------:|
| 1024² | 1  | 5.2002 | 5.2162 | **+0.31%** |
| 1024² | 2  | 5.2598 | 5.2794 | **+0.37%** |
| 1024² | 4  | 4.9500 | 4.9469 | **-0.06%** |
| 1024² | 8  | 4.7850 | 4.7928 | **+0.16%** |
| 1024² | 16 | 4.7546 | 4.8136 | **+1.24%** |
| 1328² | 1  | 9.5827 | 9.4888 | **-0.98%** |
| 1328² | 2  | 9.6983 | 9.6083 | **-0.93%** |
| 1328² | 4  | 9.8462 | 9.7155 | **-1.33%** |
| 1328² | 8  | 9.7370 | 9.6324 | **-1.07%** |
| 1536² | 1  | 12.9309 | 13.0201 | **+0.69%** |
| 1536² | 2  | 14.4385 | 14.5149 | **+0.53%** |
| 1536² | 4  | 13.9979 | 14.0983 | **+0.72%** |
| 1536² | 8  | 13.9066 | 13.9781 | **+0.51%** |

Across all 13 points, the geometric-mean SVDQuant delta is **+0.01%** (range
-1.33% to +1.24%): effectively the same E2E latency while also computing the
BF16 low-rank correction. All rows use the SVDQuant checkpoint, guidance 4,
seed 42, and identical one-pass PQS+quantize input preparation. The 1024²/b2
point is a same-node, five-iteration A/B; high-memory 1024²/b16 and 1536²/b8
were isolated endpoints.

The initial 1024²/b2 result was +1.67%. It exposed a tactic-cache alias between
startup `M=6889` and runtime `M=8192`, which previously shared a power-of-two
bucket. Caching by capped exact M and applying the production `M<128` routing
threshold reduced the same-node gap to +0.37%, without changing kernel math.

Jobs: 1024² `229015`/`229016`, corrected b2 `229034`, b16 `229024`/`229025`;
1328² `228872`/`228997`; 1536² `229017`/`229018`, b8 `229026`/`229027`.

- **cuda-graph-capturable** as-is (`fused_calls=8064 / fallback_calls=0` under
  capture).
- The principal additional cost is the rank-r **down-projection** (a thin N=r GEMM);
  fusing it into the quantize or running it in fp4 was benchmarked and is *slower*
  (thin-N defeats tensor-core GEMM N≥128 and breaks L2 tiling), so it is kept as
  the efficient bf16 GEMM (see caveats).

### Usage

```python
from flashinfer.gemm import (
    prepare_svdquant_state,   # host: weight prep, α=gscale_x·gscale_w, folds 1/α into L1
    mm_fp4_svdquant,          # run: residual + fused LoRA, returns Y
)
from flashinfer.quantization import nvfp4_quantize_cute_dsl

# The framework computes this once while loading weights.
L2_merged = (L2 * pqs).to(torch.bfloat16)
state = prepare_svdquant_state(
    M, Rq, w_sf, L1, L2_merged, gscale_x, gscale_w, r
)
Xq, act_sf = nvfp4_quantize_cute_dsl(x, input_scale, pre_quant_scale=pqs)
Y = mm_fp4_svdquant(x, state, ext_xq=Xq, ext_sf=act_sf)
```

The kernel can also be `cute.compile`d directly via `wrapper_lora`.

### Files
- `flashinfer/gemm/kernels/dense_blockscaled_gemm_lora_sm100.py` — `Sm100BlockScaledLoRADenseGemmKernel`.
- `flashinfer/gemm/kernels/svdquant_lora.py` — host glue (compiled-kernel
  cache, tactic selection, down-projection, and activation-SF injection).
- Existing `flashinfer/quantization/kernels/nvfp4_quantize.py` — modified in
  place with the optional BF16 `pre_quant_scale` path; this is not a new file.
- Existing `flashinfer/quantization/quantization_cute_dsl_utils.py` — packed
  BF16 multiply helper used before amax/FP4 conversion.
- `tests/gemm/test_svdquant_lora.py` — SVDQuant residual + LoRA correctness
  (bitwise quantizer parity, exact BF16 down projection, and output SQNR).

### Notes / caveats
- **Tile/cluster selection:** both 1-CTA (128-wide) and 2-CTA cooperative
  (256-wide) tiles are supported — `D`/`L1` are TMA-multicast across the cluster
  to match the residual. A prepare-time autotuner time-selects the fastest tile
  (1-CTA wins at small M; 2-CTA 256-tiles are 1.3–1.6× faster at large M = high
  batch). Choices are cached by capped exact M so a nearby startup shape cannot
  alias a runtime batch; `swap_ab` is unsupported (`D` is M-indexed / `L1`
  N-indexed).
- **The LoRA down-projection `D = X @ L2_mergedᵀ` stays a separate BF16
  GEMM** in the host glue. It is already bandwidth-optimal (reads the activation once at ~peak HBM),
  and the *up*-projection it feeds is fused for free. Fusing the down-proj to
  remove that read was investigated and is bandwidth/SMEM-bound on SM100 — a
  Triton quantize+down-proj cannot match the hand-tuned NVFP4 quantizer (≈4.6×
  slower), and staging bf16 `X` (4× the fp4 operand) for an in-GEMM down-proj
  collides with the residual's SMEM pipeline. It is the bulk of the residual
  overhead above; left as future work (e.g. an fp8-`X` down-proj, or a quantizer
  extended to emit `D`).
- Requires SM100a (Blackwell) + CUDA 12.8+.
- Adds no environment switches, debug prints, NVTX ranges, counters, or
  forward-path synchronization. Tactic timing is private and runs once during
  state preparation, outside the forward path.

### Related
- **Consumer integration:** TensorRT-LLM PR NVIDIA/TensorRT-LLM#15532 (Qwen-Image
  SVDQuant) calls this kernel via `prepare_svdquant_state` / `mm_fp4_svdquant`.
- sglang/vLLM can consume the same kernel unchanged (framework-agnostic CuTe-DSL).
