### PR TITLE
fix(b12x): bucket MoE workspace allocation to stop kernel-cache thrash

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -2354,6 +2354,11 @@ def allocate_sm120_moe_workspace(
     raise ValueError(f"unsupported SM120 MoE backend {backend!r}")
 
 
+def _bucket_workspace_rows(routed_rows: int) -> int:
+    """Round a workspace row request up to a power-of-two (floor 128)."""
+    return 1 << (max(128, int(routed_rows)) - 1).bit_length()
+
+
 def _get_cached_workspace(
     *,
     backend: str,
@@ -2406,10 +2411,17 @@ def _get_cached_workspace(
             "allocate_sm120_moe_workspace(..., quant_mode='w4a16') or warm the "
             "functional path before capture."
         )
+    # Allocate on a power-of-two ladder (floor 128) rather than at the exact
+    # request. Growing replaces the cached workspace, and the new max_rows is
+    # baked into every kernel cache key compiled against it (_get_static_kernel
+    # / _get_micro_kernel), so each new high-water mark invalidates all
+    # previously compiled kernels for this key - a multi-second MLIR recompile
+    # per shape class at serving time. Bucketing bounds growth (and therefore
+    # recompile waves) to O(log) events at the cost of at most 2x scratch rows.
     workspace = allocate_sm120_moe_workspace(
         state_E=state_E,
         weight_E=weight_E,
-        routed_rows=routed_rows,
+        routed_rows=_bucket_workspace_rows(routed_rows),
         k=k,
         n=n,
         num_topk=num_topk,

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -2752,3 +2752,55 @@ class TestRelu2Activation:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+@cute_dsl_available
+@sm120_required
+@cuda_13_required
+class TestWorkspaceBucketing:
+    """Workspace growth must not thrash kernel caches (vllm#47458).
+
+    ``_get_cached_workspace`` replaces the cached workspace when a larger
+    routed_rows arrives, and ``workspace.max_rows`` is baked into the
+    static/micro kernel cache keys - so every new high-water mark used to
+    invalidate all previously compiled kernels for the backend and trigger
+    multi-second MLIR recompiles at serving time. Allocations are therefore
+    bucketed on a power-of-two ladder (floor 128).
+    """
+
+    def test_bucket_ladder(self):
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_dispatch import (
+            _bucket_workspace_rows,
+        )
+
+        assert _bucket_workspace_rows(1) == 128
+        assert _bucket_workspace_rows(128) == 128
+        assert _bucket_workspace_rows(129) == 256
+        assert _bucket_workspace_rows(640) == 1024
+        assert _bucket_workspace_rows(32768) == 32768
+
+    def test_workspace_stable_within_bucket(self):
+        from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch as md
+
+        device = torch.device("cuda")
+        kwargs = dict(
+            backend="static",
+            state_E=8,
+            weight_E=8,
+            k=512,
+            n=256,
+            num_topk=4,
+            device=device,
+        )
+        ws_small = md._get_cached_workspace(routed_rows=4, **kwargs)
+        assert ws_small.max_rows >= 128
+        # Growth within the bucket must return the SAME workspace object, so
+        # kernels compiled against its max_rows stay cache-valid.
+        ws_mid = md._get_cached_workspace(routed_rows=128, **kwargs)
+        assert ws_mid is ws_small
+        # Crossing the bucket boundary is allowed to reallocate (bounded,
+        # O(log) times), never once per new high-water mark.
+        ws_big = md._get_cached_workspace(routed_rows=129, **kwargs)
+        assert ws_big.max_rows >= 256
+        ws_big2 = md._get_cached_workspace(routed_rows=200, **kwargs)
+        assert ws_big2 is ws_big


### PR DESCRIPTION
## Description

Root-caused from vllm-project/vllm#47458 (recurring ~17.5 s engine-wide stalls on large-to-small batch-shape transitions with the b12x NVFP4 MoE): `_get_cached_workspace` replaces the cached workspace whenever a larger `routed_rows` arrives, and `workspace.max_rows` is baked into the static/micro kernel cache keys (`_get_static_kernel` / `_get_micro_kernel`). So every new high-water mark invalidates every previously compiled kernel for that backend key, and each invalidated shape class pays a full MLIR JIT recompile - measured 15-18 s per class with the shipped 0.6.13 wheel on an RTX PRO 6000, and it blocks the engine's forward pass. Under mixed serving load this recurs each time a new maximum arrives, which matches the reporter's stall cadence.

The fix allocates workspaces on a power-of-two ladder (floor 128 rows) instead of at the exact request: growth - and with it the recompile wave - happens O(log) times total instead of once per new maximum, at a cost of at most 2x scratch rows. Reuse checks are unchanged, and the ladder applies to all backends flowing through `_get_cached_workspace` (static growth is bounded by the compact cutover in the non-EP case, but EP falls back to static with unbounded rows, so a hard cap would be wrong - the ladder handles both).

Measured A/B with the identical call sequence `m=1, 2, 32` then repeats (repo package, RTX PRO 6000, CUDA 13):

| call | stock | this PR |
|---|--:|--:|
| m=1 (first) | 22.4 s | 23.3 s |
| m=2 (first) | 22.8 s | 22.9 s |
| m=32 (first) | 21.2 s | 21.1 s |
| m=1 (repeat) | **21.7 s (recompile)** | 1 ms |
| m=2 (repeat) | **21.9 s (recompile)** | 2 ms |
| m=32 (repeat) | 0 ms | 1 ms |

## Related Issues

Downstream report: vllm-project/vllm#47458 (analysis in https://github.com/vllm-project/vllm/issues/47458#issuecomment-4880891551).

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed: ladder unit test + a workspace-identity regression test (same object returned within a bucket, so compiled kernels stay cache-valid).
- [x] All tests are passing: full `tests/moe/test_b12x_fused_moe.py` on RTX PRO 6000 - 142 passed in 26m53s (JIT-heavy first run).

## Reviewer Notes

The deeper alternative - making the kernels take `max_rows` as a runtime argument so the key doesn't include it at all - touches the DSL kernel signatures; the ladder gets the operational win (bounded recompiles) with a 13-line dispatch-side change. Happy to explore the runtime-arg route as a follow-up if you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace allocation behavior to grow in larger steps instead of small increments.
  * Reduced unnecessary cache invalidations and recompilations during MoE workloads.
  * Made repeated runs more likely to reuse existing workspace allocations when capacity is sufficient.

* **Tests**
  * Added coverage for the new allocation behavior and cache reuse across size boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->