### PR TITLE
docs: add missing arg docs for output_scalar_scale and activation

### DIFF
--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -440,6 +440,10 @@ def moe_a2a_combine(
     output_scales : Optional[torch.Tensor]
         Optional output scale tensor for quantized outputs.  Currently
         supports UE8M0 (packed in ``torch.uint8``) with vector size 32.
+    output_scalar_scale : float
+        Per-tensor global scale applied before FP4 block scaling
+        (NVFP4 SFScaleVal).  Defaults to ``1.0``; ignored by MXFP8/MXFP4
+        paths.
     sf_layout : SfLayout
         Output swizzle layout.  Defaults to ``SfLayout.layout_linear``.
 
@@ -870,6 +874,10 @@ class MoeAlltoAll:
         output_scales : Optional[torch.Tensor]
             Optional output scale tensor for quantized outputs.  Currently
             supports UE8M0 (packed in ``torch.uint8``) with vector size 32.
+        output_scalar_scale : float
+            Per-tensor global scale applied before FP4 block scaling
+            (NVFP4 SFScaleVal).  Defaults to ``1.0``; ignored by MXFP8/MXFP4
+            paths.
         sf_layout : SfLayout
             Output swizzle layout.  Defaults to ``SfLayout.layout_linear``.
 

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -415,6 +415,9 @@ class CuteDslMoEWrapper:
             Device on which to allocate buffers.  Defaults to ``"cuda"``.
         enable_pdl : bool
             Enable Programmatic Dependent Launch.  Defaults to ``True``.
+        activation : str
+            FC1 activation function: ``"silu"`` for gated SwiGLU (default)
+            or ``"relu2"`` for ReLU².  Defaults to ``"silu"``.
         """
         self.num_experts = num_experts
         self.top_k = top_k


### PR DESCRIPTION
## Summary

Fixes three missing parameter entries in docstrings, introduced by #3642 and #3643:

• `flashinfer.comm.trtllm_moe_alltoall.moe_a2a_combine` — document `output_scalar_scale`
• `flashinfer.comm.trtllm_moe_alltoall.MoeAlltoAll.combine` — document `output_scalar_scale`
• `flashinfer.fused_moe.cute_dsl.fused_moe.CuteDslMoEWrapper.__init__` — document `activation`

## Test plan

- [ ] Verify rendered docs include the new parameter entries
- [ ] No functional code changes — doc-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `output_scalar_scale` parameter in MoE all-to-all combine APIs.
  * Expanded activation documentation to spell out supported options and defaults.
  * Improved end-user guidance for using these MoE features correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->