### PR TITLE
fix(grouped_mm): require cuDNN >= 9.21 for the FP8 MOE grouped matmul

### DIFF
--- a/flashinfer/grouped_mm/core.py
+++ b/flashinfer/grouped_mm/core.py
@@ -22,6 +22,7 @@ from ..api_logging import flashinfer_api
 from ..utils import backend_requirement, supported_compute_capability
 from .cudnn import (
     _CUDNN_MOE_BLOCK_SCALE_MIN_VERSION,
+    _CUDNN_MOE_FP8_MIN_VERSION,
     _CUDNN_MOE_MIN_VERSION,
     _check_cudnn_version,
     _run_cudnn_moe_block_scale_grouped_gemm_fp4,
@@ -266,7 +267,7 @@ def grouped_mm_fp8(
         out_dtype = out.dtype
 
     if backend == "cudnn":
-        _check_cudnn_version(_CUDNN_MOE_MIN_VERSION, "grouped_mm_fp8")
+        _check_cudnn_version(_CUDNN_MOE_FP8_MIN_VERSION, "grouped_mm_fp8")
         return _run_cudnn_moe_grouped_gemm(
             a,
             b,

--- a/flashinfer/grouped_mm/cudnn/__init__.py
+++ b/flashinfer/grouped_mm/cudnn/__init__.py
@@ -9,6 +9,7 @@ helpers below.
 
 from .core import (
     _CUDNN_MOE_BLOCK_SCALE_MIN_VERSION,
+    _CUDNN_MOE_FP8_MIN_VERSION,
     _CUDNN_MOE_MIN_VERSION,
     _check_cudnn_version,
     _run_cudnn_moe_block_scale_grouped_gemm_fp4,
@@ -18,6 +19,7 @@ from .core import (
 
 __all__ = [
     "_CUDNN_MOE_BLOCK_SCALE_MIN_VERSION",
+    "_CUDNN_MOE_FP8_MIN_VERSION",
     "_CUDNN_MOE_MIN_VERSION",
     "_check_cudnn_version",
     "_run_cudnn_moe_block_scale_grouped_gemm_fp4",

--- a/flashinfer/grouped_mm/cudnn/core.py
+++ b/flashinfer/grouped_mm/cudnn/core.py
@@ -46,6 +46,11 @@ except OSError as e:
 # ---------------------------------------------------------------------------
 
 _CUDNN_MOE_MIN_VERSION = 91800  # 9.18.0
+# FP8 needs a higher floor than bf16: backends 9.18.0-9.20.0 pass
+# check_support() for the FP8 MOE grouped matmul but silently compute only the
+# first expert group, leaving every other group's output zero (gh #3792,
+# verified on SM120 / RTX PRO 6000; fixed in 9.21.0).
+_CUDNN_MOE_FP8_MIN_VERSION = 92100  # 9.21.0
 _CUDNN_MOE_BLOCK_SCALE_MIN_VERSION = 92100  # 9.21.0
 
 

--- a/tests/grouped_mm/conftest.py
+++ b/tests/grouped_mm/conftest.py
@@ -35,6 +35,16 @@ requires_cudnn_moe_block_scale = pytest.mark.skipif(
     reason="cuDNN MOE block-scale requires backend >= 9.21.0 and a frontend exposing moe_grouped_matmul_mode",
 )
 
+# FP8 needs a higher floor than bf16: backends 9.18.0-9.20.0 pass
+# check_support() but silently compute only the first expert group (gh #3792,
+# fixed in 9.21.0).
+requires_cudnn_moe_fp8 = pytest.mark.skipif(
+    not CUDNN_AVAILABLE or CUDNN_BACKEND_VERSION < 92100 or not CUDNN_HAS_MOE_API,
+    reason="cuDNN MOE FP8 requires backend >= 9.21.0 (9.18-9.20 silently compute "
+    "only the first expert group, gh #3792) and a frontend exposing "
+    "moe_grouped_matmul_mode",
+)
+
 
 def _requires_supported_cc(check_fn):
     # Skip mark whose allowlist is the `_supported_ccs` set attached to

--- a/tests/grouped_mm/test_grouped_mm_fp8.py
+++ b/tests/grouped_mm/test_grouped_mm_fp8.py
@@ -8,6 +8,7 @@ from flashinfer.grouped_mm import grouped_mm_fp8
 from .conftest import (
     ref_grouped_mm,
     requires_cudnn_moe,
+    requires_cudnn_moe_fp8,
     requires_grouped_mm_fp8_cc,
 )
 
@@ -20,7 +21,7 @@ class TestGroupedMmFp8:
         t = torch.randn(shape, dtype=torch.float32, device=device).clamp(-1, 1)
         return t.to(dtype)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     @pytest.mark.parametrize("num_experts", [1, 4, 8])
     @pytest.mark.parametrize("tokens_per_expert", [32, 128, 256])
     @pytest.mark.parametrize("k", [256, 512])
@@ -50,7 +51,7 @@ class TestGroupedMmFp8:
 
         torch.testing.assert_close(out, ref, atol=0.125, rtol=0.125)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     @pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
     def test_non_uniform_distribution(self, dtype):
         """Experts get different numbers of tokens."""
@@ -74,7 +75,7 @@ class TestGroupedMmFp8:
 
         torch.testing.assert_close(out, ref, atol=0.125, rtol=0.125)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     def test_empty_experts(self):
         """Some experts receive zero tokens."""
         torch.manual_seed(1)
@@ -98,7 +99,7 @@ class TestGroupedMmFp8:
 
         torch.testing.assert_close(out, ref, atol=0.125, rtol=0.125)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     def test_single_expert(self):
         """Degenerate case: only one expert (equivalent to dense mm)."""
         torch.manual_seed(2)
@@ -115,7 +116,7 @@ class TestGroupedMmFp8:
 
         torch.testing.assert_close(out, ref, atol=0.125, rtol=0.125)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     def test_preallocated_output(self):
         """Pass a pre-allocated output tensor."""
         torch.manual_seed(3)
@@ -135,7 +136,7 @@ class TestGroupedMmFp8:
         assert result.data_ptr() == out.data_ptr()
         torch.testing.assert_close(result, ref, atol=0.125, rtol=0.125)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     @pytest.mark.parametrize(
         "out_dtype", [torch.float16, torch.bfloat16, torch.float32]
     )
@@ -157,7 +158,7 @@ class TestGroupedMmFp8:
         ref = ref_grouped_mm(a, b, m_indptr, out_dtype=out_dtype, alpha=alpha)
         torch.testing.assert_close(out, ref, atol=0.125, rtol=0.125)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     @pytest.mark.parametrize("alpha_val", [0.5, 1.0, 2.0])
     def test_alpha_scaling(self, alpha_val):
         """Verify the alpha scaling factor is applied correctly."""
@@ -176,7 +177,7 @@ class TestGroupedMmFp8:
 
         torch.testing.assert_close(out, ref, atol=0.125, rtol=0.125)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     def test_no_alpha(self):
         """FP8 grouped mm without alpha scaling."""
         torch.manual_seed(7)
@@ -193,7 +194,7 @@ class TestGroupedMmFp8:
 
         torch.testing.assert_close(out, ref, atol=0.125, rtol=0.125)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     def test_graph_cache_reuse(self):
         """Calling twice with identical shapes should reuse the cached graph."""
         torch.manual_seed(5)
@@ -210,7 +211,7 @@ class TestGroupedMmFp8:
         out2 = grouped_mm_fp8(a, b, m_indptr, alpha=alpha)
         torch.testing.assert_close(out1, out2)
 
-    @requires_cudnn_moe
+    @requires_cudnn_moe_fp8
     def test_mixed_fp8_dtypes(self):
         """a and b can use different FP8 sub-types."""
         torch.manual_seed(8)
@@ -228,9 +229,27 @@ class TestGroupedMmFp8:
         torch.testing.assert_close(out, ref, atol=0.125, rtol=0.125)
 
 
+# Argument validation runs in _check_grouped_mm_fp8 BEFORE the runtime
+# version check, so these tests are valid on any MOE-capable backend (>= 9.18)
+# and keep coverage on the 9.18-9.20 installs where the kernel tests skip.
 @requires_cudnn_moe
 @requires_grouped_mm_fp8_cc
 class TestGroupedMmFp8Validation:
+    def test_version_floor_enforced(self, monkeypatch):
+        """grouped_mm_fp8 must refuse cuDNN backends < 9.21.0 (gh #3792).
+
+        Backends 9.18.0-9.20.0 pass check_support() but silently compute only
+        the first expert group; the floor turns that into a loud error.
+        """
+        from flashinfer.grouped_mm.cudnn import core as cudnn_core
+
+        monkeypatch.setattr(cudnn_core.cudnn, "backend_version", lambda: 92000)
+        a = torch.zeros(64, 128, dtype=torch.float8_e4m3fn, device="cuda")
+        b = torch.zeros(2, 64, 128, dtype=torch.float8_e4m3fn, device="cuda")
+        m_indptr = torch.tensor([0, 32, 64], dtype=torch.int32, device="cuda")
+        with pytest.raises(RuntimeError, match="92100"):
+            grouped_mm_fp8(a, b, m_indptr)
+
     def test_wrong_input_dtype(self):
         a = torch.randn(64, 128, dtype=torch.float16, device="cuda")
         b = torch.randn(2, 64, 128, dtype=torch.float16, device="cuda")


### PR DESCRIPTION
## Description

cuDNN backends **9.18.0 – 9.20.0** pass `check_support()` for the FP8 MOE grouped matmul but **silently compute only the first expert group** — every group `e >= 1` of the output is left zero, with no error or warning (full analysis, repro, and per-version bisect in #3792). bf16 through the same graph-builder path is correct on every version, so the wrapper semantics are fine; the regression is inside the cuDNN backend's FP8 MOE kernels, fixed in 9.21.0. Notably, `torch 2.11.0+cu130` pins `nvidia-cudnn-cu13==9.19.0.56` — a broken version — so a stock cu13 PyTorch environment hits this.

This PR mirrors the existing block-scale floor (`_CUDNN_MOE_BLOCK_SCALE_MIN_VERSION`):

- add `_CUDNN_MOE_FP8_MIN_VERSION = 92100` and use it in `grouped_mm_fp8`'s runtime check, so the broken combination fails fast with an actionable `RuntimeError` instead of silently corrupting MoE outputs
- add a matching `requires_cudnn_moe_fp8` test gate and switch the FP8 kernel tests to it; `TestGroupedMmFp8Validation` keeps the broad `>= 9.18` gate (argument validation runs before the version check, so those stay covered on 9.18–9.20 installs)
- add `test_version_floor_enforced`: monkeypatches `backend_version()` to 9.20.0 and asserts the `RuntimeError`, so the floor itself is exercised on any installed cuDNN

Scope note: the bisect evidence is from SM120 (I don't have SM90/SM100 hardware to check whether 9.18–9.20 also mis-execute there). Since the failure mode is silent wrong results and 9.21+ is freely available, a global floor seemed the safer call — happy to make it arch-conditional if you know 9.18–9.20 to be good on other archs.

## Related Issues

Fixes #3792

## Verification (RTX PRO 6000, SM120, CUDA 13, torch 2.11.0+cu130)

| cuDNN backend | `test_grouped_mm_fp8.py` | `test_grouped_mm_bf16.py` |
| --- | --- | --- |
| 9.23.2.1 | 93 passed | 46 passed |
| 9.19.0.56 (broken, torch pin) | 7 passed (validation + floor test) / 86 skipped | 46 passed |

Direct `grouped_mm_fp8` call on 9.19: `RuntimeError: cuDNN grouped_mm_fp8 requires backend version >= 92100, found 91900.`

`ruff check` / `ruff format --check` clean on all touched files.

## Pull Request Checklist

- [x] Pre-commit checks (ruff clean on touched files)
- [x] Tests added (`test_version_floor_enforced`) and updated (gate switch); verified on real SM120 hardware under both a broken and a fixed cuDNN

AI-assisted (Claude Code) under human direction; all numbers are from live runs on the real card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 grouped matrix-multiplication version checks to require the correct cuDNN minimum version.
  * Added clearer handling for cuDNN versions that support earlier grouped operations but not FP8 behavior fully.
  * Updated test coverage to skip FP8 cases unless the runtime meets the FP8-specific cuDNN requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->