### PR TITLE
test(comm): order rank streams after input fills in dcp_alltoall tests

### DIFF
--- a/tests/comm/test_dcp_alltoall.py
+++ b/tests/comm/test_dcp_alltoall.py
@@ -120,6 +120,10 @@ def _run_single_gpu_alltoall(cp_size, batch_size, head_dim, stats_dim, dtype):
     recv_s = [None] * cp_size
 
     for r in range(cp_size):
+        # Order each rank stream after the current stream, where the inputs
+        # were produced by torch.randn; without this the alltoall kernel can
+        # read the input buffers before the fills complete.
+        streams[r].wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(streams[r]):
             o, s = decode_cp_a2a_alltoall(
                 all_partial_o[r],
@@ -264,6 +268,9 @@ def test_repeated_alltoall(cp_size, batch_size, head_dim, stats_dim, dtype, num_
         recv_s = [None] * cp_size
 
         for r in range(cp_size):
+            # Same cross-stream ordering as _run_single_gpu_alltoall: the
+            # inputs are filled on the current stream.
+            streams[r].wait_stream(torch.cuda.current_stream())
             with torch.cuda.stream(streams[r]):
                 o, s = decode_cp_a2a_alltoall(
                     all_po[r], all_ss[r], workspace, r, cp_size


### PR DESCRIPTION
## Summary

Fixes #3806.

`tests/comm/test_dcp_alltoall.py` fills the alltoall inputs with `torch.randn(...)` on the current stream and then launches `decode_cp_a2a_alltoall` on freshly created per-rank side streams without ordering them after the producing stream. Under GPU load a rank's kernel can start before the fills complete and read partially-written input buffers, which makes `test_repeated_alltoall[cp2-3rounds]` / `[cp4-3rounds]` fail intermittently in full-file runs with 100% mismatched softmax stats (details, instrumented A/B evidence, and the race characterization are in the issue).

This is a test-side fix: the kernel and `initializeHelixWorkspace` behave correctly once the input ordering is in place.

## Change

Add `streams[r].wait_stream(torch.cuda.current_stream())` before entering each rank's stream context, at both launch sites (`_run_single_gpu_alltoall` and `test_repeated_alltoall`). This matches the pattern already used by `tests/comm/test_trtllm_moe_allreduce_fusion.py` and `test_allreduce_fusion_moe_unified_api.py`.

## Validation

On RTX PRO 6000 Blackwell (SM120), CUDA 13, torch 2.11.0+cu130, main @ bf92d49c, with a ~35-40% background GPU co-tenant (the load that exposes the race):

- Stock file: 3 of 6 full-file pytest runs fail (1 repeated_alltoall failure each).
- With this change: 10 of 10 full-file pytest runs pass.
- Standalone instrumented harness, same load: 6/12 runs fail without the wait, 12/12 pass with only `wait_stream` added.

`pre-commit run --files tests/comm/test_dcp_alltoall.py` clean (ruff check/format, whitespace hooks).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved multi-GPU all-to-all test reliability by enforcing correct stream ordering before communication begins.
  * Strengthened coverage for scenarios where data is prepared on one stream and consumed on another, reducing the chance of flaky test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->