### PR TITLE
fix(mla): validate paged kv-cache shape in BatchMLAPagedAttentionWrapper.run

### DIFF
--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -75,6 +75,73 @@ def _check_cutlass_shape(q_nope_pe, ckv_kpe_cache, kv_len, page_table):
         )
 
 
+def _check_fa_mla_cache_shape(
+    ckv_cache: torch.Tensor,
+    kpe_cache: torch.Tensor,
+    page_size: int,
+    head_dim_ckv: int,
+    head_dim_kpe: int,
+) -> None:
+    """Validate the paged kv-cache shape for the fa2/fa3 MLA kernels.
+
+    The fa2/fa3 paged MLA kernels index the kv-cache with the layout
+    ``[num_pages, page_size, head_dim]``, deriving each slot offset from the
+    ``page_size`` captured in ``plan()`` -- not from the tensor's own dim-1. A
+    collapsed layout such as ``[num_pages * page_size, 1, head_dim]`` therefore
+    addresses the wrong rows and silently produces all-zero / incorrect output
+    instead of raising. This validates eagerly so the failure is obvious.
+
+    See https://github.com/flashinfer-ai/flashinfer/issues/3219.
+
+    Args:
+        ckv_cache: Compressed-KV cache, expected ``[num_pages, page_size,
+            head_dim_ckv]``.
+        kpe_cache: Key positional-embedding cache, expected ``[num_pages,
+            page_size, head_dim_kpe]``.
+        page_size: Page size passed to ``plan()``; must match dim-1 of both caches.
+        head_dim_ckv: Expected last dim of ``ckv_cache``.
+        head_dim_kpe: Expected last dim of ``kpe_cache``.
+
+    Raises:
+        ValueError: If either cache is not 3D, dim-1 does not equal
+            ``page_size``, the last dim does not match the corresponding head
+            dim, or the two caches disagree on ``num_pages``.
+    """
+    if ckv_cache.ndim != 3 or kpe_cache.ndim != 3:
+        raise ValueError(
+            "ckv_cache and kpe_cache must be 3D "
+            "[num_pages, page_size, head_dim], got "
+            f"ckv_cache.shape={tuple(ckv_cache.shape)}, "
+            f"kpe_cache.shape={tuple(kpe_cache.shape)}"
+        )
+    if ckv_cache.shape[1] != page_size or kpe_cache.shape[1] != page_size:
+        raise ValueError(
+            "ckv_cache/kpe_cache dim-1 must equal the page_size passed to "
+            f"plan() (page_size={page_size}), got "
+            f"ckv_cache.shape={tuple(ckv_cache.shape)}, "
+            f"kpe_cache.shape={tuple(kpe_cache.shape)}. The MLA paged kv-cache "
+            "layout is [num_pages, page_size, head_dim]; a collapsed layout "
+            "such as [num_pages * page_size, 1, head_dim] is a common cause of "
+            "all-zero or incorrect output "
+            "(https://github.com/flashinfer-ai/flashinfer/issues/3219)."
+        )
+    if ckv_cache.shape[2] != head_dim_ckv:
+        raise ValueError(
+            f"ckv_cache last dim must equal head_dim_ckv={head_dim_ckv}, got "
+            f"{ckv_cache.shape[2]}"
+        )
+    if kpe_cache.shape[2] != head_dim_kpe:
+        raise ValueError(
+            f"kpe_cache last dim must equal head_dim_kpe={head_dim_kpe}, got "
+            f"{kpe_cache.shape[2]}"
+        )
+    if ckv_cache.shape[0] != kpe_cache.shape[0]:
+        raise ValueError(
+            "ckv_cache and kpe_cache must have the same num_pages (dim-0), got "
+            f"{ckv_cache.shape[0]} and {kpe_cache.shape[0]}"
+        )
+
+
 @dataclass(frozen=True)
 class MLAHeadDimensions:
     """
@@ -1604,6 +1671,8 @@ class BatchMLAPagedAttentionWrapper:
             self._kv_len_arr_buf = kv_len_arr.to(self.device, non_blocking=True)
         self._causal = causal
         self._page_size = page_size
+        self._head_dim_ckv = head_dim_ckv
+        self._head_dim_kpe = head_dim_kpe
         self._sm_scale = sm_scale
         self._use_profiler = use_profiler
 
@@ -1767,6 +1836,13 @@ class BatchMLAPagedAttentionWrapper:
                 )
         num_heads = q_nope.shape[1]
         page_size = self._page_size
+        _check_fa_mla_cache_shape(
+            ckv_cache,
+            kpe_cache,
+            page_size,
+            self._head_dim_ckv,
+            self._head_dim_kpe,
+        )
         sm_scale = self._sm_scale
         causal = self._causal
         mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value

--- a/tests/attention/test_deepseek_mla.py
+++ b/tests/attention/test_deepseek_mla.py
@@ -522,7 +522,7 @@ def test_batch_mla_collapsed_cache_shape_raises(backend):
         batch_size, num_heads, head_dim_ckv, dtype=dtype, device=device
     )
     q_pe = torch.randn(batch_size, num_heads, head_dim_kpe, dtype=dtype, device=device)
-    # Wrong (collapsed) layout: page_size folded into dim-0, dim-1 forced to 1.
+    # Invalid (collapsed) layout: page_size folded into dim-0, dim-1 forced to 1.
     ckv_bad = torch.randn(
         batch_size * pages_num * page_size, 1, head_dim_ckv, dtype=dtype, device=device
     )

--- a/tests/attention/test_deepseek_mla.py
+++ b/tests/attention/test_deepseek_mla.py
@@ -495,6 +495,73 @@ def test_batch_mla_oob_kv_nan(
         torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.parametrize("backend", ["fa2", "fa3"])
+def test_batch_mla_collapsed_cache_shape_raises(backend):
+    """Feeding a collapsed kv-cache layout must raise instead of failing silently.
+
+    Related to https://github.com/flashinfer-ai/flashinfer/issues/3219: feeding
+    the kv-cache in a collapsed ``[num_pages * page_size, 1, head_dim]`` layout
+    (instead of ``[num_pages, page_size, head_dim]``) used to silently produce
+    all-zero / incorrect output. It must now raise a clear error.
+    """
+    device = torch.device("cuda:0")
+    clear_cuda_cache(device)
+    if backend == "fa3" and not is_sm90a_supported(device):
+        pytest.skip("FA3 is not supported on this device")
+    torch.manual_seed(42)
+    batch_size = 2
+    num_heads = 16
+    head_dim_ckv = 512
+    head_dim_kpe = 64
+    page_size = 64
+    kv_len = 256
+    dtype = torch.half
+    pages_num = math.ceil(kv_len / page_size)
+
+    q_nope = torch.randn(
+        batch_size, num_heads, head_dim_ckv, dtype=dtype, device=device
+    )
+    q_pe = torch.randn(batch_size, num_heads, head_dim_kpe, dtype=dtype, device=device)
+    # Wrong (collapsed) layout: page_size folded into dim-0, dim-1 forced to 1.
+    ckv_bad = torch.randn(
+        batch_size * pages_num * page_size, 1, head_dim_ckv, dtype=dtype, device=device
+    )
+    kpe_bad = torch.randn(
+        batch_size * pages_num * page_size, 1, head_dim_kpe, dtype=dtype, device=device
+    )
+
+    sm_scale = 1.0 / ((128 + 64) ** 0.5)
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(
+        workspace_buffer, backend=backend
+    )
+    q_indptr = torch.arange(0, batch_size + 1, device=device, dtype=torch.int32)
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32) * pages_num
+    )
+    kv_indices = torch.arange(
+        0, batch_size * pages_num, device=device, dtype=torch.int32
+    )
+    kv_lens = torch.full((batch_size,), kv_len, dtype=torch.int32, device=device)
+
+    wrapper.plan(
+        q_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_lens,
+        num_heads,
+        head_dim_ckv,
+        head_dim_kpe,
+        page_size,
+        False,
+        sm_scale,
+        q_nope.dtype,
+        ckv_bad.dtype,
+    )
+    with pytest.raises(ValueError, match="page_size"):
+        wrapper.run(q_nope, q_pe, ckv_bad, kpe_bad)
+
+
 @pytest.mark.parametrize("batch_size", [1, 3, 5, 7, 157])
 @pytest.mark.parametrize("kv_len", [0, 17, 33, 96, 97, 114, 514, 1024])
 @pytest.mark.parametrize("qo_len", [1, 3, 5, 7, 9, 11, 13, 15, 17])


### PR DESCRIPTION
## 📌 Description
  
  The fa2/fa3 paged MLA kernels derive each kv-cache slot offset from the
  `page_size` captured in `plan()`, assuming the layout
  `[num_pages, page_size, head_dim]`. Passing a collapsed layout such as
  `[num_pages * page_size, 1, head_dim]` silently addresses the wrong rows and
  produces all-zero / incorrect output instead of raising.

  This PR adds `_check_fa_mla_cache_shape()`, called eagerly in
  `BatchMLAPagedAttentionWrapper.run()`, validating `ckv_cache`/`kpe_cache`
  rank, `page_size` (dim-1), head dims, and matching `num_pages` — turning a
  silent correctness bug into a clear `ValueError`.

  ## 🔍 Related Issues

  Related to #3219

  ## 🚀 Pull Request Checklist
  
  ### ✅ Pre-commit Checks
  - [x] Installed `pre-commit`
  - [x] Installed the hooks
  - [x] Ran the hooks and fixed any reported issues (all passed)

  ## 🧪 Tests
  - [x] Added regression test `test_batch_mla_collapsed_cache_shape_raises` (fa2/fa3)
  - [x] All tests passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stronger validation for paged MLA KV-cache tensor shapes to fail fast when inputs don’t match the planned page layout.
  * Improved runtime checks to ensure the KV-cache matches the planned page size, head dimensions, and page count before attention kernels run.
  * Added regression tests to verify an invalid “collapsed” KV-cache layout raises a clear `ValueError` for supported backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Note: defensive guard against an invalid (collapsed) cache layout only — does not implement arbitrary-page FA2 indexing, so it does not fully  close #3219.