### PR TITLE
fix: https://github.com/flashinfer-ai/flashinfer/issues/3823

### DIFF
--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -848,17 +848,20 @@ class TestUnifiedMoEDispatch:
 
 @sm100_required
 class TestTrtllmEPOffset:
-    """TRTLLM routed packing must shift global expert ids down by the local
-    shard offset.
+    """TRTLLM routed packing keeps GLOBAL expert ids and forwards the local
+    shard offset to the kernel as a separate launch argument.
 
-    The packed int32 top-k id is ``((expert_id - offset) << 16) | bf16(weight)``;
-    the kernel indexes local experts as ``[0, local_num_experts)``.  Before the
-    CR3 fix, ``pack_inputs`` defaulted the offset to 0, so a nonzero local shard
-    produced out-of-range local expert ids.
+    The packed int32 top-k id is ``(global_expert_id << 16) | bf16(weight)`` and
+    ``local_expert_offset`` is passed on its own; the kernel maps global ids into
+    its local ``[offset, offset + local_num_experts)`` range itself.  ``pack_inputs``
+    must NOT pre-subtract the offset — doing so pushes ids below the offset, which
+    the kernel treats as non-local and skips, producing zero output.
     """
 
     @pytest.mark.parametrize("local_expert_offset", [0, 32, 96])
-    def test_pack_inputs_applies_local_expert_offset(self, local_expert_offset):
+    def test_pack_inputs_keeps_global_ids_and_forwards_offset(
+        self, local_expert_offset
+    ):
         device = torch.device("cuda", torch.cuda.current_device())
         num_experts = 128
         local_num_experts = 32
@@ -916,13 +919,15 @@ class TestTrtllmEPOffset:
         inputs = runner.pack_inputs(act_pack, weight_pack)
         topk_ids = MoEInputs.from_list(inputs).topk_ids
 
-        # Upper 16 bits hold the (offset-shifted) local expert id.
-        decoded_local_ids = topk_ids >> 16
-        expected_local_ids = selected_experts - local_expert_offset
-        assert torch.equal(decoded_local_ids, expected_local_ids), (
-            f"offset={local_expert_offset}: packed local ids "
-            f"{decoded_local_ids} != expected {expected_local_ids}"
+        # Upper 16 bits hold the unmodified GLOBAL expert id (the offset is NOT
+        # pre-subtracted); the shard offset is forwarded to the kernel instead.
+        decoded_ids = topk_ids >> 16
+        assert torch.equal(decoded_ids, selected_experts), (
+            f"offset={local_expert_offset}: packed global ids "
+            f"{decoded_ids} != expected {selected_experts}"
         )
-        # Local ids must land inside the kernel's [0, local_num_experts) range.
-        assert int(decoded_local_ids.min()) >= 0
-        assert int(decoded_local_ids.max()) < local_num_experts
+        # Global ids stay within this rank's shard [offset, offset+local_num_experts).
+        assert int(decoded_ids.min()) >= local_expert_offset
+        assert int(decoded_ids.max()) < local_expert_offset + local_num_experts
+        # The shard offset is carried as a separate kernel launch argument.
+        assert runner._static_kwargs["local_expert_offset"] == local_expert_offset


### PR DESCRIPTION
## 📌 Description

Updates TestTrtllmEPOffset in tests/moe/test_unified_moe.py to match the packing convention #3686 introduced: pack_inputs now keeps global expert ids and forwards local_expert_offset to the kernel separately, rather than pre-subtracting it. The test now asserts decoded ids equal selected_experts (unshifted), that the offset is forwarded via _static_kwargs, and that ids fall in [offset, offset + local_num_experts). Test-only change (docstring + method name updated); fixes the stale assertion causing the offset=32/96 failures reported in #3823.

## 🔍 Related Issues

- #3823

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [X] Tests have been added or updated as needed.

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for expert-parallel input packing to reflect the corrected routing behavior.
  * Added checks that packed top-k expert IDs keep the original global IDs and that the expert offset is passed through correctly.
  * Improved validation of decoded expert IDs to ensure they stay within the expected shard-global range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->