### PR TITLE
fix(jit): keep JIT build lock on NFS and stop deleting the lockfile

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -2,10 +2,10 @@ import dataclasses
 import functools
 import logging
 import os
-from contextlib import nullcontext
+from contextlib import nullcontext, suppress
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Union, Hashable
+from typing import Dict, List, Optional, Sequence, Union, Hashable, cast
 
 import tvm_ffi
 from filelock import FileLock
@@ -15,9 +15,34 @@ from . import env as jit_env
 from .cpp_ext import generate_ninja_build_for_op, get_nvcc_parallelism_flags, run_ninja
 from .utils import write_if_different
 
+try:
+    import fcntl
+except ImportError:  # non-Unix; JIT build path is Unix-only in practice
+    fcntl = None  # type: ignore[assignment]
+
 os.makedirs(jit_env.FLASHINFER_WORKSPACE_DIR, exist_ok=True)
 # Note: Do NOT create FLASHINFER_CSRC_DIR here - it's the package directory
 # which may be read-only after installation
+
+
+class _PersistentFileLock(FileLock):
+    """FileLock that releases the lock but does not delete the lockfile.
+
+    filelock deletes the lockfile on release. On a shared NFS cache, deleting it
+    while a peer node holds it open makes that peer's handle stale, so its next
+    lock op fails with ``OSError: [Errno 116] Stale file handle``. Releasing the
+    advisory lock without unlinking removes that failure; the lock still
+    serializes the compile, and the leftover empty lockfile is harmless.
+    """
+
+    def _release(self) -> None:
+        fd = cast("int", self._context.lock_file_fd)
+        self._context.lock_file_fd = None
+        if fcntl is not None:
+            with suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        with suppress(OSError):
+            os.close(fd)
 
 
 class MissingJITCacheError(RuntimeError):
@@ -295,7 +320,9 @@ class JitSpec:
                 spec=self,
             )
         lock = (
-            FileLock(self.lock_path, thread_local=False) if need_lock else nullcontext()
+            _PersistentFileLock(self.lock_path, thread_local=False)
+            if need_lock
+            else nullcontext()
         )
         with lock:
             self.write_ninja()
@@ -308,9 +335,17 @@ class JitSpec:
         if self.is_aot:
             return self.load(self.aot_path)
 
+        # Warm path: an already-built .so needs no compile, so skip the lock. On a
+        # shared NFS cache this keeps every warm rank off the lockfile.
+        if self.is_compiled:
+            try:
+                return self.load(self.jit_library_path)
+            except Exception:
+                pass  # fall through to the locked build/load
+
         # Guard both build and load with the same lock to avoid race condition
         # where another process is building the library and removes the .so file.
-        with FileLock(self.lock_path, thread_local=False):
+        with _PersistentFileLock(self.lock_path, thread_local=False):
             so_path = self.jit_library_path
             verbose = os.environ.get("FLASHINFER_JIT_VERBOSE", "0") == "1"
             self.build(verbose, need_lock=False)
@@ -502,7 +537,7 @@ def build_jit_specs(
         if skip_prebuilt and spec.aot_path.exists():
             continue
         lines.append(f"subninja {spec.ninja_path}")
-        with FileLock(spec.lock_path, thread_local=False):
+        with _PersistentFileLock(spec.lock_path, thread_local=False):
             spec.write_ninja()
     if not lines:
         return
@@ -510,7 +545,7 @@ def build_jit_specs(
     lines = ["ninja_required_version = 1.3"] + lines + [""]
 
     tmpdir = get_tmpdir()
-    with FileLock(tmpdir / "flashinfer_jit.lock", thread_local=False):
+    with _PersistentFileLock(tmpdir / "flashinfer_jit.lock", thread_local=False):
         ninja_path = tmpdir / "flashinfer_jit.ninja"
         write_if_different(ninja_path, "\n".join(lines))
         run_ninja(jit_env.FLASHINFER_JIT_DIR, ninja_path, verbose)

--- a/tests/test_jit_cpp_ext.py
+++ b/tests/test_jit_cpp_ext.py
@@ -286,3 +286,48 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa3", 512, 512) not in calls
     assert ("single", "fa2", 512, 512) in calls
     assert ("batch", "fa2", 512, 512) in calls
+
+
+def test_persistent_file_lock_keeps_lockfile_after_release(tmp_path):
+    # filelock deletes the lockfile on release, which turns peer NFS handles
+    # stale (Errno 116). The persistent lock must leave the file in place.
+    lock_path = tmp_path / "kernel.lock"
+
+    with core._PersistentFileLock(str(lock_path), thread_local=False):
+        assert lock_path.exists()
+
+    assert lock_path.exists()
+
+    # Re-acquiring the same, still-present lockfile must work.
+    with core._PersistentFileLock(str(lock_path), thread_local=False):
+        pass
+
+
+def test_build_and_load_warm_path_skips_lock(monkeypatch, tmp_path):
+    # An already-compiled .so must load without touching the FileLock so warm
+    # ranks never contend on the shared lockfile.
+    spec = core.JitSpec(
+        name="test_module",
+        sources=[],
+        extra_cflags=None,
+        extra_cuda_cflags=None,
+        extra_ldflags=None,
+        extra_include_dirs=None,
+    )
+
+    so_path = tmp_path / "test_module.so"
+    so_path.touch()
+    monkeypatch.setattr(type(spec), "is_aot", property(lambda self: False))
+    monkeypatch.setattr(type(spec), "is_compiled", property(lambda self: True))
+    monkeypatch.setattr(type(spec), "jit_library_path", property(lambda self: so_path))
+
+    loaded = []
+    monkeypatch.setattr(spec, "load", lambda p: loaded.append(p) or "module")
+
+    def fail_lock(*args, **kwargs):
+        raise AssertionError("warm path must not acquire the lock")
+
+    monkeypatch.setattr(core, "_PersistentFileLock", fail_lock)
+
+    assert spec.build_and_load() == "module"
+    assert loaded == [so_path]


### PR DESCRIPTION
## 📌 Description

The JIT build `FileLock` lives under `FLASHINFER_JIT_DIR`, which is commonly a shared NFS cache. On a cold multi-rank start, `build_and_load` fails with `OSError: [Errno 116] Stale file handle`.

Root cause: `filelock` **deletes the lockfile on release**. When one process releases and unlinks the lockfile while a peer (often on another node) still holds that same file open, the peer's open handle becomes stale, and its next lock operation raises `ESTALE`. The problem is the delete, not the lock itself.

The lock must stay on the shared mount — that shared lockfile is exactly what serializes concurrent cold compiles across ranks and nodes, so a kernel is compiled once and reused. Moving the lock node-local would let every node race the same shared build dir.

## Changes
- Add `_PersistentFileLock`, a `FileLock` that releases the advisory lock but does **not** unlink the lockfile. The leftover empty file is harmless and reused on the next acquire.
- Use it at the JIT lock sites (`JitSpec.build`, `JitSpec.build_and_load`, `build_jit_specs`).
- `build_and_load` now short-circuits when the `.so` is already compiled: it loads without taking the lock, so warm ranks never contend on the lockfile.

## Why this is safe
The kernel cache stays shared and the lock stays on it, preserving cross-node/cross-run reuse. Skipping only the unlink keeps advisory locking intact — concurrent cold compiles are still fully serialized — while removing the delete-under-open that caused `ESTALE`. Warm starts read a fully-written `.so` with no lock, which is already safe over NFS.

## 🧪 Tests
`tests/test_jit_cpp_ext.py`:
- `test_persistent_file_lock_keeps_lockfile_after_release`: the lockfile survives release and re-acquires cleanly.
- `test_build_and_load_warm_path_skips_lock`: an already-compiled `.so` loads without acquiring the lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT compilation/build synchronization to prevent stale lock states and reduce lock contention on shared/networked storage.
  * Added more reliable lock handling during coordinated builds to avoid stale-handle failures.

* **Tests**
  * Added coverage to confirm the persistent lock behavior keeps the lockfile after release.
  * Added coverage to verify “warm” build/load skips lock acquisition when the compiled shared library already exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->