### PR TITLE
docs: install flashinfer-cubin from flashinfer.ai index; drop cubin PyPI upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,12 +356,6 @@ jobs:
           name: flashinfer-python-dist
           path: dist-python/
 
-      - name: Download flashinfer-cubin artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: flashinfer-cubin-wheel
-          path: dist-cubin/
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -375,9 +369,11 @@ jobs:
       - name: Check packages with twine
         run: |
           echo "Running twine check..."
-          twine check dist-python/* dist-cubin/*
+          twine check dist-python/*
           echo "✓ Package validation passed"
 
+      # Note: flashinfer-cubin is no longer published to PyPI; it is served from
+      # https://flashinfer.ai/whl (see update-wheel-index job).
       - name: Upload flashinfer-python to PyPI
         env:
           TWINE_USERNAME: __token__
@@ -386,15 +382,6 @@ jobs:
           echo "Uploading flashinfer (sdist and wheel) to PyPI..."
           twine upload --verbose --non-interactive dist-python/*
           echo "✓ Successfully uploaded flashinfer to PyPI"
-
-      - name: Upload flashinfer-cubin to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          echo "Uploading flashinfer-cubin wheel to PyPI..."
-          twine upload --verbose --non-interactive dist-cubin/*.whl
-          echo "✓ Successfully uploaded flashinfer-cubin to PyPI"
 
   update-wheel-index:
     needs: [setup, create-release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -372,8 +372,6 @@ jobs:
           twine check dist-python/*
           echo "✓ Package validation passed"
 
-      # Note: flashinfer-cubin is no longer published to PyPI; it is served from
-      # https://flashinfer.ai/whl (see update-wheel-index job).
       - name: Upload flashinfer-python to PyPI
         env:
           TWINE_USERNAME: __token__

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ pip install flashinfer-python
 **For faster initialization and offline usage**, install the optional packages to have most kernels pre-compiled:
 
 ```bash
-pip install flashinfer-python flashinfer-cubin
+pip install flashinfer-python
+# cubin package (served from flashinfer.ai, no longer published to PyPI)
+pip install flashinfer-cubin --index-url https://flashinfer.ai/whl
 # JIT cache (replace cu129 with your CUDA version)
 pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pip install flashinfer-python
 
 ```bash
 pip install flashinfer-python
-# cubin package (served from flashinfer.ai, no longer published to PyPI)
+# cubin package
 pip install flashinfer-cubin --index-url https://flashinfer.ai/whl
 # JIT cache (replace cu129 with your CUDA version)
 pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,8 +42,10 @@ FlashInfer provides three packages:
 
 .. code-block:: bash
 
-    pip install flashinfer-python flashinfer-cubin
-    # JIT cache package (replace cu129 with your CUDA version: cu128, cu129, or cu130)
+    pip install flashinfer-python
+    # cubin package (served from flashinfer.ai, no longer published to PyPI)
+    pip install flashinfer-cubin --index-url https://flashinfer.ai/whl
+    # JIT cache package (replace cu129 with your CUDA version: cu129 or cu130)
     pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
 
 This eliminates compilation and downloading overhead at runtime.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,7 +43,7 @@ FlashInfer provides three packages:
 .. code-block:: bash
 
     pip install flashinfer-python
-    # cubin package (served from flashinfer.ai, no longer published to PyPI)
+    # cubin package
     pip install flashinfer-cubin --index-url https://flashinfer.ai/whl
     # JIT cache package (replace cu129 with your CUDA version: cu129 or cu130)
     pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129


### PR DESCRIPTION
## 📌 Description

`flashinfer-cubin` is no longer published to PyPI (the upload has been failing) and is instead served from https://flashinfer.ai/whl. This PR:

- Updates the stable install instructions in `README.md` and `docs/installation.rst` to install `flashinfer-cubin` via `--index-url https://flashinfer.ai/whl`:
  ```sh
  pip install flashinfer-python
  pip install flashinfer-cubin --index-url https://flashinfer.ai/whl
  pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
  ```
- Removes the `flashinfer-cubin` PyPI upload step (and its artifact download / `twine check` reference) from the `publish-to-pypi` job in `.github/workflows/release.yml`. The cubin wheel is still built, attached to the GitHub release, and pushed to the flashinfer.ai wheel index via the `update-wheel-index` job — only the PyPI upload is dropped.

The nightly release workflow needs no change: it never uploaded cubin to PyPI, only to the GitHub release and the flashinfer.ai wheel index.

## 🔍 Related Issues

Per https://github.com/flashinfer-ai/flashinfer/issues/3808#issuecomment-4897372696

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed. (Docs/CI-workflow-only change; no tests applicable.)
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Docs + CI workflow change only. Note this PR does not bump `version.txt` to 0.6.14 — happy to add that if it should ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to separate the core Python package from the CUDA wheel package.
  * Clarified the recommended install command for the CUDA wheel using a dedicated package index.
  * Simplified the JIT cache guidance to show a single CUDA-version replacement example.

* **Chores**
  * Adjusted release automation so PyPI publishing now uploads only the Python package artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->