### PR TITLE
perf(moe): support caller-provided combine output

### DIFF
--- a/csrc/trtllm_moe_alltoall.cu
+++ b/csrc/trtllm_moe_alltoall.cu
@@ -331,8 +331,10 @@ void moeA2ACombineIntoOp(TensorView payload, int64_t localNumTokens, TensorView 
   TVM_FFI_ICHECK_EQ(output.ndim(), 2) << "output must be a 2D tensor";
   TVM_FFI_ICHECK_EQ(output.size(0), output_shape[0]);
   TVM_FFI_ICHECK_EQ(output.size(1), output_shape[1]);
-  TVM_FFI_ICHECK(output.dtype() == outputDtype_.value_or(payload.dtype()))
-      << "output dtype does not match output_dtype";
+  auto const expectedOutputDtype = outputDtype_.value_or(payload.dtype());
+  TVM_FFI_ICHECK(output.dtype() == expectedOutputDtype)
+      << "output dtype must match " << (outputDtype_.has_value() ? "output_dtype" : "payload dtype")
+      << " (expected " << expectedOutputDtype << ", got " << output.dtype() << ")";
   params.ep_size = static_cast<int>(epSize);
   params.ep_rank = static_cast<int>(epRank);
   params.local_num_tokens = static_cast<int>(localNumTokens);

--- a/csrc/trtllm_moe_alltoall.cu
+++ b/csrc/trtllm_moe_alltoall.cu
@@ -273,12 +273,12 @@ nvinfer1::DataType toNvDataType(DLDataType dtype) {
   return nvinfer1::DataType::kFLOAT;
 }
 
-Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView workspace,
-                       TensorView metainfo, int64_t runtimeMaxTokensPerRank, int64_t epRank,
-                       int64_t epSize, int64_t topK, int64_t combinePayloadOffset,
-                       bool payloadInWorkspace, Optional<DLDataType> outputDtype_,
-                       Optional<TensorView> outputScales, double outputScalarScale,
-                       int64_t sfLayout) {
+void moeA2ACombineIntoOp(TensorView payload, int64_t localNumTokens, TensorView workspace,
+                         TensorView metainfo, int64_t runtimeMaxTokensPerRank, int64_t epRank,
+                         int64_t epSize, int64_t topK, int64_t combinePayloadOffset,
+                         bool payloadInWorkspace, Optional<DLDataType> outputDtype_,
+                         Optional<TensorView> outputScales, double outputScalarScale,
+                         int64_t sfLayout, TensorView output) {
   using tl_throughput::MoeA2ACombineParams;
   using tl_throughput::MoeA2ACombineQuantMode;
   using tl_throughput::MoeA2ACombineSwizzleSFMode;
@@ -326,8 +326,13 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
   auto const output_shape = outputDtype_.has_value() && outputDtype_.value() == dl_uint8
                                 ? tvm::ffi::Shape{localNumTokens, elementsPerToken / 2}
                                 : tvm::ffi::Shape{localNumTokens, elementsPerToken};
-  Tensor output =
-      alloc_tensor(output_shape, outputDtype_.value_or(payload.dtype()), payload.device());
+  CHECK_INPUT(output);
+  CHECK_DEVICE(payload, output);
+  TVM_FFI_ICHECK_EQ(output.ndim(), 2) << "output must be a 2D tensor";
+  TVM_FFI_ICHECK_EQ(output.size(0), output_shape[0]);
+  TVM_FFI_ICHECK_EQ(output.size(1), output_shape[1]);
+  TVM_FFI_ICHECK(output.dtype() == outputDtype_.value_or(payload.dtype()))
+      << "output dtype does not match output_dtype";
   params.ep_size = static_cast<int>(epSize);
   params.ep_rank = static_cast<int>(epRank);
   params.local_num_tokens = static_cast<int>(localNumTokens);
@@ -396,6 +401,23 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
   auto err = cudaGetLastError();
   TVM_FFI_ICHECK(err == cudaSuccess)
       << "moe_a2a_combine launch failed: " << cudaGetErrorString(err);
+}
+
+Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView workspace,
+                       TensorView metainfo, int64_t runtimeMaxTokensPerRank, int64_t epRank,
+                       int64_t epSize, int64_t topK, int64_t combinePayloadOffset,
+                       bool payloadInWorkspace, Optional<DLDataType> outputDtype_,
+                       Optional<TensorView> outputScales, double outputScalarScale,
+                       int64_t sfLayout) {
+  int64_t const elementsPerToken = payload.size(2);
+  auto const outputShape = outputDtype_.has_value() && outputDtype_.value() == dl_uint8
+                               ? tvm::ffi::Shape{localNumTokens, elementsPerToken / 2}
+                               : tvm::ffi::Shape{localNumTokens, elementsPerToken};
+  Tensor output =
+      alloc_tensor(outputShape, outputDtype_.value_or(payload.dtype()), payload.device());
+  moeA2ACombineIntoOp(payload, localNumTokens, workspace, metainfo, runtimeMaxTokensPerRank, epRank,
+                      epSize, topK, combinePayloadOffset, payloadInWorkspace, outputDtype_,
+                      outputScales, outputScalarScale, sfLayout, output);
   return output;
 }
 
@@ -455,5 +477,6 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_a2a_get_aux_data_size, getMoeA2AAuxDataSize);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_a2a_initialize, moeA2AInitializeOp);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_a2a_dispatch, moeA2ADispatchOp);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_a2a_combine, moeA2ACombineOp);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_a2a_combine_into, moeA2ACombineIntoOp);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_a2a_sanitize_expert_ids, moeA2ASanitizeExpertIdsOp);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_a2a_get_metainfo_index_pairs, getMoeA2AMetaInfoIndexPairs);

--- a/csrc/trtllm_moe_alltoall.cu
+++ b/csrc/trtllm_moe_alltoall.cu
@@ -409,6 +409,9 @@ Tensor moeA2ACombineOp(TensorView payload, int64_t localNumTokens, TensorView wo
                        bool payloadInWorkspace, Optional<DLDataType> outputDtype_,
                        Optional<TensorView> outputScales, double outputScalarScale,
                        int64_t sfLayout) {
+  CHECK_INPUT(payload);
+  TVM_FFI_ICHECK_EQ(payload.ndim(), 3)
+      << "payload must be [ep_size, runtime_max_tokens_per_rank, hidden]";
   int64_t const elementsPerToken = payload.size(2);
   auto const outputShape = outputDtype_.has_value() && outputDtype_.value() == dl_uint8
                                ? tvm::ffi::Shape{localNumTokens, elementsPerToken / 2}

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -158,6 +158,45 @@ def get_moe_alltoall_module():
         )
 
     @register_custom_op(
+        "flashinfer::moe_a2a_combine_into",
+        mutates_args=("workspace", "output"),
+    )
+    def moe_a2a_combine_into(
+        payload: torch.Tensor,
+        local_num_tokens: int,
+        workspace: torch.Tensor,
+        metainfo: torch.Tensor,
+        runtime_max_tokens_per_rank: int,
+        ep_rank: int,
+        ep_size: int,
+        top_k: int,
+        combine_payload_offset: int,
+        payload_in_workspace: bool,
+        output_dtype: Optional[torch.dtype],
+        output_scales: Optional[torch.Tensor],
+        output_scalar_scale: float,
+        sf_layout: Optional[SfLayout],
+        output: torch.Tensor,
+    ) -> None:
+        module.moe_a2a_combine_into(
+            payload,
+            local_num_tokens,
+            workspace,
+            metainfo,
+            runtime_max_tokens_per_rank,
+            ep_rank,
+            ep_size,
+            top_k,
+            combine_payload_offset,
+            payload_in_workspace,
+            output_dtype,
+            output_scales,
+            output_scalar_scale,
+            sf_layout.value if sf_layout is not None else SfLayout.layout_linear.value,
+            output,
+        )
+
+    @register_custom_op(
         "flashinfer::moe_a2a_sanitize_expert_ids",
         mutates_args=("expert_ids",),
     )
@@ -210,6 +249,7 @@ def get_moe_alltoall_module():
         moe_a2a_initialize=moe_a2a_initialize,
         moe_a2a_dispatch=moe_a2a_dispatch,
         moe_a2a_combine=moe_a2a_combine,
+        moe_a2a_combine_into=moe_a2a_combine_into,
         moe_a2a_sanitize_expert_ids=moe_a2a_sanitize_expert_ids,
         moe_a2a_get_metainfo_index_pairs=moe_a2a_get_metainfo_index_pairs,
         moe_a2a_get_aux_data_size=moe_a2a_get_aux_data_size,
@@ -400,6 +440,7 @@ def moe_a2a_combine(
     output_scales: Optional[torch.Tensor] = None,
     output_scalar_scale: float = 1.0,
     sf_layout: SfLayout = SfLayout.layout_linear,
+    output: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     r"""Combine per-expert outputs back to the originating ranks.
 
@@ -446,13 +487,17 @@ def moe_a2a_combine(
         paths.
     sf_layout : SfLayout
         Output swizzle layout.  Defaults to ``SfLayout.layout_linear``.
+    output : Optional[torch.Tensor]
+        Caller-provided output tensor. Its shape and dtype must match the
+        requested combine output.
 
     Returns
     -------
     torch.Tensor
         ``[local_num_tokens, *]`` tensor with the combined outputs.
     """
-    return get_moe_alltoall_module().moe_a2a_combine(
+    module = get_moe_alltoall_module()
+    args = (
         payload,
         local_num_tokens,
         workspace,
@@ -468,6 +513,10 @@ def moe_a2a_combine(
         output_scalar_scale,
         sf_layout,
     )
+    if output is None:
+        return module.moe_a2a_combine(*args)
+    module.moe_a2a_combine_into(*args, output)
+    return output
 
 
 @flashinfer_api
@@ -854,6 +903,7 @@ class MoeAlltoAll:
         output_scales: Optional[torch.Tensor] = None,
         output_scalar_scale: float = 1.0,
         sf_layout: SfLayout = SfLayout.layout_linear,
+        output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         r"""Run the MoE all-to-all combine phase.
 
@@ -880,6 +930,9 @@ class MoeAlltoAll:
             paths.
         sf_layout : SfLayout
             Output swizzle layout.  Defaults to ``SfLayout.layout_linear``.
+        output : Optional[torch.Tensor]
+            Caller-provided output tensor. Its shape and dtype must match the
+            requested combine output.
 
         Returns
         -------
@@ -908,6 +961,7 @@ class MoeAlltoAll:
             output_scales,
             output_scalar_scale,
             sf_layout,
+            output,
         )
 
         # Reset state for next round

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -497,6 +497,14 @@ def moe_a2a_combine(
     torch.Tensor
         ``[local_num_tokens, *]`` tensor with the combined outputs.
     """
+    if output is not None:
+        if not output.is_cuda:
+            raise ValueError(
+                f"output must be a CUDA tensor, got device={output.device}"
+            )
+        if not output.is_contiguous():
+            raise ValueError(f"output must be contiguous, got stride={output.stride()}")
+
     module = get_moe_alltoall_module()
     args = (
         payload,

--- a/flashinfer/comm/trtllm_moe_alltoall.py
+++ b/flashinfer/comm/trtllm_moe_alltoall.py
@@ -488,8 +488,9 @@ def moe_a2a_combine(
     sf_layout : SfLayout
         Output swizzle layout.  Defaults to ``SfLayout.layout_linear``.
     output : Optional[torch.Tensor]
-        Caller-provided output tensor. Its shape and dtype must match the
-        requested combine output.
+        Caller-provided contiguous output tensor. Its shape and dtype must
+        match the requested combine output, and it must be on the same device
+        as ``payload``.
 
     Returns
     -------
@@ -931,8 +932,9 @@ class MoeAlltoAll:
         sf_layout : SfLayout
             Output swizzle layout.  Defaults to ``SfLayout.layout_linear``.
         output : Optional[torch.Tensor]
-            Caller-provided output tensor. Its shape and dtype must match the
-            requested combine output.
+            Caller-provided contiguous output tensor. Its shape and dtype must
+            match the requested combine output, and it must be on the same
+            device as ``payload``.
 
         Returns
         -------

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -263,10 +263,15 @@ def test_moe_alltoall_single_gpu(num_tokens, vector_dim, num_experts, top_k):
     # Copy first output tensor into inplace_combine_tensor
     inplace_combine_tensor.copy_(output_tensors[hidden_state_index])
 
+    output_buffer = torch.empty_like(input_tensors[hidden_state_index])
     output = moe_a2a.combine(
-        inplace_combine_tensor, num_tokens, payload_in_workspace=True
+        inplace_combine_tensor,
+        num_tokens,
+        payload_in_workspace=True,
+        output=output_buffer,
     )
 
+    assert output is output_buffer
     # Should just be a direct copy for 1 GPU
     torch.testing.assert_close(
         output, input_tensors[hidden_state_index], atol=0, rtol=0

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -194,6 +194,54 @@ def make_payload(num_tokens, vector_dim, dtype):
         )
 
 
+def test_moe_a2a_combine_rejects_cpu_output_before_jit(monkeypatch):
+    monkeypatch.setattr(
+        trtllm_moe_alltoall,
+        "get_moe_alltoall_module",
+        lambda: pytest.fail("invalid output should be rejected before JIT loading"),
+    )
+    payload = torch.empty((1, 1, 1))
+
+    with pytest.raises(ValueError, match="output must be a CUDA tensor"):
+        trtllm_moe_alltoall.moe_a2a_combine(
+            payload,
+            1,
+            torch.empty(0),
+            torch.empty(0),
+            1,
+            0,
+            1,
+            1,
+            0,
+            output=torch.empty((1, 1)),
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_moe_a2a_combine_rejects_noncontiguous_output_before_jit(monkeypatch):
+    monkeypatch.setattr(
+        trtllm_moe_alltoall,
+        "get_moe_alltoall_module",
+        lambda: pytest.fail("invalid output should be rejected before JIT loading"),
+    )
+    payload = torch.empty((1, 1, 2), device="cuda")
+    output = torch.empty((2, 2), device="cuda").T
+
+    with pytest.raises(ValueError, match="output must be contiguous"):
+        trtllm_moe_alltoall.moe_a2a_combine(
+            payload,
+            1,
+            torch.empty(0, device="cuda"),
+            torch.empty(0),
+            1,
+            0,
+            1,
+            1,
+            0,
+            output=output,
+        )
+
+
 @pytest.mark.parametrize(
     "num_tokens,vector_dim,num_experts,top_k",
     SINGLE_GPU_PARAMS,

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -198,11 +198,20 @@ def make_payload(num_tokens, vector_dim, dtype):
     "num_tokens,vector_dim,num_experts,top_k",
     SINGLE_GPU_PARAMS,
 )
+@pytest.mark.parametrize("payload_in_workspace", [False, True])
+@pytest.mark.parametrize("use_output_buffer", [False, True])
 @pytest.mark.skipif(
     not mnnvl_available(),
     reason="Mnnvl memory is not supported on this platform or container lacks SYS_PTRACE capability",
 )
-def test_moe_alltoall_single_gpu(num_tokens, vector_dim, num_experts, top_k):
+def test_moe_alltoall_single_gpu(
+    num_tokens,
+    vector_dim,
+    num_experts,
+    top_k,
+    payload_in_workspace,
+    use_output_buffer,
+):
     """Test MOE alltoall communication on single GPU."""
     torch.cuda.set_device(0)
     # Create a random input tensor
@@ -254,24 +263,30 @@ def test_moe_alltoall_single_gpu(num_tokens, vector_dim, num_experts, top_k):
         output_tensor, _ = torch.sort(output_tensor.flatten(end_dim=1), dim=0)
         torch.testing.assert_close(output_tensor, input_tensor, atol=0, rtol=0)
 
-    inplace_combine_tensor = moe_a2a.get_combine_payload_tensor_in_workspace(
-        num_tokens,
-        input_tensors[hidden_state_index].shape[-1],
-        input_tensors[hidden_state_index].dtype,
+    if payload_in_workspace:
+        combine_tensor = moe_a2a.get_combine_payload_tensor_in_workspace(
+            num_tokens,
+            input_tensors[hidden_state_index].shape[-1],
+            input_tensors[hidden_state_index].dtype,
+        )
+        combine_tensor.copy_(output_tensors[hidden_state_index])
+    else:
+        combine_tensor = output_tensors[hidden_state_index].clone()
+
+    output_buffer = (
+        torch.empty_like(input_tensors[hidden_state_index])
+        if use_output_buffer
+        else None
     )
-
-    # Copy first output tensor into inplace_combine_tensor
-    inplace_combine_tensor.copy_(output_tensors[hidden_state_index])
-
-    output_buffer = torch.empty_like(input_tensors[hidden_state_index])
     output = moe_a2a.combine(
-        inplace_combine_tensor,
+        combine_tensor,
         num_tokens,
-        payload_in_workspace=True,
+        payload_in_workspace=payload_in_workspace,
         output=output_buffer,
     )
 
-    assert output is output_buffer
+    if output_buffer is not None:
+        assert output is output_buffer
     # Should just be a direct copy for 1 GPU
     torch.testing.assert_close(
         output, input_tensors[hidden_state_index], atol=0, rtol=0


### PR DESCRIPTION
## Summary

Allow `MoeAlltoAll.combine()` to write into an optional caller-provided output tensor. The existing allocating API remains unchanged, and the output-buffer path uses the same communication and combine kernels.

Related vLLM integration: https://github.com/vllm-project/vllm/pull/47156

## Rationale

vLLM already preallocates the final MoE output. The current path creates a temporary tensor and then copies it:

```python
# Existing
temporary = combine(payload)
output.copy_(temporary)

# Proposed
combine(payload, output=output)
```

Writing directly to the caller-owned tensor removes one allocation and one serialized output-sized D2D copy per MoE layer. The communication algorithm and combine kernel are unchanged.

## Performance

One GB200 node, four GPUs, EP4, hidden size 8192, top-k 22, 512 experts, and BF16 output:

| Timed path, 8192 tokens/rank | Baseline | Direct output | Delta, 95% CI |
| --- | ---: | ---: | ---: |
| Eager combine + output copy | 817.648 us | 777.528 us | **-4.91%** [-4.93%, -4.89%] |
| CUDA-graph dispatch + combine | 1423.616 us | 1386.640 us | **-2.59%** [-2.61%, -2.57%] |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of updates

* **New Features**
  * Added a “combine into” mode that lets you supply a pre-allocated output tensor for MoE all-to-all combine.
  * Extended the Python `moe_a2a_combine` and `MoeAlltoAll.combine` APIs with an optional `output` parameter.

* **Bug Fixes**
  * Added early validation for `output` (must be CUDA, contiguous, and match the expected shape/dtype) before combine runs.

* **Tests**
  * Added tests for early rejection of CPU/non-contiguous outputs.
  * Expanded single-GPU coverage for in-workspace payloads and optional external output-buffer usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->