### PR TITLE
Add CUDA get_batch_indices_positions helper

### DIFF
--- a/csrc/flashinfer_page_binding.cu
+++ b/csrc/flashinfer_page_binding.cu
@@ -17,8 +17,8 @@
 
 using tvm::ffi::Tensor;
 
-void get_batch_indices_positions_cuda(TensorView append_indptr, TensorView seq_lens,
-                                      TensorView batch_indices, TensorView positions);
+void get_batch_indices_positions(TensorView append_indptr, TensorView seq_lens,
+                                 TensorView batch_indices, TensorView positions);
 
 void append_paged_kv_cache(TensorView append_key, TensorView append_value, TensorView batch_indices,
                            TensorView positions, TensorView paged_k_cache, TensorView paged_v_cache,
@@ -30,6 +30,6 @@ void append_paged_mla_kv_cache(TensorView append_ckv, TensorView append_kpe,
                                TensorView kpe_cache, TensorView kv_indices, TensorView kv_indptr,
                                TensorView kv_last_page_len);
 
-TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_batch_indices_positions_cuda, get_batch_indices_positions_cuda);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_batch_indices_positions, get_batch_indices_positions);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(append_paged_kv_cache, append_paged_kv_cache);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(append_paged_mla_kv_cache, append_paged_mla_kv_cache);

--- a/csrc/flashinfer_page_binding.cu
+++ b/csrc/flashinfer_page_binding.cu
@@ -17,6 +17,9 @@
 
 using tvm::ffi::Tensor;
 
+void get_batch_indices_positions_cuda(TensorView append_indptr, TensorView seq_lens,
+                                      TensorView batch_indices, TensorView positions);
+
 void append_paged_kv_cache(TensorView append_key, TensorView append_value, TensorView batch_indices,
                            TensorView positions, TensorView paged_k_cache, TensorView paged_v_cache,
                            TensorView kv_indices, TensorView kv_indptr, TensorView kv_last_page_len,
@@ -27,5 +30,6 @@ void append_paged_mla_kv_cache(TensorView append_ckv, TensorView append_kpe,
                                TensorView kpe_cache, TensorView kv_indices, TensorView kv_indptr,
                                TensorView kv_last_page_len);
 
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(get_batch_indices_positions_cuda, get_batch_indices_positions_cuda);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(append_paged_kv_cache, append_paged_kv_cache);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(append_paged_mla_kv_cache, append_paged_mla_kv_cache);

--- a/csrc/page.cu
+++ b/csrc/page.cu
@@ -21,6 +21,37 @@ using namespace flashinfer;
 
 using tvm::ffi::Tensor;
 
+void get_batch_indices_positions_cuda(TensorView append_indptr, TensorView seq_lens,
+                                      TensorView batch_indices, TensorView positions) {
+  CHECK_INPUT_AND_TYPE(append_indptr, dl_int32);
+  CHECK_INPUT_AND_TYPE(seq_lens, dl_int32);
+  CHECK_INPUT_AND_TYPE(batch_indices, dl_int32);
+  CHECK_INPUT_AND_TYPE(positions, dl_int32);
+  CHECK_DIM(1, append_indptr);
+  CHECK_DIM(1, seq_lens);
+  CHECK_DIM(1, batch_indices);
+  CHECK_DIM(1, positions);
+
+  uint32_t batch_size = seq_lens.size(0);
+  TVM_FFI_ICHECK_EQ(append_indptr.size(0), batch_size + 1);
+  TVM_FFI_ICHECK_EQ(positions.size(0), batch_indices.size(0));
+  CHECK_DEVICE(seq_lens, append_indptr);
+  CHECK_DEVICE(batch_indices, append_indptr);
+  CHECK_DEVICE(positions, append_indptr);
+
+  ffi::CUDADeviceGuard device_guard(append_indptr.device().device_id);
+  const cudaStream_t stream = get_stream(append_indptr.device());
+  uint32_t nnz = batch_indices.size(0);
+
+  cudaError_t status = GetBatchIndicesPositions<int32_t>(
+      static_cast<const int32_t*>(append_indptr.data_ptr()),
+      static_cast<const int32_t*>(seq_lens.data_ptr()),
+      static_cast<int32_t*>(batch_indices.data_ptr()), static_cast<int32_t*>(positions.data_ptr()),
+      batch_size, nnz, stream);
+  TVM_FFI_ICHECK(status == cudaSuccess)
+      << "GetBatchIndicesPositions failed with error: " << cudaGetErrorString(status);
+}
+
 void append_paged_kv_cache(TensorView append_key, TensorView append_value, TensorView batch_indices,
                            TensorView positions, TensorView paged_k_cache, TensorView paged_v_cache,
                            TensorView kv_indices, TensorView kv_indptr, TensorView kv_last_page_len,

--- a/csrc/page.cu
+++ b/csrc/page.cu
@@ -21,8 +21,8 @@ using namespace flashinfer;
 
 using tvm::ffi::Tensor;
 
-void get_batch_indices_positions_cuda(TensorView append_indptr, TensorView seq_lens,
-                                      TensorView batch_indices, TensorView positions) {
+void get_batch_indices_positions(TensorView append_indptr, TensorView seq_lens,
+                                 TensorView batch_indices, TensorView positions) {
   CHECK_INPUT_AND_TYPE(append_indptr, dl_int32);
   CHECK_INPUT_AND_TYPE(seq_lens, dl_int32);
   CHECK_INPUT_AND_TYPE(batch_indices, dl_int32);

--- a/include/flashinfer/page.cuh
+++ b/include/flashinfer/page.cuh
@@ -284,6 +284,61 @@ __global__ void AppendPagedKVCacheKernel(paged_kv_t<DType, IdType> paged_kv,
 }
 
 /*!
+ * \brief CUDA kernel to generate batch indices and positions for appended key-value pairs
+ * \tparam IdType The index data type
+ * \param append_indptr The indptr array of the appended ragged tensor
+ * \param seq_lens The final sequence lengths after append
+ * \param batch_indices The output batch indices
+ * \param positions The output positions
+ */
+template <typename IdType, int BLOCK_THREADS>
+__global__ void GetBatchIndicesPositionsKernel(const IdType* __restrict__ append_indptr,
+                                               const IdType* __restrict__ seq_lens,
+                                               IdType* __restrict__ batch_indices,
+                                               IdType* __restrict__ positions) {
+  const uint32_t batch_idx = blockIdx.x;
+  const IdType batch_start = append_indptr[batch_idx];
+  const IdType batch_end = append_indptr[batch_idx + 1];
+  const IdType seq_len = seq_lens[batch_idx];
+
+  for (IdType offset = batch_start + static_cast<IdType>(threadIdx.x); offset < batch_end;
+       offset += BLOCK_THREADS) {
+    batch_indices[offset] = static_cast<IdType>(batch_idx);
+    positions[offset] = offset + seq_len - batch_end;
+  }
+}
+
+/*!
+ * \brief Generate batch indices and positions for appended key-value pairs
+ * \tparam IdType The index data type
+ * \param append_indptr The indptr array of the appended ragged tensor
+ * \param seq_lens The final sequence lengths after append
+ * \param batch_indices The output batch indices
+ * \param positions The output positions
+ * \param batch_size The batch size
+ * \param nnz The number of appended entries
+ * \param stream The CUDA stream to execute kernels.
+ * \return status Indicates whether CUDA calls are successful
+ */
+template <typename IdType>
+cudaError_t GetBatchIndicesPositions(const IdType* append_indptr, const IdType* seq_lens,
+                                     IdType* batch_indices, IdType* positions,
+                                     uint32_t batch_size, uint32_t nnz,
+                                     cudaStream_t stream = nullptr) {
+  if (batch_size == 0 || nnz == 0) {
+    return cudaSuccess;
+  }
+
+  constexpr int BLOCK_THREADS = 128;
+  auto kernel = GetBatchIndicesPositionsKernel<IdType, BLOCK_THREADS>;
+  void* args[] = {(void*)&append_indptr, (void*)&seq_lens, (void*)&batch_indices,
+                  (void*)&positions};
+  FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, dim3(batch_size), dim3(BLOCK_THREADS),
+                                        args, 0, stream));
+  return cudaSuccess;
+}
+
+/*!
  * \brief Append new keys/values to the paged key-value cache in the decode phase
  * \tparam DType The data type of the key-value cache
  * \tparam IdType The index data type of the kv-cache

--- a/tests/attention/test_page.py
+++ b/tests/attention/test_page.py
@@ -8,10 +8,7 @@ pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is r
 
 
 def _make_indptr(lengths, device="cuda:0"):
-    if not isinstance(lengths, torch.Tensor):
-        lengths = torch.tensor(lengths, dtype=torch.int32, device=device)
-    else:
-        lengths = lengths.to(device=device, dtype=torch.int32)
+    lengths = torch.as_tensor(lengths, dtype=torch.int32, device=device)
     indptr = torch.empty(lengths.numel() + 1, dtype=torch.int32, device=device)
     indptr[0] = 0
     indptr[1:] = torch.cumsum(lengths, dim=0)
@@ -34,13 +31,13 @@ def _batch_indices_positions_ref(append_indptr, seq_lens):
     return batch_indices.to(append_indptr.device), positions.to(append_indptr.device)
 
 
-def _get_batch_indices_positions_cuda(append_indptr, seq_lens):
+def _get_batch_indices_positions_page_module(append_indptr, seq_lens):
     nnz = int(append_indptr[-1].item())
     batch_indices = torch.full(
         (nnz,), -1, dtype=torch.int32, device=append_indptr.device
     )
     positions = torch.full((nnz,), -2, dtype=torch.int32, device=append_indptr.device)
-    get_page_module().get_batch_indices_positions_cuda(
+    get_page_module().get_batch_indices_positions(
         append_indptr, seq_lens, batch_indices, positions
     )
     return batch_indices, positions
@@ -57,11 +54,11 @@ def _get_batch_indices_positions_cuda(append_indptr, seq_lens):
         ([], []),
     ],
 )
-def test_get_batch_indices_positions_cuda(append_lengths, seq_lens):
+def test_get_batch_indices_positions_page_module(append_lengths, seq_lens):
     _, append_indptr = _make_indptr(append_lengths)
     seq_lens = torch.tensor(seq_lens, dtype=torch.int32, device="cuda:0")
 
-    batch_indices, positions = _get_batch_indices_positions_cuda(
+    batch_indices, positions = _get_batch_indices_positions_page_module(
         append_indptr, seq_lens
     )
     ref_batch_indices, ref_positions = _batch_indices_positions_ref(
@@ -72,14 +69,14 @@ def test_get_batch_indices_positions_cuda(append_lengths, seq_lens):
     torch.testing.assert_close(positions, ref_positions)
 
 
-def test_get_batch_indices_positions_cuda_many_rows():
+def test_get_batch_indices_positions_page_module_many_rows():
     append_lengths = torch.arange(1024, dtype=torch.int32, device="cuda:0") % 9
     seq_lens = append_lengths + (
         torch.arange(1024, dtype=torch.int32, device="cuda:0") % 17
     )
     _, append_indptr = _make_indptr(append_lengths)
 
-    batch_indices, positions = _get_batch_indices_positions_cuda(
+    batch_indices, positions = _get_batch_indices_positions_page_module(
         append_indptr, seq_lens
     )
     ref_batch_indices, ref_positions = _batch_indices_positions_ref(
@@ -90,7 +87,7 @@ def test_get_batch_indices_positions_cuda_many_rows():
     torch.testing.assert_close(positions, ref_positions)
 
 
-def test_get_batch_indices_positions_cuda_rejects_int64_inputs():
+def test_get_batch_indices_positions_page_module_rejects_int64_inputs():
     append_lengths, append_indptr = _make_indptr([1, 2, 3])
     seq_lens = append_lengths.to(torch.int64)
     nnz = int(append_indptr[-1].item())
@@ -98,12 +95,12 @@ def test_get_batch_indices_positions_cuda_rejects_int64_inputs():
     positions = torch.empty((nnz,), dtype=torch.int32, device="cuda:0")
 
     with pytest.raises(Exception):
-        get_page_module().get_batch_indices_positions_cuda(
+        get_page_module().get_batch_indices_positions(
             append_indptr, seq_lens, batch_indices, positions
         )
 
 
-def test_append_paged_kv_cache_with_cuda_batch_indices_positions():
+def test_append_paged_kv_cache_with_page_module_batch_indices_positions():
     torch.manual_seed(0)
     append_lengths, append_indptr = _make_indptr([5, 2, 7])
     seq_lens = append_lengths.clone()
@@ -133,7 +130,7 @@ def test_append_paged_kv_cache_with_cuda_batch_indices_positions():
         dtype=torch.float16,
         device="cuda:0",
     )
-    batch_indices, positions = _get_batch_indices_positions_cuda(
+    batch_indices, positions = _get_batch_indices_positions_page_module(
         append_indptr, seq_lens
     )
 

--- a/tests/attention/test_page.py
+++ b/tests/attention/test_page.py
@@ -106,7 +106,7 @@ def test_append_paged_kv_cache_with_page_module_batch_indices_positions():
     seq_lens = append_lengths.clone()
     page_size = 4
     num_kv_heads = 2
-    head_dim = 8
+    head_dim = 64
     nnz = int(append_indptr[-1].item())
 
     num_pages_per_req = (seq_lens + page_size - 1) // page_size

--- a/tests/attention/test_page.py
+++ b/tests/attention/test_page.py
@@ -2,6 +2,164 @@ import pytest
 import torch
 
 import flashinfer
+from flashinfer.page import get_page_module
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+
+
+def _make_indptr(lengths, device="cuda:0"):
+    if not isinstance(lengths, torch.Tensor):
+        lengths = torch.tensor(lengths, dtype=torch.int32, device=device)
+    else:
+        lengths = lengths.to(device=device, dtype=torch.int32)
+    indptr = torch.empty(lengths.numel() + 1, dtype=torch.int32, device=device)
+    indptr[0] = 0
+    indptr[1:] = torch.cumsum(lengths, dim=0)
+    return lengths, indptr
+
+
+def _batch_indices_positions_ref(append_indptr, seq_lens):
+    append_indptr_cpu = append_indptr.cpu()
+    seq_lens_cpu = seq_lens.cpu()
+    nnz = int(append_indptr_cpu[-1].item())
+    batch_indices = torch.empty(nnz, dtype=torch.int32)
+    positions = torch.empty(nnz, dtype=torch.int32)
+    for batch_idx in range(seq_lens_cpu.numel()):
+        batch_start = int(append_indptr_cpu[batch_idx].item())
+        batch_end = int(append_indptr_cpu[batch_idx + 1].item())
+        seq_len = int(seq_lens_cpu[batch_idx].item())
+        for offset in range(batch_start, batch_end):
+            batch_indices[offset] = batch_idx
+            positions[offset] = offset + seq_len - batch_end
+    return batch_indices.to(append_indptr.device), positions.to(append_indptr.device)
+
+
+def _get_batch_indices_positions_cuda(append_indptr, seq_lens):
+    nnz = int(append_indptr[-1].item())
+    batch_indices = torch.full(
+        (nnz,), -1, dtype=torch.int32, device=append_indptr.device
+    )
+    positions = torch.full((nnz,), -2, dtype=torch.int32, device=append_indptr.device)
+    get_page_module().get_batch_indices_positions_cuda(
+        append_indptr, seq_lens, batch_indices, positions
+    )
+    return batch_indices, positions
+
+
+@pytest.mark.parametrize(
+    ("append_lengths", "seq_lens"),
+    [
+        ([1, 2, 3, 4], [5, 5, 5, 5]),
+        ([45, 8, 25, 22], [45, 8, 25, 22]),
+        ([0, 3, 0, 5, 1], [7, 10, 2, 8, 6]),
+        ([7], [11]),
+        ([0, 0, 0], [3, 4, 5]),
+        ([], []),
+    ],
+)
+def test_get_batch_indices_positions_cuda(append_lengths, seq_lens):
+    _, append_indptr = _make_indptr(append_lengths)
+    seq_lens = torch.tensor(seq_lens, dtype=torch.int32, device="cuda:0")
+
+    batch_indices, positions = _get_batch_indices_positions_cuda(
+        append_indptr, seq_lens
+    )
+    ref_batch_indices, ref_positions = _batch_indices_positions_ref(
+        append_indptr, seq_lens
+    )
+
+    torch.testing.assert_close(batch_indices, ref_batch_indices)
+    torch.testing.assert_close(positions, ref_positions)
+
+
+def test_get_batch_indices_positions_cuda_many_rows():
+    append_lengths = torch.arange(1024, dtype=torch.int32, device="cuda:0") % 9
+    seq_lens = append_lengths + (
+        torch.arange(1024, dtype=torch.int32, device="cuda:0") % 17
+    )
+    _, append_indptr = _make_indptr(append_lengths)
+
+    batch_indices, positions = _get_batch_indices_positions_cuda(
+        append_indptr, seq_lens
+    )
+    ref_batch_indices, ref_positions = _batch_indices_positions_ref(
+        append_indptr, seq_lens
+    )
+
+    torch.testing.assert_close(batch_indices, ref_batch_indices)
+    torch.testing.assert_close(positions, ref_positions)
+
+
+def test_get_batch_indices_positions_cuda_rejects_int64_inputs():
+    append_lengths, append_indptr = _make_indptr([1, 2, 3])
+    seq_lens = append_lengths.to(torch.int64)
+    nnz = int(append_indptr[-1].item())
+    batch_indices = torch.empty((nnz,), dtype=torch.int32, device="cuda:0")
+    positions = torch.empty((nnz,), dtype=torch.int32, device="cuda:0")
+
+    with pytest.raises(Exception):
+        get_page_module().get_batch_indices_positions_cuda(
+            append_indptr, seq_lens, batch_indices, positions
+        )
+
+
+def test_append_paged_kv_cache_with_cuda_batch_indices_positions():
+    torch.manual_seed(0)
+    append_lengths, append_indptr = _make_indptr([5, 2, 7])
+    seq_lens = append_lengths.clone()
+    page_size = 4
+    num_kv_heads = 2
+    head_dim = 8
+    nnz = int(append_indptr[-1].item())
+
+    num_pages_per_req = (seq_lens + page_size - 1) // page_size
+    kv_indptr = torch.empty(seq_lens.numel() + 1, dtype=torch.int32, device="cuda:0")
+    kv_indptr[0] = 0
+    kv_indptr[1:] = torch.cumsum(num_pages_per_req, dim=0)
+    num_pages = int(kv_indptr[-1].item())
+    kv_indices = torch.arange(num_pages, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = ((seq_lens - 1) % page_size + 1).to(torch.int32)
+
+    append_key = torch.randn(
+        nnz, num_kv_heads, head_dim, dtype=torch.float16, device="cuda:0"
+    )
+    append_value = torch.randn_like(append_key)
+    paged_kv_cache = torch.zeros(
+        num_pages,
+        2,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        dtype=torch.float16,
+        device="cuda:0",
+    )
+    batch_indices, positions = _get_batch_indices_positions_cuda(
+        append_indptr, seq_lens
+    )
+
+    flashinfer.append_paged_kv_cache(
+        append_key,
+        append_value,
+        batch_indices,
+        positions,
+        paged_kv_cache,
+        kv_indices,
+        kv_indptr,
+        kv_last_page_len,
+    )
+
+    batch_indices_cpu = batch_indices.cpu()
+    positions_cpu = positions.cpu()
+    kv_indptr_cpu = kv_indptr.cpu()
+    kv_indices_cpu = kv_indices.cpu()
+    for i in range(nnz):
+        batch_idx = int(batch_indices_cpu[i].item())
+        pos = int(positions_cpu[i].item())
+        page_iter = int(kv_indptr_cpu[batch_idx].item()) + pos // page_size
+        page = int(kv_indices_cpu[page_iter].item())
+        entry = pos % page_size
+        torch.testing.assert_close(paged_kv_cache[page, 0, entry], append_key[i])
+        torch.testing.assert_close(paged_kv_cache[page, 1, entry], append_value[i])
 
 
 @pytest.mark.parametrize("contiguous", [True, False])


### PR DESCRIPTION
## Summary
- add a framework-agnostic CUDA helper in `include/flashinfer/page.cuh` for generating append `batch_indices` and `positions`
- expose a direct page-module FFI symbol `get_batch_indices_positions` with strict CUDA int32 validation
- add direct helper tests plus an append integration path that consumes the generated arrays
- keep the public Python `flashinfer.get_batch_indices_positions()` wrapper on the existing Triton path for PR 1
- align the page-module symbol name with existing operation-style exports such as `append_paged_kv_cache`

Refs #2004

## Testing
- `git diff --check`
- `.venv/bin/python -m py_compile tests/attention/test_page.py`
- `.venv/bin/python -m pytest tests/attention/test_page.py -v` *(verified on a RunPod GPU)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new page-module API to generate batch indices and positions for appended cache entries.
  * Enabled this helper to be used with paged KV cache workflows.

* **Bug Fixes**
  * Added input validation for tensor types, shapes, and device consistency.
  * Improved handling of empty inputs by returning early when there is no work to do.

* **Tests**
  * Added coverage for correctness on small and large cases.
  * Added checks for invalid input types and end-to-end integration with cache appends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->