### PR TITLE
[cute-dsl] MLA decode: add causal toggle for non-causal multi-query (EAGLE tree verify)

### DIFF
--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
@@ -131,6 +131,7 @@ def _get_compiled_mla_kernel(
     skip_correction_threshold: float = 0.0,
     is_workspace_size_zero: bool = False,
     enable_pdl: bool = False,
+    causal: bool = True,
 ) -> Callable:
     """Compile and cache an MLA decode kernel.
 
@@ -181,6 +182,7 @@ def _get_compiled_mla_kernel(
         num_heads=num_heads,
         seq_len_q=seq_len_q,
         fold_sq=fold_sq,
+        causal=causal,
     )
 
     # All dimensions as sym_int — this matches the original kernel's use of
@@ -322,6 +324,7 @@ def cute_dsl_mla_decode(
     enable_pdl: Optional[bool] = None,
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
+    causal: bool = True,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """CuTe DSL MLA decode kernel for Blackwell SM100.
 
@@ -380,6 +383,15 @@ def cute_dsl_mla_decode(
         Whether to return LSE values.  When True, the function returns
         ``(out, lse)`` (the ``lse`` tensor returned is in whatever shape
         the caller supplied; if no ``lse`` was supplied, ``[B, q_len, H]``).
+    causal : bool, default=True
+        Controls the per-row spec-decoding (MTP) causal mask among the
+        ``q_len`` query tokens (monolithic kernel only). When True (default),
+        row ``q_tok`` attends KV positions ``< K - (q_len - 1) + q_tok`` — the
+        MTP/chain behavior, unchanged for existing callers. When False, every
+        query attends the full sequence (``k_bound = K``); this is the
+        non-causal shared-prefix pass EAGLE tree-verify needs so all draft
+        tokens see the entire prefix (the tree structure among draft tokens is
+        applied separately by the caller).
 
     Returns
     -------
@@ -521,6 +533,7 @@ def cute_dsl_mla_decode(
         skip_correction_threshold=skip_correction_threshold,
         is_workspace_size_zero=is_workspace_size_zero,
         enable_pdl=enable_pdl,
+        causal=causal,
     )
 
     # Call the kernel

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
@@ -139,6 +139,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         num_heads: int = 128,
         seq_len_q: int = 1,
         fold_sq: bool = False,
+        causal: bool = True,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -203,6 +204,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         # When fold_sq=True but the derived ratio is 1, the folding branch
         # is taken with F=1 (a no-op transform).
         self.fold_sq = fold_sq
+        self.causal = causal
         self.fold_sq_ratio = (
             BlackwellMultiHeadLatentAttentionForwardFP16.compute_fold_sq_ratio(
                 num_heads, seq_len_q, mma_qk_tiler_mn[0]
@@ -2705,7 +2707,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         )
                     else:
                         q_tok = common_params.blk_coord[1]
-                    k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                    k_bound = (
+                        common_params.K - (self.seq_len_q - 1) + q_tok
+                        if self.causal
+                        else common_params.K
+                    )
                     tTR_rAcc[i] = (
                         tTR_rAcc[i]
                         if cute.elem_less(
@@ -2749,7 +2755,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         )
                     else:
                         q_tok = common_params.blk_coord[1]
-                    k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                    k_bound = (
+                        common_params.K - (self.seq_len_q - 1) + q_tok
+                        if self.causal
+                        else common_params.K
+                    )
                     tTR_rAcc[i] = (
                         tTR_rAcc[i]
                         if cute.elem_less(

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
@@ -137,6 +137,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         num_heads: int = 128,
         seq_len_q: int = 1,
         fold_sq: bool = False,
+        causal: bool = True,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -201,6 +202,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # When fold_sq=True but the derived ratio is 1, the folding branch
         # is taken with F=1 (a no-op transform).
         self.fold_sq = fold_sq
+        self.causal = causal
         self.fold_sq_ratio = (
             BlackwellMultiHeadLatentAttentionForwardFP8.compute_fold_sq_ratio(
                 num_heads, seq_len_q, mma_qk_tiler_mn[0]
@@ -3053,7 +3055,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         )
                     else:
                         q_tok = common_params.blk_coord[1]
-                    k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                    k_bound = (
+                        common_params.K - (self.seq_len_q - 1) + q_tok
+                        if self.causal
+                        else common_params.K
+                    )
                     tTR_rAcc[i] = (
                         tTR_rAcc[i]
                         if cute.elem_less(
@@ -3100,7 +3106,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         )
                     else:
                         q_tok = common_params.blk_coord[1]
-                    k_bound = common_params.K - (self.seq_len_q - 1) + q_tok
+                    k_bound = (
+                        common_params.K - (self.seq_len_q - 1) + q_tok
+                        if self.causal
+                        else common_params.K
+                    )
                     tTR_rAcc[i] = (
                         tTR_rAcc[i]
                         if cute.elem_less(

--- a/tests/attention/test_cute_dsl_mla_decode.py
+++ b/tests/attention/test_cute_dsl_mla_decode.py
@@ -374,6 +374,88 @@ def test_cute_dsl_mla_decode_fold_sq(
         torch.testing.assert_close(out, ref_out_cast, atol=1e-2, rtol=1e-2)
 
 
+# Exercises the NON-causal (causal=False) path: every q_len query attends the FULL
+# seq_len (no MTP causal k_bound) -- the shared-prefix pass EAGLE tree-verify needs so
+# all draft tokens see the whole prefix. causal=True (default) is the MTP-masked path
+# covered by test_cute_dsl_mla_decode_fold_sq; this verifies the toggle flips the mask.
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("seq_len_k", [128, 1024])
+@pytest.mark.parametrize("num_heads", [16, 64])
+@pytest.mark.parametrize("q_len", [2, 4])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float8_e4m3fn])
+def test_cute_dsl_mla_decode_noncausal(
+    batch_size, seq_len_k, num_heads, q_len, dtype, cute_dsl_impl
+):
+    """causal=False: all q_len queries attend the full prefix (no MTP causal mask)."""
+    if cute_dsl_impl != "monolithic":
+        pytest.skip("causal toggle / MTP mask are monolithic-only features")
+    skip_if_unsupported()
+
+    from flashinfer.cute_dsl.attention import cute_dsl_mla_decode
+
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+    page_size = 64
+    latent_dim = 512
+    rope_dim = 64
+    softmax_scale = 1.0 / (latent_dim**0.5)
+    output_scale = 1.0
+    D_qk = latent_dim + rope_dim
+    is_fp8 = dtype == torch.float8_e4m3fn
+
+    def _rand(*shape):
+        t = torch.randn(*shape, dtype=torch.float16, device=device) * 0.1
+        return t.to(torch.float8_e4m3fn) if is_fp8 else t.to(dtype)
+
+    query = _rand(batch_size, q_len, num_heads, D_qk)
+    num_pages_per_batch = (seq_len_k + page_size - 1) // page_size
+    total_pages = num_pages_per_batch * batch_size + 10
+    kv_cache = _rand(total_pages, page_size, D_qk)
+
+    block_tables = torch.zeros(
+        batch_size, num_pages_per_batch, dtype=torch.int32, device=device
+    )
+    for b in range(batch_size):
+        for p in range(num_pages_per_batch):
+            block_tables[b, p] = b * num_pages_per_batch + p
+    seq_lens = torch.full((batch_size,), seq_len_k, dtype=torch.int32, device=device)
+    workspace_buffer = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    out = cute_dsl_mla_decode(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace_buffer,
+        kv_lora_rank=latent_dim,
+        qk_rope_head_dim=rope_dim,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        max_seq_len=seq_len_k,
+        softmax_scale=softmax_scale,
+        output_scale=output_scale,
+        is_var_seq=False,
+        causal=False,  # <-- the new toggle under test
+        cute_dsl_impl=cute_dsl_impl,
+    )
+
+    cast = torch.float32 if is_fp8 else None
+    kv_flat = kv_cache.reshape(-1, D_qk)
+    kv_flat = kv_flat.to(cast) if cast is not None else kv_flat
+    q_nope = query[..., :latent_dim].to(cast) if cast is not None else query[..., :latent_dim]
+    q_rope = query[..., latent_dim:].to(cast) if cast is not None else query[..., latent_dim:]
+    ref_out = torch_reference_mla(
+        q_nope, q_rope, kv_flat[:, :latent_dim], kv_flat[:, latent_dim:],
+        block_tables, seq_lens, softmax_scale, output_scale, page_size,
+        apply_mtp_mask=False,  # non-causal reference: every query sees the full prefix
+    )
+
+    if is_fp8:
+        torch.testing.assert_close(
+            out.to(torch.float32), ref_out.to(torch.float32), atol=0.1, rtol=0.1
+        )
+    else:
+        torch.testing.assert_close(out, ref_out.to(dtype), atol=1e-2, rtol=1e-2)
+
+
 def test_compute_fold_sq_ratio():
     """Unit test the static helper used by both run() and the wrapper."""
     if not is_cute_dsl_available():


### PR DESCRIPTION
## What
Add a `causal: bool = True` parameter to the monolithic cuteDSL MLA-decode kernel, threaded `cute_dsl_mla_decode` → `_get_compiled_mla_kernel` → `BlackwellMultiHeadLatentAttentionForwardFP8.__init__`. When `causal=False`, the per-row MTP `k_bound` is set to `K` (every query attends the full sequence) instead of the spec-decoding causal bound `K - (S_q - 1) + q_tok`.

## Why
The fold kernel currently hardcodes the MTP causal-among-Q mask, which is correct for a linear MTP/chain. **EAGLE tree-drafting verify** needs a **non-causal shared-prefix pass** — all `q_len` draft tokens must attend the *entire* prefix (the tree structure among draft tokens is applied separately). There is no way to request that today on the decode path (prefill gained an `is_causal` toggle, decode did not). This unblocks a downstream sglang PR that enables EAGLE tree (topk>1) verify on the trtllm_mla / cutedsl_mla MLA backends.

## Compatibility
`causal=True` is the default → **no behavior change** for existing callers (the MTP-masked path covered by `test_cute_dsl_mla_decode_fold_sq` is unchanged).

## Test
Adds `test_cute_dsl_mla_decode_noncausal` (fp16 + fp8, H∈{16,64}, q_len∈{2,4}, bs∈{1,4}) asserting `causal=False` output matches the non-causal PyTorch reference (`apply_mtp_mask=False`); the existing fold_sq test covers `causal=True`.

Draft — opening for early review; the consuming sglang tree-on-MLA PR follows.