### PR TITLE
fix(sparse-mla-sm120): add TOPK=256 DSV4 prefill instantiation

### DIFF
--- a/csrc/sparse_mla_sm120_prefill.cu
+++ b/csrc/sparse_mla_sm120_prefill.cu
@@ -293,6 +293,8 @@ inline bool dispatch_dsv4_single(int num_heads, int topk, const bf16* Q, const u
   // amortises FP8's higher Tensor-Core throughput.
   if (topk == 128)
     DISPATCH_BY_NH_CM(BF16, 128);
+  else if (topk == 256)
+    DISPATCH_BY_NH_CM(BF16, 256);
   else if (topk == 512)
     DISPATCH_BY_NH_CM(FP8, 512);
   else if (topk == 1024)

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -890,6 +890,8 @@ def test_sparse_mla_sm120_prefill_glm_nsa_arbitrary_fp32(num_heads: int) -> None
 
 _DSV4_PREFILL_CONFIGS = [
     (16, 128),
+    (16, 256),
+    (32, 256),
     (32, 512),
     (64, 1024),
     (128, 1024),


### PR DESCRIPTION
## Description

The SM120 sparse-MLA DSV4 prefill dispatch (`dispatch_dsv4_single` in `csrc/sparse_mla_sm120_prefill.cu`) only instantiates `topk in {128, 512, 1024, 2048}`, so `topk=256` (a valid `4 x BI(64)` shape, hit by DeepSeek-V4 + DSpark configs) fails with `Unsupported sparse-MLA prefill configuration: model=DSV4 num_heads=32 topk=256 ...`. This adds the missing `topk == 256` branch plus test coverage.

This is the prefill half of #3828; PR #3817 covers the decode half. No overlap: this PR touches only the prefill `.cu`, and the test configs are distinct from #3817's decode entries in the same test file (trivial rebase for whichever lands second).

Compute-mode choice: BF16, not FP8. Measured on an RTX PRO 6000 (SM120, CUDA 13), BF16 beats FP8 at `topk=256` for every shape tested, consistent with the existing small-K-loop comment (the FP8 Q-quantize prologue doesn't amortise at K=256):

| num_heads | num_tokens | FP8 median | BF16 median |
|---|---|---|---|
| 32 | 128 | 53.7 us | 51.0 us |
| 32 | 1024 | 278.5 us | 254.0 us |
| 32 | 4096 | 991.2 us | 910.6 us |
| 128 | 128 | 141.3 us | 127.0 us |
| 128 | 1024 | 958.5 us | 862.2 us |
| 128 | 4096 | 4442.1 us | 4330.8 us |

Verified on the same card: the issue's prefill repro (num_heads=32, topk=256, num_tokens=128) fails on current main and runs + matches the reference with this change.

## Related Issues

Prefill portion of #3828 (decode portion: #3817).

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.): new configs `(16, 256)` and `(32, 256)` exercise the NHG=1 and NHG=2 routes; full `tests/attention/test_sparse_mla_sm120.py` = 145 passed on SM120.

## Reviewer Notes

`dispatch_dsv4_dual` is intentionally untouched: the reporter's trace has `topk_extra=0`, which routes through `dispatch_dsv4_single`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for a 256 top-k setting in sparse MLA dispatch, preventing valid configurations from falling back unexpectedly.
  * Expanded coverage for additional head-count and top-k combinations to better verify SM120 sparse-MLA behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->