### PR TITLE
fix(aot): exclude head_dim=512 FA2 modules from AOT jit-cache wheel

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -892,8 +892,9 @@ def parse_head_dim(head_dim: str) -> Tuple[int, int]:
 def get_default_config():
     """Get default AOT configuration"""
     return {
-        # Note: (512, 512): FA2 prefill/decode only; no holistic batch-attention kernel.
-        "fa2_head_dim": [(64, 64), (128, 128), (256, 256), (512, 512)],
+        # Note: head_dim=512 (FA2 prefill/decode, SM100+) excluded to reduce
+        # space in the jit-cache wheel.
+        "fa2_head_dim": [(64, 64), (128, 128), (256, 256)],
         "fa3_head_dim": [(192, 128), (128, 128), (64, 64), (256, 256)],
         "f16_dtype": [torch.float16, torch.bfloat16],
         "f8_dtype": [torch.float8_e4m3fn],


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

#3757 reports that the `flashinfer-jit-cache` wheel for CUDA 12.9 x86_64 exceeded GitHub Releases' asset upload limit. The head_dim=512 FA2 support added in #3576 is one of the contributors.

The `(512, 512)` entry in the default `fa2_head_dim` AOT list adds ~326 MB. This PR removes `(512, 512)` from the **default** AOT configuration so those modules are no longer baked into the released wheel. **head_dim=512 remains fully functional** — it now JIT-compiles on demand on first use (FlashInfer's default behavior), exactly
  like any non-precompiled configuration.
  
This is **not a regression**: no released wheel has ever shipped head_dim=512 precompiled (the feature landed in #3576, after the last release).

## 🔍 Related Issues

* #3757
* #3576

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default build configuration to exclude one large head-dimension option.
  * This reduces the size of the generated cache wheel and can help keep installs leaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->