### PR TITLE
fix: Fix the MOE tests to properly scale NVFP4 bias

### DIFF
--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -571,11 +571,17 @@ def test_llama4_routing(
 @pytest.mark.parametrize("hidden_size", [1024])
 @pytest.mark.parametrize("intermediate_size", [2048, 1024, 768, 512])
 @pytest.mark.parametrize("bias", ["gemm2", "gemm1", "gemm1_and_gemm2"])
-def test_mxfp4_moe_gemm_bias(
-    num_tokens, hidden_size, intermediate_size, bias, cache_permute_indices
+@pytest.mark.parametrize(
+    "quant_mode",
+    [
+        pytest.param(QuantMode.FP4_MXFP4_MXFP8, id="MxFP4xMxFP8"),
+        pytest.param(QuantMode.FP4_NVFP4_NVFP4, id="NvFP4xNvFP4"),
+    ],
+)
+def test_fp4_moe_gemm_bias(
+    num_tokens, hidden_size, intermediate_size, bias, quant_mode, cache_permute_indices
 ):
-    """Test MXFP4 MoE with GEMM bias support."""
-    # TODO NVFP4 is currently broken
+    """Test FP4 MoE with GEMM bias support."""
     num_experts = 8
     top_k = 2
     device = "cuda"
@@ -595,7 +601,7 @@ def test_mxfp4_moe_gemm_bias(
         num_tokens=num_tokens,
         hidden_size=hidden_size,
         intermediate_size=intermediate_size,
-        moe_impl=FP4Moe(quant_mode=QuantMode.FP4_MXFP4_MXFP8),
+        moe_impl=FP4Moe(quant_mode=quant_mode),
         routing_config={
             "num_experts": num_experts,
             "top_k": top_k,

--- a/tests/moe/trtllm_gen_fused_moe_utils.py
+++ b/tests/moe/trtllm_gen_fused_moe_utils.py
@@ -490,8 +490,22 @@ class FP4Moe(Moe):
         gemm1_scales_fp4_shuffled = []
         gemm2_weights_fp4_shuffled = []
         gemm2_scales_fp4_shuffled = []
-        gemm1_bias_shuffled = [] if args.gemm1_bias is not None else None
-        gemm2_bias_shuffled = [] if args.gemm2_bias is not None else None
+        gemm1_bias_for_kernel = args.gemm1_bias
+        gemm2_bias_for_kernel = args.gemm2_bias
+        if self.quant_mode == QuantMode.FP4_NVFP4_NVFP4:
+            # TRTLLM-gen adds FP4 bias before applying dequantization scales.
+            if gemm1_bias_for_kernel is not None:
+                gemm1_scale_ab = (1.0 / args.gemm1_scales_global) * (
+                    1.0 / args.hidden_states_scale_global
+                )
+                gemm1_bias_for_kernel = gemm1_bias_for_kernel / gemm1_scale_ab[:, None]
+            if gemm2_bias_for_kernel is not None:
+                gemm2_scale_ab = (1.0 / args_dequant.c_global_sf) * (
+                    1.0 / args.gemm2_scales_global
+                )
+                gemm2_bias_for_kernel = gemm2_bias_for_kernel / gemm2_scale_ab[:, None]
+        gemm1_bias_shuffled = [] if gemm1_bias_for_kernel is not None else None
+        gemm2_bias_shuffled = [] if gemm2_bias_for_kernel is not None else None
         for i in range(num_experts):
             # Calculate the permute indices for the following:
             # 1. Reorder rows of W1 and scales for fused gated activation
@@ -529,12 +543,12 @@ class FP4Moe(Moe):
             if gemm1_bias_shuffled is not None:
                 permute_bias_indices = _maybe_get_cached_w3_w1_permute_indices(
                     self._cache_permute_indices,
-                    args.gemm1_bias[i].reshape(-1, 1),
+                    gemm1_bias_for_kernel[i].reshape(-1, 1),
                     epilogue_tile_m,
                     is_gated_act_gemm=is_gated_activation(args.activation_type),
                 )
                 gemm1_bias_shuffled.append(
-                    args.gemm1_bias[i]
+                    gemm1_bias_for_kernel[i]
                     .reshape(-1, 1)[permute_bias_indices.to(args.gemm1_bias.device)]
                     .contiguous()
                 )
@@ -569,11 +583,11 @@ class FP4Moe(Moe):
             if gemm2_bias_shuffled is not None:
                 permute_bias_indices = get_w2_permute_indices_with_cache(
                     self._cache_permute_indices,
-                    args.gemm2_bias[i].reshape(-1, 1),
+                    gemm2_bias_for_kernel[i].reshape(-1, 1),
                     epilogue_tile_m,
                 )
                 gemm2_bias_shuffled.append(
-                    args.gemm2_bias[i]
+                    gemm2_bias_for_kernel[i]
                     .reshape(-1, 1)[permute_bias_indices.to(args.gemm2_bias.device)]
                     .contiguous()
                 )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP4 bias handling for MoE operations, fixing a quantization-specific issue so results are adjusted correctly across supported FP4 modes.
* **Tests**
  * Expanded MoE coverage to validate the bias path under multiple FP4 quantization variants instead of a single configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->