### PR TITLE
fix-grouped-mm-cudnn-backend-mismatch

### DIFF
--- a/flashinfer/grouped_mm/core.py
+++ b/flashinfer/grouped_mm/core.py
@@ -21,7 +21,6 @@ import torch
 from ..api_logging import flashinfer_api
 from ..utils import backend_requirement, supported_compute_capability
 from .cudnn import (
-    _CUDNN_MOE_BLOCK_SCALE_MIN_VERSION,
     _CUDNN_MOE_MIN_VERSION,
     _check_cudnn_version,
     _run_cudnn_moe_block_scale_grouped_gemm_fp4,
@@ -406,7 +405,7 @@ def grouped_mm_mxfp8(
         out_dtype = out.dtype
 
     if backend == "cudnn":
-        _check_cudnn_version(_CUDNN_MOE_BLOCK_SCALE_MIN_VERSION, "grouped_mm_mxfp8")
+        _check_cudnn_version(_CUDNN_MOE_MIN_VERSION, "grouped_mm_mxfp8")
         return _run_cudnn_moe_block_scale_grouped_gemm_mxfp8(
             a,
             b,
@@ -574,7 +573,7 @@ def grouped_mm_fp4(
         out_dtype = out.dtype
 
     if backend == "cudnn":
-        _check_cudnn_version(_CUDNN_MOE_BLOCK_SCALE_MIN_VERSION, "grouped_mm_fp4")
+        _check_cudnn_version(_CUDNN_MOE_MIN_VERSION, "grouped_mm_fp4")
         return _run_cudnn_moe_block_scale_grouped_gemm_fp4(
             a,
             b,

--- a/flashinfer/grouped_mm/cudnn/__init__.py
+++ b/flashinfer/grouped_mm/cudnn/__init__.py
@@ -8,7 +8,6 @@ helpers below.
 """
 
 from .core import (
-    _CUDNN_MOE_BLOCK_SCALE_MIN_VERSION,
     _CUDNN_MOE_MIN_VERSION,
     _check_cudnn_version,
     _run_cudnn_moe_block_scale_grouped_gemm_fp4,
@@ -17,7 +16,6 @@ from .core import (
 )
 
 __all__ = [
-    "_CUDNN_MOE_BLOCK_SCALE_MIN_VERSION",
     "_CUDNN_MOE_MIN_VERSION",
     "_check_cudnn_version",
     "_run_cudnn_moe_block_scale_grouped_gemm_fp4",

--- a/flashinfer/grouped_mm/cudnn/core.py
+++ b/flashinfer/grouped_mm/cudnn/core.py
@@ -45,8 +45,7 @@ except OSError as e:
 # Constants / enums
 # ---------------------------------------------------------------------------
 
-_CUDNN_MOE_MIN_VERSION = 91800  # 9.18.0
-_CUDNN_MOE_BLOCK_SCALE_MIN_VERSION = 92100  # 9.21.0
+_CUDNN_MOE_MIN_VERSION = 92100  # 9.21.0
 
 
 class _CUDNN_UIDs(Enum):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix an incorrect cudnn support version check to prevent silent failure

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3792

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the minimum supported cuDNN version for grouped GEMM MoE operations.
  * Block-scale grouped matrix multiply paths now use the same compatibility check as other grouped GEMM variants, helping avoid mismatched backend support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->