### PR TITLE
perf: cache the bf16 x fp4 runner factories (cute-dsl + cudnn)

### DIFF
--- a/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cudnn.py
@@ -355,11 +355,9 @@ _BF16_FP4_TUNING_CONFIG = TuningConfig(
 )
 
 
-def _cudnn_bf16_fp4_runner(tuning_config):
-    """Build a ``CudnnBf16Fp4Runner`` bound to the active tuning config."""
-    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
-        tuning_config, spec_idx=0
-    )
+@functools.lru_cache(maxsize=1024)
+def _cudnn_bf16_fp4_runner_for_mapper(m_bucket_mapper):
+    """Build a ``CudnnBf16Fp4Runner`` bound to the given M-bucket mapper."""
 
     class CudnnBf16Fp4Runner(TunableRunner):
         def __init__(self):
@@ -485,6 +483,21 @@ def _cudnn_bf16_fp4_runner(tuning_config):
             return out
 
     return CudnnBf16Fp4Runner()
+
+
+def _cudnn_bf16_fp4_runner(tuning_config):
+    """Return the runner for the currently effective M-bucket mapper.
+
+    Cached per effective mapper rather than per ``tuning_config``: the mapper
+    reflects any thread-local ``autotune(tuning_buckets=..., round_up=...)``
+    override, and a runner built under one bucket scheme must not be reused
+    under another (its override-shape graphs would be keyed on stale
+    ``cache_m`` buckets).
+    """
+    m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
+        tuning_config, spec_idx=0
+    )
+    return _cudnn_bf16_fp4_runner_for_mapper(m_bucket_mapper)
 
 
 def _prepare_cudnn(

--- a/flashinfer/gemm/gemm_bf16_fp4_cute_dsl.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cute_dsl.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """CuTe-DSL backend for the bf16 x fp4 GEMM (weight repack / kernel launch)."""
 
+import functools
 from typing import List, Optional, Tuple, cast
 
 import torch
@@ -365,8 +366,15 @@ _BF16_FP4_CUTE_DSL_TUNING_CONFIG = TuningConfig(
 )
 
 
+@functools.cache
 def _cute_dsl_bf16_fp4_runner(enable_pdl: bool = True) -> TunableRunner:
-    """Build a ``CuteDslBf16Fp4Runner`` for the cute-DSL bf16 x fp4 GEMM."""
+    """Build a ``CuteDslBf16Fp4Runner`` for the cute-DSL bf16 x fp4 GEMM.
+
+    Cached: the runner is stateless, and rebuilding the class object on
+    every API call is avoidable work (~5 us/call measured with timeit on a
+    server x86 core).  Same pattern as the cudnn backend's cached graph
+    builders.
+    """
 
     class CuteDslBf16Fp4Runner(TunableRunner):
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:

--- a/flashinfer/gemm/gemm_bf16_fp4_cute_dsl.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cute_dsl.py
@@ -366,15 +366,9 @@ _BF16_FP4_CUTE_DSL_TUNING_CONFIG = TuningConfig(
 )
 
 
-@functools.cache
+@functools.lru_cache(maxsize=1024)
 def _cute_dsl_bf16_fp4_runner(enable_pdl: bool = True) -> TunableRunner:
-    """Build a ``CuteDslBf16Fp4Runner`` for the cute-DSL bf16 x fp4 GEMM.
-
-    Cached: the runner is stateless, and rebuilding the class object on
-    every API call is avoidable work (~5 us/call measured with timeit on a
-    server x86 core).  Same pattern as the cudnn backend's cached graph
-    builders.
-    """
+    """Build a ``CuteDslBf16Fp4Runner`` for the cute-DSL bf16 x fp4 GEMM."""
 
     class CuteDslBf16Fp4Runner(TunableRunner):
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:


### PR DESCRIPTION
## 📌 Description

`_cute_dsl_bf16_fp4_runner` and `_cudnn_bf16_fp4_runner` define and
instantiate a fresh runner class on every `mm_bf16_fp4` call — measured
~8 µs (cute-dsl) and ~10-12 µs (cudnn) per call of pure avoidable work on
the API hot path (timeit, server x86 core).

**cute-dsl**: the runner is stateless (the closure only captures
`enable_pdl`), so the factory is cached directly with
`@functools.lru_cache(maxsize=1024)`.

**cudnn** (per review suggestion): this factory is *not* safe to cache on
`tuning_config` — it captures
`AutoTuner.get().get_effective_map_to_tuning_buckets(...)` at build time,
which reflects the thread-local `autotune(tuning_buckets=..., round_up=...)`
override active at that moment. A naive cache would freeze a stale
`m_bucket_mapper`: measured 10/12 probed M values where the stale runner's
internal `cache_m` bucketing diverges from the autotuner's cache-lookup
bucketing (e.g. M=1000: autotuner bucket 4096 vs stale cache_m 1024) —
exactly the hazard `get_effective_map_to_tuning_buckets`'s docstring warns
about. Instead the factory is split in two: resolve the effective mapper
per call (~0.6 µs, unavoidable anyway), then cache the runner keyed on the
mapper object — stable per override thanks to `_apply_tuning_overrides`'
own cache. Verified: bucket-consistent inside/outside overrides, cache hits
within and across override scopes, `hash(runner)` (part of the autotuner
profiling-cache key) stable for the default path and distinct across
override scopes.

Net effect: cute-dsl ~8 µs → 0.03 µs; cudnn ~10-12 µs → ~0.9 µs per call
(factory microbench).  End-to-end `mm_bf16_fp4(backend="cudnn")` host time
at the repo's trace-example shape (M=128, N=2048, K=7168, the
`mm_bf16_fp4_cudnn_N2048_K7168_block_size16` benchmark definition):
~165 µs → ~142 µs per call; decode-like M=8 shows the same ~20 µs delta
(A/B on B200, interleaved 5-round medians).  The saving exceeds the factory
microbench because `timeit` disables GC, while the discarded per-call class
objects create reference cycles the real API loop must collect.

Behavior-neutral: the autotuner keys on the runner's class name,
`hash(runner)`, and `get_cache_key_extras` — all with unchanged values on
every path exercised today.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

- Original revision (cute-dsl change only): `pytest tests/gemm/test_mm_bf16_fp4.py`
  green on RTX PRO 6000 Blackwell SE (sm_120a), CUDA 13.1.
- Current revision (incl. the cudnn runner cache): `pytest
  tests/gemm/test_mm_bf16_fp4.py` — 233 passed, 1 skipped on B200 (sm_100a,
  cuDNN backend 9.24, cutlass-dsl 4.5), covering both backends.  The 1 skip
  is the pre-existing parametrize gap "cute-dsl requires out_dtype ==
  a.dtype", unrelated to this change.
- `pytest tests/trace/test_mm_bf16_fp4_reference_correctness.py` — 4 passed.
- Runner-cache semantics validated with a standalone harness: override
  bucket consistency (12 M probes × 3 override scopes), instance reuse,
  profiling-cache hash stability.

## Reviewer Notes

AI-assisted (Claude); I reviewed the change and ran the validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reuse of bf16 x fp4 GEMM runners to avoid rebuilding them repeatedly for the same settings.
  * Fixed cached cuDNN GEMM runner behavior so shape-based results are not incorrectly shared across different bucket-mapping schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->