### PR TITLE
Enable Ampere FA2 large-head attention

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -113,6 +113,12 @@ from .jit.topk import gen_topk_module
 from .jit.xqa import gen_xqa_module, gen_xqa_module_mla
 
 
+def _is_nvfp4_kv_dtype(dtype: torch.dtype) -> bool:
+    return dtype == torch.uint8 or (
+        hasattr(torch, "float4_e2m1fn_x2") and dtype == torch.float4_e2m1fn_x2
+    )
+
+
 def gen_fa2(
     dtype_qo: torch.dtype,
     dtype_kv: torch.dtype,
@@ -120,6 +126,7 @@ def gen_fa2(
     head_dim_vo: int,
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
+    prefill_only: bool = False,
 ) -> Iterator[JitSpec]:
     if dtype_qo.itemsize == dtype_kv.itemsize and dtype_qo != dtype_kv:
         return
@@ -153,28 +160,29 @@ def gen_fa2(
         use_fp16_qk_reduction=False,
     )
 
-    yield gen_single_decode_module(
-        dtype_q=dtype_qo,
-        dtype_kv=dtype_kv,
-        dtype_o=dtype_qo,
-        head_dim_qk=head_dim_qk,
-        head_dim_vo=head_dim_vo,
-        pos_encoding_mode=0,
-        use_sliding_window=use_sliding_window,
-        use_logits_soft_cap=use_logits_soft_cap,
-    )
+    if not prefill_only:
+        yield gen_single_decode_module(
+            dtype_q=dtype_qo,
+            dtype_kv=dtype_kv,
+            dtype_o=dtype_qo,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            pos_encoding_mode=0,
+            use_sliding_window=use_sliding_window,
+            use_logits_soft_cap=use_logits_soft_cap,
+        )
 
-    yield gen_batch_decode_module(
-        dtype_q=dtype_qo,
-        dtype_kv=dtype_kv,
-        dtype_o=dtype_qo,
-        dtype_idx=torch.int32,
-        head_dim_qk=head_dim_qk,
-        head_dim_vo=head_dim_vo,
-        pos_encoding_mode=0,
-        use_sliding_window=use_sliding_window,
-        use_logits_soft_cap=use_logits_soft_cap,
-    )
+        yield gen_batch_decode_module(
+            dtype_q=dtype_qo,
+            dtype_kv=dtype_kv,
+            dtype_o=dtype_qo,
+            dtype_idx=torch.int32,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            pos_encoding_mode=0,
+            use_sliding_window=use_sliding_window,
+            use_logits_soft_cap=use_logits_soft_cap,
+        )
 
 
 def gen_fa3(
@@ -226,9 +234,9 @@ def gen_attention(
     head_dim_ckv = 512
     head_dim_kpe = 64
 
-    # For 16-bit KV, head_dim > 256 FA2 modules use the Ampere+
-    # large-head path. FP8 large-head modules stay SM100+-only until that
-    # variant is validated separately.
+    # For 16-bit KV, head_dim > 256 FA2 modules use the Ampere+ large-head path.
+    # NVFP4 KV large-head is validated for FA2 batch prefill on SM8+; other
+    # one-byte large-head modules stay SM100+-only until validated separately.
     from .jit.core import current_compilation_context
 
     has_sm8_or_newer = any(
@@ -249,8 +257,10 @@ def gen_attention(
         use_sliding_window_,
         use_logits_soft_cap_,
     ):
-        if head_dim_qk > 256 or head_dim_vo > 256:
-            if dtype_kv.itemsize == 1:
+        large_head = head_dim_qk > 256 or head_dim_vo > 256
+        nvfp4_large_head = large_head and _is_nvfp4_kv_dtype(dtype_kv)
+        if large_head:
+            if dtype_kv.itemsize == 1 and not nvfp4_large_head:
                 if not has_sm100:
                     continue
             elif not has_sm8_or_newer:
@@ -262,6 +272,7 @@ def gen_attention(
             head_dim_vo=head_dim_vo,
             use_sliding_window=use_sliding_window,
             use_logits_soft_cap=use_logits_soft_cap,
+            prefill_only=nvfp4_large_head and not has_sm100,
         )
         # The holistic (persistent) batch-attention kernel
         # does not support head_dim=512.

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -226,12 +226,13 @@ def gen_attention(
     head_dim_ckv = 512
     head_dim_kpe = 64
 
-    # head_dim > 256 FA2 modules are SM100+-only; skip them entirely when no
-    # SM100+ architecture is being targeted.
+    # For 16-bit KV, head_dim > 256 FA2 modules use the Ampere+
+    # large-head path. FP8 large-head modules stay SM100+-only until that
+    # variant is validated separately.
     from .jit.core import current_compilation_context
 
-    has_sm100_or_newer = any(
-        major >= 10 for major, _ in current_compilation_context.TARGET_CUDA_ARCHS
+    has_sm8_or_newer = any(
+        major >= 8 for major, _ in current_compilation_context.TARGET_CUDA_ARCHS
     )
 
     # FA2 MHA / MQA / GQA
@@ -248,8 +249,12 @@ def gen_attention(
         use_sliding_window_,
         use_logits_soft_cap_,
     ):
-        if (head_dim_qk > 256 or head_dim_vo > 256) and not has_sm100_or_newer:
-            continue
+        if head_dim_qk > 256 or head_dim_vo > 256:
+            if dtype_kv.itemsize == 1:
+                if not has_sm100:
+                    continue
+            elif not has_sm8_or_newer:
+                continue
         yield from gen_fa2(
             dtype_qo=dtype_qo,
             dtype_kv=dtype_kv,

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -46,6 +46,7 @@ from .jit.attention import (
     gen_trtllm_gen_fmha_module,
     gen_trtllm_fmha_v2_sm120_module,
 )
+from .jit.attention.utils import _is_nvfp4_kv_dtype
 from .jit.cascade import gen_cascade_module
 from .jit.cpp_ext import get_cuda_version
 from .jit.fp4_quantization import (
@@ -111,12 +112,6 @@ from .jit.moe_utils import gen_moe_utils_module
 from .jit.tllm_utils import gen_trtllm_utils_module
 from .jit.topk import gen_topk_module
 from .jit.xqa import gen_xqa_module, gen_xqa_module_mla
-
-
-def _is_nvfp4_kv_dtype(dtype: torch.dtype) -> bool:
-    return dtype == torch.uint8 or (
-        hasattr(torch, "float4_e2m1fn_x2") and dtype == torch.float4_e2m1fn_x2
-    )
 
 
 def gen_fa2(

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -237,6 +237,9 @@ def gen_attention(
     has_sm8_or_newer = any(
         major >= 8 for major, _ in current_compilation_context.TARGET_CUDA_ARCHS
     )
+    has_sm10_or_newer = any(
+        major >= 10 for major, _ in current_compilation_context.TARGET_CUDA_ARCHS
+    )
 
     # FA2 MHA / MQA / GQA
     for (
@@ -256,7 +259,7 @@ def gen_attention(
         nvfp4_large_head = large_head and _is_nvfp4_kv_dtype(dtype_kv)
         if large_head:
             if dtype_kv.itemsize == 1 and not nvfp4_large_head:
-                if not has_sm100:
+                if not has_sm10_or_newer:
                     continue
             elif not has_sm8_or_newer:
                 continue
@@ -267,7 +270,7 @@ def gen_attention(
             head_dim_vo=head_dim_vo,
             use_sliding_window=use_sliding_window,
             use_logits_soft_cap=use_logits_soft_cap,
-            prefill_only=nvfp4_large_head and not has_sm100,
+            prefill_only=nvfp4_large_head and not has_sm10_or_newer,
         )
         # The holistic (persistent) batch-attention kernel
         # does not support head_dim=512.

--- a/flashinfer/attention/_core.py
+++ b/flashinfer/attention/_core.py
@@ -367,6 +367,8 @@ class BatchAttentionWithAttentionSinkWrapper(BatchPrefillWithPagedKVCacheWrapper
                 custom_mask_buf is not None,  # use_custom_mask
                 q_data_type,
                 kv_data_type,
+                head_dim_qk=head_dim_qk,
+                head_dim_vo=head_dim_vo,
             )
 
         jit_args = [

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1195,6 +1195,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                             False,  # use_custom_mask
                             q_data_type,
                             kv_data_type,
+                            head_dim_qk=head_dim,
+                            head_dim_vo=head_dim,
                         )
                     else:
                         self._backend = "fa2"

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1213,18 +1213,7 @@ def _fa2_head_dim_nvcc_flags(
     return None
 
 
-def _fa2_batch_prefill_head_dim_nvcc_flags(
-    head_dim_qk: int, head_dim_vo: int, dtype_kv: torch.dtype
-) -> Optional[List[str]]:
-    return _fa2_head_dim_nvcc_flags(
-        head_dim_qk,
-        head_dim_vo,
-        dtype_kv,
-        allow_nvfp4_sm8_large_head=True,
-    )
-
-
-def _fa2_single_prefill_head_dim_nvcc_flags(
+def _fa2_prefill_head_dim_nvcc_flags(
     head_dim_qk: int, head_dim_vo: int, dtype_kv: torch.dtype
 ) -> Optional[List[str]]:
     return _fa2_head_dim_nvcc_flags(
@@ -1420,7 +1409,7 @@ def gen_customize_single_prefill_module(
         return gen_jit_spec(
             uri,
             source_paths,
-            extra_cuda_cflags=_fa2_single_prefill_head_dim_nvcc_flags(
+            extra_cuda_cflags=_fa2_prefill_head_dim_nvcc_flags(
                 head_dim_qk, head_dim_vo, dtype_kv
             ),
         )
@@ -1693,9 +1682,7 @@ def gen_customize_batch_prefill_module(
             uri,
             source_paths,
             extra_cuda_cflags=(
-                _fa2_batch_prefill_head_dim_nvcc_flags(
-                    head_dim_qk, head_dim_vo, dtype_kv
-                )
+                _fa2_prefill_head_dim_nvcc_flags(head_dim_qk, head_dim_vo, dtype_kv)
                 if allow_nvfp4_sm8_large_head
                 else _fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo, dtype_kv)
             ),

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1209,9 +1209,7 @@ def _fa2_head_dim_nvcc_flags(
     """
     if head_dim_qk > 256 or head_dim_vo > 256:
         if dtype_kv.itemsize == 1:
-            if not (
-                allow_nvfp4_sm8_large_head and _is_nvfp4_kv_dtype(dtype_kv)
-            ):
+            if not (allow_nvfp4_sm8_large_head and _is_nvfp4_kv_dtype(dtype_kv)):
                 return current_compilation_context.get_nvcc_flags_list(
                     supported_major_versions=[10, 11, 12]
                 )

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1085,7 +1085,6 @@ def gen_batch_prefill_module(
         use_logits_soft_cap=use_logits_soft_cap,
         use_fp16_qk_reduction=use_fp16_qk_reduction,
         fp8_enabled=fp8_enabled,
-        allow_nvfp4_sm8_large_head=(backend == "fa2"),
     )
 
 
@@ -1588,7 +1587,6 @@ def gen_customize_batch_prefill_module(
     use_logits_soft_cap: bool = False,
     use_fp16_qk_reduction: bool = False,
     fp8_enabled: bool = False,
-    allow_nvfp4_sm8_large_head: bool = False,
 ) -> JitSpec:
     kwargs = {
         "variant_decl": variant_decl,
@@ -1681,10 +1679,8 @@ def gen_customize_batch_prefill_module(
         return gen_jit_spec(
             uri,
             source_paths,
-            extra_cuda_cflags=(
-                _fa2_prefill_head_dim_nvcc_flags(head_dim_qk, head_dim_vo, dtype_kv)
-                if allow_nvfp4_sm8_large_head
-                else _fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo, dtype_kv)
+            extra_cuda_cflags=_fa2_prefill_head_dim_nvcc_flags(
+                head_dim_qk, head_dim_vo, dtype_kv
             ),
         )
     elif backend == "fa3":

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -37,15 +37,9 @@ from ..utils import (
     pos_encoding_mode_literal,
     write_if_different,
 )
-from .utils import generate_additional_params
+from .utils import _is_nvfp4_kv_dtype, generate_additional_params
 from .fmha_v2.generate_kernels import enumerate_kernels
 from .fmha_v2.fmha_library import generate_jit_sources
-
-
-def _is_nvfp4_kv_dtype(dtype: torch.dtype) -> bool:
-    return dtype == torch.uint8 or (
-        hasattr(torch, "float4_e2m1fn_x2") and dtype == torch.float4_e2m1fn_x2
-    )
 
 
 def get_single_decode_uri(

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -42,6 +42,12 @@ from .fmha_v2.generate_kernels import enumerate_kernels
 from .fmha_v2.fmha_library import generate_jit_sources
 
 
+def _is_nvfp4_kv_dtype(dtype: torch.dtype) -> bool:
+    return dtype == torch.uint8 or (
+        hasattr(torch, "float4_e2m1fn_x2") and dtype == torch.float4_e2m1fn_x2
+    )
+
+
 def get_single_decode_uri(
     dtype_q: torch.dtype,
     dtype_kv: torch.dtype,
@@ -1085,6 +1091,7 @@ def gen_batch_prefill_module(
         use_logits_soft_cap=use_logits_soft_cap,
         use_fp16_qk_reduction=use_fp16_qk_reduction,
         fp8_enabled=fp8_enabled,
+        allow_nvfp4_sm8_large_head=(backend == "fa2"),
     )
 
 
@@ -1187,23 +1194,53 @@ def gen_batch_attention_module(
 
 
 def _fa2_head_dim_nvcc_flags(
-    head_dim_qk: int, head_dim_vo: int, dtype_kv: torch.dtype
+    head_dim_qk: int,
+    head_dim_vo: int,
+    dtype_kv: torch.dtype,
+    *,
+    allow_nvfp4_sm8_large_head: bool = False,
 ) -> Optional[List[str]]:
     """Return arch flags for FA2 large-head modules.
 
-    For 16-bit KV, head_dim > 256 uses the Ampere+ VO-split/KV-shared-memory
-    path. FP8 large-head modules remain restricted to SM100+ until that variant
-    is validated separately.
+    For 16-bit KV, head_dim > 256 uses the Ampere+ large-head path. NVFP4 KV
+    can opt into the same arch set only for validated FA2 prefill read paths.
+    Other one-byte large-head modules remain restricted to SM100+ until those
+    variants are validated separately.
     """
     if head_dim_qk > 256 or head_dim_vo > 256:
         if dtype_kv.itemsize == 1:
-            return current_compilation_context.get_nvcc_flags_list(
-                supported_major_versions=[10, 11, 12]
-            )
+            if not (
+                allow_nvfp4_sm8_large_head and _is_nvfp4_kv_dtype(dtype_kv)
+            ):
+                return current_compilation_context.get_nvcc_flags_list(
+                    supported_major_versions=[10, 11, 12]
+                )
         return current_compilation_context.get_nvcc_flags_list(
             supported_major_versions=[8, 9, 10, 11, 12]
         )
     return None
+
+
+def _fa2_batch_prefill_head_dim_nvcc_flags(
+    head_dim_qk: int, head_dim_vo: int, dtype_kv: torch.dtype
+) -> Optional[List[str]]:
+    return _fa2_head_dim_nvcc_flags(
+        head_dim_qk,
+        head_dim_vo,
+        dtype_kv,
+        allow_nvfp4_sm8_large_head=True,
+    )
+
+
+def _fa2_single_prefill_head_dim_nvcc_flags(
+    head_dim_qk: int, head_dim_vo: int, dtype_kv: torch.dtype
+) -> Optional[List[str]]:
+    return _fa2_head_dim_nvcc_flags(
+        head_dim_qk,
+        head_dim_vo,
+        dtype_kv,
+        allow_nvfp4_sm8_large_head=True,
+    )
 
 
 def gen_customize_single_decode_module(
@@ -1391,7 +1428,7 @@ def gen_customize_single_prefill_module(
         return gen_jit_spec(
             uri,
             source_paths,
-            extra_cuda_cflags=_fa2_head_dim_nvcc_flags(
+            extra_cuda_cflags=_fa2_single_prefill_head_dim_nvcc_flags(
                 head_dim_qk, head_dim_vo, dtype_kv
             ),
         )
@@ -1570,6 +1607,7 @@ def gen_customize_batch_prefill_module(
     use_logits_soft_cap: bool = False,
     use_fp16_qk_reduction: bool = False,
     fp8_enabled: bool = False,
+    allow_nvfp4_sm8_large_head: bool = False,
 ) -> JitSpec:
     kwargs = {
         "variant_decl": variant_decl,
@@ -1662,8 +1700,12 @@ def gen_customize_batch_prefill_module(
         return gen_jit_spec(
             uri,
             source_paths,
-            extra_cuda_cflags=_fa2_head_dim_nvcc_flags(
-                head_dim_qk, head_dim_vo, dtype_kv
+            extra_cuda_cflags=(
+                _fa2_batch_prefill_head_dim_nvcc_flags(
+                    head_dim_qk, head_dim_vo, dtype_kv
+                )
+                if allow_nvfp4_sm8_large_head
+                else _fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo, dtype_kv)
             ),
         )
     elif backend == "fa3":

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1186,16 +1186,22 @@ def gen_batch_attention_module(
     )
 
 
-def _fa2_head_dim_nvcc_flags(head_dim_qk: int, head_dim_vo: int) -> Optional[List[str]]:
-    """head_dim > 256 is only supported on SM100+.
+def _fa2_head_dim_nvcc_flags(
+    head_dim_qk: int, head_dim_vo: int, dtype_kv: torch.dtype
+) -> Optional[List[str]]:
+    """Return arch flags for FA2 large-head modules.
 
-    Restrict compilation of those modules to SM100/110/120 so pre-SM100
-    builds neither compile nor expose them; requesting such a module on an
-    older GPU raises "No supported CUDA architectures found".
+    For 16-bit KV, head_dim > 256 uses the Ampere+ VO-split/KV-shared-memory
+    path. FP8 large-head modules remain restricted to SM100+ until that variant
+    is validated separately.
     """
     if head_dim_qk > 256 or head_dim_vo > 256:
+        if dtype_kv.itemsize == 1:
+            return current_compilation_context.get_nvcc_flags_list(
+                supported_major_versions=[10, 11, 12]
+            )
         return current_compilation_context.get_nvcc_flags_list(
-            supported_major_versions=[10, 11, 12]
+            supported_major_versions=[8, 9, 10, 11, 12]
         )
     return None
 
@@ -1286,7 +1292,7 @@ def gen_customize_single_decode_module(
     return gen_jit_spec(
         uri,
         source_paths,
-        extra_cuda_cflags=_fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo),
+        extra_cuda_cflags=_fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo, dtype_kv),
     )
 
 
@@ -1385,7 +1391,9 @@ def gen_customize_single_prefill_module(
         return gen_jit_spec(
             uri,
             source_paths,
-            extra_cuda_cflags=_fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo),
+            extra_cuda_cflags=_fa2_head_dim_nvcc_flags(
+                head_dim_qk, head_dim_vo, dtype_kv
+            ),
         )
     elif backend == "fa3":
         gen_directory = jit_env.FLASHINFER_GEN_SRC_DIR / uri
@@ -1538,7 +1546,7 @@ def gen_customize_batch_decode_module(
     return gen_jit_spec(
         uri,
         source_paths,
-        extra_cuda_cflags=_fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo),
+        extra_cuda_cflags=_fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo, dtype_kv),
     )
 
 
@@ -1654,7 +1662,9 @@ def gen_customize_batch_prefill_module(
         return gen_jit_spec(
             uri,
             source_paths,
-            extra_cuda_cflags=_fa2_head_dim_nvcc_flags(head_dim_qk, head_dim_vo),
+            extra_cuda_cflags=_fa2_head_dim_nvcc_flags(
+                head_dim_qk, head_dim_vo, dtype_kv
+            ),
         )
     elif backend == "fa3":
         gen_directory = jit_env.FLASHINFER_GEN_SRC_DIR / uri

--- a/flashinfer/jit/attention/utils.py
+++ b/flashinfer/jit/attention/utils.py
@@ -16,6 +16,14 @@ limitations under the License.
 
 from typing import List
 
+import torch
+
+
+def _is_nvfp4_kv_dtype(dtype: torch.dtype) -> bool:
+    return dtype == torch.uint8 or (
+        hasattr(torch, "float4_e2m1fn_x2") and dtype == torch.float4_e2m1fn_x2
+    )
+
 
 def generate_additional_params(
     additional_tensor_names: List[str],

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1347,6 +1347,9 @@ def single_prefill_with_kv_cache(
         if scale_v is None:
             scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
 
+    # For NVFP4 KV (uint8 packed), last dim is head_dim//2; output uses q head_dim.
+    out_head_dim = q.shape[-1] if kv_cache_sf is not None else v.shape[-1]
+
     if backend == "auto":
         backend = determine_attention_backend(
             q.device,
@@ -1355,6 +1358,8 @@ def single_prefill_with_kv_cache(
             packed_custom_mask is not None,  # use_custom_mask
             q.dtype,
             k.dtype,
+            head_dim_qk=q.shape[-1],
+            head_dim_vo=out_head_dim,
         )
 
     # Unpack NVFP4 scale factors
@@ -1368,8 +1373,6 @@ def single_prefill_with_kv_cache(
     # o_dtype should be provided for FP8 attention
     if o_dtype is None:
         o_dtype = q.dtype
-    # For NVFP4 KV (uint8 packed), last dim is head_dim//2; output uses q head_dim
-    out_head_dim = q.shape[-1] if kv_cache_sf is not None else v.shape[-1]
     out = torch.empty(q.shape[:-1] + (out_head_dim,), dtype=o_dtype, device=q.device)
 
     module = get_single_prefill_module(
@@ -2076,6 +2079,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     self._custom_mask_buf is not None,  # use_custom_mask
                     q_data_type,
                     kv_data_type,
+                    head_dim_qk=head_dim_qk,
+                    head_dim_vo=head_dim_vo,
                 )
             if self._backend != "cudnn":
                 get_module_args = (
@@ -3186,6 +3191,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     self._custom_mask_buf is not None,  # use_custom_mask
                     q_data_type,
                     kv_data_type,
+                    head_dim_qk=head_dim_qk,
+                    head_dim_vo=head_dim_vo,
                 )
 
             get_module_args = (

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -403,6 +403,8 @@ class BlockSparseAttentionWrapper:
                     mask_mode == MaskMode.CUSTOM.value,  # use_custom_mask
                     q_data_type,
                     kv_data_type,
+                    head_dim_qk=head_dim,
+                    head_dim_vo=head_dim,
                 )
 
             get_module_args = (
@@ -959,6 +961,8 @@ class VariableBlockSparseAttentionWrapper:
                 self._mask_mode == MaskMode.CUSTOM.value,  # use_custom_mask
                 q_data_type,
                 kv_data_type,
+                head_dim_qk=head_dim,
+                head_dim_vo=head_dim,
             )
 
         get_module_args = (

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -432,6 +432,13 @@ def is_fa3_backend_supported(
     return True
 
 
+def is_fa3_prefill_head_dim_supported(head_dim_qk: int, head_dim_vo: int) -> bool:
+    """Return whether FA3 prefill supports the QK/VO head-dim pair."""
+    if head_dim_qk == head_dim_vo:
+        return head_dim_qk in {64, 128, 256}
+    return (head_dim_qk, head_dim_vo) == (192, 128)
+
+
 def is_cutlass_backend_supported(
     pos_encoding_mode: int,
     use_fp16_qk_reductions: bool,
@@ -480,6 +487,9 @@ def determine_attention_backend(
     use_custom_mask: bool,
     dtype_q: torch.dtype,
     dtype_kv: torch.dtype,
+    *,
+    head_dim_qk: Optional[int] = None,
+    head_dim_vo: Optional[int] = None,
 ) -> str:
     """
     Determine the appropriate attention backend based on the device and parameters.
@@ -500,6 +510,12 @@ def determine_attention_backend(
         The data type of the query tensor.
     dtype_kv : torch.dtype
         The data type of the key-value tensor.
+    head_dim_qk : int, optional
+        The QK head dimension. When provided with ``head_dim_vo``, this is used
+        to avoid selecting FA3 for prefill dimensions that its Hopper kernels do
+        not instantiate.
+    head_dim_vo : int, optional
+        The VO head dimension.
 
     Returns
     -------
@@ -513,9 +529,13 @@ def determine_attention_backend(
         dtype_q,
         dtype_kv,
     ):
-        return "fa3"
+        if head_dim_qk is None or head_dim_vo is None:
+            return "fa3"
+        if is_fa3_prefill_head_dim_supported(head_dim_qk, head_dim_vo):
+            return "fa3"
     else:
         return "fa2"
+    return "fa2"
 
 
 def version_at_least(version: str, base_version: str) -> bool:

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -146,6 +146,11 @@ struct SharedStorageQKVO {
                                  float2[1]> vosplit_md_smem;
 };
 
+template <typename BaseStorage, uint32_t NUM_ROPE_FREQ_ROWS>
+struct SharedStorageWithRopeFreq : BaseStorage {
+  alignas(16) float rope_freq_smem[4][NUM_ROPE_FREQ_ROWS][4];
+};
+
 template <MaskMode MASK_MODE_, uint32_t CTA_TILE_Q_, uint32_t NUM_MMA_Q_, uint32_t NUM_MMA_KV_,
           uint32_t NUM_MMA_D_QK_, uint32_t NUM_MMA_D_VO_, uint32_t NUM_WARPS_Q_,
           uint32_t NUM_WARPS_KV_, PosEncodingMode POS_ENCODING_MODE_, typename DTypeQ_,
@@ -175,6 +180,13 @@ struct KernelTraits {
   static constexpr bool USE_KV_SHARED_SMEM = USE_VO_SPLIT && !is_fp4_type_v<DTypeKV_> &&
                                              (HEAD_DIM_QK == HEAD_DIM_VO) &&
                                              (sizeof(DTypeKV_) == 2 || CTA_TILE_Q_ > 16);
+  static constexpr bool USE_16B_VO_SPLIT =
+      USE_VO_SPLIT && (sizeof(DTypeKV_) == 2) && AttentionVariant_::use_softmax;
+  static constexpr bool USE_SHARED_ROPE_FREQ =
+      POS_ENCODING_MODE_ == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
+      HEAD_DIM_QK == HEAD_DIM_VO;
+  static constexpr uint32_t SHARED_ROPE_FREQ_BYTES =
+      USE_SHARED_ROPE_FREQ ? (4 * (NUM_MMA_D_QK / 2) * 4 * sizeof(float)) : 0;
   static constexpr uint32_t UPCAST_STRIDE_Q = HEAD_DIM_QK / upcast_size<DTypeQ_>();
   static constexpr uint32_t UPCAST_STRIDE_K = HEAD_DIM_QK / upcast_size<DTypeKV_>();
   static constexpr uint32_t UPCAST_STRIDE_V = HEAD_DIM_VO / upcast_size<DTypeKV_>();
@@ -215,11 +227,19 @@ struct KernelTraits {
             (sizeof(DTypeKV) == 1 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama));
   }
 
-  using SharedStorage = SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK,
-                                          HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>;
-  using SharedStoragePaged =
+  using BaseSharedStorage = SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK,
+                                              HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>;
+  using BaseSharedStoragePaged =
       SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ,
                         DTypeKV, DTypeO, /*kEnableVOSplitOpt=*/true>;
+  using SharedStorage =
+      std::conditional_t<USE_SHARED_ROPE_FREQ,
+                         SharedStorageWithRopeFreq<BaseSharedStorage, NUM_MMA_D_QK / 2>,
+                         BaseSharedStorage>;
+  using SharedStoragePaged =
+      std::conditional_t<USE_SHARED_ROPE_FREQ,
+                         SharedStorageWithRopeFreq<BaseSharedStoragePaged, NUM_MMA_D_QK / 2>,
+                         BaseSharedStoragePaged>;
 #ifdef FP16_QK_REDUCTION_SUPPORTED
   template <typename DT>
   static constexpr DT getNegInf() {
@@ -483,6 +503,96 @@ __device__ __forceinline__ void page_produce_kv(SmemStorage* smem_storage, uint3
   }
 }
 
+template <typename KTraits, typename PagedKV>
+__device__ __forceinline__ size_t get_paged_kv_offset_for_logical_row(
+    const PagedKV& paged_kv, const uint32_t packed_page_iter_base,
+    const typename KTraits::IdType last_indptr, const uint32_t kv_head_idx,
+    const uint32_t logical_row, const uint32_t lane_idx) {
+  using DType = typename KTraits::DTypeKV;
+  constexpr bool IS_FP4 = is_fp4_type_v<DType>;
+  constexpr uint32_t KV_THR_LAYOUT_COL = KTraits::KV_THR_LAYOUT_COL;
+  uint32_t page_iter, entry_idx;
+  paged_kv.page_size.divmod(packed_page_iter_base + logical_row, page_iter, entry_idx);
+  return paged_kv.protective_get_kv_offset(
+      page_iter, kv_head_idx, entry_idx,
+      (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DType>() / (IS_FP4 ? 2 : 1), last_indptr);
+}
+
+template <bool produce_v, typename KTraits, typename SmemStorage, typename PagedKV>
+__device__ __forceinline__ void page_produce_kv_on_the_fly(
+    SmemStorage* smem_storage, uint32_t* smem_offset, typename KTraits::DTypeKV* kv_ptr,
+    const PagedKV& paged_kv, const uint32_t packed_page_iter_base,
+    const typename KTraits::IdType last_indptr, const uint32_t kv_head_idx,
+    const uint32_t kv_idx_base, const uint32_t kv_len, const uint32_t warp_idx,
+    const uint32_t lane_idx) {
+  smem_t<KTraits::SWIZZLE_MODE_KV> smem(
+      (produce_v && !KTraits::USE_KV_SHARED_SMEM) ? smem_storage->v_smem : smem_storage->k_smem);
+  using DType = typename KTraits::DTypeKV;
+  constexpr SharedMemFillMode fill_mode =
+      produce_v ? SharedMemFillMode::kFillZero : SharedMemFillMode::kNoFill;
+  constexpr uint32_t NUM_WARPS = KTraits::NUM_WARPS;
+  constexpr uint32_t NUM_WARPS_Q = KTraits::NUM_WARPS_Q;
+  constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
+  constexpr uint32_t NUM_MMA_D = produce_v ? KTraits::NUM_MMA_D_VO : KTraits::NUM_MMA_D_QK;
+  constexpr uint32_t UPCAST_STRIDE =
+      produce_v ? KTraits::UPCAST_STRIDE_V : KTraits::UPCAST_STRIDE_K;
+  constexpr bool IS_FP4 = is_fp4_type_v<DType>;
+
+  if constexpr (KTraits::SWIZZLE_MODE_KV == SwizzleMode::k128B) {
+    constexpr uint32_t ROWS_PER_ITER = 4;
+    uint32_t kv_idx = kv_idx_base + warp_idx * ROWS_PER_ITER + lane_idx / 8;
+    static_assert(NUM_MMA_KV * ROWS_PER_ITER % NUM_WARPS_Q == 0);
+#pragma unroll
+    for (uint32_t i = 0; i < NUM_MMA_KV * ROWS_PER_ITER / NUM_WARPS_Q; ++i) {
+      const uint32_t logical_row =
+          warp_idx * ROWS_PER_ITER + lane_idx / 8 + NUM_WARPS * ROWS_PER_ITER * i;
+      DType* gptr =
+          kv_ptr + get_paged_kv_offset_for_logical_row<KTraits>(
+                       paged_kv, packed_page_iter_base, last_indptr, kv_head_idx, logical_row,
+                       lane_idx);
+#pragma unroll
+      for (uint32_t j = 0; j < NUM_MMA_D / (8 / sizeof(DType)); ++j) {
+        if constexpr (IS_FP4) {
+          smem.template load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+        } else {
+          smem.template load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+        }
+        *smem_offset = smem.template advance_offset_by_column<8>(*smem_offset, j);
+        gptr += (IS_FP4 ? 4 : 8) * upcast_size<DType>();
+      }
+      kv_idx += NUM_WARPS * ROWS_PER_ITER;
+      *smem_offset =
+          smem.template advance_offset_by_row<NUM_WARPS * ROWS_PER_ITER, UPCAST_STRIDE>(
+              *smem_offset) -
+          sizeof(DType) * NUM_MMA_D;
+    }
+    *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
+  } else {
+    constexpr uint32_t ROWS_PER_ITER = 8;
+    uint32_t kv_idx = kv_idx_base + warp_idx * ROWS_PER_ITER + lane_idx / 4;
+    static_assert(NUM_MMA_KV * (ROWS_PER_ITER / 4) % NUM_WARPS_Q == 0);
+#pragma unroll
+    for (uint32_t i = 0; i < NUM_MMA_KV * (ROWS_PER_ITER / 4) / NUM_WARPS_Q; ++i) {
+      const uint32_t logical_row =
+          warp_idx * ROWS_PER_ITER + lane_idx / 4 + NUM_WARPS * ROWS_PER_ITER * i;
+      DType* gptr =
+          kv_ptr + get_paged_kv_offset_for_logical_row<KTraits>(
+                       paged_kv, packed_page_iter_base, last_indptr, kv_head_idx, logical_row,
+                       lane_idx);
+      if constexpr (IS_FP4) {
+        smem.template load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+      } else {
+        smem.template load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+      }
+      kv_idx += NUM_WARPS * ROWS_PER_ITER;
+      *smem_offset =
+          smem.template advance_offset_by_row<NUM_WARPS * ROWS_PER_ITER, UPCAST_STRIDE>(
+              *smem_offset);
+    }
+    *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
+  }
+}
+
 /*!
  * \brief Load NVFP4 KV scale-factors for one CTA tile into shared memory.
  *
@@ -593,9 +703,9 @@ __device__ __forceinline__ void page_produce_kv_sf(
  * \param warp_idx            Global warp index within the CTA.
  * \param lane_idx            Lane index within the warp.
  */
-template <bool produce_v, typename KTraits>
-__device__ __forceinline__ void produce_kv_sf(typename KTraits::SharedStorage* smem_storage,
-                                              uint8_t* sf_ptr, const uint32_t kv_abs_base,
+template <bool produce_v, typename KTraits, typename SmemStorage>
+__device__ __forceinline__ void produce_kv_sf(SmemStorage* smem_storage, uint8_t* sf_ptr,
+                                              const uint32_t kv_abs_base,
                                               const uint32_t kv_head_idx,
                                               const uint32_t kv_stride_n,
                                               const uint32_t kv_stride_h,
@@ -641,22 +751,49 @@ __device__ __forceinline__ void produce_kv_sf(typename KTraits::SharedStorage* s
 }
 
 template <typename KTraits>
+__device__ __forceinline__ float compute_rope_freq(const uint32_t mma_d, const uint32_t j,
+                                                   const float rope_rcp_scale,
+                                                   const float rope_rcp_theta,
+                                                   const uint32_t lane_mod) {
+  constexpr uint32_t HEAD_DIM = KTraits::NUM_MMA_D_QK * 16;
+  return rope_rcp_scale *
+         __powf(rope_rcp_theta,
+                float(2 * ((mma_d * 16 + (j / 2) * 8 + lane_mod * 2 + (j % 2)) %
+                           (HEAD_DIM / 2))) /
+                    float(HEAD_DIM));
+}
+
+template <typename KTraits>
 __device__ __forceinline__ void init_rope_freq(float (*rope_freq)[4], const float rope_rcp_scale,
                                                const float rope_rcp_theta,
                                                const uint32_t tid_x = threadIdx.x) {
-  constexpr uint32_t HEAD_DIM = KTraits::NUM_MMA_D_QK * 16;
   const uint32_t lane_idx = tid_x;
 #pragma unroll
   for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO / 2; ++mma_d) {
 #pragma unroll
     for (uint32_t j = 0; j < 4; ++j) {
       rope_freq[mma_d][j] =
-          rope_rcp_scale *
-          __powf(rope_rcp_theta,
-                 float(2 * ((mma_d * 16 + (j / 2) * 8 + (lane_idx % 4) * 2 + (j % 2)) %
-                            (HEAD_DIM / 2))) /
-                     float(HEAD_DIM));
+          compute_rope_freq<KTraits>(mma_d, j, rope_rcp_scale, rope_rcp_theta, lane_idx % 4);
     }
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void init_shared_rope_freq(
+    float (*rope_freq_smem)[KTraits::NUM_MMA_D_QK / 2][4], const float rope_rcp_scale,
+    const float rope_rcp_theta, const dim3 tid = threadIdx) {
+  static_assert(KTraits::USE_SHARED_ROPE_FREQ);
+  static_assert(KTraits::NUM_MMA_D_QK == KTraits::NUM_MMA_D_VO);
+  constexpr uint32_t NUM_ROWS = KTraits::NUM_MMA_D_QK / 2;
+  constexpr uint32_t NUM_ELEMS = 4 * NUM_ROWS * 4;
+  const uint32_t thread_id = get_warp_idx<KTraits>(tid.y, tid.z) * WARP_SIZE + tid.x;
+
+  for (uint32_t elem = thread_id; elem < NUM_ELEMS; elem += KTraits::NUM_THREADS) {
+    const uint32_t j = elem % 4;
+    const uint32_t mma_d = (elem / 4) % NUM_ROWS;
+    const uint32_t lane_mod = elem / (NUM_ROWS * 4);
+    rope_freq_smem[lane_mod][mma_d][j] =
+        compute_rope_freq<KTraits>(mma_d, j, rope_rcp_scale, rope_rcp_theta, lane_mod);
   }
 }
 
@@ -864,7 +1001,7 @@ __device__ __forceinline__ void k_smem_inplace_apply_rotary(
         k_smem->stmatrix_m8n8x4(k_smem_offset_r_first_half, k_frag_local[0]);
         k_smem_offset_r_first_half =
             k_smem->template advance_offset_by_column<2 * KTraits::NUM_WARPS_Q>(
-                k_smem_offset_r_first_half, mma_di);
+                k_smem_offset_r_first_half, j);
       }
       *k_smem_offset_r += 16 * UPCAST_STRIDE_K;
       kv_idx += 16;
@@ -1773,11 +1910,23 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
     alignas(16) float o_frag[NUM_MMA_Q][KTraits::NUM_MMA_D_VO_TILE][8];
     DTypeQKAccum m[NUM_MMA_Q][2];
     float d[NUM_MMA_Q][2];
-    float rope_freq[NUM_MMA_D_QK / 2][4];
+    constexpr uint32_t LOCAL_ROPE_FREQ_ROWS =
+        (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+         !KTraits::USE_SHARED_ROPE_FREQ)
+            ? (NUM_MMA_D_QK / 2)
+            : 1;
+    alignas(16) float local_rope_freq[LOCAL_ROPE_FREQ_ROWS][4];
+    float (*rope_freq)[4] = local_rope_freq;
     if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
       const float rope_rcp_theta = params.rope_rcp_theta;
-      init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+      if constexpr (KTraits::USE_SHARED_ROPE_FREQ) {
+        init_shared_rope_freq<KTraits>(smem_storage.rope_freq_smem, rope_rcp_scale, rope_rcp_theta,
+                                       tid);
+        rope_freq = smem_storage.rope_freq_smem[lane_idx % 4];
+      } else {
+        init_rope_freq<KTraits>(local_rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+      }
     }
 
     // cooperative fetch q fragment from gmem to reg
@@ -2082,14 +2231,21 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
         (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                        sizeof(DTypeQ))
                     : 0u);
+    constexpr uint32_t kSharedRopeFreqSmem =
+        (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
+         HEAD_DIM_QK == HEAD_DIM_VO)
+            ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
+            : 0u;
+    constexpr uint32_t kFixedSmem =
+        CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) + kSharedRopeFreqSmem;
     // Smallest NUM_MMA_KV satisfying the FP8 alignment constraint
     // (sizeof(DTypeKV)==1 requires NUM_MMA_KV*2 % NUM_WARPS_Q == 0); size the
     // occupancy budget against the minimum *valid* tile so the staging buffer
     // can't shrink NUM_MMA_KV onto an invalid value on tight-smem parts (SM120).
     constexpr uint32_t kMinValidMmaKV =
         (sizeof(DTypeKV) == 1 && NUM_WARPS_Q > 2) ? (NUM_WARPS_Q / 2) : 1;
-    const int num_ctas_per_sm = max_smem_per_sm >= 2 * (CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) +
-                                                        kMinValidMmaKV * kKVSmemPerMmaKV)
+    const int num_ctas_per_sm = max_smem_per_sm >=
+                                        2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV)
                                     ? 2
                                     : 1;
     const int max_smem_per_threadblock =
@@ -2100,8 +2256,9 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
          !USE_FP16_QK_REDUCTION)
             ? 2
             : (8 / NUM_MMA_Q);
-    const uint32_t max_num_mma_kv_smem =
-        (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) / kKVSmemPerMmaKV;
+    const int max_num_mma_kv_smem =
+        (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) /
+        static_cast<int>(kKVSmemPerMmaKV);
     if (max_num_mma_kv_smem < 1) {
       std::ostringstream err_msg;
       err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
@@ -2113,7 +2270,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
     }
 
     // control NUM_MMA_KV for maximum warp occupancy
-    DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
+    DISPATCH_NUM_MMA_KV(min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg),
+                        NUM_MMA_KV, {
       using KTraits =
           KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
                        NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
@@ -2195,6 +2353,29 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
   return cudaSuccess;
 }
 
+// VO-split helpers used by large-head prefill kernels. Definitions live below the
+// ragged kernel so the paged device path can stay grouped with the helper bodies.
+template <typename KTraits>
+__device__ __forceinline__ void vosplit_softmax_store_p(
+    typename KTraits::AttentionVariant variant,
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+    typename KTraits::DTypeQKAccum (*m)[2], float (*d)[2], float (*o_scale)[2],
+    typename KTraits::SharedStoragePaged* smem_storage, const uint32_t warp_kv_idx,
+    const uint32_t warp_q_idx, const uint32_t lane_idx);
+
+template <typename KTraits>
+__device__ __forceinline__ void vosplit_compute_pv(
+    typename KTraits::SharedStoragePaged* smem_storage,
+    float (*o_frag)[KTraits::NUM_MMA_D_VO_PER_WARP][8], float (*o_scale)[2],
+    const uint32_t warp_vo_base, const uint32_t warp_q_idx, const uint32_t lane_idx);
+
+template <typename KTraits>
+__device__ __forceinline__ void vosplit_write_o(
+    float (*o_frag)[KTraits::NUM_MMA_D_VO_PER_WARP][8], float (*d)[2],
+    typename KTraits::DTypeO* o_ptr_base, const uint32_t o_packed_idx_base,
+    const uint32_t qo_upper_bound, const uint32_t o_stride_n, const uint32_t o_stride_h,
+    const uint32_t warp_vo_base, const uint_fastdiv group_size, const uint32_t lane_idx);
+
 template <typename KTraits, typename Params>
 __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKVCacheKernel(
     const __grid_constant__ Params params) {
@@ -2273,7 +2454,10 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     const uint32_t request_idx = request_indices[bx], qo_tile_idx = qo_tile_indices[bx],
                    kv_tile_idx = kv_tile_indices[bx];
     extern __shared__ uint8_t smem[];
-    auto& smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+    using SmemStorage = std::conditional_t<KTraits::USE_16B_VO_SPLIT,
+                                           typename KTraits::SharedStoragePaged,
+                                           typename KTraits::SharedStorage>;
+    auto& smem_storage = reinterpret_cast<SmemStorage&>(smem);
     AttentionVariant variant(params, /*batch_idx=*/request_idx, smem);
     const uint32_t qo_len = variant.qo_len, kv_len = variant.kv_len,
                    window_left = variant.window_left;
@@ -2294,15 +2478,30 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     const uint32_t kv_abs_base = kv_indptr[request_idx] + chunk_start;
 
     DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
-    alignas(16) float o_frag[NUM_MMA_Q][KTraits::NUM_MMA_D_VO_TILE][8];
+    constexpr uint32_t O_FRAG_D =
+        KTraits::USE_16B_VO_SPLIT ? KTraits::NUM_MMA_D_VO_PER_WARP : KTraits::NUM_MMA_D_VO_TILE;
+    alignas(16) float o_frag[NUM_MMA_Q][O_FRAG_D][8];
+    [[maybe_unused]] float o_scale[NUM_MMA_Q][2];
     DTypeQKAccum m[NUM_MMA_Q][2];
     float d[NUM_MMA_Q][2];
-    float rope_freq[NUM_MMA_D_QK / 2][4];
+    constexpr uint32_t LOCAL_ROPE_FREQ_ROWS =
+        (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+         !KTraits::USE_SHARED_ROPE_FREQ)
+            ? (NUM_MMA_D_QK / 2)
+            : 1;
+    alignas(16) float local_rope_freq[LOCAL_ROPE_FREQ_ROWS][4];
+    float (*rope_freq)[4] = local_rope_freq;
 
     if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
       const float rope_rcp_theta = params.rope_rcp_theta;
-      init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+      if constexpr (KTraits::USE_SHARED_ROPE_FREQ) {
+        init_shared_rope_freq<KTraits>(smem_storage.rope_freq_smem, rope_rcp_scale, rope_rcp_theta,
+                                       tid);
+        rope_freq = smem_storage.rope_freq_smem[lane_idx % 4];
+      } else {
+        init_rope_freq<KTraits>(local_rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+      }
     }
 
     const uint32_t qo_packed_idx_base =
@@ -2323,9 +2522,26 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
 #endif
 
 #pragma unroll 1
-    for (uint32_t d_tile = 0; d_tile < KTraits::NUM_D_VO_TILES; ++d_tile) {
-      const uint32_t d_base = d_tile * KTraits::NUM_MMA_D_VO_TILE;
-      init_states<KTraits>(variant, o_frag, m, d);
+    for (uint32_t d_tile = 0; d_tile < (KTraits::USE_16B_VO_SPLIT ? 1u : KTraits::NUM_D_VO_TILES);
+         ++d_tile) {
+      [[maybe_unused]] const uint32_t d_base = d_tile * KTraits::NUM_MMA_D_VO_TILE;
+      if constexpr (KTraits::USE_16B_VO_SPLIT) {
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+          for (uint32_t local_d = 0; local_d < KTraits::NUM_MMA_D_VO_PER_WARP; ++local_d) {
+#pragma unroll
+            for (uint32_t reg = 0; reg < 8; ++reg) o_frag[mma_q][local_d][reg] = 0.f;
+          }
+#pragma unroll
+          for (uint32_t j = 0; j < 2; ++j) {
+            m[mma_q][j] = DTypeQKAccum(-math::inf);
+            d[mma_q][j] = 0.f;
+          }
+        }
+      } else {
+        init_states<KTraits>(variant, o_frag, m, d);
+      }
       uint32_t q_smem_offset_r = qo_smem.get_permuted_offset<UPCAST_STRIDE_Q>(
           get_warp_idx_q<KTraits>(tid.y) * NUM_MMA_Q * 16 + lane_idx % 16, lane_idx / 16);
 
@@ -2491,7 +2707,13 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
         }
 
         // compute m,d states in online softmax
-        update_mdo_states<KTraits>(variant, s_frag, o_frag, m, d);
+        if constexpr (KTraits::USE_16B_VO_SPLIT) {
+          vosplit_softmax_store_p<KTraits>(variant, s_frag, m, d, o_scale, &smem_storage,
+                                           get_warp_idx_kv<KTraits>(tid.z),
+                                           get_warp_idx_q<KTraits>(tid.y), lane_idx);
+        } else {
+          update_mdo_states<KTraits>(variant, s_frag, o_frag, m, d);
+        }
 
         block.sync();
         if constexpr (KTraits::USE_KV_SHARED_SMEM) {
@@ -2513,7 +2735,12 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
         block.sync();
 
         // compute sfm*v
-        if constexpr (KTraits::USE_KV_REPACK) {
+        if constexpr (KTraits::USE_16B_VO_SPLIT) {
+          const uint32_t warp_vo_base =
+              get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP;
+          vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
+                                      get_warp_idx_q<KTraits>(tid.y), lane_idx);
+        } else if constexpr (KTraits::USE_KV_REPACK) {
           // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
           repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(
               smem_storage.v_smem, smem_storage.kv_smem_repack, warp_idx * WARP_SIZE + lane_idx);
@@ -2553,22 +2780,29 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
 
       finalize_m<KTraits>(variant, m);
 
-      // threadblock synchronization
-      threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
-
       const uint32_t num_kv_chunks =
           ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
-      // transform output
-      transform_output<KTraits, Params>(params, variant, o_frag, m, d, /*batch_idx=*/request_idx,
-                                        kv_tile_idx, qo_packed_idx_base, warp_idx, lane_idx,
-                                        kv_head_idx, group_size);
+      if constexpr (KTraits::USE_16B_VO_SPLIT) {
+        vosplit_write_o<KTraits>(o_frag, d, o_ptr_base, qo_packed_idx_base, qo_len,
+                                 partition_kv ? num_kv_chunks * o_stride_n : o_stride_n, o_stride_h,
+                                 get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP,
+                                 group_size, lane_idx);
+      } else {
+        // threadblock synchronization
+        threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
 
-      // write back (o_ptr_base offset to this VO tile's columns: d_base mma * 16 elems)
-      write_o_reg_gmem<KTraits>(o_frag, &qo_smem, o_ptr_base + d_base * 16, qo_packed_idx_base,
-                                qo_len,
-                                /*o_stride_n=*/
-                                partition_kv ? num_kv_chunks * o_stride_n : o_stride_n,
-                                /*o_stride_h=*/o_stride_h, group_size, tid);
+        // transform output
+        transform_output<KTraits, Params>(params, variant, o_frag, m, d, /*batch_idx=*/request_idx,
+                                          kv_tile_idx, qo_packed_idx_base, warp_idx, lane_idx,
+                                          kv_head_idx, group_size);
+
+        // write back (o_ptr_base offset to this VO tile's columns: d_base mma * 16 elems)
+        write_o_reg_gmem<KTraits>(o_frag, &qo_smem, o_ptr_base + d_base * 16, qo_packed_idx_base,
+                                  qo_len,
+                                  /*o_stride_n=*/
+                                  partition_kv ? num_kv_chunks * o_stride_n : o_stride_n,
+                                  /*o_stride_h=*/o_stride_h, group_size, tid);
+      }
 
       // write lse (identical across VO tiles; redundant rewrite on later tiles is harmless)
       if constexpr (AttentionVariant::use_softmax) {
@@ -2954,12 +3188,24 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     [[maybe_unused]] float o_scale[NUM_MMA_Q][2];  // VO-split online rescale (per KV tile)
     DTypeQKAccum m[NUM_MMA_Q][2];
     float d[NUM_MMA_Q][2];
-    float rope_freq[NUM_MMA_D_QK / 2][4];
+    constexpr uint32_t LOCAL_ROPE_FREQ_ROWS =
+        (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+         !KTraits::USE_SHARED_ROPE_FREQ)
+            ? (NUM_MMA_D_QK / 2)
+            : 1;
+    alignas(16) float local_rope_freq[LOCAL_ROPE_FREQ_ROWS][4];
+    float (*rope_freq)[4] = local_rope_freq;
 
     if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
       const float rope_rcp_theta = params.rope_rcp_theta;
-      init_rope_freq<KTraits>(rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+      if constexpr (KTraits::USE_SHARED_ROPE_FREQ) {
+        init_shared_rope_freq<KTraits>(smem_storage.rope_freq_smem, rope_rcp_scale, rope_rcp_theta,
+                                       tid);
+        rope_freq = smem_storage.rope_freq_smem[lane_idx % 4];
+      } else {
+        init_rope_freq<KTraits>(local_rope_freq, rope_rcp_scale, rope_rcp_theta, tid.x);
+      }
     }
 
     const uint32_t qo_packed_idx_base =
@@ -3029,26 +3275,32 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
         block.sync();
       }
 
-      smem_t<SWIZZLE_MODE_KV> k_smem(smem_storage.k_smem), v_smem(smem_storage.v_smem);
-      size_t thr_local_kv_offset[NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q];
-      // K/V-shared path: V(iter) reuses the page offsets that loaded K(iter) (same
-      // tile). thr_local_kv_offset gets overwritten with the NEXT tile's offsets at
-      // the loop head, so stash the current tile's offsets here for the V load.
-      [[maybe_unused]] size_t shared_v_kv_offset[NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q];
+      // K/V-shared path: V is loaded into k_smem (time-shared); v_smem is a [1] stub.
+      smem_t<SWIZZLE_MODE_KV> k_smem(smem_storage.k_smem),
+          v_smem(KTraits::USE_KV_SHARED_SMEM ? smem_storage.k_smem : smem_storage.v_smem);
+      constexpr uint32_t NUM_PAGED_KV_OFFSETS =
+          NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q;
+      [[maybe_unused]] size_t
+          thr_local_kv_offset[KTraits::USE_KV_SHARED_SMEM ? 1 : NUM_PAGED_KV_OFFSETS];
 
       uint32_t k_smem_offset_r = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
                    get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + 8 * (lane_idx / 16) +
                        lane_idx % 8,
                    (lane_idx % 16) / 8),
-               v_smem_offset_r = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
-                   get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + lane_idx % 16,
-                   lane_idx / 16),
                k_smem_offset_w = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
                    warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL,
-                   lane_idx % KV_THR_LAYOUT_COL),
-               v_smem_offset_w = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
-                   warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL,
                    lane_idx % KV_THR_LAYOUT_COL);
+      [[maybe_unused]] uint32_t v_smem_offset_r = 0;
+      uint32_t v_smem_offset_w = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
+          warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL,
+          lane_idx % KV_THR_LAYOUT_COL);
+      if constexpr (!KTraits::USE_VO_SPLIT && !KTraits::USE_KV_REPACK) {
+        v_smem_offset_r = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
+            get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + lane_idx % 16, lane_idx / 16);
+      }
+      if constexpr (KTraits::USE_KV_SHARED_SMEM) {
+        static_assert(UPCAST_STRIDE_K == UPCAST_STRIDE_V);
+      }
 
       // FP8 repack path
       smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack),
@@ -3066,36 +3318,37 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
 
       uint32_t packed_page_iter_base =
           paged_kv.indptr[request_idx] * paged_kv.page_size + chunk_start;
+      if constexpr (KTraits::USE_KV_SHARED_SMEM) {
+        page_produce_kv_on_the_fly<false, KTraits>(
+            &smem_storage, &k_smem_offset_w, paged_kv.k_data, paged_kv, packed_page_iter_base,
+            last_indptr, kv_head_idx, 0, chunk_size, warp_idx, lane_idx);
+      } else {
 #pragma unroll
-      for (uint32_t i = 0;
-           i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
-        uint32_t page_iter, entry_idx;
-        paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * KV_THR_LAYOUT_ROW +
-                                      lane_idx / KV_THR_LAYOUT_COL +
-                                      KV_THR_LAYOUT_ROW * NUM_WARPS_Q * NUM_WARPS_KV * i,
-                                  page_iter, entry_idx);
-        // FP4: GMEM is packed (2 FP4/byte), so the column byte offset is halved relative to fp8
-        constexpr uint32_t fp4_pack_factor = is_fp4_type_v<DTypeKV> ? 2 : 1;
-        thr_local_kv_offset[i] = paged_kv.protective_get_kv_offset(
-            page_iter, kv_head_idx, entry_idx,
-            (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>() / fp4_pack_factor, last_indptr);
+        for (uint32_t i = 0;
+             i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
+          uint32_t page_iter, entry_idx;
+          paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * KV_THR_LAYOUT_ROW +
+                                        lane_idx / KV_THR_LAYOUT_COL +
+                                        KV_THR_LAYOUT_ROW * NUM_WARPS_Q * NUM_WARPS_KV * i,
+                                    page_iter, entry_idx);
+          // FP4: GMEM is packed (2 FP4/byte), so the column byte offset is halved relative to fp8
+          constexpr uint32_t fp4_pack_factor = is_fp4_type_v<DTypeKV> ? 2 : 1;
+          thr_local_kv_offset[i] = paged_kv.protective_get_kv_offset(
+              page_iter, kv_head_idx, entry_idx,
+              (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>() / fp4_pack_factor,
+              last_indptr);
+        }
+        page_produce_kv<false, KTraits>(&smem_storage, &k_smem_offset_w, paged_kv.k_data, 0,
+                                        thr_local_kv_offset, chunk_size, warp_idx, lane_idx);
       }
-      page_produce_kv<false, KTraits>(&smem_storage, &k_smem_offset_w, paged_kv.k_data, 0,
-                                      thr_local_kv_offset, chunk_size, warp_idx, lane_idx);
       page_produce_kv_sf<false, KTraits>(&smem_storage, maybe_k_cache_sf, packed_page_iter_base,
                                          last_indptr * (uint32_t)paged_kv.page_size, kv_head_idx,
                                          paged_kv.stride_page, paged_kv.stride_h, paged_kv.stride_n,
                                          paged_kv.page_size, paged_kv.indices, 0, chunk_size,
                                          warp_idx, lane_idx);
       cp_async::commit_group();
-      if constexpr (KTraits::USE_KV_SHARED_SMEM) {
-        // Shared K/V: don't preload V(0) (it would clobber K(0)); V(0) is loaded
-        // inside iter 0 after Q.K^T. Stash tile-0 offsets for that load.
-#pragma unroll
-        for (uint32_t i = 0; i < NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q; ++i) {
-          shared_v_kv_offset[i] = thr_local_kv_offset[i];
-        }
-      } else {
+      // Shared K/V loads V(0) inside iter 0 after Q.K^T; preloading it would clobber K(0).
+      if constexpr (!KTraits::USE_KV_SHARED_SMEM) {
         page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data, 0,
                                        thr_local_kv_offset, chunk_size, warp_idx, lane_idx);
         page_produce_kv_sf<true, KTraits>(&smem_storage, maybe_v_cache_sf, packed_page_iter_base,
@@ -3171,21 +3424,25 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                        ? (num_iterations_mask - num_iterations_prefix)
                        : 0)
                 : 0;
-        packed_page_iter_base += (1 + prefetch_skip_step) * CTA_TILE_KV;
+        const uint32_t next_packed_page_iter_base =
+            packed_page_iter_base + (1 + prefetch_skip_step) * CTA_TILE_KV;
+        if constexpr (!KTraits::USE_KV_SHARED_SMEM) {
+          packed_page_iter_base = next_packed_page_iter_base;
 #pragma unroll
-        for (uint32_t i = 0;
-             i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
-          uint32_t page_iter, entry_idx;
-          paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * KV_THR_LAYOUT_ROW +
-                                        lane_idx / KV_THR_LAYOUT_COL +
-                                        KV_THR_LAYOUT_ROW * NUM_WARPS_Q * NUM_WARPS_KV * i,
-                                    page_iter, entry_idx);
-          // FP4: GMEM is packed (2 FP4/byte), so the column byte offset is halved relative to fp8
-          constexpr uint32_t fp4_pack_factor = is_fp4_type_v<DTypeKV> ? 2 : 1;
-          thr_local_kv_offset[i] = paged_kv.protective_get_kv_offset(
-              page_iter, kv_head_idx, entry_idx,
-              (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>() / fp4_pack_factor,
-              last_indptr);
+          for (uint32_t i = 0;
+               i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
+            uint32_t page_iter, entry_idx;
+            paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * KV_THR_LAYOUT_ROW +
+                                          lane_idx / KV_THR_LAYOUT_COL +
+                                          KV_THR_LAYOUT_ROW * NUM_WARPS_Q * NUM_WARPS_KV * i,
+                                      page_iter, entry_idx);
+            // FP4: GMEM is packed (2 FP4/byte), so the column byte offset is halved relative to fp8
+            constexpr uint32_t fp4_pack_factor = is_fp4_type_v<DTypeKV> ? 2 : 1;
+            thr_local_kv_offset[i] = paged_kv.protective_get_kv_offset(
+                page_iter, kv_head_idx, entry_idx,
+                (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>() / fp4_pack_factor,
+                last_indptr);
+          }
         }
         // Shared K/V serializes loads (no K/V prefetch overlap) -> drain fully.
         if constexpr (KTraits::USE_KV_SHARED_SMEM) {
@@ -3270,9 +3527,9 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
 
         block.sync();
         if constexpr (KTraits::USE_KV_SHARED_SMEM) {
-          page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data,
-                                         iter * CTA_TILE_KV, shared_v_kv_offset, chunk_size,
-                                         warp_idx, lane_idx);
+          page_produce_kv_on_the_fly<true, KTraits>(
+              &smem_storage, &v_smem_offset_w, paged_kv.v_data, paged_kv, packed_page_iter_base,
+              last_indptr, kv_head_idx, iter * CTA_TILE_KV, chunk_size, warp_idx, lane_idx);
           cp_async::commit_group();
           cp_async::wait_group<0>();
         } else {
@@ -3315,14 +3572,11 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
 
         block.sync();
         if constexpr (KTraits::USE_KV_SHARED_SMEM) {
-          page_produce_kv<false, KTraits>(&smem_storage, &k_smem_offset_w, paged_kv.k_data,
-                                          (iter + 1) * CTA_TILE_KV, thr_local_kv_offset, chunk_size,
-                                          warp_idx, lane_idx);
+          page_produce_kv_on_the_fly<false, KTraits>(
+              &smem_storage, &k_smem_offset_w, paged_kv.k_data, paged_kv, next_packed_page_iter_base,
+              last_indptr, kv_head_idx, (iter + 1) * CTA_TILE_KV, chunk_size, warp_idx, lane_idx);
           cp_async::commit_group();
-#pragma unroll
-          for (uint32_t i = 0; i < NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q; ++i) {
-            shared_v_kv_offset[i] = thr_local_kv_offset[i];
-          }
+          packed_page_iter_base = next_packed_page_iter_base;
         } else {
           page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data,
                                          (iter + 1) * CTA_TILE_KV, thr_local_kv_offset, chunk_size,
@@ -3425,10 +3679,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
   const uint32_t padded_batch_size = params.padded_batch_size;
   const uint32_t num_qo_heads = params.num_qo_heads;
   const uint32_t num_kv_heads = params.num_kv_heads;
-  // hd512 uses the 2-Q x 2-KV-warp layout at CTA_TILE_Q=32. Unlike the paged
-  // (VO-split) kernel, this kernel merges warp outputs through
-  // cta_sync_o_smem (NUM_WARPS_KV * CTA_TILE_Q * 256 floats), which only fits
-  // 99KB-smem GPUs with NUM_WARPS_KV=2 — so FP8 takes this layout too.
+  // Large-head CTA_TILE_Q=32 uses a 2-Q x 2-KV-warp layout to keep the per-warp
+  // output fragment bounded. The 16-bit softmax path also uses the VO-split
+  // P/V helpers below; FP8 keeps the existing split-D merge path.
   constexpr bool kBf16VOSplit = (sizeof(DTypeKV) <= 2) && !is_fp4_type_v<DTypeKV> &&
                                 (HEAD_DIM_VO >= 512) && (CTA_TILE_Q == 32);
   constexpr uint32_t NUM_MMA_Q = kBf16VOSplit ? 1 : get_num_mma_q(CTA_TILE_Q);
@@ -3471,12 +3724,25 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
                              ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0) &&
                              (HEAD_DIM_QK == HEAD_DIM_VO) &&
                              (sizeof(DTypeKV) == 2 || CTA_TILE_Q > 16);
+  constexpr bool kVOSplitDispatch = (sizeof(DTypeKV) == 2) && AttentionVariant::use_softmax &&
+                                    (HEAD_DIM_VO / 16 > 16) &&
+                                    ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0);
   constexpr uint32_t kKVSmemPerMmaKV =
       (kKVShared ? (HEAD_DIM_QK * 16 * NUM_WARPS_KV * sizeof(DTypeKV))
                  : ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV))) +
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
-                  : 0u);
+                  : 0u) +
+      (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
+  constexpr uint32_t kVOSplitFixedSmem =
+      kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
+  constexpr uint32_t kSharedRopeFreqSmem =
+      (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
+       HEAD_DIM_QK == HEAD_DIM_VO)
+          ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
+          : 0u;
+  constexpr uint32_t kFixedSmem =
+      CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) + kVOSplitFixedSmem + kSharedRopeFreqSmem;
   // Smallest NUM_MMA_KV satisfying the FP8 alignment constraint
   // (sizeof(DTypeKV)==1 requires NUM_MMA_KV*2 % NUM_WARPS_Q == 0). When the
   // staging buffer shrinks the tile on tight-smem parts (e.g. SM120), we must
@@ -3484,8 +3750,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
   // minimum *valid* tile rather than NUM_MMA_KV=1.
   constexpr uint32_t kMinValidMmaKV =
       (sizeof(DTypeKV) == 1 && NUM_WARPS_Q > 2) ? (NUM_WARPS_Q / 2) : 1;
-  const int num_ctas_per_sm = max_smem_per_sm >= 2 * (CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) +
-                                                      kMinValidMmaKV * kKVSmemPerMmaKV)
+  const int num_ctas_per_sm = max_smem_per_sm >=
+                                      2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV)
                                   ? 2
                                   : 1;
   // The occupancy budget (max_smem_per_sm / num_ctas_per_sm) can exceed the
@@ -3502,8 +3768,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
        !USE_FP16_QK_REDUCTION)
           ? 2
           : (8 / NUM_MMA_Q);
-  const uint32_t max_num_mma_kv_smem =
-      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) / kKVSmemPerMmaKV;
+  const int max_num_mma_kv_smem =
+      (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) /
+      static_cast<int>(kKVSmemPerMmaKV);
   if (max_num_mma_kv_smem < 1) {
     std::ostringstream err_msg;
     err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
@@ -3514,7 +3781,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
     FLASHINFER_ERROR(err_msg.str());
   }
 
-  DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
+  DISPATCH_NUM_MMA_KV(min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg),
+                      NUM_MMA_KV, {
     using KTraits =
         KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
                      NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
@@ -3530,7 +3798,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
                  " and report the issue to the developers.";
       FLASHINFER_ERROR(err_msg.str());
     } else {
-      size_t smem_size = sizeof(typename KTraits::SharedStorage);
+      using SmemStorage = std::conditional_t<KTraits::USE_16B_VO_SPLIT,
+                                             typename KTraits::SharedStoragePaged,
+                                             typename KTraits::SharedStorage>;
+      size_t smem_size = sizeof(SmemStorage);
       auto kernel = BatchPrefillWithRaggedKVCacheKernel<KTraits, Params>;
       // Exact final check: the analytic NUM_MMA_KV budget can slightly
       // under-count the real struct (cross-warp merge buffers, padding);
@@ -3665,6 +3936,15 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
                      sizeof(DTypeQ))
                   : 0u) +
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
+  constexpr uint32_t kVOSplitFixedSmem =
+      kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
+  constexpr uint32_t kSharedRopeFreqSmem =
+      (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
+       HEAD_DIM_QK == HEAD_DIM_VO)
+          ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
+          : 0u;
+  constexpr uint32_t kFixedSmem =
+      CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) + kVOSplitFixedSmem + kSharedRopeFreqSmem;
   // Smallest NUM_MMA_KV satisfying the FP8 alignment constraint
   // (sizeof(DTypeKV)==1 requires NUM_MMA_KV*2 % NUM_WARPS_Q == 0). When the
   // staging buffer shrinks the tile on tight-smem parts (e.g. SM120), we must
@@ -3672,8 +3952,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
   // minimum *valid* tile rather than NUM_MMA_KV=1.
   constexpr uint32_t kMinValidMmaKV =
       (sizeof(DTypeKV) == 1 && NUM_WARPS_Q > 2) ? (NUM_WARPS_Q / 2) : 1;
-  const int num_ctas_per_sm = max_smem_per_sm >= 2 * (CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) +
-                                                      kMinValidMmaKV * kKVSmemPerMmaKV)
+  const int num_ctas_per_sm = max_smem_per_sm >=
+                                      2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV)
                                   ? 2
                                   : 1;
   const int max_smem_per_threadblock =
@@ -3684,11 +3964,9 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
        !USE_FP16_QK_REDUCTION)
           ? 2
           : (8 / NUM_MMA_Q);
-  constexpr uint32_t kVOSplitFixedSmem =
-      kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
-  const uint32_t max_num_mma_kv_smem =
-      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) - kVOSplitFixedSmem) /
-      kKVSmemPerMmaKV;
+  const int max_num_mma_kv_smem =
+      (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) /
+      static_cast<int>(kKVSmemPerMmaKV);
   if (max_num_mma_kv_smem < 1) {
     std::ostringstream err_msg;
     err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
@@ -3699,7 +3977,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
     FLASHINFER_ERROR(err_msg.str());
   }
 
-  DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
+  DISPATCH_NUM_MMA_KV(min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg),
+                      NUM_MMA_KV, {
     using KTraits =
         KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
                      NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -180,6 +180,11 @@ struct KernelTraits {
   static constexpr bool USE_KV_SHARED_SMEM = USE_VO_SPLIT && !is_fp4_type_v<DTypeKV_> &&
                                              (HEAD_DIM_QK == HEAD_DIM_VO) &&
                                              (sizeof(DTypeKV_) == 2 || CTA_TILE_Q_ > 16);
+  static constexpr bool USE_SOFTMAX_VO_SPLIT =
+      USE_VO_SPLIT && AttentionVariant_::use_softmax &&
+      ((sizeof(DTypeKV_) == 2) || is_fp4_type_v<DTypeKV_>);
+  static constexpr bool USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT =
+      USE_SOFTMAX_VO_SPLIT && is_fp4_type_v<DTypeKV_>;
   static constexpr bool USE_16B_VO_SPLIT =
       USE_VO_SPLIT && (sizeof(DTypeKV_) == 2) && AttentionVariant_::use_softmax;
   static constexpr bool USE_SHARED_ROPE_FREQ =
@@ -224,7 +229,8 @@ struct KernelTraits {
                           2 * sizeof(DTypeQKAccum) * NUM_MMA_KV) >=
              256) ||
             (sizeof(DTypeKV) == 1 && NUM_MMA_KV * 2 % NUM_WARPS_Q != 0) ||
-            (sizeof(DTypeKV) == 1 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama));
+            (sizeof(DTypeKV) == 1 && !is_fp4_type_v<DTypeKV> &&
+             POS_ENCODING_MODE == PosEncodingMode::kRoPELlama));
   }
 
   using BaseSharedStorage = SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK,
@@ -1150,6 +1156,140 @@ __device__ __forceinline__ void compute_qk(
   *k_smem_offset_r -= KTraits::NUM_MMA_D_QK * KV_ESIZE;
 }
 
+template <typename KTraits>
+__device__ __forceinline__ void load_fp4_k_frag_scaled(
+    smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem, const uint32_t k_smem_offset_r,
+    uint8_t* k_sf_smem, const uint32_t lane_idx, const uint32_t mma_kv,
+    const uint32_t mma_d, uint32_t* b_frag) {
+  using DTypeQ = typename KTraits::DTypeQ;
+  using DTypeKV = typename KTraits::DTypeKV;
+  static_assert(is_fp4_type_v<DTypeKV>);
+
+  uint32_t b_frag_quant[2];
+  if (mma_d % 2 == 0) {
+    k_smem->ldmatrix_m8n8x4_left_half(k_smem_offset_r, b_frag_quant);
+  } else {
+    k_smem->ldmatrix_m8n8x4_right_half(k_smem_offset_r, b_frag_quant);
+  }
+  b_frag_quant[0] = frag_layout_swizzle_16b_to_4b(b_frag_quant[0]);
+  b_frag_quant[1] = frag_layout_swizzle_16b_to_4b(b_frag_quant[1]);
+  vec_cast<DTypeQ, DTypeKV>::cast<8>((DTypeQ*)b_frag, (DTypeKV*)b_frag_quant);
+
+  using packed2 = std::conditional_t<std::is_same_v<DTypeQ, half>, half2, __nv_bfloat162>;
+  constexpr uint32_t SF_COLS_K = KTraits::NUM_MMA_D_QK;
+  const uint32_t sf_base = (mma_kv * 16 + lane_idx / 4) * SF_COLS_K + mma_d;
+  __nv_fp8_e4m3 sf_a_fp8, sf_b_fp8;
+  sf_a_fp8.__x = k_sf_smem[sf_base];
+  sf_b_fp8.__x = k_sf_smem[sf_base + 8 * SF_COLS_K];
+  packed2 scale_a{static_cast<DTypeQ>(sf_a_fp8), static_cast<DTypeQ>(sf_a_fp8)};
+  packed2 scale_b{static_cast<DTypeQ>(sf_b_fp8), static_cast<DTypeQ>(sf_b_fp8)};
+  *(packed2*)&b_frag[0] = __hmul2(*(packed2*)&b_frag[0], scale_a);
+  *(packed2*)&b_frag[1] = __hmul2(*(packed2*)&b_frag[1], scale_a);
+  *(packed2*)&b_frag[2] = __hmul2(*(packed2*)&b_frag[2], scale_b);
+  *(packed2*)&b_frag[3] = __hmul2(*(packed2*)&b_frag[3], scale_b);
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void compute_qk_fp4_rope(
+    smem_t<KTraits::SWIZZLE_MODE_Q>* q_smem, uint32_t* q_smem_offset_r,
+    smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem, uint32_t* k_smem_offset_r, uint8_t* k_sf_smem,
+    const uint32_t lane_idx, const uint32_t kv_rope_base, float (*rope_freq)[4],
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8]) {
+  using DTypeQ = typename KTraits::DTypeQ;
+  using DTypeKV = typename KTraits::DTypeKV;
+  static_assert(is_fp4_type_v<DTypeKV>);
+  static_assert(KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama);
+  static_assert(KTraits::NUM_MMA_D_QK % 4 == 0);
+
+  constexpr uint32_t UPCAST_STRIDE_Q = KTraits::UPCAST_STRIDE_Q;
+  constexpr uint32_t UPCAST_STRIDE_K = KTraits::UPCAST_STRIDE_K;
+  constexpr uint32_t NUM_MMA_D_HALF = KTraits::NUM_MMA_D_QK / 2;
+
+  uint32_t q_smem_offset_first = *q_smem_offset_r;
+  uint32_t k_smem_offset_first = *k_smem_offset_r;
+  uint32_t k_smem_offset_second = *k_smem_offset_r;
+
+#pragma unroll
+  for (uint32_t mma_d = 0; mma_d < NUM_MMA_D_HALF; ++mma_d) {
+    if (mma_d % 2 == 1) {
+      k_smem_offset_second =
+          k_smem->template advance_offset_by_column<2>(k_smem_offset_second, mma_d / 2);
+    }
+  }
+
+#pragma unroll
+  for (uint32_t mma_di = 0; mma_di < NUM_MMA_D_HALF; ++mma_di) {
+    uint32_t a_frag_first[KTraits::NUM_MMA_Q][4], a_frag_second[KTraits::NUM_MMA_Q][4];
+    uint32_t q_smem_offset_first_mma = q_smem_offset_first;
+    uint32_t q_smem_offset_second_mma =
+        q_smem->template advance_offset_by_column<KTraits::NUM_MMA_D_QK>(q_smem_offset_first, 0);
+
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+      q_smem->ldmatrix_m8n8x4(q_smem_offset_first_mma, a_frag_first[mma_q]);
+      q_smem_offset_first_mma =
+          q_smem->template advance_offset_by_row<16, UPCAST_STRIDE_Q>(q_smem_offset_first_mma);
+      q_smem->ldmatrix_m8n8x4(q_smem_offset_second_mma, a_frag_second[mma_q]);
+      q_smem_offset_second_mma =
+          q_smem->template advance_offset_by_row<16, UPCAST_STRIDE_Q>(q_smem_offset_second_mma);
+    }
+
+    uint32_t k_smem_offset_first_mma = k_smem_offset_first;
+    uint32_t k_smem_offset_second_mma = k_smem_offset_second;
+
+#pragma unroll
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+      uint32_t b_frag_first[4], b_frag_second[4];
+      load_fp4_k_frag_scaled<KTraits>(k_smem, k_smem_offset_first_mma, k_sf_smem, lane_idx, mma_kv,
+                                      mma_di, b_frag_first);
+      load_fp4_k_frag_scaled<KTraits>(k_smem, k_smem_offset_second_mma, k_sf_smem, lane_idx,
+                                      mma_kv, mma_di + NUM_MMA_D_HALF, b_frag_second);
+      k_frag_apply_llama_rope<DTypeQ>((DTypeQ*)b_frag_first, (DTypeQ*)b_frag_second,
+                                      rope_freq[mma_di],
+                                      kv_rope_base + mma_kv * 16 + lane_idx / 4);
+
+      k_smem_offset_first_mma =
+          k_smem->template advance_offset_by_row<16, UPCAST_STRIDE_K>(k_smem_offset_first_mma);
+      k_smem_offset_second_mma =
+          k_smem->template advance_offset_by_row<16, UPCAST_STRIDE_K>(k_smem_offset_second_mma);
+
+#pragma unroll
+      for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
+        if constexpr (std::is_same_v<typename KTraits::DTypeQKAccum, float>) {
+          if (mma_di == 0) {
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ, MMAMode::kInit>(
+                s_frag[mma_q][mma_kv], a_frag_first[mma_q], b_frag_first);
+          } else {
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(
+                s_frag[mma_q][mma_kv], a_frag_first[mma_q], b_frag_first);
+          }
+          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(
+              s_frag[mma_q][mma_kv], a_frag_second[mma_q], b_frag_second);
+        } else if (std::is_same_v<typename KTraits::DTypeQKAccum, half>) {
+          if (mma_di == 0) {
+            mma::mma_sync_m16n16k16_row_col_f16f16f16<MMAMode::kInit>(
+                (uint32_t*)s_frag[mma_q][mma_kv], a_frag_first[mma_q], b_frag_first);
+          } else {
+            mma::mma_sync_m16n16k16_row_col_f16f16f16((uint32_t*)s_frag[mma_q][mma_kv],
+                                                      a_frag_first[mma_q], b_frag_first);
+          }
+          mma::mma_sync_m16n16k16_row_col_f16f16f16((uint32_t*)s_frag[mma_q][mma_kv],
+                                                    a_frag_second[mma_q], b_frag_second);
+        }
+      }
+    }
+
+    q_smem_offset_first =
+        q_smem->template advance_offset_by_column<2>(q_smem_offset_first, mma_di);
+    if (mma_di % 2 == 1) {
+      k_smem_offset_first =
+          k_smem->template advance_offset_by_column<2>(k_smem_offset_first, mma_di / 2);
+      k_smem_offset_second = k_smem->template advance_offset_by_column<2>(
+          k_smem_offset_second, (mma_di + NUM_MMA_D_HALF) / 2);
+    }
+  }
+}
+
 template <typename KTraits, typename Params, typename DTypeQKAccum>
 __device__ __forceinline__ void logits_transform(
     const Params& params, typename KTraits::AttentionVariant variant, const uint32_t batch_idx,
@@ -1807,6 +1947,27 @@ __device__ __forceinline__ void write_o_reg_gmem(
 
 }  // namespace
 
+template <typename KTraits>
+__device__ __forceinline__ void vosplit_softmax_store_p(
+    typename KTraits::AttentionVariant variant,
+    typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][8],
+    typename KTraits::DTypeQKAccum (*m)[2], float (*d)[2], float (*o_scale)[2],
+    typename KTraits::SharedStoragePaged* smem_storage, const uint32_t warp_kv_idx,
+    const uint32_t warp_q_idx, const uint32_t lane_idx);
+
+template <typename KTraits>
+__device__ __forceinline__ void vosplit_compute_pv(
+    typename KTraits::SharedStoragePaged* smem_storage,
+    float (*o_frag)[KTraits::NUM_MMA_D_VO_PER_WARP][8], float (*o_scale)[2],
+    const uint32_t warp_vo_base, const uint32_t warp_q_idx, const uint32_t lane_idx);
+
+template <typename KTraits>
+__device__ __forceinline__ void vosplit_write_o(
+    float (*o_frag)[KTraits::NUM_MMA_D_VO_PER_WARP][8], float (*d)[2],
+    typename KTraits::DTypeO* o_ptr_base, const uint32_t o_packed_idx_base,
+    const uint32_t qo_upper_bound, const uint32_t o_stride_n, const uint32_t o_stride_h,
+    const uint32_t warp_vo_base, const uint_fastdiv group_size, const uint32_t lane_idx);
+
 /*!
  * \brief FlashAttention prefill CUDA kernel for a single request.
  * \tparam partition_kv Whether to split kv_len into chunks.
@@ -1830,9 +1991,9 @@ __device__ __forceinline__ void write_o_reg_gmem(
  * \param rope_rcp_theta 1/(rope_theta), where rope_theta is the theta
  *   used in RoPE.
  */
-template <typename KTraits, typename Params>
+template <typename KTraits, typename Params, typename SmemStorage>
 __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
-    const Params params, typename KTraits::SharedStorage& smem_storage, const dim3 tid = threadIdx,
+    const Params params, SmemStorage& smem_storage, const dim3 tid = threadIdx,
     const uint32_t bx = blockIdx.x, const uint32_t chunk_idx = blockIdx.y,
     const uint32_t kv_head_idx = blockIdx.z, const uint32_t num_chunks = gridDim.y,
     const uint32_t num_kv_heads = gridDim.z) {
@@ -1907,7 +2068,11 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
     const uint32_t window_left = variant.window_left;
 
     DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
-    alignas(16) float o_frag[NUM_MMA_Q][KTraits::NUM_MMA_D_VO_TILE][8];
+    constexpr uint32_t O_FRAG_D = KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT
+                                      ? KTraits::NUM_MMA_D_VO_PER_WARP
+                                      : KTraits::NUM_MMA_D_VO_TILE;
+    alignas(16) float o_frag[NUM_MMA_Q][O_FRAG_D][8];
+    [[maybe_unused]] float o_scale[NUM_MMA_Q][2];
     DTypeQKAccum m[NUM_MMA_Q][2];
     float d[NUM_MMA_Q][2];
     constexpr uint32_t LOCAL_ROPE_FREQ_ROWS =
@@ -1940,9 +2105,28 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
                              : o + (kv_head_idx * group_size) * o_stride_h;
 
 #pragma unroll 1
-    for (uint32_t d_tile = 0; d_tile < KTraits::NUM_D_VO_TILES; ++d_tile) {
-      const uint32_t d_base = d_tile * KTraits::NUM_MMA_D_VO_TILE;
-      init_states<KTraits>(variant, o_frag, m, d);
+    for (uint32_t d_tile = 0;
+         d_tile < (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT ? 1u
+                                                                 : KTraits::NUM_D_VO_TILES);
+         ++d_tile) {
+      [[maybe_unused]] const uint32_t d_base = d_tile * KTraits::NUM_MMA_D_VO_TILE;
+      if constexpr (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT) {
+#pragma unroll
+        for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+          for (uint32_t local_d = 0; local_d < KTraits::NUM_MMA_D_VO_PER_WARP; ++local_d) {
+#pragma unroll
+            for (uint32_t reg = 0; reg < 8; ++reg) o_frag[mma_q][local_d][reg] = 0.f;
+          }
+#pragma unroll
+          for (uint32_t j = 0; j < 2; ++j) {
+            m[mma_q][j] = DTypeQKAccum(-math::inf);
+            d[mma_q][j] = 0.f;
+          }
+        }
+      } else {
+        init_states<KTraits>(variant, o_frag, m, d);
+      }
       uint32_t q_smem_offset_r = qo_smem.template get_permuted_offset<UPCAST_STRIDE_Q>(
           get_warp_idx_q<KTraits>(tid.y) * NUM_MMA_Q * 16 + lane_idx % 16, lane_idx / 16);
       load_q_global_smem<KTraits>(qo_packed_idx_base, qo_len, q_ptr_base, q_stride_n, q_stride_h,
@@ -2034,20 +2218,31 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
         }
         block.sync();
 
-        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
+        uint32_t kv_idx_base =
+            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
+
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+                      !is_fp4_type_v<DTypeKV>) {
           k_smem_inplace_apply_rotary<KTraits>(chunk_start + iter * CTA_TILE_KV, &k_smem,
                                                &k_smem_offset_r, rope_freq, tid);
           block.sync();
         }
 
         // compute attention score
-        compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-                            smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                         KTraits::NUM_MMA_KV * 16 *
-                                                         KTraits::NUM_MMA_D_QK,
-                            lane_idx, s_frag);
-        uint32_t kv_idx_base =
-            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+                      is_fp4_type_v<DTypeKV>) {
+          compute_qk_fp4_rope<KTraits>(
+              &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
+              smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
+                                           KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_QK,
+              lane_idx, kv_idx_base, rope_freq, s_frag);
+        } else {
+          compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
+                              smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
+                                                           KTraits::NUM_MMA_KV * 16 *
+                                                           KTraits::NUM_MMA_D_QK,
+                              lane_idx, s_frag);
+        }
         logits_transform<KTraits>(params, variant, /*batch_idx=*/0, qo_packed_idx_base, kv_idx_base,
                                   qo_len, kv_len, group_size, s_frag, tid, kv_head_idx);
 
@@ -2058,7 +2253,13 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
         }
 
         // compute m,d states in online softmax
-        update_mdo_states<KTraits>(variant, s_frag, o_frag, m, d);
+        if constexpr (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT) {
+          vosplit_softmax_store_p<KTraits>(variant, s_frag, m, d, o_scale, &smem_storage,
+                                           get_warp_idx_kv<KTraits>(tid.z),
+                                           get_warp_idx_q<KTraits>(tid.y), lane_idx);
+        } else {
+          update_mdo_states<KTraits>(variant, s_frag, o_frag, m, d);
+        }
 
         block.sync();
         if constexpr (KTraits::USE_KV_SHARED_SMEM) {
@@ -2080,11 +2281,18 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
         block.sync();
 
         // compute sfm*v
-        compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r,
-                               smem_storage.v_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                                            KTraits::NUM_MMA_KV * 16 *
-                                                            KTraits::NUM_MMA_D_VO,
-                               lane_idx, s_frag, o_frag, d, d_base);
+        if constexpr (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT) {
+          const uint32_t warp_vo_base =
+              get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP;
+          vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
+                                      get_warp_idx_q<KTraits>(tid.y), lane_idx);
+        } else {
+          compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r,
+                                 smem_storage.v_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
+                                                              KTraits::NUM_MMA_KV * 16 *
+                                                              KTraits::NUM_MMA_D_VO,
+                                 lane_idx, s_frag, o_frag, d, d_base);
+        }
 
         block.sync();
         if constexpr (KTraits::USE_KV_SHARED_SMEM) {
@@ -2108,20 +2316,28 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
 
       finalize_m<KTraits>(variant, m);
 
-      // threadblock synchronization
-      threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
+      if constexpr (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT) {
+        vosplit_write_o<KTraits>(
+            o_frag, d, o_ptr_base, qo_packed_idx_base, qo_len,
+            partition_kv ? num_chunks * o_stride_n : o_stride_n, o_stride_h,
+            get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP, group_size,
+            lane_idx);
+      } else {
+        // threadblock synchronization
+        threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
 
-      // transform output
-      transform_output<KTraits, Params>(params, variant, o_frag, m, d, /*batch_idx=*/0, chunk_idx,
-                                        qo_packed_idx_base, warp_idx, lane_idx, kv_head_idx,
-                                        group_size);
+        // transform output
+        transform_output<KTraits, Params>(params, variant, o_frag, m, d, /*batch_idx=*/0, chunk_idx,
+                                          qo_packed_idx_base, warp_idx, lane_idx, kv_head_idx,
+                                          group_size);
 
-      // write back (o_ptr_base offset to this VO tile's columns: d_base mma * 16 elems)
-      write_o_reg_gmem<KTraits>(o_frag, &qo_smem, o_ptr_base + d_base * 16, qo_packed_idx_base,
-                                qo_len,
-                                /*o_stride_n=*/
-                                partition_kv ? num_chunks * o_stride_n : o_stride_n,
-                                /*o_stride_h=*/o_stride_h, group_size, tid);
+        // write back (o_ptr_base offset to this VO tile's columns: d_base mma * 16 elems)
+        write_o_reg_gmem<KTraits>(o_frag, &qo_smem, o_ptr_base + d_base * 16, qo_packed_idx_base,
+                                  qo_len,
+                                  /*o_stride_n=*/
+                                  partition_kv ? num_chunks * o_stride_n : o_stride_n,
+                                  /*o_stride_h=*/o_stride_h, group_size, tid);
+      }
 
       // write lse (identical across VO tiles; redundant rewrite on later tiles is harmless)
       if constexpr (variant.use_softmax) {
@@ -2160,7 +2376,10 @@ template <typename KTraits, typename Params>
 __global__ __launch_bounds__(KTraits::NUM_THREADS) void SinglePrefillWithKVCacheKernel(
     const __grid_constant__ Params params) {
   extern __shared__ uint8_t smem[];
-  auto& smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
+  using SmemStorage = std::conditional_t<KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT,
+                                         typename KTraits::SharedStoragePaged,
+                                         typename KTraits::SharedStorage>;
+  auto& smem_storage = reinterpret_cast<SmemStorage&>(smem);
   SinglePrefillWithKVCacheDevice<KTraits>(params, smem_storage);
 }
 
@@ -2191,15 +2410,15 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
   uint32_t cta_tile_q = FA2DetermineCtaTileQ(packed_qo_len, HEAD_DIM_VO);
 
   DISPATCH_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, {
-    // hd512 uses the 2-Q x 2-KV-warp layout at CTA_TILE_Q=32. Unlike the paged
-    // (VO-split) kernel, this kernel merges warp outputs through
-    // cta_sync_o_smem (NUM_WARPS_KV * CTA_TILE_Q * 256 floats), which only fits
-    // 99KB-smem GPUs with NUM_WARPS_KV=2 — so FP8 takes this layout too.
-    constexpr bool kBf16VOSplit = (sizeof(DTypeKV) <= 2) && !is_fp4_type_v<DTypeKV> &&
-                                  (HEAD_DIM_VO >= 512) && (CTA_TILE_Q == 32);
-    constexpr uint32_t NUM_WARPS_Q = kBf16VOSplit ? 2 : get_num_warps_q(CTA_TILE_Q);
-    constexpr uint32_t NUM_WARPS_KV = kBf16VOSplit ? 2 : get_num_warps_kv(CTA_TILE_Q);
-    constexpr uint32_t NUM_MMA_Q = kBf16VOSplit ? 1 : get_num_mma_q(CTA_TILE_Q);
+    // hd512 uses the 2-Q x 2-KV-warp layout at CTA_TILE_Q=32. FP4 large-head
+    // single-prefill additionally uses VO-split output so it avoids the
+    // cta_sync_o_smem traffic that exceeds SM86 shared memory.
+    constexpr bool kLargeHeadWarpSplit =
+        ((sizeof(DTypeKV) == 2) || is_fp4_type_v<DTypeKV>) && (HEAD_DIM_VO >= 512) &&
+        (CTA_TILE_Q == 32);
+    constexpr uint32_t NUM_WARPS_Q = kLargeHeadWarpSplit ? 2 : get_num_warps_q(CTA_TILE_Q);
+    constexpr uint32_t NUM_WARPS_KV = kLargeHeadWarpSplit ? 2 : get_num_warps_kv(CTA_TILE_Q);
+    constexpr uint32_t NUM_MMA_Q = kLargeHeadWarpSplit ? 1 : get_num_mma_q(CTA_TILE_Q);
 
     using DTypeQKAccum =
         typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ, half>, half,
@@ -2225,19 +2444,29 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
                                ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0) &&
                                (HEAD_DIM_QK == HEAD_DIM_VO) &&
                                (sizeof(DTypeKV) == 2 || CTA_TILE_Q > 16);
+    constexpr bool kSinglePrefillVOSplitDispatch =
+        AttentionVariant::use_softmax && is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO / 16 > 16) &&
+        ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0);
     constexpr uint32_t kKVSmemPerMmaKV =
         (kKVShared ? (HEAD_DIM_QK * 16 * NUM_WARPS_KV * sizeof(DTypeKV))
                    : ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV))) +
         (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                        sizeof(DTypeQ))
-                    : 0u);
+                    : 0u) +
+        (is_fp4_type_v<DTypeKV> ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV /
+                                   NVFP4_SF_VEC_SIZE)
+                                : 0u) +
+        (kSinglePrefillVOSplitDispatch ? CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ) : 0u);
     constexpr uint32_t kSharedRopeFreqSmem =
         (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
          HEAD_DIM_QK == HEAD_DIM_VO)
             ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
             : 0u;
+    constexpr uint32_t kSinglePrefillVOSplitFixedSmem =
+        kSinglePrefillVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
     constexpr uint32_t kFixedSmem =
-        CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) + kSharedRopeFreqSmem;
+        CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) + kSinglePrefillVOSplitFixedSmem +
+        kSharedRopeFreqSmem;
     // Smallest NUM_MMA_KV satisfying the FP8 alignment constraint
     // (sizeof(DTypeKV)==1 requires NUM_MMA_KV*2 % NUM_WARPS_Q == 0); size the
     // occupancy budget against the minimum *valid* tile so the staging buffer
@@ -2289,7 +2518,10 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
       } else {
         constexpr uint32_t num_threads = (NUM_WARPS_Q * NUM_WARPS_KV) * WARP_SIZE;
         auto kernel = SinglePrefillWithKVCacheKernel<KTraits, Params>;
-        size_t smem_size = sizeof(typename KTraits::SharedStorage);
+        using SmemStorage = std::conditional_t<KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT,
+                                               typename KTraits::SharedStoragePaged,
+                                               typename KTraits::SharedStorage>;
+        size_t smem_size = sizeof(SmemStorage);
         if (smem_size > (size_t)max_smem_per_block_optin) {
           std::ostringstream err_msg;
           err_msg << "Required shared memory (" << smem_size
@@ -2454,7 +2686,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     const uint32_t request_idx = request_indices[bx], qo_tile_idx = qo_tile_indices[bx],
                    kv_tile_idx = kv_tile_indices[bx];
     extern __shared__ uint8_t smem[];
-    using SmemStorage = std::conditional_t<KTraits::USE_16B_VO_SPLIT,
+    using SmemStorage = std::conditional_t<KTraits::USE_SOFTMAX_VO_SPLIT,
                                            typename KTraits::SharedStoragePaged,
                                            typename KTraits::SharedStorage>;
     auto& smem_storage = reinterpret_cast<SmemStorage&>(smem);
@@ -2479,7 +2711,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
 
     DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
     constexpr uint32_t O_FRAG_D =
-        KTraits::USE_16B_VO_SPLIT ? KTraits::NUM_MMA_D_VO_PER_WARP : KTraits::NUM_MMA_D_VO_TILE;
+        KTraits::USE_SOFTMAX_VO_SPLIT ? KTraits::NUM_MMA_D_VO_PER_WARP
+                                       : KTraits::NUM_MMA_D_VO_TILE;
     alignas(16) float o_frag[NUM_MMA_Q][O_FRAG_D][8];
     [[maybe_unused]] float o_scale[NUM_MMA_Q][2];
     DTypeQKAccum m[NUM_MMA_Q][2];
@@ -2522,10 +2755,11 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
 #endif
 
 #pragma unroll 1
-    for (uint32_t d_tile = 0; d_tile < (KTraits::USE_16B_VO_SPLIT ? 1u : KTraits::NUM_D_VO_TILES);
+    for (uint32_t d_tile = 0;
+         d_tile < (KTraits::USE_SOFTMAX_VO_SPLIT ? 1u : KTraits::NUM_D_VO_TILES);
          ++d_tile) {
       [[maybe_unused]] const uint32_t d_base = d_tile * KTraits::NUM_MMA_D_VO_TILE;
-      if constexpr (KTraits::USE_16B_VO_SPLIT) {
+      if constexpr (KTraits::USE_SOFTMAX_VO_SPLIT) {
 #pragma unroll
         for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
 #pragma unroll
@@ -2663,20 +2897,33 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
         }
         block.sync();
 
+        uint32_t kv_idx_base =
+            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
+        [[maybe_unused]] uint32_t kv_rope_base = kv_idx_base;
+
         if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
           IdType* k_rope_offset = nullptr;
           if constexpr (has_maybe_k_rope_offset_v<Params>) {
             k_rope_offset = params.maybe_k_rope_offset;
           }
-          k_smem_inplace_apply_rotary<KTraits>(
-              (k_rope_offset == nullptr ? 0 : k_rope_offset[request_idx]) + chunk_start +
-                  iter * CTA_TILE_KV,
-              &k_smem, &k_smem_offset_r, rope_freq, tid);
-          block.sync();
+          const uint32_t rope_offset = k_rope_offset == nullptr ? 0 : k_rope_offset[request_idx];
+          kv_rope_base += rope_offset;
+          if constexpr (!is_fp4_type_v<DTypeKV>) {
+            k_smem_inplace_apply_rotary<KTraits>(rope_offset + chunk_start + iter * CTA_TILE_KV,
+                                                 &k_smem, &k_smem_offset_r, rope_freq, tid);
+            block.sync();
+          }
         }
 
         // compute attention score
-        if constexpr (KTraits::USE_KV_REPACK) {
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+                      is_fp4_type_v<DTypeKV>) {
+          compute_qk_fp4_rope<KTraits>(
+              &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
+              smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
+                                           KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_QK,
+              lane_idx, kv_rope_base, rope_freq, s_frag);
+        } else if constexpr (KTraits::USE_KV_REPACK) {
           // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
           repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
               smem_storage.k_smem, smem_storage.kv_smem_repack, warp_idx * WARP_SIZE + lane_idx);
@@ -2693,8 +2940,6 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
                                                            KTraits::NUM_MMA_D_QK,
                               lane_idx, s_frag);
         }
-        uint32_t kv_idx_base =
-            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
         logits_transform<KTraits>(params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
                                   kv_idx_base, qo_len, kv_len, group_size, s_frag, tid,
                                   kv_head_idx);
@@ -2707,7 +2952,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
         }
 
         // compute m,d states in online softmax
-        if constexpr (KTraits::USE_16B_VO_SPLIT) {
+        if constexpr (KTraits::USE_SOFTMAX_VO_SPLIT) {
           vosplit_softmax_store_p<KTraits>(variant, s_frag, m, d, o_scale, &smem_storage,
                                            get_warp_idx_kv<KTraits>(tid.z),
                                            get_warp_idx_q<KTraits>(tid.y), lane_idx);
@@ -2735,7 +2980,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
         block.sync();
 
         // compute sfm*v
-        if constexpr (KTraits::USE_16B_VO_SPLIT) {
+        if constexpr (KTraits::USE_SOFTMAX_VO_SPLIT) {
           const uint32_t warp_vo_base =
               get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP;
           vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
@@ -2782,7 +3027,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
 
       const uint32_t num_kv_chunks =
           ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
-      if constexpr (KTraits::USE_16B_VO_SPLIT) {
+      if constexpr (KTraits::USE_SOFTMAX_VO_SPLIT) {
         vosplit_write_o<KTraits>(o_frag, d, o_ptr_base, qo_packed_idx_base, qo_len,
                                  partition_kv ? num_kv_chunks * o_stride_n : o_stride_n, o_stride_h,
                                  get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP,
@@ -2950,11 +3195,6 @@ __device__ __forceinline__ void vosplit_compute_pv(
     const uint32_t warp_vo_base, const uint32_t warp_q_idx, const uint32_t lane_idx) {
   using DTypeQ = typename KTraits::DTypeQ;
   using DTypeKV = typename KTraits::DTypeKV;
-  // The VO-split PV path dequants V as bf16/fp16 or FP8; it has no NVFP4 V-load, so reject FP4
-  // here rather than silently running the bf16 path on packed FP4 bytes (head_dim>256 only).
-  static_assert(!is_fp4_type_v<DTypeKV>,
-                "NVFP4 KV is not supported with the VO-split prefill kernel (head_dim > 256); "
-                "use bf16/fp16 or FP8 KV.");
   constexpr uint32_t NUM_MMA_Q = KTraits::NUM_MMA_Q;
   const uint32_t q_row_base = (warp_q_idx * NUM_MMA_Q) * 16;
   constexpr uint32_t NUM_MMA_D_VO_PER_WARP = KTraits::NUM_MMA_D_VO_PER_WARP;
@@ -2962,7 +3202,7 @@ __device__ __forceinline__ void vosplit_compute_pv(
   constexpr uint32_t NUM_MMA_KV_FULL = CTA_TILE_KV / 16;
   constexpr uint32_t UPCAST_STRIDE_V = KTraits::UPCAST_STRIDE_V;
   constexpr uint32_t VO_COLS_PER_TILE = 16 / upcast_size<DTypeKV>();
-  constexpr bool IS_FP8 = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV>;
+  constexpr bool IS_FP4 = is_fp4_type_v<DTypeKV>;
   DTypeQ* p_smem = smem_storage->p_smem;
   smem_t<KTraits::SWIZZLE_MODE_KV> v_smem(KTraits::USE_KV_SHARED_SMEM ? smem_storage->k_smem
                                                                       : smem_storage->v_smem);
@@ -2998,10 +3238,10 @@ __device__ __forceinline__ void vosplit_compute_pv(
     for (uint32_t local_d = 0; local_d < NUM_MMA_D_VO_PER_WARP; ++local_d) {
       const uint32_t global_d = warp_vo_base + local_d;
       uint32_t b_frag[4];
-      if constexpr (IS_FP8) {
-        // In-loop FP8 V dequant (no staging). FP8 packs 16 elems/b128, so a pair of
-        // VO MMA tiles (global_d, global_d^1) shares a 2-b128-col region read via
-        // the left/right ldmatrix halves; mirrors compute_sfm_v's FP8 V path.
+      if constexpr (sizeof(DTypeKV) == 1) {
+        // In-loop one-byte V dequant (no staging). FP8 and NVFP4 both share a
+        // 2-b128-column region for a pair of VO MMA tiles (global_d, global_d^1),
+        // read via the left/right ldmatrix halves; mirrors compute_sfm_v's V path.
         uint32_t b_frag_quant[2];
         const uint32_t voff = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
             mma_kv * 16 + lane_idx % 16, lane_idx / 16 + 2 * (global_d / 2));
@@ -3010,10 +3250,32 @@ __device__ __forceinline__ void vosplit_compute_pv(
         } else {
           v_smem.ldmatrix_m8n8x4_trans_right_half(voff, b_frag_quant);
         }
-        b_frag_quant[0] = frag_layout_swizzle_16b_to_8b_trans(b_frag_quant[0]);
-        b_frag_quant[1] = frag_layout_swizzle_16b_to_8b_trans(b_frag_quant[1]);
+        if constexpr (IS_FP4) {
+          b_frag_quant[0] = frag_layout_swizzle_16b_to_4b_trans(b_frag_quant[0]);
+          b_frag_quant[1] = frag_layout_swizzle_16b_to_4b_trans(b_frag_quant[1]);
+        } else {
+          b_frag_quant[0] = frag_layout_swizzle_16b_to_8b_trans(b_frag_quant[0]);
+          b_frag_quant[1] = frag_layout_swizzle_16b_to_8b_trans(b_frag_quant[1]);
+        }
         vec_cast<DTypeQ, DTypeKV>::template cast<8>((DTypeQ*)b_frag, (DTypeKV*)b_frag_quant);
         swap(b_frag[1], b_frag[2]);
+        if constexpr (IS_FP4) {
+          using packed2 = std::conditional_t<std::is_same_v<DTypeQ, half>, half2, __nv_bfloat162>;
+          constexpr uint32_t SF_COLS_V = KTraits::NUM_MMA_D_VO;
+          const uint32_t sf_base =
+              (mma_kv * 16 + 2 * (lane_idx % 4)) * SF_COLS_V + global_d;
+          __nv_fp8_e4m3 sf0_fp8, sf1_fp8, sf2_fp8, sf3_fp8;
+          sf0_fp8.__x = smem_storage->v_sf_smem[sf_base];
+          sf1_fp8.__x = smem_storage->v_sf_smem[sf_base + SF_COLS_V];
+          sf2_fp8.__x = smem_storage->v_sf_smem[sf_base + 8 * SF_COLS_V];
+          sf3_fp8.__x = smem_storage->v_sf_smem[sf_base + 9 * SF_COLS_V];
+          packed2 scale_lo{static_cast<DTypeQ>(sf0_fp8), static_cast<DTypeQ>(sf1_fp8)};
+          packed2 scale_hi{static_cast<DTypeQ>(sf2_fp8), static_cast<DTypeQ>(sf3_fp8)};
+          *(packed2*)&b_frag[0] = __hmul2(*(packed2*)&b_frag[0], scale_lo);
+          *(packed2*)&b_frag[1] = __hmul2(*(packed2*)&b_frag[1], scale_hi);
+          *(packed2*)&b_frag[2] = __hmul2(*(packed2*)&b_frag[2], scale_lo);
+          *(packed2*)&b_frag[3] = __hmul2(*(packed2*)&b_frag[3], scale_hi);
+        }
       } else {
         const uint32_t voff = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
             mma_kv * 16 + lane_idx % 16, global_d * VO_COLS_PER_TILE + lane_idx / 16);
@@ -3452,16 +3714,31 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
         }
         block.sync();
 
+        uint32_t kv_idx_base =
+            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
+        [[maybe_unused]] uint32_t kv_rope_base =
+            kv_idx_base +
+            (paged_kv.rope_pos_offset == nullptr ? 0 : paged_kv.rope_pos_offset[request_idx]);
+
         if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
-          k_smem_inplace_apply_rotary<KTraits>(
-              (paged_kv.rope_pos_offset == nullptr ? 0 : paged_kv.rope_pos_offset[request_idx]) +
-                  chunk_start + iter * CTA_TILE_KV,
-              &k_smem, &k_smem_offset_r, rope_freq, tid);
-          block.sync();
+          if constexpr (!is_fp4_type_v<DTypeKV>) {
+            k_smem_inplace_apply_rotary<KTraits>(
+                (paged_kv.rope_pos_offset == nullptr ? 0 : paged_kv.rope_pos_offset[request_idx]) +
+                    chunk_start + iter * CTA_TILE_KV,
+                &k_smem, &k_smem_offset_r, rope_freq, tid);
+            block.sync();
+          }
         }
 
         // compute attention score
-        if constexpr (KTraits::USE_KV_REPACK) {
+        if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+                      is_fp4_type_v<DTypeKV>) {
+          compute_qk_fp4_rope<KTraits>(
+              &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
+              smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
+                                           KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_QK,
+              lane_idx, kv_rope_base, rope_freq, s_frag);
+        } else if constexpr (KTraits::USE_KV_REPACK) {
           // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
           repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
               smem_storage.k_smem, smem_storage.kv_smem_repack, warp_idx * WARP_SIZE + lane_idx);
@@ -3478,8 +3755,6 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                                                            KTraits::NUM_MMA_D_QK,
                               lane_idx, s_frag);
         }
-        uint32_t kv_idx_base =
-            chunk_start + (iter * NUM_WARPS_KV + get_warp_idx_kv<KTraits>(tid.z)) * NUM_MMA_KV * 16;
         logits_transform<KTraits>(params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
                                   kv_idx_base, qo_len, kv_len, group_size, s_frag, tid,
                                   kv_head_idx);
@@ -3680,9 +3955,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
   const uint32_t num_qo_heads = params.num_qo_heads;
   const uint32_t num_kv_heads = params.num_kv_heads;
   // Large-head CTA_TILE_Q=32 uses a 2-Q x 2-KV-warp layout to keep the per-warp
-  // output fragment bounded. The 16-bit softmax path also uses the VO-split
-  // P/V helpers below; FP8 keeps the existing split-D merge path.
-  constexpr bool kBf16VOSplit = (sizeof(DTypeKV) <= 2) && !is_fp4_type_v<DTypeKV> &&
+  // output fragment bounded. The 16-bit and NVFP4 softmax paths also use the
+  // VO-split P/V helpers below; FP8 keeps the existing split-D merge path.
+  constexpr bool kBf16VOSplit = ((sizeof(DTypeKV) == 2) || is_fp4_type_v<DTypeKV>) &&
                                 (HEAD_DIM_VO >= 512) && (CTA_TILE_Q == 32);
   constexpr uint32_t NUM_MMA_Q = kBf16VOSplit ? 1 : get_num_mma_q(CTA_TILE_Q);
   constexpr uint32_t NUM_WARPS_Q = kBf16VOSplit ? 2 : get_num_warps_q(CTA_TILE_Q);
@@ -3724,9 +3999,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
                              ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0) &&
                              (HEAD_DIM_QK == HEAD_DIM_VO) &&
                              (sizeof(DTypeKV) == 2 || CTA_TILE_Q > 16);
-  constexpr bool kVOSplitDispatch = (sizeof(DTypeKV) == 2) && AttentionVariant::use_softmax &&
-                                    (HEAD_DIM_VO / 16 > 16) &&
-                                    ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0);
+  constexpr bool kVOSplitDispatch =
+      ((sizeof(DTypeKV) == 2) || is_fp4_type_v<DTypeKV>) && AttentionVariant::use_softmax &&
+      (HEAD_DIM_VO / 16 > 16) && ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0);
   constexpr uint32_t kKVSmemPerMmaKV =
       (kKVShared ? (HEAD_DIM_QK * 16 * NUM_WARPS_KV * sizeof(DTypeKV))
                  : ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV))) +
@@ -3798,7 +4073,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
                  " and report the issue to the developers.";
       FLASHINFER_ERROR(err_msg.str());
     } else {
-      using SmemStorage = std::conditional_t<KTraits::USE_16B_VO_SPLIT,
+      using SmemStorage = std::conditional_t<KTraits::USE_SOFTMAX_VO_SPLIT,
                                              typename KTraits::SharedStoragePaged,
                                              typename KTraits::SharedStorage>;
       size_t smem_size = sizeof(SmemStorage);
@@ -3882,10 +4157,11 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
   const uint32_t padded_batch_size = params.padded_batch_size;
   const uint32_t num_qo_heads = params.num_qo_heads;
   const uint32_t num_kv_heads = params.paged_kv.num_heads;
-  // hd512 + 16-bit KV uses the 2-Q x 2-KV-warp VO-split layout (CTA_TILE_KV=32,
-  // 128-reg o_frag) so CTA_TILE_Q=32 fits 100KB; FP8 keeps the default 1x4 layout.
-  constexpr bool kBf16VOSplit =
-      (sizeof(DTypeKV) == 2) && (HEAD_DIM_VO >= 512) && (CTA_TILE_Q == 32);
+  // hd512 + 16-bit/NVFP4 KV uses the 2-Q x 2-KV-warp VO-split layout
+  // (CTA_TILE_KV=32, 128-reg o_frag) so CTA_TILE_Q=32 fits 100KB; FP8 keeps the
+  // default 1x4 layout.
+  constexpr bool kBf16VOSplit = ((sizeof(DTypeKV) == 2) || is_fp4_type_v<DTypeKV>) &&
+                                (HEAD_DIM_VO >= 512) && (CTA_TILE_Q == 32);
   constexpr uint32_t NUM_MMA_Q = kBf16VOSplit ? 1 : get_num_mma_q(CTA_TILE_Q);
   constexpr uint32_t NUM_WARPS_Q = kBf16VOSplit ? 2 : get_num_warps_q(CTA_TILE_Q);
   constexpr uint32_t NUM_WARPS_KV = kBf16VOSplit ? 2 : get_num_warps_kv(CTA_TILE_Q);

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -180,16 +180,14 @@ struct KernelTraits {
   static constexpr bool USE_KV_SHARED_SMEM = USE_VO_SPLIT && !is_fp4_type_v<DTypeKV_> &&
                                              (HEAD_DIM_QK == HEAD_DIM_VO) &&
                                              (sizeof(DTypeKV_) == 2 || CTA_TILE_Q_ > 16);
-  static constexpr bool USE_SOFTMAX_VO_SPLIT =
-      USE_VO_SPLIT && AttentionVariant_::use_softmax &&
-      ((sizeof(DTypeKV_) == 2) || is_fp4_type_v<DTypeKV_>);
+  static constexpr bool USE_SOFTMAX_VO_SPLIT = USE_VO_SPLIT && AttentionVariant_::use_softmax &&
+                                               ((sizeof(DTypeKV_) == 2) || is_fp4_type_v<DTypeKV_>);
   static constexpr bool USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT =
       USE_SOFTMAX_VO_SPLIT && is_fp4_type_v<DTypeKV_>;
   static constexpr bool USE_16B_VO_SPLIT =
       USE_VO_SPLIT && (sizeof(DTypeKV_) == 2) && AttentionVariant_::use_softmax;
-  static constexpr bool USE_SHARED_ROPE_FREQ =
-      POS_ENCODING_MODE_ == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
-      HEAD_DIM_QK == HEAD_DIM_VO;
+  static constexpr bool USE_SHARED_ROPE_FREQ = POS_ENCODING_MODE_ == PosEncodingMode::kRoPELlama &&
+                                               HEAD_DIM_QK > 256 && HEAD_DIM_QK == HEAD_DIM_VO;
   static constexpr uint32_t SHARED_ROPE_FREQ_BYTES =
       USE_SHARED_ROPE_FREQ ? (4 * (NUM_MMA_D_QK / 2) * 4 * sizeof(float)) : 0;
   static constexpr uint32_t UPCAST_STRIDE_Q = HEAD_DIM_QK / upcast_size<DTypeQ_>();
@@ -552,10 +550,9 @@ __device__ __forceinline__ void page_produce_kv_on_the_fly(
     for (uint32_t i = 0; i < NUM_MMA_KV * ROWS_PER_ITER / NUM_WARPS_Q; ++i) {
       const uint32_t logical_row =
           warp_idx * ROWS_PER_ITER + lane_idx / 8 + NUM_WARPS * ROWS_PER_ITER * i;
-      DType* gptr =
-          kv_ptr + get_paged_kv_offset_for_logical_row<KTraits>(
-                       paged_kv, packed_page_iter_base, last_indptr, kv_head_idx, logical_row,
-                       lane_idx);
+      DType* gptr = kv_ptr + get_paged_kv_offset_for_logical_row<KTraits>(
+                                 paged_kv, packed_page_iter_base, last_indptr, kv_head_idx,
+                                 logical_row, lane_idx);
 #pragma unroll
       for (uint32_t j = 0; j < NUM_MMA_D / (8 / sizeof(DType)); ++j) {
         if constexpr (IS_FP4) {
@@ -567,10 +564,9 @@ __device__ __forceinline__ void page_produce_kv_on_the_fly(
         gptr += (IS_FP4 ? 4 : 8) * upcast_size<DType>();
       }
       kv_idx += NUM_WARPS * ROWS_PER_ITER;
-      *smem_offset =
-          smem.template advance_offset_by_row<NUM_WARPS * ROWS_PER_ITER, UPCAST_STRIDE>(
-              *smem_offset) -
-          sizeof(DType) * NUM_MMA_D;
+      *smem_offset = smem.template advance_offset_by_row<NUM_WARPS * ROWS_PER_ITER, UPCAST_STRIDE>(
+                         *smem_offset) -
+                     sizeof(DType) * NUM_MMA_D;
     }
     *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
   } else {
@@ -581,19 +577,17 @@ __device__ __forceinline__ void page_produce_kv_on_the_fly(
     for (uint32_t i = 0; i < NUM_MMA_KV * (ROWS_PER_ITER / 4) / NUM_WARPS_Q; ++i) {
       const uint32_t logical_row =
           warp_idx * ROWS_PER_ITER + lane_idx / 4 + NUM_WARPS * ROWS_PER_ITER * i;
-      DType* gptr =
-          kv_ptr + get_paged_kv_offset_for_logical_row<KTraits>(
-                       paged_kv, packed_page_iter_base, last_indptr, kv_head_idx, logical_row,
-                       lane_idx);
+      DType* gptr = kv_ptr + get_paged_kv_offset_for_logical_row<KTraits>(
+                                 paged_kv, packed_page_iter_base, last_indptr, kv_head_idx,
+                                 logical_row, lane_idx);
       if constexpr (IS_FP4) {
         smem.template load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
       } else {
         smem.template load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
       }
       kv_idx += NUM_WARPS * ROWS_PER_ITER;
-      *smem_offset =
-          smem.template advance_offset_by_row<NUM_WARPS * ROWS_PER_ITER, UPCAST_STRIDE>(
-              *smem_offset);
+      *smem_offset = smem.template advance_offset_by_row<NUM_WARPS * ROWS_PER_ITER, UPCAST_STRIDE>(
+          *smem_offset);
     }
     *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
   }
@@ -764,8 +758,7 @@ __device__ __forceinline__ float compute_rope_freq(const uint32_t mma_d, const u
   constexpr uint32_t HEAD_DIM = KTraits::NUM_MMA_D_QK * 16;
   return rope_rcp_scale *
          __powf(rope_rcp_theta,
-                float(2 * ((mma_d * 16 + (j / 2) * 8 + lane_mod * 2 + (j % 2)) %
-                           (HEAD_DIM / 2))) /
+                float(2 * ((mma_d * 16 + (j / 2) * 8 + lane_mod * 2 + (j % 2)) % (HEAD_DIM / 2))) /
                     float(HEAD_DIM));
 }
 
@@ -1157,10 +1150,11 @@ __device__ __forceinline__ void compute_qk(
 }
 
 template <typename KTraits>
-__device__ __forceinline__ void load_fp4_k_frag_scaled(
-    smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem, const uint32_t k_smem_offset_r,
-    uint8_t* k_sf_smem, const uint32_t lane_idx, const uint32_t mma_kv,
-    const uint32_t mma_d, uint32_t* b_frag) {
+__device__ __forceinline__ void load_fp4_k_frag_scaled(smem_t<KTraits::SWIZZLE_MODE_KV>* k_smem,
+                                                       const uint32_t k_smem_offset_r,
+                                                       uint8_t* k_sf_smem, const uint32_t lane_idx,
+                                                       const uint32_t mma_kv, const uint32_t mma_d,
+                                                       uint32_t* b_frag) {
   using DTypeQ = typename KTraits::DTypeQ;
   using DTypeKV = typename KTraits::DTypeKV;
   static_assert(is_fp4_type_v<DTypeKV>);
@@ -1242,11 +1236,10 @@ __device__ __forceinline__ void compute_qk_fp4_rope(
       uint32_t b_frag_first[4], b_frag_second[4];
       load_fp4_k_frag_scaled<KTraits>(k_smem, k_smem_offset_first_mma, k_sf_smem, lane_idx, mma_kv,
                                       mma_di, b_frag_first);
-      load_fp4_k_frag_scaled<KTraits>(k_smem, k_smem_offset_second_mma, k_sf_smem, lane_idx,
-                                      mma_kv, mma_di + NUM_MMA_D_HALF, b_frag_second);
+      load_fp4_k_frag_scaled<KTraits>(k_smem, k_smem_offset_second_mma, k_sf_smem, lane_idx, mma_kv,
+                                      mma_di + NUM_MMA_D_HALF, b_frag_second);
       k_frag_apply_llama_rope<DTypeQ>((DTypeQ*)b_frag_first, (DTypeQ*)b_frag_second,
-                                      rope_freq[mma_di],
-                                      kv_rope_base + mma_kv * 16 + lane_idx / 4);
+                                      rope_freq[mma_di], kv_rope_base + mma_kv * 16 + lane_idx / 4);
 
       k_smem_offset_first_mma =
           k_smem->template advance_offset_by_row<16, UPCAST_STRIDE_K>(k_smem_offset_first_mma);
@@ -1260,11 +1253,11 @@ __device__ __forceinline__ void compute_qk_fp4_rope(
             mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ, MMAMode::kInit>(
                 s_frag[mma_q][mma_kv], a_frag_first[mma_q], b_frag_first);
           } else {
-            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(
-                s_frag[mma_q][mma_kv], a_frag_first[mma_q], b_frag_first);
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(s_frag[mma_q][mma_kv],
+                                                              a_frag_first[mma_q], b_frag_first);
           }
-          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(
-              s_frag[mma_q][mma_kv], a_frag_second[mma_q], b_frag_second);
+          mma::mma_sync_m16n16k16_row_col_f16f16f32<DTypeQ>(s_frag[mma_q][mma_kv],
+                                                            a_frag_second[mma_q], b_frag_second);
         } else if (std::is_same_v<typename KTraits::DTypeQKAccum, half>) {
           if (mma_di == 0) {
             mma::mma_sync_m16n16k16_row_col_f16f16f16<MMAMode::kInit>(
@@ -1279,8 +1272,7 @@ __device__ __forceinline__ void compute_qk_fp4_rope(
       }
     }
 
-    q_smem_offset_first =
-        q_smem->template advance_offset_by_column<2>(q_smem_offset_first, mma_di);
+    q_smem_offset_first = q_smem->template advance_offset_by_column<2>(q_smem_offset_first, mma_di);
     if (mma_di % 2 == 1) {
       k_smem_offset_first =
           k_smem->template advance_offset_by_column<2>(k_smem_offset_first, mma_di / 2);
@@ -2081,7 +2073,7 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
             ? (NUM_MMA_D_QK / 2)
             : 1;
     alignas(16) float local_rope_freq[LOCAL_ROPE_FREQ_ROWS][4];
-    float (*rope_freq)[4] = local_rope_freq;
+    float(*rope_freq)[4] = local_rope_freq;
     if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
       const float rope_rcp_theta = params.rope_rcp_theta;
@@ -2106,8 +2098,7 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
 
 #pragma unroll 1
     for (uint32_t d_tile = 0;
-         d_tile < (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT ? 1u
-                                                                 : KTraits::NUM_D_VO_TILES);
+         d_tile < (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT ? 1u : KTraits::NUM_D_VO_TILES);
          ++d_tile) {
       [[maybe_unused]] const uint32_t d_base = d_tile * KTraits::NUM_MMA_D_VO_TILE;
       if constexpr (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT) {
@@ -2231,11 +2222,11 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
         // compute attention score
         if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
                       is_fp4_type_v<DTypeKV>) {
-          compute_qk_fp4_rope<KTraits>(
-              &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-              smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                           KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_QK,
-              lane_idx, kv_idx_base, rope_freq, s_frag);
+          compute_qk_fp4_rope<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
+                                       smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
+                                                                    KTraits::NUM_MMA_KV * 16 *
+                                                                    KTraits::NUM_MMA_D_QK,
+                                       lane_idx, kv_idx_base, rope_freq, s_frag);
         } else {
           compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
                               smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
@@ -2317,11 +2308,10 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
       finalize_m<KTraits>(variant, m);
 
       if constexpr (KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT) {
-        vosplit_write_o<KTraits>(
-            o_frag, d, o_ptr_base, qo_packed_idx_base, qo_len,
-            partition_kv ? num_chunks * o_stride_n : o_stride_n, o_stride_h,
-            get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP, group_size,
-            lane_idx);
+        vosplit_write_o<KTraits>(o_frag, d, o_ptr_base, qo_packed_idx_base, qo_len,
+                                 partition_kv ? num_chunks * o_stride_n : o_stride_n, o_stride_h,
+                                 get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP,
+                                 group_size, lane_idx);
       } else {
         // threadblock synchronization
         threadblock_sync_mdo_states<KTraits>(o_frag, &smem_storage, m, d, warp_idx, lane_idx, tid);
@@ -2376,9 +2366,9 @@ template <typename KTraits, typename Params>
 __global__ __launch_bounds__(KTraits::NUM_THREADS) void SinglePrefillWithKVCacheKernel(
     const __grid_constant__ Params params) {
   extern __shared__ uint8_t smem[];
-  using SmemStorage = std::conditional_t<KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT,
-                                         typename KTraits::SharedStoragePaged,
-                                         typename KTraits::SharedStorage>;
+  using SmemStorage =
+      std::conditional_t<KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT,
+                         typename KTraits::SharedStoragePaged, typename KTraits::SharedStorage>;
   auto& smem_storage = reinterpret_cast<SmemStorage&>(smem);
   SinglePrefillWithKVCacheDevice<KTraits>(params, smem_storage);
 }
@@ -2413,9 +2403,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
     // hd512 uses the 2-Q x 2-KV-warp layout at CTA_TILE_Q=32. FP4 large-head
     // single-prefill additionally uses VO-split output so it avoids the
     // cta_sync_o_smem traffic that exceeds SM86 shared memory.
-    constexpr bool kLargeHeadWarpSplit =
-        ((sizeof(DTypeKV) == 2) || is_fp4_type_v<DTypeKV>) && (HEAD_DIM_VO >= 512) &&
-        (CTA_TILE_Q == 32);
+    constexpr bool kLargeHeadWarpSplit = ((sizeof(DTypeKV) == 2) || is_fp4_type_v<DTypeKV>) &&
+                                         (HEAD_DIM_VO >= 512) && (CTA_TILE_Q == 32);
     constexpr uint32_t NUM_WARPS_Q = kLargeHeadWarpSplit ? 2 : get_num_warps_q(CTA_TILE_Q);
     constexpr uint32_t NUM_WARPS_KV = kLargeHeadWarpSplit ? 2 : get_num_warps_kv(CTA_TILE_Q);
     constexpr uint32_t NUM_MMA_Q = kLargeHeadWarpSplit ? 1 : get_num_mma_q(CTA_TILE_Q);
@@ -2453,30 +2442,26 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
         (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                        sizeof(DTypeQ))
                     : 0u) +
-        (is_fp4_type_v<DTypeKV> ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV /
-                                   NVFP4_SF_VEC_SIZE)
-                                : 0u) +
+        (is_fp4_type_v<DTypeKV>
+             ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
+             : 0u) +
         (kSinglePrefillVOSplitDispatch ? CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ) : 0u);
-    constexpr uint32_t kSharedRopeFreqSmem =
-        (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
-         HEAD_DIM_QK == HEAD_DIM_VO)
-            ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
-            : 0u;
+    constexpr uint32_t kSharedRopeFreqSmem = (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+                                              HEAD_DIM_QK > 256 && HEAD_DIM_QK == HEAD_DIM_VO)
+                                                 ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
+                                                 : 0u;
     constexpr uint32_t kSinglePrefillVOSplitFixedSmem =
         kSinglePrefillVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
-    constexpr uint32_t kFixedSmem =
-        CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) + kSinglePrefillVOSplitFixedSmem +
-        kSharedRopeFreqSmem;
+    constexpr uint32_t kFixedSmem = CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) +
+                                    kSinglePrefillVOSplitFixedSmem + kSharedRopeFreqSmem;
     // Smallest NUM_MMA_KV satisfying the FP8 alignment constraint
     // (sizeof(DTypeKV)==1 requires NUM_MMA_KV*2 % NUM_WARPS_Q == 0); size the
     // occupancy budget against the minimum *valid* tile so the staging buffer
     // can't shrink NUM_MMA_KV onto an invalid value on tight-smem parts (SM120).
     constexpr uint32_t kMinValidMmaKV =
         (sizeof(DTypeKV) == 1 && NUM_WARPS_Q > 2) ? (NUM_WARPS_Q / 2) : 1;
-    const int num_ctas_per_sm = max_smem_per_sm >=
-                                        2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV)
-                                    ? 2
-                                    : 1;
+    const int num_ctas_per_sm =
+        max_smem_per_sm >= 2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV) ? 2 : 1;
     const int max_smem_per_threadblock =
         min(max_smem_per_sm / num_ctas_per_sm, max_smem_per_block_optin);
 
@@ -2485,9 +2470,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
          !USE_FP16_QK_REDUCTION)
             ? 2
             : (8 / NUM_MMA_Q);
-    const int max_num_mma_kv_smem =
-        (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) /
-        static_cast<int>(kKVSmemPerMmaKV);
+    const int max_num_mma_kv_smem = (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) /
+                                    static_cast<int>(kKVSmemPerMmaKV);
     if (max_num_mma_kv_smem < 1) {
       std::ostringstream err_msg;
       err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
@@ -2499,88 +2483,89 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
     }
 
     // control NUM_MMA_KV for maximum warp occupancy
-    DISPATCH_NUM_MMA_KV(min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg),
-                        NUM_MMA_KV, {
-      using KTraits =
-          KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
-                       NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                       DTypeQKAccum, typename Params::IdType, AttentionVariant>;
-      if constexpr (KTraits::IsInvalid()) {
-        // Invalid configuration, skip
-        std::ostringstream err_msg;
-        err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
+    DISPATCH_NUM_MMA_KV(
+        min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg), NUM_MMA_KV, {
+          using KTraits =
+              KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
+                           NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
+                           DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+          if constexpr (KTraits::IsInvalid()) {
+            // Invalid configuration, skip
+            std::ostringstream err_msg;
+            err_msg
+                << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
                 << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
                 << " NUM_MMA_KV=" << NUM_MMA_KV << " NUM_WARPS_Q=" << NUM_WARPS_Q
                 << " NUM_WARPS_KV=" << NUM_WARPS_KV
                 << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
                    " and report the issue to the developers.";
-        FLASHINFER_ERROR(err_msg.str());
-      } else {
-        constexpr uint32_t num_threads = (NUM_WARPS_Q * NUM_WARPS_KV) * WARP_SIZE;
-        auto kernel = SinglePrefillWithKVCacheKernel<KTraits, Params>;
-        using SmemStorage = std::conditional_t<KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT,
-                                               typename KTraits::SharedStoragePaged,
-                                               typename KTraits::SharedStorage>;
-        size_t smem_size = sizeof(SmemStorage);
-        if (smem_size > (size_t)max_smem_per_block_optin) {
-          std::ostringstream err_msg;
-          err_msg << "Required shared memory (" << smem_size
-                  << " bytes) for head_dim_qk=" << HEAD_DIM_QK << ", head_dim_vo=" << HEAD_DIM_VO
-                  << ", cta_tile_q=" << CTA_TILE_Q << " exceeds this GPU's per-block limit ("
-                  << max_smem_per_block_optin
-                  << " bytes); this configuration is not supported on this architecture.";
-          FLASHINFER_ERROR(err_msg.str());
-        }
-        FLASHINFER_CUDA_CALL(
-            cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-        int num_blocks_per_sm = 0;
-        int num_sm = 0;
-        FLASHINFER_CUDA_CALL(
-            cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
-        FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &num_blocks_per_sm, kernel, num_threads, smem_size));
-        uint32_t max_num_kv_chunks = (num_blocks_per_sm * num_sm) /
-                                     (num_kv_heads * ceil_div(qo_len * group_size, CTA_TILE_Q));
-        uint32_t num_chunks;
-        if (max_num_kv_chunks > 0) {
-          uint32_t chunk_size = max(ceil_div(kv_len, max_num_kv_chunks), 256);
-          num_chunks = ceil_div(kv_len, chunk_size);
-        } else {
-          num_chunks = 0;
-        }
-
-        if (num_chunks <= 1 || tmp == nullptr) {
-          // Enough parallelism, do not split-kv
-          params.partition_kv = false;
-          void* args[] = {(void*)&params};
-          dim3 nblks(ceil_div(qo_len * group_size, CTA_TILE_Q), 1, num_kv_heads);
-          dim3 nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        } else {
-          // Use cooperative groups to increase occupancy
-          params.partition_kv = true;
-          float* tmp_lse = (float*)(tmp + num_chunks * qo_len * num_qo_heads * HEAD_DIM_VO);
-          auto o = params.o;
-          auto lse = params.lse;
-          params.o = tmp;
-          params.lse = tmp_lse;
-          void* args[] = {(void*)&params};
-          dim3 nblks(ceil_div(qo_len * group_size, CTA_TILE_Q), num_chunks, num_kv_heads);
-          dim3 nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
-
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-          if constexpr (AttentionVariant::use_softmax) {
-            FLASHINFER_CUDA_CALL(MergeStates(tmp, tmp_lse, o, lse, num_chunks, qo_len, num_qo_heads,
-                                             HEAD_DIM_VO, stream));
+            FLASHINFER_ERROR(err_msg.str());
           } else {
+            constexpr uint32_t num_threads = (NUM_WARPS_Q * NUM_WARPS_KV) * WARP_SIZE;
+            auto kernel = SinglePrefillWithKVCacheKernel<KTraits, Params>;
+            using SmemStorage = std::conditional_t<KTraits::USE_SINGLE_PREFILL_SOFTMAX_VO_SPLIT,
+                                                   typename KTraits::SharedStoragePaged,
+                                                   typename KTraits::SharedStorage>;
+            size_t smem_size = sizeof(SmemStorage);
+            if (smem_size > (size_t)max_smem_per_block_optin) {
+              std::ostringstream err_msg;
+              err_msg << "Required shared memory (" << smem_size
+                      << " bytes) for head_dim_qk=" << HEAD_DIM_QK
+                      << ", head_dim_vo=" << HEAD_DIM_VO << ", cta_tile_q=" << CTA_TILE_Q
+                      << " exceeds this GPU's per-block limit (" << max_smem_per_block_optin
+                      << " bytes); this configuration is not supported on this architecture.";
+              FLASHINFER_ERROR(err_msg.str());
+            }
+            FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
+                kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+            int num_blocks_per_sm = 0;
+            int num_sm = 0;
             FLASHINFER_CUDA_CALL(
-                AttentionSum(tmp, o, num_chunks, qo_len, num_qo_heads, HEAD_DIM_VO, stream));
+                cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
+            FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+                &num_blocks_per_sm, kernel, num_threads, smem_size));
+            uint32_t max_num_kv_chunks = (num_blocks_per_sm * num_sm) /
+                                         (num_kv_heads * ceil_div(qo_len * group_size, CTA_TILE_Q));
+            uint32_t num_chunks;
+            if (max_num_kv_chunks > 0) {
+              uint32_t chunk_size = max(ceil_div(kv_len, max_num_kv_chunks), 256);
+              num_chunks = ceil_div(kv_len, chunk_size);
+            } else {
+              num_chunks = 0;
+            }
+
+            if (num_chunks <= 1 || tmp == nullptr) {
+              // Enough parallelism, do not split-kv
+              params.partition_kv = false;
+              void* args[] = {(void*)&params};
+              dim3 nblks(ceil_div(qo_len * group_size, CTA_TILE_Q), 1, num_kv_heads);
+              dim3 nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
+              FLASHINFER_CUDA_CALL(
+                  cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            } else {
+              // Use cooperative groups to increase occupancy
+              params.partition_kv = true;
+              float* tmp_lse = (float*)(tmp + num_chunks * qo_len * num_qo_heads * HEAD_DIM_VO);
+              auto o = params.o;
+              auto lse = params.lse;
+              params.o = tmp;
+              params.lse = tmp_lse;
+              void* args[] = {(void*)&params};
+              dim3 nblks(ceil_div(qo_len * group_size, CTA_TILE_Q), num_chunks, num_kv_heads);
+              dim3 nthrs(32, NUM_WARPS_Q, NUM_WARPS_KV);
+
+              FLASHINFER_CUDA_CALL(
+                  cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+              if constexpr (AttentionVariant::use_softmax) {
+                FLASHINFER_CUDA_CALL(MergeStates(tmp, tmp_lse, o, lse, num_chunks, qo_len,
+                                                 num_qo_heads, HEAD_DIM_VO, stream));
+              } else {
+                FLASHINFER_CUDA_CALL(
+                    AttentionSum(tmp, o, num_chunks, qo_len, num_qo_heads, HEAD_DIM_VO, stream));
+              }
+            }
           }
-        }
-      }
-    })
+        })
   });
   return cudaSuccess;
 }
@@ -2686,9 +2671,9 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     const uint32_t request_idx = request_indices[bx], qo_tile_idx = qo_tile_indices[bx],
                    kv_tile_idx = kv_tile_indices[bx];
     extern __shared__ uint8_t smem[];
-    using SmemStorage = std::conditional_t<KTraits::USE_SOFTMAX_VO_SPLIT,
-                                           typename KTraits::SharedStoragePaged,
-                                           typename KTraits::SharedStorage>;
+    using SmemStorage =
+        std::conditional_t<KTraits::USE_SOFTMAX_VO_SPLIT, typename KTraits::SharedStoragePaged,
+                           typename KTraits::SharedStorage>;
     auto& smem_storage = reinterpret_cast<SmemStorage&>(smem);
     AttentionVariant variant(params, /*batch_idx=*/request_idx, smem);
     const uint32_t qo_len = variant.qo_len, kv_len = variant.kv_len,
@@ -2711,8 +2696,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
 
     DTypeQKAccum s_frag[NUM_MMA_Q][NUM_MMA_KV][8];
     constexpr uint32_t O_FRAG_D =
-        KTraits::USE_SOFTMAX_VO_SPLIT ? KTraits::NUM_MMA_D_VO_PER_WARP
-                                       : KTraits::NUM_MMA_D_VO_TILE;
+        KTraits::USE_SOFTMAX_VO_SPLIT ? KTraits::NUM_MMA_D_VO_PER_WARP : KTraits::NUM_MMA_D_VO_TILE;
     alignas(16) float o_frag[NUM_MMA_Q][O_FRAG_D][8];
     [[maybe_unused]] float o_scale[NUM_MMA_Q][2];
     DTypeQKAccum m[NUM_MMA_Q][2];
@@ -2723,7 +2707,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
             ? (NUM_MMA_D_QK / 2)
             : 1;
     alignas(16) float local_rope_freq[LOCAL_ROPE_FREQ_ROWS][4];
-    float (*rope_freq)[4] = local_rope_freq;
+    float(*rope_freq)[4] = local_rope_freq;
 
     if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
@@ -2756,8 +2740,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
 
 #pragma unroll 1
     for (uint32_t d_tile = 0;
-         d_tile < (KTraits::USE_SOFTMAX_VO_SPLIT ? 1u : KTraits::NUM_D_VO_TILES);
-         ++d_tile) {
+         d_tile < (KTraits::USE_SOFTMAX_VO_SPLIT ? 1u : KTraits::NUM_D_VO_TILES); ++d_tile) {
       [[maybe_unused]] const uint32_t d_base = d_tile * KTraits::NUM_MMA_D_VO_TILE;
       if constexpr (KTraits::USE_SOFTMAX_VO_SPLIT) {
 #pragma unroll
@@ -2918,11 +2901,11 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
         // compute attention score
         if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
                       is_fp4_type_v<DTypeKV>) {
-          compute_qk_fp4_rope<KTraits>(
-              &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-              smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                           KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_QK,
-              lane_idx, kv_rope_base, rope_freq, s_frag);
+          compute_qk_fp4_rope<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
+                                       smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
+                                                                    KTraits::NUM_MMA_KV * 16 *
+                                                                    KTraits::NUM_MMA_D_QK,
+                                       lane_idx, kv_rope_base, rope_freq, s_frag);
         } else if constexpr (KTraits::USE_KV_REPACK) {
           // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
           repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
@@ -3262,8 +3245,7 @@ __device__ __forceinline__ void vosplit_compute_pv(
         if constexpr (IS_FP4) {
           using packed2 = std::conditional_t<std::is_same_v<DTypeQ, half>, half2, __nv_bfloat162>;
           constexpr uint32_t SF_COLS_V = KTraits::NUM_MMA_D_VO;
-          const uint32_t sf_base =
-              (mma_kv * 16 + 2 * (lane_idx % 4)) * SF_COLS_V + global_d;
+          const uint32_t sf_base = (mma_kv * 16 + 2 * (lane_idx % 4)) * SF_COLS_V + global_d;
           __nv_fp8_e4m3 sf0_fp8, sf1_fp8, sf2_fp8, sf3_fp8;
           sf0_fp8.__x = smem_storage->v_sf_smem[sf_base];
           sf1_fp8.__x = smem_storage->v_sf_smem[sf_base + SF_COLS_V];
@@ -3456,7 +3438,7 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
             ? (NUM_MMA_D_QK / 2)
             : 1;
     alignas(16) float local_rope_freq[LOCAL_ROPE_FREQ_ROWS][4];
-    float (*rope_freq)[4] = local_rope_freq;
+    float(*rope_freq)[4] = local_rope_freq;
 
     if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama) {
       const float rope_rcp_scale = params.rope_rcp_scale;
@@ -3540,8 +3522,7 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
       // K/V-shared path: V is loaded into k_smem (time-shared); v_smem is a [1] stub.
       smem_t<SWIZZLE_MODE_KV> k_smem(smem_storage.k_smem),
           v_smem(KTraits::USE_KV_SHARED_SMEM ? smem_storage.k_smem : smem_storage.v_smem);
-      constexpr uint32_t NUM_PAGED_KV_OFFSETS =
-          NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q;
+      constexpr uint32_t NUM_PAGED_KV_OFFSETS = NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q;
       [[maybe_unused]] size_t
           thr_local_kv_offset[KTraits::USE_KV_SHARED_SMEM ? 1 : NUM_PAGED_KV_OFFSETS];
 
@@ -3581,9 +3562,9 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
       uint32_t packed_page_iter_base =
           paged_kv.indptr[request_idx] * paged_kv.page_size + chunk_start;
       if constexpr (KTraits::USE_KV_SHARED_SMEM) {
-        page_produce_kv_on_the_fly<false, KTraits>(
-            &smem_storage, &k_smem_offset_w, paged_kv.k_data, paged_kv, packed_page_iter_base,
-            last_indptr, kv_head_idx, 0, chunk_size, warp_idx, lane_idx);
+        page_produce_kv_on_the_fly<false, KTraits>(&smem_storage, &k_smem_offset_w, paged_kv.k_data,
+                                                   paged_kv, packed_page_iter_base, last_indptr,
+                                                   kv_head_idx, 0, chunk_size, warp_idx, lane_idx);
       } else {
 #pragma unroll
         for (uint32_t i = 0;
@@ -3692,7 +3673,8 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
           packed_page_iter_base = next_packed_page_iter_base;
 #pragma unroll
           for (uint32_t i = 0;
-               i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q; ++i) {
+               i < NUM_MMA_KV * (SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 2) / NUM_WARPS_Q;
+               ++i) {
             uint32_t page_iter, entry_idx;
             paged_kv.page_size.divmod(packed_page_iter_base + warp_idx * KV_THR_LAYOUT_ROW +
                                           lane_idx / KV_THR_LAYOUT_COL +
@@ -3733,11 +3715,11 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
         // compute attention score
         if constexpr (KTraits::POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
                       is_fp4_type_v<DTypeKV>) {
-          compute_qk_fp4_rope<KTraits>(
-              &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
-              smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
-                                           KTraits::NUM_MMA_KV * 16 * KTraits::NUM_MMA_D_QK,
-              lane_idx, kv_rope_base, rope_freq, s_frag);
+          compute_qk_fp4_rope<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
+                                       smem_storage.k_sf_smem + get_warp_idx_kv<KTraits>(tid.z) *
+                                                                    KTraits::NUM_MMA_KV * 16 *
+                                                                    KTraits::NUM_MMA_D_QK,
+                                       lane_idx, kv_rope_base, rope_freq, s_frag);
         } else if constexpr (KTraits::USE_KV_REPACK) {
           // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
           repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(
@@ -3848,8 +3830,9 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
         block.sync();
         if constexpr (KTraits::USE_KV_SHARED_SMEM) {
           page_produce_kv_on_the_fly<false, KTraits>(
-              &smem_storage, &k_smem_offset_w, paged_kv.k_data, paged_kv, next_packed_page_iter_base,
-              last_indptr, kv_head_idx, (iter + 1) * CTA_TILE_KV, chunk_size, warp_idx, lane_idx);
+              &smem_storage, &k_smem_offset_w, paged_kv.k_data, paged_kv,
+              next_packed_page_iter_base, last_indptr, kv_head_idx, (iter + 1) * CTA_TILE_KV,
+              chunk_size, warp_idx, lane_idx);
           cp_async::commit_group();
           packed_page_iter_base = next_packed_page_iter_base;
         } else {
@@ -3999,9 +3982,9 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
                              ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0) &&
                              (HEAD_DIM_QK == HEAD_DIM_VO) &&
                              (sizeof(DTypeKV) == 2 || CTA_TILE_Q > 16);
-  constexpr bool kVOSplitDispatch =
-      ((sizeof(DTypeKV) == 2) || is_fp4_type_v<DTypeKV>) && AttentionVariant::use_softmax &&
-      (HEAD_DIM_VO / 16 > 16) && ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0);
+  constexpr bool kVOSplitDispatch = ((sizeof(DTypeKV) == 2) || is_fp4_type_v<DTypeKV>) &&
+                                    AttentionVariant::use_softmax && (HEAD_DIM_VO / 16 > 16) &&
+                                    ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0);
   constexpr uint32_t kKVSmemPerMmaKV =
       (kKVShared ? (HEAD_DIM_QK * 16 * NUM_WARPS_KV * sizeof(DTypeKV))
                  : ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV))) +
@@ -4011,11 +3994,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
   constexpr uint32_t kVOSplitFixedSmem =
       kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
-  constexpr uint32_t kSharedRopeFreqSmem =
-      (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
-       HEAD_DIM_QK == HEAD_DIM_VO)
-          ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
-          : 0u;
+  constexpr uint32_t kSharedRopeFreqSmem = (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+                                            HEAD_DIM_QK > 256 && HEAD_DIM_QK == HEAD_DIM_VO)
+                                               ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
+                                               : 0u;
   constexpr uint32_t kFixedSmem =
       CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) + kVOSplitFixedSmem + kSharedRopeFreqSmem;
   // Smallest NUM_MMA_KV satisfying the FP8 alignment constraint
@@ -4025,10 +4007,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
   // minimum *valid* tile rather than NUM_MMA_KV=1.
   constexpr uint32_t kMinValidMmaKV =
       (sizeof(DTypeKV) == 1 && NUM_WARPS_Q > 2) ? (NUM_WARPS_Q / 2) : 1;
-  const int num_ctas_per_sm = max_smem_per_sm >=
-                                      2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV)
-                                  ? 2
-                                  : 1;
+  const int num_ctas_per_sm =
+      max_smem_per_sm >= 2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV) ? 2 : 1;
   // The occupancy budget (max_smem_per_sm / num_ctas_per_sm) can exceed the
   // hard per-block opt-in limit when only one CTA fits per SM (the two
   // attributes differ by 1KB on most arches), which would make
@@ -4044,8 +4024,7 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
           ? 2
           : (8 / NUM_MMA_Q);
   const int max_num_mma_kv_smem =
-      (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) /
-      static_cast<int>(kKVSmemPerMmaKV);
+      (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) / static_cast<int>(kKVSmemPerMmaKV);
   if (max_num_mma_kv_smem < 1) {
     std::ostringstream err_msg;
     err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
@@ -4056,92 +4035,92 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
     FLASHINFER_ERROR(err_msg.str());
   }
 
-  DISPATCH_NUM_MMA_KV(min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg),
-                      NUM_MMA_KV, {
-    using KTraits =
-        KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
-                     NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                     DTypeQKAccum, typename Params::IdType, AttentionVariant>;
-    if constexpr (KTraits::IsInvalid()) {
-      // Invalid configuration, skip
-      std::ostringstream err_msg;
-      err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
-              << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
-              << " NUM_MMA_KV=" << NUM_MMA_KV << " NUM_WARPS_Q=" << NUM_WARPS_Q
-              << " NUM_WARPS_KV=" << NUM_WARPS_KV
-              << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
-                 " and report the issue to the developers.";
-      FLASHINFER_ERROR(err_msg.str());
-    } else {
-      using SmemStorage = std::conditional_t<KTraits::USE_SOFTMAX_VO_SPLIT,
-                                             typename KTraits::SharedStoragePaged,
-                                             typename KTraits::SharedStorage>;
-      size_t smem_size = sizeof(SmemStorage);
-      auto kernel = BatchPrefillWithRaggedKVCacheKernel<KTraits, Params>;
-      // Exact final check: the analytic NUM_MMA_KV budget can slightly
-      // under-count the real struct (cross-warp merge buffers, padding);
-      // fail with a clear error instead of a launch-time cudaErrorInvalidValue.
-      if (smem_size > (size_t)max_smem_per_block_optin) {
-        std::ostringstream err_msg;
-        err_msg << "Required shared memory (" << smem_size
-                << " bytes) for head_dim_qk=" << HEAD_DIM_QK << ", head_dim_vo=" << HEAD_DIM_VO
-                << ", cta_tile_q=" << CTA_TILE_Q << " exceeds this GPU's per-block limit ("
-                << max_smem_per_block_optin
-                << " bytes); this configuration is not supported on this architecture.";
-        FLASHINFER_ERROR(err_msg.str());
-      }
-      FLASHINFER_CUDA_CALL(
-          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-      // PDL launch config
-      cudaLaunchAttribute attribute[1];
-      cudaLaunchConfig_t config;
-      if (enable_pdl) {
-        attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-        attribute[0].val.programmaticStreamSerializationAllowed = 1;
-        config.attrs = attribute;
-        config.numAttrs = 1;
-        config.gridDim = nblks;
-        config.blockDim = nthrs;
-        config.dynamicSmemBytes = smem_size;
-        config.stream = stream;
-      }
+  DISPATCH_NUM_MMA_KV(
+      min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg), NUM_MMA_KV, {
+        using KTraits =
+            KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
+                         NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
+                         DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+        if constexpr (KTraits::IsInvalid()) {
+          // Invalid configuration, skip
+          std::ostringstream err_msg;
+          err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
+                  << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
+                  << " NUM_MMA_KV=" << NUM_MMA_KV << " NUM_WARPS_Q=" << NUM_WARPS_Q
+                  << " NUM_WARPS_KV=" << NUM_WARPS_KV
+                  << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
+                     " and report the issue to the developers.";
+          FLASHINFER_ERROR(err_msg.str());
+        } else {
+          using SmemStorage = std::conditional_t<KTraits::USE_SOFTMAX_VO_SPLIT,
+                                                 typename KTraits::SharedStoragePaged,
+                                                 typename KTraits::SharedStorage>;
+          size_t smem_size = sizeof(SmemStorage);
+          auto kernel = BatchPrefillWithRaggedKVCacheKernel<KTraits, Params>;
+          // Exact final check: the analytic NUM_MMA_KV budget can slightly
+          // under-count the real struct (cross-warp merge buffers, padding);
+          // fail with a clear error instead of a launch-time cudaErrorInvalidValue.
+          if (smem_size > (size_t)max_smem_per_block_optin) {
+            std::ostringstream err_msg;
+            err_msg << "Required shared memory (" << smem_size
+                    << " bytes) for head_dim_qk=" << HEAD_DIM_QK << ", head_dim_vo=" << HEAD_DIM_VO
+                    << ", cta_tile_q=" << CTA_TILE_Q << " exceeds this GPU's per-block limit ("
+                    << max_smem_per_block_optin
+                    << " bytes); this configuration is not supported on this architecture.";
+            FLASHINFER_ERROR(err_msg.str());
+          }
+          FLASHINFER_CUDA_CALL(
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+          // PDL launch config
+          cudaLaunchAttribute attribute[1];
+          cudaLaunchConfig_t config;
+          if (enable_pdl) {
+            attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+            attribute[0].val.programmaticStreamSerializationAllowed = 1;
+            config.attrs = attribute;
+            config.numAttrs = 1;
+            config.gridDim = nblks;
+            config.blockDim = nthrs;
+            config.dynamicSmemBytes = smem_size;
+            config.stream = stream;
+          }
 
-      if (tmp_v == nullptr) {
-        // do not partition kv
-        params.partition_kv = false;
-        void* args[] = {(void*)&params};
-        if (enable_pdl) {
-          FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
-        } else {
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+          if (tmp_v == nullptr) {
+            // do not partition kv
+            params.partition_kv = false;
+            void* args[] = {(void*)&params};
+            if (enable_pdl) {
+              FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
+            } else {
+              FLASHINFER_CUDA_CALL(
+                  cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            }
+          } else {
+            // partition kv
+            params.partition_kv = true;
+            auto o = params.o;
+            auto lse = params.lse;
+            params.o = tmp_v;
+            params.lse = tmp_s;
+            void* args[] = {(void*)&params};
+            if (enable_pdl) {
+              FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
+            } else {
+              FLASHINFER_CUDA_CALL(
+                  cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            }
+            if constexpr (AttentionVariant::use_softmax) {
+              FLASHINFER_CUDA_CALL(VariableLengthMergeStates(
+                  tmp_v, tmp_s, params.merge_indptr, o, lse, params.max_total_num_rows,
+                  params.total_num_rows, num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
+            } else {
+              FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(
+                  tmp_v, params.merge_indptr, o, params.max_total_num_rows, params.total_num_rows,
+                  num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
+            }
+          }
         }
-      } else {
-        // partition kv
-        params.partition_kv = true;
-        auto o = params.o;
-        auto lse = params.lse;
-        params.o = tmp_v;
-        params.lse = tmp_s;
-        void* args[] = {(void*)&params};
-        if (enable_pdl) {
-          FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
-        } else {
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        }
-        if constexpr (AttentionVariant::use_softmax) {
-          FLASHINFER_CUDA_CALL(VariableLengthMergeStates(
-              tmp_v, tmp_s, params.merge_indptr, o, lse, params.max_total_num_rows,
-              params.total_num_rows, num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
-        } else {
-          FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(
-              tmp_v, params.merge_indptr, o, params.max_total_num_rows, params.total_num_rows,
-              num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
-        }
-      }
-    }
-  });
+      });
   return cudaSuccess;
 }
 
@@ -4214,11 +4193,10 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
   constexpr uint32_t kVOSplitFixedSmem =
       kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
-  constexpr uint32_t kSharedRopeFreqSmem =
-      (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && HEAD_DIM_QK > 256 &&
-       HEAD_DIM_QK == HEAD_DIM_VO)
-          ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
-          : 0u;
+  constexpr uint32_t kSharedRopeFreqSmem = (POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+                                            HEAD_DIM_QK > 256 && HEAD_DIM_QK == HEAD_DIM_VO)
+                                               ? (4u * (NUM_MMA_D_QK / 2) * 4u * sizeof(float))
+                                               : 0u;
   constexpr uint32_t kFixedSmem =
       CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ) + kVOSplitFixedSmem + kSharedRopeFreqSmem;
   // Smallest NUM_MMA_KV satisfying the FP8 alignment constraint
@@ -4228,10 +4206,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
   // minimum *valid* tile rather than NUM_MMA_KV=1.
   constexpr uint32_t kMinValidMmaKV =
       (sizeof(DTypeKV) == 1 && NUM_WARPS_Q > 2) ? (NUM_WARPS_Q / 2) : 1;
-  const int num_ctas_per_sm = max_smem_per_sm >=
-                                      2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV)
-                                  ? 2
-                                  : 1;
+  const int num_ctas_per_sm =
+      max_smem_per_sm >= 2 * (kFixedSmem + kMinValidMmaKV * kKVSmemPerMmaKV) ? 2 : 1;
   const int max_smem_per_threadblock =
       min(max_smem_per_sm / num_ctas_per_sm, max_smem_per_block_optin);
 
@@ -4241,8 +4217,7 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
           ? 2
           : (8 / NUM_MMA_Q);
   const int max_num_mma_kv_smem =
-      (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) /
-      static_cast<int>(kKVSmemPerMmaKV);
+      (max_smem_per_threadblock - static_cast<int>(kFixedSmem)) / static_cast<int>(kKVSmemPerMmaKV);
   if (max_num_mma_kv_smem < 1) {
     std::ostringstream err_msg;
     err_msg << "Even the smallest KV tile for head_dim_qk=" << HEAD_DIM_QK
@@ -4253,88 +4228,88 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
     FLASHINFER_ERROR(err_msg.str());
   }
 
-  DISPATCH_NUM_MMA_KV(min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg),
-                      NUM_MMA_KV, {
-    using KTraits =
-        KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
-                     NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                     DTypeQKAccum, typename Params::IdType, AttentionVariant>;
-    if constexpr (KTraits::IsInvalid()) {
-      // Invalid configuration, skip
-      std::ostringstream err_msg;
-      err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
-              << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
-              << " NUM_MMA_KV=" << NUM_MMA_KV << " NUM_WARPS_Q=" << NUM_WARPS_Q
-              << " NUM_WARPS_KV=" << NUM_WARPS_KV
-              << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
-                 " and report the issue to the developers.";
-      FLASHINFER_ERROR(err_msg.str());
-    } else {
-      size_t smem_size = sizeof(typename KTraits::SharedStoragePaged);
-      auto kernel = BatchPrefillWithPagedKVCacheKernel<KTraits, Params>;
-      // Exact final check: the analytic NUM_MMA_KV budget can slightly
-      // under-count the real struct (cross-warp merge buffers, padding);
-      // fail with a clear error instead of a launch-time cudaErrorInvalidValue.
-      if (smem_size > (size_t)max_smem_per_block_optin) {
-        std::ostringstream err_msg;
-        err_msg << "Required shared memory (" << smem_size
-                << " bytes) for head_dim_qk=" << HEAD_DIM_QK << ", head_dim_vo=" << HEAD_DIM_VO
-                << ", cta_tile_q=" << CTA_TILE_Q << " exceeds this GPU's per-block limit ("
-                << max_smem_per_block_optin
-                << " bytes); this configuration is not supported on this architecture.";
-        FLASHINFER_ERROR(err_msg.str());
-      }
-      FLASHINFER_CUDA_CALL(
-          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
-      // PDL launch config
-      cudaLaunchAttribute attribute[1];
-      cudaLaunchConfig_t config;
-      if (enable_pdl) {
-        attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-        attribute[0].val.programmaticStreamSerializationAllowed = 1;
-        config.attrs = attribute;
-        config.numAttrs = 1;
-        config.gridDim = nblks;
-        config.blockDim = nthrs;
-        config.dynamicSmemBytes = smem_size;
-        config.stream = stream;
-      }
+  DISPATCH_NUM_MMA_KV(
+      min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg), NUM_MMA_KV, {
+        using KTraits =
+            KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
+                         NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
+                         DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+        if constexpr (KTraits::IsInvalid()) {
+          // Invalid configuration, skip
+          std::ostringstream err_msg;
+          err_msg << "FlashInfer Internal Error: Invalid configuration : NUM_MMA_Q=" << NUM_MMA_Q
+                  << " NUM_MMA_D_QK=" << NUM_MMA_D_QK << " NUM_MMA_D_VO=" << NUM_MMA_D_VO
+                  << " NUM_MMA_KV=" << NUM_MMA_KV << " NUM_WARPS_Q=" << NUM_WARPS_Q
+                  << " NUM_WARPS_KV=" << NUM_WARPS_KV
+                  << " please create an issue (https://github.com/flashinfer-ai/flashinfer/issues)"
+                     " and report the issue to the developers.";
+          FLASHINFER_ERROR(err_msg.str());
+        } else {
+          size_t smem_size = sizeof(typename KTraits::SharedStoragePaged);
+          auto kernel = BatchPrefillWithPagedKVCacheKernel<KTraits, Params>;
+          // Exact final check: the analytic NUM_MMA_KV budget can slightly
+          // under-count the real struct (cross-warp merge buffers, padding);
+          // fail with a clear error instead of a launch-time cudaErrorInvalidValue.
+          if (smem_size > (size_t)max_smem_per_block_optin) {
+            std::ostringstream err_msg;
+            err_msg << "Required shared memory (" << smem_size
+                    << " bytes) for head_dim_qk=" << HEAD_DIM_QK << ", head_dim_vo=" << HEAD_DIM_VO
+                    << ", cta_tile_q=" << CTA_TILE_Q << " exceeds this GPU's per-block limit ("
+                    << max_smem_per_block_optin
+                    << " bytes); this configuration is not supported on this architecture.";
+            FLASHINFER_ERROR(err_msg.str());
+          }
+          FLASHINFER_CUDA_CALL(
+              cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+          // PDL launch config
+          cudaLaunchAttribute attribute[1];
+          cudaLaunchConfig_t config;
+          if (enable_pdl) {
+            attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+            attribute[0].val.programmaticStreamSerializationAllowed = 1;
+            config.attrs = attribute;
+            config.numAttrs = 1;
+            config.gridDim = nblks;
+            config.blockDim = nthrs;
+            config.dynamicSmemBytes = smem_size;
+            config.stream = stream;
+          }
 
-      if (tmp_v == nullptr) {
-        // do not partition kv
-        params.partition_kv = false;
-        if (enable_pdl) {
-          FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
-        } else {
-          void* args[] = {(void*)&params};
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+          if (tmp_v == nullptr) {
+            // do not partition kv
+            params.partition_kv = false;
+            if (enable_pdl) {
+              FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
+            } else {
+              void* args[] = {(void*)&params};
+              FLASHINFER_CUDA_CALL(
+                  cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            }
+          } else {
+            params.partition_kv = true;
+            auto o = params.o;
+            auto lse = params.lse;
+            params.o = tmp_v;
+            params.lse = tmp_s;
+            if (enable_pdl) {
+              FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
+            } else {
+              void* args[] = {(void*)&params};
+              FLASHINFER_CUDA_CALL(
+                  cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+            }
+            if constexpr (AttentionVariant::use_softmax) {
+              FLASHINFER_CUDA_CALL(VariableLengthMergeStates(
+                  tmp_v, tmp_s, params.merge_indptr, o, lse, params.max_total_num_rows,
+                  params.total_num_rows, num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
+            } else {
+              FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(
+                  tmp_v, params.merge_indptr, o, params.max_total_num_rows, params.total_num_rows,
+                  num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
+            }
+          }
         }
-      } else {
-        params.partition_kv = true;
-        auto o = params.o;
-        auto lse = params.lse;
-        params.o = tmp_v;
-        params.lse = tmp_s;
-        if (enable_pdl) {
-          FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(&config, kernel, params));
-        } else {
-          void* args[] = {(void*)&params};
-          FLASHINFER_CUDA_CALL(
-              cudaLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
-        }
-        if constexpr (AttentionVariant::use_softmax) {
-          FLASHINFER_CUDA_CALL(VariableLengthMergeStates(
-              tmp_v, tmp_s, params.merge_indptr, o, lse, params.max_total_num_rows,
-              params.total_num_rows, num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
-        } else {
-          FLASHINFER_CUDA_CALL(VariableLengthAttentionSum(
-              tmp_v, params.merge_indptr, o, params.max_total_num_rows, params.total_num_rows,
-              num_qo_heads, HEAD_DIM_VO, enable_pdl, stream));
-        }
-      }
-    }
-  });
+      });
   return cudaSuccess;
 }
 

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -46,6 +46,13 @@ def skip_if_head_dim_dtype_unsupported(head_dim: int, kv_dtype: torch.dtype):
         pytest.skip("head_dim > 256 with FP8 KV is only validated on SM100 or newer")
 
 
+def skip_if_nvfp4_large_head_decode_unsupported(head_dim: int):
+    if head_dim > 256 and get_compute_capability(torch.device("cuda:0"))[0] < 10:
+        pytest.skip(
+            "head_dim > 256 with NVFP4 KV decode is only validated on SM100 or newer"
+        )
+
+
 @pytest.fixture(
     autouse=not has_flashinfer_jit_cache(),
     scope="module",
@@ -832,6 +839,7 @@ def test_batch_decode_with_paged_kv_cache_nvfp4(
 
 
 def test_batch_decode_with_paged_kv_cache_nvfp4_large_head():
+    skip_if_nvfp4_large_head_decode_unsupported(512)
     test_batch_decode_with_paged_kv_cache_nvfp4(
         batch_size=4,
         kv_len=128,

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -831,6 +831,18 @@ def test_batch_decode_with_paged_kv_cache_nvfp4(
         torch.testing.assert_close(o[i], o_ref_i, rtol=1e-1, atol=1e-1)
 
 
+def test_batch_decode_with_paged_kv_cache_nvfp4_large_head():
+    test_batch_decode_with_paged_kv_cache_nvfp4(
+        batch_size=4,
+        kv_len=128,
+        page_size=16,
+        num_kv_heads=1,
+        num_qo_heads=1,
+        head_dim=512,
+        q_dtype=torch.float16,
+    )
+
+
 if __name__ == "__main__":
     test_batch_decode_with_paged_kv_cache(
         256,

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -27,13 +27,23 @@ from flashinfer.utils import get_compute_capability, has_flashinfer_jit_cache
 
 
 def head_dim_512_supported() -> bool:
-    # head_dim > 256 is only supported on SM100+.
-    return get_compute_capability(torch.device("cuda:0"))[0] >= 10
+    # 16-bit FA2 head_dim > 256 uses the Ampere+ large-head path.
+    return get_compute_capability(torch.device("cuda:0"))[0] >= 8
 
 
 def skip_if_head_dim_unsupported(head_dim: int):
     if head_dim > 256 and not head_dim_512_supported():
-        pytest.skip("head_dim > 256 is only supported on SM100 or newer")
+        pytest.skip("16-bit FA2 head_dim > 256 is only supported on SM80 or newer")
+
+
+def skip_if_head_dim_dtype_unsupported(head_dim: int, kv_dtype: torch.dtype):
+    skip_if_head_dim_unsupported(head_dim)
+    if (
+        head_dim > 256
+        and kv_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
+        and get_compute_capability(torch.device("cuda:0"))[0] < 10
+    ):
+        pytest.skip("head_dim > 256 with FP8 KV is only validated on SM100 or newer")
 
 
 @pytest.fixture(
@@ -98,7 +108,7 @@ def test_batch_decode_with_paged_kv_cache(
     kv_dtype,
     contiguous_kv,
 ):
-    skip_if_head_dim_unsupported(head_dim)
+    skip_if_head_dim_dtype_unsupported(head_dim, kv_dtype)
     q = torch.randn(batch_size, num_qo_heads, head_dim, device="cuda:0", dtype=q_dtype)
     num_pages_per_seq = (kv_len + page_size - 1) // page_size
     total_num_pages = num_pages_per_seq * batch_size

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -1239,6 +1239,7 @@ def test_batch_prefill_with_paged_kv_cache_nvfp4(
     head_dim,
     causal,
     q_dtype,
+    pos_encoding_mode="NONE",
 ):
     """Test BatchPrefillWithPagedKVCacheWrapper with NVFP4 KV cache.
 
@@ -1307,7 +1308,7 @@ def test_batch_prefill_with_paged_kv_cache_nvfp4(
         head_dim,
         page_size,
         causal=causal,
-        pos_encoding_mode="NONE",
+        pos_encoding_mode=pos_encoding_mode,
         logits_soft_cap=0.0,
         kv_data_type=torch.uint8,
         q_data_type=q_dtype,
@@ -1350,7 +1351,12 @@ def test_batch_prefill_with_paged_kv_cache_nvfp4(
         )
 
         o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
-            qi, ki, vi, causal=causal, pos_encoding_mode="NONE", logits_soft_cap=0.0
+            qi,
+            ki,
+            vi,
+            causal=causal,
+            pos_encoding_mode=pos_encoding_mode,
+            logits_soft_cap=0.0,
         )
         o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
 
@@ -1375,6 +1381,7 @@ def test_batch_prefill_with_ragged_kv_cache_nvfp4(
     head_dim,
     causal,
     q_dtype,
+    pos_encoding_mode="NONE",
 ):
     """Test BatchPrefillWithRaggedKVCacheWrapper with NVFP4 KV cache.
 
@@ -1424,7 +1431,7 @@ def test_batch_prefill_with_ragged_kv_cache_nvfp4(
         num_kv_heads,
         head_dim,
         causal=causal,
-        pos_encoding_mode="NONE",
+        pos_encoding_mode=pos_encoding_mode,
         logits_soft_cap=0.0,
         kv_data_type=torch.uint8,
         q_data_type=q_dtype,
@@ -1445,12 +1452,73 @@ def test_batch_prefill_with_ragged_kv_cache_nvfp4(
         vi = v_dq[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1]]
 
         o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
-            qi, ki, vi, causal=causal, pos_encoding_mode="NONE", logits_soft_cap=0.0
+            qi,
+            ki,
+            vi,
+            causal=causal,
+            pos_encoding_mode=pos_encoding_mode,
+            logits_soft_cap=0.0,
         )
         o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
 
         # NVFP4 is 4-bit; use relaxed tolerance
         torch.testing.assert_close(o_i, o_ref_i, rtol=1e-1, atol=1e-1)
+
+
+def test_batch_prefill_with_paged_kv_cache_nvfp4_large_head():
+    test_batch_prefill_with_paged_kv_cache_nvfp4(
+        batch_size=1,
+        kv_len=128,
+        qo_len=64,
+        page_size=16,
+        num_kv_heads=1,
+        num_qo_heads=1,
+        head_dim=512,
+        causal=False,
+        q_dtype=torch.float16,
+    )
+
+
+def test_batch_prefill_with_paged_kv_cache_nvfp4_rope_large_head():
+    test_batch_prefill_with_paged_kv_cache_nvfp4(
+        batch_size=1,
+        kv_len=128,
+        qo_len=64,
+        page_size=16,
+        num_kv_heads=1,
+        num_qo_heads=1,
+        head_dim=512,
+        causal=False,
+        q_dtype=torch.float16,
+        pos_encoding_mode="ROPE_LLAMA",
+    )
+
+
+def test_batch_prefill_with_ragged_kv_cache_nvfp4_large_head():
+    test_batch_prefill_with_ragged_kv_cache_nvfp4(
+        batch_size=1,
+        kv_len=128,
+        qo_len=64,
+        num_kv_heads=1,
+        num_qo_heads=1,
+        head_dim=512,
+        causal=False,
+        q_dtype=torch.float16,
+    )
+
+
+def test_batch_prefill_with_ragged_kv_cache_nvfp4_rope_large_head():
+    test_batch_prefill_with_ragged_kv_cache_nvfp4(
+        batch_size=1,
+        kv_len=128,
+        qo_len=64,
+        num_kv_heads=1,
+        num_qo_heads=1,
+        head_dim=512,
+        causal=False,
+        q_dtype=torch.float16,
+        pos_encoding_mode="ROPE_LLAMA",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -22,7 +22,17 @@ from tests.test_helpers.jit_utils import gen_prefill_attention_modules
 import flashinfer
 from tests.test_helpers.test_helpers import assert_close_chunked
 from tests.test_helpers.utils_fp4 import create_nvfp4_kv, nvfp4_to_float
-from flashinfer.utils import has_flashinfer_jit_cache
+from flashinfer.utils import get_compute_capability, has_flashinfer_jit_cache
+
+
+def head_dim_512_supported() -> bool:
+    # 16-bit FA2 head_dim > 256 uses the Ampere+ large-head path.
+    return get_compute_capability(torch.device("cuda:0"))[0] >= 8
+
+
+def skip_if_head_dim_unsupported(head_dim: int):
+    if head_dim > 256 and not head_dim_512_supported():
+        pytest.skip("16-bit FA2 head_dim > 256 is only supported on SM80 or newer")
 
 
 @pytest.fixture(
@@ -284,6 +294,105 @@ def test_batch_prefill_with_paged_kv_cache(
             causal=causal,
             pos_encoding_mode=pos_encoding_mode,
             logits_soft_cap=logits_soft_cap,
+        )
+        o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
+        torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA"])
+def test_batch_prefill_with_paged_kv_cache_head_dim_512(
+    causal,
+    pos_encoding_mode,
+):
+    head_dim = 512
+    skip_if_head_dim_unsupported(head_dim)
+
+    batch_size = 2
+    kv_len = 97
+    qo_len = 17
+    page_size = 16
+    num_kv_heads = 4
+    num_qo_heads = 4
+    kv_layout = "NHD"
+
+    q = torch.randn(
+        batch_size * qo_len,
+        num_qo_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    q_indptr_cpu = torch.arange(0, batch_size + 1, dtype=torch.int32) * qo_len
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_shape = [total_num_pages, 2, page_size, num_kv_heads, head_dim]
+    kv_data_fp32 = torch.randn(*kv_shape, dtype=torch.float32, device="cuda:0")
+    kv_data = kv_data_fp32.half()
+    kv_indptr_cpu = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32) * num_pages_per_seq
+    )
+    kv_indices_cpu = torch.arange(0, total_num_pages, dtype=torch.int32)
+    kv_last_page_len_cpu = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32
+    )
+
+    workspace_buffer = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout, backend="fa2"
+    )
+    wrapper.plan(
+        q_indptr_cpu.to(0),
+        kv_indptr_cpu.to(0),
+        kv_indices_cpu.to(0),
+        kv_last_page_len_cpu.to(0),
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        pos_encoding_mode=pos_encoding_mode,
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+    )
+    o, lse = wrapper.run(q, kv_data, return_lse=True)
+
+    o_buffer = torch.empty_like(o)
+    lse_buffer = torch.empty_like(lse)
+    wrapper.run(q, kv_data, out=o_buffer, lse=lse_buffer, return_lse=True)
+    torch.testing.assert_close(o, o_buffer, rtol=1e-3, atol=1e-3)
+
+    for i in range(batch_size):
+        qi = q[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
+        ki = torch.cat(
+            [
+                kv_data_fp32[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1] - 1, 0].reshape(
+                    -1, num_kv_heads, head_dim
+                ),
+                kv_data_fp32[
+                    kv_indptr_cpu[i + 1] - 1, 0, : kv_last_page_len_cpu[i], :
+                ].reshape(-1, num_kv_heads, head_dim),
+            ],
+            dim=0,
+        ).half()
+        vi = torch.cat(
+            [
+                kv_data_fp32[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1] - 1, 1].reshape(
+                    -1, num_kv_heads, head_dim
+                ),
+                kv_data_fp32[
+                    kv_indptr_cpu[i + 1] - 1, 1, : kv_last_page_len_cpu[i], :
+                ].reshape(-1, num_kv_heads, head_dim),
+            ],
+            dim=0,
+        ).half()
+        o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
+            qi,
+            ki,
+            vi,
+            causal=causal,
+            pos_encoding_mode=pos_encoding_mode,
+            backend="fa2",
         )
         o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
         torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
@@ -720,6 +829,84 @@ def test_batch_prefill_with_ragged_kv_cache(
             logits_soft_cap=logits_soft_cap,
         )
         o_i = o[q_indptr[i] : q_indptr[i + 1]]
+        torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA"])
+def test_batch_prefill_with_ragged_kv_cache_head_dim_512(
+    causal,
+    pos_encoding_mode,
+):
+    head_dim = 512
+    skip_if_head_dim_unsupported(head_dim)
+
+    batch_size = 2
+    kv_len = 97
+    qo_len = 17
+    num_kv_heads = 4
+    num_qo_heads = 4
+    kv_layout = "NHD"
+
+    q = torch.randn(
+        batch_size * qo_len,
+        num_qo_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    k = torch.randn(
+        batch_size * kv_len,
+        num_kv_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    v = torch.randn(
+        batch_size * kv_len,
+        num_kv_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    q_indptr_cpu = torch.arange(0, batch_size + 1, dtype=torch.int32) * qo_len
+    kv_indptr_cpu = torch.arange(0, batch_size + 1, dtype=torch.int32) * kv_len
+
+    workspace_buffer = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace_buffer, kv_layout, backend="fa2"
+    )
+    wrapper.plan(
+        q_indptr_cpu.to(0),
+        kv_indptr_cpu.to(0),
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        causal=causal,
+        pos_encoding_mode=pos_encoding_mode,
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+    )
+    o, lse = wrapper.run(q, k, v, return_lse=True)
+
+    o_buffer = torch.empty_like(o)
+    lse_buffer = torch.empty_like(lse)
+    wrapper.run(q, k, v, out=o_buffer, lse=lse_buffer, return_lse=True)
+    torch.testing.assert_close(o, o_buffer, rtol=1e-3, atol=1e-3)
+
+    for i in range(batch_size):
+        qi = q[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
+        ki = k[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1]]
+        vi = v[kv_indptr_cpu[i] : kv_indptr_cpu[i + 1]]
+        o_ref_i = flashinfer.prefill.single_prefill_with_kv_cache(
+            qi,
+            ki,
+            vi,
+            causal=causal,
+            pos_encoding_mode=pos_encoding_mode,
+            backend="fa2",
+        )
+        o_i = o[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
         torch.testing.assert_close(o_i, o_ref_i, rtol=1e-3, atol=1e-3)
 
 

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -361,6 +361,7 @@ def test_batch_prefill_with_paged_kv_cache_head_dim_512(
     lse_buffer = torch.empty_like(lse)
     wrapper.run(q, kv_data, out=o_buffer, lse=lse_buffer, return_lse=True)
     torch.testing.assert_close(o, o_buffer, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(lse, lse_buffer, rtol=1e-3, atol=1e-3)
 
     for i in range(batch_size):
         qi = q[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
@@ -893,6 +894,7 @@ def test_batch_prefill_with_ragged_kv_cache_head_dim_512(
     lse_buffer = torch.empty_like(lse)
     wrapper.run(q, k, v, out=o_buffer, lse=lse_buffer, return_lse=True)
     torch.testing.assert_close(o, o_buffer, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(lse, lse_buffer, rtol=1e-3, atol=1e-3)
 
     for i in range(batch_size):
         qi = q[q_indptr_cpu[i] : q_indptr_cpu[i + 1]]
@@ -1466,6 +1468,7 @@ def test_batch_prefill_with_ragged_kv_cache_nvfp4(
 
 
 def test_batch_prefill_with_paged_kv_cache_nvfp4_large_head():
+    skip_if_head_dim_unsupported(512)
     test_batch_prefill_with_paged_kv_cache_nvfp4(
         batch_size=1,
         kv_len=128,
@@ -1480,6 +1483,7 @@ def test_batch_prefill_with_paged_kv_cache_nvfp4_large_head():
 
 
 def test_batch_prefill_with_paged_kv_cache_nvfp4_rope_large_head():
+    skip_if_head_dim_unsupported(512)
     test_batch_prefill_with_paged_kv_cache_nvfp4(
         batch_size=1,
         kv_len=128,
@@ -1495,6 +1499,7 @@ def test_batch_prefill_with_paged_kv_cache_nvfp4_rope_large_head():
 
 
 def test_batch_prefill_with_ragged_kv_cache_nvfp4_large_head():
+    skip_if_head_dim_unsupported(512)
     test_batch_prefill_with_ragged_kv_cache_nvfp4(
         batch_size=1,
         kv_len=128,
@@ -1508,6 +1513,7 @@ def test_batch_prefill_with_ragged_kv_cache_nvfp4_large_head():
 
 
 def test_batch_prefill_with_ragged_kv_cache_nvfp4_rope_large_head():
+    skip_if_head_dim_unsupported(512)
     test_batch_prefill_with_ragged_kv_cache_nvfp4(
         batch_size=1,
         kv_len=128,

--- a/tests/attention/test_single_prefill.py
+++ b/tests/attention/test_single_prefill.py
@@ -7,6 +7,16 @@ import flashinfer
 from tests.test_helpers.utils_fp4 import create_nvfp4_kv, nvfp4_to_float
 
 
+def head_dim_512_supported() -> bool:
+    # 16-bit FA2 head_dim > 256 uses the Ampere+ large-head path.
+    return torch.cuda.get_device_capability()[0] >= 8
+
+
+def skip_if_head_dim_unsupported(head_dim: int):
+    if head_dim > 256 and not head_dim_512_supported():
+        pytest.skip("16-bit FA2 head_dim > 256 is only supported on SM80 or newer")
+
+
 def build_causal_mask(qo_len, kv_len):
     i = torch.arange(qo_len).unsqueeze(1).to("cuda:0")
     j = torch.arange(kv_len).unsqueeze(0).to("cuda:0")
@@ -190,6 +200,7 @@ def test_single_prefill_with_kv_cache_nvfp4(
 
 
 def test_single_prefill_with_kv_cache_nvfp4_large_head():
+    skip_if_head_dim_unsupported(512)
     _run_single_prefill_with_kv_cache_nvfp4(
         kv_len=256,
         qo_len=64,
@@ -202,6 +213,7 @@ def test_single_prefill_with_kv_cache_nvfp4_large_head():
 
 
 def test_single_prefill_with_kv_cache_nvfp4_rope_large_head():
+    skip_if_head_dim_unsupported(512)
     _run_single_prefill_with_kv_cache_nvfp4(
         kv_len=128,
         qo_len=64,

--- a/tests/attention/test_single_prefill.py
+++ b/tests/attention/test_single_prefill.py
@@ -104,14 +104,7 @@ def test_sinqle_prefill_with_paged_kv_cache(
     torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("kv_len", [128, 256])
-@pytest.mark.parametrize("qo_len", [64, 128])
-@pytest.mark.parametrize("num_kv_heads", [1])
-@pytest.mark.parametrize("num_qo_heads", [1])
-@pytest.mark.parametrize("head_dim", [128])
-@pytest.mark.parametrize("causal", [False])
-@pytest.mark.parametrize("q_dtype", [torch.float16, torch.bfloat16])
-def test_single_prefill_with_kv_cache_nvfp4(
+def _run_single_prefill_with_kv_cache_nvfp4(
     kv_len,
     qo_len,
     num_kv_heads,
@@ -119,6 +112,7 @@ def test_single_prefill_with_kv_cache_nvfp4(
     head_dim,
     causal,
     q_dtype,
+    pos_encoding_mode="NONE",
 ):
     """Test single_prefill_with_kv_cache with NVFP4 KV cache (contiguous layout).
 
@@ -147,16 +141,74 @@ def test_single_prefill_with_kv_cache_nvfp4(
         k_packed,
         v_packed,
         causal=causal,
-        pos_encoding_mode="NONE",
+        pos_encoding_mode=pos_encoding_mode,
         logits_soft_cap=0.0,
         k_scale=k_global_scale.item(),
         v_scale=v_global_scale.item(),
         kv_cache_sf=(k_sf, v_sf),
+        backend="fa2",
     )
 
     o_ref = flashinfer.prefill.single_prefill_with_kv_cache(
-        q, k_dq, v_dq, causal=causal, pos_encoding_mode="NONE", logits_soft_cap=0.0
+        q,
+        k_dq,
+        v_dq,
+        causal=causal,
+        pos_encoding_mode=pos_encoding_mode,
+        logits_soft_cap=0.0,
     )
 
     # NVFP4 is 4-bit; use relaxed tolerance
     torch.testing.assert_close(o, o_ref, rtol=1e-1, atol=1e-1)
+
+
+@pytest.mark.parametrize("kv_len", [128, 256])
+@pytest.mark.parametrize("qo_len", [64, 128])
+@pytest.mark.parametrize("num_kv_heads", [1])
+@pytest.mark.parametrize("num_qo_heads", [1])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("causal", [False])
+@pytest.mark.parametrize("q_dtype", [torch.float16, torch.bfloat16])
+def test_single_prefill_with_kv_cache_nvfp4(
+    kv_len,
+    qo_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    causal,
+    q_dtype,
+):
+    _run_single_prefill_with_kv_cache_nvfp4(
+        kv_len,
+        qo_len,
+        num_kv_heads,
+        num_qo_heads,
+        head_dim,
+        causal,
+        q_dtype,
+    )
+
+
+def test_single_prefill_with_kv_cache_nvfp4_large_head():
+    _run_single_prefill_with_kv_cache_nvfp4(
+        kv_len=256,
+        qo_len=64,
+        num_kv_heads=1,
+        num_qo_heads=1,
+        head_dim=512,
+        causal=False,
+        q_dtype=torch.float16,
+    )
+
+
+def test_single_prefill_with_kv_cache_nvfp4_rope_large_head():
+    _run_single_prefill_with_kv_cache_nvfp4(
+        kv_len=128,
+        qo_len=64,
+        num_kv_heads=1,
+        num_qo_heads=1,
+        head_dim=512,
+        causal=False,
+        q_dtype=torch.float16,
+        pos_encoding_mode="ROPE_LLAMA",
+    )

--- a/tests/attention/test_sliding_window.py
+++ b/tests/attention/test_sliding_window.py
@@ -26,13 +26,13 @@ from flashinfer.utils import get_compute_capability, has_flashinfer_jit_cache
 
 
 def head_dim_512_supported() -> bool:
-    # head_dim > 256 is only supported on SM100+.
-    return get_compute_capability(torch.device("cuda:0"))[0] >= 10
+    # 16-bit FA2 head_dim > 256 uses the Ampere+ large-head path.
+    return get_compute_capability(torch.device("cuda:0"))[0] >= 8
 
 
 def skip_if_head_dim_unsupported(head_dim: int):
     if head_dim > 256 and not head_dim_512_supported():
-        pytest.skip("head_dim > 256 is only supported on SM100 or newer")
+        pytest.skip("16-bit FA2 head_dim > 256 is only supported on SM80 or newer")
 
 
 @pytest.fixture(

--- a/tests/test_helpers/jit_utils.py
+++ b/tests/test_helpers/jit_utils.py
@@ -20,7 +20,11 @@ import torch
 
 import flashinfer
 from flashinfer.jit import JitSpec
-from flashinfer.utils import is_fa3_backend_supported, is_sm90a_supported
+from flashinfer.utils import (
+    is_fa3_backend_supported,
+    is_fa3_prefill_head_dim_supported,
+    is_sm90a_supported,
+)
 
 
 def gen_decode_attention_modules(
@@ -153,12 +157,16 @@ def gen_prefill_attention_modules(
             if kv_dtype.itemsize > 1:
                 continue  # skip fp16/bf16 mixed precision
 
-        if is_sm90a_supported(torch.device("cuda")) and is_fa3_backend_supported(
-            pos_encoding_mode,
-            use_fp16_qk_reduction,
-            use_custom_mask=False,
-            dtype_q=q_dtype,
-            dtype_kv=kv_dtype,
+        if (
+            is_sm90a_supported(torch.device("cuda"))
+            and is_fa3_backend_supported(
+                pos_encoding_mode,
+                use_fp16_qk_reduction,
+                use_custom_mask=False,
+                dtype_q=q_dtype,
+                dtype_kv=kv_dtype,
+            )
+            and is_fa3_prefill_head_dim_supported(head_dim, head_dim)
         ):
             if q_dtype != kv_dtype:
                 continue  # fa3 template do not support mixed precision

--- a/tests/test_jit_cpp_ext.py
+++ b/tests/test_jit_cpp_ext.py
@@ -1,6 +1,10 @@
 import subprocess
 
+import pytest
+import torch
+
 from flashinfer.jit import core, cpp_ext
+from flashinfer.jit.attention import modules as attention_modules
 
 
 def test_nvcc_parallelism_flags_use_flashinfer_nvcc_threads(monkeypatch):
@@ -136,3 +140,36 @@ def test_jit_spec_build_rewrites_ninja_before_build(monkeypatch):
     spec.build(verbose=False, need_lock=False)
 
     assert writes == [True]
+
+
+def test_customize_batch_prefill_nvfp4_large_head_uses_prefill_flags(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+    monkeypatch.setattr(
+        attention_modules.current_compilation_context, "TARGET_CUDA_ARCHS", {(8, 6)}
+    )
+    monkeypatch.setattr(
+        attention_modules.jit_env, "FLASHINFER_GEN_SRC_DIR", tmp_path / "gen"
+    )
+
+    spec = attention_modules.gen_customize_batch_prefill_module(
+        "fa2",
+        "test_batch_prefill_nvfp4_large_head",
+        torch.float16,
+        torch.uint8,
+        torch.float16,
+        torch.int32,
+        512,
+        512,
+        [],
+        [],
+        ["sm_scale"],
+        ["double"],
+        "DefaultAttention<false, false, false, false>",
+        "#include <flashinfer/attention/variants.cuh>",
+    )
+
+    assert any("sm_86" in flag for flag in spec.extra_cuda_cflags)
+    with pytest.raises(RuntimeError, match="No supported CUDA architectures"):
+        attention_modules._fa2_head_dim_nvcc_flags(512, 512, torch.uint8)

--- a/tests/test_jit_cpp_ext.py
+++ b/tests/test_jit_cpp_ext.py
@@ -1,10 +1,18 @@
 import subprocess
+from types import SimpleNamespace
 
 import pytest
 import torch
 
+import flashinfer
 from flashinfer.jit import core, cpp_ext
 from flashinfer.jit.attention import modules as attention_modules
+from flashinfer.utils import (
+    PosEncodingMode,
+    determine_attention_backend,
+    is_fa3_prefill_head_dim_supported,
+)
+from tests.test_helpers import jit_utils
 
 
 def test_nvcc_parallelism_flags_use_flashinfer_nvcc_threads(monkeypatch):
@@ -173,3 +181,108 @@ def test_customize_batch_prefill_nvfp4_large_head_uses_prefill_flags(
     assert any("sm_86" in flag for flag in spec.extra_cuda_cflags)
     with pytest.raises(RuntimeError, match="No supported CUDA architectures"):
         attention_modules._fa2_head_dim_nvcc_flags(512, 512, torch.uint8)
+
+
+@pytest.mark.parametrize(
+    ("head_dim_qk", "head_dim_vo", "supported"),
+    [
+        (64, 64, True),
+        (128, 128, True),
+        (256, 256, True),
+        (192, 128, True),
+        (512, 512, False),
+        (256, 128, False),
+        (128, 192, False),
+    ],
+)
+def test_fa3_prefill_head_dim_supported(head_dim_qk, head_dim_vo, supported):
+    assert is_fa3_prefill_head_dim_supported(head_dim_qk, head_dim_vo) is supported
+
+
+@pytest.mark.parametrize(
+    ("head_dim_qk", "head_dim_vo", "expected_backend"),
+    [
+        (256, 256, "fa3"),
+        (192, 128, "fa3"),
+        (512, 512, "fa2"),
+    ],
+)
+def test_determine_attention_backend_respects_fa3_prefill_head_dim(
+    monkeypatch, head_dim_qk, head_dim_vo, expected_backend
+):
+    monkeypatch.setattr(flashinfer.utils, "is_sm90a_supported", lambda device: True)
+
+    backend = determine_attention_backend(
+        torch.device("cuda"),
+        PosEncodingMode.NONE.value,
+        use_fp16_qk_reductions=False,
+        use_custom_mask=False,
+        dtype_q=torch.float16,
+        dtype_kv=torch.float16,
+        head_dim_qk=head_dim_qk,
+        head_dim_vo=head_dim_vo,
+    )
+
+    assert backend == expected_backend
+
+
+def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
+    calls = []
+
+    def fake_single_prefill_module(
+        backend,
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        head_dim_qk,
+        head_dim_vo,
+        *_args,
+    ):
+        calls.append(("single", backend, head_dim_qk, head_dim_vo))
+        return SimpleNamespace(name=f"{backend}_single_{head_dim_qk}_{head_dim_vo}")
+
+    def fake_batch_prefill_module(
+        backend,
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        idtype,
+        head_dim_qk,
+        head_dim_vo,
+        *_args,
+    ):
+        calls.append(("batch", backend, head_dim_qk, head_dim_vo))
+        return SimpleNamespace(name=f"{backend}_batch_{head_dim_qk}_{head_dim_vo}")
+
+    monkeypatch.setattr(jit_utils, "is_sm90a_supported", lambda device: True)
+    monkeypatch.setattr(
+        flashinfer.prefill, "gen_single_prefill_module", fake_single_prefill_module
+    )
+    monkeypatch.setattr(
+        flashinfer.prefill, "gen_batch_prefill_module", fake_batch_prefill_module
+    )
+    monkeypatch.setattr(
+        flashinfer.quantization,
+        "gen_quantization_module",
+        lambda: SimpleNamespace(name="quantization"),
+    )
+    monkeypatch.setattr(
+        flashinfer.page,
+        "gen_page_module",
+        lambda: SimpleNamespace(name="page"),
+    )
+
+    jit_utils.gen_prefill_attention_modules(
+        q_dtypes=[torch.float16],
+        kv_dtypes=[torch.float16],
+        head_dims=[512],
+        pos_encoding_modes=[PosEncodingMode.NONE.value],
+        use_sliding_window_options=[False],
+        use_logits_soft_cap_options=[False],
+        use_fp16_qk_reduction_options=[False],
+    )
+
+    assert ("single", "fa3", 512, 512) not in calls
+    assert ("batch", "fa3", 512, 512) not in calls
+    assert ("single", "fa2", 512, 512) in calls
+    assert ("batch", "fa2", 512, 512) in calls


### PR DESCRIPTION
## 📌 Description

Enable FA2 large-head attention on SM80+ instead of treating the whole large-head path as SM100+ only.

This PR:
- Enables FA2 large-head 16-bit KV modules on SM80+.
- Enables NVFP4 large-head FA2 prefill on SM80+.
- Keeps NVFP4 large-head decode on SM100+ only.
- Adds VO-split handling and shared-memory budgeting updates for large-head prefill paths.
- Adds focused paged/ragged/single prefill coverage and updates large-head skip logic in related tests.
- Collapses the duplicate single/batch prefill NVCC flag helper into one shared helper.

The NVFP4 part is motivated by long-context serving on pre-SM100 GPUs. On Ampere cards like RTX 3090, large-head models hit the KV-cache capacity wall pretty fast, and NVFP4 is a practical way to push that limit back while staying on the FlashInfer FA2 prefill path.

That said, the support is intentionally partial on pre-SM100. This PR only enables NVFP4 large-head FA2 prefill on SM80+. Decode large-head NVFP4 kernels stay SM100+-only; I have not validated them on Ampere and do not want to claim otherwise. The scope is just unblocking the prefill/read path for longer-context workloads, not full one-byte large-head decode on Ampere.

Scope:
- NVFP4 large-head support on pre-SM100 is prefill-only.
- NVFP4 large-head decode remains SM100+ only.
- Does not change FA3 routing or holistic batch-attention generation.
- Does not include model-specific routing changes.
- Default AOT jit-cache exclusion for head_dim=512 is already handled by #3769; this PR leaves that list unchanged.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation performed:
- `pre-commit run --all-files`
- `git diff --check`
- `/nvme512g/util/vllm/.venv/bin/python -m py_compile flashinfer/aot.py flashinfer/jit/attention/modules.py`
- SM86 runtime correctness on RTX 3090: 14 large-head prefill/single-prefill tests passed in 734.19s.
- SM86 NVFP4 large-head decode skip check: skipped as expected because this PR keeps that path SM100+ only.
- SM100/B200 runtime validation provided by @qsang-nv in review: large-head prefill and NVFP4 large-head decode both passed.

SM86 runtime command:
```bash
CUDA_VISIBLE_DEVICES=0 \
/home/lesj0610/.uvenvs/vLLM_dev/bin/python -m pytest -q \
  tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_with_paged_kv_cache_head_dim_512 \
  tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_with_ragged_kv_cache_head_dim_512 \
  tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_with_paged_kv_cache_nvfp4_large_head \
  tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_with_paged_kv_cache_nvfp4_rope_large_head \
  tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_with_ragged_kv_cache_nvfp4_large_head \
  tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_with_ragged_kv_cache_nvfp4_rope_large_head \
  tests/attention/test_single_prefill.py::test_single_prefill_with_kv_cache_nvfp4_large_head \
  tests/attention/test_single_prefill.py::test_single_prefill_with_kv_cache_nvfp4_rope_large_head
```

Result: `14 passed, 2 warnings in 734.19s (0:12:14)`.

SM86 decode check:
```bash
CUDA_VISIBLE_DEVICES=0 \
/home/lesj0610/.uvenvs/vLLM_dev/bin/python -m pytest -q \
  tests/attention/test_batch_decode_kernels.py::test_batch_decode_with_paged_kv_cache_nvfp4_large_head
```

Result: `1 skipped, 2 warnings in 0.38s`.

SM100/B200 results from @qsang-nv:
- Large-head prefill tests: `14 passed in 399.96s`.
- NVFP4 large-head decode test: `1 passed in 445.47s`.

Not yet verified:
- Full CUDA/JIT regression matrix across dtype, page-size, mask, sliding-window, and positional-encoding combinations.
- Runtime performance counters for local-memory traffic across all targeted architectures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended FA2 attention kernel generation and coverage for larger head dimensions (e.g., head_dim=512), with improved handling of NVFP4 KV formats.
  * NVFP4 large-head prefill tests now validate positional encoding modes (NONE and ROPE).

* **Bug Fixes**
  * Refined GPU compute-capability gating to better reflect supported configurations, reducing incorrect skips and aligning decode vs. prefill behavior for NVFP4 large-head cases.

* **Tests**
  * Added/updated regression and end-to-end tests for paged and ragged KV-cache prefill/decode, including NVFP4 large-head scenarios and dtype-aware skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

