### PR TITLE
Fix cuDNN batch prefill test

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -612,15 +612,15 @@ def cudnn_batch_prefill_with_kv_cache(
     max_sequence_kv : int
         Maximum number of tokens per KV sequence (``s_kv_max``).
     actual_seq_lens_q : torch.Tensor
-        Per-request query lengths, shape ``(batch_size,)``.  When cuDNN is
+        Per-request query lengths, shape ``(batch_size, 1, 1, 1)``.  When cuDNN is
         available (the default backend) this tensor must reside on the same
         CUDA device as ``q``.  Only the fallback non-cuDNN path accepts (and
         internally copies) a CPU tensor; that fallback is also the only path
         that requires a CPU tensor when ``is_cuda_graph_compatible`` is
         ``False``.
     actual_seq_lens_kv : torch.Tensor
-        Per-request KV lengths, shape ``(batch_size,)``.  Same device rules as
-        ``actual_seq_lens_q``.
+        Per-request KV lengths, shape ``(batch_size, 1, 1, 1)``.  Same device
+        rules as ``actual_seq_lens_q``.
     block_tables : Optional[torch.Tensor]
         Paged KV block table, shape ``(batch_size, num_pages_per_seq)`` on GPU.
         Pass ``None`` for non-paged KV layouts.

--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -636,15 +636,25 @@ def cudnn_batch_prefill_with_kv_cache(
     v_scale : Optional[torch.Tensor]
         FP8 dequantization scale for the value, shape ``(1, 1, 1, 1)`` on GPU.
     batch_offsets_q : Optional[torch.Tensor]
-        Per-request offsets into the query tensor, shape ``(batch_size,)`` on GPU.
+        Cumulative per-request start offsets into the packed query tensor, in
+        **elements** (``token_offset * num_heads_qo * head_dim_qk``), shape
+        ``(batch_size + 1,)``, int32, on GPU.  Required when ``batch_size > 1``
+        on the cuDNN graph path; may be omitted only for ``batch_size == 1``.
     batch_offsets_o : Optional[torch.Tensor]
-        Per-request offsets into the output tensor, shape ``(batch_size,)`` on GPU.
+        Cumulative per-request start offsets into the packed output tensor, in
+        elements (``token_offset * num_heads_qo * head_dim_vo``), shape
+        ``(batch_size + 1,)``, int32, on GPU.  Required when ``batch_size > 1``
+        on the cuDNN graph path.
     batch_offsets_k : Optional[torch.Tensor]
-        Per-request offsets into the key tensor, shape ``(batch_size,)`` on GPU.
+        Cumulative per-request start offsets into the key tensor, in elements,
+        shape ``(batch_size + 1,)`` on GPU.  Only used for non-paged (3-D) KV.
     batch_offsets_v : Optional[torch.Tensor]
-        Per-request offsets into the value tensor, shape ``(batch_size,)`` on GPU.
+        Cumulative per-request start offsets into the value tensor, in
+        elements, shape ``(batch_size + 1,)`` on GPU.  Only used for non-paged
+        (3-D) KV.
     batch_offsets_stats : Optional[torch.Tensor]
-        Per-request offsets into the LSE / stats tensor, shape ``(batch_size,)``.
+        Cumulative per-request start offsets into the LSE / stats tensor, in
+        elements, shape ``(batch_size + 1,)``.
     out : Optional[torch.Tensor]
         Pre-allocated output tensor, shape
         ``(total_qo_tokens, num_heads_qo, head_dim_vo)``.  Allocated internally
@@ -714,6 +724,19 @@ def cudnn_batch_prefill_with_kv_cache(
         out = torch.empty(out_shape, device=q.device, dtype=o_data_type)
 
     if CUDNN_AVAILABLE and backend != "cubin":
+        # The cuDNN graph declares packed q/out with THD nominal strides
+        # (batch stride == one token), which is only addressable through ragged
+        # offsets. Without them the graph is well-formed but reads/writes batch
+        # b at token offset b, silently corrupting every batch except the
+        # first, so reject instead (batch_size == 1 needs no offsets: the only
+        # batch starts at 0).
+        if num_sequences > 1 and (batch_offsets_q is None or batch_offsets_o is None):
+            raise ValueError(
+                "batch_offsets_q and batch_offsets_o are required when batch_size > 1: "
+                "packed q/out cannot be addressed without ragged offsets. Pass "
+                "cumulative element offsets of shape (batch_size + 1,), e.g. "
+                "cumsum([0, *actual_seq_lens_q]) * num_qo_heads * head_dim."
+            )
         return _batch_prefill_with_kv_cache(
             q=q,
             k_cache=k_cache,

--- a/tests/trace/test_cudnn_batch_prefill_reference_correctness.py
+++ b/tests/trace/test_cudnn_batch_prefill_reference_correctness.py
@@ -66,6 +66,9 @@ def test_cudnn_batch_prefill_reference_correctness(shape_kwargs):
     actual_seq_lens_kv = torch.full((B,), kv_len, dtype=torch.int32, device="cuda")
     scale = 1.0 / math.sqrt(D)
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda")
+    qo_indptr = torch.zeros(B + 1, dtype=torch.int32, device="cuda")
+    qo_indptr[1:] = actual_seq_lens_q.cumsum(0)
+    batch_offsets = (qo_indptr.to(torch.int64) * Hq * D).to(torch.int32)
     try:
         api_out, _ = cudnn_batch_prefill_with_kv_cache(
             q,
@@ -75,11 +78,13 @@ def test_cudnn_batch_prefill_reference_correctness(shape_kwargs):
             workspace,
             max_token_per_sequence=q_len,
             max_sequence_kv=kv_len,
-            actual_seq_lens_q=actual_seq_lens_q,
-            actual_seq_lens_kv=actual_seq_lens_kv,
+            actual_seq_lens_q=actual_seq_lens_q.reshape(B, 1, 1, 1),
+            actual_seq_lens_kv=actual_seq_lens_kv.reshape(B, 1, 1, 1),
             block_tables=block_tables,
             causal=True,
             return_lse=False,
+            batch_offsets_q=batch_offsets,
+            batch_offsets_o=batch_offsets,
         )
     except Exception as exc:
         pytest.skip(f"cudnn_batch_prefill_with_kv_cache unavailable: {exc}")

--- a/tests/trace/test_cudnn_batch_prefill_reference_correctness.py
+++ b/tests/trace/test_cudnn_batch_prefill_reference_correctness.py
@@ -68,7 +68,7 @@ def test_cudnn_batch_prefill_reference_correctness(shape_kwargs):
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda")
     qo_indptr = torch.zeros(B + 1, dtype=torch.int32, device="cuda")
     qo_indptr[1:] = actual_seq_lens_q.cumsum(0)
-    batch_offsets = (qo_indptr.to(torch.int64) * Hq * D).to(torch.int32)
+    batch_offsets = (qo_indptr.to(torch.int64) * Hq * D).to(torch.int32).reshape(B + 1, 1, 1, 1)
     try:
         api_out, _ = cudnn_batch_prefill_with_kv_cache(
             q,

--- a/tests/trace/test_cudnn_batch_prefill_reference_correctness.py
+++ b/tests/trace/test_cudnn_batch_prefill_reference_correctness.py
@@ -108,3 +108,47 @@ def test_cudnn_batch_prefill_reference_correctness(shape_kwargs):
     _check(cudnn_batch_prefill_trace, ref_out, api_out, atol=1e-2, rtol=1e-2)
     if torch.cuda.is_available():
         torch.cuda.synchronize()
+
+
+def test_cudnn_batch_prefill_requires_batch_offsets():
+    """batch_size > 1 without batch_offsets_q/_o must raise, not corrupt.
+
+    Without ragged offsets the cuDNN graph cannot address packed q/out for
+    batch entries past the first, so the API rejects the call instead of
+    silently returning wrong results for batch index >= 1.
+    """
+    from flashinfer.cudnn import cudnn_batch_prefill_with_kv_cache
+    from flashinfer.cudnn.prefill import CUDNN_AVAILABLE
+
+    if not CUDNN_AVAILABLE:
+        pytest.skip("cudnn python frontend not available")
+
+    B, Hq, Hk, D, PS, q_len, kv_len = 2, 8, 2, 128, 16, 32, 64
+    nppr = (kv_len + PS - 1) // PS
+    k_cache = torch.randn(nppr * B, Hk, PS, D, dtype=torch.bfloat16, device="cuda")
+    v_cache = torch.randn_like(k_cache)
+    q = torch.randn(B * q_len, Hq, D, dtype=torch.bfloat16, device="cuda")
+    block_tables = torch.arange(nppr * B, dtype=torch.int32, device="cuda").reshape(
+        B, nppr
+    )
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda")
+
+    with pytest.raises(ValueError, match="batch_offsets_q and batch_offsets_o"):
+        cudnn_batch_prefill_with_kv_cache(
+            q,
+            k_cache,
+            v_cache,
+            1.0 / math.sqrt(D),
+            workspace,
+            max_token_per_sequence=q_len,
+            max_sequence_kv=kv_len,
+            actual_seq_lens_q=torch.full(
+                (B, 1, 1, 1), q_len, dtype=torch.int32, device="cuda"
+            ),
+            actual_seq_lens_kv=torch.full(
+                (B, 1, 1, 1), kv_len, dtype=torch.int32, device="cuda"
+            ),
+            block_tables=block_tables,
+            causal=True,
+            return_lse=False,
+        )

--- a/tests/trace/test_cudnn_batch_prefill_reference_correctness.py
+++ b/tests/trace/test_cudnn_batch_prefill_reference_correctness.py
@@ -68,7 +68,9 @@ def test_cudnn_batch_prefill_reference_correctness(shape_kwargs):
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device="cuda")
     qo_indptr = torch.zeros(B + 1, dtype=torch.int32, device="cuda")
     qo_indptr[1:] = actual_seq_lens_q.cumsum(0)
-    batch_offsets = (qo_indptr.to(torch.int64) * Hq * D).to(torch.int32).reshape(B + 1, 1, 1, 1)
+    batch_offsets = (
+        (qo_indptr.to(torch.int64) * Hq * D).to(torch.int32).reshape(B + 1, 1, 1, 1)
+    )
     try:
         api_out, _ = cudnn_batch_prefill_with_kv_cache(
             q,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This adds missing batch offsets to the `test_cudnn_batch_prefill_reference_correctness.py` file. It fixes previous failures in CI.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated cuDNN batch prefill reference to use cumulative “packed” ragged offsets derived from sequence-lengths, with updated sequence-length tensor shaping.
  * Added a test to confirm that omitting required batch offset inputs raises a `ValueError` when batching multiple sequences.

* **Documentation**
  * Clarified `batch_offsets_*` semantics as cumulative element offsets with shape `(batch_size + 1)`, and documented cuDNN graph-path input requirements.

* **Bug Fixes**
  * Added runtime validation for the cuDNN graph path: when `batch_size > 1`, missing `batch_offsets_q` or `batch_offsets_o` now fails fast with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->