### PR TITLE
Enable cuBLASLt BF16 GEMM on SM80+

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -302,9 +302,8 @@ def _cutlass_mm_bf16_requirement(
     return True
 
 
-# Gated to Blackwell (SM100/SM103) for the initial scope of this backend.
-# cuBLASLt supports BF16 GEMM on SM80+; the gate can be widened in a follow-up.
-@supported_compute_capability([100, 103])
+# cuBLASLt supports BF16 GEMM on SM80+.
+@supported_compute_capability([80, 86, 87, 89, 90, 100, 103, 110, 120, 121])
 def _cublaslt_mm_bf16_requirement(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -70,7 +70,7 @@ def gen_gemm_module() -> JitSpec:
 
 def gen_mm_bf16_cublaslt_module() -> JitSpec:
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10]
+        supported_major_versions=[8, 9, 10, 11, 12]
     )
     return gen_jit_spec(
         "mm_bf16_cublaslt",


### PR DESCRIPTION
## What changed

- Enable the cuBLASLt BF16 `mm_bf16` backend on supported SM80+ compute capabilities, including SM110 and SM12x.
- Generate the cuBLASLt BF16 JIT module for CUDA major architectures 8 through 12.

## Why

The cuBLASLt runner is architecture-generic and supports BF16 GEMM on SM80+, but its runtime capability gate and JIT architecture list were limited to SM100/SM103. This prevented the backend from participating in explicit and autotuned BF16 GEMM dispatch on SM12x and other supported architectures.

## Impact

`mm_bf16(..., backend="cublaslt")` and auto dispatch can now consider cuBLASLt on SM80+ GPUs when the remaining problem constraints are satisfied.

## Validation

- `pre-commit run --files flashinfer/gemm/gemm_base.py flashinfer/jit/gemm/core.py`
- Existing `tests/gemm/test_mm_bf16.py` coverage automatically exercises cuBLASLt on newly enabled GPU architectures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded BF16 GEMM support to cover more GPU architectures, making the accelerated path available on a wider range of devices.
  * Broadened CUDA version compatibility for BF16 GEMM module generation, improving support across newer toolchains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->