### PR TITLE
fix(gdn): reject invalid sm120 tma lowering

### DIFF
--- a/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/custom_compile_cache.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import types
 import warnings
 from collections.abc import Hashable
 
@@ -15,14 +14,6 @@ _TMA_CLUSTER_LOAD = (
     "cp.async.bulk.tensor.3d.shared::cluster.global.tile."
     "mbarrier::complete_tx::bytes.L2::cache_hint"
 )
-_TMA_CTA_LOAD = (
-    "cp.async.bulk.tensor.3d.shared::cta.global.tile."
-    "mbarrier::complete_tx::bytes.L2::cache_hint"
-)
-_TMA_TILE_STORE = (
-    "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group.L2::cache_hint"
-)
-_TMA_CTA_STORE = "cp.async.bulk.tensor.3d.global.shared::cta.bulk_group"
 
 
 def _as_options_tuple(options):
@@ -92,11 +83,11 @@ def _has_option_value(options, option_type, option_value):
     return False
 
 
-def _needs_sm120a_tma_patch(options):
+def _needs_sm120a_ptx_check(options):
     return _has_option_value(options, cute.GPUArch, "sm_120a")
 
 
-def _patched_compile_options(options, dump_dir):
+def _ptx_check_compile_options(options, dump_dir):
     options = _as_options_tuple(options)
 
     has_keep_ptx = _has_option_value(options, cute.KeepPTX, True)
@@ -120,101 +111,17 @@ def _read_ptx_text(ptx_artifact):
     return ptx_artifact
 
 
-def _patch_sm120a_tma_ptx(ptx_text: str) -> str:
-    patched = ptx_text.replace(_TMA_CLUSTER_LOAD, _TMA_CTA_LOAD)
-    if _TMA_TILE_STORE in patched:
-        lines = []
-        for line in patched.splitlines(keepends=True):
-            if _TMA_TILE_STORE not in line:
-                lines.append(line)
-                continue
-
-            line_body = line.rstrip("\r\n")
-            line_end = line[len(line_body) :]
-            line_body = line_body.replace(_TMA_TILE_STORE, _TMA_CTA_STORE)
-            if line_body.endswith(";"):
-                operands, separator, _cache_policy = line_body[:-1].rpartition(", %rd")
-                if separator:
-                    line_body = operands + ";"
-            lines.append(line_body + line_end)
-        patched = "".join(lines)
-
-    return patched
-
-
-def _install_patched_ptx_loader(compiled_fn, patched_ptx: str):
-    import ctypes
-
-    import cuda.bindings.driver as cuda_driver
-    import cuda.bindings.runtime as cuda_runtime
-
-    from cutlass.base_dsl.common import DSLRuntimeError
-    from cutlass.base_dsl.runtime.cuda import checkCudaErrors
-
-    jit_options = [cuda_driver.CUjit_option.CU_JIT_TARGET]
-    jit_option_values = [cuda_driver.CUjit_target.CU_TARGET_COMPUTE_120A]
-
-    def _load_cuda_library(self):
-        if self.engine is None:
-            raise DSLRuntimeError("CUDA JIT engine is not available")
-
-        cuda_load_to_device = self.engine.raw_lookup("cuda_load_to_device")
-        if cuda_load_to_device is None:
-            raise DSLRuntimeError("cuda_load_to_device not found")
-        cuda_load_to_device = ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_void_p)(
-            cuda_load_to_device
-        )
-
-        library_obj = checkCudaErrors(
-            cuda_driver.cuLibraryLoadData(
-                patched_ptx.encode("utf-8"),
-                jit_options,
-                jit_option_values,
-                len(jit_options),
-                None,
-                None,
-                0,
-            )
-        )
-        library = ctypes.c_void_p(int(library_obj))
-        pointer_to_library = ctypes.pointer(library)
-        pointer_to_pointer_to_library = ctypes.pointer(pointer_to_library)
-        err = ctypes.c_int32(0)
-        pointer_to_err = ctypes.pointer(err)
-        device_id = ctypes.c_int32(0)
-        pointer_to_device_id = ctypes.pointer(device_id)
-
-        cuda_load_args = [
-            pointer_to_pointer_to_library,
-            pointer_to_device_id,
-            pointer_to_err,
-        ]
-        packed_args = (ctypes.c_void_p * len(cuda_load_args))()
-        for i, arg in enumerate(cuda_load_args):
-            packed_args[i] = ctypes.cast(arg, ctypes.c_void_p)
-
-        for dev in range(self.num_devices):
-            device_id.value = dev
-            cuda_load_to_device(packed_args)
-            checkCudaErrors((cuda_runtime.cudaError_t(err.value),))
-
-        return [library_obj]
-
-    compiled_fn._flat_patched_ptx = patched_ptx
-    compiled_fn._flat_patched_ptx_jit_options = tuple(jit_options)
-    compiled_fn._flat_patched_ptx_jit_option_values = tuple(jit_option_values)
-    compiled_fn._load_cuda_library = types.MethodType(_load_cuda_library, compiled_fn)
-
-
-def _patch_sm120a_tma(compiled_fn, options):
+def _sm120a_ptx_check(compiled_fn):
     ptx = _read_ptx_text(getattr(compiled_fn, "__ptx__", None))
     if not ptx:
-        return compiled_fn
-    patched_ptx = _patch_sm120a_tma_ptx(ptx)
-    if patched_ptx == ptx:
-        return compiled_fn
-    _install_patched_ptx_loader(compiled_fn, patched_ptx)
-    return compiled_fn
+        raise RuntimeError("Unable to inspect generated PTX for the SM120 GDN kernel")
+    if _TMA_CLUSTER_LOAD in ptx:
+        raise RuntimeError(
+            "SM120 GDN kernel compilation produced unsupported cluster-scoped TMA loads. "
+            "Install the CUDA 13 CUTLASS DSL compiler with "
+            "`pip install --upgrade --force-reinstall 'nvidia-cutlass-dsl[cu13]'`. "
+            "See https://github.com/NVIDIA/cutlass/issues/3170."
+        )
 
 
 def cached_compile(func, *args, compile_options=None, **kwargs):
@@ -222,14 +129,14 @@ def cached_compile(func, *args, compile_options=None, **kwargs):
     compiled_fn = _in_mem_compile_cache.get(cache_key)
 
     if compiled_fn is None:
-        _needs_patch = _needs_sm120a_tma_patch(compile_options)
-        if not _needs_patch:
+        _needs_ptx_check = _needs_sm120a_ptx_check(compile_options)
+        if not _needs_ptx_check:
             compiled_fn = cute.compile[compile_options](func, *args, **kwargs)
         else:
-            with tempfile.TemporaryDirectory(prefix="cutedsl_patch_") as tempdir:
-                compile_options = _patched_compile_options(compile_options, tempdir)
+            with tempfile.TemporaryDirectory(prefix="cutedsl_ptx_check_") as tempdir:
+                compile_options = _ptx_check_compile_options(compile_options, tempdir)
                 compiled_fn = cute.compile[compile_options](func, *args, **kwargs)
-                compiled_fn = _patch_sm120a_tma(compiled_fn, compile_options)
+                _sm120a_ptx_check(compiled_fn)
 
         _in_mem_compile_cache[cache_key] = compiled_fn
 


### PR DESCRIPTION
## 📌 Description

Drop PTX patch, just error out with instruction on malformed ptx, which incur huge perf degen.

## 🔍 Related Issues

Fix #3795, supersede #3799

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compile-time validation for certain GPU kernel builds, with clearer failures when unsupported features are detected.
  * Reduced reliance on fragile patching by using a more direct inspection flow during compilation.
  * Added safer handling for cached compilation results and PTX output retention to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->