### PR TITLE
fix(comm): clarify MoE finalize allreduce input shape

### DIFF
--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -532,7 +532,11 @@ def allreduce_fusion(
     Parameters
     ----------
     input : torch.Tensor
-        Input tensor of shape ``[token_num, hidden_dim]``.
+        Input tensor of shape ``[token_num, hidden_dim]`` for standard
+        allreduce patterns. For ``kMoEFinalizeARResidualRMSNorm``, this is
+        the permuted/padded MoE expert output of shape
+        ``[num_permuted_rows, hidden_dim]``; the token output shape is
+        determined by ``residual_in``.
     workspace : AllReduceFusionWorkspace
         Workspace object created by :func:`create_allreduce_fusion_workspace`.
         Its concrete type (TRT-LLM vs MNNVL) determines the backend.
@@ -552,6 +556,12 @@ def allreduce_fusion(
 
         MNNVL supports the standard FP8/NVFP4 quant patterns (2-5). MoE
         and packed group quant patterns remain TRT-LLM only.
+
+        ``kMoEFinalizeARResidualRMSNorm`` is an explicit TRT-LLM fused
+        implementation of MoE finalize + AllReduce + RMSNorm and does not
+        use the MNNVL backend. Fusion is not always the fastest path for every
+        workload; benchmark this pattern on the target hardware, model,
+        tensor-parallel size, and serving mode before enabling it by default.
     launch_with_pdl : bool
         Use Programmatic Dependent Launch.
     trigger_completion_at_end : bool

--- a/flashinfer/comm/trtllm_ar.py
+++ b/flashinfer/comm/trtllm_ar.py
@@ -1206,7 +1206,10 @@ def trtllm_moe_finalize_allreduce_fusion(
 ) -> None:
     """
     Parameters:
-    - allreduce_in: the input tensor. [token_num, top_k, hidden_dim]
+    - allreduce_in: the permuted/padded MoE expert output tensor.
+      Shape [num_permuted_rows, hidden_dim]. Rows are referenced by
+      expanded_idx_to_permuted_idx; num_permuted_rows may be larger than
+      token_num * top_k due to expert padding.
     - residual_in: the residual input tensor. [token_num, hidden_dim]
     - norm_weight: the norm weight tensor. [hidden_dim]
     - expanded_idx_to_permuted_idx: the expanded index to permuted index tensor. [token_num, top_k]
@@ -1227,7 +1230,11 @@ def trtllm_moe_finalize_allreduce_fusion(
                    1.0          -> Gemma / Qwen3.5 RMSNorm (out = (1 + gamma) * x * rsqrt(...)).
     """
 
-    required_lamport_comm_size = allreduce_in.numel() * 2 * world_size
+    # The Lamport allreduce payload is the finalized token output [token_num, hidden_dim],
+    # not the padded/permuted expert buffer allreduce_in.
+    required_lamport_comm_size = (
+        residual_in.numel() * residual_in.element_size() * world_size
+    )
 
     # Note: only one-shot is supported for moe allreduce fusion.
     if required_lamport_comm_size > MAX_COMM_SIZE:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

Fix doc issue mentioned in https://github.com/flashinfer-ai/flashinfer/issues/3671

## Summary

Fixes the MoE finalize allreduce fusion API documentation and Lamport workspace size check.

`trtllm_moe_finalize_allreduce_fusion` takes a permuted/padded MoE expert output buffer as `allreduce_in`, not a logical `[token_num, top_k, hidden_dim]` tensor. The kernel indexes this buffer by `expanded_idx_to_permuted_idx`, so the correct shape is `[num_permuted_rows, hidden_dim]`.

This also updates the one-shot Lamport size check to use the actual allreduce payload size, which is the finalized token output `[token_num, hidden_dim]`, represented by `residual_in.numel()`, instead of the padded expert buffer size.

## Changes

- Clarify `allreduce_in` shape for `trtllm_moe_finalize_allreduce_fusion`.
- Compute `required_lamport_comm_size` from `residual_in.numel() * residual_in.element_size() * world_size`.
- Add a performance note to `allreduce_fusion` docs that `kMoEFinalizeARResidualRMSNorm` is a TRT-LLM fused implementation and should be benchmarked before being used as a default replacement for optimized standalone MoE finalize + standard AR/RMSNorm fusion.

## Evidence

- `csrc/trtllm_moe_allreduce_fusion.cu` sets `params.size = residual_in.numel()`, so the allreduce payload is the finalized token output `[token_num, hidden_dim]`.
- `include/flashinfer/comm/trtllm_moe_allreduce_fusion.cuh` loads `params.allreduce_in + permuted_idx * hidden_dim + offset`, where `permuted_idx` comes from `expanded_idx_to_permuted_idx`. This means `allreduce_in` is a row-addressed permuted/padded expert output buffer.
- The previous Python wrapper docstring described `allreduce_in` as `[token_num, top_k, hidden_dim]`, and the previous size check used `allreduce_in.numel() * 2 * world_size`, which over-counts when the expert buffer is padded.


### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the expected tensor shape and usage for all-reduce fusion in MoE workflows.
  * Added a note that one fused path is TRT-LLM only and may not be the fastest option for every workload.

* **Bug Fixes**
  * Corrected communication size calculation for the MoE finalize all-reduce path, improving when the optimized one-shot route is selected.
  * Updated payload descriptions to better match the finalized token output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->