### PR TITLE
[feat] Optimize TRTLLMGEN MoE routing

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -28,6 +28,7 @@
 
 #include <cstdlib>
 #include <string>
+#include <type_traits>
 
 #include "flashinfer/trtllm/common/cudaUtils.h"
 #include "flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh"
@@ -642,23 +643,55 @@ void launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* strea
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename KernelParams>
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(NumThreads)
-    routingIndicesClusterKernel(KernelParams params) {
-  using OutputT = typename KernelParams::OutputT;
+static constexpr int ClusterBlockDim256 = NumExperts256Experts;
+static constexpr int ClusterBlockDim512 = NumExperts512Experts;
+static constexpr int ClusterBlockDim1024 = NumThreads;
+static constexpr int MaxNumTokensClusterScores256 =
+    NumBlocksPerCluster * (ClusterBlockDim256 / WarpSize);
+static constexpr int MaxNumTokensClusterScores512 =
+    NumBlocksPerCluster * (ClusterBlockDim512 / WarpSize);
+
+template <typename TierT, typename TierListT>
+struct PrependTier;
+
+template <typename TierT, typename... Tiers>
+struct PrependTier<TierT, TierList<Tiers...>> {
+  using type = TierList<TierT, Tiers...>;
+};
+
+template <int ClusterBlockDim, typename TierListT>
+struct FilterClusterTiers;
+
+template <int ClusterBlockDim>
+struct FilterClusterTiers<ClusterBlockDim, TierList<>> {
+  using type = TierList<>;
+};
+
+template <int ClusterBlockDim, typename First, typename... Rest>
+struct FilterClusterTiers<ClusterBlockDim, TierList<First, Rest...>> {
+  using Tail = typename FilterClusterTiers<ClusterBlockDim, TierList<Rest...>>::type;
+  static constexpr bool IsValid =
+      First::kExperts <= ClusterBlockDim || First::kExperts % ClusterBlockDim == 0;
+  using type = std::conditional_t<IsValid, typename PrependTier<First, Tail>::type, Tail>;
+};
+
+template <int ClusterBlockDim, typename PreProc, typename PostProc>
+struct ClusterPolicyTraits {
+  using Pairs = typename FilterClusterTiers<ClusterBlockDim,
+                                            typename PolicyTraits<PreProc, PostProc>::Pairs>::type;
+};
+
+template <typename KernelParams, typename BaseType, int ClusterBlockDim, int ClusterNumWarps>
+__device__ __forceinline__ void routingIndicesClusterKernelBody(
+    KernelParams params, PackedScoreIdx<BaseType>* smemPackedScoreIdx) {
   using InputT = typename KernelParams::InputT;
-  using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
   using TypePacked = PackedScoreIdx<BaseType>;
   static constexpr int VecSize = KernelParams::MaxNumExperts / WarpSize;
-
-  __shared__ TypePacked
-      __attribute((aligned(128))) smemPackedScoreIdx[NumWarps * KernelParams::MaxNumTopExperts];
 
   uint32_t const clusterBlockRank = blockIdx.x;
   int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
   int32_t const laneIdx = cutlass::arch::LaneId();
-  auto warpTokenIdx = clusterBlockRank * NumWarps + warpIdx;
+  auto warpTokenIdx = clusterBlockRank * ClusterNumWarps + warpIdx;
   auto scoreOffset = warpTokenIdx * params.mNumExperts;
   bool validToken = warpTokenIdx < params.mNumTokens;
   auto block = cg::this_thread_block();
@@ -693,23 +726,125 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
   __cluster_barrier_wait();
 
   if (params.mPtrScores != nullptr) {
-    routingPermutation<KernelParams, BaseType, NumThreads, NumWarps, KernelParams::MaxNumTopExperts,
-                       /*LoadExpertIdxFromGlobal=*/false>(params, smemPackedScoreIdx, warpIdx,
-                                                          clusterBlockRank);
+    routingPermutation<KernelParams, BaseType, ClusterBlockDim, ClusterNumWarps,
+                       KernelParams::MaxNumTopExperts, /*LoadExpertIdxFromGlobal=*/false>(
+        params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
   } else {
-    routingPermutation<KernelParams, BaseType, NumThreads, NumWarps, KernelParams::MaxNumTopExperts,
-                       /*LoadExpertIdxFromGlobal=*/true>(params, smemPackedScoreIdx, warpIdx,
-                                                         clusterBlockRank);
+    routingPermutation<KernelParams, BaseType, ClusterBlockDim, ClusterNumWarps,
+                       KernelParams::MaxNumTopExperts, /*LoadExpertIdxFromGlobal=*/true>(
+        params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
   }
 }
+
+template <typename KernelParams, int ClusterBlockDim = NumThreads>
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(ClusterBlockDim)
+    routingIndicesClusterKernel(KernelParams params) {
+  using InputT = typename KernelParams::InputT;
+  using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
+  using TypePacked = PackedScoreIdx<BaseType>;
+  static constexpr int NumWarpsBlock = ClusterBlockDim / WarpSize;
+  static_assert(ClusterBlockDim % WarpSize == 0);
+  static_assert(ClusterBlockDim <= NumThreads);
+  __shared__ TypePacked __attribute((
+      aligned(128))) smemPackedScoreIdx[NumWarpsBlock * KernelParams::MaxNumTopExperts];
+  routingIndicesClusterKernelBody<KernelParams, BaseType, ClusterBlockDim, NumWarpsBlock>(
+      params, smemPackedScoreIdx);
+}
 #else
-__global__ void __launch_bounds__(NumThreads)
+__global__ void __launch_bounds__(ClusterBlockDim)
     routingIndicesClusterKernel(KernelParams /* params */) {
   assert(false && "routingIndicesClusterKernel is only supported on SM90+ architectures");
 }
 #endif  // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 
+template <typename ParamsT, int ClusterBlockDim>
+void launchClusterKernelInstance(Data const& data, void* stream) {
+  static_assert(ClusterBlockDim % WarpSize == 0);
+  static_assert(ClusterBlockDim <= NumThreads);
+
+  cudaLaunchConfig_t config{};
+  config.gridDim = NumBlocksPerCluster;
+  config.blockDim = ClusterBlockDim;
+  config.dynamicSmemBytes = 0;
+  config.stream = (cudaStream_t)stream;
+
+  cudaLaunchAttribute attributes[2] = {};
+  attributes[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attributes[0].val.programmaticStreamSerializationAllowed = int(data.mUsePdl);
+  attributes[1].id = cudaLaunchAttributeCooperative;
+  attributes[1].val.cooperative = 0;
+  config.attrs = attributes;
+  config.numAttrs = 2;
+
+  auto params = ParamsT::setKernelParams(data);
+  auto kernelTyped = routingIndicesClusterKernel<ParamsT, ClusterBlockDim>;
+  CHECK_CUDA_ERROR(cudaLaunchKernelEx(&config, kernelTyped, params));
+}
+
+template <int ClusterBlockDim, typename PreProc, typename PostProc, int MaxNumExperts,
+          int MaxNumTopExperts>
+void launchClusterKernelForTier(Data const& data, void* stream) {
+  using ExpertSelect = TopKExpertSelect<PreProc, PostProc>;
+  if (data.mDtypeOutput == tg::Dtype::Fp32) {
+    using ParamsT = KernelParams<float, float, MaxNumExperts, MaxNumTopExperts, ExpertSelect>;
+    launchClusterKernelInstance<ParamsT, ClusterBlockDim>(data, stream);
+  } else if (data.mDtypeOutput == tg::Dtype::Bfloat16 && data.mDtypeInput == tg::Dtype::Fp32) {
+    using ParamsT =
+        KernelParams<float, __nv_bfloat16, MaxNumExperts, MaxNumTopExperts, ExpertSelect>;
+    launchClusterKernelInstance<ParamsT, ClusterBlockDim>(data, stream);
+  } else if (data.mDtypeOutput == tg::Dtype::Bfloat16) {
+    using ParamsT =
+        KernelParams<__nv_bfloat16, __nv_bfloat16, MaxNumExperts, MaxNumTopExperts, ExpertSelect>;
+    launchClusterKernelInstance<ParamsT, ClusterBlockDim>(data, stream);
+  } else {
+    FLASHINFER_WARN("Unsupported dtypeOutput");
+  }
+}
+
+template <int ClusterBlockDim, typename PreProc, typename PostProc>
+void launchClusterKernelForPolicy(Data const& data, void* stream) {
+  using Pairs = typename ClusterPolicyTraits<ClusterBlockDim, PreProc, PostProc>::Pairs;
+  bool dispatched =
+      dispatchTierPairs(static_cast<Pairs*>(nullptr), data, [&](auto eTag, auto kTag) {
+        launchClusterKernelForTier<ClusterBlockDim, PreProc, PostProc, decltype(eTag)::value,
+                                   decltype(kTag)::value>(data, stream);
+      });
+  if (!dispatched) {
+    FLASHINFER_WARN("No tier covers numExperts=%d topK=%d", data.mNumExperts, data.mTopK);
+  }
+}
+
+template <int ClusterBlockDim>
+void launchClusterKernelForBlockDim(Data const& data, void* stream) {
+  dispatchRoutingPolicy(data, [&](auto preProc, auto postProc, char const* /*policyName*/) {
+    launchClusterKernelForPolicy<ClusterBlockDim, decltype(preProc), decltype(postProc)>(data,
+                                                                                         stream);
+  });
+}
+
 void launchClusterKernel(Data const& data, void* stream) {
+  // Each warp owns one token, so the reduced-thread cluster variants have lower token capacity.
+  // Use them only where the requested token count fits; otherwise keep the original 1024-thread
+  // launch.
+  if (data.mNumTokens <= MaxNumTokensClusterScores256) {
+    launchClusterKernelForBlockDim<ClusterBlockDim256>(data, stream);
+    return;
+  }
+  if (data.mNumTokens <= MaxNumTokensClusterScores512) {
+    launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
+    return;
+  }
+
+  bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr &&
+                                    data.mPreprocessType == RoutingPreprocessType::None &&
+                                    data.mPostprocessType == RoutingPostprocessType::Softmax;
+  if (useNoOpSoftmaxScores) {
+    launchClusterKernelForPolicy<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>(data,
+                                                                                          stream);
+    return;
+  }
+
   LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesClusterKernel, NumBlocksPerCluster, NumThreads,
                         /*smemSize=*/0,  // No dynamic smem
                         stream);
@@ -722,16 +857,68 @@ void launchClusterKernel(Data const& data, void* stream) {
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+template <int MaxNumExperts, int MaxNumTopExperts>
+struct HistogramScoresLaunchConfig : DefaultRoutingLaunchConfig<MaxNumExperts, MaxNumTopExperts> {
+  static constexpr int DefaultBlockDim =
+      DefaultRoutingLaunchConfig<MaxNumExperts, MaxNumTopExperts>::BlockDim;
+  static constexpr int HistogramScoresBlockDim = NumExperts256Experts;
+
+  // This kernel uses one warp per token and keeps per-warp arrays sized by both the expert tier and
+  // the topK tier. The 256-expert tier already launches with 256 threads; for larger tiers, fewer
+  // warps per CTA gives each thread more register headroom while preserving total warp-level
+  // parallelism by scaling the grid cap below.
+  static constexpr bool UseHistogramScoresBlockDim = DefaultBlockDim > HistogramScoresBlockDim;
+  static constexpr int BlockDim =
+      UseHistogramScoresBlockDim ? HistogramScoresBlockDim : DefaultBlockDim;
+
+  static_assert(BlockDim % WarpSize == 0);
+  static_assert(BlockDim <= NumThreads);
+
+  static int blockDim(Data const& /*data*/, int /*numThreads*/) { return BlockDim; }
+
+  static int gridDim(Data const& data, int numBlocks, int /*blockDim*/) {
+    if constexpr (UseHistogramScoresBlockDim) {
+      static constexpr int NumWarpsBlock = BlockDim / WarpSize;
+      static constexpr int MaxBlockScale = (DefaultBlockDim + BlockDim - 1) / BlockDim;
+      int const tokenBlocks =
+          (static_cast<int>(data.mNumTokens) + NumWarpsBlock - 1) / NumWarpsBlock;
+      int const scaledMaxBlocks = numBlocks * MaxBlockScale;
+      int const selectedBlocks = tokenBlocks < scaledMaxBlocks ? tokenBlocks : scaledMaxBlocks;
+      return selectedBlocks > 0 ? selectedBlocks : 1;
+    } else {
+      return DefaultRoutingLaunchConfig<MaxNumExperts, MaxNumTopExperts>::gridDim(data, numBlocks,
+                                                                                  DefaultBlockDim);
+    }
+  }
+};
+
+template <typename ExpertSelect, int MaxNumExperts, int MaxNumTopExperts>
+struct HistogramScoresKernelConfig : HistogramScoresLaunchConfig<MaxNumExperts, MaxNumTopExperts> {
+};
+
+template <typename PreProc, typename PostProc>
+struct HistogramScoresPolicyTraits : PolicyTraits<PreProc, PostProc> {};
+
+template <>
+struct HistogramScoresPolicyTraits<NoOpPreprocess, SoftmaxPostprocess> {
+  using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
+                         Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<576, 8>,
+                         Tier<768, 32>, Tier<1024, 32>, Tier<1536, 32>, Tier<2048, 32>>;
+};
+
 template <typename KernelParams>
-__global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelParams::MaxNumExperts
-                                                                      : 1024)
+__global__ void __launch_bounds__(
+    HistogramScoresKernelConfig<typename KernelParams::ExpertSelectPolicy,
+                                KernelParams::MaxNumExperts,
+                                KernelParams::MaxNumTopExperts>::BlockDim)
     routingIndicesHistogramScoresKernel(KernelParams params) {
   using OutputT = typename KernelParams::OutputT;
   using InputT = typename KernelParams::InputT;
   using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
-  // Cap actual thread count at 1024 when MaxNumExperts > 1024.
   static constexpr int NumThreadsBlock =
-      KernelParams::MaxNumExperts <= 1024 ? KernelParams::MaxNumExperts : 1024;
+      HistogramScoresKernelConfig<typename KernelParams::ExpertSelectPolicy,
+                                  KernelParams::MaxNumExperts,
+                                  KernelParams::MaxNumTopExperts>::BlockDim;
 
   // VecSize stays based on MaxNumExperts — each warp still processes all experts for one token.
   static constexpr int VecSize = KernelParams::MaxNumExperts / WarpSize;
@@ -793,10 +980,31 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
 
 void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32_t numThreadsHist,
                                  void* stream) {
-  LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesHistogramScoresKernel, maxNumBlocks,
-                        numThreadsHist,
-                        /*smemSize=*/0,  // No dynamic smem
-                        stream);
+  dispatchRoutingPolicy(data, [&](auto preProc, auto postProc, char const* policyName) {
+    using PreProc = decltype(preProc);
+    using PostProc = decltype(postProc);
+    using Pairs = typename HistogramScoresPolicyTraits<PreProc, PostProc>::Pairs;
+    bool dispatched =
+        dispatchTierPairs(static_cast<Pairs*>(nullptr), data, [&](auto eTag, auto kTag) {
+          using ExpertSelect = TopKExpertSelect<PreProc, PostProc>;
+          using LaunchConfig = HistogramScoresKernelConfig<ExpertSelect, decltype(eTag)::value,
+                                                           decltype(kTag)::value>;
+          int const effectiveThreads =
+              LaunchConfig::blockDim(data, static_cast<int>(numThreadsHist));
+          int const effectiveBlocks =
+              LaunchConfig::gridDim(data, static_cast<int>(maxNumBlocks), effectiveThreads);
+          LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesHistogramScoresKernel,
+                                       effectiveBlocks, effectiveThreads,
+                                       /*smemSize=*/0, stream, PreProc, PostProc,
+                                       decltype(eTag)::value, decltype(kTag)::value);
+        });
+    if (!dispatched) {
+      FLASHINFER_WARN(
+          "No tier covers numExperts=%d topK=%d for policy %s in "
+          "launchHistogramScoresKernel",
+          data.mNumExperts, data.mTopK, policyName);
+    }
+  });
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -697,17 +697,20 @@ struct PolicyTraits<SoftmaxPreprocess, NoOpPostprocess> {
 /// None + Softmax (Renormalize): many model configs.
 template <>
 struct PolicyTraits<NoOpPreprocess, SoftmaxPostprocess> {
-  using Pairs = TierList<Tier<128, 4>,   // Mixtral 8x7B (topK=2), Qwen2-MoE (topK=4), Arctic
-                                         // (topK=2), DBRX (topK=4), GPT-OSS
-                         Tier<128, 8>,   // DeepSeek-V2-Lite (topK=6), Mixtral 8x22B (topK=2)
-                         Tier<160, 8>,   // Qwen3-Coder-480B
-                         Tier<256, 8>,   // Mistral Large 3 (topK=8)
-                         Tier<256, 16>,  // Models with 256 experts and topK 9..16
-                         Tier<512, 8>,   // Various 512-expert models
-                         Tier<512, 16>,  // Various 512-expert models with high topK
-                         Tier<512, 22>,  // Nemotron Super V3 (512 experts, topK=22)
-                         Tier<576, 8>,   // Customized model with 576 experts
-                         Tier<2048, 32>  // Large-expert fallback
+  using Pairs = TierList<Tier<128, 4>,    // Mixtral 8x7B (topK=2), Qwen2-MoE (topK=4), Arctic
+                                          // (topK=2), DBRX (topK=4), GPT-OSS
+                         Tier<128, 8>,    // DeepSeek-V2-Lite (topK=6), Mixtral 8x22B (topK=2)
+                         Tier<160, 8>,    // Qwen3-Coder-480B
+                         Tier<256, 8>,    // Mistral Large 3 (topK=8)
+                         Tier<256, 16>,   // Models with 256 experts and topK 9..16
+                         Tier<512, 8>,    // Various 512-expert models
+                         Tier<512, 16>,   // Various 512-expert models with high topK
+                         Tier<512, 22>,   // Nemotron Super V3 (512 experts, topK=22)
+                         Tier<512, 32>,   // 512-expert models with topK 23..32
+                         Tier<576, 8>,    // Customized model with 576 experts
+                         Tier<768, 32>,   // 576..768 experts with high topK
+                         Tier<1024, 32>,  // 768..1024 experts with high topK
+                         Tier<2048, 32>   // Large-expert fallback
                          >;
 };
 
@@ -752,18 +755,36 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
 // Generic per-policy dispatch.  Iterates PolicyTraits<PreProc, PostProc>::Pairs,
 // picking the first (expert, topK) pair that covers the runtime values.
 //
-// IMPORTANT: numThreads is clamped to at least min(MaxNumExperts, 1024) from the dispatched tier.
-#define LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,     \
-                                  stream, PreProc, PostProc)                                     \
+// THREAD-COUNT SAFETY: the default launch config clamps the launch thread count to at
+// least min(MaxNumExperts, 1024) from the dispatched tier. This prevents mismatches
+// when a policy's smallest tier is larger than getMaxNumExperts() returns for the
+// same numExperts. Kernels with a different internal block size can pass a custom
+// LaunchConfig through the WITH_CONFIG variants and must keep their own launch
+// bounds, blockDim, and gridDim consistent.
+template <int MaxNumExperts, int MaxNumTopExperts>
+struct DefaultRoutingLaunchConfig {
+  static constexpr int BlockDim = MaxNumExperts <= 1024 ? MaxNumExperts : 1024;
+
+  static int blockDim(Data const& /*data*/, int numThreads) {
+    return std::max(numThreads, BlockDim);
+  }
+
+  static int gridDim(Data const& /*data*/, int numBlocks, int /*blockDim*/) { return numBlocks; }
+};
+
+#define LAUNCH_ROUTING_FOR_POLICY_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads,   \
+                                              smemSize, stream, PreProc, PostProc, LaunchConfig) \
   [&](auto pt_tag_) {                                                                            \
     using Pairs_ = typename decltype(pt_tag_)::Pairs;                                            \
     bool dispatched_ =                                                                           \
         dispatchTierPairs(static_cast<Pairs_*>(nullptr), data, [&](auto eTag_, auto kTag_) {     \
-          constexpr int tierMaxExp_ = decltype(eTag_)::value;                                    \
-          constexpr int tierThreads_ = tierMaxExp_ <= 1024 ? tierMaxExp_ : 1024;                 \
-          int const effectiveThreads_ = std::max(static_cast<int>(numThreads), tierThreads_);    \
-          LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, effectiveThreads_,   \
-                                       smemSize, stream, PreProc, PostProc,                      \
+          using LaunchConfig_ = LaunchConfig<decltype(eTag_)::value, decltype(kTag_)::value>;    \
+          int const effectiveThreads_ =                                                          \
+              LaunchConfig_::blockDim(data, static_cast<int>(numThreads));                       \
+          int const effectiveBlocks_ =                                                           \
+              LaunchConfig_::gridDim(data, static_cast<int>(numBlocks), effectiveThreads_);      \
+          LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, effectiveBlocks_,               \
+                                       effectiveThreads_, smemSize, stream, PreProc, PostProc,   \
                                        decltype(eTag_)::value, decltype(kTag_)::value);          \
         });                                                                                      \
     if (!dispatched_) {                                                                          \
@@ -774,6 +795,11 @@ struct PolicyTraits<NoOpPreprocess, NoOpPostprocess> {
           data.mTopK);                                                                           \
     }                                                                                            \
   }(PolicyTraits<PreProc, PostProc>{})
+
+#define LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,       \
+                                  stream, PreProc, PostProc)                                       \
+  LAUNCH_ROUTING_FOR_POLICY_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, \
+                                        stream, PreProc, PostProc, DefaultRoutingLaunchConfig)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // CUSTOM EXPERT SELECT DISPATCH
@@ -898,19 +924,22 @@ inline bool queryPolicySupportsBlockPerToken(Data const& data) {
 }
 
 // Top-level dispatch: maps runtime preprocess/postprocess enums to compile-time policy types,
-// then delegates to LAUNCH_ROUTING_FOR_POLICY which reads PolicyTraits for tier support.
-#define LAUNCH_ROUTING_CUSTOM(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream) \
+// then delegates to the policy tier list using the supplied launch config.
+#define LAUNCH_ROUTING_CUSTOM_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads,       \
+                                          smemSize, stream, LaunchConfig)                        \
   dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* policyName_) {      \
     using PreProc_ = decltype(preProc_);                                                         \
     using PostProc_ = decltype(postProc_);                                                       \
     using Pairs_ = typename PolicyTraits<PreProc_, PostProc_>::Pairs;                            \
     bool dispatched_ =                                                                           \
         dispatchTierPairs(static_cast<Pairs_*>(nullptr), data, [&](auto eTag_, auto kTag_) {     \
-          constexpr int tierMaxExp_ = decltype(eTag_)::value;                                    \
-          constexpr int tierThreads_ = tierMaxExp_ <= 1024 ? tierMaxExp_ : 1024;                 \
-          int const effectiveThreads_ = std::max(static_cast<int>(numThreads), tierThreads_);    \
-          LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, effectiveThreads_,   \
-                                       smemSize, stream, PreProc_, PostProc_,                    \
+          using LaunchConfig_ = LaunchConfig<decltype(eTag_)::value, decltype(kTag_)::value>;    \
+          int const effectiveThreads_ =                                                          \
+              LaunchConfig_::blockDim(data, static_cast<int>(numThreads));                       \
+          int const effectiveBlocks_ =                                                           \
+              LaunchConfig_::gridDim(data, static_cast<int>(numBlocks), effectiveThreads_);      \
+          LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, effectiveBlocks_,               \
+                                       effectiveThreads_, smemSize, stream, PreProc_, PostProc_, \
                                        decltype(eTag_)::value, decltype(kTag_)::value);          \
         });                                                                                      \
     if (!dispatched_) {                                                                          \
@@ -921,6 +950,10 @@ inline bool queryPolicySupportsBlockPerToken(Data const& data) {
           data.mTopK);                                                                           \
     }                                                                                            \
   })
+
+#define LAUNCH_ROUTING_CUSTOM(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream) \
+  LAUNCH_ROUTING_CUSTOM_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads, smemSize,   \
+                                    stream, DefaultRoutingLaunchConfig)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION


<!-- .github/pull_request_template.md -->

## 📌 Description

Optimize TRTLLM-Gen MoE routing to reduce register pressure and avoid heavy spilling in high-expert routing cases.

- Add templated cluster routing kernels for 256/512/1024 thread block sizes while preserving the original default kernel path.
- Apply the updated routing block-size heuristic to cluster and histogram-score routing paths.
- Extend the routing tier coverage for non-power-of-two expert counts.

## Perf Benchmark
### noop_softmax


| E | K | tokens | baseline ms | opt ms | speedup |
|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 8 | 0.009216 | 0.009184 | 1.00x |
| 256 | 8 | 16 | 0.009280 | 0.009440 | 0.98x |
| 256 | 8 | 32 | 0.011264 | 0.009248 | 1.22x |
| 256 | 8 | 64 | 0.012832 | 0.009248 | 1.39x |
| 256 | 8 | 128 | 0.012800 | 0.010784 | 1.19x |
| 256 | 8 | 256 | 0.012832 | 0.013312 | 0.96x |
| 256 | 8 | 512 | 0.014208 | 0.014368 | 0.99x |
| 256 | 8 | 1024 | 0.014400 | 0.014336 | 1.00x |
| 256 | 8 | 2048 | 0.015744 | 0.016288 | 0.97x |
| 256 | 8 | 4096 | 0.018336 | 0.018336 | 1.00x |
| 256 | 8 | 8192 | 0.020512 | 0.020448 | 1.00x |
| 512 | 8 | 8 | 0.009312 | 0.009184 | 1.01x |
| 512 | 8 | 16 | 0.011168 | 0.009248 | 1.21x |
| 512 | 8 | 32 | 0.014720 | 0.009408 | 1.56x |
| 512 | 8 | 64 | 0.015392 | 0.011296 | 1.36x |
| 512 | 8 | 128 | 0.015424 | 0.011296 | 1.37x |
| 512 | 8 | 256 | 0.017376 | 0.015744 | 1.10x |
| 512 | 8 | 512 | 0.018432 | 0.016576 | 1.11x |
| 512 | 8 | 1024 | 0.018496 | 0.017920 | 1.03x |
| 512 | 8 | 2048 | 0.021696 | 0.018464 | 1.18x |
| 512 | 8 | 4096 | 0.024544 | 0.020640 | 1.19x |
| 512 | 8 | 8192 | 0.026624 | 0.024544 | 1.08x |
| 512 | 10 | 8 | 0.009376 | 0.009280 | 1.01x |
| 512 | 10 | 16 | 0.011328 | 0.009312 | 1.22x |
| 512 | 10 | 32 | 0.015392 | 0.011232 | 1.37x |
| 512 | 10 | 64 | 0.015392 | 0.011200 | 1.37x |
| 512 | 10 | 128 | 0.017440 | 0.013088 | 1.33x |
| 512 | 10 | 256 | 0.017408 | 0.017376 | 1.00x |
| 512 | 10 | 512 | 0.018432 | 0.016544 | 1.11x |
| 512 | 10 | 1024 | 0.018496 | 0.018080 | 1.02x |
| 512 | 10 | 2048 | 0.022528 | 0.018496 | 1.22x |
| 512 | 10 | 4096 | 0.024704 | 0.022368 | 1.10x |
| 512 | 10 | 8192 | 0.028480 | 0.024768 | 1.15x |
| 1024 | 32 | 8 | 0.029408 | 0.015328 | 1.92x |
| 1024 | 32 | 16 | 0.043872 | 0.015424 | 2.84x |
| 1024 | 32 | 32 | 0.078688 | 0.017408 | 4.52x |
| 1024 | 32 | 64 | 0.080608 | 0.017472 | 4.61x |
| 1024 | 32 | 128 | 0.080960 | 0.021472 | 3.77x |
| 1024 | 32 | 256 | 0.082624 | 0.031552 | 2.62x |
| 1024 | 32 | 512 | 0.097952 | 0.020608 | 4.75x |
| 1024 | 32 | 1024 | 0.100224 | 0.022464 | 4.46x |
| 1024 | 32 | 2048 | 0.100928 | 0.026688 | 3.78x |
| 1024 | 32 | 4096 | 0.112736 | 0.037312 | 3.02x |
| 1024 | 32 | 8192 | 0.183776 | 0.053760 | 3.42x |
| 2048 | 32 | 8 | 0.031264 | 0.029728 | 1.05x |
| 2048 | 32 | 16 | 0.046112 | 0.031456 | 1.47x |
| 2048 | 32 | 32 | 0.080608 | 0.033312 | 2.42x |
| 2048 | 32 | 64 | 0.082784 | 0.035584 | 2.33x |
| 2048 | 32 | 128 | 0.084448 | 0.037344 | 2.26x |
| 2048 | 32 | 256 | 0.084704 | 0.076544 | 1.11x |
| 2048 | 32 | 512 | 0.109440 | 0.037664 | 2.91x |
| 2048 | 32 | 1024 | 0.111456 | 0.037664 | 2.96x |
| 2048 | 32 | 2048 | 0.111776 | 0.047872 | 2.33x |
| 2048 | 32 | 4096 | 0.123488 | 0.068512 | 1.80x |
| 2048 | 32 | 8192 | 0.193216 | 0.101152 | 1.91x |

### softmax_sum

| E | K | tokens | baseline ms | opt ms | speedup |
|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 8 | 0.009248 | 0.009216 | 1.00x |
| 256 | 8 | 16 | 0.011264 | 0.011232 | 1.00x |
| 256 | 8 | 32 | 0.013408 | 0.009344 | 1.43x |
| 256 | 8 | 64 | 0.015360 | 0.010752 | 1.43x |
| 256 | 8 | 128 | 0.015392 | 0.011456 | 1.34x |
| 256 | 8 | 256 | 0.015424 | 0.015424 | 1.00x |
| 256 | 8 | 512 | 0.015648 | 0.015456 | 1.01x |
| 256 | 8 | 1024 | 0.015904 | 0.016320 | 0.97x |
| 256 | 8 | 2048 | 0.018368 | 0.017568 | 1.05x |
| 256 | 8 | 4096 | 0.020544 | 0.020480 | 1.00x |
| 256 | 8 | 8192 | 0.024704 | 0.024384 | 1.01x |
| 512 | 8 | 8 | 0.013280 | 0.011328 | 1.17x |
| 512 | 8 | 16 | 0.015360 | 0.011456 | 1.34x |
| 512 | 8 | 32 | 0.021440 | 0.013280 | 1.61x |
| 512 | 8 | 64 | 0.021600 | 0.012896 | 1.67x |
| 512 | 8 | 128 | 0.023616 | 0.015424 | 1.53x |
| 512 | 8 | 256 | 0.023520 | 0.023552 | 1.00x |
| 512 | 8 | 512 | 0.022528 | 0.019584 | 1.15x |
| 512 | 8 | 1024 | 0.022528 | 0.019904 | 1.13x |
| 512 | 8 | 2048 | 0.028512 | 0.022528 | 1.27x |
| 512 | 8 | 4096 | 0.028576 | 0.028544 | 1.00x |
| 512 | 8 | 8192 | 0.040896 | 0.037088 | 1.10x |
| 512 | 10 | 8 | 0.013312 | 0.011392 | 1.17x |
| 512 | 10 | 16 | 0.016608 | 0.013152 | 1.26x |
| 512 | 10 | 32 | 0.023456 | 0.013344 | 1.76x |
| 512 | 10 | 64 | 0.023584 | 0.013344 | 1.77x |
| 512 | 10 | 128 | 0.024416 | 0.015648 | 1.56x |
| 512 | 10 | 256 | 0.025536 | 0.025568 | 1.00x |
| 512 | 10 | 512 | 0.022528 | 0.019840 | 1.14x |
| 512 | 10 | 1024 | 0.022560 | 0.020320 | 1.11x |
| 512 | 10 | 2048 | 0.028800 | 0.022656 | 1.27x |
| 512 | 10 | 4096 | 0.029888 | 0.029920 | 1.00x |
| 512 | 10 | 8192 | 0.042816 | 0.038848 | 1.10x |
| 1024 | 32 | 8 | 0.136224 | 0.048032 | 2.84x |
| 1024 | 32 | 16 | 0.281088 | 0.050048 | 5.62x |
| 1024 | 32 | 32 | 0.573312 | 0.051776 | 11.07x |
| 1024 | 32 | 64 | 0.575520 | 0.052128 | 11.04x |
| 1024 | 32 | 128 | 0.576832 | 0.072480 | 7.96x |
| 1024 | 32 | 256 | 0.578560 | 0.578208 | 1.00x |
| 1024 | 32 | 512 | 0.655584 | 0.052864 | 12.40x |
| 1024 | 32 | 1024 | 0.670816 | 0.053056 | 12.64x |
| 1024 | 32 | 2048 | 0.665152 | 0.084800 | 7.84x |
| 1024 | 32 | 4096 | 0.796704 | 0.149408 | 5.33x |
| 1024 | 32 | 8192 | 1.321440 | 0.249472 | 5.30x |
| 2048 | 32 | 8 | 0.134176 | 0.050048 | 2.68x |
| 2048 | 32 | 16 | 0.278016 | 0.050176 | 5.54x |
| 2048 | 32 | 32 | 0.570304 | 0.053984 | 10.56x |
| 2048 | 32 | 64 | 0.572480 | 0.055968 | 10.23x |
| 2048 | 32 | 128 | 0.574144 | 0.072352 | 7.94x |
| 2048 | 32 | 256 | 0.576256 | 0.575744 | 1.00x |
| 2048 | 32 | 512 | 0.662112 | 0.058208 | 11.37x |
| 2048 | 32 | 1024 | 0.667264 | 0.058336 | 11.44x |
| 2048 | 32 | 2048 | 0.670048 | 0.086912 | 7.71x |
| 2048 | 32 | 4096 | 0.776832 | 0.144128 | 5.39x |
| 2048 | 32 | 8192 | 1.321120 | 0.230336 | 5.74x |

### sigmoid_bias_scaled

| E | K | tokens | baseline ms | opt ms | speedup |
|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 8 | 0.011136 | 0.011232 | 0.99x |
| 256 | 8 | 16 | 0.012768 | 0.013216 | 0.97x |
| 256 | 8 | 32 | 0.015296 | 0.011296 | 1.35x |
| 256 | 8 | 64 | 0.015456 | 0.011328 | 1.36x |
| 256 | 8 | 128 | 0.017376 | 0.013312 | 1.31x |
| 256 | 8 | 256 | 0.017440 | 0.017312 | 1.01x |
| 256 | 8 | 512 | 0.016768 | 0.016448 | 1.02x |
| 256 | 8 | 1024 | 0.018400 | 0.017696 | 1.04x |
| 256 | 8 | 2048 | 0.018496 | 0.018496 | 1.00x |
| 256 | 8 | 4096 | 0.021728 | 0.021568 | 1.01x |
| 256 | 8 | 8192 | 0.026048 | 0.025760 | 1.01x |
| 512 | 8 | 8 | 0.015360 | 0.014624 | 1.05x |
| 512 | 8 | 16 | 0.017376 | 0.015360 | 1.13x |
| 512 | 8 | 32 | 0.023520 | 0.015360 | 1.53x |
| 512 | 8 | 64 | 0.023712 | 0.015456 | 1.53x |
| 512 | 8 | 128 | 0.025568 | 0.017536 | 1.46x |
| 512 | 8 | 256 | 0.025632 | 0.025504 | 1.00x |
| 512 | 8 | 512 | 0.025984 | 0.022048 | 1.18x |
| 512 | 8 | 1024 | 0.026560 | 0.022688 | 1.17x |
| 512 | 8 | 2048 | 0.030688 | 0.024736 | 1.24x |
| 512 | 8 | 4096 | 0.030720 | 0.032256 | 0.95x |
| 512 | 8 | 8192 | 0.044800 | 0.040800 | 1.10x |
| 1024 | 32 | 8 | 0.033696 | 0.029440 | 1.14x |
| 1024 | 32 | 16 | 0.049792 | 0.029600 | 1.68x |
| 1024 | 32 | 32 | 0.082784 | 0.029664 | 2.79x |
| 1024 | 32 | 64 | 0.083040 | 0.031744 | 2.62x |
| 1024 | 32 | 128 | 0.084512 | 0.039776 | 2.12x |
| 1024 | 32 | 256 | 0.084704 | 0.084768 | 1.00x |
| 1024 | 32 | 512 | 0.130912 | 0.034912 | 3.75x |
| 1024 | 32 | 1024 | 0.134880 | 0.036576 | 3.69x |
| 1024 | 32 | 2048 | 0.137920 | 0.046816 | 2.95x |
| 1024 | 32 | 4096 | 0.150528 | 0.071552 | 2.10x |
| 1024 | 32 | 8192 | 0.249312 | 0.110560 | 2.25x |
 
## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional routing sizes and top-k combinations, improving compatibility across more model configurations.
  * Added smarter launch selection to better match workload size, including smaller execution paths when appropriate.

* **Bug Fixes**
  * Improved routing behavior for specialized preprocessing/postprocessing cases.
  * Added safer fallback handling when no matching routing tier is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->