### PR TITLE
fix(attention): correct SM120 NVFP4 qk_correction layout, row-sum reduction, and lse

### DIFF
--- a/csrc/nvfp4_attention_sm120/nvfp4_attention_sm120_binding.cu
+++ b/csrc/nvfp4_attention_sm120/nvfp4_attention_sm120_binding.cu
@@ -265,9 +265,12 @@ void fwd(TensorView q_fp4, TensorView k_fp4, TensorView v_fp4_t, TensorView q_sc
   TVM_FFI_ICHECK_EQ(v_scale_t.size(2), head_dim);
   TVM_FFI_ICHECK_EQ(v_scale_t.size(3), seq_len / 16);
 
+  // Compact correction: one row per 128-token Q block. The kernel's TMA
+  // layout addresses the tensor this way and broadcasts each row across
+  // the rows of the corresponding Q tile.
   TVM_FFI_ICHECK_EQ(qk_correction.size(0), batch);
   TVM_FFI_ICHECK_EQ(qk_correction.size(1), num_heads);
-  TVM_FFI_ICHECK_EQ(qk_correction.size(2), per_block_mean ? seq_len : 128);
+  TVM_FFI_ICHECK_EQ(qk_correction.size(2), per_block_mean ? seq_len / 128 : 1);
   TVM_FFI_ICHECK_EQ(qk_correction.size(3), seq_len);
 
   TVM_FFI_ICHECK_EQ(out.size(0), batch);

--- a/flashinfer/nvfp4_attention_sm120.py
+++ b/flashinfer/nvfp4_attention_sm120.py
@@ -121,11 +121,11 @@ def _preprocess_qkv(
         qm = q.mean(dim=-2, keepdim=True)
         q = (q - qm).contiguous()
 
+    # Compact layout: one correction row per 128-token Q block ([B, H,
+    # seq_len / 128, seq_len]), or a single row when per_block_mean=False.
+    # The kernel's TMA descriptor addresses the tensor this way and
+    # broadcasts each row across the 128 rows of the Q tile in smem.
     qk_correction = torch.matmul(qm, k.transpose(-2, -1)).to(torch.float32)
-    if per_block_mean:
-        qk_correction = qk_correction.repeat_interleave(_TOKEN_BLOCK_SIZE, dim=2)
-    else:
-        qk_correction = qk_correction.expand(-1, -1, _TOKEN_BLOCK_SIZE, -1)
     qk_correction = qk_correction.contiguous()
     return q.contiguous(), k.contiguous(), v.contiguous(), qk_correction
 
@@ -164,7 +164,9 @@ def nvfp4_attention_sm120_quantize_qkv(
     -------
     Tuple[torch.Tensor, ...]
         ``q_fp4``, ``k_fp4``, transposed ``v_fp4_t``, scale tensors
-        ``q_scale``, ``k_scale``, ``v_scale_t``, and the expanded FP32 QK correction.
+        ``q_scale``, ``k_scale``, ``v_scale_t``, and the compact FP32 QK
+        correction with shape ``[batch, num_heads, seq_len / 128, seq_len]``
+        (``[batch, num_heads, 1, seq_len]`` when ``per_block_mean=False``).
     """
     q_proc, k_proc, v_proc, qk_correction = _preprocess_qkv(q, k, v, per_block_mean)
     batch, num_heads, seq_len, head_dim = q_proc.shape
@@ -286,11 +288,11 @@ def _check_inputs(
         raise ValueError(
             "qk_correction must have shape [batch, num_heads, seq_len_s, seq_len]"
         )
-    expected_delta_groups = seq_len if per_block_mean else _TOKEN_BLOCK_SIZE
+    expected_delta_groups = seq_len // _TOKEN_BLOCK_SIZE if per_block_mean else 1
     if qk_correction.shape[2] != expected_delta_groups:
         raise ValueError(
-            f"qk_correction seq_len_s dimension must be {expected_delta_groups}, "
-            f"got {qk_correction.shape[2]}"
+            f"qk_correction must have one row per 128-token block "
+            f"({expected_delta_groups}), got {qk_correction.shape[2]}"
         )
     if qk_correction.shape[-1] != seq_len:
         raise ValueError(
@@ -332,7 +334,9 @@ def nvfp4_attention_sm120_fwd(
     q_scale, k_scale, v_scale_t : torch.Tensor
         Per-vector FP8 scale factors for Q/K/V.
     qk_correction : torch.Tensor
-        FP32 correction term returned by ``nvfp4_attention_sm120_quantize_qkv``.
+        Compact FP32 correction term returned by
+        :func:`nvfp4_attention_sm120_quantize_qkv`, one row per 128-token
+        Q block.
     sm_scale : Optional[float], optional
         Scale applied to QK scores before softmax. Defaults to
         ``1 / sqrt(head_dim)`` when omitted.

--- a/flashinfer/nvfp4_attention_sm120.py
+++ b/flashinfer/nvfp4_attention_sm120.py
@@ -125,7 +125,11 @@ def _preprocess_qkv(
     # seq_len / 128, seq_len]), or a single row when per_block_mean=False.
     # The kernel's TMA descriptor addresses the tensor this way and
     # broadcasts each row across the 128 rows of the Q tile in smem.
-    qk_correction = torch.matmul(qm, k.transpose(-2, -1)).to(torch.float32)
+    # Multiply in fp32: a float16 matmul output would overflow at 65504
+    # even though the accumulation itself runs in fp32.
+    qk_correction = torch.matmul(
+        qm.to(torch.float32), k.transpose(-2, -1).to(torch.float32)
+    )
     qk_correction = qk_correction.contiguous()
     return q.contiguous(), k.contiguous(), v.contiguous(), qk_correction
 

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/consumer/softmax.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/consumer/softmax.cuh
@@ -51,7 +51,10 @@ struct SoftmaxFused {
   static constexpr float fp4_scale = 1.f / 6.f;
   static constexpr float fp4_scale_log2 = -2.584962500721156f;
   static constexpr float AbsMaxPEps = 1.0e-8f;
-  static constexpr int RowReductionThr = 8;
+  // One accumulator row is spread across 4 threads (m16n8 acc: 2 columns
+  // per thread per 8-column atom); reducing across 8 threads would fold
+  // the neighboring row's sum into row_sum and halve the output.
+  static constexpr int RowReductionThr = 4;
 
   CUTLASS_DEVICE SoftmaxFused() {};
 

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/epilogue/lse_writer.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/epilogue/lse_writer.cuh
@@ -37,25 +37,29 @@ struct LSEWriter {
   using ShapeLSE = cute::Shape<int32_t, int32_t, int32_t>;
   using StrideLSE = cute::Stride<_1, int64_t, int64_t>;
 
+  // Writes the LSE rows owned by one consumer thread. tiled_mma must be the
+  // per-warp-group PV mma whose accumulator softmax_fused reduced over, and
+  // row_offset the first sequence position of this warp group's sub-tile
+  // (m_block * kBlockM + wg_id * kBlockMPerWG).
   template <typename SoftmaxFused, typename TiledMma, typename Shape, typename Stride>
   __device__ __forceinline__ static void write_lse(float* ptr_LSE, Shape const& shape_LSE,
                                                    Stride const& stride_LSE,
                                                    SoftmaxFused const& softmax_fused,
                                                    float softmax_scale_log2,
                                                    TiledMma const& tiled_mma, int thread_idx,
-                                                   int m_block, int bidh, int bidb) {
+                                                   int row_offset, int bidh, int bidb) {
     Tensor mLSE = make_tensor(make_gmem_ptr(ptr_LSE), shape_LSE, stride_LSE);
-    Tensor gLSE =
-        local_tile(mLSE(_, bidh, bidb), cute::Shape<cute::Int<kBlockM>>{}, make_coord(m_block));
 
     auto const& row_max = softmax_fused.row_max;
     auto const& row_sum = softmax_fused.row_sum;
 
-    Tensor caccO = cute::make_identity_tensor(select<0, 2>(TileShape_MNK{}));
+    Tensor caccO =
+        cute::make_identity_tensor(cute::Shape<Int<Traits::kBlockMPerWG>, Int<kHeadDim>>{});
     auto thread_mma = tiled_mma.get_thread_slice(thread_idx);
     Tensor taccOcO = thread_mma.partition_C(caccO);
 
-    static_assert(decltype(size<0, 0>(taccOcO))::value == 2);
+    // acc fragment atom is (AtomN, AtomM) = (8, 2) for the 16x32 mma
+    static_assert(decltype(size<0, 0>(taccOcO))::value % 8 == 0);
     static_assert(decltype(size<0, 1>(taccOcO))::value == 2);
 
     Tensor taccOcO_row = taccOcO(make_coord(_0{}, _), _, _0{});
@@ -67,15 +71,21 @@ struct LSEWriter {
 
 #pragma unroll
       for (int mi = 0; mi < size(row_max); ++mi) {
-        const int row = get<0>(taccOcO_row(mi));
+        const int row = row_offset + get<0>(taccOcO_row(mi));
 
-        if (row < get<0>(shape_LSE) - m_block * kBlockM) {
+        if (row < get<0>(shape_LSE)) {
           float max_scaled = row_max(mi) * softmax_scale_log2 / log2_e;
           float sum = row_sum(mi);
 
-          float lse = (sum == 0.f || sum != sum) ? INFINITY : (max_scaled + logf(sum));
+          // row_sum carries the 2^-fp8_scalexfp4_scale_log2 factor the
+          // softmax bakes into every exp for the FP4 P quantization;
+          // remove it so lse is the plain ln-sum-exp of the scaled scores.
+          float lse =
+              (sum == 0.f || sum != sum)
+                  ? INFINITY
+                  : (max_scaled + logf(sum) + SoftmaxFused::fp8_scalexfp4_scale_log2 * ln_2);
 
-          gLSE(row) = lse;
+          mLSE(row, bidh, bidb) = lse;
         }
       }
     }
@@ -95,22 +105,6 @@ struct LSEWriter {
 
     if (thread_idx < get<0>(shape_LSE) - m_block * kBlockM) {
       gLSE(thread_idx) = INFINITY;
-    }
-  }
-
-  template <typename ShapeO, typename ShapeLSE, typename Stride, typename SoftmaxFused,
-            typename TiledMma>
-  __device__ __forceinline__ static void run(float* ptr_LSE, ShapeO const& shape_O,
-                                             ShapeLSE const& shape_LSE, Stride const& stride_LSE,
-                                             SoftmaxFused const& softmax_fused,
-                                             float softmax_scale_log2, TiledMma const& tiled_mma,
-                                             int thread_idx, int m_block, int bidh, int bidb,
-                                             bool is_valid_block) {
-    if (is_valid_block) {
-      write_lse(ptr_LSE, shape_LSE, stride_LSE, softmax_fused, softmax_scale_log2, tiled_mma,
-                thread_idx, m_block, bidh, bidb);
-    } else {
-      write_lse_infinity(ptr_LSE, shape_O, stride_LSE, thread_idx, m_block, bidh, bidb);
     }
   }
 };

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/epilogue/lse_writer.cuh
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/compute/epilogue/lse_writer.cuh
@@ -90,47 +90,6 @@ struct LSEWriter {
       }
     }
   }
-
-  template <typename ShapeO, typename Stride>
-  __device__ __forceinline__ static void write_lse_infinity(float* ptr_LSE, ShapeO const& shape_O,
-                                                            Stride const& stride_LSE,
-                                                            int thread_idx, int m_block, int bidh,
-                                                            int bidb) {
-    auto shape_LSE = select<0, 2, 3>(shape_O);
-
-    Tensor mLSE = make_tensor(make_gmem_ptr(ptr_LSE), shape_LSE, stride_LSE);
-    Tensor gLSE = local_tile(mLSE(_, bidh, bidb), Shape<Int<kBlockM>>{}, make_coord(m_block));
-
-    static_assert(kBlockM <= NumMmaThreads);
-
-    if (thread_idx < get<0>(shape_LSE) - m_block * kBlockM) {
-      gLSE(thread_idx) = INFINITY;
-    }
-  }
 };
-
-__device__ __forceinline__ float compute_lse_log2(float row_max, float row_sum,
-                                                  float softmax_scale_log2) {
-  constexpr float log2_e = 1.44269504088896340736f;
-
-  if (row_sum == 0.f || row_sum != row_sum) {
-    return INFINITY;
-  }
-
-  float max_scaled = row_max * softmax_scale_log2;
-  float lse_log2 = max_scaled + log2f(row_sum);
-
-  return lse_log2;
-}
-
-__device__ __forceinline__ float log2_to_ln(float x_log2) {
-  constexpr float ln_2 = 0.69314718055994530942f;
-  return x_log2 * ln_2;
-}
-
-__device__ __forceinline__ float ln_to_log2(float x_ln) {
-  constexpr float log2_e = 1.44269504088896340736f;
-  return x_ln * log2_e;
-}
 
 }  // namespace nvfp4_attention

--- a/include/flashinfer/attention/sm120/nvfp4_attention_sm120/kernel/attention_kernel.h
+++ b/include/flashinfer/attention/sm120/nvfp4_attention_sm120/kernel/attention_kernel.h
@@ -246,6 +246,11 @@ __global__ void __launch_bounds__(Ktraits::kNWarps* cutlass::NumThreadsPerWarp,
 
       collective_epilogue.mma_store(shared_storage, tiled_mma_pv, tOrO, mma_thread_idx, wg_id);
 
+      LSEWriter<Ktraits>::write_lse(
+          epilogue_params.ptr_LSE, select<0, 2, 3>(epilogue_params.shape_O),
+          epilogue_params.stride_LSE, softmax_fused, mainloop_params.softmax_scale_log2,
+          tiled_mma_pv, mma_thread_idx, m_block * kBlockM + wg_id * kBlockMPerWG, bidh, bidb);
+
       barrier_o.arrive();
 
       ++work_idx;

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -272,6 +272,29 @@ def test_nvfp4_attention_sm120_output_magnitude():
     assert (lse.float() - math.log(seq_len)).abs().max().item() <= 0.02
 
 
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_rejects_expanded_correction():
+    """The old expanded [B, H, S, S] correction layout (which the kernel never
+    addressed correctly) must be rejected by the shape validation."""
+    _require_sm120()
+
+    torch.manual_seed(42)
+    batch, num_heads, seq_len, head_dim = 1, 2, 256, 128
+    q = torch.randn(
+        (batch, num_heads, seq_len, head_dim), device="cuda", dtype=torch.bfloat16
+    )
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    quantized = list(flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v))
+    quantized[6] = quantized[6].repeat_interleave(128, dim=2).contiguous()
+
+    with pytest.raises(ValueError, match="qk_correction"):
+        flashinfer.nvfp4_attention_sm120_fwd(
+            *quantized, sm_scale=head_dim**-0.5, causal=False
+        )
+
+
 @pytest.mark.parametrize("causal", [False, True])
 @torch.inference_mode()
 def test_nvfp4_attention_sm120_lse(causal):

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -259,13 +261,50 @@ def test_nvfp4_attention_sm120_output_magnitude():
     v = torch.ones_like(q)
 
     quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
-    out, _ = flashinfer.nvfp4_attention_sm120_fwd(
+    out, lse = flashinfer.nvfp4_attention_sm120_fwd(
         *quantized, sm_scale=head_dim**-0.5, causal=False
     )
     torch.cuda.synchronize()
 
     # the only remaining error is V quantization (~3%)
     assert (out.float() - 1.0).abs().max().item() <= 0.05
+    # uniform scores: lse is exactly ln(seq_len)
+    assert (lse.float() - math.log(seq_len)).abs().max().item() <= 0.02
+
+
+@pytest.mark.parametrize("causal", [False, True])
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_lse(causal):
+    """lse must be the log-sum-exp of the scaled scores the kernel attends
+    over (K is mean-centered by quantize_qkv, which shifts each row's lse)."""
+    _require_sm120()
+
+    torch.manual_seed(42)
+    batch, num_heads, seq_len, head_dim = 2, 4, 1024, 128
+    q = torch.randn(
+        (batch, num_heads, seq_len, head_dim), device="cuda", dtype=torch.bfloat16
+    )
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
+    _, lse = flashinfer.nvfp4_attention_sm120_fwd(
+        *quantized, sm_scale=head_dim**-0.5, causal=causal
+    )
+    torch.cuda.synchronize()
+
+    k_centered = k.float() - k.float().mean(dim=-2, keepdim=True)
+    scores = torch.matmul(q.float(), k_centered.transpose(-2, -1)) * head_dim**-0.5
+    if causal:
+        mask = torch.triu(
+            torch.ones(seq_len, seq_len, device="cuda", dtype=torch.bool), diagonal=1
+        )
+        scores.masked_fill_(mask, float("-inf"))
+    lse_ref = torch.logsumexp(scores, dim=-1)
+
+    diff = (lse.float() - lse_ref).abs()
+    assert diff.mean().item() <= 0.05
+    assert diff.max().item() <= 0.5
 
 
 @torch.inference_mode()

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -180,6 +180,94 @@ def test_nvfp4_attention_sm120_accuracy(
     )
 
 
+@pytest.mark.parametrize("per_block_mean", [True, False])
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_structured_q_correction(per_block_mean):
+    """Q with real block structure makes qk_correction large; a misaddressed
+    correction tensor collapses accuracy (regression test for the expanded
+    [B, H, S, S] correction layout the kernel never addressed)."""
+    _require_sm120()
+
+    torch.manual_seed(42)
+    batch, num_heads, seq_len, head_dim = 2, 4, 1024, 128
+    q = torch.randn(
+        (batch, num_heads, seq_len, head_dim), device="cuda", dtype=torch.bfloat16
+    )
+    if per_block_mean:
+        # distinct mean per 128-token block, batch, and head
+        bias = torch.randn(
+            (batch, num_heads, seq_len // 128, 1, head_dim),
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        q = (q.view(batch, num_heads, seq_len // 128, 128, head_dim) + bias).view(
+            batch, num_heads, seq_len, head_dim
+        )
+    else:
+        # distinct mean per batch and head, constant across the sequence,
+        # so the full-sequence Q centering removes it exactly
+        bias = torch.randn(
+            (batch, num_heads, 1, head_dim), device="cuda", dtype=torch.bfloat16
+        )
+        q = q + bias
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+
+    q_fp4, k_fp4, v_fp4_t, q_scale, k_scale, v_scale_t, qk_correction = (
+        flashinfer.nvfp4_attention_sm120_quantize_qkv(
+            q, k, v, per_block_mean=per_block_mean
+        )
+    )
+    expected_rows = seq_len // 128 if per_block_mean else 1
+    assert qk_correction.shape == (batch, num_heads, expected_rows, seq_len)
+
+    out, _ = flashinfer.nvfp4_attention_sm120_fwd(
+        q_fp4,
+        k_fp4,
+        v_fp4_t,
+        q_scale,
+        k_scale,
+        v_scale_t,
+        qk_correction,
+        sm_scale=head_dim**-0.5,
+        causal=False,
+        per_block_mean=per_block_mean,
+    )
+    torch.cuda.synchronize()
+
+    # smoothing + correction reproduce plain attention exactly, so the exact
+    # output is the reference; the remaining gap is FP4 quantization error
+    ref = torch.nn.functional.scaled_dot_product_attention(
+        q.float(), k.float(), v.float(), scale=head_dim**-0.5
+    )
+    cos_sim = F.cosine_similarity(out.float().reshape(1, -1), ref.reshape(1, -1)).item()
+    assert cos_sim >= 0.95
+
+
+@torch.inference_mode()
+def test_nvfp4_attention_sm120_output_magnitude():
+    """With uniform scores and V = ones the exact output is 1.0 everywhere;
+    a mis-reduced row_sum shows up as a uniform scale error that cosine
+    thresholds cannot see (regression test for the halved output)."""
+    _require_sm120()
+
+    batch, num_heads, seq_len, head_dim = 1, 2, 512, 128
+    q = torch.zeros(
+        (batch, num_heads, seq_len, head_dim), device="cuda", dtype=torch.bfloat16
+    )
+    k = torch.zeros_like(q)
+    v = torch.ones_like(q)
+
+    quantized = flashinfer.nvfp4_attention_sm120_quantize_qkv(q, k, v)
+    out, _ = flashinfer.nvfp4_attention_sm120_fwd(
+        *quantized, sm_scale=head_dim**-0.5, causal=False
+    )
+    torch.cuda.synchronize()
+
+    # the only remaining error is V quantization (~3%)
+    assert (out.float() - 1.0).abs().max().item() <= 0.05
+
+
 @torch.inference_mode()
 def test_nvfp4_attention_sm120_causal_mask_column_order():
     _require_sm120()


### PR DESCRIPTION
## Description

While benchmarking the SM120 NVFP4 attention path from #3640 on an RTX PRO 6000 for #3809, I found three defects versus the SageAttention3 kernel it ports. All are invisible to the current tests (iid inputs make the correction negligible, cosine/mean-abs-err thresholds absorb a uniform scale error, and lse is only checked for NaN), but they matter a lot on real inputs.

**1. `qk_correction` is addressed as a compact tensor, but Python passes an expanded one.**

The mainloop builds the DS TMA descriptor from `tile_to_shape(SmemLayoutAtomDS{}, ...)` where the atom is `Layout<Shape<kBlockM, kBlockN>, Stride<_0, _1>>` (`kernel/traits.h:165`, `compute/mainloop.cuh:193-200`). The resulting gmem layout has stride 0 within each 128-row block, i.e. the kernel addresses `ptr_ds` as a compact `[batch, heads, seq_len/128, seq_len]` tensor and never uses the strides passed from the binding. SageAttention3's `preprocess_qkv` produces exactly that compact `delta_s` (one `qm @ k^T` row per 128-token block). Our port added a `repeat_interleave(128, dim=2)` that materializes `[batch, heads, seq_len, seq_len]`, so at runtime the kernel read block 0's correction rows for every Q block and crossed head/batch boundaries for `bidh > 0` / `bidb > 0`.

I verified the addressing empirically before changing anything: with B=1 H=1, scrambling every row `r >= seq_len/128` of the expanded tensor leaves the output bitwise identical (those rows are never read), and a marker placed in gmem row `r` moves exactly the output rows of Q block `r`, for `r = 0..seq_len/128-1`.

The fix passes the compact tensor through (`quantize_qkv` output shape changes to `[B, H, S/128, S]`, or `[B, H, 1, S]` for `per_block_mean=False`) and updates the binding shape check. This also removes the O(seq_len^2) fp32 materialization, which was 99% of the preprocessing cost (7.3 ms of the 9.5 ms end-to-end at S=16K, and an 8.6 GB allocation). Per review feedback the correction matmul now also runs in fp32, since a float16 matmul output would overflow at 65504.

**2. Row-sum reduction folds in the neighboring row.**

One accumulator row spans 4 threads in the acc layout (2 columns per thread per 8-column group). `SoftmaxFused::RowReductionThr` was 8 -- SageAttention3 has 4 (`softmax_fused.h:35` upstream) -- so the `__shfl_xor(4)` step in `finalize()` added the neighboring row's sum into every `row_sum`, halving the output. A probe with uniform scores and V = all-ones (exact output must be 1.0 everywhere, independent of P quantization) returns 0.5156 = half the V-dequant value, exactly.

**3. `lse` is never written.**

`LSEWriter` (`compute/epilogue/lse_writer.cuh`) had no call site, so `fwd` returned an uninitialized buffer -- the existing non-NaN assertions pass or fail depending on allocator reuse (SageAttention3 has its LSE store commented out entirely; the writer here was half-adapted dead code with m16n8 fragment asserts that don't compile against this kernel's mma). It's now called from the consumer loop after the softmax finalize, using the per-warp-group PV mma for the row mapping plus an explicit row offset, and the value drops the `fp8_scalexfp4_scale_log2` factor that `row_sum` carries for the FP4 P quantization, so `lse` is the plain ln-sum-exp of the scaled scores. Uniform scores now give `lse = ln(seq_len)` exactly; iid/structured lse mean abs error vs exact `logsumexp` is 0.01-0.02.

### Accuracy A/B on RTX PRO 6000 (CUDA 13, torch 2.11, this repo at c53229ef)

Reference is exact fp32 SDPA on the same inputs; `alpha` is the least-squares scale `<out,ref>/<ref,ref>` (1.0 = unbiased), so it exposes the halving that cosine cannot see.

| case | main: cos / relL2 / alpha | fixed: cos / relL2 / alpha |
|---|---|---|
| uniform scores, V=ones (exact 1.0) | out = 0.516 | out = 1.031 (= exact V-quant value) |
| iid, B2 H4 S1024 D128 | 0.974 / 0.524 / 0.489 | 0.982 / 0.188 / 0.980 |
| block-structured Q, per_block_mean=True | 0.408 / 0.914 / 0.186 | 0.984 / 0.181 / 0.983 |
| per-(b,h)-shifted Q, per_block_mean=False | 0.455 / 0.891 / 0.212 | 0.983 / 0.182 / 0.982 |

The structured-Q rows are the case the SageAttention smoothing machinery exists for; on main the correction is applied to the wrong blocks, so accuracy collapses exactly where the algorithm is supposed to help.

### End-to-end perf (quantize_qkv + fwd, in-repo benchmark, non-causal)

| shape | main e2e | fixed e2e | BF16 SDPA-flash |
|---|---|---|---|
| B4 H8 S4096 D128 | 2.590 ms (106 TFLOPs/s) | 0.723 ms (380 TFLOPs/s) | 1.107 ms |
| B1 H8 S16384 D128 | 9.528 ms (115 TFLOPs/s) | ~2.5 ms (~440 TFLOPs/s) | 5.594 ms |

Kernel-only time is unchanged (~0.42 / ~1.9 ms, 660 / 570 TFLOPs/s); the fixed e2e includes the fp32 correction matmul and the lse store. The 16K shape shows some run-to-run spread on my box (2.5-3.1 ms) -- 3-4x faster than main either way. End-to-end goes from 2.3x slower than BF16 flash attention to roughly 1.5-2.2x faster, which is the regime diffusion workloads (fresh Q/K/V every step) actually run in.

Note: `quantize_qkv`'s output shape for `qk_correction` changes; the pair of public APIs stays self-consistent, so code using them together is unaffected.

## Related Issues

#3809 (this makes the existing SM120 NVFP4 path usable and fast end-to-end on diffusion shapes; kernel-level follow-ups tracked there), #3640.

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`pytest -q tests/attention/test_nvfp4_attention_sm120.py`: 13 passed (7 existing + 6 new) on RTX PRO 6000. The new regression tests fail on main: `test_nvfp4_attention_sm120_structured_q_correction` (cos 0.41/0.45 vs the 0.95 floor), `test_nvfp4_attention_sm120_output_magnitude` (0.516 vs 1.0 +/- 0.05), and `test_nvfp4_attention_sm120_lse` (uninitialized buffer).

## Reviewer Notes

The decisive probes are easy to re-run: (a) scramble rows `>= seq_len/128` of the expanded correction on main and observe bitwise-identical output; (b) uniform scores with V = all-ones must return 1.0 and lse = ln(seq_len). Happy to split the three fixes into separate PRs if you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LSE output support in the SM120 NVFP4 attention path, making log-sum-exp values available alongside attention results.
  * Updated FP32 correction handling to use a compact layout that matches block-based attention processing.

* **Bug Fixes**
  * Corrected shape validation for correction data to reject outdated expanded layouts and accept the expected block-wise format.
  * Improved numerical handling for LSE and softmax computation, including more stable output scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->