### PR TITLE
fix(moe): fail loudly instead of IMA when no routing tier covers (numExperts, topK)

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu
@@ -18,10 +18,14 @@
 
 namespace moe::dev::routing {
 namespace routingCustom {
-// Forward declarations of launch functions
-void launchBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
-void launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
-void launchClusterKernel(Data const& data, void* stream);
+// Forward declarations of launch functions.
+// Block/DynBlock/Cluster return whether a compiled tier covered (numExperts, topK)
+// and the kernel was actually launched; the definitions live in
+// trtllm_fused_moe_routing_custom.cu. Keep these signatures in sync (the return
+// type is not part of the mangled name, so a mismatch would silently be UB).
+bool launchBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
+bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream);
+bool launchClusterKernel(Data const& data, void* stream);
 void launchCoopKernel(Data const& data, int numBlocksCoop, uint32_t numThreadsHist, void* stream);
 void launchInitExpertCounts(Data const& data, uint32_t numThreadsHist, void* stream);
 void launchHistogramKernel(Data const& data, int numBlocksHistogram, uint32_t numThreadsHist,
@@ -83,11 +87,27 @@ void runPostTopKPipeline(DataType const& data, void* stream) {
       (smMajor >= 9) && (data.mNumTokens <= routingCustom::MaxNumTokensSingleCluster);
 
   if (useDynBlock) {
-    routingCustom::launchDynBlockKernel(customData, numThreadsHist, stream);
+    bool const launched = routingCustom::launchDynBlockKernel(customData, numThreadsHist, stream);
+    FLASHINFER_CHECK(
+        launched, "runPostTopKPipeline: no compiled tier covers numExperts=", data.mNumExperts,
+        " topK=", data.mTopK,
+        " for the post-topK permutation (dyn-block path). Add a matching Tier<E, K> to "
+        "PolicyTraits<NoOpPreprocess, SoftmaxPostprocess> in RoutingCustomPolicy.cuh.");
   } else if (useStaticBlock) {
-    routingCustom::launchBlockKernel(customData, numThreadsHist, stream);
+    bool const launched = routingCustom::launchBlockKernel(customData, numThreadsHist, stream);
+    FLASHINFER_CHECK(
+        launched, "runPostTopKPipeline: no compiled tier covers numExperts=", data.mNumExperts,
+        " topK=", data.mTopK,
+        " for the post-topK permutation (static-block path). Add a matching Tier<E, K> "
+        "to PolicyTraits<NoOpPreprocess, SoftmaxPostprocess> in RoutingCustomPolicy.cuh.");
   } else if (useSingleCluster) {
-    routingCustom::launchClusterKernel(customData, stream);
+    bool const launched = routingCustom::launchClusterKernel(customData, stream);
+    FLASHINFER_CHECK(launched,
+                     "runPostTopKPipeline: no compiled tier covers numExperts=", data.mNumExperts,
+                     " topK=", data.mTopK,
+                     " for the post-topK permutation (single-cluster path). Add a matching "
+                     "Tier<E, K> to (Cluster)PolicyTraits<NoOpPreprocess, SoftmaxPostprocess> in "
+                     "RoutingCustomPolicy.cuh.");
   } else {
     // Check if we can use the coop path (more efficient for medium token counts)
     // Requires SM90+ (grid-sync), numExperts <= 1024.

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -297,10 +297,14 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
 #endif
 }
 
-void launchBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched. A false return means no routing output was written;
+// the caller (run) must not proceed to the downstream pipeline in that case.
+bool launchBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
   LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesBlockKernel, 1, numThreadsHist,
                         /*smemSize=*/0,  // No dynamic smem
                         stream);
+  return queryPolicyHasCompiledTier(data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -625,7 +629,9 @@ __global__ void routingIndicesDynBlockKernel(KernelParams params) {
 #endif
 }
 
-void launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched (see launchBlockKernel).
+bool launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* stream) {
   int32_t const maxExperts = queryDispatchedMaxExperts(data);
   int const numSlots = data.mNumTokens * maxExperts;
   int const smemSize = numSlots + numSlots * 2 + 128 +
@@ -634,6 +640,7 @@ void launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* strea
       std::min(std::max(data.mNumTokens * static_cast<int>(WarpSize), maxExperts), 1024);
 
   LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesDynBlockKernel, 1, threads, smemSize, stream);
+  return queryPolicyHasCompiledTier(data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -802,8 +809,10 @@ void launchClusterKernelForTier(Data const& data, void* stream) {
   }
 }
 
+// Returns whether the cluster tier dispatch found a covering tier (ClusterPolicyTraits
+// is a filtered subset of PolicyTraits, so it may reject a config PolicyTraits covers).
 template <int ClusterBlockDim, typename PreProc, typename PostProc>
-void launchClusterKernelForPolicy(Data const& data, void* stream) {
+bool launchClusterKernelForPolicy(Data const& data, void* stream) {
   using Pairs = typename ClusterPolicyTraits<ClusterBlockDim, PreProc, PostProc>::Pairs;
   bool dispatched =
       dispatchTierPairs(static_cast<Pairs*>(nullptr), data, [&](auto eTag, auto kTag) {
@@ -813,41 +822,45 @@ void launchClusterKernelForPolicy(Data const& data, void* stream) {
   if (!dispatched) {
     FLASHINFER_WARN("No tier covers numExperts=%d topK=%d", data.mNumExperts, data.mTopK);
   }
+  return dispatched;
 }
 
 template <int ClusterBlockDim>
-void launchClusterKernelForBlockDim(Data const& data, void* stream) {
+bool launchClusterKernelForBlockDim(Data const& data, void* stream) {
+  bool dispatched = false;
   dispatchRoutingPolicy(data, [&](auto preProc, auto postProc, char const* /*policyName*/) {
-    launchClusterKernelForPolicy<ClusterBlockDim, decltype(preProc), decltype(postProc)>(data,
-                                                                                         stream);
+    dispatched =
+        launchClusterKernelForPolicy<ClusterBlockDim, decltype(preProc), decltype(postProc)>(
+            data, stream);
   });
+  return dispatched;
 }
 
-void launchClusterKernel(Data const& data, void* stream) {
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched (see launchBlockKernel).
+bool launchClusterKernel(Data const& data, void* stream) {
   // Each warp owns one token, so the reduced-thread cluster variants have lower token capacity.
   // Use them only where the requested token count fits; otherwise keep the original 1024-thread
   // launch.
   if (data.mNumTokens <= MaxNumTokensClusterScores256) {
-    launchClusterKernelForBlockDim<ClusterBlockDim256>(data, stream);
-    return;
+    return launchClusterKernelForBlockDim<ClusterBlockDim256>(data, stream);
   }
   if (data.mNumTokens <= MaxNumTokensClusterScores512) {
-    launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
-    return;
+    return launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
   }
 
   bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr &&
                                     data.mPreprocessType == RoutingPreprocessType::None &&
                                     data.mPostprocessType == RoutingPostprocessType::Softmax;
   if (useNoOpSoftmaxScores) {
-    launchClusterKernelForPolicy<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>(data,
-                                                                                          stream);
-    return;
+    return launchClusterKernelForPolicy<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>(
+        data, stream);
   }
 
   LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesClusterKernel, NumBlocksPerCluster, NumThreads,
                         /*smemSize=*/0,  // No dynamic smem
                         stream);
+  return queryPolicyHasCompiledTier(data);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -978,8 +991,11 @@ __global__ void __launch_bounds__(
 #endif  // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 }
 
-void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32_t numThreadsHist,
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched (see launchBlockKernel).
+bool launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32_t numThreadsHist,
                                  void* stream) {
+  bool launched = false;
   dispatchRoutingPolicy(data, [&](auto preProc, auto postProc, char const* policyName) {
     using PreProc = decltype(preProc);
     using PostProc = decltype(postProc);
@@ -998,6 +1014,7 @@ void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32
                                        /*smemSize=*/0, stream, PreProc, PostProc,
                                        decltype(eTag)::value, decltype(kTag)::value);
         });
+    launched = dispatched;
     if (!dispatched) {
       FLASHINFER_WARN(
           "No tier covers numExperts=%d topK=%d for policy %s in "
@@ -1005,6 +1022,7 @@ void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32
           data.mNumExperts, data.mTopK, policyName);
     }
   });
+  return launched;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1195,7 +1213,9 @@ __global__ void __launch_bounds__(kBlockScoresKernelBlockDim)
   }  // end `if constexpr (kSupported)` else branch
 }
 
-void launchBlockScoresKernel(Data const& data, void* stream) {
+// Returns whether a compiled tier covered the runtime (numExperts, topK) and the
+// kernel was actually launched (see launchBlockKernel).
+bool launchBlockScoresKernel(Data const& data, void* stream) {
   // Custom dispatch that does NOT clamp blockDim to the dispatched tier's
   // expert count (unlike `LAUNCH_ROUTING_CUSTOM`).  The kernel's layout —
   // kBlockScoresKernelBlockDim threads with a grid-stride loop over experts —
@@ -1203,6 +1223,7 @@ void launchBlockScoresKernel(Data const& data, void* stream) {
   // registers and shrink occupancy.  The blockDim is intentionally fixed to
   // the kernel-side constant so host and device agree (SoftmaxPreprocess
   // sizes its cub::BlockReduce with the same value at compile time).
+  bool launched = false;
   dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* policyName_) {
     using PreProc_ = decltype(preProc_);
     using PostProc_ = decltype(postProc_);
@@ -1215,6 +1236,7 @@ void launchBlockScoresKernel(Data const& data, void* stream) {
                                        /*smemSize=*/0, stream, PreProc_, PostProc_,
                                        decltype(eTag_)::value, decltype(kTag_)::value);
         });
+    launched = dispatched_;
     if (!dispatched_) {
       FLASHINFER_WARN(
           "No compiled tier covers numExperts=%d topK=%d for policy %s in "
@@ -1222,6 +1244,7 @@ void launchBlockScoresKernel(Data const& data, void* stream) {
           data.mNumExperts, data.mTopK, policyName_);
     }
   });
+  return launched;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1483,7 +1506,12 @@ void run(Data const& data, void* stream) {
     //
     // The kernel is generic in (PreprocessPolicy, PostprocessPolicy) — any
     // registered policy pair in RoutingCustomPolicy.cuh works here.
-    launchBlockScoresKernel(mutableData, stream);
+    bool const launched = launchBlockScoresKernel(mutableData, stream);
+    FLASHINFER_CHECK(
+        launched, "routingCustom::run: no compiled tier covers numExperts=", data.mNumExperts,
+        " topK=", data.mTopK,
+        " for the active routing policy (block-per-token split path; see preceding "
+        "warning). Add a matching Tier<E, K> to PolicyTraits in RoutingCustomPolicy.cuh.");
 
     // Step 2: delegate the permutation pipeline to runPostTopKPipeline, which
     //   will pick the cluster kernel (LoadExpertIdxFromGlobal=true branch) for
@@ -1499,11 +1527,26 @@ void run(Data const& data, void* stream) {
   }
 
   if (useDynBlock) {
-    launchDynBlockKernel(mutableData, numThreadsHist, stream);
+    bool const launched = launchDynBlockKernel(mutableData, numThreadsHist, stream);
+    FLASHINFER_CHECK(launched,
+                     "routingCustom::run: no compiled tier covers numExperts=", data.mNumExperts,
+                     " topK=", data.mTopK,
+                     " for the active routing policy (dyn-block path; see preceding warning). "
+                     "Add a matching Tier<E, K> to PolicyTraits in RoutingCustomPolicy.cuh.");
   } else if (useStaticBlock) {
-    launchBlockKernel(mutableData, numThreadsHist, stream);
+    bool const launched = launchBlockKernel(mutableData, numThreadsHist, stream);
+    FLASHINFER_CHECK(launched,
+                     "routingCustom::run: no compiled tier covers numExperts=", data.mNumExperts,
+                     " topK=", data.mTopK,
+                     " for the active routing policy (static-block path; see preceding warning). "
+                     "Add a matching Tier<E, K> to PolicyTraits in RoutingCustomPolicy.cuh.");
   } else if (useSingleCluster) {
-    launchClusterKernel(mutableData, stream);
+    bool const launched = launchClusterKernel(mutableData, stream);
+    FLASHINFER_CHECK(
+        launched, "routingCustom::run: no compiled tier covers numExperts=", data.mNumExperts,
+        " topK=", data.mTopK,
+        " for the active routing policy (single-cluster path; see preceding warning). "
+        "Add a matching Tier<E, K> to (Cluster)PolicyTraits in RoutingCustomPolicy.cuh.");
   } else {
     uint32_t const maxNumBlocks = 1024;
 
@@ -1545,11 +1588,18 @@ void run(Data const& data, void* stream) {
     } else if (forceMode == ForceMode::kOff) {
       useBlockScoresForTopK = false;
     }
+    bool launched = false;
     if (useBlockScoresForTopK) {
-      launchBlockScoresKernel(mutableData, stream);
+      launched = launchBlockScoresKernel(mutableData, stream);
     } else {
-      launchHistogramScoresKernel(mutableData, maxNumBlocks, numThreadsHist, stream);
+      launched = launchHistogramScoresKernel(mutableData, maxNumBlocks, numThreadsHist, stream);
     }
+    FLASHINFER_CHECK(
+        launched,
+        "routingCustom::run: no compiled score-to-topK tier covers numExperts=", data.mNumExperts,
+        " topK=", data.mTopK,
+        " for the active routing policy (large-batch path; see preceding warning). "
+        "Add a matching Tier<E, K> to (Histogram)PolicyTraits in RoutingCustomPolicy.cuh.");
 
     bool const canUseCoop =
         (smMajor >= 9) && (data.mNumExperts <= 1024) && (data.mPtrPermutedIdxSize != nullptr);

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -923,6 +923,22 @@ inline bool queryPolicySupportsBlockPerToken(Data const& data) {
   return supports;
 }
 
+// Whether the active (pre, post) policy has a compiled tier covering the runtime
+// (numExperts, topK) under the standard PolicyTraits dispatch — i.e. the tier list
+// LAUNCH_ROUTING_CUSTOM uses (block / dyn-block kernels and the cluster fallback).
+// Mirrors the dispatch predicate exactly (same policy resolution, same tier list,
+// same runtime comparison), so it reports precisely whether that launch would find
+// a tier. Lets host-side launchers surface an uncovered config as a loud error
+// instead of silently skipping the launch and leaving routing outputs uninitialized.
+inline bool queryPolicyHasCompiledTier(Data const& data) {
+  bool covered = false;
+  dispatchRoutingPolicy(data, [&](auto preProc_, auto postProc_, char const* /*policyName*/) {
+    using Pairs_ = typename PolicyTraits<decltype(preProc_), decltype(postProc_)>::Pairs;
+    covered = dispatchTierPairs(static_cast<Pairs_*>(nullptr), data, [](auto, auto) {});
+  });
+  return covered;
+}
+
 // Top-level dispatch: maps runtime preprocess/postprocess enums to compile-time policy types,
 // then delegates to the policy tier list using the supplied launch config.
 #define LAUNCH_ROUTING_CUSTOM_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads,       \


### PR DESCRIPTION
## 📌 Description

The trtllm custom-routing launchers dispatch kernels through a compile-time
`PolicyTraits` tier list. When no tier covers the runtime `(numExperts, topK)`
for the active policy, the launchers previously only emitted `FLASHINFER_WARN`
and returned **without launching any kernel**. `run()` / `runPostTopKPipeline()`
then continued with **uninitialized routing output**, and the downstream grouped
GEMM read out-of-range indices and crashed with an **illegal memory access**.

This is reproducible with 512-expert TopK-only routing (`RoutingMethodType::TopK`,
i.e. `NoOpPreprocess + NoOpPostprocess`), whose `PolicyTraits` currently only
covers ≤256 experts: during autotune the routing kernel silently fails to launch
and the next launch surfaces `CUDA error: an illegal memory access was encountered`.

This PR makes the "no compiled tier" case **fail fast** instead of corrupting
device state:

- Every tier-dispatched routing launcher now returns whether a kernel was
  actually launched: `launchBlockKernel`, `launchDynBlockKernel`,
  `launchClusterKernel` (+ its `ForPolicy` / `ForBlockDim` helpers),
  `launchHistogramScoresKernel`, `launchBlockScoresKernel` → `bool`.
- `run()` and `runPostTopKPipeline()` now `FLASHINFER_CHECK` each launch and
  raise a clear host-side error (with the offending `numExperts` / `topK` and a
  hint to add a matching `Tier<E, K>`) **before** any downstream work.
- Adds `queryPolicyHasCompiledTier()` in `RoutingCustomPolicy.cuh`, mirroring the
  existing `query*` helpers so it stays exactly in sync with the dispatch predicate.
- `launchCoopKernel` is intentionally left unchanged — it already throws for
  `numExperts > 1024` and covers everything below, so it cannot silently no-launch.

**Scope:** behavior changes only on the previously-broken path. Supported configs
are unaffected; an uncovered `(policy, numExperts, topK)` now raises a
`RuntimeError` instead of triggering an IMA. This does **not** by itself add
support for a new config (that still requires adding a `Tier<E, K>`); it turns
silent memory corruption into an actionable error. This is the fail-fast behavior
previously suggested in reviews of #2803 (`launchCoopKernel`) and #3166
(`queryPolicySupportsBlockPerToken`).

## 🔍 Related Issues

No dedicated tracking issue. #3168 and #2776 report the same *symptom* class
(autotune / graph-capture IMA in `trtllm_fp4_block_scale_moe`) but a **different
root cause** (FP4 hidden-dim padding), so they are **not** fixed by this PR.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

- No new test was added: the change only converts a silently-broken path into a
  loud error, and existing `tests/moe/test_trtllm_gen_fused_moe.py` already
  covers no-regression. Ran the trtllm-gen subset on GB300 (SM103):
  **38 passed, 0 failed** (Sigmoid / DeepSeekV3 / TopK / Llama4 / Renormalize),
  and the 512-expert TopK repro now raises a clean `RuntimeError` instead of an
  IMA. Happy to add a `pytest.raises` negative test for the no-tier path if you
  prefer.
- Follow-up (separate PR): add `Tier<512, 8>` to
  `PolicyTraits<NoOpPreprocess, NoOpPostprocess>` to actually *support*
  512-expert TopK-only routing (this PR only makes it fail cleanly).
- The `FLASHINFER_CHECK` messages use the stream-style argument form (consistent
  with `utils.cuh` / `exception.h`), so `numExperts` / `topK` are printed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Routing now validates that a matching compiled kernel path exists before running, reducing silent failures for unsupported expert/top-k combinations.
  * When no matching configuration is available, the app now stops with clearer error messages instead of continuing incorrectly.
  * Improved dispatch handling across routing paths so supported configurations are launched reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->