### PR TITLE
[Bugfix] Skip autotuning for small token counts on SM100 to prevent TMA crash

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1337,7 +1337,7 @@ def get_trtllm_moe_sm100_module():
             moe_inputs = MoeRunnerInputs.from_list(inputs)
             num_tokens = moe_inputs.hidden_states.shape[0]
 
-            major, _ = get_compute_capability(torch.cuda.current_device())
+            major, _ = get_compute_capability(moe_inputs.hidden_states.device)
             if major == 10 and num_tokens * self.top_k < 2 * self.num_local_experts:
                 return []
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1337,6 +1337,10 @@ def get_trtllm_moe_sm100_module():
             moe_inputs = MoeRunnerInputs.from_list(inputs)
             num_tokens = moe_inputs.hidden_states.shape[0]
 
+            major, _ = get_compute_capability(torch.cuda.current_device())
+            if major == 10 and num_tokens * self.top_k < 2 * self.num_local_experts:
+                return []
+
             has_gemm1_lora_delta = moe_inputs.gemm1_lora_delta is not None
 
             # Enumerate valid tactics for the fused (routed + shared) expert


### PR DESCRIPTION
## Purpose

Fixes a crash during autotuning of `trtllm_bf16_moe` on SM100 (Blackwell/B200) GPUs.

When FlashInfer's autotuner profiles with very small token counts (e.g., `num_tokens=1`), the TRTLLM BF16 grouped GEMM kernel produces TMA alignment faults (`CUDBG_EXCEPTION_WARP_ILLEGAL_ADDRESS`). This happens because during decode with DP+EP routing, the per-expert token count can be M=1, which is incompatible with the TMA-aligned kernel dispatch.

## Root cause

The TRTLLM MoE kernel uses TMA (Tensor Memory Accelerator) on SM100 for grouped GEMM. When the autotuner synthesizes random routing inputs with very small `num_tokens`, individual experts can receive M=1 tokens, triggering a TMA descriptor alignment fault in the cutlass backend at `trtllm_batched_gemm_runner.cu`.

Notably, the kernel works correctly at **inference time** with its default fallback config for these small shapes — the crash only occurs during autotune profiling when the autotuner probes different configurations.

## Fix

Added a guard in `MoERunner.get_valid_tactics()` that returns an empty tactic list when:
- The GPU is SM100 (Blackwell/B200) — `major == 10`
- The average tokens per expert is below 2 — `num_tokens * top_k < 2 * num_local_experts`

The autotuner already handles empty valid-tactic lists gracefully by skipping the profile, so no crash occurs. Inference is unaffected since this guard is only in the autotuner's `get_valid_tactics()` path, not in the `forward()` call.

## Changes

One file, 4 lines added:
- `flashinfer/fused_moe/core.py`: Add SM100 guard in `MoERunner.get_valid_tactics()`

## Testing

This is a targeted safety guard. The affected code path (autotune profiling of very small token counts on SM100) is the exact path that was crashing. Verified:
- Guard only activates on SM100 (`major == 10`)
- Guard only affects shapes where avg tokens per expert < 2
- Returns `[]` which is already handled by the autotuner (profile is skipped)

Related: vllm-project/vllm#46083

Co-authored-by: Claude
Signed-off-by: InfoSage05 <mr.infosagepoint2020@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic selection of supported Mixture-of-Experts settings by skipping invalid configurations earlier for certain GPU/workload combinations.
  * This avoids unnecessary configuration evaluation/tuning attempts and can reduce setup delays when MoE settings would otherwise be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->