### PR TITLE
feat: trtllm FP4 routed-MoE: accept fp32 `topk_weights` (copy-free)

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -1793,6 +1793,13 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
   void check_routing() const override {
     // First call base class common routing checks
     FusedMoeLauncher::check_routing_common();
+
+    if (routing_input_mode_ == RoutingInputMode::UnpackedPrecomputed) {
+      TVM_FFI_ICHECK_EQ(topk_ids.dtype(), dl_int32)
+          << "topk_ids must be int32 for unpacked precomputed routing.";
+      TVM_FFI_ICHECK(topk_weights.dtype() == dl_bfloat16 || topk_weights.dtype() == dl_float32)
+          << "topk_weights must be bfloat16 or float32 for unpacked precomputed routing.";
+    }
   }
 
   void prepare_routing() override {
@@ -1838,6 +1845,11 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
         routing_logits.has_value() ? routing_logits.value().dtype() : dl_bfloat16;
     mRoutingLogitsDtype =
         routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
+
+    if (routing_input_mode_ == RoutingInputMode::UnpackedPrecomputed) {
+      args->mDtypeExpW =
+          topk_weights.dtype() == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
+    }
   }
 
   void check_moe() const override {

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -2327,13 +2327,8 @@ def get_trtllm_moe_sm100_module():
             assert topk_weights is not None, (
                 "topk_weights must be provided for UnpackedPrecomputed mode"
             )
-            # The finalize kernel reads the expert weights as args.mDtypeExpW,
-            # which is bfloat16 for this op (see runner.h: expert_weights is
-            # "[num_tokens, top_k] in bfloat16 = mDtypeExpW"). A user-provided
-            # fp32 buffer would be reinterpreted as bf16, so reject it up front.
-            assert topk_weights.dtype == torch.bfloat16, (
-                "topk_weights must be bfloat16 for UnpackedPrecomputed mode, got "
-                f"{topk_weights.dtype}"
+            assert topk_weights.dtype in (torch.bfloat16, torch.float32), (
+                f"topk_weights must be bfloat16 or float32, got {topk_weights.dtype}."
             )
         else:
             # For Mode 1 (FromLogits) and Mode 2 (PackedPrecomputed), allocate OUTPUT buffers
@@ -4045,7 +4040,9 @@ def trtllm_fp4_block_scale_routed_moe(
         ``[seq_len, top_k]`` in packed format ``(expert_id << 16) | weight`` or
         a tuple ``(ids, weights)`` where ``ids`` is int32 of shape
         ``[seq_len, top_k]`` (plain expert indices) and ``weights`` is
-        ``bfloat16`` of the same shape (routing weights).
+        ``bfloat16`` or ``float32`` of the same shape (routing weights). The
+        weights are consumed at their native dtype (no cast), so passing the
+        ``float32`` weights emitted by typical routers is copy-free.
     routing_bias : Optional[torch.Tensor]
         ``[num_experts]`` routing bias.  May be ``None``.
     hidden_states : torch.Tensor

--- a/tests/moe/test_trtllm_gen_routed_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_routed_fused_moe.py
@@ -53,22 +53,7 @@ from .trtllm_gen_fused_moe_utils import (
 pytestmark = pytest.mark.solo
 
 
-@pytest.mark.parametrize("num_tokens", [1, 8, 1024])
-@pytest.mark.parametrize("hidden_size", [1024, 2048, 3072, 4096])
-@pytest.mark.parametrize("intermediate_size", [1024, 2048, 3072, 4096])
-@pytest.mark.parametrize("num_experts", [128, 256])
-@pytest.mark.parametrize("top_k", [4, 8])
-@pytest.mark.parametrize(
-    "routing_method_type",
-    [
-        RoutingMethodType.Renormalize,
-        RoutingMethodType.RenormalizeNaive,
-        RoutingMethodType.TopK,
-    ],
-)
-@pytest.mark.parametrize("quant_mode", ["NvFP4xNvFP4", "MxFP4xMxFP8", "MxFP4xBf16"])
-@pytest.mark.parametrize("routing_format", ["packed", "unpacked"])
-def test_trtllm_gen_routed_fused_moe(
+def _run_trtllm_gen_routed_fused_moe_case(
     num_tokens: int,
     hidden_size: int,
     intermediate_size: int,
@@ -76,7 +61,7 @@ def test_trtllm_gen_routed_fused_moe(
     num_experts: int,
     routing_method_type: RoutingMethodType,
     quant_mode: Literal["NvFP4xNvFP4", "MxFP4xMxFP8", "MxFP4xBf16"],
-    routing_format: Literal["packed", "unpacked"],
+    routing_format: Literal["packed", "unpacked", "unpacked_fp32"],
 ):
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability[0] not in [10]:
@@ -218,17 +203,21 @@ def test_trtllm_gen_routed_fused_moe(
     topk_ids = permute_info["topKIndices"].to(torch.int32)
     topk_weights = expert_weights.view(num_tokens, num_experts)[
         torch.arange(num_tokens).unsqueeze(1), topk_ids
-    ].to(torch.bfloat16)
+    ]
 
     # Prepare routing input based on format
     if routing_format == "packed":
         # Packed format: (score << 16 | expert_id)
+        topk_weights = topk_weights.to(torch.bfloat16)
         routing_input = (topk_ids.to(torch.int32) << 16) | topk_weights.view(
             torch.int16
         )
+    elif routing_format == "unpacked_fp32":
+        # Unpacked format: (topk_ids, topk_weights) tuple, float32 weights.
+        routing_input = (topk_ids, topk_weights.to(torch.float32))
     else:
-        # Unpacked format: (topk_ids, topk_weights) tuple
-        routing_input = (topk_ids, topk_weights)
+        # Unpacked format: (topk_ids, topk_weights) tuple, bfloat16 weights.
+        routing_input = (topk_ids, topk_weights.to(torch.bfloat16))
 
     output = trtllm_fp4_block_scale_routed_moe(
         routing_input,
@@ -267,6 +256,57 @@ def test_trtllm_gen_routed_fused_moe(
     # mismatch percentage
     mismatch_pct = (~mask).float().mean().item() * 100
     assert mismatch_pct < 6, f"Mismatch percentage is {mismatch_pct:.2f}"
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 1024])
+@pytest.mark.parametrize("hidden_size", [1024, 2048, 3072, 4096])
+@pytest.mark.parametrize("intermediate_size", [1024, 2048, 3072, 4096])
+@pytest.mark.parametrize("num_experts", [128, 256])
+@pytest.mark.parametrize("top_k", [4, 8])
+@pytest.mark.parametrize(
+    "routing_method_type",
+    [
+        RoutingMethodType.Renormalize,
+        RoutingMethodType.RenormalizeNaive,
+        RoutingMethodType.TopK,
+    ],
+)
+@pytest.mark.parametrize("quant_mode", ["NvFP4xNvFP4", "MxFP4xMxFP8", "MxFP4xBf16"])
+@pytest.mark.parametrize("routing_format", ["packed", "unpacked"])
+def test_trtllm_gen_routed_fused_moe(
+    num_tokens: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    num_experts: int,
+    routing_method_type: RoutingMethodType,
+    quant_mode: Literal["NvFP4xNvFP4", "MxFP4xMxFP8", "MxFP4xBf16"],
+    routing_format: Literal["packed", "unpacked"],
+):
+    _run_trtllm_gen_routed_fused_moe_case(
+        num_tokens,
+        hidden_size,
+        intermediate_size,
+        top_k,
+        num_experts,
+        routing_method_type,
+        quant_mode,
+        routing_format,
+    )
+
+
+def test_trtllm_gen_routed_fused_moe_unpacked_fp32():
+    # All quantization modes share this finalize path.
+    _run_trtllm_gen_routed_fused_moe_case(
+        num_tokens=8,
+        hidden_size=1024,
+        intermediate_size=1024,
+        top_k=4,
+        num_experts=128,
+        routing_method_type=RoutingMethodType.Renormalize,
+        quant_mode="MxFP4xBf16",
+        routing_format="unpacked_fp32",
+    )
 
 
 @pytest.mark.parametrize("num_tokens", [8, 64])


### PR DESCRIPTION
## 📌 Description

`trtllm_fp4_block_scale_routed_moe`'s unpacked routing path
(`topk_ids=(ids, weights)`) silently assumed **bf16** `topk_weights`. vLLM
routers emit **fp32** by design, so the finalize kernel reinterpreted the fp32
bytes as bf16 → ~1e36/NaN per-expert scales → garbage output).

### Fix
- **`FP4BlockScaleLauncher::prepare_routing()`** — set `args->mDtypeExpW` from the
  actual `topk_weights` dtype in `UnpackedPrecomputed` mode. The finalize kernel
  already has a compiled fp32 path; this just selects it. No new kernel, no copy.
- **`FP4BlockScaleLauncher::check_routing()`** — assert `topk_ids` is int32 and
  `topk_weights ∈ {bf16, fp32}`, so a wrong dtype fails loudly instead of being
  misread.
- **`flashinfer/fused_moe/core.py`** — matching Python-side dtype guard + docstring
  now documents bf16-or-fp32 (consumed natively, no cast).
- **Test** — new `unpacked_fp32` variant in `test_trtllm_gen_routed_fused_moe`
  (fails with garbage before the fix, matches reference after).

## 🔍 Related Issues

Enables merging https://github.com/vllm-project/vllm/pull/46872, saving 1.5 to 2 us per layer, which matters in decode.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter runtime validation for unpacked precomputed routing to ensure `topk` IDs use `int32` and `topk` weights use `bfloat16` or `float32`.
  * Improved handling of unpacked `float32` weights so they’re consumed in their native precision without unintended reinterpretation.

* **Documentation**
  * Clarified routed MoE operator behavior: unpacked `topk_weights` are consumed at native dtype (commonly copy-free for `float32` routers).

* **Tests**
  * Expanded routed fused MoE test coverage with a new `unpacked_fp32` routing format case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->