### PR TITLE
Add caller-owned workspace sizing helper

### DIFF
--- a/csrc/batch_decode.cu
+++ b/csrc/batch_decode.cu
@@ -80,6 +80,52 @@ Array<int64_t> BatchDecodeWithPagedKVCachePlan(
   return Array(plan_info.ToVector());
 }
 
+Array<int64_t> BatchDecodeWithPagedKVCacheWorkspaceSize(
+    TensorView device_buffer, TensorView indptr, int64_t batch_size, int64_t num_qo_heads,
+    int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t window_left,
+    double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo, TensorView empty_q_data,
+    TensorView empty_kv_data) {
+  (void)window_left;
+  (void)logits_soft_cap;
+  (void)empty_q_data;
+  (void)empty_kv_data;
+  CHECK_INPUT_TYPE(indptr, dl_int32);
+
+  TVM_FFI_ICHECK_EQ(head_dim_qk, head_dim_vo)
+      << "CUDA cores template only supports equal head dim for QK and VO, please use tensor "
+         "cores template for different head dim";
+
+  ffi::CUDADeviceGuard device_guard(device_buffer.device().device_id);
+  const cudaStream_t stream = get_stream(device_buffer.device());
+  size_t float_workspace_size_in_bytes = 0;
+  size_t int_workspace_size_in_bytes = 0;
+
+  DISPATCH_context(
+      DTypeQ, DTypeKV, DTypeO, IdType, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
+      USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, AttentionVariant, Params, [&] {
+        DISPATCH_GQA_GROUP_SIZE(num_qo_heads / num_kv_heads, GROUP_SIZE, {
+          auto work_estimation_func = BatchDecodeWithPagedKVCacheWorkEstimationDispatched<
+              GROUP_SIZE, HEAD_DIM_QK, POS_ENCODING_MODE, AttentionVariant, Params>;
+          cudaError_t status =
+              DecodePlanWorkspaceSize<HEAD_DIM_QK, POS_ENCODING_MODE, AttentionVariant, Params>(
+                  float_workspace_size_in_bytes, int_workspace_size_in_bytes,
+                  static_cast<IdType*>(indptr.data_ptr()), batch_size, num_qo_heads, page_size,
+                  enable_cuda_graph, /*stream=*/stream, work_estimation_func);
+
+          TVM_FFI_ICHECK(status == cudaSuccess)
+              << "BatchDecodeWithPagedKVCache workspace size failed with error "
+              << cudaGetErrorString(status);
+          return true;
+        });
+      });
+
+  std::vector<int64_t> workspace_sizes = {
+      static_cast<int64_t>(float_workspace_size_in_bytes),
+      static_cast<int64_t>(int_workspace_size_in_bytes),
+  };
+  return Array(workspace_sizes);
+}
+
 void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                     TensorView int_workspace_buffer, Array<int64_t> plan_info_vec,
                                     TensorView q, TensorView paged_k_cache,

--- a/csrc/batch_decode_jit_binding.cu
+++ b/csrc/batch_decode_jit_binding.cu
@@ -27,6 +27,12 @@ Array<int64_t> BatchDecodeWithPagedKVCachePlan(
     int64_t window_left, double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo,
     TensorView empty_q_data, TensorView empty_kv_data);
 
+Array<int64_t> BatchDecodeWithPagedKVCacheWorkspaceSize(
+    TensorView device_buffer, TensorView indptr, int64_t batch_size, int64_t num_qo_heads,
+    int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t window_left,
+    double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo, TensorView empty_q_data,
+    TensorView empty_kv_data);
+
 void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                     TensorView int_workspace_buffer, Array<int64_t> plan_info_vec,
                                     TensorView q, TensorView paged_k_cache,
@@ -38,5 +44,7 @@ void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
 
 // Batched decode with paged KV-Cache plan
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, BatchDecodeWithPagedKVCachePlan);
+// Batched decode with paged KV-Cache workspace size
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(workspace_size, BatchDecodeWithPagedKVCacheWorkspaceSize);
 // Batched decode with paged KV-Cache run
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, BatchDecodeWithPagedKVCacheRun);

--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -75,6 +75,36 @@ Array<int64_t> BatchPrefillWithKVCachePlan(
   return Array(plan_info.ToVector());
 }
 
+Array<int64_t> BatchPrefillWithKVCacheWorkspaceSize(
+    TensorView device_buffer, TensorView qo_indptr, TensorView kv_indptr, TensorView kv_len_arr,
+    int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads, int64_t num_kv_heads,
+    int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk, int64_t head_dim_vo,
+    bool causal, int64_t window_left, int64_t fixed_split_size, bool disable_split_kv,
+    int64_t num_colocated_ctas = 0) {
+  (void)kv_len_arr;
+  (void)causal;
+  size_t float_workspace_size_in_bytes = 0;
+  size_t int_workspace_size_in_bytes = 0;
+
+  ffi::CUDADeviceGuard device_guard(device_buffer.device().device_id);
+  const cudaStream_t stream = get_stream(device_buffer.device());
+  cudaError_t status = PrefillPlanWorkspaceSize<IdType>(
+      float_workspace_size_in_bytes, int_workspace_size_in_bytes,
+      static_cast<IdType*>(qo_indptr.data_ptr()), static_cast<IdType*>(kv_indptr.data_ptr()),
+      total_num_rows, batch_size, num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size,
+      enable_cuda_graph, /*sizeof_dtype_o=*/2, window_left, fixed_split_size, disable_split_kv,
+      num_colocated_ctas, stream);
+
+  TVM_FFI_ICHECK(status == cudaSuccess)
+      << "Failed to calculate prefill workspace size with error: " << cudaGetErrorString(status);
+
+  std::vector<int64_t> workspace_sizes = {
+      static_cast<int64_t>(float_workspace_size_in_bytes),
+      static_cast<int64_t>(int_workspace_size_in_bytes),
+  };
+  return Array(workspace_sizes);
+}
+
 void BatchPrefillWithRaggedKVCacheRun(TensorView float_workspace_buffer,
                                       TensorView int_workspace_buffer, Array<int64_t> plan_info_vec,
                                       TensorView q, TensorView k, TensorView v,

--- a/csrc/batch_prefill_jit_binding.cu
+++ b/csrc/batch_prefill_jit_binding.cu
@@ -27,6 +27,13 @@ Array<int64_t> BatchPrefillWithKVCachePlan(
     int64_t head_dim_vo, bool causal, int64_t window_left, int64_t fixed_split_size,
     bool disable_split_kv, int64_t num_colocated_ctas);
 
+Array<int64_t> BatchPrefillWithKVCacheWorkspaceSize(
+    TensorView device_buffer, TensorView qo_indptr, TensorView kv_indptr, TensorView kv_len_arr,
+    int64_t total_num_rows, int64_t batch_size, int64_t num_qo_heads, int64_t num_kv_heads,
+    int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk, int64_t head_dim_vo,
+    bool causal, int64_t window_left, int64_t fixed_split_size, bool disable_split_kv,
+    int64_t num_colocated_ctas);
+
 void BatchPrefillWithRaggedKVCacheRun(TensorView float_workspace_buffer,
                                       TensorView int_workspace_buffer, Array<int64_t> plan_info_vec,
                                       TensorView q, TensorView k, TensorView v,
@@ -46,5 +53,6 @@ void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                      bool enable_pdl ADDITIONAL_FUNC_PARAMS);
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(plan, BatchPrefillWithKVCachePlan);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(workspace_size, BatchPrefillWithKVCacheWorkspaceSize);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(ragged_run, BatchPrefillWithRaggedKVCacheRun);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(paged_run, BatchPrefillWithPagedKVCacheRun);

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -233,7 +233,7 @@ def get_batch_decode_module(*args):
     uri = get_batch_decode_uri(*args)
     mod = gen_batch_decode_module(*args).build_and_load()
     plan_func = mod.plan
-    workspace_size_func = mod.workspace_size
+    workspace_size_func = getattr(mod, "workspace_size", None)
     run_func = mod.run
 
     # torch library for batch_decode_with_paged_kv_cache_run
@@ -735,7 +735,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         float_workspace_buffer : torch.Tensor. Must be initialized to 0 for its first use.
             The user reserved float workspace buffer used to store intermediate attention results
             in the split-k algorithm. The recommended size is 128MB, the device of the workspace
-            buffer should be the same as the device of the input tensors.
+            buffer should be the same as the device of the input tensors. The buffer must be
+            16-byte aligned; tensors created by ``torch.empty`` satisfy this on supported devices.
 
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.
@@ -1888,7 +1889,8 @@ class BatchDecodeMlaWithPagedKVCacheWrapper:
         float_workspace_buffer : torch.Tensor
             The user reserved float workspace buffer used to store intermediate attention results
             in the split-k algorithm. The recommended size is 128MB, the device of the workspace
-            buffer should be the same as the device of the input tensors.
+            buffer should be the same as the device of the input tensors. The buffer must be
+            16-byte aligned; tensors created by ``torch.empty`` satisfy this on supported devices.
 
         use_cuda_graph : bool
             Whether to enable CUDAGraph for batch decode attention, if enabled, the

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -903,6 +903,189 @@ class BatchDecodeWithPagedKVCacheWrapper:
         )
 
     @flashinfer_api
+    def workspace_size(
+        self,
+        indptr: torch.Tensor,
+        indices: torch.Tensor,
+        last_page_len: torch.Tensor,
+        num_qo_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        page_size: int,
+        pos_encoding_mode: str = "NONE",
+        window_left: int = -1,
+        logits_soft_cap: Optional[float] = None,
+        q_data_type: Optional[Union[str, torch.dtype]] = "float16",
+        kv_data_type: Optional[Union[str, torch.dtype]] = None,
+        o_data_type: Optional[Union[str, torch.dtype]] = None,
+        data_type: Optional[Union[str, torch.dtype]] = None,
+        sm_scale: Optional[float] = None,
+        rope_scale: Optional[float] = None,
+        rope_theta: Optional[float] = None,
+        block_tables: Optional[torch.Tensor] = None,
+        seq_lens: Optional[torch.Tensor] = None,
+        fixed_split_size: Optional[int] = None,
+        disable_split_kv: bool = False,
+        q_len_per_req: int = 1,
+    ) -> Tuple[int, int]:
+        r"""Return the caller-owned workspace size required by :meth:`plan`.
+
+        The returned tuple is ``(float_workspace_size, int_workspace_size)`` in
+        bytes.  The inputs follow :meth:`plan`; host-side planning tensors such
+        as ``indptr`` and ``last_page_len`` are copied to CPU in the same way as
+        :meth:`plan`.  The wrapper's float workspace buffer is only used as the
+        device/stream selector for the underlying module query.  This method
+        does not allocate buffers and does not mutate cached plan state.
+
+        Example
+        -------
+        >>> float_bytes, int_bytes = wrapper.workspace_size(...)
+        >>> wrapper.reset_workspace_buffer(
+        ...     torch.empty(float_bytes, dtype=torch.uint8, device="cuda"),
+        ...     torch.empty(int_bytes, dtype=torch.uint8, device="cuda"),
+        ... )
+        >>> wrapper.plan(...)
+        """
+        del block_tables, q_len_per_req, rope_scale, rope_theta, sm_scale
+        batch_size = len(last_page_len)
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
+        if data_type is not None:
+            if q_data_type is None:
+                q_data_type = data_type
+            if kv_data_type is None:
+                kv_data_type = data_type
+        q_data_type = canonicalize_torch_dtype(q_data_type)
+        if kv_data_type is None:
+            kv_data_type = q_data_type
+        kv_data_type = canonicalize_torch_dtype(kv_data_type)
+        if o_data_type is None:
+            o_data_type = q_data_type
+        o_data_type = canonicalize_torch_dtype(o_data_type)
+
+        if fixed_split_size is not None and not self.use_tensor_cores:
+            raise ValueError(
+                "fixed_split_size is only supported by tensor core decode for now."
+            )
+        if fixed_split_size is None:
+            fixed_split_size = -1
+        if self.is_cuda_graph_enabled:
+            if batch_size != self._fixed_batch_size:
+                raise ValueError(
+                    "The batch size should be fixed in cudagraph mode, the runtime batch size {} "
+                    " mismatches the batch size set during initialization {}".format(
+                        batch_size, self._fixed_batch_size
+                    )
+                )
+            if len(indices) > len(self._paged_kv_indices_buf):
+                raise ValueError(
+                    "The size of indices should be less than or equal to the allocated buffer"
+                )
+
+        indptr_host = indptr.to("cpu")
+        last_page_len_host = last_page_len.to("cpu")
+        if seq_lens is None:
+            kv_lens_arr_host = get_seq_lens(indptr_host, last_page_len_host, page_size)
+        else:
+            kv_lens_arr_host = seq_lens.cpu()
+
+        backend = self._backend
+        if backend in ("cute-dsl", "trtllm-gen"):
+            raise NotImplementedError(
+                f"workspace_size is not available for decode backend {backend!r}"
+            )
+
+        if self.use_tensor_cores:
+            if self._jit_module is not None:
+                module = self._jit_module
+            else:
+                if backend == "auto":
+                    if {
+                        torch.float8_e4m3fn,
+                        torch.float8_e5m2,
+                    } & {q_data_type, kv_data_type}:
+                        backend = determine_attention_backend(
+                            self.device,
+                            PosEncodingMode[pos_encoding_mode].value,
+                            False,  # use_fp16_qk_reductions
+                            False,  # use_custom_mask
+                            q_data_type,
+                            kv_data_type,
+                        )
+                    else:
+                        backend = "fa2"
+                module = get_batch_prefill_module(
+                    backend,
+                    q_data_type,
+                    kv_data_type,
+                    o_data_type,
+                    indptr.dtype,
+                    head_dim,
+                    head_dim,
+                    PosEncodingMode[pos_encoding_mode].value,
+                    window_left != -1,
+                    logits_soft_cap > 0,
+                    False,
+                )
+            qo_indptr_host = _get_range_buf(batch_size + 1, "cpu")
+            args = [
+                self._float_workspace_buffer,
+                qo_indptr_host,
+                indptr_host,
+                kv_lens_arr_host,
+                batch_size,  # total_num_rows
+                batch_size,
+                num_qo_heads,
+                num_kv_heads,
+                page_size,
+                self.is_cuda_graph_enabled,
+                head_dim,
+                head_dim,
+                False,  # causal
+                window_left,
+            ]
+            if backend == "fa2":
+                args.append(fixed_split_size)
+                args.append(disable_split_kv)
+                args.append(0)  # num_colocated_ctas
+        else:
+            if self._jit_module is not None:
+                module = self._jit_module
+            else:
+                module = get_batch_decode_module(
+                    q_data_type,
+                    kv_data_type,
+                    o_data_type,
+                    indptr.dtype,
+                    head_dim,
+                    head_dim,
+                    PosEncodingMode[pos_encoding_mode].value,
+                    window_left != -1,
+                    logits_soft_cap > 0,
+                )
+            args = [
+                self._float_workspace_buffer,
+                indptr_host,
+                batch_size,
+                num_qo_heads,
+                num_kv_heads,
+                page_size,
+                self.is_cuda_graph_enabled,
+                window_left,
+                logits_soft_cap,
+                head_dim,
+                head_dim,
+                torch.empty(0, dtype=q_data_type),
+                torch.empty(0, dtype=kv_data_type),
+            ]
+        if module.workspace_size is None:
+            raise NotImplementedError(
+                f"workspace_size is not available for decode backend {backend!r}"
+            )
+        float_workspace_size, int_workspace_size = module.workspace_size(*args)
+        return int(float_workspace_size), int(int_workspace_size)
+
+    @flashinfer_api
     def plan(
         self,
         indptr: torch.Tensor,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -152,6 +152,7 @@ def get_single_decode_module(*args):
 @functools.cache
 def get_batch_decode_jit_module(module_name: str, jit_module: Any):
     plan_func = jit_module.plan
+    workspace_size_func = getattr(jit_module, "workspace_size", None)
     run_func = jit_module.run
 
     @register_custom_op(
@@ -222,6 +223,7 @@ def get_batch_decode_jit_module(module_name: str, jit_module: Any):
 
     return SimpleNamespace(
         plan=plan_func,
+        workspace_size=workspace_size_func,
         run=run_batch_decode,
     )
 
@@ -231,6 +233,7 @@ def get_batch_decode_module(*args):
     uri = get_batch_decode_uri(*args)
     mod = gen_batch_decode_module(*args).build_and_load()
     plan_func = mod.plan
+    workspace_size_func = mod.workspace_size
     run_func = mod.run
 
     # torch library for batch_decode_with_paged_kv_cache_run
@@ -319,6 +322,7 @@ def get_batch_decode_module(*args):
     # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
     return SimpleNamespace(
         plan=plan_func,
+        workspace_size=workspace_size_func,
         run=run_batch_decode,
     )
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -66,6 +66,7 @@ from .utils import (
     _check_cached_qkv_data_type,
     _check_kv_layout,
     _check_pos_encoding_mode,
+    _check_workspace_buffer_alignment,
     check_shape_dtype_device,
     get_alibi_slopes,
     _get_cache_alibi_slopes_buf,
@@ -779,6 +780,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
             If provided, the wrapper will use the provided arguments to create the JIT module,
             otherwise, the wrapper will use default attention implementation.
         """
+        _check_workspace_buffer_alignment(
+            float_workspace_buffer, "float_workspace_buffer"
+        )
         _check_kv_layout(kv_layout)
 
         if backend == "cute-dsl" and jit_args is not None:
@@ -893,6 +897,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
             The new int workspace buffer, the device of the new int workspace buffer should
             be the same as the device of the input tensors.
         """
+        _check_workspace_buffer_alignment(
+            float_workspace_buffer, "float_workspace_buffer"
+        )
+        _check_workspace_buffer_alignment(int_workspace_buffer, "int_workspace_buffer")
         self._float_workspace_buffer = float_workspace_buffer
         self._int_workspace_buffer = int_workspace_buffer
         self._pin_memory_int_workspace_buffer = torch.empty(
@@ -946,6 +954,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
         ... )
         >>> wrapper.plan(...)
         """
+        _check_workspace_buffer_alignment(
+            self._float_workspace_buffer, "float_workspace_buffer"
+        )
         del block_tables, q_len_per_req, rope_scale, rope_theta, sm_scale
         batch_size = len(last_page_len)
         if logits_soft_cap is None:
@@ -1193,6 +1204,12 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         The :meth:`plan` method cannot be used in Cuda Graph or in ``torch.compile``.
         """
+        _check_workspace_buffer_alignment(
+            self._float_workspace_buffer, "float_workspace_buffer"
+        )
+        _check_workspace_buffer_alignment(
+            self._int_workspace_buffer, "int_workspace_buffer"
+        )
         self._workspace_size = (
             self._float_workspace_buffer.numel()
             * self._float_workspace_buffer.element_size()

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -440,12 +440,14 @@ def get_batch_prefill_module(backend, *args):
         uri = "trtllm_gen_context"
         module = get_trtllm_gen_prefill_module()
         plan_func = module.plan
+        workspace_size_func = None
         ragged_run_func = module.ragged_run
         paged_run_func = module.paged_run
     else:
         uri = get_batch_prefill_uri(backend, *args)
         module = gen_batch_prefill_module(backend, *args).build_and_load()
         plan_func = module.plan
+        workspace_size_func = module.workspace_size
         ragged_run_func = module.ragged_run
         paged_run_func = module.paged_run
 
@@ -864,6 +866,7 @@ def get_batch_prefill_module(backend, *args):
     # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
     return SimpleNamespace(
         plan=plan_func,
+        workspace_size=workspace_size_func,
         ragged_run=ragged_run,
         paged_run=paged_run,
     )
@@ -872,6 +875,7 @@ def get_batch_prefill_module(backend, *args):
 @functools.cache
 def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
     plan_func = jit_module.plan
+    workspace_size_func = getattr(jit_module, "workspace_size", None)
     ragged_run_func = jit_module.ragged_run
     paged_run_func = jit_module.paged_run
 
@@ -1013,6 +1017,7 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
     # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
     return SimpleNamespace(
         plan=plan_func,
+        workspace_size=workspace_size_func,
         ragged_run=ragged_run,
         paged_run=paged_run,
     )

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1768,6 +1768,185 @@ class BatchPrefillWithPagedKVCacheWrapper:
         )
 
     @flashinfer_api
+    def workspace_size(
+        self,
+        qo_indptr: torch.Tensor,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        paged_kv_last_page_len: torch.Tensor,
+        num_qo_heads: int,
+        num_kv_heads: int,
+        head_dim_qk: int,
+        page_size: int,
+        head_dim_vo: Optional[int] = None,
+        custom_mask: Optional[torch.Tensor] = None,
+        packed_custom_mask: Optional[torch.Tensor] = None,
+        causal: bool = False,
+        pos_encoding_mode: str = "NONE",
+        use_fp16_qk_reduction: bool = False,
+        sm_scale: Optional[float] = None,
+        window_left: int = -1,
+        logits_soft_cap: Optional[float] = None,
+        rope_scale: Optional[float] = None,
+        rope_theta: Optional[float] = None,
+        q_data_type: Union[str, torch.dtype] = "float16",
+        kv_data_type: Optional[Union[str, torch.dtype]] = None,
+        o_data_type: Optional[Union[str, torch.dtype]] = None,
+        prefix_len_ptr: Optional[torch.Tensor] = None,
+        token_pos_in_items_ptr: Optional[torch.Tensor] = None,
+        token_pos_in_items_len: int = 0,
+        max_item_len_ptr: Optional[torch.Tensor] = None,
+        seq_lens: Optional[torch.Tensor] = None,
+        seq_lens_q: Optional[torch.Tensor] = None,
+        block_tables: Optional[torch.Tensor] = None,
+        max_token_per_sequence: Optional[int] = None,
+        max_sequence_kv: Optional[int] = None,
+        fixed_split_size: Optional[int] = None,
+        disable_split_kv: bool = False,
+    ) -> Tuple[int, int]:
+        r"""Return the caller-owned workspace size required by :meth:`plan`.
+
+        The returned tuple is ``(float_workspace_size, int_workspace_size)`` in
+        bytes.  The inputs follow :meth:`plan`; host-side planning tensors such
+        as ``qo_indptr`` and ``paged_kv_indptr`` are copied to CPU in the same
+        way as :meth:`plan`.  The wrapper's float workspace buffer is only used
+        as the device/stream selector for the underlying module query.  This
+        method does not allocate buffers and does not mutate cached plan state.
+
+        Example
+        -------
+        >>> float_bytes, int_bytes = wrapper.workspace_size(...)
+        >>> wrapper.reset_workspace_buffer(
+        ...     torch.empty(float_bytes, dtype=torch.uint8, device="cuda"),
+        ...     torch.empty(int_bytes, dtype=torch.uint8, device="cuda"),
+        ... )
+        >>> wrapper.plan(...)
+        """
+        del (
+            block_tables,
+            max_item_len_ptr,
+            max_token_per_sequence,
+            prefix_len_ptr,
+            rope_scale,
+            rope_theta,
+            seq_lens_q,
+            sm_scale,
+            token_pos_in_items_len,
+            token_pos_in_items_ptr,
+        )
+        q_data_type = canonicalize_torch_dtype(q_data_type)
+        if kv_data_type is None:
+            kv_data_type = q_data_type
+        kv_data_type = canonicalize_torch_dtype(kv_data_type)
+        if o_data_type is None:
+            o_data_type = q_data_type
+        o_data_type = canonicalize_torch_dtype(o_data_type)
+
+        if logits_soft_cap is None:
+            logits_soft_cap = 0.0
+        if head_dim_vo is None:
+            head_dim_vo = head_dim_qk
+        if fixed_split_size is None:
+            fixed_split_size = -1
+
+        batch_size = len(qo_indptr) - 1
+        qo_indptr_host = qo_indptr.to("cpu")
+        total_num_rows = int(qo_indptr_host[-1])
+        paged_kv_indptr_host = paged_kv_indptr.to("cpu")
+        paged_kv_last_page_len_host = paged_kv_last_page_len.to("cpu")
+        if seq_lens is None:
+            kv_lens_arr_host = get_seq_lens(
+                paged_kv_indptr_host, paged_kv_last_page_len_host, page_size
+            )
+        else:
+            kv_lens_arr_host = seq_lens.cpu().flatten()
+
+        if self.is_cuda_graph_enabled:
+            if batch_size != self._fixed_batch_size:
+                raise ValueError(
+                    "The batch size should be fixed during the lifecycle of the wrapper in "
+                    "cuda graph mode, the runtime batch size {} mismatches the batch size {} "
+                    " set during initialization.".format(
+                        batch_size, self._fixed_batch_size
+                    )
+                )
+            if len(paged_kv_indices) > len(self._paged_kv_indices_buf):
+                raise ValueError(
+                    "The length of paged_kv_indices exceeds the allocated buffer size."
+                )
+            if (
+                self._max_total_num_rows is not None
+                and total_num_rows > self._max_total_num_rows
+            ):
+                raise ValueError(
+                    "The total number of rows in qo_indptr {} in cuda graph mode cannot "
+                    "exceed the number of rows set during initialization {}.".format(
+                        total_num_rows, self._max_total_num_rows
+                    )
+                )
+
+        use_custom_mask = custom_mask is not None or packed_custom_mask is not None
+        backend = self._backend
+        if self._jit_module is not None:
+            module = self._jit_module
+        else:
+            if backend == "auto":
+                backend = determine_attention_backend(
+                    self.device,
+                    PosEncodingMode[pos_encoding_mode].value,
+                    use_fp16_qk_reduction,
+                    use_custom_mask,
+                    q_data_type,
+                    kv_data_type,
+                )
+            if backend == "cudnn":
+                raise NotImplementedError(
+                    "workspace_size is not available for cudnn prefill backend"
+                )
+            module = get_batch_prefill_module(
+                backend,
+                q_data_type,
+                kv_data_type,
+                o_data_type,
+                paged_kv_indptr.dtype,
+                head_dim_qk,
+                head_dim_vo,
+                PosEncodingMode[pos_encoding_mode].value,
+                window_left >= 0,
+                logits_soft_cap > 0,
+                use_fp16_qk_reduction,
+            )
+        if module.workspace_size is None:
+            raise NotImplementedError(
+                f"workspace_size is not available for prefill backend {backend!r}"
+            )
+
+        del max_sequence_kv
+        total_num_rows_for_plan = self._max_total_num_rows or total_num_rows
+        args = [
+            self._float_workspace_buffer,
+            qo_indptr_host,
+            paged_kv_indptr_host,
+            kv_lens_arr_host,
+            total_num_rows_for_plan,
+            batch_size,
+            num_qo_heads,
+            num_kv_heads,
+            page_size,
+            self.is_cuda_graph_enabled,
+            head_dim_qk,
+            head_dim_vo,
+            causal,
+            window_left,
+        ]
+        if backend == "fa2":
+            args.append(fixed_split_size)
+            args.append(disable_split_kv)
+            args.append(0)  # num_colocated_ctas
+        float_workspace_size, int_workspace_size = module.workspace_size(*args)
+        return int(float_workspace_size), int(int_workspace_size)
+
+    @flashinfer_api
     def plan(
         self,
         qo_indptr: torch.Tensor,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -447,7 +447,7 @@ def get_batch_prefill_module(backend, *args):
         uri = get_batch_prefill_uri(backend, *args)
         module = gen_batch_prefill_module(backend, *args).build_and_load()
         plan_func = module.plan
-        workspace_size_func = module.workspace_size
+        workspace_size_func = getattr(module, "workspace_size", None)
         ragged_run_func = module.ragged_run
         paged_run_func = module.paged_run
 
@@ -1593,7 +1593,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         float_workspace_buffer : torch.Tensor
             The user reserved workspace buffer used to store intermediate attention results in
             split-k algorithm. The recommended size is 128MB, the device of the workspace buffer
-            should be the same as the device of the input tensors.
+            should be the same as the device of the input tensors. The buffer must be 16-byte
+            aligned; tensors created by ``torch.empty`` satisfy this on supported devices.
 
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.
@@ -2736,7 +2737,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         float_workspace_buffer : torch.Tensor
             The user reserved float workspace buffer used to store intermediate attention results
             in the split-k algorithm. The recommended size is 128MB, the device of the workspace
-            buffer should be the same as the device of the input tensors.
+            buffer should be the same as the device of the input tensors. The buffer must be
+            16-byte aligned; tensors created by ``torch.empty`` satisfy this on supported devices.
 
         kv_layout : str
             The layout of the input k/v tensors, could be either ``NHD`` or ``HND``.

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -59,6 +59,7 @@ from .utils import (
     _check_cached_qkv_data_type,
     _check_kv_layout,
     _check_pos_encoding_mode,
+    _check_workspace_buffer_alignment,
     check_shape_dtype_device,
     get_alibi_slopes,
     _get_cache_alibi_slopes_buf,
@@ -1650,6 +1651,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
         jit_kwargs : Optional[Dict[str, Any]]
             The keyword arguments to create the JIT module, defaults to None.
         """
+        _check_workspace_buffer_alignment(
+            float_workspace_buffer, "float_workspace_buffer"
+        )
         _check_kv_layout(kv_layout)
 
         if backend == "cute-dsl":
@@ -1758,6 +1762,10 @@ class BatchPrefillWithPagedKVCacheWrapper:
             The new int workspace buffer, the device of the new int workspace buffer should
             be the same as the device of the input tensors.
         """
+        _check_workspace_buffer_alignment(
+            float_workspace_buffer, "float_workspace_buffer"
+        )
+        _check_workspace_buffer_alignment(int_workspace_buffer, "int_workspace_buffer")
         self._float_workspace_buffer = float_workspace_buffer
         self._int_workspace_buffer = int_workspace_buffer
         self._pin_memory_int_workspace_buffer = torch.empty(
@@ -1822,6 +1830,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
         ... )
         >>> wrapper.plan(...)
         """
+        _check_workspace_buffer_alignment(
+            self._float_workspace_buffer, "float_workspace_buffer"
+        )
         del (
             block_tables,
             max_item_len_ptr,
@@ -2105,6 +2116,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         The :meth:`plan` method cannot be used in Cuda Graph or in ``torch.compile``.
         """
+        _check_workspace_buffer_alignment(
+            self._float_workspace_buffer, "float_workspace_buffer"
+        )
+        _check_workspace_buffer_alignment(
+            self._int_workspace_buffer, "int_workspace_buffer"
+        )
         q_data_type = canonicalize_torch_dtype(q_data_type)
         if kv_data_type is None:
             kv_data_type = q_data_type

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -664,6 +664,19 @@ def check_shape_dtype_device(
         )
 
 
+def _check_workspace_buffer_alignment(
+    x: torch.Tensor, name: str, alignment: int = 16
+) -> None:
+    if x.numel() == 0:
+        return
+    data_ptr = x.data_ptr()
+    if data_ptr % alignment != 0:
+        raise ValueError(
+            f"{name} must be {alignment}-byte aligned, got data_ptr % "
+            f"{alignment} = {data_ptr % alignment}"
+        )
+
+
 @functools.cache
 def get_logging_module():
     return gen_spdlog_module().build_and_load()

--- a/include/flashinfer/allocator.h
+++ b/include/flashinfer/allocator.h
@@ -17,6 +17,7 @@
 #define FLASHINFER_ALLOCATOR_H_
 
 #include <memory>
+#include <limits>
 #include <sstream>
 
 #include "exception.h"
@@ -33,9 +34,28 @@ struct AlignedAllocator {
   void* base_ptr;
   void* cur_ptr;
   size_t remaining_space;
-  AlignedAllocator(void* buf, size_t space) : base_ptr(buf), cur_ptr(buf), remaining_space(space) {}
+  size_t allocated_space;
+  bool count_only;
+  AlignedAllocator(void* buf, size_t space)
+      : base_ptr(buf),
+        cur_ptr(buf),
+        remaining_space(space),
+        allocated_space(0),
+        count_only(false) {}
+  explicit AlignedAllocator(size_t space = std::numeric_limits<size_t>::max())
+      : base_ptr(nullptr),
+        cur_ptr(nullptr),
+        remaining_space(space),
+        allocated_space(0),
+        count_only(true) {}
   template <typename T>
   T* aligned_alloc(size_t size, size_t alignment, std::string name) {
+    if (count_only) {
+      std::ostringstream oss;
+      oss << "AlignedAllocator::aligned_alloc cannot return a pointer in counting mode for "
+          << name;
+      FLASHINFER_ERROR(oss.str());
+    }
     if (std::align(alignment, size, cur_ptr, remaining_space)) {
       T* result = reinterpret_cast<T*>(cur_ptr);
       cur_ptr = (char*)cur_ptr + size;
@@ -52,10 +72,29 @@ struct AlignedAllocator {
   }
 
   size_t aligned_alloc_offset(size_t size, size_t alignment, std::string name) {
+    if (count_only) {
+      size_t padding = 0;
+      if (alignment > 1) {
+        padding = (alignment - (allocated_space % alignment)) % alignment;
+      }
+      if (padding > remaining_space || size > remaining_space - padding) {
+        std::ostringstream oss;
+        oss << "Buffer overflow when allocating memory for " << name << " with size " << size
+            << " and alignment " << alignment << ", but only " << remaining_space
+            << " bytes available in AlignedAllocator. Increase the workspace buffer size.";
+        FLASHINFER_ERROR(oss.str());
+      }
+      const size_t result = allocated_space + padding;
+      allocated_space = result + size;
+      remaining_space -= padding + size;
+      return result;
+    }
     return (char*)aligned_alloc<char>(size, alignment, name) - (char*)base_ptr;
   }
 
-  size_t num_allocated_bytes() { return (char*)cur_ptr - (char*)base_ptr; }
+  size_t num_allocated_bytes() {
+    return count_only ? allocated_space : (char*)cur_ptr - (char*)base_ptr;
+  }
 };
 
 }  // namespace flashinfer

--- a/include/flashinfer/allocator.h
+++ b/include/flashinfer/allocator.h
@@ -16,8 +16,8 @@
 #ifndef FLASHINFER_ALLOCATOR_H_
 #define FLASHINFER_ALLOCATOR_H_
 
-#include <memory>
 #include <limits>
+#include <memory>
 #include <sstream>
 
 #include "exception.h"

--- a/include/flashinfer/allocator.h
+++ b/include/flashinfer/allocator.h
@@ -42,6 +42,8 @@ struct AlignedAllocator {
         remaining_space(space),
         allocated_space(0),
         count_only(false) {}
+  // Counting mode starts from offset 0 and assumes caller-owned workspace
+  // buffers are aligned to every allocation alignment requested below.
   explicit AlignedAllocator(size_t space = std::numeric_limits<size_t>::max())
       : base_ptr(nullptr),
         cur_ptr(nullptr),

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -429,6 +429,7 @@ inline cudaError_t DecodePlan(void* float_buffer, size_t float_workspace_size_in
                               typename Params::IdType* indptr_h, uint32_t batch_size,
                               uint32_t num_qo_heads, uint32_t page_size, bool enable_cuda_graph,
                               cudaStream_t stream, WorkEstimationFunc work_estimation_func) {
+  // IMPORTANT: keep workspace allocations in sync with DecodePlanWorkspaceSize.
   using DTypeO = typename Params::DTypeO;
   using IdType = typename Params::IdType;
   bool split_kv;
@@ -499,6 +500,7 @@ inline cudaError_t DecodePlanWorkspaceSize(size_t& float_workspace_size_in_bytes
                                            uint32_t num_qo_heads, uint32_t page_size,
                                            bool enable_cuda_graph, cudaStream_t stream,
                                            WorkEstimationFunc work_estimation_func) {
+  // IMPORTANT: keep workspace size accounting in sync with DecodePlan.
   using IdType = typename Params::IdType;
   bool split_kv;
   uint32_t max_grid_size, kv_chunk_size_in_pages, new_batch_size, gdy;
@@ -745,6 +747,7 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
                                int64_t num_colocated_ctas,  // for POD attention, limit prefill
                                                             // splits by #colocated decode CTAs
                                cudaStream_t stream) {
+  // IMPORTANT: keep workspace allocations in sync with PrefillPlanWorkspaceSize.
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
@@ -846,6 +849,7 @@ inline cudaError_t PrefillPlanWorkspaceSize(
     uint32_t num_kv_heads, uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
     bool enable_cuda_graph, uint32_t sizeof_dtype_o, int32_t window_left, int32_t fixed_split_size,
     bool disable_split_kv, int64_t num_colocated_ctas, cudaStream_t stream) {
+  // IMPORTANT: keep workspace size accounting in sync with PrefillPlan.
   (void)head_dim_qk;
   (void)sizeof_dtype_o;
   (void)stream;

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -495,10 +495,9 @@ template <uint32_t HEAD_DIM, PosEncodingMode POS_ENCODING_MODE, typename Attenti
           typename Params, typename WorkEstimationFunc>
 inline cudaError_t DecodePlanWorkspaceSize(size_t& float_workspace_size_in_bytes,
                                            size_t& int_workspace_size_in_bytes,
-                                           typename Params::IdType* indptr_h,
-                                           uint32_t batch_size, uint32_t num_qo_heads,
-                                           uint32_t page_size, bool enable_cuda_graph,
-                                           cudaStream_t stream,
+                                           typename Params::IdType* indptr_h, uint32_t batch_size,
+                                           uint32_t num_qo_heads, uint32_t page_size,
+                                           bool enable_cuda_graph, cudaStream_t stream,
                                            WorkEstimationFunc work_estimation_func) {
   using IdType = typename Params::IdType;
   bool split_kv;
@@ -522,8 +521,8 @@ inline cudaError_t DecodePlanWorkspaceSize(size_t& float_workspace_size_in_bytes
 
   AlignedAllocator float_allocator;
   if (split_kv) {
-    float_allocator.aligned_alloc_offset(num_qo_heads * padded_batch_size * HEAD_DIM * sizeof(float),
-                                         16, "batch_decode_tmp_v");
+    float_allocator.aligned_alloc_offset(
+        num_qo_heads * padded_batch_size * HEAD_DIM * sizeof(float), 16, "batch_decode_tmp_v");
     float_allocator.aligned_alloc_offset(num_qo_heads * padded_batch_size * sizeof(float), 16,
                                          "batch_decode_tmp_s");
     int_allocator.aligned_alloc_offset(padded_batch_size * sizeof(bool), 16,
@@ -841,16 +840,12 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
 }
 
 template <typename IdType>
-inline cudaError_t PrefillPlanWorkspaceSize(size_t& float_workspace_size_in_bytes,
-                                            size_t& int_workspace_size_in_bytes,
-                                            IdType* qo_indptr_h, IdType* kv_indptr_h,
-                                            uint32_t total_num_rows, uint32_t batch_size,
-                                            uint32_t num_qo_heads, uint32_t num_kv_heads,
-                                            uint32_t head_dim_qk, uint32_t head_dim_vo,
-                                            uint32_t page_size, bool enable_cuda_graph,
-                                            uint32_t sizeof_dtype_o, int32_t window_left,
-                                            int32_t fixed_split_size, bool disable_split_kv,
-                                            int64_t num_colocated_ctas, cudaStream_t stream) {
+inline cudaError_t PrefillPlanWorkspaceSize(
+    size_t& float_workspace_size_in_bytes, size_t& int_workspace_size_in_bytes, IdType* qo_indptr_h,
+    IdType* kv_indptr_h, uint32_t total_num_rows, uint32_t batch_size, uint32_t num_qo_heads,
+    uint32_t num_kv_heads, uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
+    bool enable_cuda_graph, uint32_t sizeof_dtype_o, int32_t window_left, int32_t fixed_split_size,
+    bool disable_split_kv, int64_t num_colocated_ctas, cudaStream_t stream) {
   (void)head_dim_qk;
   (void)sizeof_dtype_o;
   (void)stream;
@@ -903,9 +898,8 @@ inline cudaError_t PrefillPlanWorkspaceSize(size_t& float_workspace_size_in_byte
     float_allocator.aligned_alloc_offset(
         num_qo_heads * padded_batch_size * cta_tile_q * head_dim_vo * sizeof(float), 16,
         "batch_prefill_tmp_v");
-    float_allocator.aligned_alloc_offset(num_qo_heads * padded_batch_size * cta_tile_q *
-                                             sizeof(float),
-                                         16, "batch_prefill_tmp_s");
+    float_allocator.aligned_alloc_offset(
+        num_qo_heads * padded_batch_size * cta_tile_q * sizeof(float), 16, "batch_prefill_tmp_s");
     int_allocator.aligned_alloc_offset(sizeof(IdType) * (total_num_rows + 1), 16,
                                        "batch_prefill_merge_indptr");
     int_allocator.aligned_alloc_offset(sizeof(bool) * padded_batch_size, 16,

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -491,6 +491,50 @@ inline cudaError_t DecodePlan(void* float_buffer, size_t float_workspace_size_in
   return cudaSuccess;
 }
 
+template <uint32_t HEAD_DIM, PosEncodingMode POS_ENCODING_MODE, typename AttentionVariant,
+          typename Params, typename WorkEstimationFunc>
+inline cudaError_t DecodePlanWorkspaceSize(size_t& float_workspace_size_in_bytes,
+                                           size_t& int_workspace_size_in_bytes,
+                                           typename Params::IdType* indptr_h,
+                                           uint32_t batch_size, uint32_t num_qo_heads,
+                                           uint32_t page_size, bool enable_cuda_graph,
+                                           cudaStream_t stream,
+                                           WorkEstimationFunc work_estimation_func) {
+  using IdType = typename Params::IdType;
+  bool split_kv;
+  uint32_t max_grid_size, kv_chunk_size_in_pages, new_batch_size, gdy;
+
+  FLASHINFER_CUDA_CALL(work_estimation_func(split_kv, max_grid_size, kv_chunk_size_in_pages,
+                                            new_batch_size, gdy, batch_size, indptr_h, num_qo_heads,
+                                            page_size, enable_cuda_graph, stream));
+  (void)kv_chunk_size_in_pages;
+  size_t padded_batch_size =
+      (enable_cuda_graph) ? (split_kv ? max_grid_size / gdy : batch_size) : new_batch_size;
+
+  AlignedAllocator int_allocator;
+  int_allocator.aligned_alloc_offset(padded_batch_size * sizeof(IdType), 16,
+                                     "batch_decode_request_indices");
+  int_allocator.aligned_alloc_offset(padded_batch_size * sizeof(IdType), 16,
+                                     "batch_decode_kv_tile_indices");
+  int_allocator.aligned_alloc_offset((padded_batch_size + 1) * sizeof(IdType), 16,
+                                     "batch_decode_o_indptr");
+  int_allocator.aligned_alloc_offset(sizeof(IdType), 1, "batch_decode_kv_chunk_size_ptr");
+
+  AlignedAllocator float_allocator;
+  if (split_kv) {
+    float_allocator.aligned_alloc_offset(num_qo_heads * padded_batch_size * HEAD_DIM * sizeof(float),
+                                         16, "batch_decode_tmp_v");
+    float_allocator.aligned_alloc_offset(num_qo_heads * padded_batch_size * sizeof(float), 16,
+                                         "batch_decode_tmp_s");
+    int_allocator.aligned_alloc_offset(padded_batch_size * sizeof(bool), 16,
+                                       "batch_decode_block_valid_mask");
+  }
+
+  float_workspace_size_in_bytes = float_allocator.num_allocated_bytes();
+  int_workspace_size_in_bytes = int_allocator.num_allocated_bytes();
+  return cudaSuccess;
+}
+
 template <typename IdType>
 inline auto PrefillSplitQOKVIndptr(IdType* qo_indptr_h, IdType* kv_indptr_h,
                                    uint32_t total_num_rows, uint32_t batch_size,
@@ -793,6 +837,83 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
   FLASHINFER_CUDA_CALL(cudaMemcpyAsync(int_buffer, page_locked_int_buffer, num_bytes_to_copy,
                                        cudaMemcpyHostToDevice, stream));
 
+  return cudaSuccess;
+}
+
+template <typename IdType>
+inline cudaError_t PrefillPlanWorkspaceSize(size_t& float_workspace_size_in_bytes,
+                                            size_t& int_workspace_size_in_bytes,
+                                            IdType* qo_indptr_h, IdType* kv_indptr_h,
+                                            uint32_t total_num_rows, uint32_t batch_size,
+                                            uint32_t num_qo_heads, uint32_t num_kv_heads,
+                                            uint32_t head_dim_qk, uint32_t head_dim_vo,
+                                            uint32_t page_size, bool enable_cuda_graph,
+                                            uint32_t sizeof_dtype_o, int32_t window_left,
+                                            int32_t fixed_split_size, bool disable_split_kv,
+                                            int64_t num_colocated_ctas, cudaStream_t stream) {
+  (void)head_dim_qk;
+  (void)sizeof_dtype_o;
+  (void)stream;
+  if (num_qo_heads % num_kv_heads != 0) {
+    std::ostringstream err_msg;
+    err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
+            << num_kv_heads;
+    FLASHINFER_ERROR(err_msg.str());
+  }
+
+  int num_sm = 0;
+  int dev_id = 0;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
+  int num_blocks_per_sm = 2;
+  int64_t available_ctas = static_cast<int64_t>(num_blocks_per_sm) * num_sm - num_colocated_ctas;
+  int max_grid_size = static_cast<int>(std::max<int64_t>(0, available_ctas));
+  uint32_t max_batch_size_if_split = max_grid_size / num_kv_heads;
+
+  auto [split_kv, new_batch_size, padded_batch_size, cta_tile_q, kv_chunk_size, request_indices_vec,
+        qo_tile_indices_vec, kv_tile_indices_vec, merge_indptr_vec, o_indptr_vec] =
+      PrefillSplitQOKVIndptr(qo_indptr_h, kv_indptr_h, total_num_rows, batch_size, num_qo_heads,
+                             num_kv_heads, head_dim_vo, page_size, max_batch_size_if_split,
+                             enable_cuda_graph, window_left, fixed_split_size, disable_split_kv);
+  (void)new_batch_size;
+  (void)kv_chunk_size;
+  (void)request_indices_vec;
+  (void)qo_tile_indices_vec;
+  (void)kv_tile_indices_vec;
+  (void)merge_indptr_vec;
+  (void)o_indptr_vec;
+
+  AlignedAllocator int_allocator;
+  int_allocator.aligned_alloc_offset(sizeof(IdType) * padded_batch_size, 16,
+                                     "batch_prefill_request_indices");
+  int_allocator.aligned_alloc_offset(sizeof(IdType) * padded_batch_size, 16,
+                                     "batch_prefill_qo_tile_indices");
+  int_allocator.aligned_alloc_offset(sizeof(IdType) * padded_batch_size, 16,
+                                     "batch_prefill_kv_tile_indices");
+  int_allocator.aligned_alloc_offset(sizeof(IdType) * (batch_size + 1), 16,
+                                     "batch_prefill_o_indptr");
+  int_allocator.aligned_alloc_offset(sizeof(IdType), 1, "batch_prefill_kv_chunk_size_ptr");
+
+  if (enable_cuda_graph) {
+    int_allocator.aligned_alloc_offset(sizeof(uint32_t), 16, "batch_prefill_total_num_rows");
+  }
+
+  AlignedAllocator float_allocator;
+  if (split_kv) {
+    float_allocator.aligned_alloc_offset(
+        num_qo_heads * padded_batch_size * cta_tile_q * head_dim_vo * sizeof(float), 16,
+        "batch_prefill_tmp_v");
+    float_allocator.aligned_alloc_offset(num_qo_heads * padded_batch_size * cta_tile_q *
+                                             sizeof(float),
+                                         16, "batch_prefill_tmp_s");
+    int_allocator.aligned_alloc_offset(sizeof(IdType) * (total_num_rows + 1), 16,
+                                       "batch_prefill_merge_indptr");
+    int_allocator.aligned_alloc_offset(sizeof(bool) * padded_batch_size, 16,
+                                       "batch_prefill_block_valid_mask");
+  }
+
+  float_workspace_size_in_bytes = float_allocator.num_allocated_bytes();
+  int_workspace_size_in_bytes = int_allocator.num_allocated_bytes();
   return cudaSuccess;
 }
 

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -421,16 +421,15 @@ struct DecodePlanInfo {
   }
 };
 
-template <uint32_t HEAD_DIM, PosEncodingMode POS_ENCODING_MODE, typename AttentionVariant,
-          typename Params, typename WorkEstimationFunc>
-inline cudaError_t DecodePlan(void* float_buffer, size_t float_workspace_size_in_bytes,
-                              void* int_buffer, void* page_locked_int_buffer,
-                              size_t int_workspace_size_in_bytes, DecodePlanInfo& plan_info,
-                              typename Params::IdType* indptr_h, uint32_t batch_size,
-                              uint32_t num_qo_heads, uint32_t page_size, bool enable_cuda_graph,
-                              cudaStream_t stream, WorkEstimationFunc work_estimation_func) {
-  // IMPORTANT: keep workspace allocations in sync with DecodePlanWorkspaceSize.
-  using DTypeO = typename Params::DTypeO;
+template <bool MATERIALIZE, uint32_t HEAD_DIM, PosEncodingMode POS_ENCODING_MODE,
+          typename AttentionVariant, typename Params, typename WorkEstimationFunc>
+inline cudaError_t DecodePlanImpl(size_t& float_workspace_size_out, size_t& int_workspace_size_out,
+                                  void* float_buffer, size_t float_workspace_size_in_bytes,
+                                  void* int_buffer, void* page_locked_int_buffer,
+                                  size_t int_workspace_size_in_bytes, DecodePlanInfo& plan_info,
+                                  typename Params::IdType* indptr_h, uint32_t batch_size,
+                                  uint32_t num_qo_heads, uint32_t page_size, bool enable_cuda_graph,
+                                  cudaStream_t stream, WorkEstimationFunc work_estimation_func) {
   using IdType = typename Params::IdType;
   bool split_kv;
   uint32_t max_grid_size, kv_chunk_size_in_pages, new_batch_size, gdy;
@@ -447,7 +446,8 @@ inline cudaError_t DecodePlan(void* float_buffer, size_t float_workspace_size_in
   auto [request_indices_vec, kv_tile_indices_vec, o_indptr_vec] =
       DecodeSplitKVIndptr(indptr_h, batch_size, kv_chunk_size_in_pages);
 
-  AlignedAllocator int_allocator(int_buffer, int_workspace_size_in_bytes);
+  AlignedAllocator int_allocator =
+      MATERIALIZE ? AlignedAllocator(int_buffer, int_workspace_size_in_bytes) : AlignedAllocator();
   plan_info.request_indices_offset = int_allocator.aligned_alloc_offset(
       padded_batch_size * sizeof(IdType), 16, "batch_decode_request_indices");
   plan_info.kv_tile_indices_offset = int_allocator.aligned_alloc_offset(
@@ -456,21 +456,32 @@ inline cudaError_t DecodePlan(void* float_buffer, size_t float_workspace_size_in
       (padded_batch_size + 1) * sizeof(IdType), 16, "batch_decode_o_indptr");
   plan_info.kv_chunk_size_ptr_offset =
       int_allocator.aligned_alloc_offset(sizeof(IdType), 1, "batch_decode_kv_chunk_size_ptr");
-  IdType* request_indices_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.request_indices_offset);
-  IdType* kv_tile_indices_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_tile_indices_offset);
-  IdType* o_indptr_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.o_indptr_offset);
-  IdType* kv_chunk_size_ptr_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_chunk_size_ptr_offset);
-  std::copy(request_indices_vec.begin(), request_indices_vec.end(), request_indices_h);
-  std::copy(kv_tile_indices_vec.begin(), kv_tile_indices_vec.end(), kv_tile_indices_h);
-  std::copy(o_indptr_vec.begin(), o_indptr_vec.end(), o_indptr_h);
-  kv_chunk_size_ptr_h[0] = kv_chunk_size_in_pages * page_size;
+  if constexpr (MATERIALIZE) {
+    IdType* request_indices_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.request_indices_offset);
+    IdType* kv_tile_indices_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_tile_indices_offset);
+    IdType* o_indptr_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.o_indptr_offset);
+    IdType* kv_chunk_size_ptr_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_chunk_size_ptr_offset);
+    std::copy(request_indices_vec.begin(), request_indices_vec.end(), request_indices_h);
+    std::copy(kv_tile_indices_vec.begin(), kv_tile_indices_vec.end(), kv_tile_indices_h);
+    std::copy(o_indptr_vec.begin(), o_indptr_vec.end(), o_indptr_h);
+    kv_chunk_size_ptr_h[0] = kv_chunk_size_in_pages * page_size;
+  } else {
+    (void)kv_chunk_size_in_pages;
+    (void)new_batch_size;
+    (void)request_indices_vec;
+    (void)kv_tile_indices_vec;
+    (void)o_indptr_vec;
+  }
 
+  AlignedAllocator float_allocator;
   if (split_kv) {
-    AlignedAllocator float_allocator(float_buffer, float_workspace_size_in_bytes);
+    if constexpr (MATERIALIZE) {
+      float_allocator = AlignedAllocator(float_buffer, float_workspace_size_in_bytes);
+    }
     plan_info.v_offset = float_allocator.aligned_alloc_offset(
         num_qo_heads * padded_batch_size * HEAD_DIM * sizeof(float), 16, "batch_decode_tmp_v");
     plan_info.s_offset = float_allocator.aligned_alloc_offset(
@@ -478,18 +489,39 @@ inline cudaError_t DecodePlan(void* float_buffer, size_t float_workspace_size_in
 
     plan_info.block_valid_mask_offset = int_allocator.aligned_alloc_offset(
         padded_batch_size * sizeof(bool), 16, "batch_decode_block_valid_mask");
-    bool* block_valid_mask_h =
-        GetPtrFromBaseOffset<bool>(page_locked_int_buffer, plan_info.block_valid_mask_offset);
-    for (uint32_t i = 0; i < padded_batch_size; ++i) {
-      block_valid_mask_h[i] = i < new_batch_size;
+    if constexpr (MATERIALIZE) {
+      bool* block_valid_mask_h =
+          GetPtrFromBaseOffset<bool>(page_locked_int_buffer, plan_info.block_valid_mask_offset);
+      for (uint32_t i = 0; i < padded_batch_size; ++i) {
+        block_valid_mask_h[i] = i < new_batch_size;
+      }
     }
   }
 
-  size_t num_bytes_to_copy = int_allocator.num_allocated_bytes();
-
-  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(int_buffer, page_locked_int_buffer, num_bytes_to_copy,
-                                       cudaMemcpyHostToDevice, stream));
+  float_workspace_size_out = float_allocator.num_allocated_bytes();
+  int_workspace_size_out = int_allocator.num_allocated_bytes();
+  if constexpr (MATERIALIZE) {
+    FLASHINFER_CUDA_CALL(cudaMemcpyAsync(int_buffer, page_locked_int_buffer, int_workspace_size_out,
+                                         cudaMemcpyHostToDevice, stream));
+  }
   return cudaSuccess;
+}
+
+template <uint32_t HEAD_DIM, PosEncodingMode POS_ENCODING_MODE, typename AttentionVariant,
+          typename Params, typename WorkEstimationFunc>
+inline cudaError_t DecodePlan(void* float_buffer, size_t float_workspace_size_in_bytes,
+                              void* int_buffer, void* page_locked_int_buffer,
+                              size_t int_workspace_size_in_bytes, DecodePlanInfo& plan_info,
+                              typename Params::IdType* indptr_h, uint32_t batch_size,
+                              uint32_t num_qo_heads, uint32_t page_size, bool enable_cuda_graph,
+                              cudaStream_t stream, WorkEstimationFunc work_estimation_func) {
+  size_t used_float_workspace_size = 0;
+  size_t used_int_workspace_size = 0;
+  return DecodePlanImpl<true, HEAD_DIM, POS_ENCODING_MODE, AttentionVariant, Params>(
+      used_float_workspace_size, used_int_workspace_size, float_buffer,
+      float_workspace_size_in_bytes, int_buffer, page_locked_int_buffer,
+      int_workspace_size_in_bytes, plan_info, indptr_h, batch_size, num_qo_heads, page_size,
+      enable_cuda_graph, stream, work_estimation_func);
 }
 
 template <uint32_t HEAD_DIM, PosEncodingMode POS_ENCODING_MODE, typename AttentionVariant,
@@ -500,40 +532,13 @@ inline cudaError_t DecodePlanWorkspaceSize(size_t& float_workspace_size_in_bytes
                                            uint32_t num_qo_heads, uint32_t page_size,
                                            bool enable_cuda_graph, cudaStream_t stream,
                                            WorkEstimationFunc work_estimation_func) {
-  // IMPORTANT: keep workspace size accounting in sync with DecodePlan.
-  using IdType = typename Params::IdType;
-  bool split_kv;
-  uint32_t max_grid_size, kv_chunk_size_in_pages, new_batch_size, gdy;
-
-  FLASHINFER_CUDA_CALL(work_estimation_func(split_kv, max_grid_size, kv_chunk_size_in_pages,
-                                            new_batch_size, gdy, batch_size, indptr_h, num_qo_heads,
-                                            page_size, enable_cuda_graph, stream));
-  (void)kv_chunk_size_in_pages;
-  size_t padded_batch_size =
-      (enable_cuda_graph) ? (split_kv ? max_grid_size / gdy : batch_size) : new_batch_size;
-
-  AlignedAllocator int_allocator;
-  int_allocator.aligned_alloc_offset(padded_batch_size * sizeof(IdType), 16,
-                                     "batch_decode_request_indices");
-  int_allocator.aligned_alloc_offset(padded_batch_size * sizeof(IdType), 16,
-                                     "batch_decode_kv_tile_indices");
-  int_allocator.aligned_alloc_offset((padded_batch_size + 1) * sizeof(IdType), 16,
-                                     "batch_decode_o_indptr");
-  int_allocator.aligned_alloc_offset(sizeof(IdType), 1, "batch_decode_kv_chunk_size_ptr");
-
-  AlignedAllocator float_allocator;
-  if (split_kv) {
-    float_allocator.aligned_alloc_offset(
-        num_qo_heads * padded_batch_size * HEAD_DIM * sizeof(float), 16, "batch_decode_tmp_v");
-    float_allocator.aligned_alloc_offset(num_qo_heads * padded_batch_size * sizeof(float), 16,
-                                         "batch_decode_tmp_s");
-    int_allocator.aligned_alloc_offset(padded_batch_size * sizeof(bool), 16,
-                                       "batch_decode_block_valid_mask");
-  }
-
-  float_workspace_size_in_bytes = float_allocator.num_allocated_bytes();
-  int_workspace_size_in_bytes = int_allocator.num_allocated_bytes();
-  return cudaSuccess;
+  DecodePlanInfo plan_info;
+  return DecodePlanImpl<false, HEAD_DIM, POS_ENCODING_MODE, AttentionVariant, Params>(
+      float_workspace_size_in_bytes, int_workspace_size_in_bytes,
+      /*float_buffer=*/nullptr, /*float_workspace_size_in_bytes=*/0,
+      /*int_buffer=*/nullptr, /*page_locked_int_buffer=*/nullptr,
+      /*int_workspace_size_in_bytes=*/0, plan_info, indptr_h, batch_size, num_qo_heads, page_size,
+      enable_cuda_graph, stream, work_estimation_func);
 }
 
 template <typename IdType>
@@ -735,19 +740,20 @@ struct PrefillPlanInfo {
   }
 };
 
-template <typename IdType>
-inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_in_bytes,
-                               void* int_buffer, void* page_locked_int_buffer,
-                               size_t int_workspace_size_in_bytes, PrefillPlanInfo& plan_info,
-                               IdType* qo_indptr_h, IdType* kv_indptr_h, uint32_t total_num_rows,
-                               uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
-                               uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
-                               bool enable_cuda_graph, uint32_t sizeof_dtype_o, int32_t window_left,
-                               int32_t fixed_split_size, bool disable_split_kv,
-                               int64_t num_colocated_ctas,  // for POD attention, limit prefill
-                                                            // splits by #colocated decode CTAs
-                               cudaStream_t stream) {
-  // IMPORTANT: keep workspace allocations in sync with PrefillPlanWorkspaceSize.
+template <bool MATERIALIZE, typename IdType>
+inline cudaError_t PrefillPlanImpl(
+    size_t& float_workspace_size_out, size_t& int_workspace_size_out, void* float_buffer,
+    size_t float_workspace_size_in_bytes, void* int_buffer, void* page_locked_int_buffer,
+    size_t int_workspace_size_in_bytes, PrefillPlanInfo& plan_info, IdType* qo_indptr_h,
+    IdType* kv_indptr_h, uint32_t total_num_rows, uint32_t batch_size, uint32_t num_qo_heads,
+    uint32_t num_kv_heads, uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
+    bool enable_cuda_graph, uint32_t sizeof_dtype_o, int32_t window_left, int32_t fixed_split_size,
+    bool disable_split_kv,
+    int64_t num_colocated_ctas,  // for POD attention, limit prefill
+                                 // splits by #colocated decode CTAs
+    cudaStream_t stream) {
+  (void)head_dim_qk;
+  (void)sizeof_dtype_o;
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
@@ -778,7 +784,8 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
   plan_info.padded_batch_size = padded_batch_size;
   plan_info.split_kv = split_kv;
 
-  AlignedAllocator int_allocator(int_buffer, int_workspace_size_in_bytes);
+  AlignedAllocator int_allocator =
+      MATERIALIZE ? AlignedAllocator(int_buffer, int_workspace_size_in_bytes) : AlignedAllocator();
   plan_info.request_indices_offset = int_allocator.aligned_alloc_offset(
       sizeof(IdType) * padded_batch_size, 16, "batch_prefill_request_indices");
   plan_info.qo_tile_indices_offset = int_allocator.aligned_alloc_offset(
@@ -793,28 +800,43 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
   if (plan_info.enable_cuda_graph) {
     plan_info.total_num_rows_offset =
         int_allocator.aligned_alloc_offset(sizeof(uint32_t), 16, "batch_prefill_total_num_rows");
-    uint32_t* total_num_rows_h =
-        GetPtrFromBaseOffset<uint32_t>(page_locked_int_buffer, plan_info.total_num_rows_offset);
-    *total_num_rows_h = qo_indptr_h[batch_size];
+    if constexpr (MATERIALIZE) {
+      uint32_t* total_num_rows_h =
+          GetPtrFromBaseOffset<uint32_t>(page_locked_int_buffer, plan_info.total_num_rows_offset);
+      *total_num_rows_h = qo_indptr_h[batch_size];
+    }
   }
 
-  IdType* request_indices_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.request_indices_offset);
-  IdType* qo_tile_indices_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.qo_tile_indices_offset);
-  IdType* kv_tile_indices_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_tile_indices_offset);
-  IdType* o_indptr_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.o_indptr_offset);
-  IdType* kv_chunk_size_ptr_h =
-      GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_chunk_size_ptr_offset);
-  std::copy(request_indices_vec.begin(), request_indices_vec.end(), request_indices_h);
-  std::copy(qo_tile_indices_vec.begin(), qo_tile_indices_vec.end(), qo_tile_indices_h);
-  std::copy(kv_tile_indices_vec.begin(), kv_tile_indices_vec.end(), kv_tile_indices_h);
-  std::copy(o_indptr_vec.begin(), o_indptr_vec.end(), o_indptr_h);
-  kv_chunk_size_ptr_h[0] = kv_chunk_size;
+  if constexpr (MATERIALIZE) {
+    IdType* request_indices_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.request_indices_offset);
+    IdType* qo_tile_indices_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.qo_tile_indices_offset);
+    IdType* kv_tile_indices_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_tile_indices_offset);
+    IdType* o_indptr_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.o_indptr_offset);
+    IdType* kv_chunk_size_ptr_h =
+        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.kv_chunk_size_ptr_offset);
+    std::copy(request_indices_vec.begin(), request_indices_vec.end(), request_indices_h);
+    std::copy(qo_tile_indices_vec.begin(), qo_tile_indices_vec.end(), qo_tile_indices_h);
+    std::copy(kv_tile_indices_vec.begin(), kv_tile_indices_vec.end(), kv_tile_indices_h);
+    std::copy(o_indptr_vec.begin(), o_indptr_vec.end(), o_indptr_h);
+    kv_chunk_size_ptr_h[0] = kv_chunk_size;
+  } else {
+    (void)new_batch_size;
+    (void)kv_chunk_size;
+    (void)request_indices_vec;
+    (void)qo_tile_indices_vec;
+    (void)kv_tile_indices_vec;
+    (void)o_indptr_vec;
+  }
+
+  AlignedAllocator float_allocator;
   if (split_kv) {
-    AlignedAllocator float_allocator(float_buffer, float_workspace_size_in_bytes);
+    if constexpr (MATERIALIZE) {
+      float_allocator = AlignedAllocator(float_buffer, float_workspace_size_in_bytes);
+    }
     plan_info.v_offset = float_allocator.aligned_alloc_offset(
         num_qo_heads * padded_batch_size * cta_tile_q * head_dim_vo * sizeof(float), 16,
         "batch_prefill_tmp_v");
@@ -825,21 +847,52 @@ inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_i
     plan_info.block_valid_mask_offset = int_allocator.aligned_alloc_offset(
         sizeof(bool) * padded_batch_size, 16, "batch_prefill_block_valid_mask");
 
-    IdType* merge_indptr_h =
-        GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.merge_indptr_offset);
-    bool* block_valid_mask_h =
-        GetPtrFromBaseOffset<bool>(page_locked_int_buffer, plan_info.block_valid_mask_offset);
-    std::copy(merge_indptr_vec.begin(), merge_indptr_vec.end(), merge_indptr_h);
-    for (uint32_t i = 0; i < padded_batch_size; ++i) {
-      block_valid_mask_h[i] = i < new_batch_size;
+    if constexpr (MATERIALIZE) {
+      IdType* merge_indptr_h =
+          GetPtrFromBaseOffset<IdType>(page_locked_int_buffer, plan_info.merge_indptr_offset);
+      bool* block_valid_mask_h =
+          GetPtrFromBaseOffset<bool>(page_locked_int_buffer, plan_info.block_valid_mask_offset);
+      std::copy(merge_indptr_vec.begin(), merge_indptr_vec.end(), merge_indptr_h);
+      for (uint32_t i = 0; i < padded_batch_size; ++i) {
+        block_valid_mask_h[i] = i < new_batch_size;
+      }
+    } else {
+      (void)merge_indptr_vec;
     }
   }
 
-  size_t num_bytes_to_copy = int_allocator.num_allocated_bytes();
-  FLASHINFER_CUDA_CALL(cudaMemcpyAsync(int_buffer, page_locked_int_buffer, num_bytes_to_copy,
-                                       cudaMemcpyHostToDevice, stream));
+  float_workspace_size_out = float_allocator.num_allocated_bytes();
+  int_workspace_size_out = int_allocator.num_allocated_bytes();
+  if constexpr (MATERIALIZE) {
+    FLASHINFER_CUDA_CALL(cudaMemcpyAsync(int_buffer, page_locked_int_buffer, int_workspace_size_out,
+                                         cudaMemcpyHostToDevice, stream));
+  } else {
+    (void)stream;
+  }
 
   return cudaSuccess;
+}
+
+template <typename IdType>
+inline cudaError_t PrefillPlan(void* float_buffer, size_t float_workspace_size_in_bytes,
+                               void* int_buffer, void* page_locked_int_buffer,
+                               size_t int_workspace_size_in_bytes, PrefillPlanInfo& plan_info,
+                               IdType* qo_indptr_h, IdType* kv_indptr_h, uint32_t total_num_rows,
+                               uint32_t batch_size, uint32_t num_qo_heads, uint32_t num_kv_heads,
+                               uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
+                               bool enable_cuda_graph, uint32_t sizeof_dtype_o, int32_t window_left,
+                               int32_t fixed_split_size, bool disable_split_kv,
+                               int64_t num_colocated_ctas,  // for POD attention, limit prefill
+                                                            // splits by #colocated decode CTAs
+                               cudaStream_t stream) {
+  size_t used_float_workspace_size = 0;
+  size_t used_int_workspace_size = 0;
+  return PrefillPlanImpl<true>(
+      used_float_workspace_size, used_int_workspace_size, float_buffer,
+      float_workspace_size_in_bytes, int_buffer, page_locked_int_buffer,
+      int_workspace_size_in_bytes, plan_info, qo_indptr_h, kv_indptr_h, total_num_rows, batch_size,
+      num_qo_heads, num_kv_heads, head_dim_qk, head_dim_vo, page_size, enable_cuda_graph,
+      sizeof_dtype_o, window_left, fixed_split_size, disable_split_kv, num_colocated_ctas, stream);
 }
 
 template <typename IdType>
@@ -849,70 +902,15 @@ inline cudaError_t PrefillPlanWorkspaceSize(
     uint32_t num_kv_heads, uint32_t head_dim_qk, uint32_t head_dim_vo, uint32_t page_size,
     bool enable_cuda_graph, uint32_t sizeof_dtype_o, int32_t window_left, int32_t fixed_split_size,
     bool disable_split_kv, int64_t num_colocated_ctas, cudaStream_t stream) {
-  // IMPORTANT: keep workspace size accounting in sync with PrefillPlan.
-  (void)head_dim_qk;
-  (void)sizeof_dtype_o;
-  (void)stream;
-  if (num_qo_heads % num_kv_heads != 0) {
-    std::ostringstream err_msg;
-    err_msg << "num_qo_heads " << num_qo_heads << " should be divisible by num_kv_heads "
-            << num_kv_heads;
-    FLASHINFER_ERROR(err_msg.str());
-  }
-
-  int num_sm = 0;
-  int dev_id = 0;
-  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, dev_id));
-  int num_blocks_per_sm = 2;
-  int64_t available_ctas = static_cast<int64_t>(num_blocks_per_sm) * num_sm - num_colocated_ctas;
-  int max_grid_size = static_cast<int>(std::max<int64_t>(0, available_ctas));
-  uint32_t max_batch_size_if_split = max_grid_size / num_kv_heads;
-
-  auto [split_kv, new_batch_size, padded_batch_size, cta_tile_q, kv_chunk_size, request_indices_vec,
-        qo_tile_indices_vec, kv_tile_indices_vec, merge_indptr_vec, o_indptr_vec] =
-      PrefillSplitQOKVIndptr(qo_indptr_h, kv_indptr_h, total_num_rows, batch_size, num_qo_heads,
-                             num_kv_heads, head_dim_vo, page_size, max_batch_size_if_split,
-                             enable_cuda_graph, window_left, fixed_split_size, disable_split_kv);
-  (void)new_batch_size;
-  (void)kv_chunk_size;
-  (void)request_indices_vec;
-  (void)qo_tile_indices_vec;
-  (void)kv_tile_indices_vec;
-  (void)merge_indptr_vec;
-  (void)o_indptr_vec;
-
-  AlignedAllocator int_allocator;
-  int_allocator.aligned_alloc_offset(sizeof(IdType) * padded_batch_size, 16,
-                                     "batch_prefill_request_indices");
-  int_allocator.aligned_alloc_offset(sizeof(IdType) * padded_batch_size, 16,
-                                     "batch_prefill_qo_tile_indices");
-  int_allocator.aligned_alloc_offset(sizeof(IdType) * padded_batch_size, 16,
-                                     "batch_prefill_kv_tile_indices");
-  int_allocator.aligned_alloc_offset(sizeof(IdType) * (batch_size + 1), 16,
-                                     "batch_prefill_o_indptr");
-  int_allocator.aligned_alloc_offset(sizeof(IdType), 1, "batch_prefill_kv_chunk_size_ptr");
-
-  if (enable_cuda_graph) {
-    int_allocator.aligned_alloc_offset(sizeof(uint32_t), 16, "batch_prefill_total_num_rows");
-  }
-
-  AlignedAllocator float_allocator;
-  if (split_kv) {
-    float_allocator.aligned_alloc_offset(
-        num_qo_heads * padded_batch_size * cta_tile_q * head_dim_vo * sizeof(float), 16,
-        "batch_prefill_tmp_v");
-    float_allocator.aligned_alloc_offset(
-        num_qo_heads * padded_batch_size * cta_tile_q * sizeof(float), 16, "batch_prefill_tmp_s");
-    int_allocator.aligned_alloc_offset(sizeof(IdType) * (total_num_rows + 1), 16,
-                                       "batch_prefill_merge_indptr");
-    int_allocator.aligned_alloc_offset(sizeof(bool) * padded_batch_size, 16,
-                                       "batch_prefill_block_valid_mask");
-  }
-
-  float_workspace_size_in_bytes = float_allocator.num_allocated_bytes();
-  int_workspace_size_in_bytes = int_allocator.num_allocated_bytes();
-  return cudaSuccess;
+  PrefillPlanInfo plan_info;
+  return PrefillPlanImpl<false>(float_workspace_size_in_bytes, int_workspace_size_in_bytes,
+                                /*float_buffer=*/nullptr, /*float_workspace_size_in_bytes=*/0,
+                                /*int_buffer=*/nullptr, /*page_locked_int_buffer=*/nullptr,
+                                /*int_workspace_size_in_bytes=*/0, plan_info, qo_indptr_h,
+                                kv_indptr_h, total_num_rows, batch_size, num_qo_heads, num_kv_heads,
+                                head_dim_qk, head_dim_vo, page_size, enable_cuda_graph,
+                                sizeof_dtype_o, window_left, fixed_split_size, disable_split_kv,
+                                num_colocated_ctas, stream);
 }
 
 inline float cost_function(int qo_len, int kv_len) { return 2 * float(qo_len) + kv_len; }

--- a/tests/attention/test_workspace_size.py
+++ b/tests/attention/test_workspace_size.py
@@ -45,6 +45,12 @@ def _byte_workspace(num_bytes: int, device: str = "cuda"):
     return torch.empty((num_bytes,), dtype=torch.uint8, device=device)
 
 
+def _unaligned_byte_workspace(num_bytes: int, device: str = "cuda"):
+    workspace = torch.empty((num_bytes + 1,), dtype=torch.uint8, device=device)[1:]
+    assert workspace.data_ptr() % 16 != 0
+    return workspace
+
+
 @pytest.mark.parametrize("use_cuda_graph", [False, True])
 def test_batch_decode_workspace_size_plans_with_exact_buffers(use_cuda_graph):
     batch_size = 4
@@ -117,7 +123,6 @@ def _run_batch_prefill_workspace_size_plan(
     num_qo_heads = 16
     num_kv_heads = 4
     head_dim = 128
-    fixed_split_size = 16
 
     qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device="cuda") * qo_len
     paged_kv_indptr, paged_kv_indices, paged_kv_last_page_len = _paged_kv_inputs(
@@ -162,7 +167,10 @@ def _run_batch_prefill_workspace_size_plan(
         page_size,
         **plan_kwargs,
     )
-    assert float_workspace_size > 0
+    if fixed_split_size is None:
+        assert float_workspace_size >= 0
+    else:
+        assert float_workspace_size > 0
     assert int_workspace_size > 0
 
     wrapper.reset_workspace_buffer(
@@ -189,3 +197,44 @@ def test_batch_prefill_workspace_size_plans_fixed_split_with_exact_buffers():
 
 def test_batch_prefill_workspace_size_plans_cuda_graph_with_exact_buffers():
     _run_batch_prefill_workspace_size_plan(use_cuda_graph=True)
+
+
+def test_batch_decode_workspace_size_rejects_unaligned_workspace_buffer():
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        _byte_workspace(32 * 1024 * 1024)
+    )
+
+    with pytest.raises(
+        ValueError, match="float_workspace_buffer must be 16-byte aligned"
+    ):
+        wrapper.reset_workspace_buffer(
+            _unaligned_byte_workspace(1024),
+            _byte_workspace(1024),
+        )
+    with pytest.raises(
+        ValueError, match="int_workspace_buffer must be 16-byte aligned"
+    ):
+        wrapper.reset_workspace_buffer(
+            _byte_workspace(1024),
+            _unaligned_byte_workspace(1024),
+        )
+
+
+def test_batch_prefill_workspace_size_rejects_unaligned_workspace_buffer():
+    with pytest.raises(
+        ValueError, match="float_workspace_buffer must be 16-byte aligned"
+    ):
+        flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+            _unaligned_byte_workspace(32 * 1024 * 1024), backend="fa2"
+        )
+
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        _byte_workspace(32 * 1024 * 1024), backend="fa2"
+    )
+    with pytest.raises(
+        ValueError, match="int_workspace_buffer must be 16-byte aligned"
+    ):
+        wrapper.reset_workspace_buffer(
+            _byte_workspace(1024),
+            _unaligned_byte_workspace(1024),
+        )

--- a/tests/attention/test_workspace_size.py
+++ b/tests/attention/test_workspace_size.py
@@ -1,0 +1,203 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="workspace sizing tests require CUDA"
+)
+
+
+def _paged_kv_inputs(batch_size: int, kv_len: int, page_size: int):
+    pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_pages = batch_size * pages_per_seq
+    indptr = (
+        torch.arange(batch_size + 1, dtype=torch.int32, device="cuda")
+        * pages_per_seq
+    )
+    indices = torch.arange(total_pages, dtype=torch.int32, device="cuda")
+    last_page_len = torch.full(
+        (batch_size,),
+        (kv_len - 1) % page_size + 1,
+        dtype=torch.int32,
+        device="cuda",
+    )
+    return indptr, indices, last_page_len
+
+
+def _byte_workspace(num_bytes: int, device: str = "cuda"):
+    return torch.empty((num_bytes,), dtype=torch.uint8, device=device)
+
+
+def test_batch_decode_workspace_size_plans_with_exact_buffers():
+    batch_size = 4
+    kv_len = 4096
+    page_size = 16
+    num_qo_heads = 16
+    num_kv_heads = 4
+    head_dim = 128
+    dtype = torch.float16
+    logits_soft_cap = 0.0
+    window_left = -1
+
+    indptr, indices, last_page_len = _paged_kv_inputs(
+        batch_size, kv_len, page_size
+    )
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        _byte_workspace(32 * 1024 * 1024)
+    )
+    wrapper.plan(
+        indptr,
+        indices,
+        last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+
+    module = wrapper._cached_module
+    assert module is not None
+    assert module.workspace_size is not None
+
+    indptr_host = indptr.cpu()
+    float_workspace_size, int_workspace_size = module.workspace_size(
+        _byte_workspace(0),
+        indptr_host,
+        batch_size,
+        num_qo_heads,
+        num_kv_heads,
+        page_size,
+        False,  # enable_cuda_graph
+        window_left,
+        logits_soft_cap,
+        head_dim,
+        head_dim,
+        torch.empty(0, dtype=dtype),
+        torch.empty(0, dtype=dtype),
+    )
+    assert float_workspace_size > 0
+    assert int_workspace_size > 0
+
+    plan_info = module.plan(
+        _byte_workspace(float_workspace_size),
+        _byte_workspace(int_workspace_size),
+        torch.empty(int_workspace_size, dtype=torch.uint8, pin_memory=True),
+        indptr_host,
+        batch_size,
+        num_qo_heads,
+        num_kv_heads,
+        page_size,
+        False,  # enable_cuda_graph
+        window_left,
+        logits_soft_cap,
+        head_dim,
+        head_dim,
+        torch.empty(0, dtype=dtype),
+        torch.empty(0, dtype=dtype),
+    )
+    assert len(plan_info) > 0
+
+
+def test_batch_prefill_workspace_size_plans_with_exact_buffers():
+    batch_size = 3
+    qo_len = 64
+    kv_len = 1024
+    page_size = 16
+    num_qo_heads = 16
+    num_kv_heads = 4
+    head_dim = 128
+    fixed_split_size = -1
+
+    qo_indptr = (
+        torch.arange(batch_size + 1, dtype=torch.int32, device="cuda") * qo_len
+    )
+    paged_kv_indptr, paged_kv_indices, paged_kv_last_page_len = _paged_kv_inputs(
+        batch_size, kv_len, page_size
+    )
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        _byte_workspace(32 * 1024 * 1024), backend="fa2"
+    )
+    wrapper.plan(
+        qo_indptr,
+        paged_kv_indptr,
+        paged_kv_indices,
+        paged_kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        disable_split_kv=True,
+    )
+
+    module = wrapper._cached_module
+    assert module is not None
+    assert module.workspace_size is not None
+
+    qo_indptr_host = qo_indptr.cpu()
+    paged_kv_indptr_host = paged_kv_indptr.cpu()
+    kv_lens_host = torch.full((batch_size,), kv_len, dtype=torch.int32)
+    total_num_rows = int(qo_indptr_host[-1].item())
+    float_workspace_size, int_workspace_size = module.workspace_size(
+        _byte_workspace(0),
+        qo_indptr_host,
+        paged_kv_indptr_host,
+        kv_lens_host,
+        total_num_rows,
+        batch_size,
+        num_qo_heads,
+        num_kv_heads,
+        page_size,
+        False,  # enable_cuda_graph
+        head_dim,
+        head_dim,
+        False,  # causal
+        -1,  # window_left
+        fixed_split_size,
+        True,  # disable_split_kv
+        0,  # num_colocated_ctas
+    )
+    assert float_workspace_size >= 0
+    assert int_workspace_size > 0
+
+    plan_info = module.plan(
+        _byte_workspace(float_workspace_size),
+        _byte_workspace(int_workspace_size),
+        torch.empty(int_workspace_size, dtype=torch.uint8, pin_memory=True),
+        qo_indptr_host,
+        paged_kv_indptr_host,
+        kv_lens_host,
+        total_num_rows,
+        batch_size,
+        num_qo_heads,
+        num_kv_heads,
+        page_size,
+        False,  # enable_cuda_graph
+        head_dim,
+        head_dim,
+        False,  # causal
+        -1,  # window_left
+        fixed_split_size,
+        True,  # disable_split_kv
+        0,  # num_colocated_ctas
+    )
+    assert len(plan_info) > 0

--- a/tests/attention/test_workspace_size.py
+++ b/tests/attention/test_workspace_size.py
@@ -106,8 +106,10 @@ def test_batch_decode_workspace_size_plans_with_exact_buffers(use_cuda_graph):
     assert wrapper._plan_info is not None
 
 
-@pytest.mark.parametrize("use_cuda_graph", [False, True])
-def test_batch_prefill_workspace_size_plans_with_exact_buffers(use_cuda_graph):
+def _run_batch_prefill_workspace_size_plan(
+    use_cuda_graph=False,
+    fixed_split_size=None,
+):
     batch_size = 3
     qo_len = 64
     kv_len = 1024
@@ -142,6 +144,13 @@ def test_batch_prefill_workspace_size_plans_with_exact_buffers(use_cuda_graph):
         _byte_workspace(32 * 1024 * 1024), backend="fa2", **kwargs
     )
 
+    plan_kwargs = {}
+    if fixed_split_size is not None:
+        plan_kwargs = {
+            "fixed_split_size": fixed_split_size,
+            "disable_split_kv": False,
+        }
+
     float_workspace_size, int_workspace_size = wrapper.workspace_size(
         qo_indptr,
         paged_kv_indptr,
@@ -151,8 +160,7 @@ def test_batch_prefill_workspace_size_plans_with_exact_buffers(use_cuda_graph):
         num_kv_heads,
         head_dim,
         page_size,
-        fixed_split_size=fixed_split_size,
-        disable_split_kv=False,
+        **plan_kwargs,
     )
     assert float_workspace_size > 0
     assert int_workspace_size > 0
@@ -170,7 +178,14 @@ def test_batch_prefill_workspace_size_plans_with_exact_buffers(use_cuda_graph):
         num_kv_heads,
         head_dim,
         page_size,
-        fixed_split_size=fixed_split_size,
-        disable_split_kv=False,
+        **plan_kwargs,
     )
     assert wrapper._plan_info is not None
+
+
+def test_batch_prefill_workspace_size_plans_fixed_split_with_exact_buffers():
+    _run_batch_prefill_workspace_size_plan(fixed_split_size=16)
+
+
+def test_batch_prefill_workspace_size_plans_cuda_graph_with_exact_buffers():
+    _run_batch_prefill_workspace_size_plan(use_cuda_graph=True)

--- a/tests/attention/test_workspace_size.py
+++ b/tests/attention/test_workspace_size.py
@@ -45,7 +45,8 @@ def _byte_workspace(num_bytes: int, device: str = "cuda"):
     return torch.empty((num_bytes,), dtype=torch.uint8, device=device)
 
 
-def test_batch_decode_workspace_size_plans_with_exact_buffers():
+@pytest.mark.parametrize("use_cuda_graph", [False, True])
+def test_batch_decode_workspace_size_plans_with_exact_buffers(use_cuda_graph):
     batch_size = 4
     kv_len = 4096
     page_size = 16
@@ -53,12 +54,43 @@ def test_batch_decode_workspace_size_plans_with_exact_buffers():
     num_kv_heads = 4
     head_dim = 128
     dtype = torch.float16
-    logits_soft_cap = 0.0
-    window_left = -1
 
     indptr, indices, last_page_len = _paged_kv_inputs(batch_size, kv_len, page_size)
+    kwargs = {}
+    if use_cuda_graph:
+        kwargs = {
+            "use_cuda_graph": True,
+            "paged_kv_indptr_buffer": torch.empty(
+                batch_size + 1, dtype=torch.int32, device="cuda"
+            ),
+            "paged_kv_indices_buffer": torch.empty(
+                len(indices), dtype=torch.int32, device="cuda"
+            ),
+            "paged_kv_last_page_len_buffer": torch.empty(
+                batch_size, dtype=torch.int32, device="cuda"
+            ),
+        }
     wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
-        _byte_workspace(32 * 1024 * 1024)
+        _byte_workspace(32 * 1024 * 1024), **kwargs
+    )
+
+    float_workspace_size, int_workspace_size = wrapper.workspace_size(
+        indptr,
+        indices,
+        last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    assert float_workspace_size > 0
+    assert int_workspace_size > 0
+
+    wrapper.reset_workspace_buffer(
+        _byte_workspace(float_workspace_size),
+        _byte_workspace(int_workspace_size),
     )
     wrapper.plan(
         indptr,
@@ -71,51 +103,11 @@ def test_batch_decode_workspace_size_plans_with_exact_buffers():
         q_data_type=dtype,
         kv_data_type=dtype,
     )
-
-    module = wrapper._cached_module
-    assert module is not None
-    assert module.workspace_size is not None
-
-    indptr_host = indptr.cpu()
-    float_workspace_size, int_workspace_size = module.workspace_size(
-        _byte_workspace(0),
-        indptr_host,
-        batch_size,
-        num_qo_heads,
-        num_kv_heads,
-        page_size,
-        False,  # enable_cuda_graph
-        window_left,
-        logits_soft_cap,
-        head_dim,
-        head_dim,
-        torch.empty(0, dtype=dtype),
-        torch.empty(0, dtype=dtype),
-    )
-    assert float_workspace_size > 0
-    assert int_workspace_size > 0
-
-    plan_info = module.plan(
-        _byte_workspace(float_workspace_size),
-        _byte_workspace(int_workspace_size),
-        torch.empty(int_workspace_size, dtype=torch.uint8, pin_memory=True),
-        indptr_host,
-        batch_size,
-        num_qo_heads,
-        num_kv_heads,
-        page_size,
-        False,  # enable_cuda_graph
-        window_left,
-        logits_soft_cap,
-        head_dim,
-        head_dim,
-        torch.empty(0, dtype=dtype),
-        torch.empty(0, dtype=dtype),
-    )
-    assert len(plan_info) > 0
+    assert wrapper._plan_info is not None
 
 
-def test_batch_prefill_workspace_size_plans_with_exact_buffers():
+@pytest.mark.parametrize("use_cuda_graph", [False, True])
+def test_batch_prefill_workspace_size_plans_with_exact_buffers(use_cuda_graph):
     batch_size = 3
     qo_len = 64
     kv_len = 1024
@@ -123,14 +115,51 @@ def test_batch_prefill_workspace_size_plans_with_exact_buffers():
     num_qo_heads = 16
     num_kv_heads = 4
     head_dim = 128
-    fixed_split_size = -1
+    fixed_split_size = 16
 
     qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device="cuda") * qo_len
     paged_kv_indptr, paged_kv_indices, paged_kv_last_page_len = _paged_kv_inputs(
         batch_size, kv_len, page_size
     )
+    kwargs = {}
+    if use_cuda_graph:
+        kwargs = {
+            "use_cuda_graph": True,
+            "qo_indptr_buf": torch.empty(
+                batch_size + 1, dtype=torch.int32, device="cuda"
+            ),
+            "paged_kv_indptr_buf": torch.empty(
+                batch_size + 1, dtype=torch.int32, device="cuda"
+            ),
+            "paged_kv_indices_buf": torch.empty(
+                len(paged_kv_indices), dtype=torch.int32, device="cuda"
+            ),
+            "paged_kv_last_page_len_buf": torch.empty(
+                batch_size, dtype=torch.int32, device="cuda"
+            ),
+        }
     wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
-        _byte_workspace(32 * 1024 * 1024), backend="fa2"
+        _byte_workspace(32 * 1024 * 1024), backend="fa2", **kwargs
+    )
+
+    float_workspace_size, int_workspace_size = wrapper.workspace_size(
+        qo_indptr,
+        paged_kv_indptr,
+        paged_kv_indices,
+        paged_kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        fixed_split_size=fixed_split_size,
+        disable_split_kv=False,
+    )
+    assert float_workspace_size > 0
+    assert int_workspace_size > 0
+
+    wrapper.reset_workspace_buffer(
+        _byte_workspace(float_workspace_size),
+        _byte_workspace(int_workspace_size),
     )
     wrapper.plan(
         qo_indptr,
@@ -141,58 +170,7 @@ def test_batch_prefill_workspace_size_plans_with_exact_buffers():
         num_kv_heads,
         head_dim,
         page_size,
-        disable_split_kv=True,
+        fixed_split_size=fixed_split_size,
+        disable_split_kv=False,
     )
-
-    module = wrapper._cached_module
-    assert module is not None
-    assert module.workspace_size is not None
-
-    qo_indptr_host = qo_indptr.cpu()
-    paged_kv_indptr_host = paged_kv_indptr.cpu()
-    kv_lens_host = torch.full((batch_size,), kv_len, dtype=torch.int32)
-    total_num_rows = int(qo_indptr_host[-1].item())
-    float_workspace_size, int_workspace_size = module.workspace_size(
-        _byte_workspace(0),
-        qo_indptr_host,
-        paged_kv_indptr_host,
-        kv_lens_host,
-        total_num_rows,
-        batch_size,
-        num_qo_heads,
-        num_kv_heads,
-        page_size,
-        False,  # enable_cuda_graph
-        head_dim,
-        head_dim,
-        False,  # causal
-        -1,  # window_left
-        fixed_split_size,
-        True,  # disable_split_kv
-        0,  # num_colocated_ctas
-    )
-    assert float_workspace_size >= 0
-    assert int_workspace_size > 0
-
-    plan_info = module.plan(
-        _byte_workspace(float_workspace_size),
-        _byte_workspace(int_workspace_size),
-        torch.empty(int_workspace_size, dtype=torch.uint8, pin_memory=True),
-        qo_indptr_host,
-        paged_kv_indptr_host,
-        kv_lens_host,
-        total_num_rows,
-        batch_size,
-        num_qo_heads,
-        num_kv_heads,
-        page_size,
-        False,  # enable_cuda_graph
-        head_dim,
-        head_dim,
-        False,  # causal
-        -1,  # window_left
-        fixed_split_size,
-        True,  # disable_split_kv
-        0,  # num_colocated_ctas
-    )
-    assert len(plan_info) > 0
+    assert wrapper._plan_info is not None

--- a/tests/attention/test_workspace_size.py
+++ b/tests/attention/test_workspace_size.py
@@ -29,8 +29,7 @@ def _paged_kv_inputs(batch_size: int, kv_len: int, page_size: int):
     pages_per_seq = (kv_len + page_size - 1) // page_size
     total_pages = batch_size * pages_per_seq
     indptr = (
-        torch.arange(batch_size + 1, dtype=torch.int32, device="cuda")
-        * pages_per_seq
+        torch.arange(batch_size + 1, dtype=torch.int32, device="cuda") * pages_per_seq
     )
     indices = torch.arange(total_pages, dtype=torch.int32, device="cuda")
     last_page_len = torch.full(
@@ -57,9 +56,7 @@ def test_batch_decode_workspace_size_plans_with_exact_buffers():
     logits_soft_cap = 0.0
     window_left = -1
 
-    indptr, indices, last_page_len = _paged_kv_inputs(
-        batch_size, kv_len, page_size
-    )
+    indptr, indices, last_page_len = _paged_kv_inputs(batch_size, kv_len, page_size)
     wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
         _byte_workspace(32 * 1024 * 1024)
     )
@@ -128,9 +125,7 @@ def test_batch_prefill_workspace_size_plans_with_exact_buffers():
     head_dim = 128
     fixed_split_size = -1
 
-    qo_indptr = (
-        torch.arange(batch_size + 1, dtype=torch.int32, device="cuda") * qo_len
-    )
+    qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device="cuda") * qo_len
     paged_kv_indptr, paged_kv_indices, paged_kv_last_page_len = _paged_kv_inputs(
         batch_size, kv_len, page_size
     )


### PR DESCRIPTION
## 📌 Description

Add a caller-owned workspace sizing helper so integrations can allocate the FlashInfer float workspace to the actual planned requirement instead of always reserving the default workspace size.

This PR:
- Adds count-only support to `AlignedAllocator` so plan allocation offsets can be reused for sizing without touching workspace memory.
- Adds batch decode and batch prefill `workspace_size` FFI functions that return required float and int workspace bytes.
- Exposes `workspace_size` on generated and JIT batch decode/prefill Python modules, with `None` for TRTLLM-gen where the helper is not available.
- Adds CUDA tests that verify decode and FA2 prefill can plan with buffers sized exactly from `workspace_size`.
- Leaves `plan_info` layout and runtime run paths unchanged.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation performed:
- `pre-commit run --all-files`
- `FLASHINFER_DISABLE_VERSION_CHECK=1 MAX_JOBS=4 FLASHINFER_NVCC_THREADS=2 python -m pytest tests/attention/test_workspace_size.py -q -s -x --tb=short`

Not yet verified:
- Full CUDA/JIT regression matrix across all dtype, mask, sliding-window, positional-encoding, and backend combinations.

## Reviewer Notes

This PR is independent against `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace-size reporting for paged-KV batched decode and KV-cache prefill.
  * Planning modules/wrappers now expose `workspace_size` to let callers size buffers before running.
* **Bug Fixes**
  * Improved workspace sizing/allocation behavior for more accurate buffer requirements.
  * Clarified that required float workspace buffers must be 16-byte aligned.
* **Tests**
  * Added CUDA-only tests validating decode and prefill workspace sizing and planning with exact-sized buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->