### PR TITLE
Fix unbounded lru_cache leak in AutoTuner caused by fresh lambda per …

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -229,7 +229,7 @@ class DynamicTensorSpec:
     dim_idx: Tuple[int, ...]
     gen_tuning_buckets: Union[Tuple[int, ...], Callable]
     map_to_tuning_buckets: Callable
-    tensor_initializers: List[Callable] = field(default_factory=lambda: None)
+    tensor_initializers: List[Callable] = field(default_factory=lambda: None, compare=False)
 
     def __post_init__(self):
         # Set default tensor_initializers if not provided

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1180,6 +1180,11 @@ def _unpack_trtllm_moe_output(
         ]
 
 
+@functools.lru_cache(maxsize=None)
+def _get_map_to_hybrid_bucket(tune_max_num_tokens: int):
+    return lambda x: map_to_hybrid_bucket(x, tune_max_num_tokens)
+
+
 @functools.cache
 def get_trtllm_moe_sm100_module():
     module = gen_trtllm_gen_fused_moe_sm100_module()
@@ -1322,7 +1327,7 @@ def get_trtllm_moe_sm100_module():
                         input_idx,
                         dim_idx,
                         get_hybrid_num_tokens_buckets(tune_max_num_tokens, 1),
-                        lambda x: map_to_hybrid_bucket(x, tune_max_num_tokens),
+                        _get_map_to_hybrid_bucket(tune_max_num_tokens),
                         initializers,
                     ),
                 ),

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -1015,3 +1015,71 @@ def test_skip_ops_restored_after_context():
 
     # After context, skip_ops should be empty — op goes through normal path
     assert tuner._effective_skip_ops == frozenset()
+
+
+def test_find_nearest_profile_cache_stable_with_reused_callable():
+    """Reusing the same map_to_tuning_buckets callable should not grow the lru_cache.
+
+    This verifies the fix for the unbounded lru_cache leak: when the same lambda
+    object is reused (via _get_map_to_hybrid_bucket), id() stays stable, so
+    DynamicTensorSpec.__hash__ produces the same hash, and _find_nearest_profile's
+    lru_cache hits instead of creating a new entry every call.
+    """
+    map_fn = lambda x: min(x, 8192)
+    shapes = (torch.Size([128, 64]),)
+    buckets = (512, 1024, 2048, 4096, 8192)
+
+    # Warm up: first call creates one cache entry
+    config0 = TuningConfig(
+        dynamic_tensor_specs=(
+            DynamicTensorSpec(
+                (0,),
+                (0,),
+                buckets,
+                map_fn,
+            ),
+        ),
+    )
+    AutoTuner._find_nearest_profile(shapes, config0)
+    before = AutoTuner._find_nearest_profile.cache_info().currsize
+
+    for _ in range(100):
+        config = TuningConfig(
+            dynamic_tensor_specs=(
+                DynamicTensorSpec(
+                    (0,),
+                    (0,),
+                    buckets,
+                    map_fn,
+                ),
+            ),
+        )
+        AutoTuner._find_nearest_profile(shapes, config)
+    after = AutoTuner._find_nearest_profile.cache_info().currsize
+    assert after == before, f"cache grew from {before} to {after}"
+
+
+def test_find_nearest_profile_cache_grows_with_fresh_callable():
+    """Creating a new lambda each call causes the lru_cache to grow (the bug).
+
+    This is the negative control: without the fix (fresh lambda each call),
+    the cache grows by one entry per call because id() differs.
+    """
+    shapes = (torch.Size([128, 64]),)
+    buckets = (512, 1024, 2048, 4096, 8192)
+
+    before = AutoTuner._find_nearest_profile.cache_info().currsize
+    for _ in range(10):
+        config = TuningConfig(
+            dynamic_tensor_specs=(
+                DynamicTensorSpec(
+                    (0,),
+                    (0,),
+                    buckets,
+                    lambda x: min(x, 8192),
+                ),
+            ),
+        )
+        AutoTuner._find_nearest_profile(shapes, config)
+    after = AutoTuner._find_nearest_profile.cache_info().currsize
+    assert after == before + 10, f"cache should grow by 10, got {after - before}"


### PR DESCRIPTION
## 📌 Description

Fix unbounded `lru_cache` memory leak in `AutoTuner._find_nearest_profile` that caused 70s+ GC pauses and global TP stall after prolonged MoE inference.

**Root Cause:** `_make_tuning_config` created a fresh `lambda x: map_to_hybrid_bucket(x, tune_max_num_tokens)` on every MoE forward. Since `DynamicTensorSpec.__hash__` uses `id()` of the callable, each lambda got a unique hash, causing `_find_nearest_profile`'s `@lru_cache(maxsize=None)` to grow unboundedly.

**Fix:**
1. Added `_get_map_to_hybrid_bucket` with `@lru_cache` to memoize the lambda (same `tune_max_num_tokens` → same object → stable `id()`)
2. Added `compare=False` to `tensor_initializers` field, aligning `__eq__` with existing `__hash__` behavior (both exclude `tensor_initializers`)

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Added two tests in `tests/autotuner/test_autotuner_core.py`:
- `test_find_nearest_profile_cache_stable_with_reused_callable`: verifies cache stays stable after 100 calls with reused lambda
- `test_find_nearest_profile_cache_grows_with_fresh_callable`: negative control confirming fresh lambdas cause cache growth

## Reviewer Notes

This fix addresses the KV cache transfer latency spike (0.3s → 70s+) reported in production. The leak was triggered by unbounded `lru_cache` growth in `_find_nearest_profile`, which caused gen-2 GC to scan millions of cached entries, holding the GIL and stalling all TP ranks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in tuning-related workflows by reducing unnecessary cache growth when the same configuration is reused.
  * Made comparison behavior for tuning settings more consistent, helping avoid unexpected mismatches in repeated operations.
* **Tests**
  * Added coverage to verify cache behavior stays stable with reused settings and grows only when new settings are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->