### PR TITLE
Fix moe autotune scale padding

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1235,6 +1235,7 @@ def get_trtllm_moe_sm100_module():
                     shapes, dtype=dtype, device=device
                 )
             if moe_inputs.hidden_states_scale is not None:
+
                 def _init_hidden_states_scale(shapes, dtype, device):
                     rows = shapes[0]
                     buf = torch.ones(

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -62,6 +62,7 @@ from ..utils import (
     register_custom_op,
     register_fake_op,
     get_compute_capability,
+    round_up,
 )
 from .utils import (
     get_hybrid_num_tokens_buckets,
@@ -1234,9 +1235,14 @@ def get_trtllm_moe_sm100_module():
                     shapes, dtype=dtype, device=device
                 )
             if moe_inputs.hidden_states_scale is not None:
-                spec["hidden_states_scale"] = lambda shapes, dtype, device: torch.ones(
-                    shapes, device=device
-                ).to(dtype)
+                def _init_hidden_states_scale(shapes, dtype, device):
+                    rows = shapes[0]
+                    buf = torch.ones(
+                        [round_up(rows, 128), *shapes[1:]], device=device
+                    ).to(dtype)
+                    return buf[:rows]
+
+                spec["hidden_states_scale"] = _init_hidden_states_scale
             if moe_inputs.gemm1_lora_delta is not None:
                 spec["gemm1_lora_delta"] = lambda shapes, dtype, device: torch.zeros(
                     shapes, dtype=dtype, device=device


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Kernel read the scale-factor buffer swizzled/padded to round_up(rows,128); the autotuner probes sub-128 token buckets with a tightly-sized [bucket, cols] dummy buffer, causing an out-of-bounds read (illegal memory access) during warmup. Over-allocate the leading dim to a 128-multiple.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3530

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ✅ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [✅  ] I have installed the hooks with `pre-commit install`.
- [ ✅ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of model input scaling setup so it now works more reliably with row counts that aren’t already aligned to hardware-friendly sizes.
  * This update preserves the expected output shape while reducing the chance of shape-related issues during tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->