### PR TITLE
attention: asymmetric K/V cache dtypes for CUDA-core batch decode (16-bit K, FP8 V)

### DIFF
--- a/csrc/batch_decode.cu
+++ b/csrc/batch_decode.cu
@@ -188,10 +188,10 @@ void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
   DISPATCH_context(
       DTypeQ, DTypeKV, DTypeO, IdType, HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,
       USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, AttentionVariant, Params, [&] {
-        paged_kv_t<DTypeKV, IdType> paged_kv(
+        paged_kv_t<DTypeK, IdType, DTypeV> paged_kv(
             num_kv_heads, page_size, HEAD_DIM_QK, batch_size, kv_layout,
-            static_cast<DTypeKV*>(paged_k_cache.data_ptr()),
-            static_cast<DTypeKV*>(paged_v_cache.data_ptr()), kv_cache_strides,
+            static_cast<DTypeK*>(paged_k_cache.data_ptr()),
+            static_cast<DTypeV*>(paged_v_cache.data_ptr()), kv_cache_strides,
             static_cast<IdType*>(paged_kv_indices.data_ptr()),
             static_cast<IdType*>(paged_kv_indptr.data_ptr()),
             static_cast<IdType*>(paged_kv_last_page_len.data_ptr()));

--- a/csrc/batch_decode_customize_config.jinja
+++ b/csrc/batch_decode_customize_config.jinja
@@ -16,7 +16,11 @@
 using namespace flashinfer;
 
 using DTypeQ = {{ dtype_q }};
-using DTypeKV = {{ dtype_kv }};
+using DTypeK = {{ dtype_k | default(dtype_kv) }};
+using DTypeV = {{ dtype_v | default(dtype_kv) }};
+// Backward-compat alias. `DTypeKV` was the old symmetric-only type name;
+// new code should reference `DTypeK` / `DTypeV`.
+using DTypeKV = DTypeK;
 using DTypeO = {{ dtype_o }};
 using IdType = {{ idtype }};
 constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
@@ -27,12 +31,14 @@ constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct Params {
   using DTypeQ = DTypeQ;
-  using DTypeKV = DTypeKV;
+  using DTypeK = DTypeK;
+  using DTypeV = DTypeV;
+  using DTypeKV = DTypeKV;  // backward-compat alias (equal to DTypeK)
   using DTypeO = DTypeO;
   using IdType = IdType;
 
   DTypeQ* q;
-  paged_kv_t<DTypeKV, IdType> paged_kv;
+  paged_kv_t<DTypeK, IdType, DTypeV> paged_kv;
   DTypeO* o;
   float* lse;
 

--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -154,8 +154,8 @@ void BatchPrefillWithRaggedKVCacheRun(TensorView float_workspace_buffer,
         RaggedParams params;
 
         params.q = static_cast<DTypeQ*>(q.data_ptr());
-        params.k = static_cast<DTypeKV*>(k.data_ptr());
-        params.v = static_cast<DTypeKV*>(v.data_ptr());
+        params.k = static_cast<DTypeK*>(k.data_ptr());
+        params.v = static_cast<DTypeV*>(v.data_ptr());
         params.o = static_cast<DTypeO*>(o.data_ptr());
         params.lse =
             maybe_lse.has_value() ? static_cast<float*>(maybe_lse.value().data_ptr()) : nullptr;
@@ -293,10 +293,10 @@ void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
         PagedParams params;
 
         params.q = static_cast<DTypeQ*>(q.data_ptr());
-        paged_kv_t<DTypeKV, IdType> paged_kv(
+        paged_kv_t<DTypeK, IdType, DTypeV> paged_kv(
             num_kv_heads, page_size, HEAD_DIM_VO, batch_size, kv_layout,
-            static_cast<DTypeKV*>(paged_k_cache.data_ptr()),
-            static_cast<DTypeKV*>(paged_v_cache.data_ptr()), kv_cache_strides,
+            static_cast<DTypeK*>(paged_k_cache.data_ptr()),
+            static_cast<DTypeV*>(paged_v_cache.data_ptr()), kv_cache_strides,
             static_cast<IdType*>(paged_kv_indices.data_ptr()),
             static_cast<IdType*>(paged_kv_indptr.data_ptr()),
             static_cast<IdType*>(paged_kv_last_page_len.data_ptr()));

--- a/csrc/batch_prefill_customize_config.jinja
+++ b/csrc/batch_prefill_customize_config.jinja
@@ -20,7 +20,11 @@
 using namespace flashinfer;
 
 using DTypeQ = {{ dtype_q }};
-using DTypeKV = {{ dtype_kv }};
+using DTypeK = {{ dtype_k | default(dtype_kv) }};
+using DTypeV = {{ dtype_v | default(dtype_kv) }};
+// Backward-compat alias. `DTypeKV` was the old symmetric-only type name;
+// new code should reference `DTypeK` / `DTypeV`.
+using DTypeKV = DTypeK;
 using DTypeO = {{ dtype_o }};
 using IdType = {{ idtype }};
 constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
@@ -33,13 +37,15 @@ constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct RaggedParams {
   using DTypeQ = DTypeQ;
-  using DTypeKV = DTypeKV;
+  using DTypeK = DTypeK;
+  using DTypeV = DTypeV;
+  using DTypeKV = DTypeKV;  // backward-compat alias (equal to DTypeK)
   using DTypeO = DTypeO;
   using IdType = IdType;
 
   DTypeQ* q;
-  DTypeKV* k;
-  DTypeKV* v;
+  DTypeK* k;
+  DTypeV* v;
   IdType* q_indptr;
   IdType* kv_indptr;
   DTypeO* o;
@@ -86,12 +92,14 @@ struct RaggedParams {
 
 struct PagedParams {
   using DTypeQ = DTypeQ;
-  using DTypeKV = DTypeKV;
+  using DTypeK = DTypeK;
+  using DTypeV = DTypeV;
+  using DTypeKV = DTypeKV;  // backward-compat alias (equal to DTypeK)
   using DTypeO = DTypeO;
   using IdType = IdType;
 
   DTypeQ* q;
-  paged_kv_t<DTypeKV, IdType> paged_kv;
+  paged_kv_t<DTypeK, IdType, DTypeV> paged_kv;
   IdType* q_indptr;
   DTypeO* o;
   float* lse;

--- a/csrc/batch_prefill_sm90.cu
+++ b/csrc/batch_prefill_sm90.cu
@@ -108,8 +108,8 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
         RaggedParams params;
 
         params.q_ptr = static_cast<DTypeQ*>(q.data_ptr());
-        params.k_ptr = static_cast<DTypeKV*>(k.data_ptr());
-        params.v_ptr = static_cast<DTypeKV*>(v.data_ptr());
+        params.k_ptr = static_cast<DTypeK*>(k.data_ptr());
+        params.v_ptr = static_cast<DTypeV*>(v.data_ptr());
         params.o_ptr = static_cast<DTypeO*>(o.data_ptr());
         params.lse_ptr = maybe_lse ? static_cast<float*>(maybe_lse.value().data_ptr()) : nullptr;
         params.q_stride_n = q.stride(0);
@@ -204,8 +204,8 @@ void BatchPrefillWithPagedKVCacheSM90Run(
         PagedParams params;
 
         params.q_ptr = static_cast<DTypeQ*>(q.data_ptr());
-        params.k_ptr = static_cast<DTypeKV*>(paged_k_cache.data_ptr());
-        params.v_ptr = static_cast<DTypeKV*>(paged_v_cache.data_ptr());
+        params.k_ptr = static_cast<DTypeK*>(paged_k_cache.data_ptr());
+        params.v_ptr = static_cast<DTypeV*>(paged_v_cache.data_ptr());
         params.o_ptr = static_cast<DTypeO*>(o.data_ptr());
         params.lse_ptr = maybe_lse ? static_cast<float*>(maybe_lse.value().data_ptr()) : nullptr;
         params.q_stride_n = q.stride(0);

--- a/csrc/batch_prefill_sm90_customize_config.jinja
+++ b/csrc/batch_prefill_sm90_customize_config.jinja
@@ -14,7 +14,11 @@
 using namespace flashinfer;
 
 using DTypeQ = cutlass_dtype_t<{{ dtype_q }}>;
-using DTypeKV = cutlass_dtype_t<{{ dtype_kv }}>;
+using DTypeK = cutlass_dtype_t<{{ dtype_k | default(dtype_kv) }}>;
+using DTypeV = cutlass_dtype_t<{{ dtype_v | default(dtype_kv) }}>;
+// Backward-compat alias. `DTypeKV` was the old symmetric-only type name;
+// new code should reference `DTypeK` / `DTypeV`.
+using DTypeKV = DTypeK;
 using DTypeO = cutlass_dtype_t<{{ dtype_o }}>;
 using IdType = cutlass_dtype_t<{{ idtype }}>;
 
@@ -25,13 +29,15 @@ constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct RaggedParams {
   using DTypeQ = DTypeQ;
-  using DTypeKV = DTypeKV;
+  using DTypeK = DTypeK;
+  using DTypeV = DTypeV;
+  using DTypeKV = DTypeKV;  // backward-compat alias (equal to DTypeK)
   using DTypeO = DTypeO;
   using IdType = IdType;
   // The QKV matrices.
   DTypeQ* q_ptr;
-  DTypeKV* k_ptr;
-  DTypeKV* v_ptr;
+  DTypeK* k_ptr;
+  DTypeV* v_ptr;
   DTypeO* o_ptr;
   float* lse_ptr;
 
@@ -70,13 +76,15 @@ struct RaggedParams {
 
 struct PagedParams {
   using DTypeQ = DTypeQ;
-  using DTypeKV = DTypeKV;
+  using DTypeK = DTypeK;
+  using DTypeV = DTypeV;
+  using DTypeKV = DTypeKV;  // backward-compat alias (equal to DTypeK)
   using DTypeO = DTypeO;
   using IdType = IdType;
   // The QKV matrices.
   DTypeQ* q_ptr;
-  DTypeKV* k_ptr;
-  DTypeKV* v_ptr;
+  DTypeK* k_ptr;
+  DTypeV* v_ptr;
   DTypeO* o_ptr;
   float* lse_ptr;
 

--- a/csrc/single_decode.cu
+++ b/csrc/single_decode.cu
@@ -75,8 +75,8 @@ void single_decode_with_kv_cache(TensorView q, TensorView k, TensorView v, Tenso
         Params params;
 
         params.q = static_cast<DTypeQ*>(q.data_ptr());
-        params.k = static_cast<DTypeKV*>(k.data_ptr());
-        params.v = static_cast<DTypeKV*>(v.data_ptr());
+        params.k = static_cast<DTypeK*>(k.data_ptr());
+        params.v = static_cast<DTypeV*>(v.data_ptr());
         params.o = static_cast<DTypeO*>(o.data_ptr());
         params.lse =
             maybe_lse.has_value() ? static_cast<float*>(maybe_lse.value().data_ptr()) : nullptr;

--- a/csrc/single_decode_customize_config.jinja
+++ b/csrc/single_decode_customize_config.jinja
@@ -15,7 +15,11 @@
 using namespace flashinfer;
 
 using DTypeQ = {{ dtype_q }};
-using DTypeKV = {{ dtype_kv }};
+using DTypeK = {{ dtype_k | default(dtype_kv) }};
+using DTypeV = {{ dtype_v | default(dtype_kv) }};
+// Backward-compat alias. `DTypeKV` was the old symmetric-only type name;
+// new code should reference `DTypeK` / `DTypeV`.
+using DTypeKV = DTypeK;
 using DTypeO = {{ dtype_o }};
 using IdType = int32_t;
 constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
@@ -26,12 +30,14 @@ constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct Params {
   using DTypeQ = DTypeQ;
-  using DTypeKV = DTypeKV;
+  using DTypeK = DTypeK;
+  using DTypeV = DTypeV;
+  using DTypeKV = DTypeKV;  // backward-compat alias (equal to DTypeK)
   using DTypeO = DTypeO;
   using IdType = int32_t;
   DTypeQ* q;
-  DTypeKV* k;
-  DTypeKV* v;
+  DTypeK* k;
+  DTypeV* v;
   DTypeO* o;
   float* lse;
   {{ additional_params_decl }}

--- a/csrc/single_prefill.cu
+++ b/csrc/single_prefill.cu
@@ -78,8 +78,8 @@ void single_prefill_with_kv_cache(ffi::TensorView q, ffi::TensorView k, ffi::Ten
         Params params;
 
         params.q = static_cast<DTypeQ*>(q.data_ptr());
-        params.k = static_cast<DTypeKV*>(k.data_ptr());
-        params.v = static_cast<DTypeKV*>(v.data_ptr());
+        params.k = static_cast<DTypeK*>(k.data_ptr());
+        params.v = static_cast<DTypeV*>(v.data_ptr());
         params.o = static_cast<DTypeO*>(o.data_ptr());
         params.lse =
             maybe_lse.has_value() ? static_cast<float*>(maybe_lse.value().data_ptr()) : nullptr;

--- a/csrc/single_prefill_customize_config.jinja
+++ b/csrc/single_prefill_customize_config.jinja
@@ -21,7 +21,11 @@
 using namespace flashinfer;
 
 using DTypeQ = {{ dtype_q }};
-using DTypeKV = {{ dtype_kv }};
+using DTypeK = {{ dtype_k | default(dtype_kv) }};
+using DTypeV = {{ dtype_v | default(dtype_kv) }};
+// Backward-compat alias. `DTypeKV` was the old symmetric-only type name;
+// new code should reference `DTypeK` / `DTypeV`.
+using DTypeKV = DTypeK;
 using DTypeO = {{ dtype_o }};
 using IdType = int32_t;
 constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
@@ -33,12 +37,14 @@ constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct Params {
   using DTypeQ = DTypeQ;
-  using DTypeKV = DTypeKV;
+  using DTypeK = DTypeK;
+  using DTypeV = DTypeV;
+  using DTypeKV = DTypeKV;  // backward-compat alias (equal to DTypeK)
   using DTypeO = DTypeO;
   using IdType = int32_t;
   DTypeQ* q;
-  DTypeKV* k;
-  DTypeKV* v;
+  DTypeK* k;
+  DTypeV* v;
   DTypeO* o;
   float* lse;
   uint_fastdiv group_size;

--- a/csrc/single_prefill_sm90.cu
+++ b/csrc/single_prefill_sm90.cu
@@ -50,8 +50,8 @@ void single_prefill_with_kv_cache_sm90(ffi::TensorView q, ffi::TensorView k, ffi
                    USE_SLIDING_WINDOW, USE_LOGITS_SOFT_CAP, AttentionVariant, Params, [&] {
                      Params params;
                      params.q_ptr = static_cast<DTypeQ*>(q.data_ptr());
-                     params.k_ptr = static_cast<DTypeKV*>(k.data_ptr());
-                     params.v_ptr = static_cast<DTypeKV*>(v.data_ptr());
+                     params.k_ptr = static_cast<DTypeK*>(k.data_ptr());
+                     params.v_ptr = static_cast<DTypeV*>(v.data_ptr());
                      params.o_ptr = static_cast<DTypeO*>(o.data_ptr());
                      params.lse_ptr = maybe_lse.has_value()
                                           ? (static_cast<float*>(maybe_lse.value().data_ptr()))

--- a/csrc/single_prefill_sm90_customize_config.jinja
+++ b/csrc/single_prefill_sm90_customize_config.jinja
@@ -17,7 +17,11 @@
 using namespace flashinfer;
 
 using DTypeQ = cutlass_dtype_t<{{ dtype_q }}>;
-using DTypeKV = cutlass_dtype_t<{{ dtype_kv }}>;
+using DTypeK = cutlass_dtype_t<{{ dtype_k | default(dtype_kv) }}>;
+using DTypeV = cutlass_dtype_t<{{ dtype_v | default(dtype_kv) }}>;
+// Backward-compat alias. `DTypeKV` was the old symmetric-only type name;
+// new code should reference `DTypeK` / `DTypeV`.
+using DTypeKV = DTypeK;
 using DTypeO = cutlass_dtype_t<{{ dtype_o }}>;
 using IdType = cutlass_dtype_t<int32_t>;
 
@@ -28,14 +32,16 @@ constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
 
 struct Params {
   using DTypeQ = DTypeQ;
-  using DTypeKV = DTypeKV;
+  using DTypeK = DTypeK;
+  using DTypeV = DTypeV;
+  using DTypeKV = DTypeKV;  // backward-compat alias (equal to DTypeK)
   using DTypeO = DTypeO;
   using IdType = IdType;
 
   // The QKV matrices.
   DTypeQ* q_ptr;
-  DTypeKV* k_ptr;
-  DTypeKV* v_ptr;
+  DTypeK* k_ptr;
+  DTypeV* v_ptr;
   DTypeO* o_ptr;
   float* lse_ptr;
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -287,9 +287,11 @@ def get_batch_decode_jit_module(module_name: str, jit_module: Any):
 
 
 @functools.cache
-def get_batch_decode_module(*args):
-    uri = get_batch_decode_uri(*args)
-    mod = gen_batch_decode_module(*args).build_and_load()
+def get_batch_decode_module(*args, dtype_k=None, dtype_v=None):
+    uri = get_batch_decode_uri(*args, dtype_k=dtype_k, dtype_v=dtype_v)
+    mod = gen_batch_decode_module(
+        *args, dtype_k=dtype_k, dtype_v=dtype_v
+    ).build_and_load()
     plan_func = mod.plan
     workspace_size_func = getattr(mod, "workspace_size", None)
     run_func = mod.run
@@ -606,6 +608,15 @@ def single_decode_with_kv_cache(
     not equal to ``num_kv_heads``, the function will use
     `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
     """
+    if k.dtype != v.dtype:
+        # The single-decode JIT module is keyed on k.dtype only; without
+        # this check a mixed-dtype V tensor would be silently reinterpreted
+        # as k.dtype by the kernel.
+        raise NotImplementedError(
+            "single_decode_with_kv_cache does not support asymmetric K/V "
+            "dtypes; use BatchDecodeWithPagedKVCacheWrapper with "
+            "k_data_type/v_data_type instead."
+        )
     _check_pos_encoding_mode(pos_encoding_mode)
     _check_kv_layout(kv_layout)
     tmp = torch.empty(SINGLE_KERNEL_TMP_SIZE, dtype=torch.uint8, device=q.device)
@@ -994,6 +1005,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
         q_len_per_req: int = 1,
+        *,
+        k_data_type: Optional[Union[str, torch.dtype]] = None,
+        v_data_type: Optional[Union[str, torch.dtype]] = None,
     ) -> Tuple[int, int]:
         r"""Return the caller-owned workspace size required by :meth:`plan`.
 
@@ -1088,9 +1102,32 @@ class BatchDecodeWithPagedKVCacheWrapper:
         if kv_data_type is None:
             kv_data_type = q_data_type
         kv_data_type = canonicalize_torch_dtype(kv_data_type)
+        if k_data_type is None:
+            k_data_type = kv_data_type
+        k_data_type = canonicalize_torch_dtype(k_data_type)
+        if v_data_type is None:
+            v_data_type = kv_data_type
+        v_data_type = canonicalize_torch_dtype(v_data_type)
+        # Equal K/V overrides are just the symmetric case: collapse them into
+        # kv_data_type so paths that key on kv_data_type stay consistent with
+        # run()'s per-side validation.
+        if k_data_type == v_data_type:
+            kv_data_type = k_data_type
         if o_data_type is None:
             o_data_type = q_data_type
         o_data_type = canonicalize_torch_dtype(o_data_type)
+
+        # Mirror plan(): the workspace estimate must come from the same
+        # module the plan will use, and asymmetric dtypes are CUDA-core
+        # decode only.
+        if k_data_type != v_data_type and (
+            self.use_tensor_cores or self._jit_module is not None
+        ):
+            raise NotImplementedError(
+                "Asymmetric K/V dtypes (k_data_type != v_data_type) are only "
+                "supported by the CUDA-core decode path without a custom "
+                "jit_args module."
+            )
 
         if fixed_split_size is not None and not self.use_tensor_cores:
             raise ValueError(
@@ -1212,6 +1249,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     PosEncodingMode[pos_encoding_mode].value,
                     window_left != -1,
                     logits_soft_cap > 0,
+                    dtype_k=k_data_type,
+                    dtype_v=v_data_type,
                 )
             args = [
                 self._float_workspace_buffer,
@@ -1288,7 +1327,18 @@ class BatchDecodeWithPagedKVCacheWrapper:
             The data type of the query tensor, defaults torch.float16.
         kv_data_type : Optional[Union[str, torch.dtype]]
             The data type of the key/value tensor. If None, will be set to
-            ``q_data_type``. Defaults to ``None``.
+            ``q_data_type``. Defaults to ``None``. When ``k_data_type`` or
+            ``v_data_type`` are also supplied (asymmetric K/V), this still
+            acts as the fallback for whichever of the two is omitted.
+        k_data_type : Optional[Union[str, torch.dtype]]
+            The data type of the key tensor only. Use this together with
+            ``v_data_type`` to request asymmetric K/V quantization, for
+            example ``k_data_type=torch.float16, v_data_type=torch.float8_e4m3fn``
+            to keep keys at native precision while storing values in FP8.
+            If omitted, defaults to ``kv_data_type``.
+        v_data_type : Optional[Union[str, torch.dtype]]
+            The data type of the value tensor only. See ``k_data_type``.
+            If omitted, defaults to ``kv_data_type``.
         o_data_type : Optional[Union[str, torch.dtype]]
             The data type of the output tensor. If None, will be set to :attr:`q_data_type`.
             For FP8 inputs, this should typically be set to torch.float16 or torch.bfloat16.
@@ -1400,6 +1450,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
         q_len_per_req: int = 1,
+        k_data_type: Optional[Union[str, torch.dtype]] = None,
+        v_data_type: Optional[Union[str, torch.dtype]] = None,
     ) -> None:
         _check_workspace_buffer_alignment(
             self._float_workspace_buffer, "float_workspace_buffer"
@@ -1491,9 +1543,47 @@ class BatchDecodeWithPagedKVCacheWrapper:
         if kv_data_type is None:
             kv_data_type = q_data_type
         kv_data_type = canonicalize_torch_dtype(kv_data_type)
+        # Asymmetric K/V: if caller omitted either half, fall back to
+        # kv_data_type. When both are omitted (the common case) k and v
+        # dtypes both equal kv_data_type and every downstream URI is
+        # identical to the symmetric path, so no JIT cache churn.
+        if k_data_type is None:
+            k_data_type = kv_data_type
+        k_data_type = canonicalize_torch_dtype(k_data_type)
+        if v_data_type is None:
+            v_data_type = kv_data_type
+        v_data_type = canonicalize_torch_dtype(v_data_type)
+        # Equal K/V overrides are just the symmetric case: collapse them into
+        # kv_data_type so paths that key on kv_data_type stay consistent with
+        # run()'s per-side validation.
+        if k_data_type == v_data_type:
+            kv_data_type = k_data_type
         if o_data_type is None:
             o_data_type = q_data_type
         o_data_type = canonicalize_torch_dtype(o_data_type)
+
+        # Asymmetric K/V is implemented in the CUDA-core FA2 decode kernel
+        # only. The tensor-core path (including trtllm-gen and cute-dsl,
+        # which force use_tensor_cores) routes through prefill kernels that
+        # do not support split K/V dtypes yet; fail here with a clear error
+        # instead of a JIT-compile static_assert (fa2/fa3 prefill) or a
+        # silently symmetric module (trtllm-gen, cute-dsl). Custom jit_args
+        # modules were compiled with their own fixed dtypes, so asymmetric
+        # plan() requests cannot be honored by them either.
+        if k_data_type != v_data_type:
+            if self.use_tensor_cores:
+                raise NotImplementedError(
+                    "Asymmetric K/V dtypes (k_data_type != v_data_type) are "
+                    "only supported by the CUDA-core decode path; construct "
+                    "the wrapper with use_tensor_cores=False and the 'fa2' "
+                    "or 'auto' backend."
+                )
+            if self._jit_module is not None:
+                raise NotImplementedError(
+                    "Asymmetric K/V dtypes are not supported with a custom "
+                    "jit_args module; the custom module was compiled with a "
+                    "single KV dtype."
+                )
 
         if fixed_split_size is not None and not self.use_tensor_cores:
             raise ValueError(
@@ -1504,6 +1594,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         self._cached_q_data_type = q_data_type
         self._cached_kv_data_type = kv_data_type
+        self._cached_k_data_type = k_data_type
+        self._cached_v_data_type = v_data_type
         self._cached_o_data_type = o_data_type
         self._batch_size = batch_size
         self._num_qo_heads = num_qo_heads
@@ -1665,6 +1757,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     window_left != -1,  # use_sliding_window
                     logits_soft_cap > 0,  # use_logits_soft_cap
                     False,  # use_fp16_qk_reduction
+                    dtype_k=k_data_type,
+                    dtype_v=v_data_type,
                 )
 
             args = [
@@ -1707,6 +1801,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     PosEncodingMode[pos_encoding_mode].value,
                     window_left != -1,  # use_sliding_window
                     logits_soft_cap > 0,  # use_logits_soft_cap
+                    dtype_k=k_data_type,
+                    dtype_v=v_data_type,
                 )
             self._plan_info = self._cached_module.plan(
                 self._float_workspace_buffer,
@@ -1929,9 +2025,24 @@ class BatchDecodeWithPagedKVCacheWrapper:
             page_size = k_cache.shape[1]
         else:
             page_size = k_cache.shape[2]
+        # The getattr fallbacks keep plan-state producers that predate the
+        # k/v split working (e.g. fast_decode_plan, which only refreshes an
+        # existing plan and never sets the per-side dtypes).
+        cached_k_dtype = getattr(self, "_cached_k_data_type", self._cached_kv_data_type)
+        cached_v_dtype = getattr(self, "_cached_v_data_type", self._cached_kv_data_type)
         _check_cached_qkv_data_type(
-            q, k_cache, self._cached_q_data_type, self._cached_kv_data_type
+            q, k_cache, self._cached_q_data_type, cached_k_dtype
         )
+        # Asymmetric K/V: validate V dtype separately. The legacy helper
+        # above only checks K because kv_data_type used to cover both.
+        if v_cache.dtype != cached_v_dtype:
+            raise ValueError(
+                f"The dtype of v {v_cache.dtype} does not match the "
+                f"v_data_type {cached_v_dtype} specified in plan "
+                f"(kv_data_type was {self._cached_kv_data_type}). Pass "
+                f"k_data_type and v_data_type explicitly if you intended "
+                f"an asymmetric K/V cache."
+            )
         actual_batch_size = self._paged_kv_last_page_len_buf.size(0)
         # Soft-deprecation: q_len_per_req moved to plan(). Accept it at run()
         # with a warning and use to validate q.size(0)

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -42,6 +42,30 @@ from .fmha_v2.generate_kernels import enumerate_kernels
 from .fmha_v2.fmha_library import generate_jit_sources
 
 
+def _kv_uri_fragment(
+    dtype_kv: torch.dtype,
+    dtype_k: Optional[torch.dtype] = None,
+    dtype_v: Optional[torch.dtype] = None,
+) -> str:
+    """Return the KV portion of a JIT URI.
+
+    Preserves backward-compatible `dtype_kv_X` form whenever K and V share
+    the same dtype (including when `dtype_k` and `dtype_v` are both left as
+    `None`, which is how existing symmetric callers invoke the URI builders).
+    Emits the asymmetric `dtype_k_X_dtype_v_Y` form only when K and V
+    genuinely differ — this keeps the JIT cache keyed identically to today
+    for every existing call site.
+    """
+    eff_k = dtype_k if dtype_k is not None else dtype_kv
+    eff_v = dtype_v if dtype_v is not None else dtype_kv
+    if eff_k == eff_v:
+        return f"dtype_kv_{filename_safe_dtype_map[eff_k]}"
+    return (
+        f"dtype_k_{filename_safe_dtype_map[eff_k]}_"
+        f"dtype_v_{filename_safe_dtype_map[eff_v]}"
+    )
+
+
 def get_single_decode_uri(
     dtype_q: torch.dtype,
     dtype_kv: torch.dtype,
@@ -74,10 +98,13 @@ def get_batch_decode_uri(
     pos_encoding_mode: int,
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
+    *,
+    dtype_k: Optional[torch.dtype] = None,
+    dtype_v: Optional[torch.dtype] = None,
 ) -> str:
     return (
         f"batch_decode_with_kv_cache_dtype_q_{filename_safe_dtype_map[dtype_q]}_"
-        f"dtype_kv_{filename_safe_dtype_map[dtype_kv]}_"
+        f"{_kv_uri_fragment(dtype_kv, dtype_k, dtype_v)}_"
         f"dtype_o_{filename_safe_dtype_map[dtype_o]}_"
         f"dtype_idx_{filename_safe_dtype_map[dtype_idx]}_"
         f"head_dim_qk_{head_dim_qk}_"
@@ -382,10 +409,13 @@ def get_batch_prefill_uri(
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
+    *,
+    dtype_k: Optional[torch.dtype] = None,
+    dtype_v: Optional[torch.dtype] = None,
 ) -> str:
     return (
         f"batch_prefill_with_kv_cache_dtype_q_{filename_safe_dtype_map[dtype_q]}_"
-        f"dtype_kv_{filename_safe_dtype_map[dtype_kv]}_"
+        f"{_kv_uri_fragment(dtype_kv, dtype_k, dtype_v)}_"
         f"dtype_o_{filename_safe_dtype_map[dtype_o]}_"
         f"dtype_idx_{filename_safe_dtype_map[dtype_idx]}_"
         f"head_dim_qk_{head_dim_qk}_"
@@ -922,6 +952,9 @@ def gen_batch_decode_module(
     pos_encoding_mode: int,
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
+    *,
+    dtype_k: Optional[torch.dtype] = None,
+    dtype_v: Optional[torch.dtype] = None,
 ) -> JitSpec:
     uri = get_batch_decode_uri(
         dtype_q,
@@ -933,6 +966,8 @@ def gen_batch_decode_module(
         pos_encoding_mode,
         use_sliding_window,
         use_logits_soft_cap,
+        dtype_k=dtype_k,
+        dtype_v=dtype_v,
     )
     return gen_customize_batch_decode_module(
         uri,
@@ -956,6 +991,8 @@ def gen_batch_decode_module(
         pos_encoding_mode=pos_encoding_mode,
         use_sliding_window=use_sliding_window,
         use_logits_soft_cap=use_logits_soft_cap,
+        dtype_k=dtype_k,
+        dtype_v=dtype_v,
     )
 
 
@@ -971,6 +1008,9 @@ def gen_batch_prefill_module(
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
+    *,
+    dtype_k: Optional[torch.dtype] = None,
+    dtype_v: Optional[torch.dtype] = None,
 ) -> JitSpec:
     uri = get_batch_prefill_uri(
         backend,
@@ -984,6 +1024,8 @@ def gen_batch_prefill_module(
         use_sliding_window,
         use_logits_soft_cap,
         use_fp16_qk_reduction,
+        dtype_k=dtype_k,
+        dtype_v=dtype_v,
     )
 
     # use `fp8_enabled` flag to use separate kernel template
@@ -1085,6 +1127,8 @@ def gen_batch_prefill_module(
         use_logits_soft_cap=use_logits_soft_cap,
         use_fp16_qk_reduction=use_fp16_qk_reduction,
         fp8_enabled=fp8_enabled,
+        dtype_k=dtype_k,
+        dtype_v=dtype_v,
     )
 
 
@@ -1529,7 +1573,17 @@ def gen_customize_batch_decode_module(
     pos_encoding_mode: int = 0,
     use_sliding_window: bool = False,
     use_logits_soft_cap: bool = False,
+    *,
+    dtype_k: Optional[torch.dtype] = None,
+    dtype_v: Optional[torch.dtype] = None,
 ) -> JitSpec:
+    # Asymmetric K/V support: if either dtype_k or dtype_v is omitted,
+    # fall back to dtype_kv so every existing caller keeps working. The
+    # jinja templates have a matching `| default(dtype_kv)` filter on
+    # `dtype_k` and `dtype_v` so partial overrides are also fine.
+    eff_dtype_k = dtype_k if dtype_k is not None else dtype_kv
+    eff_dtype_v = dtype_v if dtype_v is not None else dtype_kv
+
     gen_directory = jit_env.FLASHINFER_GEN_SRC_DIR / uri
     (additional_params_decl, additional_func_params, additional_params_setter) = (
         generate_additional_params(
@@ -1548,6 +1602,8 @@ def gen_customize_batch_decode_module(
         "variant_name": variant_name,
         "dtype_q": dtype_map[dtype_q],
         "dtype_kv": dtype_map_kv[dtype_kv],
+        "dtype_k": dtype_map_kv[eff_dtype_k],
+        "dtype_v": dtype_map_kv[eff_dtype_v],
         "dtype_o": dtype_map[dtype_o],
         "idtype": dtype_map[idtype],
         "head_dim_qk": head_dim_qk,
@@ -1616,12 +1672,22 @@ def gen_customize_batch_prefill_module(
     use_logits_soft_cap: bool = False,
     use_fp16_qk_reduction: bool = False,
     fp8_enabled: bool = False,
+    *,
+    dtype_k: Optional[torch.dtype] = None,
+    dtype_v: Optional[torch.dtype] = None,
 ) -> JitSpec:
+    # Asymmetric K/V support: fall back to dtype_kv if K or V dtype is
+    # unspecified. Jinja templates default dtype_k/dtype_v to dtype_kv so
+    # partial overrides work too.
+    eff_dtype_k = dtype_k if dtype_k is not None else dtype_kv
+    eff_dtype_v = dtype_v if dtype_v is not None else dtype_kv
     kwargs = {
         "variant_decl": variant_decl,
         "variant_name": variant_name,
         "dtype_q": dtype_map[dtype_q],
         "dtype_kv": dtype_map_kv[dtype_kv],
+        "dtype_k": dtype_map_kv[eff_dtype_k],
+        "dtype_v": dtype_map_kv[eff_dtype_v],
         "dtype_o": dtype_map[dtype_o],
         "idtype": dtype_map[idtype],
         "head_dim_qk": head_dim_qk,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -447,7 +447,7 @@ def get_single_prefill_module(backend, *args):
 
 
 @functools.cache
-def get_batch_prefill_module(backend, *args):
+def get_batch_prefill_module(backend, *args, dtype_k=None, dtype_v=None):
     if backend == "trtllm-gen":
         uri = "trtllm_gen_context"
         module = get_trtllm_gen_prefill_module()
@@ -456,8 +456,10 @@ def get_batch_prefill_module(backend, *args):
         ragged_run_func = module.ragged_run
         paged_run_func = module.paged_run
     else:
-        uri = get_batch_prefill_uri(backend, *args)
-        module = gen_batch_prefill_module(backend, *args).build_and_load()
+        uri = get_batch_prefill_uri(backend, *args, dtype_k=dtype_k, dtype_v=dtype_v)
+        module = gen_batch_prefill_module(
+            backend, *args, dtype_k=dtype_k, dtype_v=dtype_v
+        ).build_and_load()
         plan_func = module.plan
         workspace_size_func = getattr(module, "workspace_size", None)
         ragged_run_func = module.ragged_run

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -412,13 +412,8 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
   auto block = cg::this_thread_block();
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
-  // Asymmetric K/V plumbing; see SingleDecodeWithKVCacheKernel above for
-  // the shared-memory-layout constraint.
   using DTypeK = typename Params::DTypeK;
   using DTypeV = typename Params::DTypeV;
-  static_assert(std::is_same_v<DTypeK, DTypeV>,
-                "BatchDecodeWithPagedKVCacheDevice does not yet support asymmetric "
-                "K/V dtypes; see the upstream asymmetric-kv-dtype patch plan");
   using DTypeO = typename Params::DTypeO;
   using IdType = typename Params::IdType;
   const DTypeQ* q = params.q;
@@ -446,14 +441,19 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
       partition_kv ? min((kv_tile_idx + 1) * max_chunk_size, kv_len) : kv_len;
   const uint32_t chunk_size = chunk_end - chunk_start;
 
+  // Asymmetric K/V: K and V tiles may have different byte sizes per element.
+  // k_smem stores K data typed as DTypeK; v_smem stores V data typed as DTypeV.
+  // When DTypeK == DTypeV (the symmetric case), the layout is byte-identical
+  // to the pre-asymmetric code.
+  constexpr size_t kv_tile_elems = num_stages_smem * tile_size_per_bdx * bdy * bdz * head_dim;
+  constexpr size_t k_tile_bytes = kv_tile_elems * sizeof(DTypeK);
+  constexpr size_t v_tile_bytes = kv_tile_elems * sizeof(DTypeV);
+
   AttentionVariant variant(params, batch_idx, smem);
-  DTypeKV* k_smem = (DTypeKV*)smem;
-  DTypeKV* v_smem = (DTypeKV*)(smem + num_stages_smem * tile_size_per_bdx * bdy * bdz * head_dim *
-                                          sizeof(DTypeKV));
-  size_t* kv_offset_smem = (size_t*)(smem + 2 * num_stages_smem * tile_size_per_bdx * bdy * bdz *
-                                                head_dim * sizeof(DTypeKV));
-  float* smem_md = (float*)(smem + 2 * num_stages_smem * tile_size_per_bdx * bdy * bdz * head_dim *
-                                       sizeof(DTypeKV));
+  DTypeK* k_smem = (DTypeK*)smem;
+  DTypeV* v_smem = (DTypeV*)(smem + k_tile_bytes);
+  size_t* kv_offset_smem = (size_t*)(smem + k_tile_bytes + v_tile_bytes);
+  float* smem_md = (float*)(smem + k_tile_bytes + v_tile_bytes);
 
   vec_t<float, vec_size> q_vec;
   vec_t<float, vec_size> freq;
@@ -490,7 +490,8 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
 
   // preload k/v tiles
   uint32_t stage_idx = 0;
-  constexpr uint32_t vec_bits = sizeof(DTypeKV) * vec_size * 8;
+  constexpr uint32_t vec_bits_k = sizeof(DTypeK) * vec_size * 8;
+  constexpr uint32_t vec_bits_v = sizeof(DTypeV) * vec_size * 8;
   const IdType last_indptr = paged_kv.indptr[paged_kv.batch_size];
 
   static_assert(num_stages_smem <= bdx);
@@ -514,7 +515,7 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
     }
 #pragma unroll
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
-      cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kNoFill>(
+      cp_async::pred_load<vec_bits_k, PrefetchMode::kPrefetch, SharedMemFillMode::kNoFill>(
           k_smem + (((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx + j) * head_dim +
               tx * vec_size,
           paged_kv.k_data + kv_offset[j],
@@ -523,7 +524,7 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
     cp_async::commit_group();
 #pragma unroll
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
-      cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kFillZero>(
+      cp_async::pred_load<vec_bits_v, PrefetchMode::kPrefetch, SharedMemFillMode::kFillZero>(
           v_smem + (((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx + j) * head_dim +
               tx * vec_size,
           paged_kv.v_data + kv_offset[j],
@@ -573,7 +574,7 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
     // load k tiles
 #pragma unroll
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
-      cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kNoFill>(
+      cp_async::pred_load<vec_bits_k, PrefetchMode::kPrefetch, SharedMemFillMode::kNoFill>(
           k_smem + (((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx + j) * head_dim +
               tx * vec_size,
           paged_kv.k_data + kv_offset[j],
@@ -591,7 +592,7 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
     // load v tiles
 #pragma unroll
     for (uint32_t j = 0; j < tile_size_per_bdx; ++j) {
-      cp_async::pred_load<vec_bits, PrefetchMode::kPrefetch, SharedMemFillMode::kFillZero>(
+      cp_async::pred_load<vec_bits_v, PrefetchMode::kPrefetch, SharedMemFillMode::kFillZero>(
           v_smem + (((stage_idx * bdz + tz) * bdy + ty) * tile_size_per_bdx + j) * head_dim +
               tx * vec_size,
           paged_kv.v_data + kv_offset[j],
@@ -769,20 +770,21 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(Params params, typename Params
                                                   cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
-  // Asymmetric K/V plumbing; body still requires equal K and V dtypes.
   using DTypeK = typename Params::DTypeK;
   using DTypeV = typename Params::DTypeV;
-  static_assert(std::is_same_v<DTypeK, DTypeV>,
-                "BatchDecodeWithPagedKVCacheDispatched does not yet support "
-                "asymmetric K/V dtypes; the kernel body rewrite is a follow-up "
-                "commit");
   using DTypeO = typename Params::DTypeO;
   using IdType = typename Params::IdType;
   const uint32_t num_qo_heads = params.num_qo_heads;
   const uint32_t num_kv_heads = params.paged_kv.num_heads;
   const uint32_t padded_batch_size = params.padded_batch_size;
 
-  constexpr uint32_t vec_size = std::max(16UL / sizeof(DTypeKV), HEAD_DIM / 32UL);
+  // vec_size must be large enough that both K and V cp_async loads reach
+  // the 128-bit minimum.  cp_async::pred_load requires num_bits in {128,256}.
+  // vec_bits = sizeof(DType) * vec_size * 8, so we need
+  //   sizeof(DType) * vec_size * 8 >= 128  =>  vec_size >= 16 / sizeof(DType).
+  // Using the smaller of the two element sizes ensures both meet the bound.
+  constexpr size_t min_kv_sizeof = std::min(sizeof(DTypeK), sizeof(DTypeV));
+  constexpr uint32_t vec_size = std::max(16UL / min_kv_sizeof, HEAD_DIM / 32UL);
   auto compute_capacity = GetCudaComputeCapability();
   constexpr uint32_t bdx = HEAD_DIM / vec_size;
   static_assert(bdx <= 32);
@@ -790,12 +792,17 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(Params params, typename Params
     constexpr uint32_t bdy = GROUP_SIZE;
     constexpr uint32_t num_threads = std::max(128U, bdx * bdy);
     constexpr uint32_t bdz = num_threads / (bdx * bdy);
-    constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (sizeof(DTypeKV) == 1 ? 2U : 4U) : 1U;
+    // tile_size_per_bdx: use the smaller of the two element sizes so that
+    // the smem budget fits both K and V tiles.
+    constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (min_kv_sizeof == 1 ? 2U : 4U) : 1U;
     DISPATCH_COMPUTE_CAP_DECODE_NUM_STAGES_SMEM(compute_capacity, NUM_STAGES_SMEM, {
+      // Asymmetric smem: K tiles at sizeof(DTypeK) per element, V tiles at
+      // sizeof(DTypeV) per element.  When DTypeK == DTypeV this simplifies
+      // to the pre-asymmetric formula.
       const uint32_t smem_size =
-          2 * NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz * HEAD_DIM * sizeof(DTypeKV) +
-          std::max(tile_size_per_bdx * num_threads * sizeof(DTypeKV*),
-                   2 * bdy * bdz * sizeof(float));
+          NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz * HEAD_DIM *
+              (sizeof(DTypeK) + sizeof(DTypeV)) +
+          std::max(tile_size_per_bdx * num_threads * sizeof(size_t), 2 * bdy * bdz * sizeof(float));
       auto kernel =
           BatchDecodeWithPagedKVCacheKernel<POS_ENCODING_MODE, NUM_STAGES_SMEM, tile_size_per_bdx,
                                             vec_size, bdx, bdy, bdz, AttentionVariant, Params>;

--- a/include/flashinfer/attention/decode.cuh
+++ b/include/flashinfer/attention/decode.cuh
@@ -22,6 +22,7 @@
 #include <cuda_runtime.h>
 
 #include <iostream>
+#include <type_traits>
 
 #include "../cp_async.cuh"
 #include "../math.cuh"
@@ -217,10 +218,19 @@ template <PosEncodingMode pos_encoding_mode, uint32_t num_stages_smem, uint32_t 
 __global__ void SingleDecodeWithKVCacheKernel(const __grid_constant__ Params params) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
+  // Asymmetric K/V plumbing. For now DTypeK must equal DTypeV because this
+  // kernel body's shared-memory layout and load vectorization assume a
+  // single KV element size. The plumbing is in place for the follow-up
+  // commit that splits the K and V load paths.
+  using DTypeK = typename Params::DTypeK;
+  using DTypeV = typename Params::DTypeV;
+  static_assert(std::is_same_v<DTypeK, DTypeV>,
+                "SingleDecodeWithKVCacheKernel does not yet support asymmetric "
+                "K/V dtypes; see the upstream asymmetric-kv-dtype patch plan");
   using DTypeO = typename Params::DTypeO;
   const DTypeQ* q = params.q;
-  const DTypeKV* k = params.k;
-  const DTypeKV* v = params.v;
+  const DTypeK* k = params.k;
+  const DTypeV* v = params.v;
   const uint32_t q_stride_n = params.q_stride_n;
   const uint32_t q_stride_h = params.q_stride_h;
   const uint32_t kv_stride_n = params.kv_stride_n;
@@ -402,6 +412,13 @@ __device__ __inline__ void BatchDecodeWithPagedKVCacheDevice(const Params& param
   auto block = cg::this_thread_block();
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
+  // Asymmetric K/V plumbing; see SingleDecodeWithKVCacheKernel above for
+  // the shared-memory-layout constraint.
+  using DTypeK = typename Params::DTypeK;
+  using DTypeV = typename Params::DTypeV;
+  static_assert(std::is_same_v<DTypeK, DTypeV>,
+                "BatchDecodeWithPagedKVCacheDevice does not yet support asymmetric "
+                "K/V dtypes; see the upstream asymmetric-kv-dtype patch plan");
   using DTypeO = typename Params::DTypeO;
   using IdType = typename Params::IdType;
   const DTypeQ* q = params.q;
@@ -661,6 +678,13 @@ cudaError_t SingleDecodeWithKVCacheDispatched(Params params, typename Params::DT
                                               cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
+  // Asymmetric K/V plumbing; body still requires equal K and V dtypes.
+  using DTypeK = typename Params::DTypeK;
+  using DTypeV = typename Params::DTypeV;
+  static_assert(std::is_same_v<DTypeK, DTypeV>,
+                "SingleDecodeWithKVCacheDispatched does not yet support "
+                "asymmetric K/V dtypes; the kernel body rewrite is a follow-up "
+                "commit");
   using DTypeO = typename Params::DTypeO;
   const uint32_t num_qo_heads = params.num_qo_heads;
   const uint32_t num_kv_heads = params.num_kv_heads;
@@ -745,6 +769,13 @@ cudaError_t BatchDecodeWithPagedKVCacheDispatched(Params params, typename Params
                                                   cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
+  // Asymmetric K/V plumbing; body still requires equal K and V dtypes.
+  using DTypeK = typename Params::DTypeK;
+  using DTypeV = typename Params::DTypeV;
+  static_assert(std::is_same_v<DTypeK, DTypeV>,
+                "BatchDecodeWithPagedKVCacheDispatched does not yet support "
+                "asymmetric K/V dtypes; the kernel body rewrite is a follow-up "
+                "commit");
   using DTypeO = typename Params::DTypeO;
   using IdType = typename Params::IdType;
   const uint32_t num_qo_heads = params.num_qo_heads;

--- a/include/flashinfer/attention/default_decode_params.cuh
+++ b/include/flashinfer/attention/default_decode_params.cuh
@@ -25,15 +25,17 @@
 
 namespace flashinfer {
 
-template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_>
+template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename DTypeV_ = DTypeKV_>
 struct SingleDecodeParams {
   using DTypeQ = DTypeQ_;
-  using DTypeKV = DTypeKV_;
+  using DTypeKV = DTypeKV_;  // backward-compat name; equal to DTypeK
+  using DTypeK = DTypeKV_;
+  using DTypeV = DTypeV_;
   using DTypeO = DTypeO_;
   using IdType = int32_t;
   DTypeQ* q;
-  DTypeKV* k;
-  DTypeKV* v;
+  DTypeK* k;
+  DTypeV* v;
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
@@ -72,7 +74,7 @@ struct SingleDecodeParams {
         rope_rcp_theta(0.0f),
         kv_chunk_size(0) {}
 
-  __device__ __host__ SingleDecodeParams(DTypeQ* q, DTypeKV* k, DTypeKV* v, DTypeO* o,
+  __device__ __host__ SingleDecodeParams(DTypeQ* q, DTypeK* k, DTypeV* v, DTypeO* o,
                                          float* maybe_alibi_slopes, uint32_t seq_len,
                                          uint32_t num_qo_heads, uint32_t num_kv_heads,
                                          QKVLayout kv_layout, uint32_t head_dim,
@@ -105,16 +107,19 @@ struct SingleDecodeParams {
   }
 };
 
-template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_>
+template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_,
+          typename DTypeV_ = DTypeKV_>
 struct BatchDecodeParams {
   using DTypeQ = DTypeQ_;
-  using DTypeKV = DTypeKV_;
+  using DTypeKV = DTypeKV_;  // backward-compat name; equal to DTypeK
+  using DTypeK = DTypeKV_;
+  using DTypeV = DTypeV_;
   using DTypeO = DTypeO_;
   using IdType = IdType_;
 
   DTypeQ* q;
   IdType* q_rope_offset;
-  paged_kv_t<DTypeKV, IdType> paged_kv;
+  paged_kv_t<DTypeK, IdType, DTypeV> paged_kv;
   DTypeO* o;
   float* lse;
   float* maybe_alibi_slopes;
@@ -159,11 +164,11 @@ struct BatchDecodeParams {
         partition_kv(false) {}
 
   __device__ __host__ BatchDecodeParams(DTypeQ* q, IdType* q_rope_offset,
-                                        paged_kv_t<DTypeKV, IdType> paged_kv, DTypeO* o, float* lse,
-                                        float* maybe_alibi_slopes, uint32_t num_qo_heads,
-                                        IdType q_stride_n, IdType q_stride_h, int32_t window_left,
-                                        float logits_soft_cap, float sm_scale, float rope_scale,
-                                        float rope_theta)
+                                        paged_kv_t<DTypeK, IdType, DTypeV> paged_kv, DTypeO* o,
+                                        float* lse, float* maybe_alibi_slopes,
+                                        uint32_t num_qo_heads, IdType q_stride_n, IdType q_stride_h,
+                                        int32_t window_left, float logits_soft_cap, float sm_scale,
+                                        float rope_scale, float rope_theta)
       : q(q),
         q_rope_offset(q_rope_offset),
         paged_kv(paged_kv),

--- a/include/flashinfer/attention/default_prefill_params.cuh
+++ b/include/flashinfer/attention/default_prefill_params.cuh
@@ -25,15 +25,17 @@
 
 namespace flashinfer {
 
-template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_>
+template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename DTypeV_ = DTypeKV_>
 struct SinglePrefillParams {
   using DTypeQ = DTypeQ_;
-  using DTypeKV = DTypeKV_;
+  using DTypeKV = DTypeKV_;  // backward-compat name; equal to DTypeK
+  using DTypeK = DTypeKV_;
+  using DTypeV = DTypeV_;
   using DTypeO = DTypeO_;
   using IdType = int32_t;
   DTypeQ* q;
-  DTypeKV* k;
-  DTypeKV* v;
+  DTypeK* k;
+  DTypeV* v;
   uint8_t* maybe_custom_mask;
   DTypeO* o;
   float* lse;
@@ -85,7 +87,7 @@ struct SinglePrefillParams {
         rope_rcp_theta(0.0f),
         partition_kv(false) {}
 
-  __host__ SinglePrefillParams(DTypeQ* q, DTypeKV* k, DTypeKV* v, uint8_t* maybe_custom_mask,
+  __host__ SinglePrefillParams(DTypeQ* q, DTypeK* k, DTypeV* v, uint8_t* maybe_custom_mask,
                                DTypeO* o, float* lse, float* maybe_alibi_slopes,
                                uint32_t num_qo_heads, uint32_t num_kv_heads, uint32_t qo_len,
                                uint32_t kv_len, uint32_t q_stride_n, uint32_t q_stride_h,
@@ -127,16 +129,19 @@ struct SinglePrefillParams {
   }
 };
 
-template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_>
+template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_,
+          typename DTypeV_ = DTypeKV_>
 struct BatchPrefillRaggedParams {
   using DTypeQ = DTypeQ_;
-  using DTypeKV = DTypeKV_;
+  using DTypeKV = DTypeKV_;  // backward-compat name; equal to DTypeK
+  using DTypeK = DTypeKV_;
+  using DTypeV = DTypeV_;
   using DTypeO = DTypeO_;
   using IdType = IdType_;
 
   DTypeQ* q;
-  DTypeKV* k;
-  DTypeKV* v;
+  DTypeK* k;
+  DTypeV* v;
   uint8_t* maybe_custom_mask;
   IdType* q_indptr;
   IdType* kv_indptr;
@@ -232,7 +237,7 @@ struct BatchPrefillRaggedParams {
         token_pos_in_items_len(0),
         maybe_max_item_len_ptr(nullptr) {}
 
-  __host__ BatchPrefillRaggedParams(DTypeQ* q, DTypeKV* k, DTypeKV* v, uint8_t* maybe_custom_mask,
+  __host__ BatchPrefillRaggedParams(DTypeQ* q, DTypeK* k, DTypeV* v, uint8_t* maybe_custom_mask,
                                     IdType* q_indptr, IdType* kv_indptr, IdType* maybe_mask_indptr,
                                     IdType* maybe_q_rope_offset, IdType* maybe_k_rope_offset,
                                     DTypeO* o, float* lse, float* maybe_alibi_slopes,
@@ -298,15 +303,18 @@ struct BatchPrefillRaggedParams {
   }
 };
 
-template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_>
+template <typename DTypeQ_, typename DTypeKV_, typename DTypeO_, typename IdType_,
+          typename DTypeV_ = DTypeKV_>
 struct BatchPrefillPagedParams {
   using DTypeQ = DTypeQ_;
-  using DTypeKV = DTypeKV_;
+  using DTypeKV = DTypeKV_;  // backward-compat name; equal to DTypeK
+  using DTypeK = DTypeKV_;
+  using DTypeV = DTypeV_;
   using DTypeO = DTypeO_;
   using IdType = IdType_;
 
   DTypeQ* q;
-  paged_kv_t<DTypeKV, IdType> paged_kv;
+  paged_kv_t<DTypeK, IdType, DTypeV> paged_kv;
   uint8_t* maybe_custom_mask;
   IdType* q_indptr;
   IdType* maybe_mask_indptr;
@@ -387,7 +395,7 @@ struct BatchPrefillPagedParams {
         token_pos_in_items_len(0),
         maybe_max_item_len_ptr(nullptr) {}
 
-  __host__ BatchPrefillPagedParams(DTypeQ* q, paged_kv_t<DTypeKV, IdType> paged_kv,
+  __host__ BatchPrefillPagedParams(DTypeQ* q, paged_kv_t<DTypeK, IdType, DTypeV> paged_kv,
                                    uint8_t* maybe_custom_mask, IdType* q_indptr,
                                    IdType* maybe_mask_indptr, IdType* maybe_q_rope_offset,
                                    DTypeO* o, float* lse, float* maybe_alibi_slopes,

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -528,6 +528,12 @@ template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool L
           typename AttentionVariant, typename Params>
 cudaError_t SinglePrefillWithKVCacheDispatched(Params& params, cudaStream_t stream) {
   static_assert(HEAD_DIM_VO == 64 || HEAD_DIM_VO == 128 || HEAD_DIM_VO == 256);
+  // Asymmetric K/V plumbing: the SM90 mainloop, TMA descriptors and kernel
+  // traits are parameterized on a single KV dtype. Guard until the Hopper
+  // path splits DTypeK/DTypeV; asymmetric K/V is decode-only today.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "SM90 SinglePrefillWithKVCacheDispatched does not yet support "
+                "asymmetric K/V dtypes; only decode kernels do");
   if (MASK_MODE == MaskMode::kCustom) {
     return cudaErrorNotSupported;  // Not supported yet.
   }
@@ -549,6 +555,10 @@ template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool L
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params& params, bool enable_pdl,
                                                     cudaStream_t stream) {
   static_assert(HEAD_DIM_VO == 64 || HEAD_DIM_VO == 128 || HEAD_DIM_VO == 256);
+  // Asymmetric K/V plumbing; see SM90 SinglePrefillWithKVCacheDispatched.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "SM90 BatchPrefillWithRaggedKVCacheDispatched does not yet "
+                "support asymmetric K/V dtypes; only decode kernels do");
   if (MASK_MODE == MaskMode::kCustom) {
     return cudaErrorNotSupported;  // Not supported yet.
   }
@@ -570,6 +580,10 @@ template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool L
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_pdl,
                                                    cudaStream_t stream) {
   static_assert(HEAD_DIM_VO == 64 || HEAD_DIM_VO == 128 || HEAD_DIM_VO == 256);
+  // Asymmetric K/V plumbing; see SM90 SinglePrefillWithKVCacheDispatched.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "SM90 BatchPrefillWithPagedKVCacheDispatched does not yet "
+                "support asymmetric K/V dtypes; only decode kernels do");
   if (MASK_MODE == MaskMode::kCustom) {
     return cudaErrorNotSupported;  // Not supported yet.
   }

--- a/include/flashinfer/attention/hopper/quantization/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/quantization/prefill_sm90.cuh
@@ -393,6 +393,10 @@ template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
 cudaError_t SingleFP8PrefillWithKVCacheDispatched(Params& params, cudaStream_t stream) {
   static_assert(cutlass::sizeof_bits_v<typename Params::DTypeQ> == 8);
   static_assert(cutlass::sizeof_bits_v<typename Params::DTypeKV> == 8);
+  // Asymmetric K/V plumbing; this quantized path assumes one KV dtype.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "SM90 SingleFP8PrefillWithKVCacheDispatched does not support "
+                "asymmetric K/V dtypes; only decode kernels do");
   static_assert(HEAD_DIM == 64 || HEAD_DIM == 128 || HEAD_DIM == 256);
   if (MASK_MODE == MaskMode::kCustom) {
     return cudaErrorNotSupported;  // Not supported yet.
@@ -436,6 +440,10 @@ template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
 cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched(Params& params, bool enable_pdl,
                                                       cudaStream_t stream) {
   static_assert(HEAD_DIM == 64 || HEAD_DIM == 128 || HEAD_DIM == 256);
+  // Asymmetric K/V plumbing; this quantized path assumes one KV dtype.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "SM90 BatchFP8PrefillWithPagedKVCacheDispatched does not "
+                "support asymmetric K/V dtypes; only decode kernels do");
   if (MASK_MODE == MaskMode::kCustom) {
     return cudaErrorNotSupported;  // Not supported yet.
   }
@@ -556,6 +564,10 @@ template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
 cudaError_t BatchFP8PrefillWithRaggedKVCacheDispatched(Params& params, bool enable_pdl,
                                                        cudaStream_t stream) {
   static_assert(HEAD_DIM == 64 || HEAD_DIM == 128 || HEAD_DIM == 256);
+  // Asymmetric K/V plumbing; this quantized path assumes one KV dtype.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "SM90 BatchFP8PrefillWithRaggedKVCacheDispatched does not "
+                "support asymmetric K/V dtypes; only decode kernels do");
   if (MASK_MODE == MaskMode::kCustom) {
     return cudaErrorNotSupported;  // Not supported yet.
   }

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -25,6 +25,8 @@
 #endif
 #include <cuda_runtime.h>
 
+#include <type_traits>
+
 #include "../cp_async.cuh"
 #include "../fastdiv.cuh"
 #ifdef FP16_QK_REDUCTION_SUPPORTED
@@ -2376,6 +2378,13 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
                                                cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
+  // Asymmetric K/V plumbing: the prefill kernel body still assumes a single
+  // KV element type for shared-memory layout, swizzle mode selection, and
+  // FP8 dequantization. Guard until the kernel body splits DTypeK/DTypeV;
+  // asymmetric K/V is currently supported by the decode kernels only.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "SinglePrefillWithKVCacheDispatched does not yet support "
+                "asymmetric K/V dtypes; only decode kernels do");
   using DTypeO = typename Params::DTypeO;
   const uint32_t num_qo_heads = params.num_qo_heads;
   const uint32_t num_kv_heads = params.num_kv_heads;
@@ -3979,6 +3988,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
                                                     cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
+  // Asymmetric K/V plumbing; see SinglePrefillWithKVCacheDispatched above.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "BatchPrefillWithRaggedKVCacheDispatched does not yet support "
+                "asymmetric K/V dtypes; only decode kernels do");
   using DTypeO = typename Params::DTypeO;
   const uint32_t padded_batch_size = params.padded_batch_size;
   const uint32_t num_qo_heads = params.num_qo_heads;
@@ -4181,6 +4194,10 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
                                                    cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
+  // Asymmetric K/V plumbing; see SinglePrefillWithKVCacheDispatched above.
+  static_assert(std::is_same_v<typename Params::DTypeK, typename Params::DTypeV>,
+                "BatchPrefillWithPagedKVCacheDispatched does not yet support "
+                "asymmetric K/V dtypes; only decode kernels do");
   using DTypeO = typename Params::DTypeO;
   const uint32_t padded_batch_size = params.padded_batch_size;
   const uint32_t num_qo_heads = params.num_qo_heads;

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -153,8 +153,12 @@ inline cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatched(
     typename Params::IdType* kv_indptr_h, const uint32_t num_qo_heads, const uint32_t page_size,
     bool enable_cuda_graph, cudaStream_t stream) {
   using DTypeKV = typename Params::DTypeKV;
+  using DTypeK = typename Params::DTypeK;
+  using DTypeV = typename Params::DTypeV;
   using IdType = typename Params::IdType;
-  constexpr uint32_t vec_size = std::max(16UL / sizeof(DTypeKV), HEAD_DIM / 32UL);
+  // Must match the vec_size in BatchDecodeWithPagedKVCacheDispatched.
+  constexpr size_t min_kv_sizeof = std::min(sizeof(DTypeK), sizeof(DTypeV));
+  constexpr uint32_t vec_size = std::max(16UL / min_kv_sizeof, HEAD_DIM / 32UL);
   auto compute_capacity = GetCudaComputeCapability();
   DISPATCH_COMPUTE_CAP_DECODE_NUM_STAGES_SMEM(compute_capacity, NUM_STAGES_SMEM, {
     constexpr uint32_t bdx = HEAD_DIM / vec_size;
@@ -162,12 +166,13 @@ inline cudaError_t BatchDecodeWithPagedKVCacheWorkEstimationDispatched(
     constexpr uint32_t bdy = GROUP_SIZE;
     constexpr uint32_t num_threads = std::max(128U, bdx * bdy);
     constexpr uint32_t bdz = num_threads / (bdx * bdy);
-    constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (sizeof(DTypeKV) == 1 ? 2U : 4U) : 1U;
+    constexpr uint32_t tile_size_per_bdx = GROUP_SIZE == 1 ? (min_kv_sizeof == 1 ? 2U : 4U) : 1U;
     const uint32_t num_kv_heads = num_qo_heads / GROUP_SIZE;
     gdy = num_kv_heads;
     const uint32_t smem_size =
-        2 * NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz * HEAD_DIM * sizeof(DTypeKV) +
-        std::max(tile_size_per_bdx * num_threads * sizeof(DTypeKV*), 2 * bdy * bdz * sizeof(float));
+        NUM_STAGES_SMEM * tile_size_per_bdx * bdy * bdz * HEAD_DIM *
+            (sizeof(DTypeK) + sizeof(DTypeV)) +
+        std::max(tile_size_per_bdx * num_threads * sizeof(size_t), 2 * bdy * bdz * sizeof(float));
 
     auto kernel =
         BatchDecodeWithPagedKVCacheKernel<POS_ENCODING_MODE, NUM_STAGES_SMEM, tile_size_per_bdx,

--- a/include/flashinfer/page.cuh
+++ b/include/flashinfer/page.cuh
@@ -31,11 +31,22 @@ namespace flashinfer {
 /*!
  * \brief Paged key-value cache
  * \tparam layout The layout of last 3 dimensions in KV-Cache.
- * \tparam DType The data type of the key-value cache
- * \tparam IdType The index data type of the kv-cache
+ * \tparam DTypeK The data type of the key cache.
+ * \tparam IdType The index data type of the kv-cache.
+ * \tparam DTypeV The data type of the value cache (defaults to DTypeK for
+ *                symmetric caches; may differ for asymmetric K/V quantization
+ *                schemes such as FP16-K / FP8-V).
+ *
+ * Backward compatibility: existing `paged_kv_t<DType, IdType>` call sites
+ * continue to work because `DTypeV` defaults to `DTypeK`. Asymmetric callers
+ * supply all three template arguments.
  */
-template <typename DType, typename IdType>
+template <typename DTypeK, typename IdType, typename DTypeV = DTypeK>
 struct paged_kv_t {
+  // Backward-compat alias for callers that reference
+  // `paged_kv_t<...>::DType`. New code should use `DTypeK` / `DTypeV`.
+  using DType = DTypeK;
+
   uint_fastdiv page_size;
   uint32_t num_heads;
   uint32_t head_dim;
@@ -47,8 +58,11 @@ struct paged_kv_t {
   // Internal layout:
   // [max_num_pages, num_heads, page_size, head_dim] if layout == HND
   // [max_num_pages, page_size, num_heads, head_dim] if layout == NHD
-  DType* k_data;
-  DType* v_data;
+  //
+  // K and V may point at buffers of different element types. See class
+  // docstring above for the backward-compat rule.
+  DTypeK* k_data;
+  DTypeV* v_data;
   IdType* indices;
 
   // [batch_size + 1] The page indptr array, with the first element 0, the last element nnz_pages
@@ -91,8 +105,8 @@ struct paged_kv_t {
    * \param rope_pos_offset The start position of each request in the batch.
    */
   __host__ __forceinline__ paged_kv_t(uint32_t num_heads, uint32_t page_size, uint32_t head_dim,
-                                      uint32_t batch_size, QKVLayout layout, DType* k_data,
-                                      DType* v_data, IdType* indices, IdType* indptr,
+                                      uint32_t batch_size, QKVLayout layout, DTypeK* k_data,
+                                      DTypeV* v_data, IdType* indices, IdType* indptr,
                                       IdType* last_page_len, IdType* rope_pos_offset = nullptr)
       : num_heads(num_heads),
         page_size(page_size),
@@ -125,8 +139,8 @@ struct paged_kv_t {
    * \param rope_pos_offset The start position of each request in the batch.
    */
   __host__ __forceinline__ paged_kv_t(uint32_t num_heads, uint32_t page_size, uint32_t head_dim,
-                                      uint32_t batch_size, QKVLayout layout, DType* k_data,
-                                      DType* v_data, const int64_t* kv_strides, IdType* indices,
+                                      uint32_t batch_size, QKVLayout layout, DTypeK* k_data,
+                                      DTypeV* v_data, const int64_t* kv_strides, IdType* indices,
                                       IdType* indptr, IdType* last_page_len,
                                       IdType* rope_pos_offset = nullptr)
       : num_heads(num_heads),
@@ -176,8 +190,8 @@ struct paged_kv_t {
     return head_idx * stride_h + entry_idx * stride_n + feat_idx;
   }
 
-  __device__ __forceinline__ DType* get_k_ptr(IdType page_iter, uint32_t head_idx,
-                                              uint32_t entry_idx, uint32_t feat_idx) const {
+  __device__ __forceinline__ DTypeK* get_k_ptr(IdType page_iter, uint32_t head_idx,
+                                               uint32_t entry_idx, uint32_t feat_idx) const {
     return k_data + get_elem_offset(__ldg(indices + page_iter), head_idx, entry_idx, feat_idx);
   }
 
@@ -191,20 +205,20 @@ struct paged_kv_t {
     }
   }
 
-  __device__ __forceinline__ DType* protective_get_k_ptr(IdType page_iter, uint32_t head_idx,
-                                                         uint32_t entry_idx, uint32_t feat_idx,
-                                                         IdType last_indptr) const {
+  __device__ __forceinline__ DTypeK* protective_get_k_ptr(IdType page_iter, uint32_t head_idx,
+                                                          uint32_t entry_idx, uint32_t feat_idx,
+                                                          IdType last_indptr) const {
     return k_data + protective_get_kv_offset(page_iter, head_idx, entry_idx, feat_idx, last_indptr);
   }
 
-  __device__ __forceinline__ DType* get_v_ptr(IdType page_iter, uint32_t head_idx,
-                                              uint32_t entry_idx, uint32_t feat_idx) const {
+  __device__ __forceinline__ DTypeV* get_v_ptr(IdType page_iter, uint32_t head_idx,
+                                               uint32_t entry_idx, uint32_t feat_idx) const {
     return v_data + get_elem_offset(__ldg(indices + page_iter), head_idx, entry_idx, feat_idx);
   }
 
-  __device__ __forceinline__ DType* protective_get_v_ptr(IdType page_iter, uint32_t head_idx,
-                                                         uint32_t entry_idx, uint32_t feat_idx,
-                                                         IdType last_indptr) const {
+  __device__ __forceinline__ DTypeV* protective_get_v_ptr(IdType page_iter, uint32_t head_idx,
+                                                          uint32_t entry_idx, uint32_t feat_idx,
+                                                          IdType last_indptr) const {
     return v_data + protective_get_kv_offset(page_iter, head_idx, entry_idx, feat_idx, last_indptr);
   }
 };

--- a/tests/attention/test_asymmetric_kv_decode.py
+++ b/tests/attention/test_asymmetric_kv_decode.py
@@ -1,0 +1,382 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Tests for asymmetric K/V cache dtypes in batch decode: the K cache stays
+at native precision (fp16/bf16) while the V cache is stored in FP8. Keys
+feed the softmax score path, so K precision dominates output quality;
+values sit behind the associative reduction, so FP8 V costs only FP8-level
+noise. These tests validate the plumbing (JIT URI keying, plan/run dtype
+validation, backend guards) and the kernel numerics against a float32
+torch reference that reads K natively and dequantizes V.
+"""
+
+import itertools
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.jit.attention.modules import (
+    gen_batch_decode_module,
+    get_batch_decode_uri,
+)
+from flashinfer.utils import has_flashinfer_jit_cache
+
+K_DTYPES = [torch.float16, torch.bfloat16]
+V_DTYPES = [torch.float8_e4m3fn, torch.float8_e5m2]
+HEAD_DIMS = [128, 256]
+
+# fp8-e4m3 quantization of V bounds the relative error of the attention
+# output; empirically the median sits near 0.02 for random inputs. 0.10
+# gives comfortable headroom without letting a K-side bug (whose error
+# would be O(1)) pass.
+MEDIAN_REL_ERR_BOUND = 0.10
+
+
+@pytest.fixture(
+    autouse=not has_flashinfer_jit_cache(),
+    scope="module",
+)
+def warmup_jit():
+    specs = []
+    for k_dtype, v_dtype, head_dim in itertools.product(K_DTYPES, V_DTYPES, HEAD_DIMS):
+        specs.append(
+            gen_batch_decode_module(
+                k_dtype,  # dtype_q (q matches k precision)
+                k_dtype,  # dtype_kv (anchor; dtype_k defaults to this)
+                k_dtype,  # dtype_o
+                torch.int32,
+                head_dim,
+                head_dim,
+                0,  # pos_encoding_mode
+                False,  # use_sliding_window
+                False,  # use_logits_soft_cap
+                dtype_k=k_dtype,
+                dtype_v=v_dtype,
+            )
+        )
+    flashinfer.jit.build_jit_specs(specs, verbose=False)
+    yield
+
+
+def _build_paged_cache(
+    batch_size, kv_len, page_size, num_kv_heads, head_dim, kv_layout, dtype
+):
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    if kv_layout == "HND":
+        shape = [total_num_pages, num_kv_heads, page_size, head_dim]
+    else:
+        shape = [total_num_pages, page_size, num_kv_heads, head_dim]
+    data_fp32 = torch.randn(*shape, dtype=torch.float32, device="cuda:0") * 0.5
+    data = data_fp32.to(dtype)
+    return data, data_fp32, num_pages_per_seq, total_num_pages
+
+
+def _gather_seq(cache_fp32, indptr, last_page_len, i, kv_layout):
+    """Gather sequence i's entries from a paged cache into [L, H, D]."""
+    if kv_layout == "HND":
+        full = cache_fp32[indptr[i] : indptr[i + 1] - 1].permute(0, 2, 1, 3)
+        last = cache_fp32[indptr[i + 1] - 1, :, : last_page_len[i]].permute(1, 0, 2)
+    else:
+        full = cache_fp32[indptr[i] : indptr[i + 1] - 1]
+        last = cache_fp32[indptr[i + 1] - 1, : last_page_len[i]]
+    num_kv_heads, head_dim = full.shape[-2], full.shape[-1]
+    return torch.cat([full.reshape(-1, num_kv_heads, head_dim), last], dim=0)
+
+
+def _ref_decode(q, k, v, sm_scale):
+    """float32 reference decode. q: [H_qo, D]; k, v: [L, H_kv, D]."""
+    num_qo_heads = q.shape[0]
+    num_kv_heads = k.shape[1]
+    group_size = num_qo_heads // num_kv_heads
+    k = k.repeat_interleave(group_size, dim=1)  # [L, H_qo, D]
+    v = v.repeat_interleave(group_size, dim=1)
+    logits = torch.einsum("hd,lhd->hl", q.float(), k.float()) * sm_scale
+    p = torch.softmax(logits, dim=-1)
+    return torch.einsum("hl,lhd->hd", p, v.float())
+
+
+@pytest.mark.parametrize("batch_size", [7, 61])
+@pytest.mark.parametrize("kv_len", [54, 517])
+@pytest.mark.parametrize("page_size", [1, 16])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("head_dim", HEAD_DIMS)
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("k_dtype", K_DTYPES)
+@pytest.mark.parametrize("v_dtype", V_DTYPES)
+def test_batch_decode_asymmetric_kv(
+    batch_size,
+    kv_len,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    kv_layout,
+    k_dtype,
+    v_dtype,
+):
+    torch.manual_seed(42)
+    q = torch.randn(batch_size, num_qo_heads, head_dim, device="cuda:0", dtype=k_dtype)
+    k_cache, _, num_pages_per_seq, total_num_pages = _build_paged_cache(
+        batch_size, kv_len, page_size, num_kv_heads, head_dim, kv_layout, k_dtype
+    )
+    v_cache, _, _, _ = _build_paged_cache(
+        batch_size, kv_len, page_size, num_kv_heads, head_dim, kv_layout, v_dtype
+    )
+
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device="cuda:0", dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,),
+        (kv_len - 1) % page_size + 1,
+        dtype=torch.int32,
+        device="cuda:0",
+    )
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=k_dtype,
+        k_data_type=k_dtype,
+        v_data_type=v_dtype,
+    )
+    o = wrapper.run(q, (k_cache, v_cache))
+
+    # Reference: K read at its stored precision (native fp16/bf16), V
+    # dequantized from fp8 -- exactly what the kernel is expected to do.
+    sm_scale = 1.0 / (head_dim**0.5)
+    k_stored_fp32 = k_cache.float()
+    v_dequant_fp32 = v_cache.float()
+    rel_errs = []
+    for i in range(batch_size):
+        ki = _gather_seq(k_stored_fp32, kv_indptr, kv_last_page_len, i, kv_layout)
+        vi = _gather_seq(v_dequant_fp32, kv_indptr, kv_last_page_len, i, kv_layout)
+        o_ref = _ref_decode(q[i], ki, vi, sm_scale)
+        rel = (o[i].float() - o_ref).norm() / o_ref.norm().clamp_min(1e-6)
+        rel_errs.append(rel.item())
+    median_rel_err = sorted(rel_errs)[len(rel_errs) // 2]
+    assert median_rel_err < MEDIAN_REL_ERR_BOUND, (
+        f"median rel err {median_rel_err} exceeds {MEDIAN_REL_ERR_BOUND} "
+        f"(k={k_dtype}, v={v_dtype})"
+    )
+
+
+def test_asymmetric_one_hot_v_selection_and_lse():
+    """Structured oracle: K concentrates attention on one known token per
+    sequence and V carries a distinctive fp8-representable constant there,
+    so the output must reproduce the selected V row exactly. The LSE and
+    output are also compared against the symmetric kernel run on the
+    dequantized V (a convention-free oracle: LSE depends only on Q and K,
+    and K is stored bit-exact)."""
+    batch, page_size, pages_per_seq = 4, 16, 4
+    num_kv = num_qo = 4
+    head_dim = 128
+    k_dtype, v_dtype = torch.bfloat16, torch.float8_e4m3fn
+
+    q = torch.ones(batch, num_qo, head_dim, device="cuda:0", dtype=k_dtype)
+    k = torch.zeros(
+        batch * pages_per_seq,
+        page_size,
+        num_kv,
+        head_dim,
+        device="cuda:0",
+        dtype=k_dtype,
+    )
+    v = torch.zeros(
+        batch * pages_per_seq,
+        page_size,
+        num_kv,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float32,
+    )
+    expected = torch.zeros(batch, num_qo, head_dim, device="cuda:0")
+    targets = [3, 17, 40, 62]  # one token per sequence, distinct pages
+    for i, t in enumerate(targets):
+        page, slot = divmod(t, page_size)
+        k[i * pages_per_seq + page, slot, :, :] = 10.0
+        val = 0.5 + 0.25 * i  # exactly representable in fp8 e4m3
+        v[i * pages_per_seq + page, slot, :, :] = val
+        expected[i, :, :] = val
+    v_fp8 = v.to(v_dtype)
+
+    indptr = (
+        torch.arange(0, batch + 1, device="cuda:0", dtype=torch.int32) * pages_per_seq
+    )
+    indices = torch.arange(0, batch * pages_per_seq, device="cuda:0", dtype=torch.int32)
+    last = torch.full((batch,), page_size, dtype=torch.int32, device="cuda:0")
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+
+    w = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, "NHD")
+    w.plan(
+        indptr,
+        indices,
+        last,
+        num_qo,
+        num_kv,
+        head_dim,
+        page_size,
+        q_data_type=k_dtype,
+        k_data_type=k_dtype,
+        v_data_type=v_dtype,
+    )
+    out, lse = w.run(q, (k, v_fp8), return_lse=True)
+    assert (out.float() - expected).abs().max().item() < 1e-2
+    assert torch.isfinite(out.float()).all()
+    assert torch.isfinite(lse).all()
+
+    w_sym = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0"),
+        "NHD",
+    )
+    w_sym.plan(
+        indptr,
+        indices,
+        last,
+        num_qo,
+        num_kv,
+        head_dim,
+        page_size,
+        q_data_type=k_dtype,
+        kv_data_type=k_dtype,
+    )
+    out_sym, lse_sym = w_sym.run(q, (k, v_fp8.to(k_dtype)), return_lse=True)
+    assert (lse.float() - lse_sym.float()).abs().max().item() < 1e-2
+    assert (out.float() - out_sym.float()).abs().max().item() < 1e-2
+
+
+def test_asymmetric_uri_backward_compat():
+    """Symmetric callers must keep their exact JIT cache keys."""
+    common = (
+        torch.float16,  # dtype_q
+        torch.float16,  # dtype_kv
+        torch.float16,  # dtype_o
+        torch.int32,
+        128,
+        128,
+        0,
+        False,
+        False,
+    )
+    legacy = get_batch_decode_uri(*common)
+    explicit_symmetric = get_batch_decode_uri(
+        *common, dtype_k=torch.float16, dtype_v=torch.float16
+    )
+    assert legacy == explicit_symmetric
+    assert "dtype_kv_f16" in legacy
+
+    asym = get_batch_decode_uri(
+        *common, dtype_k=torch.float16, dtype_v=torch.float8_e4m3fn
+    )
+    assert asym != legacy
+    assert "dtype_k_f16" in asym and "dtype_v_e4m3" in asym
+
+
+def _plan_asym(wrapper, head_dim=128, page_size=16):
+    batch_size, kv_len = 4, 64
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(
+        0, num_pages_per_seq * batch_size, device="cuda:0", dtype=torch.int32
+    )
+    kv_last_page_len = torch.full(
+        (batch_size,), page_size, dtype=torch.int32, device="cuda:0"
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        4,
+        4,
+        head_dim,
+        page_size,
+        q_data_type=torch.float16,
+        k_data_type=torch.float16,
+        v_data_type=torch.float8_e4m3fn,
+    )
+    return batch_size, kv_len
+
+
+def test_asymmetric_run_v_dtype_mismatch_raises():
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer, "NHD"
+    )
+    batch_size, kv_len = _plan_asym(wrapper)
+    page_size, num_kv_heads, head_dim = 16, 4, 128
+    total_pages = ((kv_len + page_size - 1) // page_size) * batch_size
+    q = torch.randn(batch_size, 4, head_dim, device="cuda:0", dtype=torch.float16)
+    k_cache = torch.randn(
+        total_pages,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    # V handed over in fp16 against a plan that promised fp8 must raise,
+    # not silently reinterpret bytes.
+    v_cache_wrong = torch.randn(
+        total_pages,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    with pytest.raises(ValueError, match="v_data_type"):
+        wrapper.run(q, (k_cache, v_cache_wrong))
+
+
+def test_asymmetric_tensor_cores_raises():
+    workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer, "NHD", use_tensor_cores=True
+    )
+    with pytest.raises(NotImplementedError, match=r"[Aa]symmetric"):
+        _plan_asym(wrapper)
+
+
+def test_single_decode_asymmetric_raises():
+    # The public single-decode API keys its JIT module on k.dtype only;
+    # mixed-dtype V must be rejected, not reinterpreted.
+    q = torch.randn(4, 128, device="cuda:0", dtype=torch.float16)
+    k = torch.randn(64, 4, 128, device="cuda:0", dtype=torch.float16)
+    v = torch.randn(64, 4, 128, device="cuda:0", dtype=torch.float16).to(
+        torch.float8_e4m3fn
+    )
+    with pytest.raises(NotImplementedError, match=r"[Aa]symmetric"):
+        flashinfer.single_decode_with_kv_cache(q, k, v)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

K and V cache precision should be independently selectable. Today FlashInfer
forces a single `dtype_kv` for both. This PR adds the first narrow instance of
splitting them: the **CUDA-core (FA2) batch-decode path** can keep K at native
precision (fp16/bf16) while storing V in FP8 (e4m3/e5m2). Everything else —
prefill (SM80 and SM90), and the tensor-core / trtllm-gen / cute-dsl decode
paths — is explicitly out of scope and **fails closed** (a clear
`NotImplementedError` at `plan()` or a `static_assert` at compile), so no code
path silently reinterprets bytes.

Opt-in on the wrapper:

```python
wrapper.plan(
    ...,
    k_data_type=torch.bfloat16,        # keys stay native precision
    v_data_type=torch.float8_e4m3fn,   # values in FP8
    use_tensor_cores=False,            # CUDA-core decode only
)
```

Both new kwargs default to `kv_data_type`, so **existing callers are unchanged
and generate the same JIT module URIs** — no cache churn.

## Motivation

Symmetric FP8 KV quantization degrades output quality on a specific,
*predictable* class of models rather than uniformly. The sensitivity lives in
the keys: keys feed the softmax score path, so quantization error there is
amplified through the exponential, whereas values sit behind the associative
reduction and tolerate FP8 well. Which architectures are fragile is
predictable from their positional-encoding design (models whose keys carry a
systematic bias — RoPE-with-bias and partial-RoPE families — are the fragile
ones; QK-Norm architectures are largely immune). We characterized the affected
set and root-caused the mechanism here:

- **FP8 KV-Cache Failure Atlas** — which models break under symmetric FP8 KV
  and the architectural reason why: https://knlp.io/fp8-kv-failure-atlas.html
- **Decode-path validation / reproduction**: https://knlp.io/decode

Keeping K native and storing only V in FP8 sidesteps the failure while still
recovering most of the memory: **0.75× the KV bytes of FP16** (K16 + V8), with
**zero calibration** (K is bit-exact; only V is quantized, using a hardware
dtype). On models where symmetric FP8 KV collapses, this preserves quality;
on models that already tolerate symmetric FP8, users simply keep using it.

This is complementary to, not competing with, the NVFP4 packed-KV work: today
`dtype_kv` is a single slot, and this PR is the minimal generalization that
lets K and V occupy independently-chosen slots. The same plumbing is what a
future "K in one low-precision format, V in another" would build on.

## Scope and guards (what is and isn't covered)

Covered: `BatchDecodeWithPagedKVCacheWrapper` on the CUDA-core FA2 decode path.

Fail-closed everywhere else, in the same PR:
- Prefill (SM80 `prefill.cuh` + SM90 `hopper/prefill_sm90.cuh` and
  `hopper/quantization/prefill_sm90.cuh`): `static_assert(DTypeK == DTypeV)` at
  all dispatch entry points. Symmetric prefill is untouched and byte-identical.
- `use_tensor_cores=True` (which routes decode through *prefill* kernels), and
  the trtllm-gen / cute-dsl backends (which force tensor cores): rejected with
  `NotImplementedError` at `plan()` — not a silent symmetric fallback.
- `single_decode_with_kv_cache`: guarded and not implemented (the `single_*`
  JIT configs don't receive per-side dtypes yet); the public API raises rather
  than reinterpreting a V cache under a K-keyed module.
- Asymmetric request + a user-supplied custom `jit_args` module: rejected in
  both `plan()` and `workspace_size()`.

## No intended change for symmetric users (with regression tests)

This is not claimed as a bit-identical no-op at the SASS level, but there is no
*intended* behavioral change for anyone not passing split dtypes, and it is
covered by regression tests:
- The JIT URI helper emits the **legacy `dtype_kv_X` fragment** whenever the
  effective K and V dtypes match, so every existing cache key is preserved.
- Shared-memory sizing and load vectorization reduce algebraically to the prior
  `2 * sizeof(DTypeKV)` form when `DTypeK == DTypeV`, so symmetric
  instantiations are byte-identical.
- `paged_kv_t`'s third template parameter defaults to `DTypeK`, keeping every
  two-arg call site compiling and meaning exactly what it did.

## Validation

**This series — fresh gate on the upstream-rebased branch (L40S / SM89).**
Direct evidence for the exact code submitted here:

- `test_asymmetric_kv_decode.py` full matrix: **260/260 passed** —
  {fp16,bf16} × {e4m3,e5m2} × head_dim {128,256} × {NHD,HND} × GQA {1,8} ×
  page {1,16} × kv {54,517} × batch {7,61}, plus URI back-compat, negative,
  and oracle tests.
- Symmetric regression (`test_batch_decode_with_paged_kv_cache`): **576 passed,
  0 failed** (288 hd512 cells skipped — need SM100).
- Structured oracles: one-hot V selection max err **0.0**; LSE vs the symmetric
  kernel **0.0**; output vs symmetric kernel on FP8-representable values
  **0.0**; fp8 quantization error percentiles P50/P95/MAX ≈ 0.0017/0.0018/0.0018.
- End-to-end model gate: decode relative error **0.0248**.
- Symmetric decode perf vs `main`: **≤0.07% delta** (noise) at fp16 and
  fp8 (batch 64, kv 1024, 8 heads, hd128, median of 100).
- Symmetric SM90 prefill JIT compile (arch-forced 9.0a): **OK** — the new
  guards are inert for symmetric Hopper builds.

**The preview branch — prior end-to-end validation.**
This PR is the decode half of the `mcgrof/flashinfer` preview branch
[`paper-memory-decode-v0.18`](https://github.com/mcgrof/flashinfer/tree/paper-memory-decode-v0.18),
restructured into 6 atomic commits and rebased onto current upstream `main` —
same code, new base and commit layout. That preview branch was validated end to
end across NVIDIA **H100, A100, and B200** (plus consumer Ada/Ampere parts used
for kernel bring-up), over **14 models across 7 families**. Full matrix +
methodology: https://knlp.io/decode · https://knlp.io/fp8-kv-failure-atlas.html .
Headline results:

- Decode kernel, BF16-K / FP8-V: **rel err 0.0254** vs a BF16 reference;
  matches FP16 within measurement noise and is ~**33% faster** than symmetric
  FP8 (no K-dequant on the softmax score path).
- Quality on a fragile-key model (Qwen2.5-7B) where symmetric FP8 collapses:
  perplexity matches FP16 at 2K/8K; **GSM8K 90.0% vs 90.5% FP16** (n=200);
  **NIAH multi-key @32K: 0.89 asym vs 0.84 FP16 vs 0.00 symmetric FP8**.
  Tolerant models (e.g. Llama-3.1-8B) are unaffected either way.
- Throughput: across 8 open-weight models at batch 32 on H100, asymmetric is
  **4.8–9.6% faster** than symmetric FP8 at **1.33× KV capacity**.

That end-to-end validation used the full research stack (which also carried an
asymmetric *prefill* path); **this PR upstreams the decode kernel only**, with
prefill fail-closed as described above. The fresh gate above confirms the
rebase reproduces that decode accuracy (0.0248 rel err) and stays
symmetric-safe and perf-neutral.

## Known constraint (inherited, not introduced)

The CUDA-core decode dispatch supports GQA group size ∈ **{1, 2, 3, 4, 8}**
(upstream `DISPATCH_GQA_GROUP_SIZE`, unchanged). Asymmetric K/V inherits this
exactly — it neither widens nor narrows it. Models with a q:kv head ratio of 7
(e.g. Qwen2.5-7B at TP=1, 28q/4kv) cannot use this wrapper at all, symmetric or
asymmetric; that is a pre-existing property of the path, called out here so it
isn't mistaken for an asym limitation.

## Who consumes this

The immediate consumer is a companion vLLM integration in the `mcgrof/vllm`
fork (asymmetric K16/V8 KV cache), together with the LMCache asymmetric K16/V8
storage codec (merged upstream, LMCache https://github.com/LMCache/LMCache/pull/3277), which already produces exactly
this K16+V8 object. That vLLM work (branch `20260702-k16fp8`) is a separate,
later upstream train and does not run on vLLM mainline today — this PR stands
on its own and does not depend on it.

## Commits (6, atomic)

1. `page.cuh: split paged_kv_t DType into DTypeK and DTypeV`
2. `attention: plumb DTypeK/DTypeV through params and JIT configs, assert equal`
3. `jit: thread dtype_k/dtype_v through module generators and bindings`
4. `decode: implement asymmetric K/V in the BatchDecode kernel and scheduler`
5. `decode.py: add k_data_type/v_data_type to BatchDecodeWithPagedKVCacheWrapper.plan`
6. `tests: add asymmetric K/V batch decode tests`

## For reviewers

- New test: `pytest tests/attention/test_asymmetric_kv_decode.py`
- Symmetric regression: `pytest tests/attention/test_batch_decode_kernels.py`
- The symmetric-safety argument is checkable from commit 1 (default template
  arg), commit 3 (URI fragment), and commit 4 (smem/vec algebra).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asymmetric KV cache datatype support for paged batch decode, enabling independent key (K) and value (V) dtypes.
  * JIT module selection and cache-key/URI generation now reflect the (K dtype, V dtype) pair for asymmetric runs, while preserving the legacy key for symmetric cases.
* **Bug Fixes**
  * Improved runtime dtype validation with clearer, more specific mismatch errors (including checks against the planned V dtype).
* **Tests**
  * Added new tests covering asymmetric correctness, JIT cache-key behavior, and negative cases (including decode-only support and tensor-core/custom-module limitations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->