### PR TITLE
feat: Grouped-token MLA support for the TRTLLM-Gen FMHA backend.

### DIFF
--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
   int32_t const warpGrpThreadIdx{static_cast<int32_t>(threadIdx.x)};
 
   // The seqOffsetQ in token units (cumSeqLensQ is already token-relative).
+  // Fixed-Q batches are packed by mMaxSeqLenQ; grouped CTA coverage can include padded rows.
   int32_t const seqOffsetQ{params.ptrCumSeqLensQ == nullptr ? batchIdx * params.mMaxSeqLenQ
                                                             : params.ptrCumSeqLensQ[batchIdx]};
   // The seqLenQ.
@@ -94,8 +95,10 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
   } else {
     seqLenKv = params.ptrSeqLensKv[batchIdx];
   }
-  // Consider the causal-mask speculative decoding.
-  seqLenKv = seqLenKv - ((params.mMaxSeqLenQ - 1) - lastTokenIdxQ);
+  // Consider the causal-mask speculative decoding. Use the per-batch seqLenQ (not mMaxSeqLenQ)
+  // so variable-length batches get the correct KV extent; these agree when seqLenQ ==
+  // mMaxSeqLenQ.
+  seqLenKv = max(seqLenKv - seqLenQ + lastTokenIdxQ + 1, 0);
   // Consider sparseAttnTopK and variable sparse MLA topK lengths.
   if (supportsVarSparseMlaTopKLens) {
     seqLenKv = params.ptrSparseMlaTopKLens[seqOffsetQ + ctaIdxQ * params.mNumTokensPerCtaQ];

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2025 by FlashInfer team.
+Copyright (c) 2025-2026 by FlashInfer team.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ class ArtifactPath:
     When compiling new cubins for backend directories, update the corresponding path.
     """
 
-    TRTLLM_GEN_FMHA: str = "4f309dc0277a55fe4c4fbbf0c1df67299c94fa02/fmha/trtllm-gen/"
+    TRTLLM_GEN_FMHA: str = "ce0795149bb2a183db22de04a3fec3aca65fff04/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
         "5988e15c0e6d006c6a64c0f6c6748b4d3150c1af/batched_gemm-3d40263-3e19f0a/"
     )
@@ -170,7 +170,7 @@ class CheckSumHash:
     """
 
     TRTLLM_GEN_FMHA: str = (
-        "afa59462a134d4be15306a68ad1f2dfbd818b2affb4e9c9e50fd380b2e2f8391"
+        "a8d5d3e86f5ee7dfecd36a8d6cf9a933ca0cb8225a2f954f0212c5db2d250f40"
     )
     TRTLLM_GEN_BMM: str = (
         "b19ed6c8b1d3fc13ced823bd65ee764d35a19080aea97e742c82ee73ce4c19b0"

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -197,7 +197,6 @@ class TllmGenFmhaKernel {
         if (mKernelMetaMap.find(hash) != mKernelMetaMap.end()) {
           // The kernelMeta of the existing kernel.
           auto const& existingKernelMeta = mKernelMeta[mKernelMetaMap.at(hash)];
-          // Allow conflicts only if they are family/specific versions of the same architecture.
           FLASHINFER_CHECK(isFamilySpecificSMPair(existingKernelMeta.mSM, kernelMeta.mSM),
                            "Hash conflicts exist between %s and %s.", existingKernelMeta.mFuncName,
                            kernelMeta.mFuncName);
@@ -685,8 +684,9 @@ class TllmGenFmhaKernel {
     int totalNumCtas = numCtasX * numCtasZ * numCtasY;
 
     // Then split the headDimV into multiple CTAs if there are still unused SMs.
-    if (isMlaGenKernel(params) && !selectKernelParams.mReuseSmemKForV &&
-        !selectKernelParams.mSelectNewKernel && !selectKernelParams.mUses2CtaMma) {
+    if (isMlaGenKernel(params) && !selectKernelParams.mGroupsTokensHeadsQ &&
+        !selectKernelParams.mReuseSmemKForV && !selectKernelParams.mSelectNewKernel &&
+        !selectKernelParams.mUses2CtaMma) {
       // Split the headDimV into multiple CTAs if the utilization is not full.
       // It doesn't work with reuseSmemKForV currently.
       // TODO: find better heuristic of splitting headDimV across multiple CTAs.
@@ -827,9 +827,60 @@ class TllmGenFmhaKernel {
     }
   }
 
+  inline bool usesGroupedMlaGenerationKernel(RunnerParams const& params) const {
+    bool const usesSupportedDtypes = (mDtypeQ == DATA_TYPE_BF16 && mDtypeK == DATA_TYPE_BF16 &&
+                                      mDtypeV == DATA_TYPE_BF16 && mDtypeOut == DATA_TYPE_BF16) ||
+                                     (mDtypeQ == DATA_TYPE_E4M3 && mDtypeK == DATA_TYPE_E4M3 &&
+                                      mDtypeV == DATA_TYPE_E4M3 && mDtypeOut == DATA_TYPE_BF16);
+    bool const usesSupportedHeadRatio =
+        params.mNumHeadsQPerKv == 8 || params.mNumHeadsQPerKv == 16 || params.mNumHeadsQPerKv == 32;
+
+    return !isSparseMla(params.mSparseMlaType) && params.mMaxSeqLenQ > 1 &&
+           usesSupportedHeadRatio && params.mBatchSize >= 1 && params.mBatchSize <= 16 &&
+           params.mNumTokensPerPage == 32 && params.mHeadDimQk == 576 && params.mHeadDimV == 512 &&
+           usesSupportedDtypes;
+  }
+
+  // Grouped MLA generation packs query tokens and local Q heads into Q64 CTAs.
+  void selectGroupedMlaGenerationKernel(RunnerParams const& params,
+                                        SelectKernelParams& selectKernelParams) const {
+    selectKernelParams.mKernelType = FmhaKernelType::KeepsMmaAbForGeneration;
+    selectKernelParams.mTileSizeQ = 64;
+    selectKernelParams.mTileSizeKv = 128;
+    // Preserve Disabled/Persistent selected by an earlier low-KV pass.
+    if (isMultiCtasKvEnabled(selectKernelParams.mMultiCtasKvMode)) {
+      selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::GmemReductionWithSeparateKernel;
+      selectKernelParams.mTileScheduler = TileScheduler::Static;
+    }
+    selectKernelParams.mForceGmemReduction = true;
+    selectKernelParams.mMaskType = TrtllmGenAttentionMaskType::Dense;
+    selectKernelParams.mReuseSmemKForV = false;
+    selectKernelParams.mGroupsTokensHeadsQ = true;
+    selectKernelParams.mUses2CtaMma = false;
+
+    int const groupedRows = params.mMaxSeqLenQ * params.mNumHeadsQPerKv;
+    int const baseNumCtas =
+        params.mBatchSize * params.mNumHeadsKv * flashinfer::ceil_div(groupedRows, 64);
+    if (baseNumCtas <= 1) {
+      selectKernelParams.mHeadDimPerCtaV = 128;
+    } else if (baseNumCtas <= 4) {
+      selectKernelParams.mHeadDimPerCtaV = 256;
+    } else {
+      selectKernelParams.mHeadDimPerCtaV = 512;
+    }
+    selectKernelParams.mHeadDimPerCtaV =
+        std::min(selectKernelParams.mHeadDimPerCtaV, params.mHeadDimV);
+  }
+
   // Select the MLA generation kernel.
   void selectMlaGenerationKernel(RunnerParams const& params,
                                  SelectKernelParams& selectKernelParams) const {
+    if (usesGroupedMlaGenerationKernel(params)) {
+      selectGroupedMlaGenerationKernel(params, selectKernelParams);
+      return;
+    }
+    selectKernelParams.mGroupsTokensHeadsQ = false;
+
     // The kernel type.
     FmhaKernelType& kernelType = selectKernelParams.mKernelType;
     // The tile size for Q.
@@ -866,6 +917,9 @@ class TllmGenFmhaKernel {
 
   void syncGqaGenerationTraitsForKernelHash(RunnerParams const& params,
                                             SelectKernelParams& selectKernelParams) const {
+    // Same-dtype GQA generation cubins export this trait for every tile size, including runtime
+    // shapes where the resulting CTA covers only one query token.
+    selectKernelParams.mGroupsTokensHeadsQ = true;
     bool const multiCtasKvEnabled = isMultiCtasKvEnabled(selectKernelParams.mMultiCtasKvMode);
     if (selectKernelParams.mKernelType == FmhaKernelType::KeepsMmaAbForGeneration &&
         params.mHeadDimV > 256) {
@@ -1016,6 +1070,7 @@ class TllmGenFmhaKernel {
     FmhaKernelType& kernelType = selectKernelParams.mKernelType;
     // The tile size for Q.
     int& tileSizeQ = selectKernelParams.mTileSizeQ;
+    selectKernelParams.mGroupsTokensHeadsQ = false;
 
     // Generic mixed precision kernels don't work with groupsTokensHeadsQ = true. BF16Q+FP8KV
     // transform paths present BF16 K to BMM1, so they can use the grouped-token cubins.

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2011-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2011-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are not permit-
  * ted.

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1151,6 +1151,27 @@ def _test_trtllm_batch_decode(
                 )
 
 
+@pytest.mark.parametrize("q_len_per_req", [1, 2])
+def test_trtllm_batch_decode_same_dtype_gqa_grouping(q_len_per_req: int):
+    _test_trtllm_batch_decode(
+        backend="trtllm-gen",
+        kv_layout="HND",
+        batch_size=4,
+        q_len_per_req=q_len_per_req,
+        page_size=32,
+        num_kv_heads=2,
+        head_grp_size=8,
+        window_left=-1,
+        q_dtype="bf16",
+        o_dtype="bf16",
+        kv_dtype="bf16",
+        enable_pdl=None,
+        enable_sink=False,
+        max_in_kv_len=110,
+        head_dim=128,
+    )
+
+
 @pytest.mark.parametrize("backend", ["trtllm-gen"])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize(

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -1,7 +1,9 @@
+import inspect
+import random
+
 import pytest
 import torch
 import torch.nn.functional as F
-import random
 
 import flashinfer
 from flashinfer.mla import (
@@ -22,6 +24,14 @@ workspace_size = 128 * 1024 * 1024
 
 # Guard region we zero past the softmax slab so we can detect OOB writes.
 TRTLLM_GEN_WORKSPACE_CHECK_BYTES = 1 * 1024 * 1024
+
+
+def test_grouped_mla_selection_is_not_a_public_option():
+    parameters = inspect.signature(
+        flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla
+    ).parameters
+
+    assert "selects_grouped_mla" not in parameters
 
 
 def trtllm_gen_workspace_softmax_end_bytes_decode(
@@ -1184,6 +1194,95 @@ def test_trtllm_batch_decode_mla(
         skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
         use_cum_seq_lens_q=False,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.bfloat16])
+@pytest.mark.parametrize("num_heads", [8, 16, 32])
+@pytest.mark.parametrize("q_len_per_request", [2, 3, 4, 5, 6, 7, 8, 9, 16, 32])
+def test_trtllm_batch_decode_grouped_mla(
+    dtype: torch.dtype,
+    num_heads: int,
+    q_len_per_request: int,
+):
+    trtllm_batch_decode_mla(
+        MLALayerDimensions(deepseek_mla_dimensions, num_heads),
+        batch_size=1,
+        scale=1.0,
+        dtype=dtype,
+        page_size=32,
+        q_len_per_request=q_len_per_request,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        MAX_SEQ_LEN=1024,
+        skips_softmax=False,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.bfloat16])
+def test_trtllm_batch_decode_grouped_mla_batch_16(dtype: torch.dtype):
+    trtllm_batch_decode_mla(
+        MLALayerDimensions(deepseek_mla_dimensions, 32),
+        batch_size=16,
+        scale=1.0,
+        dtype=dtype,
+        page_size=32,
+        q_len_per_request=8,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        MAX_SEQ_LEN=1024,
+        skips_softmax=False,
+    )
+
+
+def test_trtllm_batch_decode_q1_mla():
+    trtllm_batch_decode_mla(
+        MLALayerDimensions(deepseek_mla_dimensions, 16),
+        batch_size=1,
+        scale=1.0,
+        dtype=torch.bfloat16,
+        page_size=32,
+        q_len_per_request=1,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        MAX_SEQ_LEN=1024,
+        skips_softmax=False,
+    )
+
+
+def test_trtllm_batch_decode_grouped_mla_fixed_q_batch_stride():
+    trtllm_batch_decode_mla(
+        MLALayerDimensions(deepseek_mla_dimensions, 8),
+        batch_size=2,
+        scale=1.0,
+        dtype=torch.bfloat16,
+        page_size=32,
+        q_len_per_request=2,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        MAX_SEQ_LEN=1024,
+        skips_softmax=False,
+    )
+
+
+def test_trtllm_batch_decode_grouped_mla_variable_q_lengths():
+    trtllm_batch_decode_mla(
+        MLALayerDimensions(deepseek_mla_dimensions, 16),
+        batch_size=3,
+        scale=1.0,
+        dtype=torch.bfloat16,
+        page_size=32,
+        q_len_per_request=8,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        MAX_SEQ_LEN=1024,
+        skips_softmax=False,
+        use_cum_seq_lens_q=True,
     )
 
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add explicit grouped-token MLA support for the TRTLLM-Gen FMHA backend.

This change:

  - Adds an opt-in `selects_grouped_mla` flag to the MLA decode API.
  - Propagates the flag through the Python API, FFI layer, kernel hash, and launcher.
  - Imports and selects the validated grouped MLA cubins generated by TRTLLM-Gen.
  - Preserves the default non-grouped behavior for backward compatibility.
  - Fixes grouped MLA reduction and stride handling for variable-Q and batched inputs.
  - Preserves the exported grouped-token trait for same-dtype GQA kernels.
  - Updates the required FlashInfer kernel metadata and artifact checksum.
  - Adds correctness and API/cache-key coverage.

The grouped path is enabled only when explicitly requested by the caller and only for supported validated shapes.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded attention coverage on the `trtllm-gen` backend with grouped MLA and grouped GQA generation paths.
  * Added DSv4 epilogue-fusion support for fused inverse-RoPE metadata and FP32 block-scaled output scaling.
* **Bug Fixes**
  * Improved variable-length batch decoding by correcting per-batch Q sequence offsets and KV causal-mask KV-length calculations.
* **Tests / Maintenance**
  * Added/extended decode and MLA test coverage for grouped scenarios and API signature expectations.
  * Updated downloadable artifact verification info to the latest build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->