### PR TITLE
perf: optimize sm90 cp delta rule

### DIFF
--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -2485,40 +2485,38 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         tQKrQK: cute.Tensor,
         tQKcMqk: cute.Tensor,
         sT: cute.Tensor,
+        sQK: cute.Tensor,
         sKK_opd: cute.Tensor,
         sAlpha: cute.Tensor,
         alpha_stage: cutlass.Int32,
         is_final_block: bool,
         B: cutlass.Int32,
         scale: cutlass.Float32,
+        qk_tiled_mma,
         kk_tiled_mma,
-        tKKcMkk: cute.Tensor,
         aux_tidx: cutlass.Int32,
     ):
         alpha_log = sAlpha[None, AlphaProcessor.CUMSUM_LOG, alpha_stage]
-        for i in cutlass.range_constexpr(cute.size(tQKrQK)):
-            s, t = tQKcMqk[i]
-            alpha = cute.math.exp2(
-                cutlass.Float32(alpha_log[s]) - cutlass.Float32(alpha_log[t]),
-                fastmath=True,
-            )
-            pred = s >= t
-            if cutlass.const_expr(is_final_block):
-                pred = pred and (s < B or t < B)
-            tQKrQK[i] = tQKrQK[i] * alpha * scale if pred else cutlass.Float32(0.0)
-
         stsm_atom = cute.make_copy_atom(
             warp.StMatrix8x8x16bOp(transpose=False, num_matrices=4), self.dtype
         )
-        tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
-        thr_store = tiled_store.get_slice(aux_tidx)
-        tKKsKK = thr_store.partition_D(sKK_opd)
-        tKKcMkk_cv = thr_store.retile(tKKcMkk)
+        qk_tiled_store = cute.make_tiled_copy_C(stsm_atom, qk_tiled_mma)
+        kk_tiled_store = cute.make_tiled_copy_C(stsm_atom, kk_tiled_mma)
+        qk_thr_store = qk_tiled_store.get_slice(aux_tidx)
+        kk_thr_store = kk_tiled_store.get_slice(aux_tidx)
+        tQKsQK = qk_thr_store.partition_D(sQK)
+        tKKsKK = kk_thr_store.partition_D(sKK_opd)
+        tQKcMqk_cv = kk_thr_store.retile(tQKcMqk)
+        tQKrQK_cv = kk_thr_store.retile(tQKrQK)
+        tQKrQK_cvt = cute.make_fragment_like(tQKrQK, self.dtype)
+        tQKrQK_cvt_cv = kk_thr_store.retile(tQKrQK_cvt)
         tKKrT = cute.make_fragment_like(tKKsKK, self.dtype)
 
         for i in cutlass.range_constexpr(cute.size(tKKrT)):
-            s, t = tKKcMkk_cv[i]
-            value = cutlass.Float32(0.0)
+            s, t = tQKcMqk_cv[i]
+            gamma = cutlass.Float32(0.0)
+            qk_value = cutlass.Float32(0.0)
+            t_value = cutlass.Float32(0.0)
             pred = s >= t
             if cutlass.const_expr(is_final_block):
                 pred = pred and s < B and t < B
@@ -2527,9 +2525,16 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
                     cutlass.Float32(alpha_log[s]) - cutlass.Float32(alpha_log[t]),
                     fastmath=True,
                 )
-                value = -gamma * cutlass.Float32(sT[t, s])
-            tKKrT[i] = self.dtype(value)
-        cute.copy(tiled_store, tKKrT, tKKsKK)
+            qk_value = tQKrQK_cv[i] * gamma * scale
+            t_value = -gamma * cutlass.Float32(sT[t, s])
+            if cutlass.const_expr(is_final_block):
+                qk_value = qk_value if pred else cutlass.Float32(0.0)
+                t_value = t_value if pred else cutlass.Float32(0.0)
+
+            tQKrQK_cvt_cv[i] = self.dtype(qk_value)
+            tKKrT[i] = self.dtype(t_value)
+        cute.copy(qk_tiled_store, qk_thr_store.retile(tQKrQK_cvt), tQKsQK)
+        cute.copy(kk_tiled_store, tKKrT, tKKsKK)
 
     @cute.jit
     def run_aux_loop_body(
@@ -2592,18 +2597,20 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         cute.arch.fence_view_async_shared()
 
         kk_pipeline.producer_acquire(kk_producer_state)
+        qk_pipeline.producer_acquire(qk_producer_state)
         self.cp_qk_and_t_epi(
             tQKrQK,
             tQKcMqk,
             sT[None, None, t_consumer_state.index],
+            sQK[None, None, qk_producer_state.index],
             sKK_opd[None, None, kk_producer_state.index],
             sAlpha,
             alpha_consumer_state.index,
             is_final_block,
             B,
             scale,
+            qk_tiled_mma,
             kk_tiled_mma,
-            tKKcMkk,
             aux_tidx,
         )
         cute.arch.fence_view_async_shared()
@@ -2611,15 +2618,6 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         kk_producer_state.advance()
         t_pipeline.consumer_release(t_consumer_state)
         t_consumer_state.advance()
-
-        qk_pipeline.producer_acquire(qk_producer_state)
-        self.qk_store(
-            tQKrQK,
-            sQK[None, None, qk_producer_state.index],
-            qk_tiled_mma,
-            aux_tidx,
-        )
-        cute.arch.fence_view_async_shared()
         qk_pipeline.producer_commit(qk_producer_state)
         qk_producer_state.advance()
 

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -1694,11 +1694,10 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
             num_sab_heads * 64 * 64,
         ),
     )
-    workspace_ctor = torch.empty if num_seqs == 1 else torch.zeros
-    transfer_t = workspace_ctor(
+    transfer_t = torch.empty(
         (total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device
     )
-    state_t = workspace_ctor(
+    state_t = torch.empty(
         (total_cp_chunks, num_sab_heads, d, d), dtype=torch.float32, device=k.device
     )
     if total_cp_chunks == 0:
@@ -2330,11 +2329,7 @@ def cp_delta_rule_fixup_dsl_sm90(
             raise RuntimeError("cu_seqlens must be contiguous")
     num_seqs = cu_seqlens.shape[0] - 1
 
-    fixed_state = (
-        torch.empty_like(local_state)
-        if num_seqs == 1
-        else torch.zeros_like(local_state)
-    )
+    fixed_state = torch.empty_like(local_state)
     if total_cp_chunks == 0:
         return fixed_state
 
@@ -3980,8 +3975,6 @@ def cp_delta_rule_dsl_sm90(
         _skip_check=True,
     )
 
-    if num_seqs != 1:
-        state.zero_()
     cp_delta_rule_prefill_dsl_sm90(
         o,
         state,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -320,7 +320,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
             tQKrQK[i] = tQKrQK[i] if pred else cutlass.Float32(0.0)
             tKKrKK[i] = tKKrKK[i] if pred else cutlass.Float32(0.0)
             if cutlass.const_expr(is_final_block):
-                pred = s < B or t < B
+                pred = s < B and t < B
                 tQKrQK[i] = tQKrQK[i] if pred else cutlass.Float32(0.0)
                 tKKrKK[i] = tKKrKK[i] if pred else cutlass.Float32(0.0)
 

--- a/tests/gdn/test_prefill_delta_rule.py
+++ b/tests/gdn/test_prefill_delta_rule.py
@@ -359,6 +359,72 @@ def test_prefill_kernel_zero_length_sequence(
     torch.testing.assert_close(our_o, ref_o, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.parametrize("use_cp", [False, True])
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_prefill_zero_length_sequence_state_untouched(
+    qkv_factory,
+    dtype: str,
+    use_cp: bool,
+    scale: float = 0.1,
+    seed: int = int(os.environ.get("SEED", "0")),
+):
+    _skip_if_unsupported()
+    if use_cp:
+        _skip_if_cp_unsupported()
+
+    random.seed(seed)
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    seq_len = 256
+    head_size = 128
+    num_heads = 1
+    sentinel = 123.0
+    dtype = getattr(torch, dtype)
+    device = torch.device("cuda")
+
+    with device:
+        q, k, v = qkv_factory(
+            [seq_len], num_heads, num_heads, num_heads, head_size, dtype
+        )
+        k = torch.nn.functional.normalize(k, p=2.0, dim=-1)
+        alpha = torch.rand(seq_len, num_heads)
+        beta = torch.rand(seq_len, num_heads)
+        cu_seq_lens = torch.tensor([0, seq_len, seq_len], dtype=torch.int64)
+
+    our_o = torch.empty([seq_len, num_heads, head_size], dtype=q.dtype, device=q.device)
+    our_state = torch.empty(
+        (2, num_heads, head_size, head_size),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    our_state.fill_(sentinel)
+
+    chunk_gated_delta_rule(
+        q,
+        k,
+        v,
+        alpha,
+        beta,
+        scale,
+        None,
+        True,
+        cu_seq_lens,
+        True,
+        output=our_o,
+        output_state=our_state,
+        use_cp=use_cp,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        our_state[1],
+        torch.full_like(our_state[1], sentinel),
+        atol=0,
+        rtol=0,
+    )
+
+
 def _test_chunked_prefill(
     qkv_factory,
     dtype: str,


### PR DESCRIPTION
## 📌 Description

1. Fused qk and inversion epilogue.
2. Removed unnecessary intermediate buffer zeroing.

## 🔍 Related Issues

Similar optimization has been integrated in e9ad55ce884e5d87c15a3a0e853b11b42ff5d245 93050535021a9421781f7b5b85259527da4d762e and 171e5edbcc2ac1573a14dc5ffea7f13590d646c8

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Compared to record in #3481, it is about ~10% E2E improvement.

```
GPU: NVIDIA H100 80GB HBM3 [Hopper (SM90)]
Models: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128

Heads            Seqlens           h_qk  h_v        FI Hopper (SM90)   TFLOPS  FLA/Triton   Speedup
---------------------------------------------------------------------------------------------------
397B/122B TP8    1x65536              2    8                  0.449ms    76.5      2.006ms     4.47x +
397B/122B TP8    1x32768              2    8                  0.284ms    60.6      0.998ms     3.52x +
397B/122B TP8    1x16384              2    8                  0.197ms    43.7      0.505ms     2.56x +
397B/122B TP8    1x8192               2    8                  0.153ms    28.2      0.258ms     1.69x +
397B/122B TP8    1x4096               2    8                  0.102ms    21.0      0.143ms     1.40x +
397B/122B TP8    1x2048               2    8                  0.080ms    13.4      0.086ms     1.07x +
397B/122B TP8    6144+2048            2    8                  0.136ms    31.6      0.221ms     1.63x +
397B/122B TP8    4096+4096            2    8                  0.120ms    35.7      0.184ms     1.53x +
397B/122B TP8    2048+6144            2    8                  0.136ms    31.6      0.221ms     1.63x +
397B/122B TP8    1024+7168            2    8                  0.146ms    29.5      0.241ms     1.65x +
397B/122B TP8    2048x4               2    8                  0.114ms    37.8      0.149ms     1.31x +
397B/122B TP8    1024x8               2    8                  0.128ms    33.7      0.155ms     1.22x +
397B/122B TP8    8192x8               2    8                  0.460ms    74.8      1.087ms     2.37x +
397B/122B TP8    8192x16              2    8                  0.370ms   185.8      2.140ms     5.78x +
397B/122B TP8    8192x32              2    8                  0.802ms   171.5      4.232ms     5.28x +

397B/122B TP4    1x65536              4   16                  0.782ms    87.9      2.744ms     3.51x +
397B/122B TP4    1x32768              4   16                  0.424ms    81.1      1.388ms     3.28x +
397B/122B TP4    1x16384              4   16                  0.252ms    68.1      0.707ms     2.80x +
397B/122B TP4    1x8192               4   16                  0.164ms    52.2      0.361ms     2.19x +
397B/122B TP4    1x4096               4   16                  0.119ms    36.0      0.187ms     1.56x +
397B/122B TP4    1x2048               4   16                  0.084ms    25.6      0.107ms     1.28x +
397B/122B TP4    6144+2048            4   16                  0.156ms    55.1      0.324ms     2.08x +
397B/122B TP4    4096+4096            4   16                  0.150ms    57.3      0.287ms     1.91x +
397B/122B TP4    2048+6144            4   16                  0.157ms    54.6      0.324ms     2.06x +
397B/122B TP4    1024+7168            4   16                  0.162ms    53.1      0.343ms     2.12x +
397B/122B TP4    2048x4               4   16                  0.153ms    56.1      0.293ms     1.92x +
397B/122B TP4    1024x8               4   16                  0.058ms   147.4      0.305ms     5.24x +
397B/122B TP4    8192x8               4   16                  0.368ms   186.8      2.181ms     5.93x +
397B/122B TP4    8192x16              4   16                  0.792ms   173.5      4.351ms     5.49x +
397B/122B TP4    8192x32              4   16                  1.641ms   167.5      8.707ms     5.31x +

397B/122B TP2    1x65536              8   32                  1.549ms    88.7      4.408ms     2.84x +
397B/122B TP2    1x32768              8   32                  0.771ms    89.1      2.202ms     2.86x +
397B/122B TP2    1x16384              8   32                  0.411ms    83.6      1.091ms     2.66x +
397B/122B TP2    1x8192               8   32                  0.238ms    72.3      0.554ms     2.33x +
397B/122B TP2    1x4096               8   32                  0.150ms    57.1      0.288ms     1.91x +
397B/122B TP2    1x2048               8   32                  0.105ms    40.8      0.152ms     1.45x +
397B/122B TP2    6144+2048            8   32                  0.238ms    72.3      0.559ms     2.35x +
397B/122B TP2    4096+4096            8   32                  0.236ms    72.7      0.560ms     2.37x +
397B/122B TP2    2048+6144            8   32                  0.240ms    71.5      0.558ms     2.32x +
397B/122B TP2    1024+7168            8   32                  0.256ms    67.1      0.561ms     2.19x +
397B/122B TP2    2048x4               8   32                  0.104ms   165.7      0.571ms     5.51x +
397B/122B TP2    1024x8               8   32                  0.113ms   152.0      0.592ms     5.24x +
397B/122B TP2    8192x8               8   32                  0.742ms   185.2      4.446ms     5.99x +
397B/122B TP2    8192x16              8   32                  1.656ms   165.9      8.935ms     5.39x +
397B/122B TP2    8192x32              8   32                  3.211ms   171.2     18.081ms     5.63x +

397B/122B TP1    1x65536             16   64                  3.022ms    91.0      8.633ms     2.86x +
397B/122B TP1    1x32768             16   64                  1.541ms    89.2      4.273ms     2.77x +
397B/122B TP1    1x16384             16   64                  0.747ms    91.9      2.090ms     2.80x +
397B/122B TP1    1x8192              16   64                  0.404ms    85.0      1.045ms     2.59x +
397B/122B TP1    1x4096              16   64                  0.231ms    74.3      0.536ms     2.32x +
397B/122B TP1    1x2048              16   64                  0.143ms    60.0      0.279ms     1.94x +
397B/122B TP1    6144+2048           16   64                  0.281ms   122.2      1.049ms     3.73x +
397B/122B TP1    4096+4096           16   64                  0.192ms   178.9      1.055ms     5.49x +
397B/122B TP1    2048+6144           16   64                  0.282ms   122.0      1.059ms     3.76x +
397B/122B TP1    1024+7168           16   64                  0.325ms   105.7      1.060ms     3.26x +
397B/122B TP1    2048x4              16   64                  0.203ms   169.4      1.068ms     5.27x +
397B/122B TP1    1024x8              16   64                  0.220ms   156.3      1.089ms     4.95x +
397B/122B TP1    8192x8              16   64                  1.644ms   167.2      8.676ms     5.28x +
397B/122B TP1    8192x16             16   64                  3.204ms   171.6     17.469ms     5.45x +
397B/122B TP1    8192x32             16   64                  6.415ms   171.4     35.823ms     5.58x +

35B/9B/4B TP1    1x65536             16   32                  1.623ms    84.7      4.409ms     2.72x +
35B/9B/4B TP1    1x32768             16   32                  0.806ms    85.3      2.203ms     2.73x +
35B/9B/4B TP1    1x16384             16   32                  0.423ms    81.2      1.089ms     2.57x +
35B/9B/4B TP1    1x8192              16   32                  0.246ms    69.9      0.553ms     2.25x +
35B/9B/4B TP1    1x4096              16   32                  0.155ms    55.5      0.288ms     1.86x +
35B/9B/4B TP1    1x2048              16   32                  0.108ms    39.7      0.153ms     1.41x +
35B/9B/4B TP1    6144+2048           16   32                  0.248ms    69.4      0.559ms     2.26x +
35B/9B/4B TP1    4096+4096           16   32                  0.244ms    70.3      0.558ms     2.29x +
35B/9B/4B TP1    2048+6144           16   32                  0.249ms    69.0      0.562ms     2.26x +
35B/9B/4B TP1    1024+7168           16   32                  0.263ms    65.4      0.562ms     2.14x +
35B/9B/4B TP1    2048x4              16   32                  0.105ms   164.2      0.571ms     5.46x +
35B/9B/4B TP1    1024x8              16   32                  0.115ms   149.4      0.594ms     5.17x +
35B/9B/4B TP1    8192x8              16   32                  0.820ms   167.5      4.462ms     5.44x +
35B/9B/4B TP1    8192x16             16   32                  1.707ms   161.1      8.931ms     5.23x +
35B/9B/4B TP1    8192x32             16   32                  3.226ms   170.4     18.087ms     5.61x +

27B TP1          1x65536             16   48                  2.614ms    78.9      6.524ms     2.50x +
27B TP1          1x32768             16   48                  1.319ms    78.2      3.280ms     2.49x +
27B TP1          1x16384             16   48                  0.670ms    76.9      1.607ms     2.40x +
27B TP1          1x8192              16   48                  0.368ms    69.9      0.805ms     2.18x +
27B TP1          1x4096              16   48                  0.210ms    61.4      0.417ms     1.99x +
27B TP1          1x2048              16   48                  0.132ms    48.8      0.229ms     1.73x +
27B TP1          6144+2048           16   48                  0.279ms    92.4      0.822ms     2.95x +
27B TP1          4096+4096           16   48                  0.191ms   135.2      0.844ms     4.43x +
27B TP1          2048+6144           16   48                  0.279ms    92.5      0.835ms     3.00x +
27B TP1          1024+7168           16   48                  0.321ms    80.2      0.825ms     2.57x +
27B TP1          2048x4              16   48                  0.199ms   129.5      0.824ms     4.14x +
27B TP1          1024x8              16   48                  0.167ms   154.4      0.839ms     5.03x +
27B TP1          8192x8              16   48                  1.238ms   166.6      6.571ms     5.31x +
27B TP1          8192x16             16   48                  2.421ms   170.3     13.185ms     5.45x +
27B TP1          8192x32             16   48                  4.838ms   170.5     26.763ms     5.53x +

2B/0.8B TP1      1x65536             16   16                  0.879ms    78.2      2.755ms     3.13x +
2B/0.8B TP1      1x32768             16   16                  0.482ms    71.3      1.393ms     2.89x +
2B/0.8B TP1      1x16384             16   16                  0.284ms    60.5      0.701ms     2.47x +
2B/0.8B TP1      1x8192              16   16                  0.185ms    46.4      0.360ms     1.95x +
2B/0.8B TP1      1x4096              16   16                  0.131ms    32.9      0.187ms     1.43x +
2B/0.8B TP1      1x2048              16   16                  0.086ms    24.9      0.107ms     1.24x +
2B/0.8B TP1      6144+2048           16   16                  0.177ms    48.5      0.324ms     1.83x +
2B/0.8B TP1      4096+4096           16   16                  0.171ms    50.2      0.287ms     1.68x +
2B/0.8B TP1      2048+6144           16   16                  0.177ms    48.4      0.324ms     1.83x +
2B/0.8B TP1      1024+7168           16   16                  0.181ms    47.4      0.341ms     1.89x +
2B/0.8B TP1      2048x4              16   16                  0.170ms    50.5      0.294ms     1.73x +
2B/0.8B TP1      1024x8              16   16                  0.062ms   139.3      0.305ms     4.94x +
2B/0.8B TP1      8192x8              16   16                  0.380ms   180.6      2.179ms     5.73x +
2B/0.8B TP1      8192x16             16   16                  0.852ms   161.4      4.356ms     5.11x +
2B/0.8B TP1      8192x32             16   16                  1.711ms   160.7      8.707ms     5.09x +

Sym h32          1x65536             32   32                  1.734ms    79.3      4.405ms     2.54x +
Sym h32          1x32768             32   32                  0.879ms    78.2      2.208ms     2.51x +
Sym h32          1x16384             32   32                  0.472ms    72.9      1.089ms     2.31x +
Sym h32          1x8192              32   32                  0.272ms    63.2      0.552ms     2.03x +
Sym h32          1x4096              32   32                  0.172ms    50.0      0.287ms     1.67x +
Sym h32          1x2048              32   32                  0.117ms    36.8      0.152ms     1.30x +
Sym h32          6144+2048           32   32                  0.274ms    62.7      0.561ms     2.05x +
Sym h32          4096+4096           32   32                  0.274ms    62.8      0.559ms     2.05x +
Sym h32          2048+6144           32   32                  0.278ms    61.7      0.559ms     2.01x +
Sym h32          1024+7168           32   32                  0.287ms    59.8      0.560ms     1.95x +
Sym h32          2048x4              32   32                  0.107ms   160.4      0.572ms     5.34x +
Sym h32          1024x8              32   32                  0.120ms   142.8      0.593ms     4.93x +
Sym h32          8192x8              32   32                  0.849ms   161.9      4.453ms     5.25x +
Sym h32          8192x16             32   32                  1.760ms   156.2      8.929ms     5.07x +
Sym h32          8192x32             32   32                  3.374ms   162.9     18.091ms     5.36x +
```