### PR TITLE
fix(bench): make fused_dit_layernorm and FP8 quant refcheck work correctly

### DIFF
--- a/benchmarks/routines/norm.py
+++ b/benchmarks/routines/norm.py
@@ -929,7 +929,7 @@ def testRmsnormQuant(args):
         rmsnorm_output = input_tensor.float() / rms * weight.float()
         # Quantize to output dtype
         reference_output = (
-            (rmsnorm_output * scale)
+            (rmsnorm_output / scale)
             .clamp(torch.finfo(out_dtype).min, torch.finfo(out_dtype).max)
             .to(out_dtype)
         )
@@ -1115,18 +1115,14 @@ def testFusedAddRmsnormQuant(args):
     # Reference: PyTorch implementation of fused add + RMSNorm + quantization
     has_reference_output = False
     if run_refcheck:
-        # Clone residual for reference computation since it gets modified
-        ref_residual = residual_tensor.clone()
-        # Step 1: residual += input
-        ref_residual = ref_residual + input_tensor
+        # Compute the add in fp32 to match the CuTe kernel and unit-test reference.
+        ref_residual = input_tensor.float() + residual_tensor.float()
         # Step 2: RMSNorm on residual
-        rms = torch.sqrt(
-            torch.mean(ref_residual.float() ** 2, dim=-1, keepdim=True) + eps
-        )
-        rmsnorm_output = ref_residual.float() / rms * weight.float()
+        rms = torch.sqrt(torch.mean(ref_residual**2, dim=-1, keepdim=True) + eps)
+        rmsnorm_output = ref_residual / rms * weight.float()
         # Quantize to output dtype
         reference_output = (
-            (rmsnorm_output * scale)
+            (rmsnorm_output / scale)
             .clamp(torch.finfo(out_dtype).min, torch.finfo(out_dtype).max)
             .to(out_dtype)
         )

--- a/benchmarks/routines/norm.py
+++ b/benchmarks/routines/norm.py
@@ -1874,8 +1874,10 @@ def testFusedDitLayernorm(args):
     res = []
     cur_res = defaultdict(str)
     cur_res["routine"] = args.routine
-    cur_res["median_ms"] = fused_ms
-    cur_res["std_ms"] = float(np.std(fused_times))
+    cur_res["median_time"] = fused_ms
+    cur_res["std_time"] = float(np.std(fused_times))
+    cur_res["tflops"] = 0.0
+    cur_res["tb_per_sec"] = tb_per_sec
     cur_res["batch_size"] = batch_size
     cur_res["hidden_size"] = hidden_dim
     cur_res["input_dtype"] = str(torch.bfloat16)
@@ -1892,6 +1894,7 @@ def testFusedDitLayernorm(args):
         )
 
     res.append(cur_res)
+    return res
 
 
 def testFusedQkRmsnormRope(args):


### PR DESCRIPTION
## Problem

Two independent bugs in norm benchmark routines.

## Fix 1 — fused_dit_layernorm: missing `return res` + wrong column names

- `testFusedDitLayernorm` returned `None` instead of `res`, crashing the harness with `TypeError: 'NoneType' object is not iterable` whenever `--output_path` is set.
- Result dict used `median_ms`/`std_ms` — not in `full_output_columns`, so they were silently dropped and perf columns came out empty.

Fix: add `return res`; write canonical columns `median_time`/`std_time`/`tflops`/`tb_per_sec` (`tflops=0.0`, matching existing print call).

## Fix 2 — rmsnorm_quant / fused_add_rmsnorm_quant: FP8 refcheck mismatch

Reference used `rmsnorm_output * scale` but the CuTe kernel treats `scale` as a dequant factor → correct form is `value / scale`.

Also: residual add in `fused_add_rmsnorm_quant` now done in fp32 to match the CuTe kernel and unit-test reference.

## Testing

Verified on B200 with `--refcheck` for `rmsnorm_quant`,`fused_add_rmsnorm_quant`, and `fused_dit_layernorm`..

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected quantized normalization reference calculations so results are now computed consistently.
  * Fixed the fused normalization reference path to use a single, more accurate residual combination before quantization.
  * Updated benchmark result fields to use clearer time-based labels and ensure results are returned properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->