### PR TITLE
docs: add API reference page for parallel_attention module

### DIFF
--- a/docs/api/parallel_attention.rst
+++ b/docs/api/parallel_attention.rst
@@ -1,0 +1,37 @@
+.. _apiparallel_attention:
+
+flashinfer.parallel_attention
+==============================
+
+Context-parallel attention utilities. These wrap an attention backend with
+Ulysses and/or Ring parallelism and provide the helpers to shard
+variable-length inputs and build the required process groups.
+
+.. currentmodule:: flashinfer.parallel_attention
+
+Attention Wrapper
+-----------------
+
+.. autoclass:: ParallelAttention
+    :members:
+
+Parallelism Configs
+-------------------
+
+.. autoclass:: UnevenCPConfig
+    :members:
+
+.. autoclass:: VarlenCPConfig
+    :members:
+
+Sharding and Group Helpers
+--------------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    split_varlen_input
+    ulysses_varlen_config
+    ring_varlen_config
+    uneven_cp_config
+    get_parallel_groups

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    api/activation
    api/gdn_decode
    api/gdn_prefill
+   api/parallel_attention
    api/mamba
    api/quantization
    api/green_ctx


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The `parallel_attention` module was introduced in #2630 (Ulysses / Ring context-parallel attention) but never got an API reference page, so its public symbols are absent from the rendered docs, so its 8 public symbols (__all__) are absent from the rendered docs.

This PR adds `docs/api/parallel_attention.rst` and wires it into the docs toctree.

The page documents all 8 public symbols re-exported in parallel_attention/__init__.py (the ParallelAttention wrapper, two CP config classes, and five sharding/group helpers). Docs-only change — no source or docstrings touched.

## 🔍 Related Issues

Follow-up to #2630, which added the module without docs.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new API reference page for parallel attention, including class and helper function listings.
  * Updated the documentation navigation so the new reference page appears in the PyTorch API section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->