### PR TITLE
Fix TRTLLM ragged prefill edge cases

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -811,10 +811,13 @@ void trtllm_ragged_attention(
   int head_dim_v = value.size(2);
   int k_stride_keys_values = key.stride(0);
   int k_stride_heads = key.stride(1);
-  int k_stride_batch = key.numel();
+  // Ragged SeparateQkv K/V is packed along one token axis. The generated TMA
+  // shape uses a singleton batch dimension, so the launcher must pass zero
+  // batch stride instead of a synthetic numel-derived stride.
+  int k_stride_batch = 0;
   int v_stride_keys_values = value.stride(0);
   int v_stride_heads = value.stride(1);
-  int v_stride_batch = value.numel();
+  int v_stride_batch = 0;
 
   // SageAttention scaling factor pointers.
   const float* sage_attn_sfs_q_ptr =

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4598,6 +4598,8 @@ def trtllm_ragged_attention_deepseek(
     ] = (None, None, None, None),
     num_elts_per_sage_attn_blk: Tuple[int, int, int, int] = (0, 0, 0, 0),
     backend: str = "trtllm-gen",
+    q_seq_lens_cpu: Optional[torch.Tensor] = None,
+    kv_seq_lens_cpu: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Parameters
@@ -4664,6 +4666,16 @@ def trtllm_ragged_attention_deepseek(
         contains non-``None`` tensors.
     backend : str
         Attention backend to use. "trtllm-gen" (default) or "cute-dsl".
+    q_seq_lens_cpu : Optional[torch.Tensor]
+        Optional trusted CPU mirror of the per-row query lengths. When provided
+        together with ``kv_seq_lens_cpu``, the Python wrapper can keep the
+        all-active ragged fast path asynchronous while still compacting empty-KV
+        rows. If omitted, the wrapper derives lengths from the device indptrs
+        and may synchronize to preserve correctness for direct callers.
+        Currently only consulted by the ``trtllm-gen`` backend.
+    kv_seq_lens_cpu : Optional[torch.Tensor]
+        Optional trusted CPU mirror of the per-row KV lengths. Currently only
+        consulted by the ``trtllm-gen`` backend.
 
     Returns
     -------
@@ -4779,6 +4791,276 @@ def trtllm_ragged_attention_deepseek(
         if isinstance(bmm2_scale, torch.Tensor):
             assert bmm2_scale.dtype == torch.float32
 
+        def _validate_cpu_seq_lens(
+            lengths: torch.Tensor,
+            name: str,
+            total_tokens: int,
+            max_len: int,
+        ) -> int:
+            if lengths.device.type != "cpu":
+                raise ValueError(f"{name} must be a CPU tensor")
+            if lengths.dtype not in (torch.int32, torch.int64):
+                raise ValueError(f"{name} must have dtype torch.int32 or torch.int64")
+            if lengths.shape != (batch_size,):
+                raise ValueError(f"{name} must have shape ({batch_size},)")
+            if bool((lengths < 0).any().item()):
+                raise ValueError(f"{name} must contain non-negative lengths")
+
+            actual_total = int(lengths.sum().item())
+            if actual_total != total_tokens:
+                raise ValueError(
+                    f"{name} sums to {actual_total}, but expected {total_tokens} "
+                    "tokens from the corresponding ragged tensor"
+                )
+            if batch_size > 0 and int(lengths.max().item()) > max_len:
+                raise ValueError(f"{name} contains a length larger than max_len")
+            return actual_total
+
+        run_out = out
+        run_lse = lse
+        run_query = query
+        run_key = key
+        run_value = value
+        run_seq_lens = seq_lens
+        run_max_q_len = max_q_len
+        run_max_kv_len = max_kv_len
+        run_batch_size = batch_size
+        run_cum_seq_lens_q = cum_seq_lens_q
+        run_cum_seq_lens_kv = cum_seq_lens_kv
+        q_active_indices = None
+        should_launch = True
+
+        q_lens = None
+        kv_lens = None
+        q_lens_cpu = None
+        kv_lens_cpu = None
+        active_rows = None
+        has_inactive_rows = False
+        has_active_rows = True
+
+        if q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
+            if q_seq_lens_cpu is None or kv_seq_lens_cpu is None:
+                raise ValueError(
+                    "q_seq_lens_cpu and kv_seq_lens_cpu must be provided together"
+                )
+
+            _validate_cpu_seq_lens(
+                q_seq_lens_cpu,
+                "q_seq_lens_cpu",
+                query.shape[0],
+                max_q_len,
+            )
+            kv_total = _validate_cpu_seq_lens(
+                kv_seq_lens_cpu,
+                "kv_seq_lens_cpu",
+                key.shape[0],
+                max_kv_len,
+            )
+            if kv_total != value.shape[0]:
+                raise ValueError(
+                    "kv_seq_lens_cpu must sum to both key and value token counts"
+                )
+
+            q_lens_cpu = q_seq_lens_cpu
+            kv_lens_cpu = kv_seq_lens_cpu
+            active_rows_cpu = (q_lens_cpu > 0) & (kv_lens_cpu > 0)
+            if not bool(active_rows_cpu.all().item()):
+                has_inactive_rows = True
+                has_active_rows = bool(active_rows_cpu.any().item())
+        else:
+            if (
+                query.is_cuda
+                and hasattr(torch.cuda, "is_current_stream_capturing")
+                and torch.cuda.is_current_stream_capturing()
+            ):
+                raise ValueError(
+                    "q_seq_lens_cpu and kv_seq_lens_cpu must be provided during "
+                    "CUDA graph capture"
+                )
+            q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
+            kv_lens = cum_seq_lens_kv[1:] - cum_seq_lens_kv[:-1]
+            active_rows = (q_lens > 0) & (kv_lens > 0)
+            has_inactive_rows = bool((~active_rows).any().item())
+            if has_inactive_rows:
+                has_active_rows = bool(active_rows.any().item())
+
+        if has_inactive_rows:
+            if isinstance(bmm1_scale, torch.Tensor) or isinstance(
+                bmm2_scale, torch.Tensor
+            ):
+                raise ValueError(
+                    "TRTLLM-GEN ragged attention does not support compacting "
+                    "empty KV rows when bmm scale tensors are provided."
+                )
+            if attention_sinks is not None:
+                raise ValueError(
+                    "TRTLLM-GEN ragged attention does not support compacting "
+                    "empty KV rows when attention sinks are provided."
+                )
+            if any(scale_tensor is not None for scale_tensor in sage_attn_sfs):
+                raise ValueError(
+                    "TRTLLM-GEN ragged attention does not support compacting "
+                    "empty KV rows when SageAttention scale-factor tensors are "
+                    "provided."
+                )
+
+            if not has_active_rows:
+                out.zero_()
+                if lse is not None:
+                    lse.fill_(-float("inf"))
+                should_launch = False
+            else:
+                if q_lens_cpu is not None:
+                    assert kv_lens_cpu is not None
+
+                    active_rows_cpu = (q_lens_cpu > 0) & (kv_lens_cpu > 0)
+                    q_active_mask_cpu = torch.repeat_interleave(
+                        active_rows_cpu, q_lens_cpu
+                    )
+                    q_inactive_indices_cpu = torch.nonzero(
+                        ~q_active_mask_cpu, as_tuple=False
+                    ).flatten()
+                    if q_inactive_indices_cpu.numel() > 0:
+                        q_inactive_indices = q_inactive_indices_cpu.to(
+                            query.device, non_blocking=True
+                        )
+                        out.index_fill_(0, q_inactive_indices, 0)
+                        if lse is not None:
+                            lse.index_fill_(0, q_inactive_indices, -float("inf"))
+
+                    active_indices_cpu = torch.nonzero(
+                        active_rows_cpu, as_tuple=False
+                    ).flatten()
+                    kv_active_mask_cpu = torch.repeat_interleave(
+                        active_rows_cpu, kv_lens_cpu
+                    )
+                    q_active_indices_cpu = torch.nonzero(
+                        q_active_mask_cpu, as_tuple=False
+                    ).flatten()
+                    kv_active_indices_cpu = torch.nonzero(
+                        kv_active_mask_cpu, as_tuple=False
+                    ).flatten()
+
+                    q_active_indices = q_active_indices_cpu.to(
+                        query.device, non_blocking=True
+                    )
+                    kv_active_indices = kv_active_indices_cpu.to(
+                        query.device, non_blocking=True
+                    )
+                    run_query = query.index_select(0, q_active_indices).contiguous()
+                    run_key = key.index_select(0, kv_active_indices).contiguous()
+                    run_value = value.index_select(0, kv_active_indices).contiguous()
+
+                    run_q_lens_cpu = q_lens_cpu.index_select(0, active_indices_cpu).to(
+                        dtype=cum_seq_lens_q.dtype
+                    )
+                    run_seq_lens_cpu = kv_lens_cpu.index_select(
+                        0, active_indices_cpu
+                    ).to(dtype=seq_lens.dtype)
+                    run_cum_seq_lens_q_cpu = torch.cat(
+                        [
+                            torch.zeros(1, dtype=cum_seq_lens_q.dtype),
+                            torch.cumsum(
+                                run_q_lens_cpu, dim=0, dtype=cum_seq_lens_q.dtype
+                            ),
+                        ],
+                        dim=0,
+                    )
+                    run_cum_seq_lens_kv_cpu = torch.cat(
+                        [
+                            torch.zeros(1, dtype=cum_seq_lens_kv.dtype),
+                            torch.cumsum(
+                                run_seq_lens_cpu.to(dtype=cum_seq_lens_kv.dtype),
+                                dim=0,
+                                dtype=cum_seq_lens_kv.dtype,
+                            ),
+                        ],
+                        dim=0,
+                    )
+
+                    run_seq_lens = run_seq_lens_cpu.to(query.device, non_blocking=True)
+                    run_cum_seq_lens_q = run_cum_seq_lens_q_cpu.to(
+                        query.device, non_blocking=True
+                    )
+                    run_cum_seq_lens_kv = run_cum_seq_lens_kv_cpu.to(
+                        query.device, non_blocking=True
+                    )
+                    run_max_q_len = int(run_q_lens_cpu.max().item())
+                    run_max_kv_len = int(run_seq_lens_cpu.max().item())
+                    run_batch_size = int(active_indices_cpu.numel())
+                else:
+                    if q_lens is None:
+                        q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
+                    if kv_lens is None:
+                        kv_lens = cum_seq_lens_kv[1:] - cum_seq_lens_kv[:-1]
+                    assert active_rows is not None
+
+                    q_active_mask = torch.repeat_interleave(active_rows, q_lens)
+                    q_inactive_indices = torch.nonzero(
+                        ~q_active_mask, as_tuple=False
+                    ).flatten()
+                    if q_inactive_indices.numel() > 0:
+                        out.index_fill_(0, q_inactive_indices, 0)
+                        if lse is not None:
+                            lse.index_fill_(0, q_inactive_indices, -float("inf"))
+
+                    active_indices = torch.nonzero(
+                        active_rows, as_tuple=False
+                    ).flatten()
+                    kv_active_mask = torch.repeat_interleave(active_rows, kv_lens)
+                    kv_active_indices = torch.nonzero(
+                        kv_active_mask, as_tuple=False
+                    ).flatten()
+                    q_active_indices = torch.nonzero(
+                        q_active_mask, as_tuple=False
+                    ).flatten()
+
+                    run_query = query.index_select(0, q_active_indices).contiguous()
+                    run_key = key.index_select(0, kv_active_indices).contiguous()
+                    run_value = value.index_select(0, kv_active_indices).contiguous()
+                    run_seq_lens = kv_lens.index_select(0, active_indices).contiguous()
+                    run_q_lens = q_lens.index_select(0, active_indices).contiguous()
+                    run_cum_seq_lens_q = torch.cat(
+                        [
+                            torch.zeros(
+                                1, device=query.device, dtype=cum_seq_lens_q.dtype
+                            ),
+                            torch.cumsum(run_q_lens, dim=0, dtype=cum_seq_lens_q.dtype),
+                        ],
+                        dim=0,
+                    )
+                    run_cum_seq_lens_kv = torch.cat(
+                        [
+                            torch.zeros(
+                                1, device=query.device, dtype=cum_seq_lens_kv.dtype
+                            ),
+                            torch.cumsum(
+                                run_seq_lens, dim=0, dtype=cum_seq_lens_kv.dtype
+                            ),
+                        ],
+                        dim=0,
+                    )
+                    run_max_q_len = int(run_q_lens.max().item())
+                    run_max_kv_len = int(run_seq_lens.max().item())
+                    run_batch_size = int(active_indices.numel())
+                run_out = torch.empty(
+                    run_query.shape[0],
+                    query.shape[1],
+                    value.shape[2],
+                    device=query.device,
+                    dtype=out.dtype,
+                )
+                run_lse = (
+                    torch.empty(
+                        run_query.shape[0],
+                        query.shape[1],
+                        device=query.device,
+                        dtype=torch.float32,
+                    )
+                    if lse is not None
+                    else None
+                )
+
         workspace_size = workspace_buffer.numel() * workspace_buffer.element_size()
         sage_attn_sfs_q, sage_attn_sfs_k, sage_attn_sfs_p, sage_attn_sfs_v = (
             sage_attn_sfs
@@ -4786,38 +5068,44 @@ def trtllm_ragged_attention_deepseek(
         num_elts_sage_q, num_elts_sage_k, num_elts_sage_p, num_elts_sage_v = (
             num_elts_per_sage_attn_blk
         )
-        run_func(
-            out,
-            query,
-            key,
-            value,
-            workspace_buffer,
-            seq_lens,
-            max_q_len,
-            max_kv_len,
-            bmm1_scale,
-            bmm2_scale,
-            o_sf_scale,
-            batch_size,
-            window_left,
-            cum_seq_lens_q,
-            cum_seq_lens_kv,
-            sm_count,
-            enable_pdl,
-            is_causal,
-            workspace_size,
-            attention_sinks,
-            skip_softmax_threshold_scale_factor,
-            lse,
-            sage_attn_sfs_q,
-            sage_attn_sfs_k,
-            sage_attn_sfs_p,
-            sage_attn_sfs_v,
-            num_elts_sage_q,
-            num_elts_sage_k,
-            num_elts_sage_p,
-            num_elts_sage_v,
-        )
+        if should_launch:
+            run_func(
+                run_out,
+                run_query,
+                run_key,
+                run_value,
+                workspace_buffer,
+                run_seq_lens,
+                run_max_q_len,
+                run_max_kv_len,
+                bmm1_scale,
+                bmm2_scale,
+                o_sf_scale,
+                run_batch_size,
+                window_left,
+                run_cum_seq_lens_q,
+                run_cum_seq_lens_kv,
+                sm_count,
+                enable_pdl,
+                is_causal,
+                workspace_size,
+                attention_sinks,
+                skip_softmax_threshold_scale_factor,
+                run_lse,
+                sage_attn_sfs_q,
+                sage_attn_sfs_k,
+                sage_attn_sfs_p,
+                sage_attn_sfs_v,
+                num_elts_sage_q,
+                num_elts_sage_k,
+                num_elts_sage_p,
+                num_elts_sage_v,
+            )
+            if q_active_indices is not None:
+                out.index_copy_(0, q_active_indices, run_out)
+                if lse is not None:
+                    assert run_lse is not None
+                    lse.index_copy_(0, q_active_indices, run_lse)
 
     if return_lse:
         assert lse is not None, (

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -382,8 +382,11 @@ struct KernelParams {
       strideBatch = options.vStrideBatch;
     }
 
-    // Ragged layout has no batch stride; reset negative overflow to 0 for TMA descriptor.
-    if (!isPagedKv(options.mQkvLayout) && !isContiguousKv(options.mQkvLayout) && strideBatch < 0) {
+    // The TRTLLM-GEN ragged prefill launcher uses SeparateQkv for packed non-paged
+    // K/V. makeShapeKv collapses non-paged/non-contiguous K/V to a singleton batch
+    // dimension, so the TMA descriptor must not inherit a synthetic numel-derived
+    // batch stride. Zero handles both negative and positive int32 wraparound.
+    if (isSeparateQkv(options.mQkvLayout)) {
       strideBatch = 0;
     }
 

--- a/tests/attention/test_trtllm_ragged_kv_stride.py
+++ b/tests/attention/test_trtllm_ragged_kv_stride.py
@@ -5,114 +5,425 @@ import flashinfer
 from flashinfer.utils import get_compute_capability
 
 
-@pytest.mark.cuda
-def test_trtllm_ragged_kv_large_stride_overflow():
-    """
-    Test that ragged KV with large numel (>2^31) doesn't cause TMA descriptor error.
-
-    Constructs a scenario where key.numel() = 131072 * 128 * 192 > 2^31, which
-    triggers int32 overflow in kStrideBatch. Before the fix, this caused negative
-    stride and TMA descriptor error. After the fix, negative strideBatch is clamped
-    to 0 for ragged layouts.
-    """
+def _require_trtllm_ragged(device: torch.device) -> None:
     if not torch.cuda.is_available():
         pytest.skip("CUDA is not available")
-
     if not hasattr(flashinfer.prefill, "trtllm_ragged_attention_deepseek"):
-        pytest.skip("trtllm_ragged_attention_deepseek is not available in this build")
+        pytest.skip("trtllm_ragged_attention_deepseek is not available")
 
-    device = torch.device("cuda")
     compute_capability = get_compute_capability(device)
     if compute_capability[0] != 10:
         pytest.skip(
-            f"TRTLLM-gen ragged attention requires SM100 and SM103 GPUs, got sm{compute_capability[0]}{compute_capability[1]}"
+            "TRTLLM-gen ragged attention requires SM100 or SM103 GPUs, "
+            f"got sm{compute_capability[0]}{compute_capability[1]}"
         )
 
-    torch.manual_seed(42)
 
-    # Configuration that triggers numel > 2^31
-    batch_size = 16
-    max_kv_len = 8192
-    num_kv_heads = 128
-    head_dim_qk = 192
-    head_dim_vo = 128
-
-    # Construct ragged Q
-    seq_lens_q = torch.randint(
-        low=50, high=150, size=(batch_size,), device=device, dtype=torch.int32
-    )
-    cum_seq_lens_q = torch.cat(
+def _indptr(seq_lens: torch.Tensor) -> torch.Tensor:
+    return torch.cat(
         [
-            torch.zeros(1, device=device, dtype=torch.int32),
-            torch.cumsum(seq_lens_q, dim=0, dtype=torch.int32),
+            torch.zeros(1, device=seq_lens.device, dtype=torch.int32),
+            torch.cumsum(seq_lens, dim=0, dtype=torch.int32),
         ],
         dim=0,
     )
-    total_q = int(cum_seq_lens_q[-1].item())
-    max_q_len = int(seq_lens_q.max().item())
+
+
+def _workspace(device: torch.device) -> torch.Tensor:
+    return torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+
+
+def _run_trtllm_ragged(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_lens: torch.Tensor,
+    *,
+    max_q_len: int | None = None,
+    max_kv_len: int | None = None,
+    return_lse: bool = True,
+    out: torch.Tensor | None = None,
+    lse: torch.Tensor | None = None,
+    q_lens_cpu: torch.Tensor | None = None,
+    kv_lens_cpu: torch.Tensor | None = None,
+):
+    head_dim_qk = q.shape[2]
+    return flashinfer.prefill.trtllm_ragged_attention_deepseek(
+        query=q,
+        key=k,
+        value=v,
+        workspace_buffer=_workspace(q.device),
+        seq_lens=kv_lens,
+        max_q_len=(
+            max_q_len
+            if max_q_len is not None
+            else int(torch.diff(q_indptr).max().item())
+        ),
+        max_kv_len=(
+            max_kv_len if max_kv_len is not None else int(torch.diff(kv_indptr).max())
+        ),
+        bmm1_scale=float(1.0 / (head_dim_qk**0.5)),
+        bmm2_scale=1.0,
+        o_sf_scale=1.0,
+        batch_size=kv_lens.shape[0],
+        window_left=-1,
+        cum_seq_lens_q=q_indptr,
+        cum_seq_lens_kv=kv_indptr,
+        enable_pdl=False,
+        is_causal=False,
+        return_lse=return_lse,
+        out=out,
+        lse=lse,
+        q_seq_lens_cpu=q_lens_cpu,
+        kv_seq_lens_cpu=kv_lens_cpu,
+    )
+
+
+def _pack_rows(
+    tensor: torch.Tensor,
+    indptr: torch.Tensor,
+    row_indices: list[int],
+) -> torch.Tensor:
+    return torch.cat(
+        [
+            tensor[int(indptr[row].item()) : int(indptr[row + 1].item())]
+            for row in row_indices
+        ],
+        dim=0,
+    )
+
+
+@pytest.mark.cuda
+def test_trtllm_ragged_kv_large_stride_overflow():
+    """Ragged KV with numel > int32 max should not poison the TMA batch stride."""
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    torch.manual_seed(42)
+
+    batch_size = 16
+    max_kv_len = 8192
+    num_heads = 128
+    head_dim_qk = 192
+    head_dim_vo = 128
+
+    q_lens = torch.randint(
+        low=50, high=150, size=(batch_size,), device=device, dtype=torch.int32
+    )
+    q_indptr = _indptr(q_lens)
+    kv_lens = torch.full((batch_size,), max_kv_len, device=device, dtype=torch.int32)
+    kv_indptr = _indptr(kv_lens)
+
+    total_q = int(q_indptr[-1].item())
+    total_kv = int(kv_indptr[-1].item())
+    assert total_kv * num_heads * head_dim_qk > 2**31
 
     q = torch.randn(
-        total_q,
-        num_kv_heads,
+        total_q, num_heads, head_dim_qk, device=device, dtype=torch.bfloat16
+    )
+    k = torch.randn(
+        total_kv, num_heads, head_dim_qk, device=device, dtype=torch.bfloat16
+    )
+    v = torch.randn(
+        total_kv, num_heads, head_dim_vo, device=device, dtype=torch.bfloat16
+    )
+
+    output = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        max_q_len=int(q_lens.max().item()),
+        max_kv_len=max_kv_len,
+        return_lse=False,
+    )
+
+    assert output.shape == (total_q, num_heads, head_dim_vo)
+
+
+@pytest.mark.cuda
+def test_trtllm_ragged_kv_positive_stride_wrap_matches_cutlass():
+    """A positive int32 wraparound must not become a fake ragged batch stride."""
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+
+    free_mem, _ = torch.cuda.mem_get_info(device)
+    required_mem = 24 * 1024**3
+    if free_mem < required_mem:
+        pytest.skip(
+            f"requires at least {required_mem / 1024**3:.0f} GiB free GPU memory"
+        )
+
+    torch.manual_seed(42)
+    batch_size = 8
+    max_kv_len = 24576
+    num_heads = 128
+    head_dim_qk = 192
+    head_dim_vo = 128
+
+    q_lens = torch.ones(batch_size, device=device, dtype=torch.int32)
+    q_indptr = _indptr(q_lens)
+    kv_lens = torch.full((batch_size,), max_kv_len, device=device, dtype=torch.int32)
+    kv_indptr = _indptr(kv_lens)
+
+    total_kv = int(kv_indptr[-1].item())
+    key_numel = total_kv * num_heads * head_dim_qk
+    assert key_numel > 2**32
+    assert key_numel % 2**32 < 2**31
+
+    q = (torch.randn(batch_size, num_heads, head_dim_qk, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    k = (torch.randn(total_kv, num_heads, head_dim_qk, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+    v = (torch.randn(total_kv, num_heads, head_dim_vo, device=device) * 0.1).to(
+        torch.bfloat16
+    )
+
+    ref_workspace = torch.empty_like(_workspace(device))
+    wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+        ref_workspace,
+        kv_layout="NHD",
+        backend="cutlass",
+    )
+    scale = float(1.0 / (head_dim_qk**0.5))
+    wrapper.plan(
+        q_indptr,
+        kv_indptr,
+        num_heads,
+        num_heads,
+        head_dim_qk,
+        head_dim_vo=head_dim_vo,
+        causal=False,
+        sm_scale=scale,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    output_ref, _ = wrapper.run(q, k, v, return_lse=True)
+
+    output, lse = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        max_q_len=1,
+        max_kv_len=max_kv_len,
+    )
+
+    assert torch.isfinite(output).all()
+    assert torch.isfinite(lse).all()
+    torch.testing.assert_close(output, output_ref, atol=2e-2, rtol=2e-2)
+
+
+def _empty_kv_case(device: torch.device):
+    num_heads = 16
+    head_dim_qk = 128
+    head_dim_vo = 128
+    q_lens = torch.tensor([4, 5, 3, 2, 1], device=device, dtype=torch.int32)
+    kv_lens = torch.tensor([0, 7, 0, 2, 0], device=device, dtype=torch.int32)
+    q_indptr = _indptr(q_lens)
+    kv_indptr = _indptr(kv_lens)
+    q = torch.randn(
+        int(q_indptr[-1].item()),
+        num_heads,
         head_dim_qk,
         device=device,
         dtype=torch.bfloat16,
     )
-
-    # Construct ragged KV: total_kv = 16 * 8192 = 131072
-    # key.numel() = 131072 * 128 * 192 = 3,221,225,472 (0xC0000000) > 2^31
-    seq_lens_kv = torch.full(
-        (batch_size,), max_kv_len, device=device, dtype=torch.int32
-    )
-    cum_seq_lens_kv = torch.arange(
-        0,
-        (batch_size + 1) * max_kv_len,
-        max_kv_len,
-        device=device,
-        dtype=torch.int32,
-    )
-    total_kv = int(cum_seq_lens_kv[-1].item())
-
     k = torch.randn(
-        total_kv,
-        num_kv_heads,
+        int(kv_indptr[-1].item()),
+        num_heads,
         head_dim_qk,
         device=device,
         dtype=torch.bfloat16,
     )
     v = torch.randn(
-        total_kv,
-        num_kv_heads,
+        int(kv_indptr[-1].item()),
+        num_heads,
         head_dim_vo,
         device=device,
         dtype=torch.bfloat16,
     )
+    return q, k, v, q_lens, kv_lens, q_indptr, kv_indptr
 
-    workspace_buffer = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device)
-    scale = float(1.0 / (head_dim_qk**0.5))
 
-    # Should not raise "buildNdTmaDescriptor: invalid argument" error
-    output = flashinfer.prefill.trtllm_ragged_attention_deepseek(
-        query=q,
-        key=k,
-        value=v,
-        workspace_buffer=workspace_buffer,
-        seq_lens=seq_lens_kv,
-        max_q_len=max_q_len,
-        max_kv_len=max_kv_len,
-        bmm1_scale=scale,
-        bmm2_scale=1.0,
-        o_sf_scale=1.0,
-        batch_size=batch_size,
-        window_left=-1,
-        cum_seq_lens_q=cum_seq_lens_q,
-        cum_seq_lens_kv=cum_seq_lens_kv,
-        enable_pdl=False,
-        is_causal=True,
-        return_lse=False,
+@pytest.mark.cuda
+def test_trtllm_ragged_empty_kv_rows_are_neutral_and_match_compacted_call():
+    """Rows with query tokens and no KV tokens must contribute out=0, lse=-inf."""
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    torch.manual_seed(42)
+
+    q, k, v, q_lens, kv_lens, q_indptr, kv_indptr = _empty_kv_case(device)
+    out = torch.full(
+        (q.shape[0], q.shape[1], v.shape[2]),
+        7.0,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    lse = torch.full((q.shape[0], q.shape[1]), 3.0, device=device)
+
+    output, lse_out = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        out=out,
+        lse=lse,
+        q_lens_cpu=q_lens.cpu(),
+        kv_lens_cpu=kv_lens.cpu(),
     )
 
-    # Basic shape check
-    assert output.shape[0] == total_q
-    assert output.shape[1] == num_kv_heads
-    assert output.shape[2] == head_dim_vo
+    assert output.data_ptr() == out.data_ptr()
+    assert lse_out.data_ptr() == lse.data_ptr()
+
+    active_rows = [row for row, length in enumerate(kv_lens.tolist()) if length > 0]
+    for row in range(kv_lens.shape[0]):
+        q_start = int(q_indptr[row].item())
+        q_end = int(q_indptr[row + 1].item())
+        if row not in active_rows:
+            assert torch.all(output[q_start:q_end] == 0)
+            assert torch.isneginf(lse_out[q_start:q_end]).all()
+
+    compact_q_lens = q_lens[active_rows]
+    compact_kv_lens = kv_lens[active_rows]
+    compact_q_indptr = _indptr(compact_q_lens)
+    compact_kv_indptr = _indptr(compact_kv_lens)
+    compact_output, compact_lse = _run_trtllm_ragged(
+        _pack_rows(q, q_indptr, active_rows),
+        _pack_rows(k, kv_indptr, active_rows),
+        _pack_rows(v, kv_indptr, active_rows),
+        compact_q_indptr,
+        compact_kv_indptr,
+        compact_kv_lens,
+        q_lens_cpu=compact_q_lens.cpu(),
+        kv_lens_cpu=compact_kv_lens.cpu(),
+    )
+
+    for compact_row, row in enumerate(active_rows):
+        q_start = int(q_indptr[row].item())
+        q_end = int(q_indptr[row + 1].item())
+        compact_start = int(compact_q_indptr[compact_row].item())
+        compact_end = int(compact_q_indptr[compact_row + 1].item())
+        torch.testing.assert_close(
+            output[q_start:q_end],
+            compact_output[compact_start:compact_end],
+            atol=2e-2,
+            rtol=2e-2,
+        )
+        torch.testing.assert_close(
+            lse_out[q_start:q_end],
+            compact_lse[compact_start:compact_end],
+            atol=2e-2,
+            rtol=2e-2,
+        )
+
+
+@pytest.mark.cuda
+def test_trtllm_ragged_empty_kv_rows_direct_fallback_matches_cpu_mirror_path():
+    """Direct callers without CPU mirrors still get the same neutral semantics."""
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    torch.manual_seed(42)
+
+    q, k, v, q_lens, kv_lens, q_indptr, kv_indptr = _empty_kv_case(device)
+    mirror_output, mirror_lse = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        q_lens_cpu=q_lens.cpu(),
+        kv_lens_cpu=kv_lens.cpu(),
+    )
+    fallback_output, fallback_lse = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+    )
+
+    torch.testing.assert_close(fallback_output, mirror_output, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(fallback_lse, mirror_lse, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("use_cpu_lens", [True, False])
+@pytest.mark.cuda
+def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(use_cpu_lens):
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    torch.manual_seed(42)
+
+    batch_size = 3
+    num_heads = 16
+    head_dim_qk = 128
+    head_dim_vo = 128
+    q_lens = torch.tensor([4, 2, 3], device=device, dtype=torch.int32)
+    kv_lens = torch.zeros(batch_size, device=device, dtype=torch.int32)
+    q_indptr = _indptr(q_lens)
+    kv_indptr = _indptr(kv_lens)
+    q = torch.randn(
+        int(q_indptr[-1].item()),
+        num_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k = torch.empty((0, num_heads, head_dim_qk), device=device, dtype=torch.bfloat16)
+    v = torch.empty((0, num_heads, head_dim_vo), device=device, dtype=torch.bfloat16)
+    out = torch.full(
+        (q.shape[0], num_heads, head_dim_vo),
+        7.0,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    lse = torch.full((q.shape[0], num_heads), 3.0, device=device)
+
+    cpu_lens_kwargs = (
+        {"q_lens_cpu": q_lens.cpu(), "kv_lens_cpu": kv_lens.cpu()}
+        if use_cpu_lens
+        else {}
+    )
+    output, lse_out = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        max_kv_len=0,
+        out=out,
+        lse=lse,
+        **cpu_lens_kwargs,
+    )
+
+    assert output.data_ptr() == out.data_ptr()
+    assert lse_out.data_ptr() == lse.data_ptr()
+    assert torch.all(output == 0)
+    assert torch.isneginf(lse_out).all()
+
+
+@pytest.mark.cuda
+def test_trtllm_ragged_requires_cpu_lens_for_cuda_graph_capture(monkeypatch):
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    torch.manual_seed(42)
+
+    q, k, v, _, kv_lens, q_indptr, kv_indptr = _empty_kv_case(device)
+    monkeypatch.setattr(
+        torch.cuda, "is_current_stream_capturing", lambda: True, raising=False
+    )
+
+    with pytest.raises(ValueError, match="must be provided during CUDA graph capture"):
+        _run_trtllm_ragged(q, k, v, q_indptr, kv_indptr, kv_lens)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

I found my way here while debugging https://github.com/vllm-project/vllm/issues/42426 which eventually brought me to #3047 which seemed very similar to my issue, and porting a similar fix to the trtllm ragged path solved it for me. This approach uses a wrapper since the underlying kernel appears to still be closed source despite the variety of OSS kernel dumps to flashinfer.

I had a similar branch to vllm https://github.com/vllm-project/vllm/compare/main...alexeldeib:ace/trtllm-ragged-empty-row-compact-no-lse but since #3047 was originally affecting sglang I thought it might make sense to take it here instead

also i'm a kernel noob so forgive any basic errors, this was AI assisted, but conceptually it seems to align with prior art/bugs, and it does reliably resolve my issue in vllm (happy to share more details but I figure 3047 is already validation of the theory in some part)

---

TRTLLM-GEN ragged attention packs non-paged SeparateQkv K/V rows along a single token axis. Do not pass a synthetic batch stride into the TMA descriptor for that singleton-batch layout; use zero stride instead so both negative and positive int32 wraparound cases are avoided.

The Python wrapper now defines the empty-attention identity for rows that have query tokens but no current KV tokens: out=0 and lse=-inf. It launches the kernel only for active rows and scatters active results back into the original output buffers, avoiding undefined empty-KV kernel behavior.

Optional trusted CPU length mirrors let framework callers keep the all-active fast path asynchronous. Direct callers without mirrors still derive lengths from device indptrs and take the correctness-preserving compaction path when empty rows are present. CUDA regression coverage exercises stride overflow, positive stride wraparound, mixed empty-KV rows, all-empty rows, direct-caller fallback, and invalid CPU length mirrors.

Note, that last part does change the signature and may be an issue, but might be useful in lieu of modifying the underlying kernel to handle this directly?

## 🔍 Related Issues

Related: https://github.com/flashinfer-ai/flashinfer/issues/3047. This is the TRTLLM-GEN empty-KV case called out in https://github.com/flashinfer-ai/flashinfer/issues/3047#issuecomment-4473332762, distinct from the FA2/FA3 path fixed in https://github.com/flashinfer-ai/flashinfer/pull/3251.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional CPU-side Q/KV sequence-length mirrors to compact ragged batches and efficiently handle empty KV rows.
* **Bug Fixes**
  * Corrected K/V batch-stride handling for SeparateQkv layouts.
  * Ensured empty KV rows produce zero outputs and `-inf` log-sum-exp values.
  * Added validation requiring CPU length mirrors during CUDA graph capture.
* **Tests**
  * Expanded coverage for stride behavior, empty-row semantics, CPU-mirror equivalence, and CUDA graph capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->