### PR TITLE
fix(cudnn): use a full-sequence Q batch stride in batch prefill (silent corruption for batch > 0 without ragged offsets)

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -196,7 +196,13 @@ if CUDNN_AVAILABLE:
             cudnn_q = g.tensor(
                 name="q",
                 dim=(graph_b, h_qo, graph_s_qo, d_qk),
-                stride=(h_qo * d_qk, h_stride, s_stride, d_stride),
+                # The batch stride must cover a full sequence of tokens
+                # (mirroring the O descriptor below). With the previous
+                # one-token stride (h_qo * d_qk), every batch after the first
+                # read its queries from the wrong rows whenever no
+                # batch_offsets_q ragged offset was supplied - silently wrong
+                # outputs for batch_size > 1.
+                stride=(graph_s_qo * s_stride, h_stride, s_stride, d_stride),
                 data_type=cudnn_q_data_type,
             )
 


### PR DESCRIPTION
## Description

`cudnn_batch_prefill_with_kv_cache` builds its Q tensor descriptor with a one-token batch stride (`h_qo * d_qk`), so whenever the caller does not pass `batch_offsets_q`, batch `b`'s queries are read starting at token `b` instead of token `b * s_qo`. Batch 0 is coincidentally correct; every later batch silently computes attention over the wrong query rows and returns finite, plausible-looking garbage. Full analysis, per-batch error maps, and independent-reference arbitration in #3800.

The public wrapper path (`BatchPrefillWithPagedKVCacheWrapper(backend="cudnn")`) always supplies ragged offsets, and `set_ragged_offset` overrides the batch stride - which is why the wrapper test suite passes while flashinfer's own trace suite (`tests/trace/test_cudnn_batch_prefill_reference_correctness.py`), which calls the function directly, is red on main for its `B2` case.

Fix: use `graph_s_qo * s_stride` (a full sequence, expressed via the tensor's own per-token stride so non-contiguous `q` stays correct), mirroring the O descriptor a few lines below which already does this correctly.

## Related Issues

Fixes #3800

## Verification (RTX PRO 6000, SM120, CUDA 13.0; identical results with cuDNN backend 9.19.0.56 and 9.23.2.1)

- `tests/trace/test_cudnn_batch_prefill_reference_correctness.py`: 1 failed / 1 passed -> **2 passed**.
- `tests/attention/test_cudnn_prefill.py` + `test_cudnn_prefill_deepseek.py`: **384 passed** before and after - the ragged-offset wrapper path is unaffected by construction.
- Direct-call probes without offsets: B=2 and B=3, GQA (Hq8/Hk2) and MHA (Hq8/Hk8) - every batch now matches an independently hand-written torch reference (per-page gather + causal softmax), max abs diff <= 0.0078, where batch 1 was 1.72 before the fix.

`ruff check` / `ruff format --check` clean.

## Pull Request Checklist

- [x] Pre-commit checks (ruff clean on the touched file)
- [x] Tests: the previously-red trace test now passes and covers this path; wrapper suites re-run green

AI-assisted (Claude Code) under human direction; all numbers are from live runs on the real card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected query tensor batching in cuDNN SDPA graph construction, improving indexing behavior when ragged query offsets are not provided.
  * Fixed the batch stride used for query tensors so each batch now maps to the full query sequence layout as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->