### PR TITLE
ci: stop creating GitHub release pages for nightly builds

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -202,87 +202,6 @@ jobs:
           path: flashinfer-jit-cache/dist/*.whl
           retention-days: 7
 
-  create-release:
-    needs: [setup, build-flashinfer-python, build-flashinfer-cubin, build-flashinfer-jit-cache]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Create GitHub Release (empty first)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG="${{ needs.setup.outputs.release_tag }}"
-
-          # Delete existing release and tag if they exist
-          if gh release view "$TAG" &>/dev/null; then
-            echo "Deleting existing release: $TAG"
-            gh release delete "$TAG" --yes --cleanup-tag
-          fi
-
-          # Create new release without assets first
-          gh release create "$TAG" \
-            --title "Nightly Release v${{ needs.setup.outputs.version }}-${{ needs.setup.outputs.dev_suffix }}" \
-            --notes "Automated nightly build for version ${{ needs.setup.outputs.version }} (dev${{ needs.setup.outputs.dev_suffix }})" \
-            --prerelease
-
-      - name: Download flashinfer-python artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: flashinfer-python-dist
-          path: dist-python/
-
-      - name: Upload flashinfer-python to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${{ needs.setup.outputs.release_tag }}" dist-python/* --clobber
-
-      - name: Download flashinfer-cubin artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: flashinfer-cubin-wheel
-          path: dist-cubin/
-
-      - name: Upload flashinfer-cubin to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${{ needs.setup.outputs.release_tag }}" dist-cubin/* --clobber
-
-      - name: Upload flashinfer-jit-cache wheels to release (one at a time to avoid OOM)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Upload jit-cache wheels one at a time to avoid OOM
-          # Each wheel can be several GB, so we download, upload, delete, repeat
-          mkdir -p dist-jit-cache
-
-          for cuda in 128 129 130; do
-            for arch in x86_64 aarch64; do
-              ARTIFACT_NAME="jit-cache-cu${cuda}-${arch}"
-              echo "Processing ${ARTIFACT_NAME}..."
-
-              # Download this specific artifact
-              gh run download ${{ github.run_id }} -n "${ARTIFACT_NAME}" -D dist-jit-cache/ || {
-                echo "Warning: Failed to download ${ARTIFACT_NAME}, skipping..."
-                continue
-              }
-
-              # Upload to release
-              if [ -n "$(ls -A dist-jit-cache/)" ]; then
-                gh release upload "${{ needs.setup.outputs.release_tag }}" dist-jit-cache/* --clobber
-                echo "✅ Uploaded ${ARTIFACT_NAME}"
-              fi
-
-              # Clean up to save disk space before next iteration
-              rm -rf dist-jit-cache/*
-            done
-          done
-
   test-nightly-build:
     needs: [setup, build-flashinfer-python, build-flashinfer-cubin, build-flashinfer-jit-cache]
     strategy:
@@ -392,7 +311,7 @@ jobs:
           fi
 
   update-wheel-index:
-    needs: [setup, create-release, test-nightly-build]
+    needs: [setup, build-flashinfer-python, build-flashinfer-cubin, build-flashinfer-jit-cache, test-nightly-build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout flashinfer repo


### PR DESCRIPTION
## 📌 Description

Nightly builds are distributed via the flashinfer.ai wheel index (`https://flashinfer.ai/whl/nightly/`), which is the documented install channel for nightlies. The nightly workflow additionally creates a **GitHub prerelease page every day**, which only clutters the repo's releases list.

This PR stops creating those release pages while keeping wheel-index publishing intact:

- **Removes the `create-release` job** from `.github/workflows/nightly-release.yml` (the only job that created/updated the GitHub release and attached wheels to it).
- **Rewires `update-wheel-index`'s `needs`** from `[setup, create-release, test-nightly-build]` to `[setup, build-flashinfer-python, build-flashinfer-cubin, build-flashinfer-jit-cache, test-nightly-build]`. Previously `create-release` was the transitive guarantee that all build jobs had finished before "Download all artifacts"; depending directly on the build jobs preserves that guarantee.

`update-wheel-index` obtains its wheels from build artifacts (`actions/download-artifact`), not from the release page, and only consumes `release_tag`/`dev_suffix` from the `setup` job — so nightly publishing to flashinfer.ai is unchanged.

## 🔍 Related Issues

N/A — release-page cleanup requested internally.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed. (CI-workflow-only change; no unit tests applicable.)
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

- Behavior after this change: `workflow_dispatch`/scheduled nightly runs no longer create a GitHub release/tag; wheels still land at `https://flashinfer.ai/whl/nightly/` via the `update-wheel-index` job.
- The `version` output of the `setup` job is now unused (was only referenced by the removed release title) but left in place as it is harmless and still logged.
- Best validated by triggering the workflow via the Actions tab and confirming no new release is created while the wheel index commit still lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the nightly release workflow and updated the publishing flow to rely directly on completed build jobs.
  * Improved how the package index is refreshed so nightly artifacts are picked up more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->