### PR TITLE
fix: CUtensorMap variable alignment vs CUDA 13.0+ headers

### DIFF
--- a/csrc/nv_internal/cpp/kernels/quantization.cu
+++ b/csrc/nv_internal/cpp/kernels/quantization.cu
@@ -479,13 +479,16 @@ void launchFP4QuantizationTma(int b, int m, int n, T const* input, float const* 
       static_cast<uint32_t>(NUM_CONSUMER_WARPS)  // Number of tiles loaded (for 8 consumer warps)
   };
 
-  // CUtensorMap must be 64-byte aligned
+  // CUtensorMap's declared alignment grew from 64B (CUDA <= 12.x) to 128B
+  // (CUDA 13.0+); an explicit weaker alignas is ill-formed (clang host
+  // compilers reject it, gcc accepts silently).  Use the type's own
+  // alignment so the declaration tracks every toolkit.
   // Use SWIZZLE_128B for half/bf16 (2-byte types), SWIZZLE_NONE for FP8 (1-byte types)
   constexpr CUtensorMapSwizzle swizzle_type =
       (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>)
           ? CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_128B
           : CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_NONE;
-  alignas(64) CUtensorMap tensor_map = make_3d_tma_copy_desc(
+  alignas(alignof(CUtensorMap)) CUtensorMap tensor_map = make_3d_tma_copy_desc(
       const_cast<T*>(input), gmem_dim, stride_in_bytes, smem_dim, swizzle_type);
 
   // Select and launch the TMA kernel


### PR DESCRIPTION
 ## 📌 Description

CUDA 13.0 bumped the declared alignment of `CUtensorMap` from 64 to 128 bytes:

| cuda.h (official redist) | `CUtensorMap_st` alignment |
|---|---|
| 12.8, 12.9.79 | `alignas(64)` |
| 13.0.48 and later (13.1, 13.2) | `alignas(128)` |

In `launchFP4QuantizationTma`, `alignas(64) CUtensorMap tensor_map` now
requests a weaker alignment than the type's own, which is ill-formed per
`[dcl.align]`. Whether it actually breaks the build is **host-compiler
specific**:

- A **clang** host compiler (`-ccbin clang`) rejects it: `requested
  alignment is less than minimum alignment of 128 for type CUtensorMap`, so
  the fp4_quantization module fails to JIT-compile.
- A **gcc** host compiler silently accepts it (it just keeps the type's 128B
  natural alignment), which is why gcc-based builds never surface the error.

So the break is a conjunction of **CUDA 13.0+ headers × clang host**, not
every CUDA 13 toolchain — but the declaration is ill-formed on all of them
and should be fixed regardless. Hit on sm_120a (RTX PRO 6000 Blackwell SE)
with CUDA 13.1 + clang.

The fix uses `alignas(alignof(CUtensorMap))` so the declaration tracks the
type's own alignment on every toolkit: it satisfies clang on 13.0+, stays
valid on older toolkits, and always meets the TMA hardware requirement (64B)
since `alignof` is 64 on ≤12.x and 128 on 13.0+ — both ≥ 64. Over-aligning
is always allowed and costs only a few bytes of stack padding.

The other `alignas(64)` sites in the tree (xqa/tma.h,
deep_gemm/nvrtc_cutlass.cuh, fmha_v2/tma_types.h, cudnn_sdpa_utils.h) define
their own descriptor structs and are unaffected; this is the only variable
declaration of the driver header's `CUtensorMap` with an explicit weaker
alignas.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Verified on RTX PRO 6000 Blackwell SE (sm_120a), CUDA 13.1 JIT:

- Before: with a clang host compiler, every JIT compile of the
  fp4_quantization module fails in seconds with the alignment error above.
- After: the module compiles; exercised end to end via
  `pytest tests/utils/test_fp4_quantize.py` and
  `pytest tests/gemm/test_mm_bf16_fp4.py` (the weight-prepare path goes
  through `nvfp4_quantize`).

No test changes needed: this un-breaks compilation for a toolchain the
existing tests already cover once they can build.

## Reviewer Notes

The header table above is reproducible from the official redist archives,
e.g. `cuda_cudart-linux-x86_64-13.0.48-archive.tar.xz` on
developer.download.nvidia.com (`include/cuda.h`, `typedef struct
CUtensorMap_st`).

AI-assisted (Claude): root-cause investigation and validation runs. I
reviewed the change and reproduced the failure and the fix on hardware.
