### PR TITLE
test: seed test_mm_fp4 inputs to fix flaky cos_sim threshold failures

### DIFF
--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -53,6 +53,10 @@ def _test_mm_fp4(
     if not use_nvfp4 and backend not in ["cudnn", "auto", "cute-dsl"]:
         pytest.skip("mx_fp4 is only supported for cudnn, cute-dsl, and auto backends")
 
+    # Seed per test case so every parametrization checks the same data
+    # regardless of suite composition (unseeded draws depend on how many
+    # earlier cases ran/skipped, which made the 0.97 check flaky in CI).
+    torch.manual_seed(123)
     input = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
     mat2 = torch.randn([n, k], device="cuda", dtype=torch.bfloat16)
     a_sf_layout = SfLayout.layout_128x4 if use_128x4_sf_layout else SfLayout.layout_8x4


### PR DESCRIPTION
## Description

Fixes #3824.

`test_mm_fp4` draws its inputs from unseeded `torch.randn`, so the data a given parametrization checks depends on how many earlier cases ran or skipped in the same process. Suite composition differs across CI configurations (the b12x cases skip below CUDA 13, for example), which shifts the RNG stream and occasionally lands a case on a draw whose cos_sim falls below the hard `> 0.97` check -- the `0.9688` in #3824. This adds `torch.manual_seed(123)` inside `_test_mm_fp4`, mirroring how `test_mm_fp8.py` seeds, so every parametrization checks fixed data regardless of suite composition. Real accuracy regressions still fail, now deterministically.

Why the threshold trips at all: on an RTX PRO 6000 (SM120) I measured 9k+ independent draws at the smallest shape (m=1, n=128, k=128). The distribution floor is 0.9727 (mxfp4, bf16 -- nvfp4 floors at 0.9766), within two bf16 quanta of 0.97, so rare sub-0.97 draws are expected under CI's continuous re-draws. Same shape on both the pip wheel (0.6.13) and repo JIT kernels; 0 of 9k draws crossed the threshold locally, consistent with a low-probability tail rather than a kernel regression.

## Test plan

On RTX PRO 6000 (SM120), CUDA 13.0, torch 2.11:

- Full grid with the seed: `pytest tests/gemm/test_mm_fp4.py -q` -> 3965 passed, 19993 skipped, 0 failed.
- Determinism: two consecutive runs of the 792-case `cudnn and nvfp4 and not auto_tuning` slice produce identical results.

AI-assisted (Claude); measured and verified on the hardware above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Made a test helper use a fixed random seed for each case, improving consistency across parameterized runs.
  * Reduced the chance of flaky CI failures caused by test-order-dependent random inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->