### PR TITLE
perf(moe): optimize CUTLASS fused MoE mem-bound kernels

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -2595,13 +2595,15 @@ void doActivation(T* output, GemmOutputType const* gemm_result, float const* fp8
   // Select block size (up to MAX_ACTIVATION_THREADS_PER_BLOCK) per the threads
   // needed to process each row to avoid inactive warps and improve occupancy.
 #ifdef ENABLE_FP4
-  constexpr bool use_fpx_elem_per_thread =
-      std::is_same_v<T, Fp4Type> || std::is_same_v<T, __nv_fp8_e4m3>;
+  bool const use_mxfp8_block_scaling = quant_params.mxfp8_mxfp4.fc2.weight_block_scale ||
+                                       quant_params.mxfp8_mxfp8.fc2.weight_block_scale;
+  bool const use_fpx_block_scaling =
+      std::is_same_v<T, Fp4Type> || (std::is_same_v<T, __nv_fp8_e4m3> && use_mxfp8_block_scaling);
 #else
-  constexpr bool use_fpx_elem_per_thread = false;
+  constexpr bool use_fpx_block_scaling = false;
 #endif
-  constexpr int64_t elem_per_thread =
-      use_fpx_elem_per_thread
+  int64_t const elem_per_thread =
+      use_fpx_block_scaling
           ? CVT_ELTS_PER_THREAD
           : (128 / std::min(sizeof_bits<T>::value, sizeof_bits<GemmOutputType>::value));
   int64_t const loads_per_row = std::max<int64_t>(inter_size / elem_per_thread, int64_t{1});
@@ -2692,10 +2694,8 @@ void doActivation(T* output, GemmOutputType const* gemm_result, float const* fp8
             return fn(NVFP4, disableFP4QuantFastMathTag, nvfp4_4over6_config_tag);
           });
     } else if constexpr (std::is_same_v<T, __nv_fp8_e4m3>) {
-      return (quant_params.mxfp8_mxfp4.fc2.weight_block_scale ||
-              quant_params.mxfp8_mxfp8.fc2.weight_block_scale)
-                 ? fn(MXFPX, std::false_type{}, std::false_type{})
-                 : fn(NONE, std::false_type{}, std::false_type{});
+      return use_mxfp8_block_scaling ? fn(MXFPX, std::false_type{}, std::false_type{})
+                                     : fn(NONE, std::false_type{}, std::false_type{});
     } else
 #endif
     {

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -1799,6 +1799,16 @@ void expandInputRowsKernelLauncher(
                        "Per-expert act scale for FC1 is only supported for NVFP4 activations");
 #endif
 
+  TLLM_CHECK_WITH_INFO(((hidden_size * std::min(sizeof_bits<InputActivationsType>::value,
+                                                sizeof_bits<ExpandedActivationsType>::value)) %
+                        128) == 0,
+                       "hidden_size %ld rows are not a multiple of 16B; expandInputRowsKernel "
+                       "requires 16B-aligned rows",
+                       hidden_size);
+  TLLM_CHECK_WITH_INFO(reinterpret_cast<uintptr_t>(unpermuted_input) % 16 == 0 &&
+                           reinterpret_cast<uintptr_t>(permuted_output) % 16 == 0,
+                       "expandInputRowsKernel input/output pointers must be 16B-aligned");
+
   static int64_t const smCount = tensorrt_llm::common::getMultiProcessorCount();
   // Note: Launching 8 blocks per SM can fully leverage the memory bandwidth (tested on B200).
   // N-dim SF padding has been removed (CUTLASS grouped GEMM never reads beyond
@@ -2570,6 +2580,15 @@ void doActivation(T* output, GemmOutputType const* gemm_result, float const* fp8
                   TmaWarpSpecializedGroupedGemmInput::ElementSF* fc2_act_sf_flat,
                   float* fp8_token_dequant_scale, float const* fp8_expert_residual_scale,
                   bool enable_pdl, cudaStream_t stream) {
+  TLLM_CHECK_WITH_INFO(
+      (inter_size * std::min(sizeof_bits<T>::value, sizeof_bits<GemmOutputType>::value)) % 128 == 0,
+      "inter_size %ld rows are not a multiple of 16B; doActivationKernel requires 16B-aligned rows",
+      inter_size);
+  TLLM_CHECK_WITH_INFO(reinterpret_cast<uintptr_t>(gemm_result) % 16 == 0 &&
+                           reinterpret_cast<uintptr_t>(output) % 16 == 0 &&
+                           reinterpret_cast<uintptr_t>(bias) % 16 == 0,
+                       "doActivationKernel input/output/bias pointers must be 16B-aligned");
+
   // N-dim SF padding has been removed (CUTLASS grouped GEMM never reads beyond
   // tokens_to_expert), so the grid is driven purely by the expanded token count.
 

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -2236,7 +2236,7 @@ struct SwigluStepAdaptor {
 };
 
 // ============================== Gated Activation =================================
-constexpr static int ACTIVATION_THREADS_PER_BLOCK = 256;
+constexpr static int MAX_ACTIVATION_THREADS_PER_BLOCK = 256;
 
 template <class ActivationOutputType, class GemmOutputType, class ActFn>
 __global__ void doGatedActivationKernel(ActivationOutputType* output,
@@ -2261,7 +2261,7 @@ __global__ void doGatedActivationKernel(ActivationOutputType* output,
   auto gemm_result_vec = reinterpret_cast<GemmResultElem const*>(gemm_result);
   auto output_vec = reinterpret_cast<OutputElem*>(output);
   int64_t const start_offset = tid;
-  int64_t const stride = ACTIVATION_THREADS_PER_BLOCK;
+  int64_t const stride = MAX_ACTIVATION_THREADS_PER_BLOCK;
   assert(inter_size % ACTIVATION_ELEM_PER_THREAD == 0);
   int64_t const num_elems_in_col = inter_size / ACTIVATION_ELEM_PER_THREAD;
   int64_t const inter_size_vec = inter_size / ACTIVATION_ELEM_PER_THREAD;
@@ -2303,7 +2303,7 @@ void doGatedActivation(ActivationOutputType* output, GemmOutputType const* gemm_
                        int64_t num_tokens, int64_t num_experts_per_node,
                        ActivationParams activation_type, cudaStream_t stream) {
   int64_t const blocks = num_tokens;
-  int64_t const threads = ACTIVATION_THREADS_PER_BLOCK;
+  int64_t const threads = MAX_ACTIVATION_THREADS_PER_BLOCK;
 
   auto* fn = (activation_type == ActivationType::Swiglu)
                  ? &doGatedActivationKernel<ActivationOutputType, GemmOutputType,
@@ -2329,7 +2329,7 @@ void doGatedActivation(ActivationOutputType* output, GemmOutputType const* gemm_
 template <class T, class GemmOutputType, class ScaleBiasType, class ActFn,
           TmaWarpSpecializedGroupedGemmInput::FpXBlockScalingType BlockScalingType,
           bool DISABLE_FP4_QUANT_FAST_MATH = false, typename NVFP4_4OVER6_CONFIG = std::false_type>
-__global__ __launch_bounds__(ACTIVATION_THREADS_PER_BLOCK) void doActivationKernel(
+__global__ __launch_bounds__(MAX_ACTIVATION_THREADS_PER_BLOCK) void doActivationKernel(
     T* output, GemmOutputType const* gemm_result, float const* fp8_quant,
     ScaleBiasType const* bias_ptr, bool bias_is_broadcast, int64_t const* expert_first_token_offset,
     int const* permuted_token_selected_experts, int num_experts_per_node, int64_t inter_size,
@@ -2427,7 +2427,7 @@ __global__ __launch_bounds__(ACTIVATION_THREADS_PER_BLOCK) void doActivationKern
     assert(reinterpret_cast<std::uintptr_t>(bias_ptr_vec) % sizeof(BiasElem) == 0);
 
     int64_t const start_offset = tid;
-    int64_t const stride = ACTIVATION_THREADS_PER_BLOCK;
+    int64_t const stride = blockDim.x;
     assert(inter_size % ACTIVATION_ELEM_PER_THREAD == 0);
     int64_t const num_elems_in_col = inter_size / ACTIVATION_ELEM_PER_THREAD;
     assert(gated_off % ACTIVATION_ELEM_PER_THREAD == 0);
@@ -2489,7 +2489,7 @@ __global__ __launch_bounds__(ACTIVATION_THREADS_PER_BLOCK) void doActivationKern
         }
       }
 
-      using BlockReduce = cub::BlockReduce<float, ACTIVATION_THREADS_PER_BLOCK>;
+      using BlockReduce = cub::BlockReduce<float, MAX_ACTIVATION_THREADS_PER_BLOCK>;
       __shared__ typename BlockReduce::TempStorage reduce_storage;
       __shared__ float shared_token_quant_scale;
       float const row_amax = BlockReduce(reduce_storage).Reduce(thread_amax, FloatMaxOp{});
@@ -2570,12 +2570,40 @@ void doActivation(T* output, GemmOutputType const* gemm_result, float const* fp8
                   TmaWarpSpecializedGroupedGemmInput::ElementSF* fc2_act_sf_flat,
                   float* fp8_token_dequant_scale, float const* fp8_expert_residual_scale,
                   bool enable_pdl, cudaStream_t stream) {
-  static int64_t const smCount = tensorrt_llm::common::getMultiProcessorCount();
-  // Note: Launching 8 blocks per SM can fully leverage the memory bandwidth (tested on B200).
   // N-dim SF padding has been removed (CUTLASS grouped GEMM never reads beyond
   // tokens_to_expert), so the grid is driven purely by the expanded token count.
-  int64_t const blocks = std::min(smCount * 8, std::max(expanded_num_tokens, int64_t{1}));
-  int64_t const threads = ACTIVATION_THREADS_PER_BLOCK;
+
+  // Select block size (up to MAX_ACTIVATION_THREADS_PER_BLOCK) per the threads
+  // needed to process each row to avoid inactive warps and improve occupancy.
+#ifdef ENABLE_FP4
+  constexpr bool use_fpx_elem_per_thread =
+      std::is_same_v<T, Fp4Type> || std::is_same_v<T, __nv_fp8_e4m3>;
+#else
+  constexpr bool use_fpx_elem_per_thread = false;
+#endif
+  constexpr int64_t elem_per_thread =
+      use_fpx_elem_per_thread
+          ? CVT_ELTS_PER_THREAD
+          : (128 / std::min(sizeof_bits<T>::value, sizeof_bits<GemmOutputType>::value));
+  int64_t const loads_per_row = std::max<int64_t>(inter_size / elem_per_thread, int64_t{1});
+  // The per-token FP8 quant path reduces the row amax with
+  // cub::BlockReduce<float, MAX_ACTIVATION_THREADS_PER_BLOCK>, which requires
+  // blockDim.x to match the compile-time block size, so force a full block there.
+  int64_t const threads =
+      fp8_token_dequant_scale != nullptr
+          ? MAX_ACTIVATION_THREADS_PER_BLOCK
+          : std::min<int64_t>(MAX_ACTIVATION_THREADS_PER_BLOCK,
+                              tensorrt_llm::common::roundUp(loads_per_row, int64_t{WARP_SIZE}));
+
+  // Limit the grid size to be proportional to the SM count in order to mitigate
+  // the warp scheduling pressure on each SM. The proportion can range from 8 to
+  // 32 blocks per SM and is adaptive to the block size.
+  static int64_t const smCount = tensorrt_llm::common::getMultiProcessorCount();
+  int64_t const blocks_per_sm = std::min<int64_t>(
+      int64_t{32},
+      tensorrt_llm::common::ceilDiv(int64_t{8} * MAX_ACTIVATION_THREADS_PER_BLOCK, threads));
+  int64_t const blocks =
+      std::min(smCount * blocks_per_sm, std::max(expanded_num_tokens, int64_t{1}));
 
   auto fn = [&]() {
     auto fn = [&](auto block_scaling_type, auto disableFP4QuantFastMathTag,

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -21,6 +21,7 @@
 #include <math.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <numeric>
 #include <random>
@@ -36,6 +37,7 @@
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif
 #include "cute/tensor.hpp"
+#include "cutlass/arch/memory.h"
 #include "cutlass/conv/convolution.h"
 // Order matters here, packed_stride.hpp is missing cute and convolution includes
 #include "cutlass/array.h"
@@ -75,6 +77,7 @@ using namespace tensorrt_llm::common;
 
 namespace tensorrt_llm::kernels::cutlass_kernels {
 
+constexpr int WARP_SIZE = 32;
 constexpr int CVT_ELTS_PER_THREAD = 8;
 
 struct FloatMaxOp {
@@ -1632,6 +1635,8 @@ __global__ void expandInputRowsKernel(
     // Cast first to handle when this is FP4
     auto* dest_row_ptr = reinterpret_cast<OutputElem*>(permuted_output) +
                          permuted_row * hidden_size / ELEM_PER_THREAD;
+    assert(reinterpret_cast<std::uintptr_t>(source_row_ptr) % sizeof(DataElem) == 0);
+    assert(reinterpret_cast<std::uintptr_t>(dest_row_ptr) % sizeof(OutputElem) == 0);
 
     int64_t const start_offset = threadIdx.x;
     int64_t const stride = EXPAND_THREADS_PER_BLOCK;
@@ -1651,7 +1656,9 @@ __global__ void expandInputRowsKernel(
       int64_t num_tokens_before_expert = expert_first_token_offset[expert];
 
       for (int elem_index = start_offset; elem_index < num_elems_in_col; elem_index += stride) {
-        auto in_vec = source_row_ptr[elem_index];
+        DataElem in_vec;
+        cutlass::arch::global_load<DataElem, sizeof(DataElem)>(in_vec, source_row_ptr + elem_index,
+                                                               true);
         if constexpr (need_nvfp4_quant || need_mxfp8_quant) {
           auto res =
               quantizePackedFPXValue<InputActivationsType, ExpandedActivationsType, DataElem,
@@ -1662,14 +1669,18 @@ __global__ void expandInputRowsKernel(
                            : TmaWarpSpecializedGroupedGemmInput::FpXBlockScalingType::MXFPX);
           static_assert(sizeof(res) == sizeof(*dest_row_ptr),
                         "Quantized value must be the same size as the output");
-          dest_row_ptr[elem_index] = res;
+          auto out_vec = cutlass::platform::bit_cast<OutputElem>(res);
+          cutlass::arch::global_store<OutputElem, sizeof(OutputElem)>(
+              out_vec, dest_row_ptr + elem_index, true);
         } else {
           assert(act_scale_idx == 0 &&
                  "Cannot use per-expert act scale for pre-quantized activations");
           writeSF<VecSize, ELEM_PER_THREAD>(num_tokens_before_expert, expert, source_row,
                                             permuted_row, elem_index, padded_hidden_size,
                                             fc1_act_sf_flat, input_sf, swizzled_input_sf);
-          dest_row_ptr[elem_index] = in_vec;
+          auto out_vec = cutlass::platform::bit_cast<OutputElem>(in_vec);
+          cutlass::arch::global_store<OutputElem, sizeof(OutputElem)>(
+              out_vec, dest_row_ptr + elem_index, true);
         }
       }
 
@@ -1689,14 +1700,18 @@ __global__ void expandInputRowsKernel(
       static_assert(!std::is_same_v<InputActivationsType, ExpandedActivationsType>,
                     "Input and output types must be different for AWQ");
       for (int elem_index = start_offset; elem_index < num_elems_in_col; elem_index += stride) {
-        auto frag_elems = source_row_ptr[elem_index];
+        DataElem frag_elems;
+        cutlass::arch::global_load<DataElem, sizeof(DataElem)>(frag_elems,
+                                                               source_row_ptr + elem_index, true);
 
         CUTLASS_PRAGMA_UNROLL
         for (int e = 0; e < ELEM_PER_THREAD; e++) {
           frag_elems[e] = frag_elems[e] * prequant_scales[elem_index * ELEM_PER_THREAD + e];
         }
 
-        dest_row_ptr[elem_index] = arrayConvert<DataElem, OutputElem>(frag_elems);
+        auto out_vec = arrayConvert<DataElem, OutputElem>(frag_elems);
+        cutlass::arch::global_store<OutputElem, sizeof(OutputElem)>(
+            out_vec, dest_row_ptr + elem_index, true);
       }
     } else if constexpr (need_per_token_fp8_quant) {
       using AmaxOp = AbsMaxOp<InputActivationsType>;
@@ -1738,7 +1753,12 @@ __global__ void expandInputRowsKernel(
       }
     } else {
       for (int elem_index = start_offset; elem_index < num_elems_in_col; elem_index += stride) {
-        dest_row_ptr[elem_index] = source_row_ptr[elem_index];
+        DataElem in_vec;
+        cutlass::arch::global_load<DataElem, sizeof(DataElem)>(in_vec, source_row_ptr + elem_index,
+                                                               true);
+        auto out_vec = cutlass::platform::bit_cast<OutputElem>(in_vec);
+        cutlass::arch::global_store<OutputElem, sizeof(OutputElem)>(
+            out_vec, dest_row_ptr + elem_index, true);
       }
     }
 
@@ -2402,6 +2422,10 @@ __global__ __launch_bounds__(ACTIVATION_THREADS_PER_BLOCK) void doActivationKern
         reinterpret_cast<GemmResultElem const*>(gemm_result + gemm_result_offset);
     auto output_vec = reinterpret_cast<OutputElem*>(safe_inc_ptr(output, output_offset));
     auto bias_ptr_vec = reinterpret_cast<BiasElem const*>(bias_ptr + bias_offset);
+    assert(reinterpret_cast<std::uintptr_t>(gemm_result_vec) % sizeof(GemmResultElem) == 0);
+    assert(reinterpret_cast<std::uintptr_t>(output_vec) % sizeof(OutputElem) == 0);
+    assert(reinterpret_cast<std::uintptr_t>(bias_ptr_vec) % sizeof(BiasElem) == 0);
+
     int64_t const start_offset = tid;
     int64_t const stride = ACTIVATION_THREADS_PER_BLOCK;
     assert(inter_size % ACTIVATION_ELEM_PER_THREAD == 0);
@@ -2418,20 +2442,28 @@ __global__ __launch_bounds__(ACTIVATION_THREADS_PER_BLOCK) void doActivationKern
       fn.limit = gate_limit;
     }
     auto compute_activation = [&](int64_t elem_index) {
-      auto fc1_value =
-          arrayConvert<GemmResultElem, ComputeElem>(gemm_result_vec[elem_index + gated_off_vec]);
+      GemmResultElem fc1_gemm_value;
+      cutlass::arch::global_load<GemmResultElem, sizeof(GemmResultElem)>(
+          fc1_gemm_value, gemm_result_vec + elem_index + gated_off_vec, true);
+      auto fc1_value = arrayConvert<GemmResultElem, ComputeElem>(fc1_gemm_value);
       if (bias_ptr) {
-        fc1_value = fc1_value +
-                    arrayConvert<BiasElem, ComputeElem>(bias_ptr_vec[elem_index + gated_off_vec]);
+        BiasElem fc1_bias_value;
+        cutlass::arch::global_load<BiasElem, sizeof(BiasElem)>(
+            fc1_bias_value, bias_ptr_vec + elem_index + gated_off_vec, true);
+        fc1_value = fc1_value + arrayConvert<BiasElem, ComputeElem>(fc1_bias_value);
       }
 
       auto gate_act = [&]() {
         if constexpr (IsGated) {
-          auto linear_value =
-              arrayConvert<GemmResultElem, ComputeElem>(gemm_result_vec[elem_index]);
-          if (bias_ptr_vec) {
-            linear_value =
-                linear_value + arrayConvert<BiasElem, ComputeElem>(bias_ptr_vec[elem_index]);
+          GemmResultElem linear_gemm_value;
+          cutlass::arch::global_load<GemmResultElem, sizeof(GemmResultElem)>(
+              linear_gemm_value, gemm_result_vec + elem_index, true);
+          auto linear_value = arrayConvert<GemmResultElem, ComputeElem>(linear_gemm_value);
+          if (bias_ptr) {
+            BiasElem linear_bias_value;
+            cutlass::arch::global_load<BiasElem, sizeof(BiasElem)>(linear_bias_value,
+                                                                   bias_ptr_vec + elem_index, true);
+            linear_value = linear_value + arrayConvert<BiasElem, ComputeElem>(linear_bias_value);
           }
           return fn(fc1_value, linear_value);
         } else {
@@ -2490,9 +2522,13 @@ __global__ __launch_bounds__(ACTIVATION_THREADS_PER_BLOCK) void doActivationKern
                     : TmaWarpSpecializedGroupedGemmInput::FpXBlockScalingType::MXFPX);
         static_assert(sizeof(res) == sizeof(*output_vec),
                       "Quantized value must be the same size as the output");
-        output_vec[elem_index] = res;
+        auto out_vec = cutlass::platform::bit_cast<OutputElem>(res);
+        cutlass::arch::global_store<OutputElem, sizeof(OutputElem)>(out_vec,
+                                                                    output_vec + elem_index, true);
       } else {
-        output_vec[elem_index] = arrayConvert<ComputeElem, OutputElem>(post_act_val);
+        auto out_vec = arrayConvert<ComputeElem, OutputElem>(post_act_val);
+        cutlass::arch::global_store<OutputElem, sizeof(OutputElem)>(out_vec,
+                                                                    output_vec + elem_index, true);
       }
     }
 

--- a/csrc/nv_internal/include/tensorrt_llm/common/cudaUtils.h
+++ b/csrc/nv_internal/include/tensorrt_llm/common/cudaUtils.h
@@ -388,12 +388,16 @@ inline size_t divUp(T1 const& a, T2 const& b) {
   return (tmp_a + tmp_b - 1) / tmp_b;
 }
 
-inline int roundUp(int a, int b) { return divUp(a, b) * b; }
-
 template <typename T, typename U, typename = std::enable_if_t<std::is_integral<T>::value>,
           typename = std::enable_if_t<std::is_integral<U>::value>>
 auto constexpr ceilDiv(T numerator, U denominator) {
   return (numerator + denominator - 1) / denominator;
+}
+
+template <typename T, typename U, typename = std::enable_if_t<std::is_integral<T>::value>,
+          typename = std::enable_if_t<std::is_integral<U>::value>>
+auto constexpr roundUp(T numerator, U denominator) {
+  return ceilDiv(numerator, denominator) * denominator;
 }
 
 template <typename T>

--- a/include/flashinfer/trtllm/common/cudaUtils.h
+++ b/include/flashinfer/trtllm/common/cudaUtils.h
@@ -154,12 +154,16 @@ inline size_t divUp(T1 const& a, T2 const& b) {
   return (tmp_a + tmp_b - 1) / tmp_b;
 }
 
-inline int roundUp(int a, int b) { return divUp(a, b) * b; }
-
 template <typename T, typename U, typename = std::enable_if_t<std::is_integral<T>::value>,
           typename = std::enable_if_t<std::is_integral<U>::value>>
 auto constexpr ceilDiv(T numerator, U denominator) {
   return (numerator + denominator - 1) / denominator;
+}
+
+template <typename T, typename U, typename = std::enable_if_t<std::is_integral<T>::value>,
+          typename = std::enable_if_t<std::is_integral<U>::value>>
+auto constexpr roundUp(T numerator, U denominator) {
+  return ceilDiv(numerator, denominator) * denominator;
 }
 
 template <typename T>

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -3887,6 +3887,7 @@ def _small_moe_inputs(m, hidden, inter, e, top_k, dtype=torch.bfloat16):
     return w31, w2, weights.float().contiguous(), ids.to(torch.int)
 
 
+@_WS_CUTLASS_MOE_SKIP
 def test_vectorized_kernel_rejects_misaligned_input():
     """The vectorized expand/activation kernels need 16B-aligned rows; a
     misaligned input base must fail fast on the host with a clear diagnostic

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -3879,5 +3879,39 @@ def test_workspace_cuda_graph_capture_replay():
     torch.testing.assert_close(out_t, out_e, rtol=0, atol=0)
 
 
+def _small_moe_inputs(m, hidden, inter, e, top_k, dtype=torch.bfloat16):
+    w31 = torch.randn(e, 2 * inter, hidden, dtype=dtype, device="cuda") / 10
+    w2 = torch.randn(e, hidden, inter, dtype=dtype, device="cuda") / 10
+    logits = torch.randn(m, e, dtype=torch.float32, device="cuda")
+    weights, ids = torch.topk(torch.softmax(logits, -1), top_k)
+    return w31, w2, weights.float().contiguous(), ids.to(torch.int)
+
+
+def test_vectorized_kernel_rejects_misaligned_input():
+    """The vectorized expand/activation kernels need 16B-aligned rows; a
+    misaligned input base must fail fast on the host with a clear diagnostic
+    instead of an IMA (device asserts are compiled out in release builds)."""
+    torch.manual_seed(42)
+    m, hidden, inter, e, top_k = 4, 128, 128, 8, 2
+    w31, w2, weights, ids = _small_moe_inputs(m, hidden, inter, e, top_k)
+
+    # Contiguous view whose base is 2B- but not 16B-aligned.
+    buf = torch.randn(m * hidden + 8, dtype=torch.bfloat16, device="cuda")
+    x = buf[1 : 1 + m * hidden].view(m, hidden)
+    assert x.is_contiguous() and x.data_ptr() % 16 != 0
+
+    with pytest.raises(Exception, match="16B-aligned"):
+        fused_moe.cutlass_fused_moe(
+            x,
+            ids,
+            weights,
+            w31,
+            w2,
+            torch.bfloat16,
+            quant_scales=None,
+            output=torch.empty_like(x),
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Key Findings

We observed that the Triton implementation outperforms the FlashInfer CUTLASS fused MoE backend on Hopper for BF16 data types (#3521), and thus we started investigating kernel optimization opportunities related to the associated kernels. Here are some key findings regarding the helper memory-bound kernels:
* Lack of vectorization: In kernels such as `expandInputRowsKernel` and `doActivationKernel`, vectorization is not actually enabled. The generated SASS shows occurrences of four contiguous `LDG.E` instructions rather than a single `LDG.E.128`.
* Inactive warp: The `doActivationKernel` is currently hardcoded to use 256 threads per row. For workloads with small intermediate sizes, this can be excessive and can result in inactive warps and suboptimal occupancy.

### Changes Made

This PR improves the performance of the CUTLASS fused MoE input-expansion and activation kernels.
  * Explicitly vectorize global/store in `expandInputRowsKernel` and `doActivationKernel`.
      * This did not work on `finalizeMoeRoutingKernel` as it was observed to increase register usage and did not improve perf.
  * Select the activation kernel block size based on the work required per row, which reduces inactive warps and improves occupancy for smaller intermediate dimensions (e.g., 768 for `Qwen/Qwen3-30B-A3B`). Also, cap the grid size 8~32 blocks (which was constantly 8) per SM based on block size. This limits unnecessary warp-scheduling pressure.

## 🔍 Related Issues

<!-- Link any related issues here -->

#3521

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## ⚡ Performance

### SASS verification (SM100, CUDA 13.2)

| row-data access | before (main) | after (this PR) |
|---|---|---|
| expandInputRows (bf16→bf16), per 16B copy | 4× `LDG.E` + 4× `STG.E` | 1× `LDG.E.128` + 1× `STG.E.128` |
| doActivation (bf16, Swiglu), per 16B of fc1/linear/bias | 4× `LDG.E` each | 1× `LDG.E.128` each |
| doActivation (fp8 out, Swiglu), per 32B gemm vector | 8× `LDG.E` | 2× `LDG.E.128` |
| doActivation (nvfp4 out, Swiglu), fp4 output + SF | unchanged (`STG.E` packed + `STG.E.U8`) | unchanged |

### benchmarks/flashinfer_benchmark.py

#### Setup
  * Single B100 (SM100), clocks locked at 1400 MHz SM / 4000 MHz mem, CUDA 13.2
  * Autotune off so both builds run identical default GEMM tactics
  * Baseline = main @ 2e97a607d
  * Cell = median of per-pair speedups

#### Result
* Achieved up to 1.08x end-to-end speedup
* No regression observed

| case | M=1 | M=16 | M=128 | M=512 | M=2048 | M=8192 | M=16384 |
|---|---|---|---|---|---|---|---|
| qwen3_tp1 | 1.00x | 0.99x | 1.00x | 0.99x | 1.02x | 1.04x | 1.05x |
| qwen3_tp2 | 1.01x | 1.00x | 1.01x | 1.01x | 1.04x | 1.05x | 1.05x |
| qwen3_tp4 | 1.00x | 1.00x | 1.01x | 1.01x | 1.04x | 1.04x | 1.05x |
| qwen3_tp2_fp8 | 1.00x | 1.03x | 1.00x | 1.02x | 1.02x | 1.04x | 1.05x |
| qwen3_tp4_fp8 | 1.00x | 1.00x | 1.01x | 1.03x | 1.06x | **1.07x** | **1.07x** |
| dsv3_nvfp4 | 1.01x | 1.03x | 1.04x | 1.06x | **1.08x** | 1.01x | 1.05x |
| mixtral_tp4 (guard) | 1.00x | 1.00x | 1.00x | 1.00x | 1.01x | 1.02x | 1.01x |

### vLLM end-to-end benchmarking on H200x8

#### Setup

```
vllm bench throughput --model Qwen/Qwen3-30B-A3B --dataset-name random --moe-backend <backend> -tp <tp>
```

#### Result

| TP | main | this PR | gain | vs triton backend |
|---:|---:|---:|---:|---:|
| 1 | 41.52 | 42.09 | **+1.4%** | +1.5% |
| 2 | 60.92 | 61.69 | **+1.3%** | −3.3% (was −4.5%) |
| 4 | 69.36 | 71.51 | **+3.1%** | ~parity |
| 8 | 74.17 | 75.74 | **+2.1%** | −2.4% |

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Mixture-of-Experts processing with vectorized memory operations for quantized, unquantized, and FP8 data paths.
  * Optimized activation workload distribution, memory access, and scaling across available GPU resources.

* **Bug Fixes**
  * Added validation for memory alignment in MoE inputs, outputs, and biases.
  * Improved rounding utilities to support a broader range of integral values.

* **Tests**
  * Added regression coverage confirming that improperly aligned inputs produce a clear diagnostic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->