### PR TITLE
feat(comm): support MNNVL packed group FP8 fusion

### DIFF
--- a/benchmarks/routines/allreduce_comm.py
+++ b/benchmarks/routines/allreduce_comm.py
@@ -21,7 +21,8 @@ FlashInfer's unified AllReduce API (create_allreduce_fusion_workspace +
 allreduce_fusion). Designed to run with mpirun for multi-GPU benchmarking.
 
 Supports backends: trtllm, mnnvl, auto
-Supports patterns: allreduce, ar_residual_rmsnorm, ar_residual_rmsnorm_dynamic_fp8
+Supports patterns: allreduce, ar_residual_rmsnorm, ar_residual_rmsnorm_dynamic_fp8,
+    ar_residual_rmsnorm_group_fp8
 
 Launch examples:
     # Basic allreduce with auto backend
@@ -68,6 +69,7 @@ from flashinfer.comm import (
     create_allreduce_fusion_workspace,
 )
 from flashinfer.comm.mnnvl import MnnvlMemory, TorchDistBackend
+from flashinfer.comm.trtllm_mnnvl_ar import MNNVLAllreduceFusionStrategy
 from flashinfer.norm import rmsnorm
 from flashinfer.testing.utils import bench_gpu_time
 
@@ -90,9 +92,50 @@ PATTERN_NAME_TO_CODE = {
     "ar_residual_rmsnorm_dynamic_fp8": (
         AllReduceFusionPattern.kARResidualRMSNormDynamicFP8Quant
     ),
+    "ar_residual_rmsnorm_group_fp8": (
+        AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant
+    ),
 }
 
 PATTERN_CODE_TO_NAME = {v: k for k, v in PATTERN_NAME_TO_CODE.items()}
+
+
+def _allocate_group_scale_out(
+    num_tokens: int,
+    hidden_size: int,
+    group_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Allocate packed UE8M0 scales in the DeepGEMM-compatible layout."""
+    groups_per_row = hidden_size // group_size
+    k_num_packed = (groups_per_row + 3) // 4
+    tma_aligned_mn = ((num_tokens + 3) // 4) * 4
+    return torch.empty_strided(
+        (num_tokens, k_num_packed),
+        (1, tma_aligned_mn),
+        dtype=torch.int32,
+        device=device,
+    )
+
+
+def _unpack_group_scales(
+    scale_out: torch.Tensor,
+    hidden_size: int,
+    group_size: int,
+) -> torch.Tensor:
+    """Unpack UE8M0 exponent bytes to float32 scales on the input device."""
+    groups_per_row = hidden_size // group_size
+    shifts = torch.arange(4, dtype=torch.int64, device=scale_out.device) * 8
+    exponents = (
+        ((scale_out.to(torch.int64).unsqueeze(-1) >> shifts) & 0xFF)
+        .flatten(1)[:, :groups_per_row]
+        .to(torch.int32)
+    )
+    return torch.where(
+        exponents > 0,
+        torch.exp2(exponents.float() - 127.0),
+        torch.zeros_like(exponents, dtype=torch.float32),
+    )
 
 
 def _setup_mpi_and_device() -> Tuple[MPI.Comm, int, int, int]:
@@ -106,7 +149,7 @@ def _setup_mpi_and_device() -> Tuple[MPI.Comm, int, int, int]:
 
 
 def _init_torch_distributed(rank: int, world_size: int):
-    """Initialize torch.distributed for TRTLLM backend (uses NCCL for IPC)."""
+    """Initialize the NCCL process group used by allreduce workspaces."""
     import os
 
     import torch.distributed as dist
@@ -163,6 +206,7 @@ def _validate_allreduce(
     world_size: int,
     rank: int,
     comm: MPI.Comm,
+    block_quant_group_size: int,
     verbose: int = 0,
 ) -> bool:
     """Validate allreduce correctness via comparison with torch sum reference."""
@@ -199,6 +243,7 @@ def _validate_allreduce(
     elif pattern_code in (
         AllReduceFusionPattern.kARResidualRMSNorm,
         AllReduceFusionPattern.kARResidualRMSNormDynamicFP8Quant,
+        AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant,
     ):
         residual = torch.randn(
             (num_tokens, hidden_size), dtype=input_dtype, device="cuda"
@@ -219,10 +264,22 @@ def _validate_allreduce(
         is_dynamic_fp8 = (
             pattern_code == AllReduceFusionPattern.kARResidualRMSNormDynamicFP8Quant
         )
+        is_group_fp8 = (
+            pattern_code
+            == AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant
+        )
         quant_out = scale_out = None
         if is_dynamic_fp8:
             quant_out = torch.empty_like(x_local, dtype=torch.float8_e4m3fn)
             scale_out = torch.empty(num_tokens, 1, dtype=torch.float32, device="cuda")
+        elif is_group_fp8:
+            quant_out = torch.empty_like(x_local, dtype=torch.float8_e4m3fn)
+            scale_out = _allocate_group_scale_out(
+                num_tokens,
+                hidden_size,
+                block_quant_group_size,
+                torch.device("cuda"),
+            )
 
         allreduce_fusion(
             input=x_local,
@@ -230,13 +287,14 @@ def _validate_allreduce(
             pattern=pattern_code,
             launch_with_pdl=False,
             residual_out=residual_out,
-            norm_out=None if is_dynamic_fp8 else norm_out,
+            norm_out=None if is_dynamic_fp8 or is_group_fp8 else norm_out,
             quant_out=quant_out,
             scale_out=scale_out,
             residual_in=residual,
             rms_gamma=norm_weight,
             rms_eps=eps,
             use_oneshot=use_oneshot,
+            block_quant_group_size=(block_quant_group_size if is_group_fp8 else None),
         )
         torch.cuda.synchronize()
 
@@ -269,6 +327,25 @@ def _validate_allreduce(
                     ref_quant.float() * ref_scale,
                     atol=0.5,
                     rtol=0.5,
+                )
+            elif is_group_fp8:
+                groups_per_row = hidden_size // block_quant_group_size
+                fused_scales = _unpack_group_scales(
+                    scale_out,
+                    hidden_size,
+                    block_quant_group_size,
+                )
+                dequant = (
+                    quant_out.float().reshape(
+                        num_tokens, groups_per_row, block_quant_group_size
+                    )
+                    * fused_scales.unsqueeze(-1)
+                ).reshape(num_tokens, hidden_size)
+                torch.testing.assert_close(
+                    dequant,
+                    ref_norm_out.float(),
+                    atol=0.8,
+                    rtol=0.05,
                 )
             else:
                 torch.testing.assert_close(norm_out, ref_norm_out, atol=0.15, rtol=0.05)
@@ -310,8 +387,19 @@ def _benchmark_single_config(
     device = torch.device("cuda")
 
     # Check workspace capacity
+    workspace_strategy = use_oneshot
+    if workspace.backend == "mnnvl":
+        workspace_strategy = (
+            MNNVLAllreduceFusionStrategy.AUTO
+            if use_oneshot is None
+            else (
+                MNNVLAllreduceFusionStrategy.ONESHOT
+                if use_oneshot
+                else MNNVLAllreduceFusionStrategy.TWOSHOT
+            )
+        )
     if not workspace.is_buffer_size_sufficient(
-        world_size, num_tokens, hidden_size, input_dtype, use_oneshot
+        world_size, num_tokens, hidden_size, input_dtype, workspace_strategy
     ):
         if rank == 0 and args.verbose >= 1:
             print(
@@ -340,6 +428,7 @@ def _benchmark_single_config(
     elif pattern_code in (
         AllReduceFusionPattern.kARResidualRMSNorm,
         AllReduceFusionPattern.kARResidualRMSNormDynamicFP8Quant,
+        AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant,
     ):
         residual = torch.randn_like(x)
         norm_weight = torch.randn((hidden_size,), dtype=input_dtype, device=device)
@@ -348,10 +437,22 @@ def _benchmark_single_config(
         is_dynamic_fp8 = (
             pattern_code == AllReduceFusionPattern.kARResidualRMSNormDynamicFP8Quant
         )
+        is_group_fp8 = (
+            pattern_code
+            == AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant
+        )
         quant_out = scale_out = None
         if is_dynamic_fp8:
             quant_out = torch.empty_like(x, dtype=torch.float8_e4m3fn)
             scale_out = torch.empty(num_tokens, 1, dtype=torch.float32, device=device)
+        elif is_group_fp8:
+            quant_out = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+            scale_out = _allocate_group_scale_out(
+                num_tokens,
+                hidden_size,
+                args.block_quant_group_size,
+                device,
+            )
 
         def run_allreduce(inp):
             allreduce_fusion(
@@ -360,15 +461,18 @@ def _benchmark_single_config(
                 pattern=pattern_code,
                 launch_with_pdl=True,
                 residual_out=residual_out,
-                norm_out=None if is_dynamic_fp8 else norm_out,
+                norm_out=None if is_dynamic_fp8 or is_group_fp8 else norm_out,
                 quant_out=quant_out,
                 scale_out=scale_out,
                 residual_in=residual,
                 rms_gamma=norm_weight,
                 rms_eps=1e-5,
                 use_oneshot=use_oneshot,
+                block_quant_group_size=(
+                    args.block_quant_group_size if is_group_fp8 else None
+                ),
             )
-            return quant_out if is_dynamic_fp8 else norm_out
+            return quant_out if is_dynamic_fp8 or is_group_fp8 else norm_out
 
     else:
         if rank == 0:
@@ -501,6 +605,12 @@ def parse_allreduce_comm_args(line, parser):
         default=False,
         help="Run correctness validation before benchmarking.",
     )
+    parser.add_argument(
+        "--block_quant_group_size",
+        type=int,
+        default=128,
+        help="Hidden-dimension group size for packed per-token-group FP8.",
+    )
 
     args = parser.parse_args(line)
     return args
@@ -536,7 +646,7 @@ def test_allreduce_fusion(args):
     torch_dist_initialized = False
 
     needs_mnnvl = any(b in ("mnnvl", "auto") for b in backend_list)
-    needs_trtllm = any(b in ("trtllm", "auto") for b in backend_list)
+    needs_torch_dist = any(b in ("trtllm", "mnnvl", "auto") for b in backend_list)
 
     if needs_mnnvl:
         try:
@@ -550,20 +660,15 @@ def test_allreduce_fusion(args):
                     print("[ERROR] No backends available after MNNVL init failure")
                 return []
 
-    if needs_trtllm:
+    if needs_torch_dist:
         try:
             _init_torch_distributed(rank, world_size)
             torch_dist_initialized = True
         except Exception as e:
             if rank == 0:
                 print(f"[WARNING] torch.distributed initialization failed: {e}")
-            backend_list = [b for b in backend_list if b != "trtllm"]
-            if not backend_list:
-                if rank == 0:
-                    print(
-                        "[ERROR] No backends available after torch.distributed init failure"
-                    )
-                return []
+                print("[ERROR] No backends available without torch.distributed")
+            return []
 
     try:
         for backend in backend_list:
@@ -599,11 +704,12 @@ def test_allreduce_fusion(args):
                 for pattern_name in pattern_list:
                     pattern_code = PATTERN_NAME_TO_CODE[pattern_name]
 
-                    # MNNVL supports allreduce, AR+RMSNorm, and dynamic FP8 AR+RMSNorm.
+                    # MNNVL supports allreduce, AR+RMSNorm, and quantized variants.
                     if workspace.backend == "mnnvl" and pattern_code not in (
                         AllReduceFusionPattern.kAllReduce,
                         AllReduceFusionPattern.kARResidualRMSNorm,
                         AllReduceFusionPattern.kARResidualRMSNormDynamicFP8Quant,
+                        AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant,
                     ):
                         if rank == 0 and args.verbose >= 1:
                             print(
@@ -640,6 +746,7 @@ def test_allreduce_fusion(args):
                                 world_size=world_size,
                                 rank=rank,
                                 comm=comm,
+                                block_quant_group_size=args.block_quant_group_size,
                                 verbose=args.verbose,
                             )
                             if not valid:

--- a/benchmarks/routines/allreduce_comm.py
+++ b/benchmarks/routines/allreduce_comm.py
@@ -646,7 +646,11 @@ def test_allreduce_fusion(args):
     torch_dist_initialized = False
 
     needs_mnnvl = any(b in ("mnnvl", "auto") for b in backend_list)
-    needs_torch_dist = any(b in ("trtllm", "mnnvl", "auto") for b in backend_list)
+    # Validation uses torch.distributed as an independent all-reduce reference.
+    # MNNVL-only timing can still use its MPI handle-exchange backend.
+    needs_torch_dist = args.validate or any(
+        b in ("trtllm", "auto") for b in backend_list
+    )
 
     if needs_mnnvl:
         try:

--- a/csrc/trtllm_mnnvl_allreduce.cu
+++ b/csrc/trtllm_mnnvl_allreduce.cu
@@ -27,16 +27,14 @@ using tvm::ffi::Optional;
     }                                                                               \
   }()
 
-void trtllm_mnnvl_allreduce_fusion(TensorView input, int64_t multicast_buffer_ptr,
-                                   int64_t buffer_ptrs_dev, int64_t buffer_ptr_local,
-                                   TensorView buffer_flags_mnnvl, int64_t nranks, int64_t rank,
-                                   bool rmsnorm_fusion, bool launch_with_pdl, bool use_oneshot,
-                                   Optional<TensorView> output, Optional<TensorView> residual_out,
-                                   Optional<TensorView> residual_in, Optional<TensorView> gamma,
-                                   Optional<double> epsilon, Optional<double> weight_bias,
-                                   Optional<int64_t> quant_type, Optional<TensorView> quant_out,
-                                   Optional<TensorView> sf_out, Optional<TensorView> output_scale,
-                                   Optional<int64_t> layout_code) {
+void trtllm_mnnvl_allreduce_fusion(
+    TensorView input, int64_t multicast_buffer_ptr, int64_t buffer_ptrs_dev,
+    int64_t buffer_ptr_local, TensorView buffer_flags_mnnvl, int64_t nranks, int64_t rank,
+    bool rmsnorm_fusion, bool launch_with_pdl, bool use_oneshot, Optional<TensorView> output,
+    Optional<TensorView> residual_out, Optional<TensorView> residual_in, Optional<TensorView> gamma,
+    Optional<double> epsilon, Optional<double> weight_bias, Optional<int64_t> quant_type,
+    Optional<TensorView> quant_out, Optional<TensorView> sf_out, Optional<TensorView> output_scale,
+    Optional<int64_t> layout_code, Optional<int64_t> block_quant_group_size) {
   ffi::CUDADeviceGuard device_guard(input.device().device_id);
   auto stream = get_stream(input.device());
 
@@ -79,6 +77,7 @@ void trtllm_mnnvl_allreduce_fusion(TensorView input, int64_t multicast_buffer_pt
         << "MNNVL quantization fusion requires rmsnorm_fusion=true";
     TVM_FFI_ICHECK(quant_type_enum == QuantType::kNone ||
                    quant_type_enum == QuantType::kDynamicFP8 ||
+                   quant_type_enum == QuantType::kPerTokenGroupFP8Packed ||
                    (output_scale.has_value() &&
                     encode_dlpack_dtype(output_scale.value().dtype()) == float32_code))
         << "output_scale must be provided for static MNNVL quantization fusion and must be float32";
@@ -150,6 +149,36 @@ void trtllm_mnnvl_allreduce_fusion(TensorView input, int64_t multicast_buffer_pt
         TVM_FFI_ICHECK(encode_dlpack_dtype(sf_out.value().dtype()) == float32_code)
             << "scale_out for dynamic FP8 must have dtype float32";
         break;
+      case QuantType::kPerTokenGroupFP8Packed: {
+        TVM_FFI_ICHECK(block_quant_group_size.has_value() && block_quant_group_size.value() > 0)
+            << "block_quant_group_size must be provided and positive for group FP8";
+        int64_t const group_size = block_quant_group_size.value();
+        TVM_FFI_ICHECK(token_dim % group_size == 0)
+            << "token_dim must be divisible by block_quant_group_size";
+        TVM_FFI_ICHECK(quant_out.value().size(0) == num_tokens &&
+                       quant_out.value().size(1) == token_dim)
+            << "quant_out shape mismatch for group FP8: expected (" << num_tokens << ", "
+            << token_dim << ") but got (" << quant_out.value().size(0) << ", "
+            << quant_out.value().size(1) << ")";
+        TVM_FFI_ICHECK(encode_dlpack_dtype(quant_out.value().dtype()) == float8_e4m3fn_code)
+            << "quant_out for group FP8 must have dtype float8_e4m3fn";
+        TVM_FFI_ICHECK(sf_out.has_value())
+            << "scale_out must be provided for group FP8 MNNVL quantization fusion";
+        int64_t const groups_per_row = token_dim / group_size;
+        int64_t const k_num_packed = (groups_per_row + 3) / 4;
+        int64_t const tma_aligned_mn = ((num_tokens + 3) / 4) * 4;
+        TVM_FFI_ICHECK(sf_out.value().size(0) == num_tokens &&
+                       sf_out.value().size(1) == k_num_packed)
+            << "scale_out shape mismatch for group FP8: expected (" << num_tokens << ", "
+            << k_num_packed << ") but got (" << sf_out.value().size(0) << ", "
+            << sf_out.value().size(1) << ")";
+        TVM_FFI_ICHECK(sf_out.value().stride(0) == 1 && sf_out.value().stride(1) == tma_aligned_mn)
+            << "scale_out stride mismatch for group FP8: expected (1, " << tma_aligned_mn
+            << ") but got (" << sf_out.value().stride(0) << ", " << sf_out.value().stride(1) << ")";
+        TVM_FFI_ICHECK(encode_dlpack_dtype(sf_out.value().dtype()) == int32_code)
+            << "scale_out for group FP8 must have dtype int32";
+        break;
+      }
       default:
         TVM_FFI_LOG_AND_THROW(NotImplementedError)
             << "Unsupported MNNVL quantization type " << static_cast<int>(quant_type_enum);
@@ -171,6 +200,9 @@ void trtllm_mnnvl_allreduce_fusion(TensorView input, int64_t multicast_buffer_pt
     params.launchWithPdl = launch_with_pdl;
     params.sfLayout = sf_layout;
     params.quantType = quant_type_enum;
+    params.blockQuantGroupSize =
+        block_quant_group_size.has_value() ? static_cast<int>(block_quant_group_size.value()) : 0;
+    params.tmaAlignedMn = static_cast<int>(((num_tokens + 3) / 4) * 4);
 
     // input data
     params.input = const_cast<void const*>(input.data_ptr());

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -633,7 +633,10 @@ def allreduce_fusion(
         Optional shared-expert output to add, shape
         ``[token_num, hidden_dim]``.
     block_quant_group_size : Optional[int]
-        Group size for per-token-group FP8 packed quantization patterns.
+        Group size for per-token-group FP8 packed quantization patterns. The
+        MNNVL backend requires an exact row partition in which each CTA owns an
+        integral number of groups; unsupported ``(hidden_dim, group_size)``
+        pairs raise ``ValueError`` before launch.
     weight_bias : float
         Bias added to ``rms_gamma`` before scaling.
 
@@ -1070,19 +1073,19 @@ def allreduce_fusion(
             if requires_preallocated_outputs:
                 if residual_out is None:
                     raise ValueError(
-                        "residual_out is required for MNNVL dynamic quantization patterns"
+                        "residual_out is required for MNNVL preallocated quantization patterns"
                     )
                 if quant_out is None:
                     raise ValueError(
-                        "quant_out is required for MNNVL dynamic quantization patterns"
+                        "quant_out is required for MNNVL preallocated quantization patterns"
                     )
                 if scale_out is None:
                     raise ValueError(
-                        "scale_out is required for MNNVL dynamic quantization patterns"
+                        "scale_out is required for MNNVL preallocated quantization patterns"
                     )
                 if has_norm_out and norm_out is None:
                     raise ValueError(
-                        "norm_out is required for MNNVL dynamic quantization norm-out patterns"
+                        "norm_out is required for MNNVL preallocated quantization norm-out patterns"
                     )
             elif has_norm_out and norm_out is None:
                 norm_out = torch.empty_like(input)

--- a/flashinfer/comm/allreduce.py
+++ b/flashinfer/comm/allreduce.py
@@ -274,7 +274,7 @@ def _workspace_creation_heuristic(
     # Single-node scenarios
     # From benchmarking data, we can see that MNNVL is either on par (smaller problem sizes) or significantly faster than TRTLLM (larger problem sizes such as hidden_dim=8192, token_num=64 for TP=4), for single-node scenarios.
     # TRTLLM still has the larger specialized-fusion surface, such as MoE
-    # patterns and packed group FP8 quantization.
+    # patterns.
     if "mnnvl" in suitable_backends:
         return ["mnnvl"]
     else:
@@ -551,14 +551,14 @@ def allreduce_fusion(
         * ``kARResidualRMSNormOutFP4Quant = 5``
         * ``kMoEReductionARResidualRMSNorm = 6`` (TRT-LLM only)
         * ``kMoEFinalizeARResidualRMSNorm = 7`` (TRT-LLM only)
-        * ``kARResidualRMSNormPerTokenGroupFP8PackedQuant = 8`` (TRT-LLM only)
-        * ``kARResidualRMSNormOutPerTokenGroupFP8PackedQuant = 9`` (TRT-LLM only)
+        * ``kARResidualRMSNormPerTokenGroupFP8PackedQuant = 8``
+        * ``kARResidualRMSNormOutPerTokenGroupFP8PackedQuant = 9``
         * ``kARResidualRMSNormDynamicFP8Quant = 10``
         * ``kARResidualRMSNormOutDynamicFP8Quant = 11``
 
-        MNNVL supports the standard FP8/NVFP4 quant patterns (2-5) and
-        dynamic FP8 patterns (10-11). MoE and packed group quant patterns
-        remain TRT-LLM only.
+        MNNVL supports the standard FP8/NVFP4 quant patterns (2-5), packed
+        per-token-group FP8 patterns (8-9), and dynamic FP8 patterns (10-11).
+        MoE patterns remain TRT-LLM only.
 
         ``kMoEFinalizeARResidualRMSNorm`` is an explicit TRT-LLM fused
         implementation of MoE finalize + AllReduce + RMSNorm and does not
@@ -588,8 +588,10 @@ def allreduce_fusion(
     scale_out : Optional[torch.Tensor]
         Pre-allocated quantization scale-factor buffer. Dynamic FP8 uses
         shape ``[token_num, 1]`` and dtype ``torch.float32``. NVFP4 uses
-        the layout selected by ``layout_code``. Per-tensor FP8 does not use
-        ``scale_out``.
+        the layout selected by ``layout_code``. Packed per-token-group FP8
+        uses shape ``[token_num, ceil(groups_per_row / 4)]``, dtype
+        ``torch.int32``, and stride ``(1, ceil(token_num / 4) * 4)``.
+        Per-tensor FP8 does not use ``scale_out``.
     residual_in : Optional[torch.Tensor]
         Residual tensor to add, shape ``[token_num, hidden_dim]``.
     rms_gamma : Optional[torch.Tensor]
@@ -631,8 +633,7 @@ def allreduce_fusion(
         Optional shared-expert output to add, shape
         ``[token_num, hidden_dim]``.
     block_quant_group_size : Optional[int]
-        Group size for per-token-group FP8 packed quantization patterns
-        (TRT-LLM only).
+        Group size for per-token-group FP8 packed quantization patterns.
     weight_bias : float
         Bias added to ``rms_gamma`` before scaling.
 
@@ -642,7 +643,7 @@ def allreduce_fusion(
           (``out = (1 + gamma) * x * rsqrt(...)``).
 
         Supported by both TRT-LLM and MNNVL backends for standard RMSNorm
-        and quant patterns (1-5), and by TRT-LLM for MoE RMSNorm
+        and quant patterns (1-5, 8-11), and by TRT-LLM for MoE RMSNorm
         variants. Ignored for ``kAllReduce``.
 
     Returns
@@ -971,6 +972,14 @@ def allreduce_fusion(
                 MNNVLQuantType.NVFP4,
                 True,
             ),
+            AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant: (
+                MNNVLQuantType.PER_TOKEN_GROUP_FP8_PACKED,
+                False,
+            ),
+            AllReduceFusionPattern.kARResidualRMSNormOutPerTokenGroupFP8PackedQuant: (
+                MNNVLQuantType.PER_TOKEN_GROUP_FP8_PACKED,
+                True,
+            ),
             AllReduceFusionPattern.kARResidualRMSNormDynamicFP8Quant: (
                 MNNVLQuantType.DYNAMIC_FP8,
                 False,
@@ -1054,23 +1063,26 @@ def allreduce_fusion(
                 )
 
             quant_type, has_norm_out = mnnvl_quant_patterns[pattern]
-            is_dynamic_fp8 = quant_type == MNNVLQuantType.DYNAMIC_FP8
-            if is_dynamic_fp8:
+            requires_preallocated_outputs = quant_type in (
+                MNNVLQuantType.DYNAMIC_FP8,
+                MNNVLQuantType.PER_TOKEN_GROUP_FP8_PACKED,
+            )
+            if requires_preallocated_outputs:
                 if residual_out is None:
                     raise ValueError(
-                        "residual_out is required for MNNVL dynamic FP8 patterns"
+                        "residual_out is required for MNNVL dynamic quantization patterns"
                     )
                 if quant_out is None:
                     raise ValueError(
-                        "quant_out is required for MNNVL dynamic FP8 patterns"
+                        "quant_out is required for MNNVL dynamic quantization patterns"
                     )
                 if scale_out is None:
                     raise ValueError(
-                        "scale_out is required for MNNVL dynamic FP8 patterns"
+                        "scale_out is required for MNNVL dynamic quantization patterns"
                     )
                 if has_norm_out and norm_out is None:
                     raise ValueError(
-                        "norm_out is required for MNNVL dynamic FP8 norm-out pattern"
+                        "norm_out is required for MNNVL dynamic quantization norm-out patterns"
                     )
             elif has_norm_out and norm_out is None:
                 norm_out = torch.empty_like(input)
@@ -1093,6 +1105,7 @@ def allreduce_fusion(
                 launch_with_pdl=launch_with_pdl,
                 strategy=strategy,
                 weight_bias=weight_bias,
+                block_quant_group_size=block_quant_group_size,
             )
             return quant_result
 

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -57,6 +57,7 @@ class MNNVLQuantType:
     FP8 = 1
     NVFP4 = 2
     DYNAMIC_FP8 = 3
+    PER_TOKEN_GROUP_FP8_PACKED = 4
 
 
 class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
@@ -294,6 +295,7 @@ def get_trtllm_mnnvl_comm_module():
             "sf_out",
             "output_scale",
             "layout_code",
+            "block_quant_group_size",
         ],
     )
     def trtllm_mnnvl_allreduce_fusion(
@@ -318,6 +320,7 @@ def get_trtllm_mnnvl_comm_module():
         sf_out: Optional[torch.Tensor] = None,
         output_scale: Optional[torch.Tensor] = None,
         layout_code: int = QuantizationSFLayout.SWIZZLED_128x4,
+        block_quant_group_size: Optional[int] = None,
     ) -> None:
         """
         Perform a multi-node NVLink all-reduce operation with fusion.
@@ -359,6 +362,7 @@ def get_trtllm_mnnvl_comm_module():
             sf_out,
             output_scale,
             layout_code,
+            block_quant_group_size,
         )
 
     return SimpleNamespace(
@@ -583,8 +587,9 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
     launch_with_pdl: bool = False,
     strategy: MNNVLAllreduceFusionStrategy = MNNVLAllreduceFusionStrategy.AUTO,
     weight_bias: float = 0.0,
+    block_quant_group_size: Optional[int] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor, Optional[torch.Tensor]]:
-    """Perform MNNVL AllReduce + Residual + RMSNorm + FP8/NVFP4 quantization.
+    """Perform MNNVL AllReduce + Residual + RMSNorm + quantization.
 
     Quantization is applied after RMSNorm. ``output`` is optional; pass it only
     when the normalized non-quantized tensor is also needed. The quantized result
@@ -607,17 +612,23 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
         scale_out: Optional scale output. Dynamic FP8 uses ``[num_tokens, 1]``
             float32. NVFP4 uses ``[num_tokens, hidden_dim // 16]`` for
             ``LINEAR`` layout, or a 1-D tensor large enough for the padded
-            ``SWIZZLED_128x4`` layout. Static FP8 ignores this argument.
+            ``SWIZZLED_128x4`` layout. Per-token-group FP8 uses packed UE8M0
+            scales with shape ``[num_tokens, ceil(groups_per_row / 4)]``, dtype
+            ``torch.int32``, and stride ``(1, ceil(num_tokens / 4) * 4)``.
+            Static FP8 ignores this argument.
         output_scale: Scalar float or float32 tensor used as the quantization
             output scale. Defaults to ``1.0``.
         layout_code: NVFP4 scale layout. MNNVL supports ``SWIZZLED_128x4`` and
             ``LINEAR``; ``SWIZZLED_8x4`` is not supported.
         quant_type: ``MNNVLQuantType.FP8``, ``MNNVLQuantType.NVFP4``, or
-            ``MNNVLQuantType.DYNAMIC_FP8``.
+            ``MNNVLQuantType.DYNAMIC_FP8``, or
+            ``MNNVLQuantType.PER_TOKEN_GROUP_FP8_PACKED``.
         launch_with_pdl: Whether to launch with PDL.
         strategy: MNNVL execution strategy. ``AUTO`` uses internal heuristics.
         weight_bias: Bias added to gamma before scaling. ``0.0`` for standard
             RMSNorm; ``1.0`` for Gemma / Qwen3.5 RMSNorm.
+        block_quant_group_size: Group size along the hidden dimension for
+            per-token-group FP8 quantization.
 
     Returns:
         A tuple ``(quant_out, scale_out, residual_out, output)``. ``scale_out``
@@ -626,7 +637,10 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
 
     if epsilon is None:
         epsilon = torch.finfo(input.dtype).eps
-    if output_scale is None and quant_type != MNNVLQuantType.DYNAMIC_FP8:
+    if output_scale is None and quant_type not in (
+        MNNVLQuantType.DYNAMIC_FP8,
+        MNNVLQuantType.PER_TOKEN_GROUP_FP8_PACKED,
+    ):
         output_scale = 1.0
 
     if len(input.shape) != 2:
@@ -663,7 +677,10 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
             f"output shape must match input shape, got {output.shape} and {input.shape}."
         )
 
-    if quant_type == MNNVLQuantType.DYNAMIC_FP8:
+    if quant_type in (
+        MNNVLQuantType.DYNAMIC_FP8,
+        MNNVLQuantType.PER_TOKEN_GROUP_FP8_PACKED,
+    ):
         output_scale_tensor = None
     elif isinstance(output_scale, torch.Tensor):
         if output_scale.numel() < 1:
@@ -769,6 +786,52 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
             )
         if not scale_out.is_contiguous():
             raise ValueError("scale_out must be contiguous for dynamic FP8.")
+    elif quant_type == MNNVLQuantType.PER_TOKEN_GROUP_FP8_PACKED:
+        if block_quant_group_size is None or block_quant_group_size <= 0:
+            raise ValueError(
+                "block_quant_group_size must be provided and positive for group FP8."
+            )
+        if hidden_dim % block_quant_group_size != 0:
+            raise ValueError(
+                f"hidden_dim must be divisible by block_quant_group_size, got {hidden_dim} and {block_quant_group_size}."
+            )
+        if quant_out is None:
+            quant_out = torch.empty_like(input, dtype=torch.float8_e4m3fn)
+        elif quant_out.shape != input.shape:
+            raise ValueError(
+                f"quant_out shape must be {tuple(input.shape)} for group FP8, got {tuple(quant_out.shape)}."
+            )
+        if quant_out.dtype != torch.float8_e4m3fn:
+            raise ValueError(
+                f"quant_out dtype for group FP8 must be float8_e4m3fn, got {quant_out.dtype}."
+            )
+        if not quant_out.is_contiguous():
+            raise ValueError("quant_out must be contiguous for group FP8.")
+
+        groups_per_row = hidden_dim // block_quant_group_size
+        k_num_packed = (groups_per_row + 3) // 4
+        tma_aligned_mn = ((token_num + 3) // 4) * 4
+        expected_scale_shape = (token_num, k_num_packed)
+        expected_scale_stride = (1, tma_aligned_mn)
+        if scale_out is None:
+            scale_out = torch.empty_strided(
+                expected_scale_shape,
+                expected_scale_stride,
+                dtype=torch.int32,
+                device=input.device,
+            )
+        elif tuple(scale_out.shape) != expected_scale_shape:
+            raise ValueError(
+                f"scale_out shape must be {expected_scale_shape} for group FP8, got {tuple(scale_out.shape)}."
+            )
+        if scale_out.stride() != expected_scale_stride:
+            raise ValueError(
+                f"scale_out stride must be {expected_scale_stride} for group FP8, got {scale_out.stride()}."
+            )
+        if scale_out.dtype != torch.int32:
+            raise ValueError(
+                f"scale_out dtype for group FP8 must be int32, got {scale_out.dtype}."
+            )
     else:
         raise ValueError(f"Unsupported MNNVL quant_type: {quant_type}")
 
@@ -817,6 +880,7 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
         scale_out,
         output_scale_tensor,
         layout_code,
+        block_quant_group_size,
     )
     return quant_out, scale_out, residual_out, output
 

--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -50,6 +50,30 @@ class MNNVLAllreduceFusionStrategy(Enum):
 
 # Empirical result calculated from num_tokens * hidden_dim * tp_size * elem_size
 MNNVL_ONE_SHOT_THRESHOLD = 64 * 1024 * 8 * 2
+_MNNVL_MAX_CLUSTER_SIZE = 8
+_MNNVL_MAX_THREADS_PER_BLOCK = 1024
+_MNNVL_VECTOR_BYTES = 16
+
+
+def _supports_exact_group_quant_partition(
+    hidden_dim: int, group_size: int, element_size: int
+) -> bool:
+    """Return whether MNNVL can assign whole quantization groups to each CTA."""
+    elements_per_thread = _MNNVL_VECTOR_BYTES // element_size
+    if hidden_dim % elements_per_thread != 0:
+        return False
+
+    threads_needed = hidden_dim // elements_per_thread
+    for cluster_size in (1, 2, 4, _MNNVL_MAX_CLUSTER_SIZE):
+        if threads_needed % cluster_size != 0:
+            continue
+        block_size = threads_needed // cluster_size
+        if (
+            block_size <= _MNNVL_MAX_THREADS_PER_BLOCK
+            and (block_size * elements_per_thread) % group_size == 0
+        ):
+            return True
+    return False
 
 
 class MNNVLQuantType:
@@ -628,7 +652,9 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
         weight_bias: Bias added to gamma before scaling. ``0.0`` for standard
             RMSNorm; ``1.0`` for Gemma / Qwen3.5 RMSNorm.
         block_quant_group_size: Group size along the hidden dimension for
-            per-token-group FP8 quantization.
+            per-token-group FP8 quantization. MNNVL requires an exact row
+            partition into at most eight CTAs, with at most 1024 vector threads
+            per CTA and an integral number of groups owned by each CTA.
 
     Returns:
         A tuple ``(quant_out, scale_out, residual_out, output)``. ``scale_out``
@@ -794,6 +820,15 @@ def trtllm_mnnvl_fused_allreduce_add_rmsnorm_quant(
         if hidden_dim % block_quant_group_size != 0:
             raise ValueError(
                 f"hidden_dim must be divisible by block_quant_group_size, got {hidden_dim} and {block_quant_group_size}."
+            )
+        if not _supports_exact_group_quant_partition(
+            hidden_dim, block_quant_group_size, input.element_size()
+        ):
+            raise ValueError(
+                "MNNVL packed group FP8 has no exact CTA partition for "
+                f"hidden_dim={hidden_dim}, group_size={block_quant_group_size}, "
+                f"and dtype={input.dtype}; each CTA must have at most 1024 "
+                "threads and own whole quantization groups."
             )
         if quant_out is None:
             quant_out = torch.empty_like(input, dtype=torch.float8_e4m3fn)

--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -37,6 +37,48 @@ static constexpr float kFP8E4M3Max = 448.0f;
 // produce a zero scale.
 static constexpr float kFP8E4M3MinSubnormal = 1.0f / 512.0f;
 static constexpr float kDynamicFP8MinScale = kFP8E4M3MinSubnormal / kFP8E4M3Max;
+static constexpr float kUE8M0MinScaleInput = 1e-10f;
+
+__device__ __forceinline__ float compute_ue8m0_scale(float group_absmax) {
+  float scale = fmaxf(group_absmax / kFP8E4M3Max, kUE8M0MinScaleInput);
+  unsigned int scale_bits = __float_as_uint(scale);
+  if (scale_bits & 0x7fffff) {
+    scale_bits = (scale_bits + 0x800000) & 0x7f800000;
+  }
+  return __uint_as_float(scale_bits);
+}
+
+__device__ __forceinline__ void write_packed_ue8m0_scale(void* scale_out, int token_id,
+                                                         int token_num, int hidden_dim,
+                                                         int group_size, int tma_aligned_mn,
+                                                         int group_idx_in_row, float group_absmax) {
+  float scale = compute_ue8m0_scale(group_absmax);
+  int groups_per_row = hidden_dim / group_size;
+  int k_num_packed = (groups_per_row + 3) / 4;
+  int pack_idx = group_idx_in_row / 4;
+  int pos = group_idx_in_row % 4;
+  int elem_idx = pack_idx * tma_aligned_mn + token_id;
+
+  unsigned int bits = __float_as_uint(scale);
+  reinterpret_cast<uint8_t*>(scale_out)[elem_idx * 4 + pos] =
+      static_cast<uint8_t>((bits >> 23u) & 0xffu);
+
+  if (group_idx_in_row == groups_per_row - 1) {
+    for (int p = pos + 1; p < 4; p++) {
+      reinterpret_cast<uint8_t*>(scale_out)[elem_idx * 4 + p] = 0;
+    }
+  }
+
+  // The final packed column only allocates token_num rows. Earlier columns
+  // include the TMA-aligned token padding and must be initialized explicitly.
+  if (token_id == token_num - 1 && group_idx_in_row == 0) {
+    for (int pad_t = token_num; pad_t < tma_aligned_mn; pad_t++) {
+      for (int pk = 0; pk < k_num_packed - 1; pk++) {
+        reinterpret_cast<uint32_t*>(scale_out)[pk * tma_aligned_mn + pad_t] = 0;
+      }
+    }
+  }
+}
 
 }  // namespace details
 
@@ -1067,7 +1109,6 @@ class FusedOp {
       reinterpret_cast<PackedQuantizedType*>(m_params.quant_out)[m_access_id] = ret;
     } else if constexpr (GetQuantType<Pattern> == QuantType::kPerTokenGroupFP8Packed) {
       // Per-token-group FP8 quantization with UE8M0 packed scales.
-      constexpr float FP8_E4M3_MAX = 448.0f;
       int group_size = m_params.block_quant_group_size;
       int groups_in_block = blockDim.x * VEC_SIZE / group_size;
       int block_elem_start = threadIdx.x * VEC_SIZE;
@@ -1121,23 +1162,13 @@ class FusedOp {
         }
       }
 
-      // compute UE8M0 scale and quantize to FP8
-      auto compute_ue8m0_scale = [](float group_absmax) -> float {
-        float y_s = fmaxf(group_absmax / FP8_E4M3_MAX, 1e-10f);
-        unsigned int y_s_bits = __float_as_uint(y_s);
-        if (y_s_bits & 0x7fffff) {
-          y_s_bits = (y_s_bits + 0x800000) & 0x7f800000;
-        }
-        return __uint_as_float(y_s_bits);
-      };
-
       using PackedQuantizedType = std::conditional_t<std::is_same_v<T, float>, float, float2>;
       PackedQuantizedType ret;
 #pragma unroll
       for (int i = 0; i < VEC_SIZE; ++i) {
-        float y_s = compute_ue8m0_scale(elem_group_absmax[i]);
+        float y_s = details::compute_ue8m0_scale(elem_group_absmax[i]);
         float q = static_cast<float>(reinterpret_cast<T*>(&val)[i]) / y_s;
-        q = fminf(fmaxf(q, -FP8_E4M3_MAX), FP8_E4M3_MAX);
+        q = fminf(fmaxf(q, -details::kFP8E4M3Max), details::kFP8E4M3Max);
         reinterpret_cast<__nv_fp8_e4m3*>(&ret)[i] = static_cast<__nv_fp8_e4m3>(q);
       }
       reinterpret_cast<PackedQuantizedType*>(m_params.quant_out)[m_access_id] = ret;
@@ -1146,47 +1177,15 @@ class FusedOp {
       // For warp-shuffle path: one thread per group (first thread in each group).
       // For smem path: one thread per group in the block (threadIdx.x < groups_in_block).
       int block_first_elem = (m_access_id_in_token - threadIdx.x) * VEC_SIZE;
-      auto write_group_scale = [&](int group_idx_in_row, float group_absmax) {
-        float y_s = compute_ue8m0_scale(group_absmax);
-        int groups_per_row = m_params.hidden_dim / group_size;
-        int k_num_packed = (groups_per_row + 3) / 4;
-        int token_num = m_params.size / m_params.hidden_dim;
-        int pack_idx = group_idx_in_row / 4;
-        int pos = group_idx_in_row % 4;
-        int elem_idx = pack_idx * m_params.tma_aligned_mn + token_id;
-
-        // Write valid exponent
-        unsigned int bits = __float_as_uint(y_s);
-        uint8_t exponent = static_cast<uint8_t>((bits >> 23u) & 0xffu);
-        reinterpret_cast<uint8_t*>(m_params.scale_out)[elem_idx * 4 + pos] = exponent;
-
-        // K-padding: last valid group zeros trailing bytes in its pack
-        if (group_idx_in_row == groups_per_row - 1) {
-          for (int p = pos + 1; p < 4; p++) {
-            reinterpret_cast<uint8_t*>(m_params.scale_out)[elem_idx * 4 + p] = 0;
-          }
-        }
-
-        // MN-padding: on last valid token, first group zeros all packs
-        // for padding tokens (token_num .. tma_aligned_mn - 1).
-        // Skip the last packed column (pk = k_num_packed - 1) because
-        // scale_out storage is (token_num + (k_num_packed-1)*tma_aligned_mn)
-        // elements — the last column only has token_num rows allocated.
-        if (token_id == token_num - 1 && group_idx_in_row == 0) {
-          for (int pad_t = token_num; pad_t < m_params.tma_aligned_mn; pad_t++) {
-            for (int pk = 0; pk < k_num_packed - 1; pk++) {
-              int pad_elem = pk * m_params.tma_aligned_mn + pad_t;
-              reinterpret_cast<uint32_t*>(m_params.scale_out)[pad_elem] = 0;
-            }
-          }
-        }
-      };
+      int token_num = m_params.size / m_params.hidden_dim;
 
       if (use_warp_shuffle) {
         int lane_in_group = m_access_id_in_token % group_size_in_vecs;
         if (lane_in_group == 0) {
           int group_idx_in_row = m_access_id_in_token / group_size_in_vecs;
-          write_group_scale(group_idx_in_row, elem_group_absmax[0]);
+          details::write_packed_ue8m0_scale(
+              m_params.scale_out, token_id, token_num, m_params.hidden_dim, group_size,
+              m_params.tma_aligned_mn, group_idx_in_row, elem_group_absmax[0]);
         }
       } else {
         // Loop: groups_in_block may exceed blockDim.x when group_size < VEC_SIZE
@@ -1194,7 +1193,9 @@ class FusedOp {
              local_group += blockDim.x) {
           float group_absmax = __uint_as_float(smem_group_absmax[local_group]);
           int group_idx_in_row = block_first_elem / group_size + local_group;
-          write_group_scale(group_idx_in_row, group_absmax);
+          details::write_packed_ue8m0_scale(
+              m_params.scale_out, token_id, token_num, m_params.hidden_dim, group_size,
+              m_params.tma_aligned_mn, group_idx_in_row, group_absmax);
         }
       }
     } else if constexpr (GetQuantType<Pattern> == QuantType::kDynamicFP8) {

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -118,14 +118,15 @@ constexpr float kFP8E4M3Max = 448.0f;
 constexpr float kFP8E4M3MinSubnormal = 1.0f / 512.0f;
 constexpr float kDynamicFP8MinScale = kFP8E4M3MinSubnormal / kFP8E4M3Max;
 
-inline __host__ __device__ bool useWarpGroupReduction(int groupSize, int eltsPerThread) {
+inline __host__ __device__ bool useWarpGroupReduction(int groupSize, int eltsPerThread,
+                                                      int blockSize) {
   int groupThreads = groupSize / eltsPerThread;
-  return groupSize % eltsPerThread == 0 && groupThreads <= 32 &&
+  return blockSize % 32 == 0 && groupSize % eltsPerThread == 0 && groupThreads <= 32 &&
          (groupThreads & (groupThreads - 1)) == 0;
 }
 
 inline size_t groupQuantSmemSize(int blockSize, int groupSize, int eltsPerThread) {
-  if (useWarpGroupReduction(groupSize, eltsPerThread)) {
+  if (useWarpGroupReduction(groupSize, eltsPerThread, blockSize)) {
     return 0;
   }
   return blockSize * eltsPerThread / groupSize * sizeof(unsigned int);
@@ -935,11 +936,11 @@ inline __device__ void quant_per_token_group_fp8_packed(
     void* quantOutPtr, void* sfOutPtr, unsigned int* smemGroupAbsmax) {
   static_assert(ELTS_PER_THREAD == 8 || ELTS_PER_THREAD == 4, "ELTS_PER_THREAD must be 8 or 4");
   // Dispatch guarantees an exact row partition: every launched thread owns a full vector,
-  // every CTA spans whole quantization groups, and warp-reduced groups use a power-of-two
-  // thread count no larger than a warp. The inBounds/blockValidElements plumbing is retained
-  // for a future tail-capable path; relaxing the dispatch checks also requires updating both
-  // reductions below.
-  bool const useWarpShuffle = utils::useWarpGroupReduction(groupSize, ELTS_PER_THREAD);
+  // every CTA spans whole quantization groups, and warp-reduced groups use full warps with a
+  // power-of-two thread count per group. Partial-warp CTAs use shared memory. The
+  // inBounds/blockValidElements plumbing is retained for a future tail-capable path; relaxing
+  // the dispatch checks also requires updating both reductions below.
+  bool const useWarpShuffle = utils::useWarpGroupReduction(groupSize, ELTS_PER_THREAD, blockDim.x);
   int const groupThreads = groupSize / ELTS_PER_THREAD;
   float localAbsmax = 0.F;
 
@@ -950,17 +951,8 @@ inline __device__ void quant_per_token_group_fp8_packed(
         localAbsmax = fmaxf(localAbsmax, fabsf(values[i]));
       }
     }
-    int const fullWarpThreadCount = blockDim.x & ~31;
-    if (threadIdx.x < fullWarpThreadCount) {
-      for (int offset = groupThreads / 2; offset > 0; offset /= 2) {
-        localAbsmax = fmaxf(localAbsmax, __shfl_xor_sync(0xffffffffu, localAbsmax, offset));
-      }
-    } else {
-      int const partialWarpThreads = blockDim.x - fullWarpThreadCount;
-      unsigned int const partialWarpMask = (1u << partialWarpThreads) - 1u;
-      for (int offset = groupThreads / 2; offset > 0; offset /= 2) {
-        localAbsmax = fmaxf(localAbsmax, __shfl_xor_sync(partialWarpMask, localAbsmax, offset));
-      }
+    for (int offset = groupThreads / 2; offset > 0; offset /= 2) {
+      localAbsmax = fmaxf(localAbsmax, __shfl_xor_sync(0xffffffffu, localAbsmax, offset));
     }
   } else {
     int const groupsInBlock = blockValidElements / groupSize;

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -950,13 +950,17 @@ inline __device__ void quant_per_token_group_fp8_packed(
         localAbsmax = fmaxf(localAbsmax, fabsf(values[i]));
       }
     }
-    int const laneIdx = threadIdx.x & 31;
-    int const groupFirstLane = laneIdx & ~(groupThreads - 1);
-    unsigned int const groupMask =
-        groupThreads == 32 ? 0xffffffffu : ((1u << groupThreads) - 1u) << groupFirstLane;
-    for (int offset = groupThreads / 2; offset > 0; offset /= 2) {
-      localAbsmax =
-          fmaxf(localAbsmax, __shfl_xor_sync(groupMask, localAbsmax, offset, groupThreads));
+    int const fullWarpThreadCount = blockDim.x & ~31;
+    if (threadIdx.x < fullWarpThreadCount) {
+      for (int offset = groupThreads / 2; offset > 0; offset /= 2) {
+        localAbsmax = fmaxf(localAbsmax, __shfl_xor_sync(0xffffffffu, localAbsmax, offset));
+      }
+    } else {
+      int const partialWarpThreads = blockDim.x - fullWarpThreadCount;
+      unsigned int const partialWarpMask = (1u << partialWarpThreads) - 1u;
+      for (int offset = groupThreads / 2; offset > 0; offset /= 2) {
+        localAbsmax = fmaxf(localAbsmax, __shfl_xor_sync(partialWarpMask, localAbsmax, offset));
+      }
     }
   } else {
     int const groupsInBlock = blockValidElements / groupSize;

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -934,6 +934,11 @@ inline __device__ void quant_per_token_group_fp8_packed(
     uint32_t blockFirstElement, uint32_t blockValidElements, int groupSize, int tmaAlignedMn,
     void* quantOutPtr, void* sfOutPtr, unsigned int* smemGroupAbsmax) {
   static_assert(ELTS_PER_THREAD == 8 || ELTS_PER_THREAD == 4, "ELTS_PER_THREAD must be 8 or 4");
+  // Dispatch guarantees an exact row partition: every launched thread owns a full vector,
+  // every CTA spans whole quantization groups, and warp-reduced groups use a power-of-two
+  // thread count no larger than a warp. The inBounds/blockValidElements plumbing is retained
+  // for a future tail-capable path; relaxing the dispatch checks also requires updating both
+  // reductions below.
   bool const useWarpShuffle = utils::useWarpGroupReduction(groupSize, ELTS_PER_THREAD);
   int const groupThreads = groupSize / ELTS_PER_THREAD;
   float localAbsmax = 0.F;
@@ -945,9 +950,13 @@ inline __device__ void quant_per_token_group_fp8_packed(
         localAbsmax = fmaxf(localAbsmax, fabsf(values[i]));
       }
     }
-    unsigned int const activeMask = __activemask();
+    int const laneIdx = threadIdx.x & 31;
+    int const groupFirstLane = laneIdx & ~(groupThreads - 1);
+    unsigned int const groupMask =
+        groupThreads == 32 ? 0xffffffffu : ((1u << groupThreads) - 1u) << groupFirstLane;
     for (int offset = groupThreads / 2; offset > 0; offset /= 2) {
-      localAbsmax = fmaxf(localAbsmax, __shfl_xor_sync(activeMask, localAbsmax, offset));
+      localAbsmax =
+          fmaxf(localAbsmax, __shfl_xor_sync(groupMask, localAbsmax, offset, groupThreads));
     }
   } else {
     int const groupsInBlock = blockValidElements / groupSize;
@@ -1545,7 +1554,7 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(AllReduceKernelParams<T> 
       ceil_div(params.tokenDim, clusterSize * kELTS_PER_LOAD) * kELTS_PER_LOAD;
   uint32_t const baseTokenOffset = clusterBlockRank * blockChunkSize;
 
-  extern __shared__ uint8_t smem[];
+  extern __shared__ __align__(alignof(float4)) uint8_t smem[];
   uint32_t const smemBufferSize = blockSize * elemsPerThread * sizeof(T);
   T* smemInput = reinterpret_cast<T*>(&smem[0]);
   T* smemResidual = reinterpret_cast<T*>(&smem[smemBufferSize]);
@@ -1686,6 +1695,8 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(AllReduceKernelParams<T> 
   if constexpr (QType == QuantType::kPerTokenGroupFP8Packed) {
     static_assert(LoadsPerThread == 1,
                   "Per-token-group FP8 quantization requires one load per thread");
+    static_assert((3 * kELTS_PER_LOAD * sizeof(T)) % alignof(unsigned int) == 0,
+                  "Group-FP8 scratch must be uint32-aligned");
     uint32_t const tokenOffset = baseTokenOffset + threadOffset * kELTS_PER_LOAD;
     bool const inBounds = tokenOffset < params.tokenDim;
     uint32_t const blockElements = blockDim.x * kELTS_PER_LOAD;

--- a/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
+++ b/include/flashinfer/comm/trtllm_mnnvl_allreduce.cuh
@@ -46,6 +46,7 @@ enum class QuantType : int {
   kFP8 = 1,
   kFP4 = 2,
   kDynamicFP8 = 3,
+  kPerTokenGroupFP8Packed = 4,
 };
 
 struct AllReduceFusionParams {
@@ -70,6 +71,8 @@ struct AllReduceFusionParams {
   float* outputScale = nullptr;
   QuantizationSFLayout sfLayout = QuantizationSFLayout::SWIZZLED_128x4;
   QuantType quantType = QuantType::kNone;
+  int blockQuantGroupSize = 0;
+  int tmaAlignedMn = 0;
 
   void* residualOut;
   void* output;
@@ -98,6 +101,8 @@ struct AllReduceKernelParams {
   void* quantOutPtr;
   void* scalingFactorOutPtr;
   QuantizationSFLayout sfLayout;
+  int blockQuantGroupSize;
+  int tmaAlignedMn;
   uint32_t* bufferFlags;
 };
 
@@ -112,6 +117,19 @@ constexpr float kFP8E4M3Max = 448.0f;
 // produce a zero scale.
 constexpr float kFP8E4M3MinSubnormal = 1.0f / 512.0f;
 constexpr float kDynamicFP8MinScale = kFP8E4M3MinSubnormal / kFP8E4M3Max;
+
+inline __host__ __device__ bool useWarpGroupReduction(int groupSize, int eltsPerThread) {
+  int groupThreads = groupSize / eltsPerThread;
+  return groupSize % eltsPerThread == 0 && groupThreads <= 32 &&
+         (groupThreads & (groupThreads - 1)) == 0;
+}
+
+inline size_t groupQuantSmemSize(int blockSize, int groupSize, int eltsPerThread) {
+  if (useWarpGroupReduction(groupSize, eltsPerThread)) {
+    return 0;
+  }
+  return blockSize * eltsPerThread / groupSize * sizeof(unsigned int);
+}
 
 template <typename T>
 union Fp16BitCast {
@@ -844,6 +862,40 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
   }
   return {blockSize, clusterSize, loadsPerThread};
 }
+
+std::tuple<int, int, int> adjustGroupQuantGridConfig(int numTokens, int dim, int eltsPerThread,
+                                                     int groupSize) {
+  auto const preferredGridConfig = adjustGridConfig(numTokens, dim, eltsPerThread, true);
+  int const preferredClusterSize = std::get<1>(preferredGridConfig);
+  int const threadsNeeded = dim / eltsPerThread;
+  auto isValid = [&](int clusterSize) {
+    if (threadsNeeded % clusterSize != 0) {
+      return false;
+    }
+    int const blockSize = threadsNeeded / clusterSize;
+    return blockSize <= 1024 && (blockSize * eltsPerThread) % groupSize == 0;
+  };
+
+  // Preserve the regular grid heuristic when possible, then prefer fewer CTAs.
+  // Every returned CTA covers complete groups and the cluster covers the row
+  // exactly; the one-shot kernel cannot safely carry inactive threads through
+  // the shared-memory reduction.
+  for (int clusterSize = preferredClusterSize; clusterSize >= 1; clusterSize /= 2) {
+    if (isValid(clusterSize)) {
+      return {threadsNeeded / clusterSize, clusterSize, 1};
+    }
+  }
+  for (int clusterSize = preferredClusterSize * 2; clusterSize <= kMaxClusterSize;
+       clusterSize *= 2) {
+    if (isValid(clusterSize)) {
+      return {threadsNeeded / clusterSize, clusterSize, 1};
+    }
+  }
+
+  // Return an exact single-CTA partition. Dispatch rejects it if it exceeds
+  // the CUDA thread limit, without launching a partially active CTA.
+  return {threadsNeeded, 1, 1};
+}
 };  // namespace utils
 
 using utils::blockReduceMax;
@@ -874,6 +926,84 @@ inline __device__ void quant_fp8(PackedVec<PackedType, T> packedAccum, void* qua
         __nv_fp8_e4m3(toFloat<T>(packedAccum.elements[i]) * invOutputScale);
   }
   reinterpret_cast<QuantizedPackedType*>(&quantOut[threadOffset])[0] = quantizedAccum.packed;
+}
+
+template <int ELTS_PER_THREAD>
+inline __device__ void quant_per_token_group_fp8_packed(
+    float const* values, bool inBounds, uint32_t tokenIdx, uint32_t tokenDim, uint32_t tokenOffset,
+    uint32_t blockFirstElement, uint32_t blockValidElements, int groupSize, int tmaAlignedMn,
+    void* quantOutPtr, void* sfOutPtr, unsigned int* smemGroupAbsmax) {
+  static_assert(ELTS_PER_THREAD == 8 || ELTS_PER_THREAD == 4, "ELTS_PER_THREAD must be 8 or 4");
+  bool const useWarpShuffle = utils::useWarpGroupReduction(groupSize, ELTS_PER_THREAD);
+  int const groupThreads = groupSize / ELTS_PER_THREAD;
+  float localAbsmax = 0.F;
+
+  if (useWarpShuffle) {
+    if (inBounds) {
+#pragma unroll
+      for (int i = 0; i < ELTS_PER_THREAD; ++i) {
+        localAbsmax = fmaxf(localAbsmax, fabsf(values[i]));
+      }
+    }
+    unsigned int const activeMask = __activemask();
+    for (int offset = groupThreads / 2; offset > 0; offset /= 2) {
+      localAbsmax = fmaxf(localAbsmax, __shfl_xor_sync(activeMask, localAbsmax, offset));
+    }
+  } else {
+    int const groupsInBlock = blockValidElements / groupSize;
+    for (int group = threadIdx.x; group < groupsInBlock; group += blockDim.x) {
+      smemGroupAbsmax[group] = 0;
+    }
+    __syncthreads();
+
+    if (inBounds) {
+#pragma unroll
+      for (int i = 0; i < ELTS_PER_THREAD; ++i) {
+        int const localGroup =
+            (tokenOffset - blockFirstElement + static_cast<uint32_t>(i)) / groupSize;
+        atomicMax(&smemGroupAbsmax[localGroup], __float_as_uint(fabsf(values[i])));
+      }
+    }
+    __syncthreads();
+  }
+
+  if (inBounds) {
+    using QuantizedPackedType = std::conditional_t<ELTS_PER_THREAD == 8, float2, float>;
+    QuantizedPackedType quantized;
+#pragma unroll
+    for (int i = 0; i < ELTS_PER_THREAD; ++i) {
+      float groupAbsmax = localAbsmax;
+      if (!useWarpShuffle) {
+        int const localGroup =
+            (tokenOffset - blockFirstElement + static_cast<uint32_t>(i)) / groupSize;
+        groupAbsmax = __uint_as_float(smemGroupAbsmax[localGroup]);
+      }
+      float const scale = trtllm_allreduce_fusion::details::compute_ue8m0_scale(groupAbsmax);
+      float q = values[i] / scale;
+      q = fminf(fmaxf(q, -utils::kFP8E4M3Max), utils::kFP8E4M3Max);
+      reinterpret_cast<__nv_fp8_e4m3*>(&quantized)[i] = static_cast<__nv_fp8_e4m3>(q);
+    }
+    reinterpret_cast<QuantizedPackedType*>(&reinterpret_cast<__nv_fp8_e4m3*>(
+        quantOutPtr)[tokenIdx * tokenDim + tokenOffset])[0] = quantized;
+  }
+
+  if (useWarpShuffle) {
+    int const vectorIdxInGroup = (tokenOffset / ELTS_PER_THREAD) % groupThreads;
+    if (inBounds && vectorIdxInGroup == 0) {
+      int const groupIdxInRow = tokenOffset / groupSize;
+      trtllm_allreduce_fusion::details::write_packed_ue8m0_scale(sfOutPtr, tokenIdx, gridDim.x,
+                                                                 tokenDim, groupSize, tmaAlignedMn,
+                                                                 groupIdxInRow, localAbsmax);
+    }
+  } else {
+    int const groupsInBlock = blockValidElements / groupSize;
+    for (int localGroup = threadIdx.x; localGroup < groupsInBlock; localGroup += blockDim.x) {
+      int const groupIdxInRow = blockFirstElement / groupSize + localGroup;
+      trtllm_allreduce_fusion::details::write_packed_ue8m0_scale(
+          sfOutPtr, tokenIdx, gridDim.x, tokenDim, groupSize, tmaAlignedMn, groupIdxInRow,
+          __uint_as_float(smemGroupAbsmax[localGroup]));
+    }
+  }
 }
 
 template <typename T, typename PackedType, int ELTS_PER_THREAD>
@@ -1048,7 +1178,23 @@ __global__ void __launch_bounds__(1024)
         tokenDim, packedIdx, params.sfLayout);
   }
 #endif
-  else if constexpr (QType == QuantType::kDynamicFP8) {
+  else if constexpr (QType == QuantType::kPerTokenGroupFP8Packed) {
+    float values[kELTS_PER_THREAD];
+#pragma unroll
+    for (int i = 0; i < kELTS_PER_THREAD; ++i) {
+      values[i] = toFloat<T>(packedAccum.elements[i]);
+    }
+    uint32_t const blockFirstElement = cluster.block_rank() * blockDim.x * kELTS_PER_THREAD;
+    uint32_t const blockElements = blockDim.x * kELTS_PER_THREAD;
+    uint32_t const remainingElements = tokenDim - blockFirstElement;
+    uint32_t const blockValidElements =
+        remainingElements < blockElements ? remainingElements : blockElements;
+    extern __shared__ unsigned int smemGroupAbsmax[];
+    quant::quant_per_token_group_fp8_packed<kELTS_PER_THREAD>(
+        values, true, token, tokenDim, packedIdx * kELTS_PER_THREAD, blockFirstElement,
+        blockValidElements, params.blockQuantGroupSize, params.tmaAlignedMn, params.quantOutPtr,
+        params.scalingFactorOutPtr, smemGroupAbsmax);
+  } else if constexpr (QType == QuantType::kDynamicFP8) {
     float threadMax = 0.F;
 #pragma unroll
     for (int i = 0; i < kELTS_PER_THREAD; i++) {
@@ -1096,8 +1242,23 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
   int const tokenDim = params.tokenDim;
   int const eltsPerThread = sizeof(float4) / sizeof(T);
 
-  auto [blockSize, clusterSize, loadsPerThread] =
-      adjustGridConfig(numTokens, tokenDim, eltsPerThread, true);
+  if (params.quantType == QuantType::kPerTokenGroupFP8Packed) {
+    if (params.blockQuantGroupSize <= 0 || tokenDim % params.blockQuantGroupSize != 0) {
+      FLASHINFER_ERROR(
+          "[MNNVL AllReduceOneShot] tokenDim must be divisible by a positive group size");
+      return cudaErrorInvalidValue;
+    }
+    if (params.scalingFactorOut == nullptr) {
+      FLASHINFER_ERROR("[MNNVL AllReduceOneShot] scale_out is required for group FP8");
+      return cudaErrorInvalidValue;
+    }
+  }
+
+  auto gridConfig = params.quantType == QuantType::kPerTokenGroupFP8Packed
+                        ? utils::adjustGroupQuantGridConfig(numTokens, tokenDim, eltsPerThread,
+                                                            params.blockQuantGroupSize)
+                        : adjustGridConfig(numTokens, tokenDim, eltsPerThread, true);
+  auto [blockSize, clusterSize, loadsPerThread] = gridConfig;
   dim3 grid(numTokens, clusterSize, 1);
 
   FLASHINFER_LOG_DEBUG(
@@ -1108,6 +1269,15 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
       numTokens, clusterSize, blockSize, clusterSize, loadsPerThread,
       ceil_div(tokenDim, eltsPerThread));
 
+  if (params.quantType == QuantType::kPerTokenGroupFP8Packed &&
+      (blockSize > 1024 || loadsPerThread != 1 ||
+       clusterSize * blockSize * eltsPerThread != tokenDim ||
+       (blockSize * eltsPerThread) % params.blockQuantGroupSize != 0)) {
+    FLASHINFER_ERROR("[MNNVL AllReduceOneShot] no exact CTA partition for token_dim " +
+                     std::to_string(tokenDim) + " and group_size " +
+                     std::to_string(params.blockQuantGroupSize));
+    return cudaErrorInvalidValue;
+  }
   FLASHINFER_CHECK(blockSize <= 1024 && loadsPerThread == 1,
                    "Hidden Dimension %d exceeds the maximum supported hidden dimension (%d)",
                    tokenDim, 1024 * 8 * eltsPerThread);
@@ -1122,7 +1292,8 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
           "[MNNVL AllReduceOneShot] quantOut must be non-null when quantization is enabled");
       return cudaErrorInvalidValue;
     }
-    if (params.quantType != QuantType::kDynamicFP8 && params.outputScale == nullptr) {
+    if (params.quantType != QuantType::kDynamicFP8 &&
+        params.quantType != QuantType::kPerTokenGroupFP8Packed && params.outputScale == nullptr) {
       FLASHINFER_ERROR(
           "[MNNVL AllReduceOneShot] outputScale must be non-null for static quantization");
       return cudaErrorInvalidValue;
@@ -1154,6 +1325,10 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
                      " exceeds shared max buffer " + std::to_string(utils::kMaxClusterSize));
     return cudaErrorInvalidValue;
   }
+  size_t const groupSmemSize =
+      params.quantType == QuantType::kPerTokenGroupFP8Packed
+          ? utils::groupQuantSmemSize(blockSize, params.blockQuantGroupSize, eltsPerThread)
+          : 0;
 
   cudaLaunchAttribute attrs[2];
   attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
@@ -1166,7 +1341,7 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
   cudaLaunchConfig_t config{
       .gridDim = grid,
       .blockDim = blockSize,
-      .dynamicSmemBytes = 0,
+      .dynamicSmemBytes = groupSmemSize,
       .stream = params.stream,
       .attrs = attrs,
       .numAttrs = 2,
@@ -1175,35 +1350,38 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
 #define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, RMSNORM, QTYPE) \
   FLASHINFER_CUDA_CALL(cudaLaunchKernelEx(                  \
       &config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM, QTYPE>, kernelParams));
-#define DISPATCH_ALLREDUCE_KERNEL(WORLD_SIZE)                                        \
-  if (params.rmsNormFusion) {                                                        \
-    switch (params.quantType) {                                                      \
-      case QuantType::kFP8:                                                          \
-        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kFP8);                  \
-        break;                                                                       \
-      case QuantType::kFP4:                                                          \
-        if constexpr (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) { \
-          LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kFP4);                \
-        } else {                                                                     \
-          FLASHINFER_ERROR(                                                          \
-              "[MNNVL AllReduceOneShot] FP4 quantization is only "                   \
-              "supported for FP16/BF16");                                            \
-          return cudaErrorInvalidValue;                                              \
-        }                                                                            \
-        break;                                                                       \
-      case QuantType::kDynamicFP8:                                                   \
-        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kDynamicFP8);           \
-        break;                                                                       \
-      case QuantType::kNone:                                                         \
-        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kNone);                 \
-        break;                                                                       \
-      default:                                                                       \
-        FLASHINFER_ERROR("[MNNVL AllReduceOneShot] Unsupported quant type " +        \
-                         std::to_string(static_cast<int>(params.quantType)));        \
-        return cudaErrorInvalidValue;                                                \
-    }                                                                                \
-  } else {                                                                           \
-    LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, false, QuantType::kNone);                    \
+#define DISPATCH_ALLREDUCE_KERNEL(WORLD_SIZE)                                          \
+  if (params.rmsNormFusion) {                                                          \
+    switch (params.quantType) {                                                        \
+      case QuantType::kFP8:                                                            \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kFP8);                    \
+        break;                                                                         \
+      case QuantType::kFP4:                                                            \
+        if constexpr (std::is_same_v<T, half> || std::is_same_v<T, __nv_bfloat16>) {   \
+          LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kFP4);                  \
+        } else {                                                                       \
+          FLASHINFER_ERROR(                                                            \
+              "[MNNVL AllReduceOneShot] FP4 quantization is only "                     \
+              "supported for FP16/BF16");                                              \
+          return cudaErrorInvalidValue;                                                \
+        }                                                                              \
+        break;                                                                         \
+      case QuantType::kDynamicFP8:                                                     \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kDynamicFP8);             \
+        break;                                                                         \
+      case QuantType::kPerTokenGroupFP8Packed:                                         \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kPerTokenGroupFP8Packed); \
+        break;                                                                         \
+      case QuantType::kNone:                                                           \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, true, QuantType::kNone);                   \
+        break;                                                                         \
+      default:                                                                         \
+        FLASHINFER_ERROR("[MNNVL AllReduceOneShot] Unsupported quant type " +          \
+                         std::to_string(static_cast<int>(params.quantType)));          \
+        return cudaErrorInvalidValue;                                                  \
+    }                                                                                  \
+  } else {                                                                             \
+    LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, false, QuantType::kNone);                      \
   }
 
   AllReduceKernelParams<T> kernelParams{
@@ -1225,6 +1403,8 @@ cudaError_t oneshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
       .quantOutPtr = params.quantOut,
       .scalingFactorOutPtr = params.scalingFactorOut,
       .sfLayout = params.sfLayout,
+      .blockQuantGroupSize = params.blockQuantGroupSize,
+      .tmaAlignedMn = params.tmaAlignedMn,
       .bufferFlags = params.bufferFlags,
   };
 
@@ -1476,9 +1656,13 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(AllReduceKernelParams<T> 
       for (int j = 0; j < kELTS_PER_LOAD; j++) {
         float normVal = (params.weightBias + toFloat<T>(gamma.elements[j])) *
                         rInput[i * kELTS_PER_LOAD + j] * rcpRms;
-        rNorm[i * kELTS_PER_LOAD + j] = normVal;
         threadMax = fmaxf(threadMax, fabsf(normVal));
         out.elements[j] = fromFloat<T>(normVal);
+        if constexpr (QType == QuantType::kPerTokenGroupFP8Packed) {
+          rNorm[i * kELTS_PER_LOAD + j] = toFloat<T>(out.elements[j]);
+        } else {
+          rNorm[i * kELTS_PER_LOAD + j] = normVal;
+        }
       }
       if (params.outputPtr != nullptr) {
         reinterpret_cast<PackedType*>(&params.outputPtr[token * params.tokenDim + tokenOffset])[0] =
@@ -1499,7 +1683,21 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(AllReduceKernelParams<T> 
     }
   }
 
-  if constexpr (QType == QuantType::kDynamicFP8) {
+  if constexpr (QType == QuantType::kPerTokenGroupFP8Packed) {
+    static_assert(LoadsPerThread == 1,
+                  "Per-token-group FP8 quantization requires one load per thread");
+    uint32_t const tokenOffset = baseTokenOffset + threadOffset * kELTS_PER_LOAD;
+    bool const inBounds = tokenOffset < params.tokenDim;
+    uint32_t const blockElements = blockDim.x * kELTS_PER_LOAD;
+    uint32_t const remainingElements = params.tokenDim - baseTokenOffset;
+    uint32_t const blockValidElements =
+        remainingElements < blockElements ? remainingElements : blockElements;
+    auto* smemGroupAbsmax = reinterpret_cast<unsigned int*>(&smem[3 * smemBufferSize]);
+    quant::quant_per_token_group_fp8_packed<kELTS_PER_LOAD>(
+        rNorm, inBounds, token, params.tokenDim, tokenOffset, baseTokenOffset, blockValidElements,
+        params.blockQuantGroupSize, params.tmaAlignedMn, params.quantOutPtr,
+        params.scalingFactorOutPtr, smemGroupAbsmax);
+  } else if constexpr (QType == QuantType::kDynamicFP8) {
     float tokenMax = blockReduceMax<float, true>(threadMax);
     __shared__ float sharedMax[utils::kMaxClusterSize];
     if constexpr (UseCGA) {
@@ -1566,7 +1764,8 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
           "[MNNVL AllReduceTwoShot] quantOut must be non-null when quantization is enabled");
       return cudaErrorInvalidValue;
     }
-    if (params.quantType != QuantType::kDynamicFP8 && params.outputScale == nullptr) {
+    if (params.quantType != QuantType::kDynamicFP8 &&
+        params.quantType != QuantType::kPerTokenGroupFP8Packed && params.outputScale == nullptr) {
       FLASHINFER_ERROR(
           "[MNNVL AllReduceTwoShot] outputScale must be non-null for static quantization");
       return cudaErrorInvalidValue;
@@ -1575,6 +1774,17 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
   if (params.quantType == QuantType::kDynamicFP8 && params.scalingFactorOut == nullptr) {
     FLASHINFER_ERROR("[MNNVL AllReduceTwoShot] scale_out is required for dynamic FP8");
     return cudaErrorInvalidValue;
+  }
+  if (params.quantType == QuantType::kPerTokenGroupFP8Packed) {
+    if (params.blockQuantGroupSize <= 0 || tokenDim % params.blockQuantGroupSize != 0) {
+      FLASHINFER_ERROR(
+          "[MNNVL AllReduceTwoShot] tokenDim must be divisible by a positive group size");
+      return cudaErrorInvalidValue;
+    }
+    if (params.scalingFactorOut == nullptr) {
+      FLASHINFER_ERROR("[MNNVL AllReduceTwoShot] scale_out is required for group FP8");
+      return cudaErrorInvalidValue;
+    }
   }
   if (params.quantType == QuantType::kFP4) {
 #if CUDA_VERSION < 12080
@@ -1616,6 +1826,8 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
       .quantOutPtr = params.quantOut,
       .scalingFactorOutPtr = params.scalingFactorOut,
       .sfLayout = params.sfLayout,
+      .blockQuantGroupSize = params.blockQuantGroupSize,
+      .tmaAlignedMn = params.tmaAlignedMn,
       .bufferFlags = params.bufferFlags,
   };
 
@@ -1676,7 +1888,10 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
 #undef DISPATCH_ALLREDUCE_KERNEL
 #undef LAUNCH_ALLREDUCE_KERNEL
 
-  auto gridConfig = adjustGridConfig(numTokens, tokenDim, numEltsPerThread, true);
+  auto gridConfig = params.quantType == QuantType::kPerTokenGroupFP8Packed
+                        ? utils::adjustGroupQuantGridConfig(numTokens, tokenDim, numEltsPerThread,
+                                                            params.blockQuantGroupSize)
+                        : adjustGridConfig(numTokens, tokenDim, numEltsPerThread, true);
   int rnBlockSize = std::get<0>(gridConfig);
   int rnClusterSize = std::get<1>(gridConfig);
   int rnLoadsPerThread = std::get<2>(gridConfig);
@@ -1690,6 +1905,15 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
     rnUseCGA = false;
   }
 
+  if (params.quantType == QuantType::kPerTokenGroupFP8Packed &&
+      (rnBlockSize > 1024 || rnLoadsPerThread != 1 ||
+       rnClusterSize * rnBlockSize * numEltsPerThread != tokenDim ||
+       (rnBlockSize * numEltsPerThread) % params.blockQuantGroupSize != 0)) {
+    FLASHINFER_ERROR("[MNNVL AllReduceTwoShotRMSNorm] no exact CTA partition for token_dim " +
+                     std::to_string(tokenDim) + " and group_size " +
+                     std::to_string(params.blockQuantGroupSize));
+    return cudaErrorInvalidValue;
+  }
   if (rnBlockSize > 1024 || rnLoadsPerThread > 8) {
     FLASHINFER_ERROR("[MNNVL AllReduceTwoShotRMSNorm] Unsupported hidden dimension " +
                      std::to_string(tokenDim));
@@ -1705,7 +1929,11 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
   int const rnNumThreads = rnClusterSize * rnBlockSize;
   int const dimPadded = round_up(tokenDim, numEltsPerThread * rnNumThreads);
   int const iters = dimPadded / rnNumThreads;
-  size_t const smemSize = 3 * rnBlockSize * iters * sizeof(T);
+  size_t const groupSmemSize =
+      params.quantType == QuantType::kPerTokenGroupFP8Packed
+          ? utils::groupQuantSmemSize(rnBlockSize, params.blockQuantGroupSize, numEltsPerThread)
+          : 0;
+  size_t const smemSize = 3 * rnBlockSize * iters * sizeof(T) + groupSmemSize;
 
   dim3 rnGrid(numTokens, rnClusterSize, 1);
   cudaLaunchConfig_t rnConfig;
@@ -1756,6 +1984,16 @@ cudaError_t twoshotAllreduceFusionDispatch(AllReduceFusionParams const& params) 
       break;                                                                       \
     case QuantType::kDynamicFP8:                                                   \
       LAUNCH_RMSNORM_KERNEL(USE_CGA, LOADS_PER_THREAD, QuantType::kDynamicFP8);    \
+      break;                                                                       \
+    case QuantType::kPerTokenGroupFP8Packed:                                       \
+      if constexpr (LOADS_PER_THREAD == 1) {                                       \
+        LAUNCH_RMSNORM_KERNEL(USE_CGA, 1, QuantType::kPerTokenGroupFP8Packed);     \
+      } else {                                                                     \
+        FLASHINFER_ERROR(                                                          \
+            "[MNNVL AllReduceTwoShotRMSNorm] group FP8 requires one load per "     \
+            "thread");                                                             \
+        return cudaErrorInvalidValue;                                              \
+      }                                                                            \
       break;                                                                       \
     case QuantType::kNone:                                                         \
       LAUNCH_RMSNORM_KERNEL(USE_CGA, LOADS_PER_THREAD, QuantType::kNone);          \

--- a/scripts/task_test_multi_node_comm_kernels.sh
+++ b/scripts/task_test_multi_node_comm_kernels.sh
@@ -23,7 +23,10 @@ DISABLE_SANITY_TEST=true
 source "${SCRIPT_DIR}/test_utils.sh"
 
 # Define the specific test files for multi-node comm tests
-TEST_FILES="tests/comm/test_mnnvl_memory.py tests/comm/test_trtllm_mnnvl_allreduce.py tests/comm/test_mnnvl_moe_alltoall.py"
+TEST_FILES="tests/comm/test_mnnvl_memory.py \
+tests/comm/test_trtllm_mnnvl_allreduce.py \
+tests/comm/test_trtllm_mnnvl_allreduce_group_fp8_quant.py \
+tests/comm/test_mnnvl_moe_alltoall.py"
 
 # Main execution
 main() {

--- a/tests/comm/test_trtllm_mnnvl_allreduce_group_fp8_quant.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce_group_fp8_quant.py
@@ -1,0 +1,385 @@
+import os
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+from mpi4py import MPI
+
+import flashinfer.comm as comm
+from flashinfer.comm.mnnvl import TorchDistBackend
+from tests.test_helpers.comm import init_torch_distributed_from_mpi
+
+
+FP8_E4M3_MAX = float(torch.finfo(torch.float8_e4m3fn).max)
+
+
+def _prefer_mpi_launcher_env() -> None:
+    """Prefer MPI rank variables over Slurm rank variables for this test."""
+    mpi_comm = MPI.COMM_WORLD
+    if mpi_comm.Get_size() <= 1:
+        return
+
+    local_comm = mpi_comm.Split_type(MPI.COMM_TYPE_SHARED)
+    os.environ["RANK"] = str(mpi_comm.Get_rank())
+    os.environ["WORLD_SIZE"] = str(mpi_comm.Get_size())
+    os.environ["LOCAL_RANK"] = str(local_comm.Get_rank())
+    if "MASTER_ADDR" not in os.environ:
+        master_addr = mpi_comm.bcast(
+            socket.gethostname() if mpi_comm.Get_rank() == 0 else None, root=0
+        )
+        os.environ["MASTER_ADDR"] = master_addr
+    local_comm.Free()
+
+    for key in ("SLURM_PROCID", "SLURM_NTASKS", "SLURM_LOCALID", "SLURM_NODEID"):
+        os.environ.pop(key, None)
+
+
+def _scale_storage_size(token_num: int, groups_per_row: int) -> int:
+    """Return the int32 storage size for packed, TMA-aligned UE8M0 scales."""
+    k_num_packed = (groups_per_row + 3) // 4
+    tma_aligned_mn = ((token_num + 3) // 4) * 4
+    return token_num + (k_num_packed - 1) * tma_aligned_mn
+
+
+def _allocate_scale_out(
+    token_num: int, hidden_dim: int, group_size: int, device: torch.device
+) -> torch.Tensor:
+    """Allocate the packed UE8M0 scale tensor expected by the fused API."""
+    groups_per_row = hidden_dim // group_size
+    k_num_packed = (groups_per_row + 3) // 4
+    tma_aligned_mn = ((token_num + 3) // 4) * 4
+    return torch.empty_strided(
+        (token_num, k_num_packed),
+        (1, tma_aligned_mn),
+        dtype=torch.int32,
+        device=device,
+    )
+
+
+def _unpack_scale_exponents(
+    packed_scales: torch.Tensor, groups_per_row: int
+) -> torch.Tensor:
+    """Unpack four UE8M0 exponent bytes from each logical int32."""
+    shifts = torch.arange(4, dtype=torch.int64, device=packed_scales.device) * 8
+    return (
+        ((packed_scales.to(torch.int64).unsqueeze(-1) >> shifts) & 0xFF)
+        .flatten(1)[:, :groups_per_row]
+        .to(torch.uint8)
+    )
+
+
+def _assert_scale_padding_zero(
+    packed_scales: torch.Tensor, token_num: int, groups_per_row: int
+) -> None:
+    """Verify packed-K and TMA-aligned token padding are initialized."""
+    valid_bytes_in_last_pack = groups_per_row % 4
+    if valid_bytes_in_last_pack:
+        valid_mask = (1 << (valid_bytes_in_last_pack * 8)) - 1
+        last_pack = packed_scales[:, -1].to(torch.int64) & 0xFFFFFFFF
+        assert torch.count_nonzero(last_pack & (0xFFFFFFFF ^ valid_mask)) == 0
+
+    k_num_packed = (groups_per_row + 3) // 4
+    tma_aligned_mn = ((token_num + 3) // 4) * 4
+    if token_num < tma_aligned_mn and k_num_packed > 1:
+        storage_size = _scale_storage_size(token_num, groups_per_row)
+        storage = torch.as_strided(packed_scales, (storage_size,), (1,))
+        pack_offsets = (
+            torch.arange(k_num_packed - 1, device=packed_scales.device) * tma_aligned_mn
+        )
+        token_padding = torch.arange(
+            token_num, tma_aligned_mn, device=packed_scales.device
+        )
+        assert (
+            torch.count_nonzero(
+                storage[(pack_offsets[:, None] + token_padding).flatten()]
+            )
+            == 0
+        )
+
+
+def _reference_norm(
+    allreduce_in: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute distributed residual and RMSNorm references."""
+    reduced = allreduce_in.clone()
+    dist.all_reduce(reduced)
+    residual_out = reduced + residual
+    norm_out = torch.nn.functional.rms_norm(
+        residual_out, (residual_out.shape[-1],), weight=weight, eps=eps
+    )
+    return residual_out, norm_out
+
+
+def _reference_group_quant(
+    norm_out: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute per-token-group FP8 values and UE8M0 scales."""
+    token_num, hidden_dim = norm_out.shape
+    groups_per_row = hidden_dim // group_size
+    grouped = norm_out.float().reshape(token_num, groups_per_row, group_size)
+    absmax = grouped.abs().amax(dim=-1)
+    scales = torch.exp2(
+        torch.ceil(torch.log2((absmax / FP8_E4M3_MAX).clamp(min=1e-10)))
+    )
+    quant = (
+        (grouped / scales.unsqueeze(-1))
+        .clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX)
+        .reshape(token_num, hidden_dim)
+        .to(torch.float8_e4m3fn)
+    )
+    exponents = ((scales.view(torch.int32) >> 23) & 0xFF).to(torch.uint8)
+    return quant, exponents, scales
+
+
+def _assert_dequant_close(
+    quant_out: torch.Tensor,
+    packed_scales: torch.Tensor,
+    reference: torch.Tensor,
+    group_size: int,
+    atol: float = 8e-1,
+) -> None:
+    """Compare dequantized packed-group FP8 output to an RMSNorm reference."""
+    token_num, hidden_dim = reference.shape
+    groups_per_row = hidden_dim // group_size
+    exponents = _unpack_scale_exponents(packed_scales, groups_per_row).to(torch.int32)
+    scales_t = torch.where(
+        exponents > 0,
+        torch.exp2(exponents.float() - 127.0),
+        torch.zeros_like(exponents, dtype=torch.float32),
+    )
+    dequant = (
+        quant_out.float().reshape(token_num, groups_per_row, group_size)
+        * scales_t.unsqueeze(-1)
+    ).reshape(token_num, hidden_dim)
+    torch.testing.assert_close(
+        dequant,
+        reference.float(),
+        atol=atol,
+        rtol=0.05,
+    )
+
+
+@pytest.mark.parametrize("with_norm_out", [False, True])
+@pytest.mark.parametrize(
+    "use_oneshot,token_num,hidden_dim,group_size,expected_error",
+    [
+        (True, 15, 4096, 128, None),
+        (True, 3, 4224, 128, None),
+        (False, 127, 4096, 64, None),
+        (False, 129, 4224, 128, None),
+        (True, 3, 768, 12, None),
+        (False, 127, 4096, 512, None),
+        (True, 1, 32808, 24, "no exact CTA partition"),
+    ],
+)
+def test_mnnvl_allreduce_group_fp8_quant(
+    use_oneshot: bool,
+    token_num: int,
+    hidden_dim: int,
+    group_size: int,
+    expected_error: str | None,
+    with_norm_out: bool,
+) -> None:
+    """Validate MNNVL packed per-token-group FP8 fusion."""
+    if torch.cuda.device_count() == 0:
+        pytest.skip("requires CUDA")
+
+    _prefer_mpi_launcher_env()
+    init_torch_distributed_from_mpi()
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        pytest.skip(f"requires at least 2 ranks, got {world_size}")
+
+    local_rank = rank % torch.cuda.device_count()
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    dtype = torch.bfloat16
+    eps = 1e-6
+
+    workspace = None
+    try:
+        workspace = comm.create_allreduce_fusion_workspace(
+            backend="mnnvl",
+            world_size=world_size,
+            rank=rank,
+            max_token_num=token_num,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            gpus_per_node=torch.cuda.device_count(),
+            comm_backend=TorchDistBackend(),
+            force_oneshot_support=use_oneshot,
+        )
+        torch.manual_seed(1234 + rank)
+        allreduce_in = torch.randn(token_num, hidden_dim, device=device, dtype=dtype)
+        residual = torch.empty(token_num, hidden_dim, device=device, dtype=dtype)
+        weight = torch.empty(hidden_dim, device=device, dtype=dtype)
+        if rank == 0:
+            residual.copy_(torch.randn_like(residual))
+            weight.copy_(torch.randn_like(weight))
+        dist.broadcast(residual, src=0)
+        dist.broadcast(weight, src=0)
+
+        residual_out = torch.empty_like(allreduce_in)
+        norm_out = torch.empty_like(allreduce_in) if with_norm_out else None
+        quant_out = torch.empty_like(allreduce_in, dtype=torch.float8_e4m3fn)
+        scale_out = _allocate_scale_out(token_num, hidden_dim, group_size, device)
+        num_scale_elems = _scale_storage_size(token_num, hidden_dim // group_size)
+        torch.as_strided(scale_out, (num_scale_elems,), (1,)).fill_(0x7F7F7F7F)
+        pattern = (
+            comm.AllReduceFusionPattern.kARResidualRMSNormOutPerTokenGroupFP8PackedQuant
+            if with_norm_out
+            else comm.AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant
+        )
+
+        def run_op() -> None:
+            comm.allreduce_fusion(
+                input=allreduce_in,
+                workspace=workspace,
+                pattern=pattern,
+                residual_in=residual,
+                residual_out=residual_out,
+                norm_out=norm_out,
+                quant_out=quant_out,
+                scale_out=scale_out,
+                rms_gamma=weight,
+                rms_eps=eps,
+                block_quant_group_size=group_size,
+                fp32_acc=True,
+                use_oneshot=use_oneshot,
+            )
+
+        if expected_error is not None:
+            with pytest.raises(RuntimeError, match=expected_error):
+                run_op()
+            return
+
+        run_op()
+        torch.cuda.synchronize()
+        _assert_scale_padding_zero(scale_out, token_num, hidden_dim // group_size)
+
+        ref_residual, ref_norm = _reference_norm(allreduce_in, residual, weight, eps)
+        torch.testing.assert_close(
+            residual_out.float(), ref_residual.float(), atol=8e-1, rtol=1e-2
+        )
+
+        if norm_out is not None:
+            torch.testing.assert_close(
+                norm_out.float(), ref_norm.float(), atol=8e-1, rtol=1e-2
+            )
+            ref_quant, ref_exponents, _ = _reference_group_quant(norm_out, group_size)
+            fused_exponents = _unpack_scale_exponents(
+                scale_out, hidden_dim // group_size
+            )
+            assert torch.equal(fused_exponents, ref_exponents)
+            assert torch.equal(quant_out.view(torch.uint8), ref_quant.view(torch.uint8))
+        else:
+            _assert_dequant_close(quant_out, scale_out, ref_norm, group_size)
+    finally:
+        if workspace is not None:
+            workspace.destroy()
+        dist.barrier()
+
+
+@pytest.mark.parametrize("use_oneshot", [True, False])
+def test_mnnvl_allreduce_group_fp8_cuda_graph_replay(use_oneshot: bool) -> None:
+    """Validate MNNVL packed group FP8 CUDA Graph replay."""
+    if torch.cuda.device_count() == 0:
+        pytest.skip("requires CUDA")
+
+    _prefer_mpi_launcher_env()
+    init_torch_distributed_from_mpi()
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    if world_size < 2:
+        pytest.skip(f"requires at least 2 ranks, got {world_size}")
+
+    local_rank = rank % torch.cuda.device_count()
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    token_num = 16 if use_oneshot else 128
+    hidden_dim = 4096
+    group_size = 128
+    dtype = torch.bfloat16
+    eps = 1e-6
+
+    workspace = None
+    try:
+        workspace = comm.create_allreduce_fusion_workspace(
+            backend="mnnvl",
+            world_size=world_size,
+            rank=rank,
+            max_token_num=token_num,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            gpus_per_node=torch.cuda.device_count(),
+            comm_backend=TorchDistBackend(),
+            force_oneshot_support=use_oneshot,
+        )
+        static_input = torch.empty(token_num, hidden_dim, device=device, dtype=dtype)
+        residual = torch.empty_like(static_input)
+        weight = torch.empty(hidden_dim, device=device, dtype=dtype)
+        if rank == 0:
+            residual.copy_(torch.randn_like(residual))
+            weight.copy_(torch.randn_like(weight))
+        dist.broadcast(residual, src=0)
+        dist.broadcast(weight, src=0)
+
+        residual_out = torch.empty_like(static_input)
+        quant_out = torch.empty_like(static_input, dtype=torch.float8_e4m3fn)
+        scale_out = _allocate_scale_out(token_num, hidden_dim, group_size, device)
+
+        def run_op() -> None:
+            comm.allreduce_fusion(
+                input=static_input,
+                workspace=workspace,
+                pattern=comm.AllReduceFusionPattern.kARResidualRMSNormPerTokenGroupFP8PackedQuant,
+                residual_in=residual,
+                residual_out=residual_out,
+                quant_out=quant_out,
+                scale_out=scale_out,
+                rms_gamma=weight,
+                rms_eps=eps,
+                block_quant_group_size=group_size,
+                use_oneshot=use_oneshot,
+            )
+
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(3):
+                static_input.copy_(torch.randn_like(static_input))
+                run_op()
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+        torch.cuda.synchronize()
+        dist.barrier()
+
+        graph = torch.cuda.CUDAGraph()
+        static_input.copy_(torch.randn_like(static_input))
+        with torch.cuda.graph(graph):
+            run_op()
+        torch.cuda.synchronize()
+
+        for step in range(2):
+            torch.manual_seed(8000 + step * world_size + rank)
+            replay_input = torch.randn_like(static_input)
+            static_input.copy_(replay_input)
+            dist.barrier()
+            graph.replay()
+            torch.cuda.synchronize()
+
+            ref_residual, ref_norm = _reference_norm(
+                replay_input, residual, weight, eps
+            )
+            torch.testing.assert_close(
+                residual_out.float(), ref_residual.float(), atol=8e-1, rtol=1e-2
+            )
+            _assert_dequant_close(quant_out, scale_out, ref_norm, group_size)
+    finally:
+        if workspace is not None:
+            workspace.destroy()
+        dist.barrier()

--- a/tests/comm/test_trtllm_mnnvl_allreduce_group_fp8_quant.py
+++ b/tests/comm/test_trtllm_mnnvl_allreduce_group_fp8_quant.py
@@ -122,9 +122,13 @@ def _reference_group_quant(
     groups_per_row = hidden_dim // group_size
     grouped = norm_out.float().reshape(token_num, groups_per_row, group_size)
     absmax = grouped.abs().amax(dim=-1)
-    scales = torch.exp2(
-        torch.ceil(torch.log2((absmax / FP8_E4M3_MAX).clamp(min=1e-10)))
-    )
+    scale_input = (absmax / FP8_E4M3_MAX).clamp(min=1e-10).contiguous()
+    scale_bits = scale_input.view(torch.int32)
+    scales = torch.where(
+        (scale_bits & 0x7FFFFF) != 0,
+        (scale_bits + 0x800000) & 0x7F800000,
+        scale_bits,
+    ).view(torch.float32)
     quant = (
         (grouped / scales.unsqueeze(-1))
         .clamp(-FP8_E4M3_MAX, FP8_E4M3_MAX)
@@ -254,7 +258,7 @@ def test_mnnvl_allreduce_group_fp8_quant(
             )
 
         if expected_error is not None:
-            with pytest.raises(RuntimeError, match=expected_error):
+            with pytest.raises(ValueError, match=expected_error):
                 run_op()
             return
 


### PR DESCRIPTION
## Description

Extends the packed per-token-group FP8 fusion patterns from #3059 to the MNNVL backend:

- `kARResidualRMSNormPerTokenGroupFP8PackedQuant`
- `kARResidualRMSNormOutPerTokenGroupFP8PackedQuant`

Both one-shot and two-shot paths produce FP8 activations and packed UE8M0 scales in the existing DeepGEMM-compatible layout. Scale computation and packing are shared with the TRT path; no pattern IDs or output formats are added.

The MNNVL implementation requires an exact CTA partition where each CTA owns whole quantization groups. Unsupported shapes fail early with a descriptive `ValueError`. Full-warp CTAs use shuffle reduction with an explicit full mask; partial-warp CTAs use shared memory.

## Performance

4xGB200, BF16 input, group size 128, CUDA Graphs, cold-L2 rotation, CUDA-event timing. Values are arithmetic means of two independent run medians; each run contains 100 iterations and reports max-rank latency. Across the best strategy for each measured shape, fusion is `2.33x-5.98x` faster than the exact unfused FlashInfer AR+RMSNorm plus Torch quantization/scale-packing composition.

| Shape | Strategy | Fused | Unfused | Speedup |
| --- | --- | ---: | ---: | ---: |
| `1x4096` | one-shot | `6.338 us` | `34.272 us` | `5.408x` |
| `16x4096` | one-shot | `6.546 us` | `39.111 us` | `5.975x` |
| `128x4096` | two-shot | `9.207 us` | `43.405 us` | `4.715x` |
| `1024x4096` | two-shot | `32.826 us` | `94.907 us` | `2.891x` |
| `1024x8192` | two-shot | `64.501 us` | `150.007 us` | `2.326x` |

A same-node ABBA comparison against the pre-review kernel measured `-0.97%` to `+0.51%` latency deltas across all 18 shape/strategy pairs, i.e. no measurable regression from the review hardening.

## Validation

- [x] Pre-commit passes on all edited files.
- [x] Existing TRT packed-group regression: `4/4` on 4xGB200.
- [x] MNNVL correctness and CUDA Graph matrix: `16/16` per rank on 4xGB200.
- [x] Prior MNNVL multi-node validation: 8xGB200 across two nodes.
- [x] Fused-vs-unfused benchmark validation across the measured sweep.

The hardware results are author-run on Lyris. Public GPU jobs are currently skipped pending maintainer CI authorization.

## Related

Related to #2434 and #2364.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for packed per-token-group FP8 quantization in allreduce fusion paths.
  * Introduced a new group size option for FP8 quantization workflows.
  * Expanded benchmarking and CUDA Graph replay coverage for the new quantization mode.

* **Bug Fixes**
  * Improved validation for tensor shapes, scale storage, and padding requirements.
  * Added stricter checks for distributed execution and runtime configuration handling.

* **Tests**
  * Added distributed correctness tests for normal execution and graph replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->