### PR TITLE
fix(moe): disable PDL for finalize kernel to prevent GEMM2-write TMA race

### DIFF
--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -712,7 +712,19 @@ void Runner::setOpsData(MoERunnerArgs const& args, MoEWorkspace const& workspace
     // Setup finalize data
     finalizeData.mDtypeElt = args.mDtypeOut;
     finalizeData.mDtypeExpW = args.mDtypeExpW;
-    finalizeData.mUsePdl = enablePdl;
+    // Disable PDL for the finalize kernel. The trt-llm MoE pipeline runs
+    // routing -> GEMM1 -> (quant) -> GEMM2 -> finalize on one stream. With
+    // PDL, the dependency chain signals after the routing kernel
+    // (cudaTriggerProgrammaticLaunchCompletion), but GEMM2 runs between
+    // routing and finalize. finalizeKernelVecLoad's cudaGridDependencySynchronize()
+    // therefore sees the routing signal and starts while GEMM2 is still writing
+    // gemm2_output. The finalize kernel reads gemm2_output via ld.global.v4.f32,
+    // which on sm_100+ lowers to a bulk async load waited on with ACQBULK. Since
+    // GEMM2 has not finished writing, ACQBULK parks forever (observed: all 225K
+    // threads stuck at the same ACQBULK PC). Setting mUsePdl = false makes
+    // finalize use normal stream ordering, so it waits for GEMM2 to complete.
+    // This only affects the finalize kernel; GEMM1/GEMM2 keep their own PDL.
+    finalizeData.mUsePdl = false;
     finalizeData.mUseDeepSeekFp8 = false;
     finalizeData.inPtr = workspace.gemm2_output;
     finalizeData.outPtr = args.output;


### PR DESCRIPTION
## Summary

Single-line fix: set `finalizeData.mUsePdl = false` in `trtllm_fused_moe_runner.cu`. Nothing else changed — no `fence.proxy.alias`, no kernel edits, no dispatch changes. GEMM1/GEMM2 keep their own PDL; only the finalize kernel drops it.

## Root Cause

The trt-llm MoE pipeline runs `routing -> GEMM1 -> (quant) -> GEMM2 -> finalize` on one stream with PDL. The PDL dependency chain signals after the **routing** kernel (`cudaTriggerProgrammaticLaunchCompletion`), but GEMM2 runs **between** routing and finalize. `finalizeKernelVecLoad`'s `cudaGridDependencySynchronize()` sees the routing signal and starts **while GEMM2 is still writing `gemm2_output`**.

The finalize kernel reads `gemm2_output` via `vectorizedLoadPtx` -> `ld.global.v4.f32`. On sm_100+, the compiler lowers this to a bulk async load waited on with `ACQBULK`. Since GEMM2 hasn't finished writing, `ACQBULK` parks forever.

## Fix

```cpp
// Before:
finalizeData.mUsePdl = enablePdl;   // PDL -> starts after routing, before GEMM2 finishes

// After:
finalizeData.mUsePdl = false;       // stream ordering -> waits for GEMM2 to complete
```

The lost PDL overlap between GEMM2 and finalize **is** the bug — there is no safe way to overlap them here. Measured cost: ~0% (within noise) across batch 1..16384; the finalize kernel is ~3.9% of MoE runtime and PDL only affects its launch overlap.

## Why no `fence.proxy.alias`

`fence.proxy.alias` orders a thread's **own** async-proxy writes before its **own** generic-proxy reads. Here the writer is GEMM2 — a different, still-active kernel. No reader-side fence can make another kernel's uncommitted TMA writes visible. The only correct fix is to not let finalize start until GEMM2 completes, i.e. disable PDL for finalize.

## Scope

The race only engages when the dispatcher selects `finalizeKernelVecLoad`, which happens at **>= 1184 finalize blocks** (148 SMs × 8 blocks/SM on Blackwell = one full wave). Below that it uses the scalar `finalizeKernel` (plain `ld.global`, no `ACQBULK`, no race). Threshold in tokens = ⌈1184 / ⌈hiddenDim/256⌉⌉, e.g. ~74 tokens at hidden=4096, ~50 at hidden=6148.

**Affected**: trt-llm MoE `_ll` paths above the wave threshold (bf16_ll, mxfp8_ll, mxfp4_ll, nvfp4_ll, fp8_block_scale, mxint4) on sm_100+.
**Not affected**: cutlass paths (finalize fused in GEMM epilogue), DeepSeek FP8 (`finalizeDeepSeekKernel` with regular `ld.global`), and sub-threshold batches.

## Evidence (CUDA Core Dump)

Production: qwen3p5-VL MoE (512 experts, top_k=10, hidden=4096, EP=4, fp4) on L20D sm_103.

- All 225,792 threads (882 blocks × 256) parked at the same PC = `ACQBULK` in `finalizeKernelVecLoad`, followed by `BAR.SYNC.DEFER_BLOCKING` (never reached).
- GEMM2 (`bmm_..._sm100f`) simultaneously active — still writing `gemm2_output`.
- No Xid — pure PDL scheduling race, not a hardware fault.

## Test Plan

- [ ] Deploy to shadow, verify no ACQBULK stalls over 4+ hours (historical rate: ~45 min)
- [ ] Verify MoE output correctness (stream ordering does not change results)
- [ ] Confirm latency parity (finalize is ~3.9% of MoE runtime; PDL overlap loss is sub-1%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in mixture-of-experts inference by preventing a rare finalize-stage hang during GPU execution.
  * Final output generation is now more reliable under high-performance configurations, reducing the chance of stalled requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->