### PR TITLE
perf(moe): optimize one-sided EP4 NVFP4 dispatch

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -32,6 +32,8 @@ namespace tensorrt_llm::kernels::moe_alltoall {
 #define DISABLE_SYNC_FOR_PROFILING 0
 
 constexpr int kEp4Size = 4;
+constexpr int kCompactDispatchMaxPayloadBytes = 1024;
+constexpr int kCompactDispatchBlockSize = 128;
 
 #ifndef DISABLE_TIMEOUT
 #define DISABLE_TIMEOUT 0
@@ -333,6 +335,7 @@ __global__ void moeA2ADispatchKernel(
     int num_payloads,                       // Number of payloads
     int max_tokens_per_rank,                // Maximum tokens per rank
     int local_num_tokens, int rank_id, int ep_size, int num_experts_per_rank) {
+  static_assert(!COMPACT_EP4 || TOP_K > kEp4Size);
   int thread_idx = threadIdx.x;
   int local_token_idx = blockIdx.x;
 
@@ -547,23 +550,19 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
 
   int block_size = tensorrt_llm::common::getEnvMoeA2ADispatchBlockSize();
 
-  bool const is_ep4_topk22 = params.ep_size == kEp4Size && params.top_k == 22;
-  // H2048 NVFP4 dispatch carries packed activations (1024 B), scales (128 B),
-  // expert IDs (88 B), and routing weights (88 B). Callers may order the
-  // auxiliary payloads differently.
-  bool const has_h2048_nvfp4_payloads = params.num_payloads == 4 &&
-                                        kernel_ptrs.payload_bytes_per_token[0] == 1024 &&
-                                        ((kernel_ptrs.payload_bytes_per_token[1] == 128 &&
-                                          kernel_ptrs.payload_bytes_per_token[2] == 88 &&
-                                          kernel_ptrs.payload_bytes_per_token[3] == 88) ||
-                                         (kernel_ptrs.payload_bytes_per_token[1] == 88 &&
-                                          kernel_ptrs.payload_bytes_per_token[2] == 88 &&
-                                          kernel_ptrs.payload_bytes_per_token[3] == 128));
-  bool const use_compact_ep4 = is_ep4_topk22 && has_h2048_nvfp4_payloads;
-  // H2048 NVFP4 has only 64 aligned 16-byte activation vectors. More than four warps
-  // leaves most threads idle during the dominant payload copy.
-  if (use_compact_ep4 && block_size > 128) {
-    block_size = 128;
+  bool const use_compact_ep4 = params.ep_size == kEp4Size && params.top_k > kEp4Size;
+
+  int max_payload_bytes_per_token = 0;
+  for (int i = 0; i < params.num_payloads; ++i) {
+    if (kernel_ptrs.payload_bytes_per_token[i] > max_payload_bytes_per_token) {
+      max_payload_bytes_per_token = kernel_ptrs.payload_bytes_per_token[i];
+    }
+  }
+  // Small payloads do not have enough 16-byte vectors to use larger CTAs. A GB200
+  // sweep found 128 threads faster than both 64 and 256 at prefill token counts.
+  if (use_compact_ep4 && max_payload_bytes_per_token <= kCompactDispatchMaxPayloadBytes &&
+      block_size > kCompactDispatchBlockSize) {
+    block_size = kCompactDispatchBlockSize;
   }
 
   // Configure kernel launch: one block per token
@@ -575,9 +574,12 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
   }
   if (use_compact_ep4) {
     int shared_bytes = kEp4Size * (int)sizeof(int);
-    moeA2ADispatchKernel<22, true><<<grid_size, block_size, shared_bytes, params.stream>>>(
-        params.token_selected_experts, kernel_ptrs, params.num_payloads, params.max_tokens_per_rank,
-        params.local_num_tokens, params.ep_rank, params.ep_size, params.num_experts_per_rank);
+    SWITCH_TOP_K(params.top_k, TOP_K,
+                 moeA2ADispatchKernel<TOP_K, true>
+                 <<<grid_size, block_size, shared_bytes, params.stream>>>(
+                     params.token_selected_experts, kernel_ptrs, params.num_payloads,
+                     params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank,
+                     params.ep_size, params.num_experts_per_rank))
   } else {
     int shared_bytes = 2 * params.top_k * (int)sizeof(int);
     SWITCH_TOP_K(params.top_k, TOP_K,

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -574,12 +574,13 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
   }
   if (use_compact_ep4) {
     int shared_bytes = kEp4Size * (int)sizeof(int);
-    SWITCH_TOP_K(params.top_k, TOP_K,
-                 moeA2ADispatchKernel<TOP_K, true>
-                 <<<grid_size, block_size, shared_bytes, params.stream>>>(
-                     params.token_selected_experts, kernel_ptrs, params.num_payloads,
-                     params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank,
-                     params.ep_size, params.num_experts_per_rank))
+    SWITCH_TOP_K(
+        params.top_k, TOP_K, if constexpr (TOP_K > kEp4Size) {
+          moeA2ADispatchKernel<TOP_K, true><<<grid_size, block_size, shared_bytes, params.stream>>>(
+              params.token_selected_experts, kernel_ptrs, params.num_payloads,
+              params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank, params.ep_size,
+              params.num_experts_per_rank);
+        })
   } else {
     int shared_bytes = 2 * params.top_k * (int)sizeof(int);
     SWITCH_TOP_K(params.top_k, TOP_K,

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -351,35 +351,29 @@ __global__ void moeA2ADispatchKernel(
     int* smem_topk_target_ranks = smem;
     int* smem_topk_send_indices = smem + TOP_K;
 
-    uint64_t already_copied = 0;
-    for (int k = 0; k < TOP_K; k++) {
-      int expert_id = token_selected_experts[local_token_idx * TOP_K + k];
-      // Use contiguous partitioning to determine target rank
-      int target_rank = compute_target_rank_id(expert_id, num_experts_per_rank);
+    if (thread_idx < warpSize) {
+      int lane_id = thread_idx;
+      unsigned topk_mask = __ballot_sync(0xffffffff, lane_id < TOP_K);
+      if (lane_id < TOP_K) {
+        int k = lane_id;
+        int expert_id = token_selected_experts[local_token_idx * TOP_K + k];
+        int target_rank = compute_target_rank_id(expert_id, num_experts_per_rank);
 
-      if (already_copied & (1ULL << target_rank)) {
-        if (thread_idx == 0) {
-          ptrs.topk_target_ranks[local_token_idx * TOP_K + k] = -1;
-          ptrs.topk_send_indices[local_token_idx * TOP_K + k] = -1;
-          // Mirror to shared memory immediately
-          smem_topk_target_ranks[k] = -1;
-          smem_topk_send_indices[k] = -1;
+        // Elect the first top-k lane for each destination rank.
+        unsigned matching_lanes = __match_any_sync(topk_mask, target_rank);
+        bool is_first = lane_id == __ffs(matching_lanes) - 1;
+        int dst_token_idx = -1;
+        if (is_first) {
+          dst_token_idx = atomicAdd(&ptrs.send_counters[target_rank], 1);
+        } else {
+          target_rank = -1;
         }
-        continue;
-      }
-
-      // Only one thread per warp should increment the counter
-      int dst_token_idx;
-      if (thread_idx == 0) {
-        dst_token_idx = atomicAdd(&ptrs.send_counters[target_rank], 1);
 
         ptrs.topk_target_ranks[local_token_idx * TOP_K + k] = target_rank;
         ptrs.topk_send_indices[local_token_idx * TOP_K + k] = dst_token_idx;
-        // Mirror to shared memory immediately
         smem_topk_target_ranks[k] = target_rank;
         smem_topk_send_indices[k] = dst_token_idx;
       }
-      already_copied |= 1ULL << target_rank;
     }
     // Sync before dispatching data
     __syncthreads();

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -31,6 +31,8 @@ namespace tensorrt_llm::kernels::moe_alltoall {
 #define ENABLE_DEBUG_PRINT 0
 #define DISABLE_SYNC_FOR_PROFILING 0
 
+constexpr int kEp4Size = 4;
+
 #ifndef DISABLE_TIMEOUT
 #define DISABLE_TIMEOUT 0
 #endif
@@ -321,13 +323,10 @@ __global__ void moeA2APrepareDispatchKernel(int* send_counters, int* local_token
 
 // ============================================================================
 // Generic Dispatch Kernel Implementation
-// One warp per token design:
-// - Each CTA has 256 threads = 8 warps
-// - Each warp independently processes one token and all its payloads
-// - Better GPU utilization and reduced synchronization overhead
+// One CTA processes one token and all its payloads.
 // ============================================================================
 
-template <int TOP_K>
+template <int TOP_K, bool COMPACT_EP4>
 __global__ void moeA2ADispatchKernel(
     int32_t const* token_selected_experts,  // [local_num_tokens, TOP_K]
     const DispatchKernelPointers ptrs,      // Struct containing all kernel pointers
@@ -349,10 +348,21 @@ __global__ void moeA2ADispatchKernel(
     // Prepare per-policy shared-memory tiles for this token
     extern __shared__ int smem[];
     int* smem_topk_target_ranks = smem;
-    int* smem_topk_send_indices = smem + TOP_K;
+    int* smem_topk_send_indices = nullptr;
+    int* smem_compact_send_indices = smem;
+    if constexpr (!COMPACT_EP4) {
+      smem_topk_send_indices = smem + TOP_K;
+    }
 
     if (thread_idx < warpSize) {
       int lane_id = thread_idx;
+      if constexpr (COMPACT_EP4) {
+        if (lane_id < kEp4Size) {
+          smem_compact_send_indices[lane_id] = -1;
+        }
+        __syncwarp();
+      }
+
       unsigned topk_mask = __ballot_sync(0xffffffff, lane_id < TOP_K);
       if (lane_id < TOP_K) {
         int k = lane_id;
@@ -365,36 +375,51 @@ __global__ void moeA2ADispatchKernel(
         int dst_token_idx = -1;
         if (is_first) {
           dst_token_idx = atomicAdd(&ptrs.send_counters[target_rank], 1);
+          if constexpr (COMPACT_EP4) {
+            smem_compact_send_indices[target_rank] = dst_token_idx;
+          }
         } else {
           target_rank = -1;
         }
 
         ptrs.topk_target_ranks[local_token_idx * TOP_K + k] = target_rank;
         ptrs.topk_send_indices[local_token_idx * TOP_K + k] = dst_token_idx;
-        smem_topk_target_ranks[k] = target_rank;
-        smem_topk_send_indices[k] = dst_token_idx;
+        if constexpr (!COMPACT_EP4) {
+          smem_topk_target_ranks[k] = target_rank;
+          smem_topk_send_indices[k] = dst_token_idx;
+        }
       }
     }
     // Sync before dispatching data
     __syncthreads();
 
-    // Read staged routing once into registers per thread
-    int topk_target_ranks[TOP_K];
-    int topk_send_indices[TOP_K];
+    // EP4 has at most four unique destinations, regardless of TOP_K. The compact
+    // specialization avoids expanding those destinations back to TOP_K entries.
+    constexpr int NUM_DESTINATIONS = COMPACT_EP4 ? kEp4Size : TOP_K;
+    int target_ranks[NUM_DESTINATIONS];
+    int send_indices[NUM_DESTINATIONS];
+    if constexpr (COMPACT_EP4) {
 #pragma unroll
-    for (int k = 0; k < TOP_K; ++k) {
-      topk_target_ranks[k] = smem_topk_target_ranks[k];
-      topk_send_indices[k] = smem_topk_send_indices[k];
+      for (int target_rank = 0; target_rank < NUM_DESTINATIONS; ++target_rank) {
+        target_ranks[target_rank] = target_rank;
+        send_indices[target_rank] = smem_compact_send_indices[target_rank];
+      }
+    } else {
+#pragma unroll
+      for (int k = 0; k < TOP_K; ++k) {
+        target_ranks[k] = smem_topk_target_ranks[k];
+        send_indices[k] = smem_topk_send_indices[k];
+      }
     }
 
-    // Perform a single source load and TOP_K fanout per payload
+    // Perform a single source load and fan out to each unique destination.
     for (int payload_idx = 0; payload_idx < num_payloads; payload_idx++) {
       uint8_t const* src_data = static_cast<uint8_t const*>(ptrs.src_data_ptrs[payload_idx]);
       int bytes_per_token = ptrs.payload_bytes_per_token[payload_idx];
       uint8_t const* src_ptr = src_data + local_token_idx * bytes_per_token;
 
-      vectorized_dispatch<TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
-                                 payload_idx, ptrs, topk_target_ranks, topk_send_indices);
+      vectorized_dispatch<NUM_DESTINATIONS>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
+                                            payload_idx, ptrs, target_ranks, send_indices);
     }
 
     __syncthreads();
@@ -520,7 +545,26 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
   kernel_ptrs.topk_target_ranks = params.topk_target_ranks;
   kernel_ptrs.topk_send_indices = params.topk_send_indices;
 
-  int const kBlockSize = tensorrt_llm::common::getEnvMoeA2ADispatchBlockSize();
+  int block_size = tensorrt_llm::common::getEnvMoeA2ADispatchBlockSize();
+
+  bool const is_ep4_topk22 = params.ep_size == kEp4Size && params.top_k == 22;
+  // H2048 NVFP4 dispatch carries packed activations (1024 B), scales (128 B),
+  // expert IDs (88 B), and routing weights (88 B). Callers may order the
+  // auxiliary payloads differently.
+  bool const has_h2048_nvfp4_payloads = params.num_payloads == 4 &&
+                                        kernel_ptrs.payload_bytes_per_token[0] == 1024 &&
+                                        ((kernel_ptrs.payload_bytes_per_token[1] == 128 &&
+                                          kernel_ptrs.payload_bytes_per_token[2] == 88 &&
+                                          kernel_ptrs.payload_bytes_per_token[3] == 88) ||
+                                         (kernel_ptrs.payload_bytes_per_token[1] == 88 &&
+                                          kernel_ptrs.payload_bytes_per_token[2] == 88 &&
+                                          kernel_ptrs.payload_bytes_per_token[3] == 128));
+  bool const use_compact_ep4 = is_ep4_topk22 && has_h2048_nvfp4_payloads;
+  // H2048 NVFP4 has only 64 aligned 16-byte activation vectors. More than four warps
+  // leaves most threads idle during the dominant payload copy.
+  if (use_compact_ep4 && block_size > 128) {
+    block_size = 128;
+  }
 
   // Configure kernel launch: one block per token
   int grid_size = params.local_num_tokens;
@@ -529,12 +573,20 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
   if (grid_size == 0) {
     grid_size = 1;
   }
-  int shared_bytes = 2 * params.top_k * (int)sizeof(int);
-  SWITCH_TOP_K(params.top_k, TOP_K,
-               moeA2ADispatchKernel<TOP_K><<<grid_size, kBlockSize, shared_bytes, params.stream>>>(
-                   params.token_selected_experts, kernel_ptrs, params.num_payloads,
-                   params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank,
-                   params.ep_size, params.num_experts_per_rank))
+  if (use_compact_ep4) {
+    int shared_bytes = kEp4Size * (int)sizeof(int);
+    moeA2ADispatchKernel<22, true><<<grid_size, block_size, shared_bytes, params.stream>>>(
+        params.token_selected_experts, kernel_ptrs, params.num_payloads, params.max_tokens_per_rank,
+        params.local_num_tokens, params.ep_rank, params.ep_size, params.num_experts_per_rank);
+  } else {
+    int shared_bytes = 2 * params.top_k * (int)sizeof(int);
+    SWITCH_TOP_K(params.top_k, TOP_K,
+                 moeA2ADispatchKernel<TOP_K, false>
+                 <<<grid_size, block_size, shared_bytes, params.stream>>>(
+                     params.token_selected_experts, kernel_ptrs, params.num_payloads,
+                     params.max_tokens_per_rank, params.local_num_tokens, params.ep_rank,
+                     params.ep_size, params.num_experts_per_rank))
+  }
 }
 
 // ============================================================================

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -491,7 +491,10 @@ def test_moe_alltoall_compact_ep4_dispatch(top_k):
         total_tokens * top_k, dtype=torch.int32, device=torch.device("cuda")
     ).reshape(total_tokens, top_k)
     token_selected_experts = (
-        expert_ids * 7 + torch.arange(total_tokens, device="cuda").unsqueeze(1)
+        expert_ids * 7
+        + torch.arange(
+            total_tokens, dtype=torch.int32, device=torch.device("cuda")
+        ).unsqueeze(1)
     ).remainder(num_experts)
 
     output_tensors, _, _, _ = dispatch_from_single_rank(

--- a/tests/comm/test_trtllm_moe_alltoall.py
+++ b/tests/comm/test_trtllm_moe_alltoall.py
@@ -468,6 +468,54 @@ def test_moe_alltoall_multi_rank_single_gpu(world_size, num_tokens, vector_dim):
             torch.testing.assert_close(actual, ref, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("top_k", [6, 8, 10, 16, 22])
+def test_moe_alltoall_compact_ep4_dispatch(top_k):
+    """Test the compact EP4 dispatch path with repeated destination ranks."""
+    torch.cuda.set_device(0)
+    world_size = 4
+    num_tokens = 4
+    num_experts = 64
+    total_tokens = world_size * num_tokens
+    num_experts_per_rank = num_experts // world_size
+
+    input_tensors = [
+        make_payload(total_tokens, 256, torch.int32),  # 1024 bytes per token
+        make_payload(total_tokens, 128, torch.uint8),
+        make_payload(total_tokens, 22, torch.int32),
+        make_payload(total_tokens, 22, torch.int32),
+    ]
+
+    # Rotate through experts so each token has repeated destinations and the set
+    # of destination ranks varies with both the token and top-k width.
+    expert_ids = torch.arange(
+        total_tokens * top_k, dtype=torch.int32, device=torch.device("cuda")
+    ).reshape(total_tokens, top_k)
+    token_selected_experts = (
+        expert_ids * 7 + torch.arange(total_tokens, device="cuda").unsqueeze(1)
+    ).remainder(num_experts)
+
+    output_tensors, _, _, _ = dispatch_from_single_rank(
+        input_tensors,
+        token_selected_experts,
+        world_size,
+        num_experts,
+        num_tokens,
+    )
+    target_ranks = token_selected_experts.div(
+        num_experts_per_rank, rounding_mode="floor"
+    )
+
+    for rank in range(world_size):
+        expected_token_mask = (target_ranks == rank).any(dim=1)
+        for actual, ref in zip(output_tensors[rank], input_tensors, strict=True):
+            actual = actual.flatten(end_dim=1)
+            actual = actual[actual.any(dim=1)]
+            expected = ref[expected_token_mask]
+            actual, _ = torch.sort(actual, dim=0)
+            expected, _ = torch.sort(expected, dim=0)
+            torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize(
     "world_size,num_tokens,vector_dim,num_payloads", LARGER_PAYLOADS_PARAMS
 )


### PR DESCRIPTION
## Summary

Optimize one-sided MoE dispatch by:

- constructing routing metadata cooperatively across a warp instead of using a
  serial thread-0 loop;
- retaining one compact destination per rank when `ep_size == 4` and
  `top_k > 4`;
- using a 128-thread CTA for that compact path when every payload is at most
  1,024 bytes per token.

The compact path reduces destination state from `top_k` entries to at most
four and no longer depends on an exact model payload fingerprint. Other EP
sizes and `top_k <= 4` retain the generic path. There is no API change.

The 128-thread choice was measured against 64 and 256 threads on two GB200
nodes. Compared with 64 threads, 128 was effectively neutral at 4-64
tokens/rank, 0.9-2.9% faster at 512 tokens/rank, and 2.5-10.0% faster at 8,192
tokens/rank.

## Performance

GB200, EP4, top-k22, H2048 NVFP4, CUDA graphs. Values average the
medians from two independent opposite-order runs.

| Tokens/rank | Dispatch baseline → candidate | Reduction | Dispatch + combine baseline → candidate | Reduction |
|---:|---:|---:|---:|---:|
| 4 | 19.68 → 13.79 us | 29.9% | 31.78 → 25.83 us | 18.7% |
| 64 | 22.15 → 15.52 us | 29.9% | 35.59 → 28.95 us | 18.7% |
| 512 | 46.90 → 18.21 us | 61.2% | 67.77 → 38.71 us | 42.9% |
| 8192 | 456.43 → 53.04 us | 88.4% | 599.90 → 192.65 us | 67.9% |

End-to-end Nemotron Ultra NVFP4 was measured with vLLM on one GB200 node,
`TP=1`, `DP=4`, `EP=4`, concurrency 16, and `ISL/OSL=50000/2048`.
Four balanced ABBA/BAAB allocations covered 3,072 requests.

| Metric | Baseline | Candidate | Geometric-mean change |
|---|---:|---:|---:|
| Aggregate output throughput | 532.75 tok/s | 562.09 tok/s | +5.5% |
| Mean TPOT | 23.12 ms | 23.06 ms | -0.3% |
| Mean TTFT | 13.16 s | 10.96 s | -16.7% |

## Validation

- all supported top-k values: 200 generic-path changing-payload graph replays each;
- exact packed-NVFP4 target: 1,000 replays in vLLM payload order and 200 in
  the alternate FlashInfer order;
- nonmatching top-k22 payload: 200 replays through the generic fallback;
- four-rank GB200 CUDA-graph validation for compact EP4 `top_k` 6, 8, 10,
  16, and 22 with packed H2048 payloads, plus a wide-BF16 case that retains
  the configured CTA size (Lyris job `2301707`, commit `8a5a6f93`);
- local and GitHub `pre-commit`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a compact EP4 dispatch mode for MOE AlltoAll routing, improving how repeated destinations are handled.
  * Updated dispatch launch behavior to better match the payload size and expert routing layout.

* **Tests**
  * Added a new test covering compact EP4 dispatch to validate token routing and dispatched outputs across ranks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->