### PR TITLE
fix(wan example): timestep embedding sin/cos halves were swapped

### DIFF
--- a/examples/pytorch/wan/transformer_wan_flashinfer.py
+++ b/examples/pytorch/wan/transformer_wan_flashinfer.py
@@ -687,7 +687,11 @@ class Timesteps(nn.Module):
         exponent = exponent / (half_dim - self.downscale_freq_shift)
 
         emb = timesteps[:, None].float() * exponent[None, :].exp()
-        emb = torch.cat([emb.cos(), emb.sin()], dim=-1)
+        # Match diffusers get_timestep_embedding: [sin, cos] BEFORE the flip,
+        # so flip_sin_to_cos=True yields [cos, sin]. (Starting from [cos, sin]
+        # here would make the flip produce [sin, cos] -- swapped halves that
+        # silently scramble the timestep conditioning.)
+        emb = torch.cat([emb.sin(), emb.cos()], dim=-1)
 
         if self.flip_sin_to_cos:
             emb = torch.cat([emb[:, half_dim:], emb[:, :half_dim]], dim=-1)


### PR DESCRIPTION
Timesteps.forward concatenated [cos, sin] before the flip_sin_to_cos flip; diffusers' get_timestep_embedding concatenates [sin, cos] so the flip yields [cos, sin]. Starting from [cos, sin] made the flip produce [sin, cos] -- swapped halves that silently scrambled the timestep conditioning: with identical weights and inputs the transformer output diverged from the diffusers original by 37% relative error, and generations kept local sharpness but lost prompt composition (the two-cats-boxing demo prompt produced a tiled crowd of cats).

After this one-line fix the transformer matches diffusers to bf16 noise (rel err 3.1e-2 over 40 blocks) and the same-seed video matches the pure diffusers baseline composition. Verified on Wan2.2-T2V-A14B, 8xH20.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ordering of sinusoidal timestep embeddings (sin/cos concatenation) to match the expected convention.
  * Clarified how this interacts with the sin-to-cos flipping behavior, improving consistency with other implementations and reducing confusion for users reading the guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->