### PR TITLE
Fix B Matrix Layout in BMM MXFP8 Test

### DIFF
--- a/tests/gemm/test_bmm_mxfp8.py
+++ b/tests/gemm/test_bmm_mxfp8.py
@@ -26,9 +26,22 @@ def test_bmm_mxfp8(
         pytest.skip("bmm_mxfp8 cutlass backend requires SM12x.")
     if backend == "cutlass" and not is_sf_swizzled_layout:
         pytest.skip("bmm_mxfp8 cutlass backend on SM12x only supports swizzled layout.")
+    if backend == "cudnn" and not is_sf_swizzled_layout:
+        pytest.skip(
+            "bmm_mxfp8 cudnn backend requires 128x4-swizzled block scales "
+            "(the cuDNN graph declares tensor_reordering.F8_128x4)."
+        )
+
+    def block_varying_randn(shape):
+        # Vary each 32-element K-block's magnitude so the MXFP8 scale factors
+        # are non-uniform; plain randn makes all scales roughly equal, which
+        # masks scale-layout bugs.
+        x = torch.randn(shape, device="cuda", dtype=torch.float32)
+        e = torch.randint(-6, 7, (*shape[:-1], shape[-1] // 32), device="cuda")
+        return torch.ldexp(x, e.repeat_interleave(32, dim=-1)).to(input_dtype)
 
     # Create inputs and quantize them to MXFP8 format
-    input_mat = torch.randn([b, m, k], device="cuda", dtype=input_dtype)
+    input_mat = block_varying_randn([b, m, k])
 
     # input_mxfp8 dtype will be float8_e4m3fn
     # input_scale dtype will be uint8
@@ -37,14 +50,14 @@ def test_bmm_mxfp8(
     # Block size is 32 in MXFP8
     assert input_mxfp8.numel() == (input_scale.numel() * 32)
 
-    weight = torch.randn([b, n, k], device="cuda", dtype=input_dtype)
+    weight = block_varying_randn([b, n, k])
     weight_mxfp8, mat2_scale = mxfp8_quantize(weight, is_sf_swizzled_layout)
     mat2_mxfp8 = weight_mxfp8.transpose(-2, -1)
 
     assert mat2_mxfp8.numel() == (mat2_scale.numel() * 32)
 
     # Compute reference result
-    reference = torch.bmm(input_mat, weight.transpose(-2, -1))
+    reference = torch.bmm(input_mat.float(), weight.transpose(-2, -1).float())
 
     # Create output tensor
     res = torch.empty([b, m, n], device="cuda", dtype=res_dtype)
@@ -66,8 +79,8 @@ def test_bmm_mxfp8(
     assert not torch.isnan(res).any(), "Output contains NaN values"
 
     # Use the same metric as in test_bmm_fp8
-    min_cos_sim = 0.9  # TODO: check if can be increased
-    cos_sim = F.cosine_similarity(reference.reshape(-1), res.reshape(-1), dim=0)
+    min_cos_sim = 0.98
+    cos_sim = F.cosine_similarity(reference.reshape(-1), res.float().reshape(-1), dim=0)
     assert cos_sim > min_cos_sim, (
         f"Cosine similarity {cos_sim:.4f} is too low (expected > {min_cos_sim})"
     )

--- a/tests/gemm/test_bmm_mxfp8.py
+++ b/tests/gemm/test_bmm_mxfp8.py
@@ -37,17 +37,14 @@ def test_bmm_mxfp8(
     # Block size is 32 in MXFP8
     assert input_mxfp8.numel() == (input_scale.numel() * 32)
 
-    mat2 = (
-        torch.randn([b, n, k], device="cuda", dtype=input_dtype)
-        .transpose(-2, -1)
-        .contiguous()
-    )
-    mat2_mxfp8, mat2_scale = mxfp8_quantize(mat2, is_sf_swizzled_layout)
+    weight = torch.randn([b, n, k], device="cuda", dtype=input_dtype)
+    weight_mxfp8, mat2_scale = mxfp8_quantize(weight, is_sf_swizzled_layout)
+    mat2_mxfp8 = weight_mxfp8.transpose(-2, -1)
 
     assert mat2_mxfp8.numel() == (mat2_scale.numel() * 32)
 
     # Compute reference result
-    reference = torch.bmm(input_mat, mat2)
+    reference = torch.bmm(input_mat, weight.transpose(-2, -1))
 
     # Create output tensor
     res = torch.empty([b, m, n], device="cuda", dtype=res_dtype)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

`test_bmm_mxfp8` was too lenient. In the test, the MXFP8 quantization was done on the row-wise version of the B matrix, while the engine expects the B tensor to be quantized on the column-wise version. i.e. the MXFP8 GEMM requires the micro-scaling blocks to be along the K dim for both input matrices. The test should be failing, but does not for 2 reasons:
- input matrices are fairly uniform, causing the scaling factor tensor to be mostly the same whether or not the quantization was along the rows or columns
- the similarity threshold is low

This PR makes the input matrics less uniform, increases the similarity threshold, and corrects which dimension the quantization is over in the B matrix of the test.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for MXFP8 matrix multiplication with more realistic, uneven block magnitudes.
  * Updated validation to require the expected swizzled layout and tightened result checks for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->