### PR TITLE
Fix 0/0 NaN in GLM52 routing renorm on sigmoid underflow

### DIFF
--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -79,9 +79,10 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mRouteScale = routedScalingFactor;
     // Floor the renorm denominator. ScaledSumNormalizePostprocess computes
     // sigmoid * routeScale / (sum + mSumEpsilon). If a token's top-K selected experts all have
-    // strongly negative pre-bias logits, their sigmoids underflow to exactly 0.0 (bf16) so sum == 0,
-    // and mSumEpsilon's 0.0f default makes this 0/0 = NaN across the token's whole output row. 1e-20f
-    // matches DeepSeek-V3's reference gate (modeling_deepseek.py: sum + 1e-20) and the MiniMax2 branch.
+    // strongly negative pre-bias logits, their sigmoids underflow to exactly 0.0 (bf16) so sum ==
+    // 0, and mSumEpsilon's 0.0f default makes this 0/0 = NaN across the token's whole output row.
+    // 1e-20f matches DeepSeek-V3's reference gate (modeling_deepseek.py: sum + 1e-20) and the
+    // MiniMax2 branch.
     routingData.mSumEpsilon = 1e-20f;
 
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -77,6 +77,12 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mPtrRoutingBias = routingBias;
     routingData.mDtypeBias = dtypeBias;
     routingData.mRouteScale = routedScalingFactor;
+    // Floor the renorm denominator. ScaledSumNormalizePostprocess computes
+    // sigmoid * routeScale / (sum + mSumEpsilon). If a token's top-K selected experts all have
+    // strongly negative pre-bias logits, their sigmoids underflow to exactly 0.0 (bf16) so sum == 0,
+    // and mSumEpsilon's 0.0f default makes this 0/0 = NaN across the token's whole output row. 1e-20f
+    // matches DeepSeek-V3's reference gate (modeling_deepseek.py: sum + 1e-20) and the MiniMax2 branch.
+    routingData.mSumEpsilon = 1e-20f;
 
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;
     routingData.mPtrTopKIds = expertIds;


### PR DESCRIPTION
The DeepSeekV3 no routing path (SigmoidBias preprocess, ScaledSumNormalizePostprocess) renormalizes the top-K weights as weight = sigmoidScore * routeScale / (sum + mSumEpsilon), where sum is the sum of the selected experts' un-biased sigmoid scores. mSumEpsilon defaults to 0 on this path.

Selection uses the bias-added score, so a token can select K experts whose pre-bias logits are all strongly negative; their sigmoids underflow to exactly 0.0 in bf16, so sum is bit-exactly 0 and the divide is 0.0/0.0 = NaN, poisoning the token's whole output row.

Set mSumEpsilon = 1e-20f, matching the DeepSeek-V3 reference gate (modeling_deepseek.py normalizes with sum + 1e-20) and the sibling MiniMax2 branch in this file (already 1e-20f). Normal tokens (sum >> 1e-20) are bit-identical; degenerate tokens no longer NaN.

Link: https://github.com/deepseek-ai/DeepSeek-VL2/blob/main/deepseek_vl2/models/modeling_deepseek.py

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing stability for DeepSeekV3 in the no-groups path.
  * Prevented rare `NaN` values during normalization when values underflow to zero.
  * Aligned normalization behavior more closely with reference DeepSeek-V3 results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->