### PR TITLE
Add cold-L2 and CUDA graph to mm_bf16 API

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1284,6 +1284,8 @@ def get_mm_bf16_cublaslt_module():
 
 
 _BF16_GEMM_SM100_TUNING_CONFIG = TuningConfig(
+    use_cuda_graph=True,
+    use_cold_l2_cache=True,
     dynamic_tensor_specs=(
         DynamicTensorSpec(
             (0,),  # a_tensor_index


### PR DESCRIPTION
Add cold L2 + CUDA graph, which is needed for autotune stability:
https://github.com/bzhng-development/flashinfer/commit/c76ca31fbfe87ee514bc928c9ebb935c1e7846d9

<img width="2400" height="900" alt="image" src="https://github.com/user-attachments/assets/afda0689-fcad-4bd3-ac8c-db192fb2e2d0" />
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved BF16 GEMM execution on supported SM100 hardware by enabling optimizations that can reduce overhead and improve cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->