### PR TITLE
Switches download_artifacts to use one requests.Session per thread

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -277,9 +277,6 @@ def get_subdir_file_list() -> Generator[tuple[str, str], None, None]:
 def download_artifacts() -> None:
     from tqdm.contrib.logging import tqdm_logging_redirect
 
-    # use a shared session to make use of HTTP keep-alive and reuse of
-    # HTTPS connections.
-    session = requests.Session()
     cubin_files = list[tuple[str, str]](get_subdir_file_list())
     num_threads = int(os.environ.get("FLASHINFER_CUBIN_DOWNLOAD_THREADS", "4"))
     with tqdm_logging_redirect(
@@ -296,9 +293,7 @@ def download_artifacts() -> None:
                 local_path = FLASHINFER_CUBIN_DIR / name
                 # Ensure parent directory exists
                 local_path.parent.mkdir(parents=True, exist_ok=True)
-                fut = pool.submit(
-                    download_file, source, str(local_path), session=session
-                )
+                fut = pool.submit(download_file, source, str(local_path))
                 fut.add_done_callback(update_pbar_cb)
                 futures.append(fut)
 

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -288,12 +288,14 @@ def download_artifacts() -> None:
 
         with ThreadPoolExecutor(num_threads) as pool:
             futures = []
-            for name, _ in cubin_files:
+            for name, checksum in cubin_files:
                 source = safe_urljoin(FLASHINFER_CUBINS_REPOSITORY, name)
                 local_path = FLASHINFER_CUBIN_DIR / name
                 # Ensure parent directory exists
                 local_path.parent.mkdir(parents=True, exist_ok=True)
-                fut = pool.submit(download_file, source, str(local_path))
+                fut = pool.submit(
+                    download_file, source, str(local_path), expected_sha256=checksum
+                )
                 fut.add_done_callback(update_pbar_cb)
                 futures.append(fut)
 

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -21,6 +21,7 @@ import pathlib
 import random
 from urllib.parse import urljoin
 import shutil
+import threading
 import time
 from typing import Union
 import uuid
@@ -45,6 +46,19 @@ def safe_urljoin(base, path):
     return urljoin(base, path)
 
 
+_thread_local = threading.local()
+
+
+def _get_thread_session():
+    import requests  # type: ignore[import-untyped]
+
+    session = getattr(_thread_local, "session", None)
+    if session is None:
+        session = requests.Session()
+        _thread_local.session = session
+    return session
+
+
 def download_file(
     source: str,
     destination: str,
@@ -66,6 +80,7 @@ def download_file(
     - delay (int): Initial delay in seconds for exponential backoff (default: 5).
     - timeout (int): Timeout for the HTTP request in seconds (default: 10).
     - lock_timeout (int): Timeout in seconds for the file lock (default: 30).
+    - session: When None, a per-thread session is used
 
     Returns:
     - bool: True if download or copy is successful, False otherwise.
@@ -74,7 +89,7 @@ def download_file(
     import requests  # type: ignore[import-untyped]
 
     if session is None:
-        session = requests.Session()
+        session = _get_thread_session()
 
     lock_path = f"{destination}.lock"  # Lock file path
     lock = filelock.FileLock(lock_path, timeout=lock_timeout)

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -23,7 +23,7 @@ from urllib.parse import urljoin
 import shutil
 import threading
 import time
-from typing import Union
+from typing import Optional, Union
 import uuid
 
 import filelock
@@ -67,6 +67,7 @@ def download_file(
     timeout: int = 10,
     lock_timeout: int = 30,
     session=None,
+    expected_sha256: Optional[str] = None,
 ):
     """
     Downloads a file from a URL or copies from a local path to a destination.
@@ -81,6 +82,7 @@ def download_file(
     - timeout (int): Timeout for the HTTP request in seconds (default: 10).
     - lock_timeout (int): Timeout in seconds for the file lock (default: 30).
     - session: When None, a per-thread session is used
+    - expected_sha256 (Optional[str]): bytes verified against this hash if provided.
 
     Returns:
     - bool: True if download or copy is successful, False otherwise.
@@ -116,42 +118,54 @@ def download_file(
 
             # Handle URL downloads with exponential backoff
             for attempt in range(retries):
+                failure = None
                 try:
-                    response = session.get(source, timeout=timeout)
-                    response.raise_for_status()
-
-                    with open(temp_path, "wb") as file:
-                        file.write(response.content)
-
-                    # Atomic rename to prevent readers from seeing partial writes
-                    os.replace(temp_path, destination)
-
-                    logger.info(
-                        f"File downloaded successfully: {source} -> {destination}"
-                    )
-                    return True
-
-                except requests.exceptions.RequestException as e:
-                    logger.warning(
-                        f"Downloading {source}: attempt {attempt + 1} failed: {e}"
-                    )
-
-                    if attempt < retries - 1:
-                        # Equal jitter: uniform[cap, 2*cap] with cap=base*2^attempt.
-                        # Preserves an exponentially-growing lower bound on the delay
-                        # so retries adapt to sustained congestion, while still
-                        # decorrelating the 4 parallel download threads (and many CI
-                        # runners) hitting the same CDN edge.
-                        backoff_cap = delay * (2**attempt)
-                        backoff_delay = backoff_cap + random.uniform(0, backoff_cap)  # noqa: S311
-                        logger.info(f"Retrying in {backoff_delay:.2f} seconds...")
-                        time.sleep(backoff_delay)
+                    try:
+                        response = session.get(source, timeout=timeout)
+                        response.raise_for_status()
+                        content = response.content
+                    except requests.exceptions.RequestException as e:
+                        failure = f"request failed: {e}"
                     else:
-                        logger.error("Max retries reached. Download failed.")
-                        return False
+                        if expected_sha256 is not None:
+                            actual_sha256 = hashlib.sha256(content).hexdigest()
+                            if actual_sha256 != expected_sha256:
+                                failure = (
+                                    f"checksum mismatch (expected {expected_sha256} "
+                                    f"actual {actual_sha256})"
+                                )
+                        if failure is None:
+                            with open(temp_path, "wb") as file:
+                                file.write(content)
+
+                            # Atomic rename to prevent readers from seeing partial writes
+                            os.replace(temp_path, destination)
+
+                            logger.info(
+                                f"File downloaded successfully: {source} -> {destination}"
+                            )
+                            return True
                 finally:
                     if os.path.exists(temp_path):
                         os.remove(temp_path)
+
+                logger.warning(
+                    f"Downloading {source}: attempt {attempt + 1} failed: {failure}"
+                )
+
+                if attempt < retries - 1:
+                    # Equal jitter: uniform[cap, 2*cap] with cap=base*2^attempt.
+                    # Preserves an exponentially-growing lower bound on the delay
+                    # so retries adapt to sustained congestion, while still
+                    # decorrelating the 4 parallel download threads (and many CI
+                    # runners) hitting the same CDN edge.
+                    backoff_cap = delay * (2**attempt)
+                    backoff_delay = backoff_cap + random.uniform(0, backoff_cap)  # noqa: S311
+                    logger.info(f"Retrying in {backoff_delay:.2f} seconds...")
+                    time.sleep(backoff_delay)
+                else:
+                    logger.error("Max retries reached. Download failed.")
+                    return False
 
     except filelock.Timeout:
         logger.error(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The cubin download step in the build process is multi-threaded. However all threads share the same `requests.Session`. `requests.Session` instances are not thread-safe. Thus, this PR allocates a new `requests.Session` for each thread.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact download handling to be more reliable during concurrent downloads.
  * Download progress and verification behavior remain unchanged, with smoother session reuse behind the scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->