### PR TITLE
feat(comm): preserve all-reduce graph VAs across checkpoint restore

### DIFF
--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -92,6 +92,31 @@ Unified AllReduce Fusion API
     TRTLLMAllReduceFusionWorkspace
     MNNVLAllReduceFusionWorkspace
 
+All-reduce workspaces backed by ``SymmDeviceMemory`` preserve their CUDA
+virtual addresses across process checkpoint/restore.  After quiescing all
+work, release the physical handles and restore them with a fresh communication
+backend before replaying a captured CUDA graph:
+
+.. code-block:: python
+
+    workspace.checkpoint_prepare()
+    workspace.checkpoint_restore(comm_backend)
+
+Both methods are collective.  Every rank must call them in the same order, and
+``comm_backend`` must reproduce the original rank and world size.  Repeated
+calls are no-ops after the workspace reaches the requested state.  If an
+exception occurs after detach or reattach begins, do not retry or reuse the
+workspace; restart the affected rank.  Workspaces backed by torch symmetric
+memory do not support this lifecycle.
+
+.. autosummary::
+    :toctree: ../generated
+
+    TRTLLMAllReduceFusionWorkspace.checkpoint_prepare
+    TRTLLMAllReduceFusionWorkspace.checkpoint_restore
+    MNNVLAllReduceFusionWorkspace.checkpoint_prepare
+    MNNVLAllReduceFusionWorkspace.checkpoint_restore
+
 vLLM AllReduce
 --------------
 

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -63,6 +63,7 @@ from flashinfer.trace.templates.comm import allreduce_fusion_trace
 
 from .trtllm_ar import trtllm_allreduce_fusion
 from .trtllm_ar import trtllm_create_ipc_workspace_for_all_reduce_fusion
+from .trtllm_ar import _initialize_allreduce_fusion_protocol
 from .trtllm_ar import check_trtllm_allreduce_fusion_workspace_metadata
 from .trtllm_ar import trtllm_moe_allreduce_fusion
 from .trtllm_ar import trtllm_moe_finalize_allreduce_fusion
@@ -177,6 +178,59 @@ class TRTLLMAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         except ValueError as e:
             logger.warning("Workspace is insufficient for problem size. %s", e)
             return False
+
+    @flashinfer_api
+    def checkpoint_prepare(self) -> None:
+        """Detach physical backing; repeated successful calls are no-ops."""
+        if not self.mem_handles or not all(
+            isinstance(handle, SymmDeviceMemory) for handle in self.mem_handles
+        ):
+            raise NotImplementedError(
+                "Stable-VA checkpointing is unavailable for workspaces backed "
+                "by torch symmetric memory"
+            )
+
+        mapped = [handle.mapped for handle in self.mem_handles]
+        if not any(mapped):
+            return
+        if not all(mapped):
+            raise RuntimeError("TRT-LLM symmetric-memory handle state is inconsistent")
+
+        for handle in self.mem_handles:
+            handle._unmap_and_release_handles()
+        # Do not return until every rank has released all workspace handles.
+        self.mem_handles[0].comm_backend.barrier()
+
+    @flashinfer_api
+    def checkpoint_restore(self, comm_backend: CommBackend) -> None:
+        """Restore physical backing; repeated successful calls are no-ops."""
+        if not self.mem_handles or not all(
+            isinstance(handle, SymmDeviceMemory) for handle in self.mem_handles
+        ):
+            raise NotImplementedError(
+                "Stable-VA checkpointing is unavailable for workspaces backed "
+                "by torch symmetric memory"
+            )
+
+        mapped = [handle.mapped for handle in self.mem_handles]
+        if all(mapped):
+            return
+        if any(mapped):
+            raise RuntimeError("TRT-LLM symmetric-memory handle state is inconsistent")
+        for handle in self.mem_handles:
+            handle._create_and_map_handles(comm_backend)
+
+        _initialize_allreduce_fusion_protocol(
+            ipc_handles=self.ipc_handles,
+            tp_rank=self.rank,
+            flag_size=self.metadata["flag_size"],
+            lamport_buffer_size=self.metadata["lamport_buffer_size"],
+            lamport_comm_size=self.metadata["lamport_comm_size"],
+            use_fp32_lamport=self.metadata["use_fp32_lamport"],
+            control_flag_ptr=self.metadata["control_flag_ptr"],
+        )
+        torch.cuda.synchronize()
+        comm_backend.barrier()
 
     def destroy(self) -> None:
         """Destroy workspace and free resources."""
@@ -671,6 +725,11 @@ def allreduce_fusion(
     # Dispatch based on workspace type
     if isinstance(workspace, TRTLLMAllReduceFusionWorkspace):
         # TensorRT-LLM backend implementation
+        if any(
+            isinstance(handle, SymmDeviceMemory) and not handle.mapped
+            for handle in workspace.mem_handles
+        ):
+            raise RuntimeError("TRT-LLM symmetric-memory handles are not attached")
 
         # ---- MOE Reduction pattern ----
         if pattern == AllReduceFusionPattern.kMoEReductionARResidualRMSNorm:

--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -942,6 +942,7 @@ class SymmDeviceMemory:
         self.signal_pad_offset = 0
         self.allocation_size = 0
         self.comm_backend = comm_backend_for_handle_transfer or MPIBackend()
+        self._enable_multicast = enable_multicast
 
         # CUDA memory handles and pointers
         self.mc_ptr = 0  # CUdeviceptr mMcPtr
@@ -953,22 +954,24 @@ class SymmDeviceMemory:
         self.uc_handles: List[
             int
         ] = []  # std::vector<CUmemGenericAllocationHandle> mUcHandles
+        self._mapped = False
 
         # Signal pad constants
         self.SIGNAL_PAD_ALIGNMENT = 16
         self.SIGNAL_PAD_SIZE = SIGNAL_PAD_SIZE
 
         # Check if device supports multicasting
-        multicast_supported = checkCudaErrors(
-            cuda.cuDeviceGetAttribute(
-                cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED,
-                device_idx,
+        if self._enable_multicast:
+            multicast_supported = checkCudaErrors(
+                cuda.cuDeviceGetAttribute(
+                    cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED,
+                    device_idx,
+                )
             )
-        )
-        if multicast_supported == 0:
-            raise RuntimeError(
-                "[SymmDeviceMemory] Device does not support multicasting."
-            )
+            if multicast_supported == 0:
+                raise RuntimeError(
+                    "[SymmDeviceMemory] Device does not support multicasting."
+                )
 
         # Calculate signal pad offset with alignment (matching C++ exactly)
         self.signal_pad_offset = round_up(buf_size, self.SIGNAL_PAD_ALIGNMENT)
@@ -979,16 +982,8 @@ class SymmDeviceMemory:
             f"Signal pad offset: {self.signal_pad_offset}"
         )
 
-        # Create handle exchanger
-        if is_mnnvl_fabric_supported(device_idx):
-            self._exchanger: HandleExchanger = FabricHandleExchanger(
-                self.comm_backend, self.group_rank, self.group_size
-            )
-        else:
-            self._exchanger = PosixFDHandleExchanger(
-                self.comm_backend, self.group_rank, self.group_size
-            )
-        self._alloc_mn_mcast_mem(buf_size, enable_multicast)
+        self._exchanger: Optional[HandleExchanger] = None
+        self._create_and_map_handles(self.comm_backend)
 
         if allocate_signal_pads:
             # Initialize signal pads
@@ -1006,7 +1001,7 @@ class SymmDeviceMemory:
     def __del__(self):
         """Destructor - cleanup allocated memory"""
 
-        if hasattr(self, "_exchanger"):
+        if hasattr(self, "_exchanger") and self._exchanger is not None:
             self._exchanger.close()
 
         # Skip cleanup during Python finalization to avoid segfaults
@@ -1064,6 +1059,8 @@ class SymmDeviceMemory:
                 checkCudaErrors(cuda.cuMemRelease(self.mc_handle))
             except Exception as e:
                 logger.warning("Destructor: Failed to release MC handle: %s", e)
+        elif hasattr(self, "mc_ptr") and self.mc_ptr:
+            checkCudaErrors(cuda.cuMemAddressFree(self.mc_ptr, self.allocation_size))
 
     def get_signal_pad_ptrs_host(self) -> List[int]:
         """Get the raw array of signal pad pointers to all ranks (including self)"""
@@ -1113,19 +1110,64 @@ class SymmDeviceMemory:
         """Get the usable buffer size (excluding signal pad)"""
         return self.allocation_size - self.SIGNAL_PAD_SIZE
 
-    def _alloc_mn_mcast_mem(self, buf_size: int, enable_multicast: bool):
-        """Allocate multi-node multicast memory using MNNVL"""
+    @property
+    def mapped(self) -> bool:
+        return self._mapped
+
+    def _create_and_map_handles(self, comm: CommBackend) -> None:
+        """Create physical backing and map it at the reserved addresses."""
+        # Create handle exchanger
+        if is_mnnvl_fabric_supported(self.device_idx):
+            self._exchanger = FabricHandleExchanger(
+                comm, self.group_rank, self.group_size
+            )
+        else:
+            self._exchanger = PosixFDHandleExchanger(
+                comm, self.group_rank, self.group_size
+            )
+
         self._verify_cuda_context()
 
         # Compute allocation size and get allocation properties
-        allocation_prop, mc_prop = self._get_allocation_prop(buf_size)
+        allocation_prop, mc_prop = self._get_allocation_prop(self.buf_size)
 
         # Allocate, exchange, and map unicast buffers
         self._allocate_unicast_buffers(allocation_prop)
 
         # Setup multicast object, exchange handles, map and bind memory
-        if enable_multicast:
+        if self._enable_multicast:
             self._setup_multicast(mc_prop)
+
+        self.comm_backend = comm
+        self._mapped = True
+
+    def _unmap_and_release_handles(self) -> None:
+        """Unmap and release physical backing while retaining reserved addresses."""
+        # Drain local work, then align ranks before changing shared mappings.
+        cuda.cuCtxSynchronize()
+        self.comm_backend.barrier()
+
+        if self._enable_multicast:
+            checkCudaErrors(
+                cuda.cuMulticastUnbind(
+                    self.mc_handle, self.device_idx, 0, self.allocation_size
+                )
+            )
+            checkCudaErrors(cuda.cuMemUnmap(self.mc_ptr, self.allocation_size))
+
+        for ptr in self.uc_ptrs:
+            checkCudaErrors(cuda.cuMemUnmap(ptr, self.allocation_size))
+
+        if self._enable_multicast:
+            checkCudaErrors(cuda.cuMemRelease(self.mc_handle))
+            self.mc_handle = 0
+        for handle in self.uc_handles:
+            checkCudaErrors(cuda.cuMemRelease(handle))
+
+        self._exchanger.close()
+        self.uc_handles = [0] * self.group_size
+        self._exchanger = None
+        self._mapped = False
 
     def _verify_cuda_context(self):
         """Verify CUDA context is set to the correct device."""
@@ -1164,20 +1206,23 @@ class SymmDeviceMemory:
             buf_size + self.SIGNAL_PAD_SIZE, alloc_granularity
         )
 
-        # Set up multicast properties
-        mc_prop = cuda.CUmulticastObjectProp()
-        mc_prop.numDevices = self.group_size
-        mc_prop.size = self.allocation_size
-        mc_prop.handleTypes = self._exchanger.handle_type
+        self._mc_granularity = alloc_granularity
+        mc_prop = None
+        if self._enable_multicast:
+            # Set up multicast properties
+            mc_prop = cuda.CUmulticastObjectProp()
+            mc_prop.numDevices = self.group_size
+            mc_prop.size = self.allocation_size
+            mc_prop.handleTypes = self._exchanger.handle_type
 
-        # Get multicast granularity and adjust allocation size
-        self._mc_granularity = checkCudaErrors(
-            cuda.cuMulticastGetGranularity(
-                mc_prop,
-                cuda.CUmulticastGranularity_flags.CU_MULTICAST_GRANULARITY_RECOMMENDED,
+            # Get multicast granularity and adjust allocation size
+            self._mc_granularity = checkCudaErrors(
+                cuda.cuMulticastGetGranularity(
+                    mc_prop,
+                    cuda.CUmulticastGranularity_flags.CU_MULTICAST_GRANULARITY_RECOMMENDED,
+                )
             )
-        )
-        self.allocation_size = round_up(self.allocation_size, self._mc_granularity)
+            self.allocation_size = round_up(self.allocation_size, self._mc_granularity)
 
         return allocation_prop, mc_prop
 
@@ -1213,21 +1258,24 @@ class SymmDeviceMemory:
                         self._exchanger.handle_type,
                     )
                 )
-                self._exchanger.cleanup(all_shareable_uc_handles[p])
+            self._exchanger.cleanup(all_shareable_uc_handles[p])
+        self._exchanger.cleanup(local_shareable_uc_handle)
 
         # Reserve address space for UC pointers
-        self.uc_ptrs = [0] * self.group_size
-        total_uc_size = self.allocation_size * self.group_size
-        self.total_uc_size = total_uc_size
-        uc_base_ptr = checkCudaErrors(
-            cuda.cuMemAddressReserve(total_uc_size, self._mc_granularity, 0, 0)
-        )
-        self.uc_base_ptr = uc_base_ptr
+        if not self.uc_ptrs:
+            self.uc_ptrs = [0] * self.group_size
+            total_uc_size = self.allocation_size * self.group_size
+            self.total_uc_size = total_uc_size
+            uc_base_ptr = checkCudaErrors(
+                cuda.cuMemAddressReserve(total_uc_size, self._mc_granularity, 0, 0)
+            )
+            self.uc_base_ptr = uc_base_ptr
+            for i in range(self.group_size):
+                offset = self.allocation_size * i
+                self.uc_ptrs[i] = int(uc_base_ptr) + offset
 
         # Map UC memory
         for i in range(self.group_size):
-            offset = self.allocation_size * i
-            self.uc_ptrs[i] = int(uc_base_ptr) + offset
             checkCudaErrors(
                 cuda.cuMemMap(
                     self.uc_ptrs[i], self.allocation_size, 0, self.uc_handles[i], 0
@@ -1237,7 +1285,7 @@ class SymmDeviceMemory:
         # Set memory access permissions for UC
         access_desc = self._get_mem_access_desc()
         checkCudaErrors(
-            cuda.cuMemSetAccess(uc_base_ptr, total_uc_size, [access_desc], 1)
+            cuda.cuMemSetAccess(self.uc_base_ptr, self.total_uc_size, [access_desc], 1)
         )
 
     def _setup_multicast(self, mc_prop):
@@ -1267,15 +1315,18 @@ class SymmDeviceMemory:
                     self._exchanger.handle_type,
                 )
             )
-            self._exchanger.cleanup(shareable_mc_handle)
+        self._exchanger.cleanup(shareable_mc_handle)
 
         # Add device to multicast
         checkCudaErrors(cuda.cuMulticastAddDevice(self.mc_handle, self.device_idx))
 
         # Reserve and map MC pointer
-        self.mc_ptr = checkCudaErrors(
-            cuda.cuMemAddressReserve(self.allocation_size, self._mc_granularity, 0, 0)
-        )
+        if not self.mc_ptr:
+            self.mc_ptr = checkCudaErrors(
+                cuda.cuMemAddressReserve(
+                    self.allocation_size, self._mc_granularity, 0, 0
+                )
+            )
         checkCudaErrors(
             cuda.cuMemMap(self.mc_ptr, self.allocation_size, 0, self.mc_handle, 0)
         )

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 import functools
 import logging
-from ctypes import c_void_p, cast
+from ctypes import c_void_p, cast, create_string_buffer
 from types import SimpleNamespace
 from typing import List, Optional, Tuple, Union
 from typing_extensions import deprecated
@@ -571,7 +571,9 @@ def _initialize_allreduce_fusion_protocol(
     )
 
     cudart.cudaMemset(c_void_p(control_flag_ptr), 0, 5 * 4)
-    lamport_comm_size_bytes = lamport_comm_size.to_bytes(4, byteorder="little")
+    lamport_comm_size_bytes = create_string_buffer(
+        lamport_comm_size.to_bytes(4, byteorder="little"), 4
+    )
     cudart.cudaMemcpy(
         c_void_p(control_flag_ptr + 3 * 4), cast(lamport_comm_size_bytes, c_void_p), 4
     )

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -427,7 +427,7 @@ OneShotMaxToken = 128
 MAX_ALL_REDUCE_BLOCKS = 24
 LamportTokenNumThreshold = 16
 
-_symm_workspace_refs: dict[int, list[torch.Tensor]] = {}
+_symm_workspace_refs: dict[int, list[object]] = {}
 
 
 @deprecated(
@@ -551,6 +551,32 @@ BarrierFlagCount = 256
 MAX_COMM_SIZE = 2147483647 & ~((1 << 21) - 1)  # MAX_INT32 rounded down to 2MB
 
 
+def _initialize_allreduce_fusion_protocol(
+    ipc_handles: List[List[int]],
+    tp_rank: int,
+    flag_size: int,
+    lamport_buffer_size: int,
+    lamport_comm_size: int,
+    use_fp32_lamport: bool,
+    control_flag_ptr: int,
+) -> None:
+    cudart.cudaMemset(c_void_p(ipc_handles[1][tp_rank]), 0, flag_size)
+
+    lamport_dtype = torch.float32 if use_fp32_lamport else torch.float16
+    aligned_size = round_up(lamport_buffer_size, 16)
+    trtllm_lamport_initialize(
+        ipc_handles[2][tp_rank],
+        aligned_size // (4 if use_fp32_lamport else 2),
+        lamport_dtype,
+    )
+
+    cudart.cudaMemset(c_void_p(control_flag_ptr), 0, 5 * 4)
+    lamport_comm_size_bytes = lamport_comm_size.to_bytes(4, byteorder="little")
+    cudart.cudaMemcpy(
+        c_void_p(control_flag_ptr + 3 * 4), cast(lamport_comm_size_bytes, c_void_p), 4
+    )
+
+
 @deprecated(
     "use the unified API allreduce.py instead. It will internally call trtllm_create_ipc_workspace_for_all_reduce_fusion."
 )
@@ -588,7 +614,8 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
       use_fp32_lamport, buffer_size, flag_size, lamport_comm_size, lamport_buffer_size
     - If create_metadata=True: and use_symm_dev_mem=True: (ipc_handles, workspace_tensor, mem_handles,metadata)
       where metadata contains: tp_rank, tp_size, max_token_num, hidden_dim,
-      use_fp32_lamport, buffer_size, flag_size, lamport_comm_size, lamport_buffer_size
+      use_fp32_lamport, buffer_size, flag_size, lamport_comm_size,
+      lamport_buffer_size, control_flag_ptr
       and mem_handles is a list of SymmDeviceMemory objects.
 
     Note: The optional parameters make the API clunky at this time. This will be refactored in the future, at the cost of backward compatibility, where the default behavior will be
@@ -635,12 +662,7 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     lamport_buffer_size = lamport_comm_size * 3
 
     device = torch.device(f"cuda:{torch.cuda.current_device()}")
-    group_name = (
-        group.group_name
-        if group is not None
-        else torch.distributed.group.WORLD.group_name
-    )
-    symm_refs: list[torch.Tensor] = []
+    symm_refs: list[object] = []
 
     # we should init 3 buffers for all reduce fusion:
     # [buffer_size, flag_size, lamport_buffer_size]
@@ -655,16 +677,35 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     ]:
         aligned_size = round_up(size, 16)
 
-        ptrs, tensor, handle = _alloc_symm_buffer_bytes(
-            aligned_size,
-            tp_size,
-            dtype,
-            device,
-            group_name,
-        )
-        symm_refs.append((tensor, handle))
+        if use_symm_dev_mem:
+            assert comm_backend is not None
+            handle = SymmDeviceMemory(
+                buf_size=aligned_size,
+                group_size=tp_size,
+                group_rank=tp_rank,
+                device_idx=device.index,
+                comm_backend_for_handle_transfer=comm_backend,
+                enable_multicast=False,
+                allocate_signal_pads=False,
+            )
+            ptrs = handle.get_buffer_ptrs_host()
+            symm_refs.append(handle)
+            mem_handles.append(handle)
+        else:
+            group_name = (
+                group.group_name
+                if group is not None
+                else torch.distributed.group.WORLD.group_name
+            )
+            ptrs, tensor, handle = _alloc_symm_buffer_bytes(
+                aligned_size,
+                tp_size,
+                dtype,
+                device,
+                group_name,
+            )
+            symm_refs.append((tensor, handle))
         ipc_handles.append(ptrs)
-        mem_handles.append(handle)
 
     logger.debug(
         "rank %s allocated ipc_handles: %s",
@@ -673,6 +714,9 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     )
 
     _symm_workspace_refs[id(ipc_handles)] = symm_refs
+
+    if use_symm_dev_mem:
+        cudart.cudaMemset(c_void_p(ipc_handles[1][tp_rank]), 0, flag_size)
 
     # Initialize lamport buffer
     aligned_lamport_buffer_size = round_up(lamport_buffer_size, 16)
@@ -724,6 +768,7 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     )
 
     if use_symm_dev_mem:
+        torch.cuda.synchronize()
         comm_backend.barrier()  # must sync after create_workspace
     else:
         dist.barrier(group=group)
@@ -741,6 +786,7 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
             "lamport_buffer_size": lamport_buffer_size,
         }
         if use_symm_dev_mem:
+            metadata["control_flag_ptr"] = flag_ptr.value
             return ipc_handles, workspace_tensor, mem_handles, metadata
         else:
             return ipc_handles, workspace_tensor, metadata

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -14,15 +14,14 @@ import torch
 from typing_extensions import deprecated
 
 from flashinfer.comm.mapping import Mapping
-from flashinfer.comm.mnnvl import TorchDistBackend
+from flashinfer.api_logging import flashinfer_api
 
 from ..jit import gen_trtllm_mnnvl_comm_module
 from ..utils import register_custom_op
 from ..fp4_quantization import _compute_swizzled_layout_sf_size
-from .mnnvl import CommBackend, MPIBackend
+from .mnnvl import CommBackend, McastGPUBuffer, MPIBackend, SymmDeviceMemory
 from .trtllm_ar import QuantizationSFLayout
 from .workspace_base import AllReduceFusionWorkspace
-from .torch_symmetric_memory import _alloc_symm_buffer_bytes
 
 
 def mpi_barrier():
@@ -146,26 +145,16 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         # support base_gpu_id != 0 scenarios where the actual CUDA device
         # index differs from the TP rank / local_rank.
         device = torch.device("cuda", torch.cuda.current_device())
-        if isinstance(comm_backend, TorchDistBackend):
-            group = (
-                comm_backend._group
-                if comm_backend._group is not None
-                else torch.distributed.group.WORLD
-            )
-            group_name = group.group_name
-        else:
-            group_name = torch.distributed.group.WORLD.group_name
-        self.ptrs, self.tensor, self.handle = _alloc_symm_buffer_bytes(
-            requested_workspace_size,
-            mapping.tp_size,
-            torch.float32,
-            device,
-            group_name,
+        self.handle = McastGPUBuffer(
+            buf_size=requested_workspace_size,
+            group_size=mapping.tp_size,
+            group_rank=mapping.tp_rank,
+            device=device,
+            comm_backend_for_handle_transfer=comm_backend,
         )
+        self.ptrs = self.handle.mcast_device_memory.get_buffer_ptrs_host()
 
-        # handle.buffer_size is the usable data size. torch symmetric memory
-        # allocator places signal_pad on top of it, not carved from within.
-        allocated_size = self.handle.buffer_size
+        allocated_size = self.handle.buf_size
         # We want the buffer size to be aligned to 16B which is the granularity for buffer management.
         self.buffer_size_bytes = (
             math.floor(allocated_size / self.NUM_LAMPORT_BUFFERS) // 16 * 16
@@ -177,9 +166,7 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             f"[MNNVL Allreduce] Actual allocated size: {allocated_size} bytes, Actual buffer size per lamport buffer: {self.buffer_size_bytes} bytes, total workspace: {self.workspace_size_bytes} bytes."
         )
 
-        # lamport initialize tensor to negative zero.
-        self.tensor.fill_(-0.0)
-        # Wait until the initialization is done
+        self.handle.lamport_initialize(self.rank, torch.float32)
         torch.cuda.synchronize()
         comm_backend.barrier()
 
@@ -194,9 +181,9 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
             device=torch.device("cuda", torch.cuda.current_device()),
         )
 
-        self.uc_ptrs_dev = self.handle.buffer_ptrs_dev
-        self.uc_ptr_local = self.handle.buffer_ptrs[self.rank]
-        self.mc_ptr = self.handle.multicast_ptr
+        self.uc_ptrs_dev = self.handle.get_buffer_ptrs_dev()
+        self.uc_ptr_local = self.handle.get_unicast_ptr(self.rank)
+        self.mc_ptr = self.handle.get_multicast_ptr()
 
     @functools.cache
     def is_buffer_size_sufficient(
@@ -251,6 +238,53 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
     def backend(self) -> str:
         return "mnnvl"
 
+    def _require_handles_attached(self) -> None:
+        memory = getattr(self.handle, "mcast_device_memory", None)
+        if isinstance(memory, SymmDeviceMemory) and not memory.mapped:
+            raise RuntimeError("MNNVL handles are not attached")
+
+    def _initialize_protocol(self) -> None:
+        self.handle.lamport_initialize(self.rank, torch.float32)
+        num_bytes_to_clear = [0] * 4
+        self.buffer_flags.copy_(
+            torch.tensor(
+                [0, 2, self.buffer_size_bytes, 0, *num_bytes_to_clear, 0],
+                dtype=torch.uint32,
+                device=self.buffer_flags.device,
+            )
+        )
+        torch.cuda.synchronize()
+
+    @flashinfer_api
+    def checkpoint_prepare(self) -> None:
+        """Detach physical backing; repeated successful calls are no-ops."""
+        memory = getattr(self.handle, "mcast_device_memory", None)
+        if not isinstance(memory, SymmDeviceMemory):
+            raise NotImplementedError(
+                "Stable-VA checkpointing is unavailable for workspaces backed "
+                "by torch symmetric memory"
+            )
+        if not memory.mapped:
+            return
+        memory._unmap_and_release_handles()
+        # Do not return until every rank has released its workspace handles.
+        memory.comm_backend.barrier()
+
+    @flashinfer_api
+    def checkpoint_restore(self, comm_backend: CommBackend) -> None:
+        """Restore physical backing; repeated successful calls are no-ops."""
+        memory = getattr(self.handle, "mcast_device_memory", None)
+        if not isinstance(memory, SymmDeviceMemory):
+            raise NotImplementedError(
+                "Stable-VA checkpointing is unavailable for workspaces backed "
+                "by torch symmetric memory"
+            )
+        if memory.mapped:
+            return
+        memory._create_and_map_handles(comm_backend)
+        self._initialize_protocol()
+        comm_backend.barrier()
+
     def destroy(self) -> None:
         """Destroy workspace and free resources."""
         if getattr(self, "_destroyed", False):
@@ -260,7 +294,6 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
         del self.uc_ptrs_dev
         del self.uc_ptr_local
         del self.mc_ptr
-        del self.tensor
         del self.handle
         del self.ptrs
         self._destroyed = True
@@ -432,6 +465,8 @@ def trtllm_mnnvl_allreduce(
             f"The output tensor must be 2D, got {len(output.shape)}D. The shape is {output.shape}."
         )
 
+    workspace._require_handles_attached()
+
     module = get_trtllm_mnnvl_comm_module()
 
     if strategy == MNNVLAllreduceFusionStrategy.AUTO:
@@ -531,6 +566,8 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm(
         raise ValueError(
             f"The residual output tensor must be 2D, got {len(residual_out.shape)}D. The shape is {residual_out.shape}."
         )
+
+    workspace._require_handles_attached()
 
     module = get_trtllm_mnnvl_comm_module()
 
@@ -736,6 +773,8 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
     else:
         raise ValueError(f"Unsupported MNNVL quant_type: {quant_type}")
 
+    workspace._require_handles_attached()
+
     if strategy == MNNVLAllreduceFusionStrategy.AUTO:
         strategy = MNNVLAllreduceFusionStrategy.select_strategy(
             workspace.tp_size, token_num, hidden_dim, input.dtype
@@ -809,7 +848,7 @@ def get_allreduce_mnnvl_workspace(
 
     Returns:
         Tuple containing:
-        - MNNVLAllReduceFusionWorkspace: The workspace object backed by torch symmetric memory
+        - MNNVLAllReduceFusionWorkspace: The CUDA VMM-backed workspace object
         - torch.Tensor: Buffer flags tensor tracking state
         - int: Maximum number of elements that can fit in buffer
     """

--- a/tests/comm/test_trtllm_allreduce_checkpoint.py
+++ b/tests/comm/test_trtllm_allreduce_checkpoint.py
@@ -1,0 +1,120 @@
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+
+def test_checkpoint_lifecycle_rejects_torch_symmetric_memory_backing() -> None:
+    from flashinfer.comm.allreduce import (
+        MNNVLAllReduceFusionWorkspace,
+        TRTLLMAllReduceFusionWorkspace,
+    )
+    from flashinfer.comm.workspace_base import AllReduceFusionWorkspace
+
+    trt_workspace = object.__new__(TRTLLMAllReduceFusionWorkspace)
+    AllReduceFusionWorkspace.__init__(trt_workspace, world_size=1, rank=0)
+    trt_workspace.mem_handles = []
+    trt_workspace._destroyed = True
+
+    mnnvl_workspace = object.__new__(MNNVLAllReduceFusionWorkspace)
+    AllReduceFusionWorkspace.__init__(mnnvl_workspace, world_size=1, rank=0)
+    mnnvl_workspace.handle = object()
+    mnnvl_workspace._destroyed = True
+
+    for workspace in (trt_workspace, mnnvl_workspace):
+        with pytest.raises(NotImplementedError, match="torch symmetric memory"):
+            workspace.checkpoint_prepare()
+        with pytest.raises(NotImplementedError, match="torch symmetric memory"):
+            workspace.checkpoint_restore(None)
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _run_worker(
+    rank: int, world_size: int, port: int, num_tokens: int, use_oneshot: bool
+) -> None:
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        "gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+    workspace = None
+    try:
+        import flashinfer.comm as comm
+        from flashinfer.comm.mnnvl import TorchDistBackend
+
+        workspace = comm.create_allreduce_fusion_workspace(
+            backend="trtllm",
+            world_size=world_size,
+            rank=rank,
+            max_token_num=num_tokens,
+            hidden_dim=4096,
+            dtype=torch.bfloat16,
+            comm_backend=TorchDistBackend(),
+        )
+        input_ = torch.full(
+            (num_tokens, 4096), rank + 1, dtype=torch.bfloat16, device="cuda"
+        )
+        output = torch.empty_like(input_)
+
+        def all_reduce() -> None:
+            comm.allreduce_fusion(
+                input=input_,
+                workspace=workspace,
+                output=output,
+                pattern=comm.AllReduceFusionPattern.kAllReduce,
+                use_oneshot=use_oneshot,
+            )
+
+        all_reduce()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output, torch.full_like(output, 3))
+
+        graph = torch.cuda.CUDAGraph()
+        dist.barrier()
+        with torch.cuda.graph(graph):
+            all_reduce()
+
+        dist.barrier()
+        workspace.checkpoint_prepare()
+        workspace.checkpoint_prepare()
+        with pytest.raises(RuntimeError, match="not attached"):
+            all_reduce()
+        dist.barrier()
+        fresh_backend = TorchDistBackend()
+        workspace.checkpoint_restore(fresh_backend)
+        workspace.checkpoint_restore(fresh_backend)
+        dist.barrier()
+
+        input_.fill_(rank + 2)
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output, torch.full_like(output, 5))
+    finally:
+        if workspace is not None:
+            workspace.destroy()
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("num_tokens,use_oneshot", [(1, True), (4, False)])
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="checkpointable TRT-LLM all-reduce requires two CUDA devices",
+)
+def test_graph_replay_after_symmetric_memory_remap(
+    num_tokens: int, use_oneshot: bool
+) -> None:
+    mp.spawn(
+        _run_worker,
+        args=(2, _free_port(), num_tokens, use_oneshot),
+        nprocs=2,
+        join=True,
+    )

--- a/tests/comm/test_trtllm_mnnvl_allreduce.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce.py
@@ -458,7 +458,7 @@ def run_mnnvl_ar_full(
 
             multicast_ptr = legacy_workspace.mc_ptr
             buffer_ptrs_dev = legacy_workspace.uc_ptrs_dev
-            unicast_ptr = legacy_workspace.handle.buffer_ptrs[mapping.tp_rank]
+            unicast_ptr = legacy_workspace.uc_ptr_local
 
         else:
             workspace = trtllm_mnnvl_ar.MNNVLAllReduceFusionWorkspace(


### PR DESCRIPTION
## Summary

Adds checkpoint lifecycle support for all-reduce workspaces whose pointers are captured by CUDA graphs. Physical CUDA VMM backing can be released before checkpoint and recreated at the same reserved virtual addresses after restore.

The workspace API is:

- `checkpoint_prepare()` collectively quiesces the group and detaches physical backing while preserving graph-visible virtual addresses.
- `checkpoint_restore(comm_backend)` attaches fresh backing at those addresses, reinitializes protocol state, and collectively fences before returning.
- Repeating a successfully completed prepare or restore is a no-op.
- Lifecycle failures propagate without rollback or retry; the affected workspace must not be reused.
- Workspaces backed by torch symmetric memory explicitly reject this lifecycle because that allocator does not provide the required stable-address remap contract.

## Implementation

- Decomposes `SymmDeviceMemory` construction around `_create_and_map_handles()` and adds the inverse `_unmap_and_release_handles()` operation. Initial allocation and restore therefore use the same mapping path.
- Retains CUDA virtual-address reservations while releasing unicast and multicast physical handles.
- Uses a fresh communicator and handle exchanger during restore.
- Supports unicast-only TRT-LLM workspaces without requiring multicast capability.
- Moves the MNNVL all-reduce workspace to the same VMM-backed memory core.
- Reinitializes TRT-LLM Lamport/barrier/control state and MNNVL Lamport/flag state before graph replay.
- Rejects all-reduce launches while native backing is detached.

## Validation

- `ruff format` leaves the changed Python files unchanged.
- `ruff check` passes for the changed Python files.
- `py_compile` passes for the changed Python files.
- `git diff --check origin/main` passes.
- The torch-symmetric-memory rejection test passes for both all-reduce workspace types.
- Checkpoint and MNNVL all-reduce test collection succeeds (278 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `checkpoint_prepare()` / `checkpoint_restore(comm_backend)` lifecycle support for symmetric-memory–backed all-reduce fusion workspaces (TRT-LLM and MNNVL), enabling safe reattachment and protocol reinitialization.

* **Bug Fixes**
  * Tightened validation for consistent handle attachment/detachment; fused all-reduce now rejects launches when required workspace handles are not attached.

* **Documentation**
  * Documented required call order, rank synchronization expectations, idempotency, and unsupported backings.

* **Tests**
  * Added distributed CUDA-graph coverage to verify behavior before/after symmetric-memory remapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->