### PR TITLE
fix(sampling): resolve boundary tie over-acceptance in rejection sampling

### DIFF
--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -109,7 +109,8 @@ constexpr BlockReduceAlgorithm REDUCE_ALGO = BLOCK_REDUCE_WARP_REDUCTIONS;
 #define FLASHINFER_SAMPLING_LAUNCH_BOUNDS(block_threads)
 #endif
 
-#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120100)
+#if (defined(CUB_VERSION) && CUB_VERSION >= 200200) || \
+    (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 120300)
 #define FLASHINFER_CUB_SUBTRACTLEFT_DEFINED
 #endif
 
@@ -586,8 +587,10 @@ __device__ __forceinline__ void DeviceSamplingFromProb(
   bool greater_than_u[VEC_SIZE], valid[VEC_SIZE];
 #pragma unroll
   for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-    prob_greater_than_threshold[j] = pred(prob_vec[j]) ? prob_vec[j] : 0;
-    valid[j] = pred(prob_vec[j]) && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d;
+    const uint32_t token_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+    const bool selected = token_idx < d && pred(prob_vec[j], token_idx);
+    prob_greater_than_threshold[j] = selected ? prob_vec[j] : 0;
+    valid[j] = selected;
   }
   float aggregate_local =
       BlockReduce<float, BLOCK_THREADS, REDUCE_ALGORITHM>(temp_storage->block_prim.reduce)
@@ -818,7 +821,8 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void SamplingFromPro
 
     DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
                            DETERMINISTIC>(
-        i, d, [](float x) { return x > 0; }, u, probs_vec, aggregate, &temp_storage);
+        i, d, [](float x, uint32_t token_idx) { return x > 0; }, u, probs_vec, aggregate,
+        &temp_storage);
     if (float(aggregate) > u) {
       break;
     }
@@ -873,7 +877,8 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKSamplingFro
   float aggregate;
   float q = 1;
   float low = 0, high = 1.f;
-  int sampled_id;
+  int sampled_id = -1;
+  int low_tie_break_id = -1;
   int round = 0;
   do {
     round += 1;
@@ -882,6 +887,8 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKSamplingFro
     __syncthreads();
     float u = curand_uniform(&state) * q;
     aggregate = 0;
+    // Only lower bounds that come from an actual sampled pivot carry an index tie-break.
+    // Midpoint bounds (pivot_1) are pure numeric thresholds and must stay value-only.
 #pragma unroll 2
     for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
       probs_vec.fill(0);
@@ -891,7 +898,12 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKSamplingFro
 
       DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
                              DETERMINISTIC>(
-          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+          i, d,
+          [low, low_tie_break_id](float x, uint32_t token_idx) {
+            if (low_tie_break_id < 0) return x > low;
+            return x > low || (x == low && token_idx > static_cast<uint32_t>(low_tie_break_id));
+          },
+          u, probs_vec, aggregate, &temp_storage);
       if (aggregate > u) {
         break;
       }
@@ -927,12 +939,17 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKSamplingFro
       ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
 #pragma unroll
       for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        probs_gt_pivot_0[j] = {
-            (probs_vec[j] > pivot_0) ? probs_vec[j] : 0,
-            (probs_vec[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
-        probs_gt_pivot_1[j] = {
-            (probs_vec[j] > pivot_1) ? probs_vec[j] : 0,
-            (probs_vec[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+        const uint32_t token_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+        // Index tie-break against pivot_0 (= prob of the sampled token): tokens tied with the
+        // pivot but with a larger index rank strictly above it, so `count` equals the sampled
+        // token's true rank under the (prob, index) total order.
+        const bool gt_pivot_0 =
+            token_idx < d &&
+            (probs_vec[j] > pivot_0 ||
+             (probs_vec[j] == pivot_0 && token_idx > static_cast<uint32_t>(sampled_id)));
+        const bool gt_pivot_1 = token_idx < d && probs_vec[j] > pivot_1;
+        probs_gt_pivot_0[j] = {gt_pivot_0 ? probs_vec[j] : 0, gt_pivot_0};
+        probs_gt_pivot_1[j] = {gt_pivot_1 ? probs_vec[j] : 0, gt_pivot_1};
         threadlocal_gt_pivot_0 += probs_gt_pivot_0[j];
         threadlocal_gt_pivot_1 += probs_gt_pivot_1[j];
       }
@@ -961,11 +978,13 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKSamplingFro
     if (aggregate_gt_pivot_1.count < k) {
       // case 2: pivot_0 rejected, pivot_1 accepted
       low = pivot_0;
+      low_tie_break_id = sampled_id;
       high = pivot_1;
       q = aggregate_gt_pivot_0.value;
     } else {
       // case 3: pivot_0 rejected, pivot_1 rejected
       low = pivot_1;
+      low_tie_break_id = -1;
       q = aggregate_gt_pivot_1.value;
     }
   } while (low < high);
@@ -1005,13 +1024,16 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopPSamplingFro
   float aggregate;
   float q = 1;
   float low = 0, high = 1.f;
-  int sampled_id;
+  int sampled_id = -1;
+  int low_tie_break_id = -1;
   do {
     temp_storage.sampled_id = d;
     temp_storage.last_valid_id = -1;
     __syncthreads();
     float u = curand_uniform(&state) * q;
     aggregate = 0;
+    // Only lower bounds that come from an actual sampled pivot carry an index tie-break.
+    // Midpoint bounds (pivot_1) are pure numeric thresholds and must stay value-only.
 #pragma unroll 2
     for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
       probs_vec.fill(0);
@@ -1021,7 +1043,12 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopPSamplingFro
 
       DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
                              DETERMINISTIC>(
-          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+          i, d,
+          [low, low_tie_break_id](float x, uint32_t token_idx) {
+            if (low_tie_break_id < 0) return x > low;
+            return x > low || (x == low && token_idx > static_cast<uint32_t>(low_tie_break_id));
+          },
+          u, probs_vec, aggregate, &temp_storage);
       if (aggregate > u) {
         break;
       }
@@ -1058,7 +1085,15 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopPSamplingFro
       float probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
 #pragma unroll
       for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        probs_gt_pivot_0[j] = (probs_vec[j] > pivot_0) ? probs_vec[j] : 0;
+        const uint32_t token_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+        // Index tie-break against pivot_0 (= prob of the sampled token): tokens tied with the
+        // pivot but with a larger index are counted as strictly above it, so the accumulated
+        // mass `aggregate_gt_pivot_0` matches the (prob, index) total order used for sampling.
+        const bool gt_pivot_0 =
+            token_idx < d &&
+            (probs_vec[j] > pivot_0 ||
+             (probs_vec[j] == pivot_0 && token_idx > static_cast<uint32_t>(sampled_id)));
+        probs_gt_pivot_0[j] = gt_pivot_0 ? probs_vec[j] : 0;
         probs_gt_pivot_1[j] = (probs_vec[j] > pivot_1) ? probs_vec[j] : 0;
         threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
         threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
@@ -1087,11 +1122,13 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopPSamplingFro
     if (aggregate_gt_pivot_1 < top_p) {
       // case 2: pivot_0 rejected, pivot_1 accepted
       low = pivot_0;
+      low_tie_break_id = sampled_id;
       high = pivot_1;
       q = aggregate_gt_pivot_0;
     } else {
       // case 3: pivot_0 rejected, pivot_1 rejected
       low = pivot_1;
+      low_tie_break_id = -1;
       q = aggregate_gt_pivot_1;
     }
   } while (low < high);
@@ -1173,7 +1210,8 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void MinPSamplingFro
 
     DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
                            DETERMINISTIC>(
-        i, d, [&](float x) { return x >= pivot; }, u, probs_vec, aggregate, &temp_storage);
+        i, d, [pivot](float x, uint32_t token_idx) { return x >= pivot; }, u, probs_vec, aggregate,
+        &temp_storage);
     if (aggregate > u) {
       break;
     }
@@ -1227,13 +1265,16 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKTopPSamplin
   float aggregate;
   float q = 1;
   float low = 0, high = 1.f;
-  int sampled_id;
+  int sampled_id = -1;
+  int low_tie_break_id = -1;
   do {
     temp_storage.sampled_id = d;
     temp_storage.last_valid_id = -1;
     __syncthreads();
     float u = curand_uniform(&state) * q;
     aggregate = 0;
+    // Only lower bounds that come from an actual sampled pivot carry an index tie-break.
+    // Midpoint bounds (pivot_1) are pure numeric thresholds and must stay value-only.
 #pragma unroll 2
     for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
       probs_vec.fill(0);
@@ -1243,7 +1284,12 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKTopPSamplin
 
       DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
                              DETERMINISTIC>(
-          i, d, [&](float x) { return x > low; }, u, probs_vec, aggregate, &temp_storage);
+          i, d,
+          [low, low_tie_break_id](float x, uint32_t token_idx) {
+            if (low_tie_break_id < 0) return x > low;
+            return x > low || (x == low && token_idx > static_cast<uint32_t>(low_tie_break_id));
+          },
+          u, probs_vec, aggregate, &temp_storage);
       if (aggregate > u) {
         break;
       }
@@ -1280,12 +1326,17 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKTopPSamplin
       ValueCount<float> probs_gt_pivot_0[VEC_SIZE], probs_gt_pivot_1[VEC_SIZE];
 #pragma unroll
       for (uint32_t j = 0; j < VEC_SIZE; ++j) {
-        probs_gt_pivot_0[j] = {
-            (probs_vec[j] > pivot_0) ? probs_vec[j] : 0,
-            (probs_vec[j] > pivot_0 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
-        probs_gt_pivot_1[j] = {
-            (probs_vec[j] > pivot_1) ? probs_vec[j] : 0,
-            (probs_vec[j] > pivot_1 && (i * BLOCK_THREADS + tx) * VEC_SIZE + j < d)};
+        const uint32_t token_idx = (i * BLOCK_THREADS + tx) * VEC_SIZE + j;
+        // Index tie-break against pivot_0 (= prob of the sampled token): tokens tied with the
+        // pivot but with a larger index rank strictly above it, so both the count (for top-k)
+        // and the accumulated mass (for top-p) match the (prob, index) total order.
+        const bool gt_pivot_0 =
+            token_idx < d &&
+            (probs_vec[j] > pivot_0 ||
+             (probs_vec[j] == pivot_0 && token_idx > static_cast<uint32_t>(sampled_id)));
+        const bool gt_pivot_1 = token_idx < d && probs_vec[j] > pivot_1;
+        probs_gt_pivot_0[j] = {gt_pivot_0 ? probs_vec[j] : 0, gt_pivot_0};
+        probs_gt_pivot_1[j] = {gt_pivot_1 ? probs_vec[j] : 0, gt_pivot_1};
         threadlocal_aggregate_gt_pivot_0 += probs_gt_pivot_0[j];
         threadlocal_aggregate_gt_pivot_1 += probs_gt_pivot_1[j];
       }
@@ -1314,11 +1365,13 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKTopPSamplin
     if (aggregate_gt_pivot_1.count < k && aggregate_gt_pivot_1.value < p) {
       // case 2: pivot_0 rejected, pivot_1 accepted
       low = pivot_0;
+      low_tie_break_id = sampled_id;
       high = pivot_1;
       q = aggregate_gt_pivot_0.value;
     } else {
       // case 3: pivot_0 rejected, pivot_1 rejected
       low = pivot_1;
+      low_tie_break_id = -1;
       q = aggregate_gt_pivot_1.value;
     }
   } while (low < high);
@@ -1978,8 +2031,8 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void ChainSpeculativ
 
     DeviceSamplingFromProb<VEC_SIZE, BLOCK_THREADS, SCAN_ALGORITHM, REDUCE_ALGORITHM,
                            DETERMINISTIC>(
-        i, d, [&](float x) { return x > 0; }, u, relu_q_minus_p_vec, aggregate_relu_q_minus_p,
-        &temp_storage);
+        i, d, [](float x, uint32_t token_idx) { return x > 0; }, u, relu_q_minus_p_vec,
+        aggregate_relu_q_minus_p, &temp_storage);
     if (aggregate_relu_q_minus_p > u) {
       break;
     }

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -289,6 +289,125 @@ def test_top_k_sampling_with_variable_k(batch_size, vocab_size, k):
         ]
 
 
+def _sample_freq_single_row(sample_fn, row_probs, num_trials):
+    """Draw ``num_trials`` samples from a single probability row and return frequencies.
+
+    Uses the ``indices`` mechanism so every output samples from the same row but with
+    independent randomness (one block per output), mirroring ``test_sampling_freq``.
+    """
+    vocab_size = row_probs.numel()
+    probs = row_probs.view(1, vocab_size).contiguous()
+    indices = torch.zeros(num_trials, dtype=torch.int32, device=probs.device)
+    samples = sample_fn(probs, indices)
+    counter = torch.zeros(vocab_size, dtype=torch.int64, device=probs.device)
+    counter.scatter_add_(0, samples.long(), torch.ones_like(samples, dtype=torch.int64))
+    return counter, counter.float() / num_trials
+
+
+def test_midpoint_low_does_not_apply_index_tie_break():
+    """A midpoint lower bound is value-only, unlike a sampled-pivot lower bound.
+
+    In the dual-pivot rejection loop, case 3 sets ``low = pivot_1`` where
+    ``pivot_1 = (pivot_0 + high) / 2``.  That midpoint is not tied to the previously sampled
+    token, so tokens exactly equal to it must remain excluded by the next predicate.  Only
+    case 2, which sets ``low = pivot_0`` from an actual sampled token, may carry an index
+    tie-break.
+    """
+
+    def accepted_indices(row_probs, low, low_tie_break_id):
+        return [
+            idx
+            for idx, prob in enumerate(row_probs)
+            if prob > low
+            or (low_tie_break_id >= 0 and prob == low and idx > low_tie_break_id)
+        ]
+
+    row_probs = [0.4, 0.1, 0.25, 0.25]
+
+    # Model case 3: sampled_id=1 gave pivot_0=0.1 and high=0.4, so pivot_1=0.25.
+    # Since low is a midpoint, both 0.25 tokens must stay excluded.
+    assert accepted_indices(row_probs, low=0.25, low_tie_break_id=-1) == [0]
+
+    # Model case 2 with a real sampled-pivot lower bound. Here the index tie-break is valid.
+    assert accepted_indices(row_probs, low=0.1, low_tie_break_id=1) == [0, 2, 3]
+
+
+def test_top_k_sampling_boundary_tie():
+    """Tokens tied with the k-th token but outside top-k must not be over-accepted.
+
+    Distribution [0.4, 0.3, 0.3, 0.0] with k=2 has a tie at the boundary: tokens 1 and 2
+    both have probability 0.3 == p_min. The buggy value-only acceptance accepts all three of
+    {0, 1, 2}; the index tie-break must keep exactly 2 tokens and renormalize over mass 0.7.
+    """
+    torch.manual_seed(42)
+    row_probs = torch.tensor([0.4, 0.3, 0.3, 0.0], dtype=torch.float32, device="cuda:0")
+    k = 2
+    num_trials = 200000
+
+    counter, freq = _sample_freq_single_row(
+        lambda probs, indices: flashinfer.sampling.top_k_sampling_from_probs(
+            probs, k, indices=indices
+        ),
+        row_probs,
+        num_trials,
+    )
+
+    # Zero-probability token is never sampled.
+    assert counter[3].item() == 0
+    # Exactly k distinct tokens are accepted (no over-acceptance of the tied token).
+    assert int((counter > 0).sum().item()) == k
+    # The highest-probability token is always present, and the normalizer covers exactly the
+    # top-k mass (0.4 + 0.3 = 0.7), so its frequency is 0.4 / 0.7 rather than the buggy 0.4.
+    assert abs(freq[0].item() - 0.4 / 0.7) < 0.02, freq
+    # The single surviving tied token carries the remaining 0.3 / 0.7 mass.
+    tie_freq = freq[1].item() + freq[2].item()
+    assert abs(tie_freq - 0.3 / 0.7) < 0.02, freq
+
+
+def test_top_p_sampling_boundary_tie():
+    """Tokens tied at the top-p truncation boundary must not be over-accepted."""
+    torch.manual_seed(42)
+    row_probs = torch.tensor([0.5, 0.25, 0.25], dtype=torch.float32, device="cuda:0")
+    p = 0.7
+    num_trials = 200000
+
+    counter, freq = _sample_freq_single_row(
+        lambda probs, indices: flashinfer.sampling.top_p_sampling_from_probs(
+            probs, p, indices=indices
+        ),
+        row_probs,
+        num_trials,
+    )
+
+    # Exactly 2 tokens survive: {0.5, one of the tied 0.25}; normalizer is 0.75.
+    assert int((counter > 0).sum().item()) == 2
+    assert abs(freq[0].item() - 0.5 / 0.75) < 0.02, freq
+    tie_freq = freq[1].item() + freq[2].item()
+    assert abs(tie_freq - 0.25 / 0.75) < 0.02, freq
+
+
+def test_top_k_top_p_sampling_boundary_tie():
+    """Joint top-k/top-p must also resolve boundary ties via the index tie-break."""
+    torch.manual_seed(42)
+    row_probs = torch.tensor([0.4, 0.3, 0.3, 0.0], dtype=torch.float32, device="cuda:0")
+    k, p = 2, 0.99
+    num_trials = 200000
+
+    counter, freq = _sample_freq_single_row(
+        lambda probs, indices: flashinfer.sampling.top_k_top_p_sampling_from_probs(
+            probs, k, p, indices=indices, filter_apply_order="joint"
+        ),
+        row_probs,
+        num_trials,
+    )
+
+    assert counter[3].item() == 0
+    assert int((counter > 0).sum().item()) == k
+    assert abs(freq[0].item() - 0.4 / 0.7) < 0.02, freq
+    tie_freq = freq[1].item() + freq[2].item()
+    assert abs(tie_freq - 0.3 / 0.7) < 0.02, freq
+
+
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 0.7, 1])


### PR DESCRIPTION


<!-- .github/pull_request_template.md -->

## 📌 Description

### Summary

This PR fixes a correctness issue in FlashInfer rejection sampling when multiple tokens have exactly the same probability at the top-k or top-p truncation boundary.

The previous kernels accepted a sampled token using only its probability value, for example by checking whether enough probability mass or enough tokens were strictly greater than the pivot. When a non-candidate token had the same probability as the boundary token, it could be accepted as if it belonged to the truncated set. This made the output distribution differ from the intended top-k/top-p distribution.

The fix promotes the acceptance rule to a deterministic total order on `(probability, token_index)`. Tokens with higher probability still rank first; for exact probability ties, token index is used as the tie-breaker. The same ordering is applied consistently when sampling and when counting or accumulating tokens above the pivot.

### Minimal Example

For probabilities `[0.4, 0.3, 0.3, 0.0]` with `top_k = 2`, the boundary probability is `0.3`.

The old value-only predicate could accept all three non-zero tokens because both `0.3` tokens matched the boundary value. The correct behavior is to keep exactly two tokens under a deterministic tie-break, so the retained mass is `0.4 + 0.3 = 0.7` and the leading token should appear with probability `0.4 / 0.7`, not `0.4`.

The added tests exercise the exact boundary-tie cases for:

- `top_k_sampling_from_probs`
- `top_p_sampling_from_probs`
- `top_k_top_p_sampling_from_probs` in joint mode

### Performance

A before/after benchmark was run to check whether the additional tie handling causes a meaningful regression.

- Benchmark environment: NVIDIA H20 GPU, PyTorch 2.10.0+cu130
- Comparable before/after benchmark cases: 1040, covering different sampling routines, vocab sizes, batch sizes, distributions, sampling parameters, and deterministic modes
- Geomean slowdown: `1.0005x`
- Median slowdown: `1.0000x`
- Regressions above 5%: 1 / 1040
- Regressions above 20%: 1 / 1040
- Control paths `sampling_from_probs` and `min_p` stayed effectively unchanged at about `0.9998x`

The benchmark covered `top_k`, `top_p`, joint `top_k_top_p`, `top_k_first`, `min_p`, and basic sampling across vocab sizes 32000 and 128512, batch sizes 1/32/128/512, deterministic and non-deterministic modes, and continuous, quantized, plateau, and all-tie distributions.

Overall, the fix restores the intended distribution semantics for exact boundary ties with negligible aggregate performance impact.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

  ## 🧪 Tests

  - [x] Tests have been added or updated as needed.
  - [ ] Full project CI has not been triggered yet on this fork PR.

  Targeted sampling boundary tests were run on `ada-4090`:

  ```bash
    python -u -m pytest -q -s \
    tests/utils/test_sampling.py::test_midpoint_low_does_not_apply_index_tie_break \
    tests/utils/test_sampling.py::test_top_k_sampling_boundary_tie \
    tests/utils/test_sampling.py::test_top_p_sampling_boundary_tie \
    tests/utils/test_sampling.py::test_top_k_top_p_sampling_boundary_tie
  ```
  Result: 4 passed, 2 warnings in 53.47s.

  Environment:

  - Node: ada-4090
  - GPU: NVIDIA GeForce RTX 4090
  - PyTorch: 2.6.0+cu124


## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sampling stability when tokens share boundary probabilities.
  * Added deterministic tie-breaking for top-k, top-p, and combined sampling.
  * Corrected boundary filtering, excluding invalid and zero-probability tokens where appropriate.
  * Ensured retained tokens and normalized sampling frequencies match expected results.
* **Tests**
  * Added regression coverage for midpoint handling, boundary ties, token selection, and normalized sampling across supported sampling modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->