### PR TITLE
[feat] New CuTe DSL JIT kernels for FMHA: Dense & MXFP8 & NVFP4 formats

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       -   id: mypy
           args: ["--config-file", "pyproject.toml", "--exclude", "flashinfer-cubin/"]
           files: ^flashinfer/
-          exclude: ^(flashinfer-cubin/|3rdparty/|build/)
+          exclude: ^(flashinfer-cubin/|3rdparty/|build/|flashinfer/cute_dsl/attention/fmha/)
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       -   id: mypy
           args: ["--config-file", "pyproject.toml", "--exclude", "flashinfer-cubin/"]
           files: ^flashinfer/
-          exclude: ^(flashinfer-cubin/|3rdparty/|build/|flashinfer/cute_dsl/attention/fmha/)
+          exclude: ^(flashinfer-cubin/|3rdparty/|build/|flashinfer/cute_dsl/attention/fmha/(fmha\.py|fmha_blockscaled\.py|helpers/))
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/flashinfer/attention/cute_dsl/__init__.py
+++ b/flashinfer/attention/cute_dsl/__init__.py
@@ -25,11 +25,13 @@ if is_cute_dsl_available():
         get_cute_dsl_fmha_kernel,
         cute_dsl_fmha_ragged_prefill,
     )
+    from .fmha_blockscaled import cute_dsl_fmha_blockscaled_prefill
 
     __all__ = [
         "is_cute_dsl_available",
         "get_cute_dsl_fmha_kernel",
         "cute_dsl_fmha_ragged_prefill",
+        "cute_dsl_fmha_blockscaled_prefill",
     ]
 else:
     __all__ = [

--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -418,38 +418,31 @@ def cute_dsl_fmha_ragged_prefill(
                 use_pdl=enable_pdl,
             )
         except (RuntimeError, FileNotFoundError) as e:
-            # Cubin variant not published / repo unreachable: JIT-compile the
-            # vendored kernel from source instead.
-            logger.info(
-                f"DSL FMHA cubin unavailable ({e}); falling back to JIT runner."
-            )
-            from flashinfer.cute_dsl.attention.fmha.runner import (
-                cute_dsl_fmha_prefill as jit_runner,
+            # Cubin variant not available / repo unreachable.
+            # JIT-compile the trtllm kernel instead.
+            logger.info(f"DSL FMHA cubin unavailable ({e}); JIT-compiling the kernel.")
+            from flashinfer.cute_dsl.attention.fmha.compile import (
+                compile_cute_dsl_fmha_kernel,
             )
 
-            jit_runner(
-                q,
-                k,
-                v,
-                o,
-                qo_indptr,
-                kv_indptr,
-                is_causal=is_causal,
-                sm_scale=sm_scale,
-                window_left=window_left,
-                window_right=window_right,
-                lse=lse,
-                attention_sinks=attention_sinks,
-                scale_q=scale_q,
-                scale_k=scale_k,
-                scale_v=scale_v,
-                scale_o=scale_o,
-                max_qo_len=max_qo_len,
-                max_kv_len=max_kv_len,
-                skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
-                enable_pdl=enable_pdl,
+            kernel_fn = compile_cute_dsl_fmha_kernel(
+                q.dtype,
+                v.dtype,
+                o.dtype,
+                H_q,
+                H_k,
+                D,
+                D_v,
+                is_causal,
+                lse is not None,
+                attention_sinks is not None,
+                use_skip_softmax,
+                enable_pdl,
+                q.device,
             )
-            return
+            # JIT kernels are compiled with --enable-tvm-ffi; the CuTe-native branch
+            # would not accept them.
+            enable_tvm_ffi = True
 
     # Compute scale factors
     if sm_scale is None:

--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -400,20 +400,56 @@ def cute_dsl_fmha_ragged_prefill(
 
     if kernel_fn is None:
         gpu_arch = _get_gpu_arch(q.device)
-        kernel_fn = get_cute_dsl_fmha_kernel(
-            gpu_arch,
-            q.dtype,
-            o.dtype,
-            D,
-            is_causal,
-            is_persistent=False,  # varlen always uses non-persistent
-            varlen=True,
-            enable_tvm_ffi=enable_tvm_ffi,
-            with_lse=lse is not None,
-            enable_skip_softmax=use_skip_softmax,
-            enable_sink=attention_sinks is not None,
-            use_pdl=enable_pdl,
-        )
+        try:
+            if q.dtype != k.dtype or k.dtype != v.dtype:
+                raise RuntimeError("Separate dtype_qk / dtype_vo requires JIT")
+            kernel_fn = get_cute_dsl_fmha_kernel(
+                gpu_arch,
+                q.dtype,
+                o.dtype,
+                D,
+                is_causal,
+                is_persistent=False,  # varlen always uses non-persistent
+                varlen=True,
+                enable_tvm_ffi=enable_tvm_ffi,
+                with_lse=lse is not None,
+                enable_skip_softmax=use_skip_softmax,
+                enable_sink=attention_sinks is not None,
+                use_pdl=enable_pdl,
+            )
+        except (RuntimeError, FileNotFoundError) as e:
+            # Cubin variant not published / repo unreachable: JIT-compile the
+            # vendored kernel from source instead.
+            logger.info(
+                f"DSL FMHA cubin unavailable ({e}); falling back to JIT runner."
+            )
+            from flashinfer.cute_dsl.attention.fmha.runner import (
+                cute_dsl_fmha_prefill as jit_runner,
+            )
+
+            jit_runner(
+                q,
+                k,
+                v,
+                o,
+                qo_indptr,
+                kv_indptr,
+                is_causal=is_causal,
+                sm_scale=sm_scale,
+                window_left=window_left,
+                window_right=window_right,
+                lse=lse,
+                attention_sinks=attention_sinks,
+                scale_q=scale_q,
+                scale_k=scale_k,
+                scale_v=scale_v,
+                scale_o=scale_o,
+                max_qo_len=max_qo_len,
+                max_kv_len=max_kv_len,
+                skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+                enable_pdl=enable_pdl,
+            )
+            return
 
     # Compute scale factors
     if sm_scale is None:

--- a/flashinfer/attention/cute_dsl/fmha_blockscaled.py
+++ b/flashinfer/attention/cute_dsl/fmha_blockscaled.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Block-scaled CuTe DSL FMHA entry (JIT)
+======================================
+
+PyTorch-friendly wrapper for the trtllm block-scaled (MXFP8 / NVFP4) FMHA kernel.
+Unlike :mod:`flashinfer.attention.cute_dsl.fmha`, there is no published cubin for the
+block-scaled kernel, so this path is always JIT-compiled: the kernel handle comes from
+``flashinfer.cute_dsl.attention.fmha.compile.compile_cute_dsl_fmha_blockscaled_kernel``
+and this module only does the tensor marshalling. Pre-quantized Q/K + scale-factor tensors
+are produced by ``flashinfer.cute_dsl.attention.fmha.quantize.quantize_blockscaled_qk``.
+"""
+
+import math
+from typing import Optional
+
+from cutlass.cute.typing import Float32, Int32
+
+import torch
+
+from flashinfer.cute_dsl.attention.fmha.compile import (
+    _BLOCKSCALED_MODES,
+    compile_cute_dsl_fmha_blockscaled_kernel,
+)
+
+
+def cute_dsl_fmha_blockscaled_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_sf: torch.Tensor,
+    k_sf: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    *,
+    qk_mode: str,
+    is_causal: bool = False,
+    sm_scale: Optional[float] = None,
+    window_left: int = -1,
+    window_right: int = -1,
+    lse: Optional[torch.Tensor] = None,
+    scale_q: float | torch.Tensor = 1.0,
+    scale_k: float | torch.Tensor = 1.0,
+    scale_v: float | torch.Tensor = 1.0,
+    scale_o: float | torch.Tensor = 1.0,
+    skip_softmax_threshold_scale_factor: Optional[float] = None,
+    enable_pdl: bool = False,
+) -> None:
+    """Batched (non-varlen) block-scaled prefill via the JIT-compiled trtllm kernel.
+
+    Inputs are batched:
+    - q (b, s_q, H_q, D), q_sf (quantized block-scaled format)
+    - k (b, s_k, H_k, D), k_sf (quantized block-scaled format)
+    - v/o: (b, s, H, D_v)
+
+    The per-tensor scales accept a Python float or a 0-d tensor (as returned by the
+    quantizer); tensors are converted to floats here at the eager boundary.
+    """
+    if qk_mode not in _BLOCKSCALED_MODES:
+        raise ValueError(
+            f"qk_mode must be one of {tuple(_BLOCKSCALED_MODES)}, got {qk_mode!r}"
+        )
+    batch_size, s_q, H_q, _ = q.shape
+    _, s_k, H_k, _ = k.shape
+    D = D_v = v.shape[-1]
+    h_r = H_q // H_k
+
+    use_skip = (
+        skip_softmax_threshold_scale_factor is not None
+        and skip_softmax_threshold_scale_factor > 0
+    )
+    kernel_fn = compile_cute_dsl_fmha_blockscaled_kernel(
+        qk_mode,
+        o.dtype,
+        H_q,
+        H_k,
+        D,
+        is_causal,
+        lse is not None,
+        use_skip,
+        enable_pdl,
+        q.device,
+    )
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(D)
+    # The block-scale quantizer returns scales as 0-d tensors (no ``.item()`` sync, so it
+    # stays torch.compile-friendly); materialize to floats here at the eager boundary.
+    scale_q, scale_k, scale_v, scale_o = map(
+        lambda x: x.item() if isinstance(x, torch.Tensor) else x,
+        (scale_q, scale_k, scale_v, scale_o),
+    )
+    scale_softmax = scale_q * scale_k * sm_scale
+    scale_softmax_log2 = scale_softmax * math.log2(math.e)
+    scale_output = scale_v / scale_o
+    problem_size = (batch_size, s_q, s_q, s_k, H_q, H_k, D, D_v)
+
+    skip_threshold_log2 = None
+    if use_skip:
+        skip_threshold_log2 = Float32(
+            math.log2(skip_softmax_threshold_scale_factor / s_k)
+        )
+
+    ws_left = None if window_left == -1 else Int32(window_left)
+    ws_right = None if window_right == -1 else Int32(window_right)
+    if is_causal and ws_right is None:
+        ws_right = Int32(0)
+
+    q_5d = q.reshape(batch_size, s_q, H_k, h_r, q.shape[-1])
+    k_5d = k.reshape(batch_size, s_k, H_k, 1, k.shape[-1])
+    v_5d = v.reshape(batch_size, s_k, H_k, 1, D_v)
+    assert o.data_ptr() % 32 == 0, "o must be 32-byte aligned (256-bit stores)"
+    o_5d = o.reshape(batch_size, s_q, H_k, h_r, D_v)
+    lse_4d = lse.reshape(batch_size, s_q, H_k, h_r) if lse is not None else None
+
+    kernel_fn(
+        q_5d,
+        k_5d,
+        q_sf.reshape(-1),
+        k_sf.reshape(-1),
+        v_5d,
+        o_5d,
+        problem_size,
+        None,  # cum_seqlen_q
+        None,  # cum_seqlen_k
+        lse_4d,
+        None,  # attention_sinks
+        Float32(scale_softmax_log2),
+        Float32(scale_softmax),
+        Float32(scale_output),
+        None,  # scale_v_channels
+        skip_threshold_log2,
+        ws_left,
+        ws_right,
+        None,  # skip_softmax_count
+        None,  # total_softmax_count
+        enable_pdl,
+    )

--- a/flashinfer/cute_dsl/attention/fmha/__init__.py
+++ b/flashinfer/cute_dsl/attention/fmha/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/flashinfer/cute_dsl/attention/fmha/compile.py
+++ b/flashinfer/cute_dsl/attention/fmha/compile.py
@@ -1,36 +1,32 @@
-# Copyright (c) 2026 by FlashInfer team.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""PyTorch runner for the trtllm CuTe DSL FMHA kernels (JIT-compiled).
+"""JIT-compilers for the trtllm CuTe DSL FMHA kernels.
 
-JIT-compiles the trtllm BlackwellFusedMultiHead[BlockScaled]AttentionForward classes and exposes
-PyTorch-friendly ragged/batched prefill entry points. This is the JIT runner invoked by
-flashinfer.attention.cute_dsl.fmha
+``compile_cute_dsl_fmha_kernel`` / ``compile_cute_dsl_fmha_blockscaled_kernel``
+``cute.compile`` (and cache) the trtllm ``BlackwellFusedMultiHead[BlockScaled]AttentionForward``
+classes with symbolic batch/seqlen dims, returning a TVM-FFI-callable kernel handle.
 """
 
 import functools
 import math
-from typing import Optional
 
 import cutlass
 import cutlass.cute as cute
 import torch
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
 from cutlass.cute.typing import Float32, Int32
-
-from .fmha import BlackwellFusedMultiHeadAttentionForward
-from .fmha_blockscaled import BlackwellFusedMultiHeadBlockScaledAttentionForward
-from .helpers import fmha_helpers as fmha_utils
 
 # torch dtype -> cutlass dtype
 _CUTLASS_DTYPE = {
@@ -47,6 +43,8 @@ _BLOCKSCALED_MODES = {
 
 
 def _mask_type(is_causal: bool):
+    from .helpers import fmha_helpers as fmha_utils
+
     # Bottom-right aligned causal, matching FlashInfer convention.
     return (
         fmha_utils.MaskEnum.WINDOW_MASK_INFERENCE
@@ -67,7 +65,7 @@ def _ex2_emulation_enabled(device: torch.device) -> bool:
 
 
 @functools.cache
-def _get_compiled_fmha(
+def compile_cute_dsl_fmha_kernel(
     qk_dtype: torch.dtype,
     v_dtype: torch.dtype,
     out_dtype: torch.dtype,
@@ -80,13 +78,17 @@ def _get_compiled_fmha(
     enable_sink: bool,
     enable_skip_softmax: bool,
     use_pdl: bool,
-    enable_ex2_emulation: bool,
+    device: torch.device,
 ):
-    """Compile (and cache) the vendored FMHA kernel for a static config.
+    """Compile (and cache) the trtllm FMHA kernel for a static config.
 
-    Uses symbolic batch/seqlen dims (TVM-FFI ABI) so a single compile serves all
-    shapes with the given dtypes / head counts / head_dim / mask.
+    Compiles with the TVM-FFI ABI (the handle takes ``torch.Tensor`` args on the env
+    stream) and symbolic batch/seqlen dims, so a single compile serves all shapes for the
+    given dtypes / head counts / head_dim / mask.
     """
+    from .fmha import BlackwellFusedMultiHeadAttentionForward
+
+    enable_ex2_emulation = _ex2_emulation_enabled(device)
     qk = _CUTLASS_DTYPE[qk_dtype]
     pv = _CUTLASS_DTYPE[v_dtype]
     out = _CUTLASS_DTYPE[out_dtype]
@@ -187,119 +189,13 @@ def _get_compiled_fmha(
     )
 
 
-def cute_dsl_fmha_prefill(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    o: torch.Tensor,
-    qo_indptr: torch.Tensor,
-    kv_indptr: torch.Tensor,
-    *,
-    is_causal: bool = False,
-    sm_scale: Optional[float] = None,
-    window_left: int = -1,
-    window_right: int = -1,
-    lse: Optional[torch.Tensor] = None,
-    attention_sinks: Optional[torch.Tensor] = None,
-    scale_q: float | torch.Tensor = 1.0,
-    scale_k: float | torch.Tensor = 1.0,
-    scale_v: float | torch.Tensor = 1.0,
-    scale_o: float | torch.Tensor = 1.0,
-    max_qo_len: Optional[int] = None,
-    max_kv_len: Optional[int] = None,
-    skip_softmax_threshold_scale_factor: Optional[float] = None,
-    enable_pdl: bool = False,
-) -> None:
-    """Ragged (varlen) prefill via the JIT-compiled vendored FMHA kernel."""
-    total_q, H_q, D = q.shape
-    total_kv, H_k, _ = k.shape
-    D_v = v.shape[-1]
-    h_r = H_q // H_k
-    batch_size = len(qo_indptr) - 1
-
-    use_skip = (
-        skip_softmax_threshold_scale_factor is not None
-        and skip_softmax_threshold_scale_factor > 0
-    )
-    kernel_fn = _get_compiled_fmha(
-        q.dtype,
-        v.dtype,
-        o.dtype,
-        H_q,
-        H_k,
-        D,
-        D_v,
-        is_causal,
-        lse is not None,
-        attention_sinks is not None,
-        use_skip,
-        enable_pdl,
-        _ex2_emulation_enabled(q.device),
-    )
-
-    if sm_scale is None:
-        sm_scale = 1.0 / math.sqrt(D)
-    scale_q, scale_k, scale_v, scale_o = map(
-        lambda x: x.item() if isinstance(x, torch.Tensor) else x,
-        (scale_q, scale_k, scale_v, scale_o),
-    )
-    scale_softmax = scale_q * scale_k * sm_scale
-    scale_softmax_log2 = scale_softmax * math.log2(math.e)
-    scale_output = scale_v / scale_o
-
-    if max_qo_len is None:
-        max_qo_len = int((qo_indptr[1:] - qo_indptr[:-1]).max().item())
-    if max_kv_len is None:
-        max_kv_len = int((kv_indptr[1:] - kv_indptr[:-1]).max().item())
-    problem_size = (batch_size, max_qo_len, total_q, max_kv_len, H_q, H_k, D, D_v)
-
-    skip_threshold_log2 = None
-    if use_skip:
-        skip_threshold_log2 = Float32(
-            math.log2(skip_softmax_threshold_scale_factor / max_kv_len)
-        )
-
-    ws_left = None if window_left == -1 else Int32(window_left)
-    ws_right = None if window_right == -1 else Int32(window_right)
-    if is_causal and ws_right is None:
-        ws_right = Int32(0)
-
-    q_5d = q.view(1, total_q, H_k, h_r, D)
-    k_5d = k.view(1, total_kv, H_k, 1, D)
-    v_5d = v.view(1, total_kv, H_k, 1, D_v)
-    assert o.data_ptr() % 32 == 0, "o must be 32-byte aligned (256-bit stores)"
-    o_5d = o.view(1, total_q, H_k, h_r, D_v)
-    lse_4d = lse.view(1, total_q, H_k, h_r) if lse is not None else None
-
-    kernel_fn(
-        q_5d,
-        k_5d,
-        v_5d,
-        o_5d,
-        problem_size,
-        qo_indptr.to(torch.int32),
-        kv_indptr.to(torch.int32),
-        lse_4d,
-        attention_sinks,
-        Float32(scale_softmax_log2),
-        Float32(scale_softmax),
-        Float32(scale_output),
-        skip_threshold_log2,
-        ws_left,
-        ws_right,
-        None,  # skip_softmax_count
-        None,  # total_softmax_count
-        enable_pdl,
-    )
-
-
 # =============================================================================
 # Block-scaled (MXFP8 / NVFP4)
 # =============================================================================
 
 
 @functools.cache
-def _get_compiled_fmha_blockscaled(
+def compile_cute_dsl_fmha_blockscaled_kernel(
     qk_mode: str,
     out_dtype: torch.dtype,
     num_qo_heads: int,
@@ -309,9 +205,12 @@ def _get_compiled_fmha_blockscaled(
     with_lse: bool,
     enable_skip_softmax: bool,
     use_pdl: bool,
-    enable_ex2_emulation: bool,
+    device: torch.device,
 ):
-    """Compile (and cache) the vendored block-scaled FMHA kernel (batched, non-varlen)."""
+    """Compile (and cache) the trtllm block-scaled FMHA kernel (batched, non-varlen)."""
+    from .fmha_blockscaled import BlackwellFusedMultiHeadBlockScaledAttentionForward
+
+    enable_ex2_emulation = _ex2_emulation_enabled(device)
     qk, sf_dt, sf_vec = _BLOCKSCALED_MODES[qk_mode]
     out = _CUTLASS_DTYPE[out_dtype]
     d = dv = head_dim
@@ -408,114 +307,4 @@ def _get_compiled_fmha_blockscaled(
         stream_fake,
         use_pdl,
         options="--enable-tvm-ffi --opt-level 2",
-    )
-
-
-def cute_dsl_fmha_blockscaled_prefill(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    q_sf: torch.Tensor,
-    k_sf: torch.Tensor,
-    v: torch.Tensor,
-    o: torch.Tensor,
-    *,
-    qk_mode: str,
-    is_causal: bool = False,
-    sm_scale: Optional[float] = None,
-    window_left: int = -1,
-    window_right: int = -1,
-    lse: Optional[torch.Tensor] = None,
-    scale_q: float | torch.Tensor = 1.0,
-    scale_k: float | torch.Tensor = 1.0,
-    scale_v: float | torch.Tensor = 1.0,
-    scale_o: float | torch.Tensor = 1.0,
-    skip_softmax_threshold_scale_factor: Optional[float] = None,
-    enable_pdl: bool = False,
-) -> None:
-    """Batched (non-varlen) block-scaled prefill via the JIT-compiled vendored kernel.
-
-    Inputs are batched:
-    - q (b, s_q, H_q, D), q_sf (quantized block-scaled format)
-    - k (b, s_k, H_k, D), k_sf (quantized block-scaled format)
-    - v/o: (b, s, H, D_v)
-    """
-    if qk_mode not in _BLOCKSCALED_MODES:
-        raise ValueError(
-            f"qk_mode must be one of {tuple(_BLOCKSCALED_MODES)}, got {qk_mode!r}"
-        )
-    batch_size, s_q, H_q, _ = q.shape
-    _, s_k, H_k, _ = k.shape
-    D = D_v = v.shape[-1]
-    h_r = H_q // H_k
-
-    use_skip = (
-        skip_softmax_threshold_scale_factor is not None
-        and skip_softmax_threshold_scale_factor > 0
-    )
-    kernel_fn = _get_compiled_fmha_blockscaled(
-        qk_mode,
-        o.dtype,
-        H_q,
-        H_k,
-        D,
-        is_causal,
-        lse is not None,
-        use_skip,
-        enable_pdl,
-        _ex2_emulation_enabled(q.device),
-    )
-
-    if sm_scale is None:
-        sm_scale = 1.0 / math.sqrt(D)
-    # The block-scale quantizer returns scales as 0-d tensors (no ``.item()`` sync, so it
-    # stays torch.compile-friendly); materialize to floats here at the eager boundary.
-    scale_q, scale_k, scale_v, scale_o = map(
-        lambda x: x.item() if isinstance(x, torch.Tensor) else x,
-        (scale_q, scale_k, scale_v, scale_o),
-    )
-    scale_softmax = scale_q * scale_k * sm_scale
-    scale_softmax_log2 = scale_softmax * math.log2(math.e)
-    scale_output = scale_v / scale_o
-    problem_size = (batch_size, s_q, s_q, s_k, H_q, H_k, D, D_v)
-
-    skip_threshold_log2 = None
-    if use_skip:
-        skip_threshold_log2 = Float32(
-            math.log2(skip_softmax_threshold_scale_factor / s_k)
-        )
-
-    ws_left = None if window_left == -1 else Int32(window_left)
-    ws_right = None if window_right == -1 else Int32(window_right)
-    if is_causal and ws_right is None:
-        ws_right = Int32(0)
-
-    q_5d = q.reshape(batch_size, s_q, H_k, h_r, q.shape[-1])
-    k_5d = k.reshape(batch_size, s_k, H_k, 1, k.shape[-1])
-    v_5d = v.reshape(batch_size, s_k, H_k, 1, D_v)
-    assert o.data_ptr() % 32 == 0, "o must be 32-byte aligned (256-bit stores)"
-    o_5d = o.reshape(batch_size, s_q, H_k, h_r, D_v)
-    lse_4d = lse.reshape(batch_size, s_q, H_k, h_r) if lse is not None else None
-
-    kernel_fn(
-        q_5d,
-        k_5d,
-        q_sf.reshape(-1),
-        k_sf.reshape(-1),
-        v_5d,
-        o_5d,
-        problem_size,
-        None,  # cum_seqlen_q
-        None,  # cum_seqlen_k
-        lse_4d,
-        None,  # attention_sinks
-        Float32(scale_softmax_log2),
-        Float32(scale_softmax),
-        Float32(scale_output),
-        None,  # scale_v_channels
-        skip_threshold_log2,
-        ws_left,
-        ws_right,
-        None,  # skip_softmax_count
-        None,  # total_softmax_count
-        enable_pdl,
     )

--- a/flashinfer/cute_dsl/attention/fmha/fmha.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha.py
@@ -1,0 +1,3205 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# ruff: noqa: I001, E501, F841
+
+import math
+from typing import Callable, Type, Tuple, Union, Optional
+from functools import partial
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import tcgen05
+from cutlass.cute.nvgpu.common import OperandMajorMode
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass.cute.typing import Int8, Int32, Int64, Float32
+from cutlass.base_dsl.arch import Arch
+from cutlass.cutlass_dsl import BaseDSL
+
+from .helpers import fmha_helpers as fmha_utils
+
+"""
+A fused multi-head attention (FMHA) example for the NVIDIA Blackwell SM100 architecture using CUTE DSL
+
+This example demonstrates an implementation of fused multi-head attention using a TMA + Blackwell SM100
+TensorCore warp-specialized persistent kernel. The implementation integrates the Q*K^T matrix multiplication,
+softmax normalization, and softmax(Q*K^T)*V into a single kernel, avoiding intermediate data movement between
+global memory and shared memory, thus improving computational efficiency.
+
+The kernel implements key optimizations including:
+- Warp specialization for different computation phases (load, MMA, softmax, correction, epilogue)
+- Pipeline stages between different warps for overlapping computation and memory access
+- Support for different precision data types
+- Optional causal masking for autoregressive models
+
+To run this example:
+
+.. code-block:: bash
+
+    python examples/cute/blackwell/kernel/attention/fmha/fmha.py                                     \
+      --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
+      --mma_tiler_mn 128,128                                              \
+      --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \
+      --is_persistent
+
+The above example runs FMHA with batch size 4, sequence length 1024, 8 attention heads, and head
+dimension 64. The Blackwell tcgen05 MMA tile shape is (128, 128), and the kernel uses fp16 for input/output
+with fp32 for accumulation.
+
+To collect performance with NCU profiler:
+
+.. code-block:: bash
+
+    ncu python examples/cute/blackwell/kernel/attention/fmha/fmha.py                                 \
+      --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
+      --mma_tiler_mn 128,128                                              \
+      --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \
+      --is_persistent --warmup_iterations 10                              \
+      --iterations 10 --skip_ref_check
+
+Constraints for this example:
+* Supported head dimensions: 32, 64, and 128
+* Number of heads in Q must be divisible by number of heads in K
+* mma_tiler_mn must be 128,128
+* Batch size must be the same for Q, K, and V tensors
+* For causal masking, use --is_causal (note: specify without =True/False)
+* For persistent scheduling, use --is_persistent (note: specify without =True/False)
+
+For details on the skip softmax algorithm, please refer to the paper: https://arxiv.org/abs/2512.12087.
+"""
+
+
+def make_thread_cooperative_group(size: int):
+    return pipeline.CooperativeGroup(pipeline.Agent.Thread, size)
+
+
+class BlackwellFusedMultiHeadAttentionForward:
+    arch_str: str = "sm_100"
+    arch_name: str = "Blackwell SM100"
+
+    def __init__(
+        self,
+        qk_acc_dtype: Type[cutlass.Numeric],
+        pv_acc_dtype: Type[cutlass.Numeric],
+        mma_tiler: Tuple[int, int],
+        head_dim: Union[int, Tuple[int, int]],
+        is_persistent: bool,
+        mask_type: fmha_utils.MaskEnum,
+        enable_ex2_emulation: bool,
+        enable_skip_correction: bool,
+        use_tma_store: bool = True,
+    ):
+        """Initializes the configuration for a Blackwell Fused Multi-Head Attention (FMHA) kernel.
+
+        This configuration includes several key aspects:
+
+        1.  Data Type Settings:
+            - qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
+            - pv_acc_dtype: Data type for P*V matrix multiplication accumulator
+
+        2.  MMA Instruction Settings:
+            - mma_tiler: The shape of the MMA instruction unit: (M, N) for BMM1 and (M, K) for BMM2
+            - head_dim: The head dimension, it can be a single integer or a tuple of two integers (D, Dv).
+                        If it is a tuple, Dv is the head dimension of the value & output tensors.
+                        It also determines the K dimension of the BMM1's MMA instruction unit
+                        & N dimension of the BMM2's MMA instruction unit.
+            - qk_mma_tiler: MMA shape for Q*K^T computation
+            - pv_mma_tiler: MMA shape for P*V computation
+
+        3.  Kernel Execution Mode:
+            - is_persistent: Boolean indicating whether to use persistent kernel mode
+            - mask_type: Specifies the type of mask to use (no mask, residual mask, or causal mask)
+            - window_size_left/right: Sliding window size for attention masking
+            - enable_ex2_emulation: Whether to enable exp2 emulation
+            - enable_skip_correction: Whether to skip the correction when rowmax is not updated larger than a threshold
+
+        :param qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
+        :type qk_acc_dtype: Type[cutlass.Numeric]
+        :param pv_acc_dtype: Data type for P*V matrix multiplication accumulator
+        :type pv_acc_dtype: Type[cutlass.Numeric]
+        :param mma_tiler: The (M, N) shape of the MMA instruction
+        :type mma_tiler: Tuple[int, int]
+        :param head_dim: The head dimension, it can be a single integer or a tuple of two integers (D, Dv).
+        :type head_dim: Union[int, Tuple[int, int]]
+        :param is_persistent: Whether to use persistent kernel mode
+        :type is_persistent: bool
+        :param mask_type: Type of mask to use
+        :type mask_type: fmha_utils.MaskEnum
+        :param window_size_left: Left-side sliding window size for attention masking
+        :type window_size_left: int
+        :param window_size_right: Right-side sliding window size for attention masking
+        :type window_size_right: int
+        """
+
+        self.qk_acc_dtype = qk_acc_dtype
+        self.pv_acc_dtype = pv_acc_dtype
+        if isinstance(head_dim, tuple):
+            self.head_dim = head_dim[0]
+            self.head_dim_v = head_dim[1]
+            assert self.head_dim == 192 and self.head_dim_v == 128, (
+                f"When Headdim is a tuple, it's for MLA. Must be (192, 128), but got {head_dim}"
+            )
+        else:
+            self.head_dim = head_dim
+            self.head_dim_v = head_dim
+        self.cta_tiler = (
+            2 * mma_tiler[0],  # 2 O tile per CTA
+            mma_tiler[1],
+            self.head_dim_v,
+        )
+        self.qk_mma_tiler = (
+            *mma_tiler,
+            self.head_dim,
+        )
+        self.pv_mma_tiler = (
+            mma_tiler[0],
+            self.head_dim_v,
+            mma_tiler[1],
+        )
+        self.cluster_shape_mn = (1, 1)
+        self.is_persistent = is_persistent
+        self.mask_type = mask_type
+        self.enable_skip_correction = enable_skip_correction
+        self.enable_ex2_emulation = enable_ex2_emulation
+        self.use_tma_store = use_tma_store
+
+        self.softmax0_warp_ids = (0, 1, 2, 3)
+        self.softmax1_warp_ids = (4, 5, 6, 7)
+        self.correction_warp_ids = (8, 9, 10, 11)
+        self.mma_warp_id = 12
+        self.load_warp_id = 13
+        self.epilogue_warp_id = 14
+        self.empty_warp_id = 15
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch_str)
+
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * len(
+            (
+                *self.softmax0_warp_ids,
+                *self.softmax1_warp_ids,
+                *self.correction_warp_ids,
+                self.mma_warp_id,
+                self.load_warp_id,
+                self.epilogue_warp_id,
+                self.empty_warp_id,
+            )
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_warp
+            * sum(
+                (
+                    len((self.mma_warp_id,)),
+                    len(self.softmax0_warp_ids),
+                    len(self.softmax1_warp_ids),
+                    len(self.correction_warp_ids),
+                )
+            ),
+        )
+        self.sequence_s0_s1_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=self.threads_per_warp
+            * len((*self.softmax0_warp_ids, *self.softmax1_warp_ids)),
+        )
+        self.sequence_s1_s0_barrier = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=self.threads_per_warp
+            * len((*self.softmax0_warp_ids, *self.softmax1_warp_ids)),
+        )
+        self.s0_warpgroup_barrier = pipeline.NamedBarrier(
+            barrier_id=5,
+            num_threads=self.threads_per_warp * len(self.softmax0_warp_ids),
+        )
+        self.s1_warpgroup_barrier = pipeline.NamedBarrier(
+            barrier_id=6,
+            num_threads=self.threads_per_warp * len(self.softmax1_warp_ids),
+        )
+        self.tmem_dealloc_barrier = pipeline.NamedBarrier(
+            barrier_id=7,
+            num_threads=self.threads_per_warp * len(self.correction_warp_ids),
+        )
+
+        self.tmem_s0_offset = 0
+        self.tmem_s1_offset = 128
+        self.tmem_o0_offset = 256
+        self.tmem_o1_offset = 384
+        # inplaced with s1
+        self.tmem_p0_offset = 160
+        # inplaced with s0
+        self.tmem_p1_offset = 32
+        # vec buffer for row_max & row_sum
+        # inplaced with s0
+        self.tmem_vec0_offset = 0
+        # inplaced with s1
+        self.tmem_vec1_offset = 128
+        # skip mma pv flag offset regarding to the vec buffer
+        # inplaced with s1
+        self.tmem_skip_softmax0_offset = 136
+        # inplaced with s0
+        self.tmem_skip_softmax1_offset = 8
+
+        self.num_regs_softmax = 192
+        self.num_regs_correction = 96
+        self.num_regs_other = 32
+        self.buffer_align_bytes = 1024
+        self.arch = BaseDSL._get_dsl().get_arch_enum()
+
+        if self.arch >= Arch.sm_103:
+            assert self.enable_ex2_emulation == False, (  # noqa
+                f"Don't enable exp2 emulation for {self.arch}, it doesn't help performance"
+            )
+
+        num_warps_per_warpgroup = 4
+        self.softmax_warpgroup_count = (
+            len((*self.softmax0_warp_ids, *self.softmax1_warp_ids)) // num_warps_per_warpgroup
+        )
+
+    def _make_qk_tiled_mma(self, cta_group):
+        """Build the QK tiled MMA. Override in subclasses to target a different arch."""
+        return sm100_utils.make_trivial_tiled_mma(
+            self.q_dtype,
+            self.q_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.qk_acc_dtype,
+            cta_group,
+            self.qk_mma_tiler[:2],
+        )
+
+    def _make_pv_tiled_mma(self, cta_group, p_major_mode, p_source):
+        """Build the PV tiled MMA. Override in subclasses to target a different arch."""
+        return sm100_utils.make_trivial_tiled_mma(
+            self.v_dtype,
+            self.v_dtype,
+            p_major_mode,
+            self.v_major_mode,
+            self.pv_acc_dtype,
+            cta_group,
+            self.pv_mma_tiler[:2],
+            p_source,
+        )
+
+    def _setup_attributes(self):
+        """Set up configurations and parameters for the FMHA kernel operation.
+
+        This method initializes and configures various attributes required for the
+        execution of the fused multi-head attention kernel, mainly about the pipeline stages:
+
+        - Sets up staging parameters for Q, K, V inputs and accumulator data
+        - Configures pipeline stages for softmax, correction, and epilogue operations
+        """
+
+        self.q_stage = 2
+        k_stage = 4 if self.q_dtype.width == 8 else 3
+        v_stage = 4 if self.v_dtype.width == 8 else 3
+        self.kv_stage = min(k_stage, v_stage)
+        # For D192, the smem usage of Q & K is larger. So, we need to reduce the stage count.
+        if self.head_dim == 192 and self.q_dtype.width == 16:
+            self.kv_stage = 2
+        self.p_mma_stage = 1
+        self.acc_stage = 1
+        self.softmax_corr_stage = 1
+        self.mma_corr_stage = 2
+        self.mma_softmax_stage = 1
+        self.epi_stage = 2
+
+        # Tunable parameters
+        self.rescale_threshold = 8.0 if self.enable_skip_correction else 0.0
+        # FP8 P pre-scale: offset added to exp2 exponent so that P*2^offset fills
+        # more of E4M3's [0, 448] range, improving quantization precision.
+        # Derived from rescale_threshold to guarantee P*2^offset <= 448.
+        self.p_fp8_prescale_log2 = max(0.0, math.floor(math.log2(448) - self.rescale_threshold))
+        # ln(2) * offset correction for LSE when pre-scale is active
+        self.p_fp8_prescale_lse_correction = self.p_fp8_prescale_log2 * math.log(2)
+        # For most cases, seq barrier is needed to help keep the pipeline stable
+        # But sometimes, compiler will schedule the barrier at an unexpected place
+        # if it hurts perf a lot, try to quickly fix it by disabling seq barrier
+        self.enable_sequence_barrier = False
+        # Optional double buffering for correction rescale.
+        self.enable_correction_double_buffer = False
+
+    @cute.jit
+    def __call__(
+        self,
+        q_tensor: cute.Tensor,
+        k_tensor: cute.Tensor,
+        v_tensor: cute.Tensor,
+        o_tensor: cute.Tensor,
+        problem_size: Tuple[Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32],
+        cum_seqlen_q: Optional[cute.Tensor],
+        cum_seqlen_k: Optional[cute.Tensor],
+        lse_tensor: Optional[cute.Tensor],
+        sink_tensor: Optional[cute.Tensor],
+        scale_softmax_log2: Float32,
+        scale_softmax: Float32,
+        scale_output: Float32,
+        skip_softmax_threshold_log2: Optional[Float32],
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        skip_softmax_count: Optional[cute.Tensor],
+        total_softmax_count: Optional[cute.Tensor],
+        stream: cuda.CUstream,
+        use_pdl: bool,
+    ):
+        """Execute the Fused Multi-Head Attention operation on the provided tensors.
+
+        This method prepares the input tensors for processing, validates their shapes and types,
+        configures the computation parameters, and launches the CUDA kernel.
+
+        The method handles:
+        1. Tensor layout transformations for specific memory access patterns
+        2. Validation of tensor shapes and data types
+        3. Initialization of hardware-specific parameters and memory layouts
+        4. Configuration of TMA (Tensor Memory Access) operations
+        5. Grid and work scheduling computation
+        6. Kernel launch with appropriate parameters
+
+        :param q_tensor: The query tensor with shape (b, s_q, h_k, h_r, d)
+        :type q_tensor: cute.Tensor
+        :param k_tensor: The key tensor with shape (b, s_k, h_k, 1, d)
+        :type k_tensor: cute.Tensor
+        :param v_tensor: The value tensor with shape (b, s_v, h_k, 1, dv)
+        :type v_tensor: cute.Tensor
+        :param o_tensor: The output tensor with shape (b, s_q, h_k, h_r, dv)
+        :type o_tensor: cute.Tensor
+        :param problem_size: The problem size with shape [b, s_q_max, s_lse_max, s_k_max, h_q, h_k, d, dv]. If cum_seqlen_q or cum_seqlen_k is not None, s_q_max and s_k_max are the max of the per-batch sequence lengths respectively.
+        :type problem_size: Tuple[Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32]
+        :param cum_seqlen_q: The cumulative sequence length tensor for query
+        :type cum_seqlen_q: Optional[cute.Tensor]
+        :param cum_seqlen_k: The cumulative sequence length tensor for key
+        :type cum_seqlen_k: Optional[cute.Tensor]
+        :param scale_softmax_log2: The log2 scale factor for softmax
+        :type scale_softmax_log2: Float32
+        :param scale_softmax: The scale factor for softmax
+        :type scale_softmax: Float32
+        :param scale_output: The scale factor for the output
+        :type scale_output: Float32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param stream: The CUDA stream to execute the kernel on
+        :type stream: cuda.CUstream
+        :raises TypeError: If tensor data types don't match or aren't supported
+        :raises RuntimeError: If tensor layouts aren't in supported formats
+        """
+        b, s_q_max, s_lse_max, s_k_max, h_q, h_k, d, dv = problem_size
+        h_r = h_q // h_k
+        # setup static attributes before smem/grid/tma computation
+        self.q_dtype = q_tensor.element_type
+        self.k_dtype = k_tensor.element_type
+        self.v_dtype = v_tensor.element_type
+        self.o_dtype = o_tensor.element_type
+
+        # s_q, s_k, s_v are the actual tensor dimensions (total seqlen for varlen)
+        s_q = q_tensor.shape[1]
+        s_k = k_tensor.shape[1]
+        s_v = v_tensor.shape[1]
+        s_lse = s_lse_max
+        # Important for performance
+        align = 256 // self.o_dtype.width
+        d = cute.assume(Int32(d), align)
+        dv = cute.assume(Int32(dv), align)
+
+        stride_b_q = h_r * h_k * s_q * d if cum_seqlen_q is None else 0
+        stride_b_o = h_r * h_k * s_q * dv if cum_seqlen_q is None else 0
+        stride_b_k = h_k * s_k * d if cum_seqlen_k is None else 0
+        stride_b_v = h_k * s_v * dv if cum_seqlen_k is None else 0
+        stride_b_lse = h_r * h_k * s_lse if cum_seqlen_q is None else 0
+
+        # (b, s_q, h_k, h_r, d) -> (s_q, d, ((h_r, h_k), b))
+        q_layout = cute.make_layout(
+            (s_q, d, ((h_r, h_k), b)),
+            stride=(d * h_r * h_k, 1, ((d, d * h_r), stride_b_q)),
+        )
+        q = cute.make_tensor(q_tensor.iterator, q_layout)
+        # (b, s_k, h_k, 1, d) -> (s_k, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        k_layout = cute.make_layout(
+            (s_k, d, ((h_r, h_k), b)),
+            stride=(d * h_k, 1, ((0, d), stride_b_k)),
+        )
+        k = cute.make_tensor(k_tensor.iterator, k_layout)
+        # (b, s_v, h_k, 1, dv) -> (dv, s_v, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        v_layout = cute.make_layout(
+            (dv, s_v, ((h_r, h_k), b)),
+            stride=(1, dv * h_k, ((0, dv), stride_b_v)),
+        )
+        v = cute.make_tensor(v_tensor.iterator, v_layout)
+        # (b, s_q, h_k, h_r, dv) -> (s_q, dv, ((h_r, h_k), b))
+        o_layout = cute.make_layout(
+            (s_q, dv, ((h_r, h_k), b)),
+            stride=(dv * h_r * h_k, 1, ((dv, dv * h_r), stride_b_o)),
+        )
+        o = cute.make_tensor(o_tensor.iterator, o_layout)
+        if cutlass.const_expr(lse_tensor is not None):
+            # (s, ((h_r, h_k), b)) - head stride=1 to match FlashInfer (total_q, h_q) convention
+            lse_layout = cute.make_layout(
+                (s_lse, ((h_r, h_k), b)),
+                stride=(h_r * h_k, ((1, h_r), stride_b_lse)),
+            )
+            lse = cute.make_tensor(lse_tensor.iterator, lse_layout)
+        else:
+            lse = None
+
+        if cutlass.const_expr(sink_tensor is not None):
+            # sink_tensor is 1D with shape (h_q,) = (h_k * h_r,)
+            # Create layout ((h_r, h_k), b) with stride 0 for batch so blk_coord[2] works
+            sink_layout = cute.make_layout(
+                ((h_r, h_k), b),
+                stride=((1, h_r), 0),
+            )
+            sink = cute.make_tensor(sink_tensor.iterator, sink_layout)
+        else:
+            sink = None
+
+        self.tile_sched_params, grid = fmha_utils.compute_grid(
+            cute.shape((s_q_max, d, ((h_r, h_k), b))),
+            self.cta_tiler,
+            self.is_persistent,
+        )
+        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = utils.LayoutEnum.from_tensor(o)
+
+        if cutlass.const_expr(self.q_major_mode != OperandMajorMode.K):
+            raise RuntimeError("The layout of q is not supported")
+        if cutlass.const_expr(self.k_major_mode != OperandMajorMode.K):
+            raise RuntimeError("The layout of k is not supported")
+        if cutlass.const_expr(self.v_major_mode != OperandMajorMode.MN):
+            raise RuntimeError("The layout of v is not supported")
+
+        # check type consistency: Q and K must share the same dtype (qk_dtype);
+        # V may use a different dtype (pv_dtype) to allow qk_dtype != pv_dtype.
+        if cutlass.const_expr(self.q_dtype != self.k_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
+        self._setup_attributes()
+
+        cta_group = tcgen05.CtaGroup.ONE
+        # the intermediate tensor p is from tmem & k-major
+        p_source = tcgen05.OperandSource.TMEM
+        p_major_mode = cute.nvgpu.OperandMajorMode.K
+        qk_tiled_mma = self._make_qk_tiled_mma(cta_group)
+        pv_tiled_mma = self._make_pv_tiled_mma(cta_group, p_major_mode, p_source)
+
+        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (qk_tiled_mma.thr_id.shape,),
+        )
+        self.epi_tile = self.pv_mma_tiler[:2]
+
+        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.q_dtype,
+            self.q_stage,
+        )
+        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.k_dtype,
+            self.kv_stage,
+        )
+        p_tmem_layout_staged = sm100_utils.make_smem_layout_a(
+            pv_tiled_mma,
+            self.pv_mma_tiler,
+            self.v_dtype,
+            self.acc_stage,
+        )
+        v_smem_layout_staged_origin = sm100_utils.make_smem_layout_b(
+            pv_tiled_mma,
+            self.pv_mma_tiler,
+            self.v_dtype,
+            self.kv_stage,
+        )
+        # k & v share the same smem buffer. Pad the smaller-tile operand's stage stride to
+        # match the larger tile. Stride is scaled to the target operand's element width.
+        # sK_cosize covers all kv_stage slots at the larger tile's byte footprint.
+        if cutlass.const_expr(self.k_dtype.width >= self.v_dtype.width):
+            # k tile >= v tile: give v k's stage stride in v_dtype units
+            k_tile_cosize = cute.cosize(cute.select(k_smem_layout_staged, mode=[0, 1, 2]))
+            v_stage_stride = k_tile_cosize * self.k_dtype.width // self.v_dtype.width
+            v_smem_layout_staged = cute.append(
+                cute.select(v_smem_layout_staged_origin, mode=[0, 1, 2]),
+                cute.make_layout(self.kv_stage, stride=v_stage_stride),
+            )
+            sK_cosize = cute.cosize(k_smem_layout_staged)
+        else:
+            # v tile > k tile: give k v's stage stride in k_dtype units
+            v_tile_cosize = cute.cosize(cute.select(v_smem_layout_staged_origin, mode=[0, 1, 2]))
+            k_stage_stride = v_tile_cosize * self.v_dtype.width // self.k_dtype.width
+            k_smem_layout_staged = cute.append(
+                cute.select(k_smem_layout_staged, mode=[0, 1, 2]),
+                cute.make_layout(self.kv_stage, stride=k_stage_stride),
+            )
+            v_smem_layout_staged = v_smem_layout_staged_origin
+            # cute.cosize gives (kv_stage-1)*k_stage_stride + k_tile_cosize, but the
+            # last stage must also accommodate a full V tile, so size for kv_stage slots.
+            sK_cosize = self.kv_stage * k_stage_stride
+
+        o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.o_dtype,
+            self.o_layout,
+            self.epi_tile,
+            self.epi_stage,
+        )
+
+        # TMA load for Q
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_store_op = cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+
+        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            q,
+            q_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load for K
+        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k,
+            k_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        # TMA load for V
+        v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            v,
+            v_smem_layout,
+            self.pv_mma_tiler,
+            pv_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        o_smem_layout = cute.select(o_smem_layout_staged, mode=[0, 1])
+        tma_atom_o, tma_tensor_o = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_store_op,
+            o,
+            o_smem_layout,
+            self.epi_tile,
+        )
+
+        q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
+        k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
+        v_copy_size = cute.size_in_bytes(self.v_dtype, v_smem_layout)
+        self.tma_copy_q_bytes = q_copy_size
+        self.tma_copy_k_bytes = k_copy_size
+        self.tma_copy_v_bytes = v_copy_size
+
+        @cute.struct
+        class SharedStorage:
+            # Pipeline barriers
+            load_q_mbar_ptr: cute.struct.MemRange[Int64, self.q_stage * 2]
+            load_kv_mbar_ptr: cute.struct.MemRange[Int64, self.kv_stage * 2]
+            mma_s0_mbar_ptr: cute.struct.MemRange[Int64, self.mma_softmax_stage * 2]
+            mma_s1_mbar_ptr: cute.struct.MemRange[Int64, self.mma_softmax_stage * 2]
+            p0_mma_mbar_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            p1_mma_mbar_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            s0_corr_mbar_ptr: cute.struct.MemRange[Int64, self.softmax_corr_stage * 2]
+            s1_corr_mbar_ptr: cute.struct.MemRange[Int64, self.softmax_corr_stage * 2]
+            corr_epi_mbar_ptr: cute.struct.MemRange[Int64, self.epi_stage * 2]
+            mma_corr_mbar_ptr: cute.struct.MemRange[Int64, self.mma_corr_stage * 2]
+            s0_p1_inplace_barrier_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            s1_p0_inplace_barrier_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            # Tmem holding buffer
+            tmem_holding_buf: Int32
+            # Smem tensors
+            sO: cute.struct.Align[
+                cute.struct.MemRange[self.o_dtype, cute.cosize(o_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.q_dtype, cute.cosize(q_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.k_dtype, sK_cosize],
+                self.buffer_align_bytes,
+            ]
+            # Skip softmax and PV warpgroup votes
+            s0_warp_wants_skip_softmax_exchange: cute.struct.MemRange[Int8, 4]
+            s1_warp_wants_skip_softmax_exchange: cute.struct.MemRange[Int8, 4]
+
+        self.shared_storage = SharedStorage
+
+        # Launch the kernel synchronously
+        self.kernel(
+            qk_tiled_mma,
+            pv_tiled_mma,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_o,
+            tma_tensor_o,
+            o,
+            cum_seqlen_q,
+            cum_seqlen_k,
+            lse,
+            sink,
+            scale_softmax_log2,
+            scale_softmax,
+            scale_output,
+            skip_softmax_threshold_log2,
+            window_size_left,
+            window_size_right,
+            q_smem_layout_staged,
+            k_smem_layout_staged,
+            p_tmem_layout_staged,
+            v_smem_layout_staged,
+            o_smem_layout_staged,
+            skip_softmax_count,
+            total_softmax_count,
+            self.tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+            use_pdl=use_pdl,
+        )
+
+    #  GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        qk_tiled_mma: cute.TiledMma,
+        pv_tiled_mma: cute.TiledMma,
+        tma_atom_q: cute.CopyAtom,
+        mQ_qdl: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_kdl: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_dkl: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        mO_qdl: cute.Tensor,
+        mO: cute.Tensor,
+        cum_seqlen_q: Optional[cute.Tensor],
+        cum_seqlen_k: Optional[cute.Tensor],
+        mLSE: Optional[cute.Tensor],
+        mSink: Optional[cute.Tensor],
+        scale_softmax_log2: Float32,
+        scale_softmax: Float32,
+        scale_output: Float32,
+        skip_softmax_threshold_log2: Optional[Float32],
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        q_smem_layout_staged: cute.ComposedLayout,
+        k_smem_layout_staged: cute.ComposedLayout,
+        p_tmem_layout_staged: cute.ComposedLayout,
+        v_smem_layout_staged: cute.ComposedLayout,
+        o_smem_layout_staged: cute.ComposedLayout,
+        skip_softmax_count: Optional[cute.Tensor],
+        total_softmax_count: Optional[cute.Tensor],
+        tile_sched_params: fmha_utils.FmhaStaticTileSchedulerParams,
+    ):
+        """The device kernel implementation of the Fused Multi-Head Attention.
+
+        This kernel coordinates multiple specialized warps to perform different phases of the FMHA computation:
+        1. Load warp: Loads Q, K, V data from global memory to shared memory using TMA
+        2. MMA warp: Performs matrix multiplications (Q*K^T and P*V)
+        3. Softmax warps: Compute softmax normalization on attention scores
+        4. Correction warps: Apply adjustments to intermediate results
+        5. Epilogue warp: Handles final output transformation and storage
+
+        The kernel implements a complex pipeline with overlapping computation and memory operations,
+        using tensor memory access (TMA) for efficient data loading, warp specialization for different
+        computation phases, and optional attention masking.
+
+        :param qk_tiled_mma: Tiled MMA for Q*K^T
+        :type qk_tiled_mma: cute.TiledMma
+        :param pv_tiled_mma: Tiled MMA for P*V
+        :type pv_tiled_mma: cute.TiledMma
+        :param tma_atom_q: TMA copy atom for query tensor
+        :type tma_atom_q: cute.CopyAtom
+        :param mQ_qdl: Partitioned query tensor
+        :type mQ_qdl: cute.Tensor
+        :param tma_atom_k: TMA copy atom for key tensor
+        :type tma_atom_k: cute.CopyAtom
+        :param mK_kdl: Partitioned key tensor
+        :type mK_kdl: cute.Tensor
+        :param tma_atom_v: TMA copy atom for value tensor
+        :type tma_atom_v: cute.CopyAtom
+        :param mV_dkl: Partitioned value tensor
+        :type mV_dkl: cute.Tensor
+        :param tma_atom_o: TMA copy atom for output tensor
+        :type tma_atom_o: cute.CopyAtom
+        :param mO_qdl: Partitioned output tensor
+        :type mO_qdl: cute.Tensor
+        :param mO: Non-partitioned output tensor
+        :type mO: cute.Tensor
+        :param scale_softmax_log2: The log2 scale factor for softmax
+        :type scale_softmax_log2: Float32
+        :param scale_output: The scale factor for the output
+        :type scale_output: Float32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param q_smem_layout_staged: Shared memory layout for query tensor
+        :type q_smem_layout_staged: cute.ComposedLayout
+        :param k_smem_layout_staged: Shared memory layout for key tensor
+        :type k_smem_layout_staged: cute.ComposedLayout
+        :param p_tmem_layout_staged: Tensor memory layout for probability matrix
+        :type p_tmem_layout_staged: cute.ComposedLayout
+        :param v_smem_layout_staged: Shared memory layout for value tensor
+        :type v_smem_layout_staged: cute.ComposedLayout
+        :param o_smem_layout_staged: Shared memory layout for output tensor
+        :type o_smem_layout_staged: cute.ComposedLayout
+        :param tile_sched_params: Scheduling parameters for work distribution
+        :type tile_sched_params: fmha_utils.FmhaStaticTileSchedulerParams
+        """
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        # coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.load_warp_id:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+            if cutlass.const_expr(self.use_tma_store):
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
+
+        # Alloc
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.q_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_q_bytes,
+            barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        load_kv_producer, load_kv_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.kv_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_k_bytes,
+            barrier_storage=storage.load_kv_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        load_kv_full_mbar_ptr = storage.load_kv_mbar_ptr.data_ptr()
+        load_kv_empty_mbar_ptr = load_kv_full_mbar_ptr + self.kv_stage
+        mma_s0_producer, mma_s0_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_softmax_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            barrier_storage=storage.mma_s0_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        mma_s1_producer, mma_s1_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_softmax_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            barrier_storage=storage.mma_s1_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        p0_mma_producer, p0_mma_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.p_mma_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.p0_mma_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        p1_mma_producer, p1_mma_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.p_mma_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.p1_mma_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        s0_corr_producer, s0_corr_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.softmax_corr_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len((*self.softmax0_warp_ids, self.mma_warp_id))
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            barrier_storage=storage.s0_corr_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        s1_corr_producer, s1_corr_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.softmax_corr_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len((*self.softmax1_warp_ids, self.mma_warp_id))
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            barrier_storage=storage.s1_corr_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        corr_epi_producer, corr_epi_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.epi_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len([self.epilogue_warp_id])
+            ),
+            barrier_storage=storage.corr_epi_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        mma_corr_producer, mma_corr_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_corr_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            barrier_storage=storage.mma_corr_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        s0_p1_inplace_producer, s0_p1_inplace_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.p_mma_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            barrier_storage=storage.s0_p1_inplace_barrier_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        s1_p0_inplace_producer, s1_p0_inplace_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.p_mma_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            barrier_storage=storage.s1_p0_inplace_barrier_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            # Correction warp is the last one that accesses tmem
+            allocator_warp_id=self.correction_warp_ids[0],
+            arch=self.arch_str,
+        )
+        pipeline_init_arrive(is_relaxed=True)
+
+        #  Generate smem tensor Q/K/V/O
+        # (MMA, MMA_Q, MMA_D, PIPE)
+        sQ = storage.sQ.get_tensor(q_smem_layout_staged.outer, swizzle=q_smem_layout_staged.inner)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        sK = storage.sK.get_tensor(k_smem_layout_staged.outer, swizzle=k_smem_layout_staged.inner)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        # Reuse k's smem buffer for v. Recast element type so MMA descriptor matches v_dtype.
+        sV_ptr = cute.recast_ptr(
+            cute.recast_ptr(sK.iterator, dtype=self.v_dtype),
+            v_smem_layout_staged.inner,
+        )
+        sV = cute.make_tensor(sV_ptr, v_smem_layout_staged.outer)
+        sO = storage.sO.get_tensor(o_smem_layout_staged.outer, swizzle=o_smem_layout_staged.inner)
+        s0_warp_wants_skip_softmax_exchange = (
+            storage.s0_warp_wants_skip_softmax_exchange.get_tensor(cute.make_layout((4,)))
+        )
+        s1_warp_wants_skip_softmax_exchange = (
+            storage.s1_warp_wants_skip_softmax_exchange.get_tensor(cute.make_layout((4,)))
+        )
+
+        qk_thr_mma = qk_tiled_mma.get_slice(0)  # default 1sm
+        pv_thr_mma = pv_tiled_mma.get_slice(0)  # default 1sm
+        tSrQ = qk_thr_mma.make_fragment_A(sQ)
+        tSrK = qk_thr_mma.make_fragment_B(sK)
+        tOrV = pv_thr_mma.make_fragment_B(sV)
+
+        def make_tmem_tensors(
+            self,
+            qk_thr_mma: cute.TiledMma,
+            pv_thr_mma: cute.TiledMma,
+            p_tmem_layout_staged: cute.Layout,
+            tmem_ptr: cute.Pointer,
+        ):
+            qk_acc_shape = qk_thr_mma.partition_shape_C(
+                (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
+            )
+            tStS_fake = qk_thr_mma.make_fragment_C(qk_acc_shape)
+            tStS = cute.make_tensor(tmem_ptr + self.tmem_s0_offset, tStS_fake.layout)
+            pv_acc_shape = pv_thr_mma.partition_shape_C(
+                (self.pv_mma_tiler[0], self.pv_mma_tiler[1])
+            )
+            tOtO = pv_thr_mma.make_fragment_C(pv_acc_shape)
+            tStS0 = cute.make_tensor(tmem_ptr + self.tmem_s0_offset, tStS.layout)
+            tStS1 = cute.make_tensor(tmem_ptr + self.tmem_s1_offset, tStS.layout)
+            tOtO0 = cute.make_tensor(tmem_ptr + self.tmem_o0_offset, tOtO.layout)
+            tOtO1 = cute.make_tensor(tmem_ptr + self.tmem_o1_offset, tOtO.layout)
+            tP = cute.make_tensor(tStS.iterator, p_tmem_layout_staged.outer)
+            tOrP = pv_thr_mma.make_fragment_A(tP)[None, None, None, 0]
+            tOrP0 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr + self.tmem_p0_offset,
+                    dtype=tOrP.dtype,
+                ),
+                tOrP.layout,
+            )
+            tOrP1 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr + self.tmem_p1_offset,
+                    dtype=tOrP.dtype,
+                ),
+                tOrP.layout,
+            )
+            return tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1
+
+        tile_sched = fmha_utils.create_fmha_static_tile_scheduler(
+            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+        pipeline_init_wait()
+        softmax_fn = partial(
+            self.softmax,
+            qk_thr_mma=qk_thr_mma,
+            value_args=(
+                mK_kdl.shape[0],
+                mQ_qdl.shape[0],
+                scale_softmax_log2,
+                skip_softmax_threshold_log2,
+            ),
+            mask_args=(window_size_left, window_size_right),
+            sched_args=(tile_sched, work_tile),
+        )
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  EMPTY
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.empty_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  LOAD
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.load_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            cute.arch.griddepcontrol_wait()
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cum_seqlen_k[batch_coord]
+                    continue_cond = seqlen_k <= 0
+                if not continue_cond:
+                    mQ_qdl_ = mQ_qdl
+                    mK_kdl_ = mK_kdl
+                    mV_dkl_ = mV_dkl
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        mQ_qdl_ = cute.domain_offset(
+                            (cum_seqlen_q[batch_coord], 0, ((0, 0), 0)), mQ_qdl
+                        )
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        mK_kdl_ = cute.domain_offset(
+                            (cum_seqlen_k[batch_coord], 0, ((0, 0), 0)), mK_kdl
+                        )
+                        mV_dkl_ = cute.domain_offset(
+                            (0, cum_seqlen_k[batch_coord], ((0, 0), 0)), mV_dkl
+                        )
+                    # Local tile partition global tensors
+                    gQ_qdl = cute.flat_divide(mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2]))
+                    tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
+                    tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_q,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sQ, 0, 3),
+                        cute.group_modes(tSgQ_qdl, 0, 3),
+                    )
+                    tQgQ = tQgQ_qdl[None, None, 0, curr_block_coord[2]]
+                    gK_kdl = cute.flat_divide(mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2]))
+                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
+                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sK, 0, 3),
+                        cute.group_modes(tSgK_kdl, 0, 3),
+                    )
+                    tKgK = tKgK_kdl[None, None, 0, curr_block_coord[2]]
+                    gV_dkl = cute.flat_divide(mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2]))
+                    tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
+                    tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_v,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sV, 0, 3),
+                        cute.group_modes(tSgV_dkl, 0, 3),
+                    )
+                    tVgV = tVgV_dkl[None, 0, None, curr_block_coord[2]]
+                    seqlen_kv_loop_start = fmha_utils.FusedMask.get_trip_start(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        window_size_left,
+                    )
+                    # Q0
+                    q0_coord = 2 * curr_block_coord[0]
+                    q0_handle = load_q_producer.acquire_and_advance()
+                    cute.copy(
+                        tma_atom_q,
+                        tQgQ[None, q0_coord],
+                        tQsQ[None, q0_handle.index],
+                        tma_bar_ptr=q0_handle.barrier,
+                    )
+                    seqlen_kv_loop_steps = fmha_utils.FusedMask.get_trip_count(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    # K0
+                    kv_coord = seqlen_kv_loop_start
+                    k_handle = load_kv_producer.acquire_and_advance()
+                    cute.copy(
+                        tma_atom_k,
+                        tKgK[None, kv_coord],
+                        tKsK[None, k_handle.index],
+                        tma_bar_ptr=k_handle.barrier,
+                    )
+                    # Q1
+                    q1_coord = q0_coord + 1
+                    q1_handle = load_q_producer.acquire_and_advance()
+                    cute.copy(
+                        tma_atom_q,
+                        tQgQ[None, q1_coord],
+                        tQsQ[None, q1_handle.index],
+                        tma_bar_ptr=q1_handle.barrier,
+                    )
+                    kv_coord += 1
+
+                    for i in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Ki
+                        k_handle = load_kv_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_k,
+                            tKgK[None, kv_coord],
+                            tKsK[None, k_handle.index],
+                            tma_bar_ptr=k_handle.barrier,
+                        )
+                        # Vi-1
+                        v_handle, load_kv_producer = self.kv_producer_update_tx_acquire_and_advance(
+                            load_kv_producer,
+                            load_kv_empty_mbar_ptr,
+                            load_kv_full_mbar_ptr,
+                            self.tma_copy_v_bytes,
+                        )
+                        cute.copy(
+                            tma_atom_v,
+                            tVgV[None, kv_coord - 1],
+                            tVsV[None, v_handle.index],
+                            tma_bar_ptr=load_kv_full_mbar_ptr + v_handle.index,
+                        )
+                        kv_coord += 1
+                    # End of seqlen_kv loop
+                    # Vi_end
+                    v_handle, load_kv_producer = self.kv_producer_update_tx_acquire_and_advance(
+                        load_kv_producer,
+                        load_kv_empty_mbar_ptr,
+                        load_kv_full_mbar_ptr,
+                        self.tma_copy_v_bytes,
+                    )
+                    cute.copy(
+                        tma_atom_v,
+                        tVgV[None, kv_coord - 1],
+                        tVsV[None, v_handle.index],
+                        tma_bar_ptr=load_kv_full_mbar_ptr + v_handle.index,
+                    )
+                # End of if not continue_cond
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                # End of persistent scheduler loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  MMA
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
+                self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            enable_skip_softmax = skip_softmax_threshold_log2 is not None
+            tiled_tmem_load_v = None
+            tTMEM_LOADtS_v0, tTMEM_LOADtS_v1 = None, None
+            tTMEM_LOADrS_v0, tTMEM_LOADrS_v1 = None, None
+            if cutlass.const_expr(enable_skip_softmax):
+                cS = cute.make_identity_tensor(cute.select(self.qk_mma_tiler, mode=[0, 1]))
+                tScS = qk_thr_mma.partition_C(cS)
+                tStS_v = cute.composition(tStS, cute.make_layout((self.threads_per_warp, 1)))
+                tScS_v = cute.composition(tScS, cute.make_layout((self.threads_per_warp, 1)))
+                tmem_load_v_atom = cute.make_copy_atom(
+                    tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(1)),
+                    self.qk_acc_dtype,
+                )
+                thread_idx = tidx % self.threads_per_warp
+
+                tiled_tmem_load_v = tcgen05.make_tmem_copy(tmem_load_v_atom, tStS_v)
+                thr_tmem_load_v = tiled_tmem_load_v.get_slice(thread_idx)
+                tTMEM_LOADtS_v = thr_tmem_load_v.partition_S(tStS_v)
+                tTMEM_LOADcS_v = thr_tmem_load_v.partition_D(tScS_v)
+                tTMEM_LOADrS_v0 = cute.make_rmem_tensor(tTMEM_LOADcS_v.shape, self.qk_acc_dtype)
+                tTMEM_LOADrS_v1 = cute.make_rmem_tensor(tTMEM_LOADcS_v.shape, self.qk_acc_dtype)
+                tTMEM_LOADtS_v0 = cute.make_tensor(
+                    tTMEM_LOADtS_v.iterator + self.tmem_skip_softmax0_offset,
+                    tTMEM_LOADtS_v.layout,
+                )
+                tTMEM_LOADtS_v1 = cute.make_tensor(
+                    tTMEM_LOADtS_v.iterator + self.tmem_skip_softmax1_offset,
+                    tTMEM_LOADtS_v.layout,
+                )
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    continue_cond = seqlen_k <= 0
+                if not continue_cond:
+                    # Wait for Q0
+                    q0_handle = load_q_consumer.wait_and_advance()
+                    tSrQ0 = tSrQ[None, None, None, q0_handle.index]
+                    # Wait for K0
+                    k_handle = load_kv_consumer.wait_and_advance()
+                    tSrK0 = tSrK[None, None, None, k_handle.index]
+                    # GEMM_QK00 (Q0 * K0 -> S0)
+                    mma_s0_producer, s0_corr_producer = self.mma_qk(
+                        qk_tiled_mma,
+                        (tSrQ0, tSrK0, tStS0),
+                        (mma_s0_producer, s0_corr_producer),
+                    )
+                    # Wait for Q1
+                    q1_handle = load_q_consumer.wait_and_advance()
+                    tSrQ1 = tSrQ[None, None, None, q1_handle.index]
+                    # GEMM_QK10 (Q1 * K0 -> S1), K0 is ready in GEMM_QK00
+                    mma_s1_producer, s1_corr_producer = self.mma_qk(
+                        qk_tiled_mma,
+                        (tSrQ1, tSrK0, tStS1),
+                        (mma_s1_producer, s1_corr_producer),
+                    )
+                    # Release K0
+                    k_handle.release()
+                    # Note: Q0 & Q1 are still needed in the seqlen_kv loop
+                    # so we need to release them after the seqlen_kv loop
+                    seqlen_kv_loop_steps = fmha_utils.FusedMask.get_trip_count(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    # O1 hasn't been accumulated yet, its first MMA calculation doesn't need to accumulate
+                    pv_whether_acc = False
+                    for i in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Wait for Ki
+                        k_handle = load_kv_consumer.wait_and_advance()
+                        tSrKi = tSrK[None, None, None, k_handle.index]
+                        # GEMM_QK0i (Q0 * Ki -> S0)
+                        mma_s0_producer, s0_corr_producer = self.mma_qk(
+                            qk_tiled_mma,
+                            (tSrQ0, tSrKi, tStS0),
+                            (mma_s0_producer, s0_corr_producer),
+                        )
+                        # Wait for Vi-1
+                        v_handle = load_kv_consumer.wait_and_advance()
+                        tOrVi = tOrV[None, None, None, v_handle.index]
+                        # GEMM_PV0(i-1) (P0 * Vi-1 -> O0_partial)
+                        mma_corr_producer, p0_mma_consumer = self.mma_pv(
+                            pv_tiled_mma,
+                            pv_whether_acc,
+                            (tOrP0, tOrVi, tOtO0),
+                            (mma_corr_producer, p0_mma_consumer),
+                            (
+                                enable_skip_softmax,
+                                tiled_tmem_load_v,
+                                tTMEM_LOADtS_v0,
+                                tTMEM_LOADrS_v0,
+                            ),
+                        )
+                        # GEMM_QK1i (Q1 * Ki -> S1)
+                        mma_s1_producer, s1_corr_producer = self.mma_qk(
+                            qk_tiled_mma,
+                            (tSrQ1, tSrKi, tStS1),
+                            (mma_s1_producer, s1_corr_producer),
+                        )
+                        # Release Ki
+                        k_handle.release()
+                        # GEMM_PV1(i-1) (P1 * Vi-1 -> O1_partial)
+                        mma_corr_producer, p1_mma_consumer = self.mma_pv(
+                            pv_tiled_mma,
+                            pv_whether_acc,
+                            (tOrP1, tOrVi, tOtO1),
+                            (mma_corr_producer, p1_mma_consumer),
+                            (
+                                enable_skip_softmax,
+                                tiled_tmem_load_v,
+                                tTMEM_LOADtS_v1,
+                                tTMEM_LOADrS_v1,
+                            ),
+                        )
+                        pv_whether_acc = True
+                        # Release Vi-1
+                        v_handle.release()
+                    # End of seqlen_kv loop
+                    # release Q0 & Q1
+                    q0_handle.release()
+                    q1_handle.release()
+                    # Wait for Vi_end
+                    v_handle = load_kv_consumer.wait_and_advance()
+                    tOrVi = tOrV[None, None, None, v_handle.index]
+                    # GEMM_PV0(i_end) (P0 * Vi_end -> O0)
+                    mma_corr_producer, p0_mma_consumer = self.mma_pv(
+                        pv_tiled_mma,
+                        pv_whether_acc,
+                        (tOrP0, tOrVi, tOtO0),
+                        (mma_corr_producer, p0_mma_consumer),
+                        (
+                            enable_skip_softmax,
+                            tiled_tmem_load_v,
+                            tTMEM_LOADtS_v0,
+                            tTMEM_LOADrS_v0,
+                        ),
+                    )
+                    # GEMM_PV1(i_end) (P1 * Vi_end -> O1)
+                    mma_corr_producer, p1_mma_consumer = self.mma_pv(
+                        pv_tiled_mma,
+                        pv_whether_acc,
+                        (tOrP1, tOrVi, tOtO1),
+                        (mma_corr_producer, p1_mma_consumer),
+                        (
+                            enable_skip_softmax,
+                            tiled_tmem_load_v,
+                            tTMEM_LOADtS_v1,
+                            tTMEM_LOADrS_v1,
+                        ),
+                    )
+                    # Release Vi_end
+                    v_handle.release()
+                    # Empty step for correction epilog
+                    vec0_handle = s0_corr_producer.acquire_and_advance()
+                    vec0_handle.commit()
+                    vec1_handle = s1_corr_producer.acquire_and_advance()
+                    vec1_handle.commit()
+                # End of if not continue_cond
+                # Advance to next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+            # End of persistent scheduler loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Epilogue (TMA store path only)
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.epilogue_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            if cutlass.const_expr(self.use_tma_store):
+                while work_tile.is_valid_tile:
+                    curr_block_coord = work_tile.tile_idx
+                    batch_coord = curr_block_coord[2][1]
+                    continue_cond = False
+                    cuseqlen_q = Int32(0)
+                    seqlen_q = mQ_qdl.shape[0]
+
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        cuseqlen_q = cum_seqlen_q[batch_coord]
+                        seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                        continue_cond = (
+                            not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                                self.cta_tiler[0],
+                                curr_block_coord[0],
+                                seqlen_q,
+                            )
+                        )
+                    if not continue_cond:
+                        mO_qdl_ = mO_qdl
+                        if cutlass.const_expr(cum_seqlen_q is not None):
+                            mO_qdl_ = cute.domain_offset(
+                                (cum_seqlen_q[batch_coord], 0, ((0, 0), 0)), mO_qdl
+                            )
+
+                        o0_coord = 2 * curr_block_coord[0]
+                        o1_coord = o0_coord + 1
+                        gO_qdl = cute.flat_divide(
+                            mO_qdl_, cute.select(self.pv_mma_tiler, mode=[0, 1])
+                        )
+                        gO = gO_qdl[None, None, None, 0, curr_block_coord[2]]
+                        tOsO, tOgO = cute.nvgpu.cpasync.tma_partition(
+                            tma_atom_o,
+                            0,
+                            cute.make_layout(1),
+                            cute.group_modes(sO, 0, 2),
+                            cute.group_modes(gO, 0, 2),
+                        )
+
+                        # O0 O1 using the same pipeline
+                        # wait from corr, issue tma store on smem
+                        # O0
+                        # 1. Wait for O0 final
+                        o0_handle = corr_epi_consumer.wait_and_advance()
+                        # 2. Copy O0 to gmem
+                        cute.copy(tma_atom_o, tOsO[None, 0], tOgO[None, o0_coord])
+                        cute.arch.cp_async_bulk_commit_group()
+                        # O1
+                        # 1. Wait for O1 final
+                        o1_handle = corr_epi_consumer.wait_and_advance()
+                        # 2. Copy O1 to gmem
+                        cute.copy(tma_atom_o, tOsO[None, 1], tOgO[None, o1_coord])
+                        cute.arch.cp_async_bulk_commit_group()
+
+                        # Ensure O0 buffer is ready to be released
+                        cute.arch.cp_async_bulk_wait_group(1, read=True)
+                        o0_handle.release()
+                        # Ensure O1 buffer is ready to be released
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
+                        o1_handle.release()
+
+                    # Advance to next tile
+                    tile_sched.advance_to_next_work()
+                    work_tile = tile_sched.get_current_work()
+                cute.arch.griddepcontrol_launch_dependents()
+            # End of persistent scheduler loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Softmax0
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx < self.softmax1_warp_ids[0]:
+            cute.arch.setmaxregister_increase(self.num_regs_softmax)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
+                self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            softmax_fn(
+                stage=0,
+                tensor_args=(
+                    tStS,
+                    tStS0,
+                    cum_seqlen_k,
+                    cum_seqlen_q,
+                    s0_warp_wants_skip_softmax_exchange,
+                    skip_softmax_count,
+                    total_softmax_count,
+                ),
+                pipeline_args=(mma_s0_consumer, s0_corr_producer, p0_mma_producer),
+                inplace_args=(s0_p1_inplace_producer, s1_p0_inplace_consumer),
+            )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Softmax1
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx < self.correction_warp_ids[0] and warp_idx >= self.softmax1_warp_ids[0]:
+            cute.arch.setmaxregister_increase(self.num_regs_softmax)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
+                self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            softmax_fn(
+                stage=1,
+                tensor_args=(
+                    tStS,
+                    tStS1,
+                    cum_seqlen_k,
+                    cum_seqlen_q,
+                    s1_warp_wants_skip_softmax_exchange,
+                    skip_softmax_count,
+                    total_softmax_count,
+                ),
+                pipeline_args=(mma_s1_consumer, s1_corr_producer, p1_mma_producer),
+                inplace_args=(s1_p0_inplace_producer, s0_p1_inplace_consumer),
+            )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Correction
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx >= self.correction_warp_ids[0] and warp_idx < self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_correction)
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
+                self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            cS = cute.make_identity_tensor((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+            tScS = qk_thr_mma.partition_C(cS)
+
+            tStS_vec_layout = cute.composition(tStS.layout, cute.make_layout((128, 2)))
+
+            tStS_vec0 = cute.make_tensor(tStS.iterator + self.tmem_vec0_offset, tStS_vec_layout)
+            tStS_vec1 = cute.make_tensor(tStS.iterator + self.tmem_vec1_offset, tStS_vec_layout)
+
+            tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
+            tScS_vec = cute.make_tensor(tScS.iterator, tScS_vec_layout)
+            tmem_load_v_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(2)),
+                self.qk_acc_dtype,
+            )
+            tiled_tmem_load_vec = tcgen05.make_tmem_copy(tmem_load_v_atom, tStS_vec0)
+            thread_idx = tidx % (self.threads_per_warp * len(self.correction_warp_ids))
+            thr_tmem_load_vec = tiled_tmem_load_vec.get_slice(thread_idx)
+            tTMEM_LOAD_VECtS0 = thr_tmem_load_vec.partition_S(tStS_vec0)
+            tTMEM_LOAD_VECtS1 = thr_tmem_load_vec.partition_S(tStS_vec1)
+            tTMEM_LOAD_VECcS = thr_tmem_load_vec.partition_D(tScS_vec)
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                batch_coord = curr_block_coord[2][1]
+                seqlen_k = mK_kdl.shape[0]
+                row_idx = Int32(0)
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+                if not continue_cond:
+                    row_idx = curr_block_coord[0] * self.cta_tiler[0] + tTMEM_LOAD_VECcS[0][0]
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    continue_cond = seqlen_k <= 0
+                if not continue_cond:
+                    # Ignore first signal from softmax as no correction is required
+                    vec0_handle = s0_corr_consumer.wait_and_advance()
+                    vec0_handle.release()
+                    vec1_handle = s1_corr_consumer.wait_and_advance()
+                    vec1_handle.release()
+                    # O0/O1 share the same mma_corr consumer state, so the Oi
+                    # peek token rolls from O0 -> O1 -> next O0. Seed with a
+                    # blocking token; the rescale helper refreshes it near the
+                    # end of each iteration.
+                    oi_peek_status = cutlass.Boolean(False)
+                    seqlen_kv_loop_steps = fmha_utils.FusedMask.get_trip_count(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    for i in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Rescale O0
+                        (
+                            (s0_corr_consumer, mma_corr_consumer),
+                            oi_peek_status,
+                        ) = self.correction_rescale(
+                            pv_thr_mma,
+                            tiled_tmem_load_vec,
+                            scale_softmax_log2,
+                            (tOtO0, tTMEM_LOAD_VECtS0, tTMEM_LOAD_VECcS),
+                            (s0_corr_consumer, mma_corr_consumer),
+                            oi_peek_status,
+                        )
+                        # Rescale O1
+                        (
+                            (s1_corr_consumer, mma_corr_consumer),
+                            oi_peek_status,
+                        ) = self.correction_rescale(
+                            pv_thr_mma,
+                            tiled_tmem_load_vec,
+                            scale_softmax_log2,
+                            (tOtO1, tTMEM_LOAD_VECtS1, tTMEM_LOAD_VECcS),
+                            (s1_corr_consumer, mma_corr_consumer),
+                            oi_peek_status,
+                        )
+                    # End of seqlen_corr_loop_steps
+                    value_args = (
+                        cuseqlen_q,
+                        seqlen_q,
+                        curr_block_coord,
+                        scale_softmax,
+                        scale_output,
+                    )
+                    if cutlass.const_expr(self.use_tma_store):
+                        # TMA store path: write to sO, signal epilogue warp
+                        # Normalize O0
+                        s0_corr_consumer, mma_corr_consumer, corr_epi_producer = (
+                            self.correction_epilog(
+                                pv_thr_mma,
+                                tiled_tmem_load_vec,
+                                (
+                                    tOtO0,
+                                    tTMEM_LOAD_VECtS0,
+                                    tTMEM_LOAD_VECcS,
+                                    sO[None, None, 0],
+                                    mLSE,
+                                    mSink,
+                                ),
+                                (
+                                    s0_corr_consumer,
+                                    mma_corr_consumer,
+                                    corr_epi_producer,
+                                ),
+                                (row_idx, *value_args),
+                            )
+                        )
+                        row_idx += self.qk_mma_tiler[0]
+                        # Normalize O1
+                        s1_corr_consumer, mma_corr_consumer, corr_epi_producer = (
+                            self.correction_epilog(
+                                pv_thr_mma,
+                                tiled_tmem_load_vec,
+                                (
+                                    tOtO1,
+                                    tTMEM_LOAD_VECtS1,
+                                    tTMEM_LOAD_VECcS,
+                                    sO[None, None, 1],
+                                    mLSE,
+                                    mSink,
+                                ),
+                                (
+                                    s1_corr_consumer,
+                                    mma_corr_consumer,
+                                    corr_epi_producer,
+                                ),
+                                (row_idx, *value_args),
+                            )
+                        )
+                    else:
+                        # st.global path: store directly to global memory
+                        block_offset_o = Int32(0)
+                        if cutlass.const_expr(cum_seqlen_q is not None):
+                            block_offset_o = cum_seqlen_q[batch_coord]
+                        mO_ = cute.make_tensor(
+                            mO.iterator + block_offset_o * mO.stride[0],
+                            cute.make_layout(
+                                (seqlen_q, mO.shape[1], mO.shape[2]),
+                                stride=mO.stride,
+                            ),
+                        )
+                        o0_coord = 2 * curr_block_coord[0]
+                        o1_coord = o0_coord + 1
+                        gO_stg = cute.local_tile(
+                            mO_,
+                            (self.pv_mma_tiler[0], self.pv_mma_tiler[1]),
+                            (None, None, None),
+                        )
+                        gO0 = gO_stg[None, None, o0_coord, 0, curr_block_coord[2]]
+                        gO1 = gO_stg[None, None, o1_coord, 0, curr_block_coord[2]]
+                        # Normalize O0 and store to global memory
+                        s0_corr_consumer, mma_corr_consumer = self.correction_epilog(
+                            pv_thr_mma,
+                            tiled_tmem_load_vec,
+                            (
+                                tOtO0,
+                                tTMEM_LOAD_VECtS0,
+                                tTMEM_LOAD_VECcS,
+                                gO0,
+                                mLSE,
+                                mSink,
+                            ),
+                            (s0_corr_consumer, mma_corr_consumer),
+                            (row_idx, *value_args),
+                        )
+                        row_idx += self.qk_mma_tiler[0]
+                        # Normalize O1 and st.global to global memory
+                        s1_corr_consumer, mma_corr_consumer = self.correction_epilog(
+                            pv_thr_mma,
+                            tiled_tmem_load_vec,
+                            (
+                                tOtO1,
+                                tTMEM_LOAD_VECtS1,
+                                tTMEM_LOAD_VECcS,
+                                gO1,
+                                mLSE,
+                                mSink,
+                            ),
+                            (s1_corr_consumer, mma_corr_consumer),
+                            (row_idx, *value_args),
+                        )
+                # End of if not continue_cond
+                # Advance to next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+            if cutlass.const_expr(not self.use_tma_store):
+                cute.arch.griddepcontrol_launch_dependents()
+            # End of persistent scheduler loop
+            tmem.relinquish_alloc_permit()
+            # Synchronize before TMEM dealloc (done by the caller)
+            self.tmem_dealloc_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+        return
+
+    @cute.jit
+    def kv_producer_update_tx_acquire_and_advance(
+        self, tma_producer, empty_mbar_ptr, full_mbar_ptr, tx_bytes
+    ):
+        # This utility function is a special version of tma_producer.acquire_and_advance().
+        # This is used to customize the tx bytes which is different from
+        # the initialized tx bytes of tma_producer.
+        state = tma_producer._PipelineProducer__state.clone()
+        cute.arch.mbarrier_wait(empty_mbar_ptr + state.index, state.phase)
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_arrive_and_expect_tx(
+                full_mbar_ptr + state.index,
+                tx_bytes,
+            )
+        tma_producer.advance()
+        return state, tma_producer
+
+    @cute.jit
+    def get_skip_softmax_flag(self, tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v):
+        cute.copy(tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v)
+        tTMEM_LOADrS_v_i32 = cute.recast_tensor(tTMEM_LOADrS_v, dtype=cutlass.Int32)
+        skip_softmax_flag = cute.arch.make_warp_uniform(tTMEM_LOADrS_v_i32[0])
+        return skip_softmax_flag
+
+    @cute.jit
+    def mma_qk(
+        self,
+        tiled_mma: cute.TiledMma,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        pipeline_tokens: Tuple = (None, None),
+    ) -> Tuple[pipeline.PipelineProducer, pipeline.PipelineProducer]:
+        """Perform a single step of the QK GEMM computation on a block of attention scores.
+
+        :param tiled_mma: Tiled MMA for QK GEMM
+        :type tiled_mma: cute.TiledMma
+        :param tensor_args: Tuple containing Qi, K, and Si
+        :type tensor_args: Tuple
+        :param pipeline_args: Tuple containing mma_si_producer and si_corr_producer
+        :type pipeline_args: Tuple
+        :param pipeline_tokens: Optional non-blocking peek tokens for the Si and
+            vec_i producers, in the form ``(si_peek_status, veci_peek_status)``.
+            ``None`` for either token falls back to a blocking acquire.
+        :type pipeline_tokens: Tuple
+        :return: Tuple containing mma_si_producer and si_corr_producer
+        :rtype: Tuple[pipeline.PipelineProducer, pipeline.PipelineProducer]
+        """
+        tSrQi, tSrK, tStSi = tensor_args
+        mma_si_producer, si_corr_producer = pipeline_args
+        si_peek_status, veci_peek_status = pipeline_tokens
+        # 0. Make sure Qi & K are ready when calling mma_qk
+        # 1. acquire S0
+        si_handle = mma_si_producer.acquire_and_advance(si_peek_status)
+        # 2. make sure vec is already released in corr
+        veci_handle = si_corr_producer.acquire_and_advance(veci_peek_status)
+        veci_handle.commit()
+        # 3. gemm
+        num_kphases = cute.size(tSrQi, mode=[2])
+        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+            kphase_coord = (None, None, kphase_idx)
+            tiled_mma.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+            cute.gemm(
+                tiled_mma,
+                tStSi,
+                tSrQi[kphase_coord],
+                tSrK[kphase_coord],
+                tStSi,
+            )
+        # 4. release S0
+        si_handle.commit()
+        return mma_si_producer, si_corr_producer
+
+    @cute.jit
+    def mma_pv(
+        self,
+        tiled_mma: cute.TiledMma,
+        whether_acc: bool,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        skip_pv_args: Tuple,
+    ) -> Tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Perform a single step of the PV GEMM computation on accumulating O.
+
+        :param tiled_mma: Tiled MMA for PV GEMM
+        :type tiled_mma: cute.TiledMma
+        :param whether_acc: Whether to accumulate O
+        :type whether_acc: bool
+        :param tensor_args: Tuple containing Pi, Vi, and Oi
+        :type tensor_args: Tuple
+        :param pipeline_args: Tuple containing mma_corr_producer and pi_mma_consumer
+        :type pipeline_args: Tuple
+        :param skip_pv_args: Tuple containing enable_skip_softmax, tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v
+        :type skip_pv_args: Tuple
+        :return: Tuple containing mma_corr_producer and pi_mma_consumer
+        :rtype: Tuple[pipeline.PipelineProducer, pipeline.PipelineConsumer]
+        """
+        tOrPi, tOrVi, tOtOi = tensor_args
+        mma_corr_producer, pi_mma_consumer = pipeline_args
+        enable_skip_softmax, tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v = skip_pv_args
+        # 0. Make sure Vi is ready when calling mma_pv
+        # 1. acquire Oi
+        oi_handle = mma_corr_producer.acquire_and_advance()
+        # 2. wait for Pi
+        pi_handle = pi_mma_consumer.wait_and_advance()
+        # 3. gemm
+        num_kphases = cute.size(tOrPi, mode=[2])
+        if cutlass.const_expr(enable_skip_softmax):
+            skip_pv = self.get_skip_softmax_flag(tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v)
+            if not skip_pv:
+                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                    kphase_coord = (None, None, kphase_idx)
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, whether_acc or kphase_idx != 0)
+                    cute.gemm(
+                        tiled_mma,
+                        tOtOi,
+                        tOrPi[kphase_coord],
+                        tOrVi[kphase_coord],
+                        tOtOi,
+                    )
+        else:
+            for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                kphase_coord = (None, None, kphase_idx)
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, whether_acc or kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma,
+                    tOtOi,
+                    tOrPi[kphase_coord],
+                    tOrVi[kphase_coord],
+                    tOtOi,
+                )
+        # 4. commit Pi
+        pi_handle.release()
+        # 5. commit Oi
+        oi_handle.commit()
+        return mma_corr_producer, pi_mma_consumer
+
+    @cute.jit
+    def calculate_skip_softmax_flag(
+        self,
+        row_max,
+        tile_row_max,
+        scale_softmax_log2,
+        skip_softmax_threshold_log2,
+        seqlen_q,
+        thread_idx,
+        logical_offset,
+        warp_wants_skip_softmax_exchange,
+        stage,
+        skip_softmax_count,
+        total_softmax_count,
+    ) -> Tuple[bool, float]:
+        """Calculate the skip softmax flag and the row maximum.
+
+        :param row_max: The row maximum.
+        :type row_max: float
+        :param tile_row_max: The tile row maximum.
+        :type tile_row_max: float
+        :param scale_softmax_log2: The scale softmax log2.
+        :type scale_softmax_log2: float
+        :param skip_softmax_threshold_log2: The skip softmax threshold log2.
+        :type skip_softmax_threshold_log2: float
+        :param seqlen_q: The sequence length q.
+        :type seqlen_q: int
+        :param thread_idx: The thread index.
+        :type thread_idx: int
+        :param logical_offset: The logical offset.
+        :type logical_offset: Tuple[int, int]
+        :param warp_wants_skip_softmax_exchange: The warp wants skip softmax exchange.
+        :type warp_wants_skip_softmax_exchange: cute.Tensor
+        :param stage: The stage.
+        :type stage: int
+        :param skip_softmax_count: The skip softmax count.
+        :type skip_softmax_count: cute.Tensor
+        :param total_softmax_count: The total softmax count.
+        :type total_softmax_count: cute.Tensor
+        :return: Tuple containing the skip softmax flag and the row maximum.
+        :rtype: Tuple[bool, float]
+        """
+        thread_wants_skip = (
+            tile_row_max * scale_softmax_log2 - row_max * scale_softmax_log2
+        ) < skip_softmax_threshold_log2
+        thread_wants_skip = thread_wants_skip or ((logical_offset[0] + thread_idx) >= seqlen_q)
+        warp_wants_skip = cute.arch.vote_all_sync(thread_wants_skip)
+
+        with cute.arch.elect_one():
+            warp_wants_skip_softmax_exchange[cute.arch.warp_idx() % 4] = warp_wants_skip
+        softmax_barrier = self.s0_warpgroup_barrier if stage == 0 else self.s1_warpgroup_barrier
+        softmax_barrier.arrive_and_wait()
+        warp_wants_skip_softmax_exchange_i32 = cute.make_tensor(
+            cute.recast_ptr(warp_wants_skip_softmax_exchange.iterator, dtype=cutlass.Int32),
+            cute.make_layout((1,)),
+        )
+        skip_softmax = cute.arch.popc(warp_wants_skip_softmax_exchange_i32[0]) == 4
+
+        if not skip_softmax:
+            row_max = max(row_max, tile_row_max)
+
+        if cutlass.const_expr(skip_softmax_count is not None):
+            if thread_idx == 0:
+                if skip_softmax:
+                    cute.arch.atomic_add(skip_softmax_count.iterator.llvm_ptr, Int32(1))
+                cute.arch.atomic_add(total_softmax_count.iterator.llvm_ptr, Int32(1))
+        return skip_softmax, row_max
+
+    @cute.jit
+    def apply_exp_and_cvt(
+        self,
+        tTMEM_LOADrS,
+        tTMEM_LOADrS_cvt,
+        tTMEM_STORErS_x4_e_cvt,
+        stage,
+        scale,
+        minus_row_max_scale,
+        local_row_sum,
+        inplace_consumer,
+        EXP2_EMULATION_OFFSET,
+        EXP2_EMULATION_COUNT,
+        CVT_COUNT,
+        CVT_PER_STEP,
+        FMA_COUNT,
+        ARV_COUNT,
+    ):
+        """Apply the exp and conversion to the P data type on fragment.
+
+        :param tTMEM_LOADrS: The tTMEM_LOADrS tensor.
+        :type tTMEM_LOADrS: cute.Tensor
+        :param tTMEM_LOADrS_cvt: The tTMEM_LOADrS_cvt tensor.
+        :type tTMEM_LOADrS_cvt: cute.Tensor
+        :param tTMEM_STORErS_x4_e_cvt: The tTMEM_STORErS_x4_e_cvt tensor.
+        :type tTMEM_STORErS_x4_e_cvt: cute.Tensor
+        :param stage: The stage.
+        :type stage: int
+        :param scale: The scale.
+        :type scale: float
+        :param minus_row_max_scale: The minus row maximum scale.
+        :type minus_row_max_scale: float
+        :param local_row_sum: The local row sum.
+        :type local_row_sum: float
+        :param inplace_consumer: The inplace consumer.
+        :type inplace_consumer: cute.Tensor
+        :param EXP2_EMULATION_OFFSET: The exp2 emulation offset.
+        :type EXP2_EMULATION_OFFSET: int
+        :param EXP2_EMULATION_COUNT: The exp2 emulation count.
+        :type EXP2_EMULATION_COUNT: int
+        :param CVT_COUNT: The cvt count.
+        :type CVT_COUNT: int
+        :param CVT_PER_STEP: The cvt per step.
+        :type CVT_PER_STEP: int
+        :param FMA_COUNT: The fma count.
+        :type FMA_COUNT: int
+        :param ARV_COUNT: The arv count.
+        :type ARV_COUNT: int
+        :return: The local row sum and the inplace consumer.
+        :rtype: Tuple[float, cute.Tensor]
+        """
+        for i in cutlass.range_constexpr(0, EXP2_EMULATION_OFFSET, 2):
+            if cutlass.const_expr(i >= CVT_COUNT):
+                if cutlass.const_expr(i % CVT_PER_STEP == 0):
+                    if cutlass.const_expr(self.v_dtype.width == 8):
+                        fmha_utils.cvt_f32x4_to_f8x4(
+                            tTMEM_LOADrS_cvt[None, (i - CVT_COUNT) // CVT_PER_STEP],
+                            tTMEM_STORErS_x4_e_cvt[None, (i - CVT_COUNT) // CVT_PER_STEP],
+                        )
+                    else:
+                        s_vec = tTMEM_LOADrS_cvt[None, (i - CVT_COUNT) // CVT_PER_STEP].load()
+                        tTMEM_STORErS_x4_e_cvt[None, (i - CVT_COUNT) // CVT_PER_STEP].store(
+                            s_vec.to(self.v_dtype)
+                        )
+                local_row_sum = cute.arch.add_packed_f32x2(
+                    local_row_sum,
+                    (
+                        tTMEM_LOADrS[i - CVT_COUNT],
+                        tTMEM_LOADrS[i - CVT_COUNT + 1],
+                    ),
+                )
+            tTMEM_LOADrS[i] = cute.math.exp2(tTMEM_LOADrS[i], fastmath=True)
+            if cutlass.const_expr(i + FMA_COUNT < EXP2_EMULATION_OFFSET):
+                (
+                    tTMEM_LOADrS[i + FMA_COUNT],
+                    tTMEM_LOADrS[i + FMA_COUNT + 1],
+                ) = cute.arch.fma_packed_f32x2(
+                    (
+                        tTMEM_LOADrS[i + FMA_COUNT],
+                        tTMEM_LOADrS[i + FMA_COUNT + 1],
+                    ),
+                    (scale, scale),
+                    (minus_row_max_scale, minus_row_max_scale),
+                )
+            tTMEM_LOADrS[i + 1] = cute.math.exp2(tTMEM_LOADrS[i + 1], fastmath=True)
+            if cutlass.const_expr(i == EXP2_EMULATION_OFFSET - ARV_COUNT):
+                if cutlass.const_expr(self.enable_sequence_barrier):
+                    if cutlass.const_expr(stage == 0):
+                        self.sequence_s1_s0_barrier.arrive()
+                    else:
+                        self.sequence_s0_s1_barrier.arrive()
+
+        # The remaining conversion steps
+        for i in cutlass.range_constexpr(
+            EXP2_EMULATION_OFFSET - CVT_COUNT,
+            EXP2_EMULATION_OFFSET,
+            2,
+        ):
+            if cutlass.const_expr(i % CVT_PER_STEP == 0):
+                if cutlass.const_expr(self.v_dtype.width == 8):
+                    fmha_utils.cvt_f32x4_to_f8x4(
+                        tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP],
+                        tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP],
+                    )
+                else:
+                    s_vec = tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP].load()
+                    tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP].store(s_vec.to(self.v_dtype))
+            local_row_sum = cute.arch.add_packed_f32x2(
+                local_row_sum, (tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1])
+            )
+        for i in cutlass.range_constexpr(
+            EXP2_EMULATION_OFFSET, EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT // 2, 2
+        ):
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = cute.arch.fma_packed_f32x2(
+                (tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]),
+                (scale, scale),
+                (minus_row_max_scale, minus_row_max_scale),
+            )
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = fmha_utils.ex2_emulation_packed_f32x2(
+                tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]
+            )
+            if cutlass.const_expr((i + 2) % CVT_PER_STEP == 0):
+                if cutlass.const_expr(self.v_dtype.width == 8):
+                    fmha_utils.cvt_f32x4_to_f8x4(
+                        tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP],
+                        tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP],
+                    )
+                else:
+                    s_vec = tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP].load()
+                    tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP].store(s_vec.to(self.v_dtype))
+
+        inplace_peek_status = inplace_consumer.try_wait()
+        for i in cutlass.range_constexpr(
+            EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT // 2,
+            EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT,
+            2,
+        ):
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = cute.arch.fma_packed_f32x2(
+                (tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]),
+                (scale, scale),
+                (minus_row_max_scale, minus_row_max_scale),
+            )
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = fmha_utils.ex2_emulation_packed_f32x2(
+                tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]
+            )
+            if cutlass.const_expr((i + 2) % CVT_PER_STEP == 0):
+                if cutlass.const_expr(self.v_dtype.width == 8):
+                    fmha_utils.cvt_f32x4_to_f8x4(
+                        tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP],
+                        tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP],
+                    )
+                else:
+                    s_vec = tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP].load()
+                    tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP].store(s_vec.to(self.v_dtype))
+        inplace_consumer.wait_and_advance(inplace_peek_status)
+        return local_row_sum, inplace_consumer
+
+    @cute.jit
+    def softmax_step(
+        self,
+        stage: int,
+        whether_apply_mask: bool,
+        iter_args: Tuple,
+        stats_args: Tuple,
+        pipeline_args: Tuple,
+        value_args: Tuple,
+        atom_args: Tuple,
+        tensor_args: Tuple,
+    ) -> Tuple[Tuple, Tuple]:
+        """Perform a single step of the softmax computation on a block of attention scores.
+
+        This method processes one block of the attention matrix, computing numerically stable
+        softmax by first finding the row maximum, subtracting it from all elements, applying
+        exponential function, and then normalizing by the sum of exponentials. It also handles
+        optional masking of attention scores.
+
+        The method involves several key operations:
+        1. Loading attention scores from tensor memory
+        2. Applying optional masking based on position
+        3. Computing row-wise maximum values for numerical stability
+        4. Transforming scores using exp2(x*scale - max*scale)
+        5. Computing row sums for normalization
+        6. Coordinating pipeline synchronization between different processing stages
+
+        :param stage: Processing stage (0 for first half, 1 for second half)
+        :type stage: int
+        :param whether_apply_mask: Whether to apply attention masking
+        :type whether_apply_mask: bool
+        :param iter_args: Tuple containing the counting tensor, row_max, row_sum, and vector buffer's handle for current iteration
+        :type iter_args: Tuple
+        :param stats_args: Tuple containing row_sum and row_max
+        :type stats_args: Tuple
+        :param pipeline_args: Tuple containing pipeline related arguments for MMA, correction, and sequence synchronization
+        :type pipeline_args: Tuple
+        :param value_args: Tuple containing seqlen_k, seqlen_q, and scale_softmax_log2
+        :type value_args: Tuple
+        :param atom_args: Tuple containing mma & copy atoms
+        :type atom_args: Tuple
+        :param tensor_args: Tuple containing softmax related tensors
+        :type tensor_args: Tuple
+        :param fused_mask: Compute trip counts and apply masking for attention blocks
+        :type fused_mask: fmha_utils.FusedMask
+        :return: Updated stats_args and pipeline_args
+        :rtype: Tuple[Tuple, Tuple]
+        """
+        row_sum, row_max = stats_args
+        cS, is_last_iter = iter_args
+        (
+            seqlen_k,
+            seqlen_q,
+            scale_softmax_log2,
+            window_size_left,
+            window_size_right,
+            skip_softmax_threshold_log2,
+            thread_idx,
+            logical_offset,
+        ) = value_args
+        (
+            si_peek_status,
+            mma_si_consumer,
+            si_corr_producer,
+            pi_mma_producer,
+            inplace_producer,
+            inplace_consumer,
+        ) = pipeline_args
+        (
+            qk_thr_mma,
+            tiled_tmem_load,
+            tiled_tmem_store,
+            tiled_tmem_store_vec,
+            thr_tmem_load,
+            thr_tmem_store,
+            thr_tmem_store_vec,
+        ) = atom_args
+        (
+            tTMEM_LOADtS,
+            tTMEM_STORE_VECtS,
+            tTMEM_STORE_SKIP_SOFTMAX,
+            tTMEM_STOREtS_x4,
+            warp_wants_skip_softmax_exchange,
+            skip_softmax_count,
+            total_softmax_count,
+        ) = tensor_args
+        tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.o_dtype.width
+        tScS = qk_thr_mma.partition_C(cS)
+        enable_skip_softmax = skip_softmax_threshold_log2 is not None
+        tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
+        tScS_vec = cute.make_tensor(tScS.iterator, tScS_vec_layout)
+        tScS_P_layout = cute.composition(tScS.layout, cute.make_layout((128, tilePlikeFP32)))
+        tScS_P = cute.make_tensor(tScS.iterator, tScS_P_layout)
+        tTMEM_LOADcS = thr_tmem_load.partition_D(tScS)
+        tTMEM_STORE_VECcS = thr_tmem_store_vec.partition_S(tScS_vec)
+        tTMEM_STOREcS = thr_tmem_store.partition_S(tScS_P)
+        # Wait for Si
+        si_handle = mma_si_consumer.wait_and_advance(si_peek_status)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcS.shape, self.qk_acc_dtype)
+        old_row_max = row_max
+        skip_softmax = cutlass.Boolean(False)
+        if whether_apply_mask:
+            if cutlass.const_expr(self.arch >= Arch.sm_100 and self.arch <= Arch.sm_100f):
+                cute.copy(tiled_tmem_load, tTMEM_LOADtS, tTMEM_LOADrS)
+            else:
+                tTMEM_LOADrMax = cute.make_rmem_tensor(
+                    cute.make_layout((1, cute.size(tTMEM_LOADrS, mode=[1]))),
+                    self.qk_acc_dtype,
+                )
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[1])):
+                    cute.copy_atom_call(
+                        tiled_tmem_load,
+                        tTMEM_LOADtS[None, i, 0, 0],
+                        (tTMEM_LOADrS[None, i, 0, 0], tTMEM_LOADrMax[None, i]),
+                    )
+            fmha_utils.FusedMask.apply_mask(
+                self.mask_type,
+                tTMEM_LOADrS,
+                tTMEM_LOADcS,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            tile_row_max = tTMEM_LOADrS.load().reduce(cute.ReductionOp.MAX, -cutlass.Float32.inf, 0)
+            if cutlass.const_expr(not enable_skip_softmax):
+                row_max = cute.arch.fmax(row_max, tile_row_max)
+            else:
+                skip_softmax, row_max = self.calculate_skip_softmax_flag(
+                    row_max,
+                    tile_row_max,
+                    scale_softmax_log2,
+                    skip_softmax_threshold_log2,
+                    seqlen_q,
+                    thread_idx,
+                    logical_offset,
+                    warp_wants_skip_softmax_exchange,
+                    stage,
+                    skip_softmax_count,
+                    total_softmax_count,
+                )
+            si_handle.release()
+            # S0 -> P1 / S1 -> P0
+            inplace_producer.commit()
+            inplace_producer.advance()
+        else:
+            if cutlass.const_expr(self.arch >= Arch.sm_100 and self.arch <= Arch.sm_100f):
+                cute.copy(
+                    tiled_tmem_load,
+                    tTMEM_LOADtS[None, 0, None, None],
+                    tTMEM_LOADrS[None, 0, None, None],
+                )
+                cute.copy(
+                    tiled_tmem_load,
+                    tTMEM_LOADtS[None, 1, None, None],
+                    tTMEM_LOADrS[None, 1, None, None],
+                )
+                tile_row_max = -cutlass.Float32.inf
+                tile_row_max_ = tile_row_max
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[0]), 4):
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i, 0, 0, 0])
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i + 1, 0, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 0, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 0, 0, 0])
+                cute.copy(
+                    tiled_tmem_load,
+                    tTMEM_LOADtS[None, 2, None, None],
+                    tTMEM_LOADrS[None, 2, None, None],
+                )
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[0]), 4):
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i, 1, 0, 0])
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i + 1, 1, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 1, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 1, 0, 0])
+                cute.copy(
+                    tiled_tmem_load,
+                    tTMEM_LOADtS[None, 3, None, None],
+                    tTMEM_LOADrS[None, 3, None, None],
+                )
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[0]), 4):
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i, 2, 0, 0])
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i + 1, 2, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 2, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 2, 0, 0])
+                cute.arch.fence_view_async_tmem_store()
+                si_handle.release()
+                # S0 -> P1 / S1 -> P0
+                inplace_producer.commit()
+                inplace_producer.advance()
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[0]), 4):
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i, 3, 0, 0])
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i + 1, 3, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 3, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 3, 0, 0])
+                tile_row_max = cute.arch.fmax(tile_row_max, tile_row_max_)
+                if cutlass.const_expr(not enable_skip_softmax):
+                    row_max = cute.arch.fmax(tile_row_max, row_max)
+                else:
+                    skip_softmax, row_max = self.calculate_skip_softmax_flag(
+                        row_max,
+                        tile_row_max,
+                        scale_softmax_log2,
+                        skip_softmax_threshold_log2,
+                        seqlen_q,
+                        thread_idx,
+                        logical_offset,
+                        warp_wants_skip_softmax_exchange,
+                        stage,
+                        skip_softmax_count,
+                        total_softmax_count,
+                    )
+            else:
+                tTMEM_LOADrMax = cute.make_rmem_tensor(
+                    cute.make_layout((1, cute.size(tTMEM_LOADrS, mode=[1]))),
+                    self.qk_acc_dtype,
+                )
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[1])):
+                    cute.copy_atom_call(
+                        tiled_tmem_load,
+                        tTMEM_LOADtS[None, i, 0, 0],
+                        (tTMEM_LOADrS[None, i, 0, 0], tTMEM_LOADrMax[None, i]),
+                    )
+                cute.arch.fence_view_async_tmem_store()
+                tile_row_max = tTMEM_LOADrMax.load().reduce(
+                    cute.ReductionOp.MAX, -cutlass.Float32.inf, 0
+                )
+                if cutlass.const_expr(not enable_skip_softmax):
+                    row_max = cute.arch.fmax(tile_row_max, row_max)
+                else:
+                    skip_softmax, row_max = self.calculate_skip_softmax_flag(
+                        row_max,
+                        tile_row_max,
+                        scale_softmax_log2,
+                        skip_softmax_threshold_log2,
+                        seqlen_q,
+                        thread_idx,
+                        logical_offset,
+                        warp_wants_skip_softmax_exchange,
+                        stage,
+                        skip_softmax_count,
+                        total_softmax_count,
+                    )
+                si_handle.release()
+                # S0 -> P1 / S1 -> P0
+                inplace_producer.commit()
+                inplace_producer.advance()
+
+        row_max_safe = row_max
+        if row_max == -cutlass.Float32.inf:
+            row_max_safe = 0.0
+        if cutlass.const_expr(self.rescale_threshold > 0.0):
+            if (row_max_safe - old_row_max) * scale_softmax_log2 <= self.rescale_threshold:
+                row_max_safe = old_row_max
+        tTMEM_STORE_VECrS = cute.make_rmem_tensor(tTMEM_STORE_VECcS.shape, self.qk_acc_dtype)
+        tTMEM_STORE_VECrS[0] = old_row_max
+        tTMEM_STORE_VECrS[1] = row_max_safe
+        vec_i_peek_status = si_corr_producer.try_acquire()
+        tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.qk_acc_dtype)
+        tTMEM_STORErS_x4_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS_x4.iterator, dtype=self.v_dtype),
+            tTMEM_LOADrS.layout,
+        )
+        scale = scale_softmax_log2
+        minus_row_max_scale = (0.0 - row_max_safe) * scale
+        if cutlass.const_expr(self.v_dtype.width == 8 and self.p_fp8_prescale_log2 > 0):
+            minus_row_max_scale = minus_row_max_scale + self.p_fp8_prescale_log2
+
+        ARV_COUNT = 4
+        FMA_COUNT = 8
+        CVT_COUNT = 8 if self.v_dtype.width == 8 else 4
+        CVT_PER_STEP = 4 if self.v_dtype.width == 8 else 2
+        assert CVT_COUNT % CVT_PER_STEP == 0, (
+            f"CVT_COUNT {CVT_COUNT} must be divisible by CVT_PER_STEP {CVT_PER_STEP}"
+        )
+        tTMEM_LOADrS_cvt = cute.logical_divide(tTMEM_LOADrS, cute.make_layout(CVT_PER_STEP))
+        tTMEM_STORErS_x4_e_cvt = cute.logical_divide(
+            tTMEM_STORErS_x4_e, cute.make_layout(CVT_PER_STEP)
+        )
+        for i in cutlass.range_constexpr(0, FMA_COUNT, 2):
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = cute.arch.fma_packed_f32x2(
+                (tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]),
+                (scale, scale),
+                (minus_row_max_scale, minus_row_max_scale),
+            )
+        vec_i_handle = si_corr_producer.acquire_and_advance(vec_i_peek_status)
+        cute.copy(tiled_tmem_store_vec, tTMEM_STORE_VECrS, tTMEM_STORE_VECtS)
+        cute.arch.fence_view_async_tmem_store()
+        # Notify correction wg that row_max is ready
+        vec_i_handle.commit()
+
+        EXP2_EMULATION_COUNT = 20 if self.enable_ex2_emulation and not whether_apply_mask else 0
+        EXP2_EMULATION_OFFSET = cute.size(tTMEM_LOADrS) - EXP2_EMULATION_COUNT
+        acc_scale_ = scale * (old_row_max - row_max_safe)
+        acc_scale = cute.math.exp2(acc_scale_, fastmath=True) * 0.5
+        if cutlass.const_expr(self.enable_sequence_barrier):
+            if cutlass.const_expr(stage == 0):
+                self.sequence_s0_s1_barrier.arrive_and_wait()
+            else:
+                self.sequence_s1_s0_barrier.arrive_and_wait()
+
+        if cutlass.const_expr(enable_skip_softmax):
+            if not skip_softmax:
+                row_sum *= acc_scale
+                local_row_sum = (row_sum, row_sum)
+                local_row_sum, inplace_consumer = self.apply_exp_and_cvt(
+                    tTMEM_LOADrS,
+                    tTMEM_LOADrS_cvt,
+                    tTMEM_STORErS_x4_e_cvt,
+                    stage,
+                    scale,
+                    minus_row_max_scale,
+                    local_row_sum,
+                    inplace_consumer,
+                    EXP2_EMULATION_OFFSET,
+                    EXP2_EMULATION_COUNT,
+                    CVT_COUNT,
+                    CVT_PER_STEP,
+                    FMA_COUNT,
+                    ARV_COUNT,
+                )
+                tTMEM_STORE_VECrS_i32 = cute.recast_tensor(tTMEM_STORE_VECrS, dtype=cutlass.Int32)
+                tTMEM_STORE_VECrS_i32[0] = 0
+                pi_handle = pi_mma_producer.acquire_and_advance()
+                # store skip softmax flag
+                cute.copy(
+                    tiled_tmem_store_vec,
+                    tTMEM_STORE_VECrS_i32,
+                    tTMEM_STORE_SKIP_SOFTMAX,
+                )
+                # store P
+                cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
+                cute.arch.fence_view_async_tmem_store()
+                pi_handle.commit()
+                for j in cutlass.range_constexpr(
+                    EXP2_EMULATION_OFFSET,
+                    EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT,
+                    2,
+                ):
+                    local_row_sum = cute.arch.add_packed_f32x2(
+                        (tTMEM_LOADrS[j], tTMEM_LOADrS[j + 1]),
+                        local_row_sum,
+                    )
+                row_sum = local_row_sum[0] + local_row_sum[1]
+                cute.arch.fence_view_async_tmem_store()
+            else:
+                if cutlass.const_expr(self.enable_sequence_barrier):
+                    if cutlass.const_expr(stage == 0):
+                        self.sequence_s1_s0_barrier.arrive()
+                    else:
+                        self.sequence_s0_s1_barrier.arrive()
+                inplace_peek_status = inplace_consumer.try_wait()
+                inplace_consumer.wait_and_advance(inplace_peek_status)
+                tTMEM_STORE_VECrS_i32 = cute.recast_tensor(tTMEM_STORE_VECrS, dtype=cutlass.Int32)
+                tTMEM_STORE_VECrS_i32[0] = 1
+                pi_handle = pi_mma_producer.acquire_and_advance()
+                # store skip softmax flag
+                cute.copy(
+                    tiled_tmem_store_vec,
+                    tTMEM_STORE_VECrS_i32,
+                    tTMEM_STORE_SKIP_SOFTMAX,
+                )
+                cute.arch.fence_view_async_tmem_store()
+                pi_handle.commit()
+        else:
+            row_sum *= acc_scale
+            local_row_sum = (row_sum, row_sum)
+            local_row_sum, inplace_consumer = self.apply_exp_and_cvt(
+                tTMEM_LOADrS,
+                tTMEM_LOADrS_cvt,
+                tTMEM_STORErS_x4_e_cvt,
+                stage,
+                scale,
+                minus_row_max_scale,
+                local_row_sum,
+                inplace_consumer,
+                EXP2_EMULATION_OFFSET,
+                EXP2_EMULATION_COUNT,
+                CVT_COUNT,
+                CVT_PER_STEP,
+                FMA_COUNT,
+                ARV_COUNT,
+            )
+            pi_handle = pi_mma_producer.acquire_and_advance()
+            # store P
+            cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
+            cute.arch.fence_view_async_tmem_store()
+            for j in cutlass.range_constexpr(
+                EXP2_EMULATION_OFFSET,
+                EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT,
+                2,
+            ):
+                local_row_sum = cute.arch.add_packed_f32x2(
+                    (tTMEM_LOADrS[j], tTMEM_LOADrS[j + 1]),
+                    local_row_sum,
+                )
+            row_sum = local_row_sum[0] + local_row_sum[1]
+            cute.arch.fence_view_async_tmem_store()
+            # Notify tensor core warp that softmax(S->P) is ready
+            pi_handle.commit()
+        if not is_last_iter:
+            si_peek_status = mma_si_consumer.try_wait()
+
+        stats_args = (row_sum, row_max_safe)
+        pipeline_args = (
+            si_peek_status,
+            mma_si_consumer,
+            si_corr_producer,
+            pi_mma_producer,
+            inplace_producer,
+            inplace_consumer,
+        )
+        return stats_args, pipeline_args
+
+    # For both softmax0 and softmax1 warp group
+    @cute.jit
+    def softmax(
+        self,
+        stage: int,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        inplace_args: Tuple,
+        qk_thr_mma: cute.ThrMma,
+        value_args: Tuple,
+        mask_args: Tuple,
+        sched_args: Tuple,
+    ):
+        """Compute softmax on attention scores from QK matrix multiplication.
+
+        This method handles the softmax computation for either the first or second half of the
+        attention matrix, depending on the 'stage' parameter. It calculates row-wise maximum
+        and sum values needed for stable softmax computation, applies optional masking, and
+        transforms raw attention scores into probability distributions.
+
+        The implementation uses specialized memory access patterns and efficient math operations
+        for computing exp(x) using exp2 functions. It also coordinates pipeline
+        synchronization between MMA, correction, and sequence processing stages.
+
+        :param stage: Processing stage (0 for first half, 1 for second half of attention matrix)
+        :type stage: int
+        :param seqlen_k: Length of the key sequence
+        :type seqlen_k: Int32
+        :param seqlen_q: Length of the query sequence
+        :type seqlen_q: Int32
+        :param cum_seqlen_q: Cumulative sequence lengths for queries
+        :type cum_seqlen_q: cute.Tensor | None
+        :param cum_seqlen_k: Cumulative sequence lengths for keys
+        :type cum_seqlen_k: cute.Tensor | None
+        :param scale_softmax_log2: Log2 scale factor for softmax operation
+        :type scale_softmax_log2: Float32
+        :param qk_thr_mma: Thread MMA operation for QK matrix multiplication
+        :type qk_thr_mma: cute.ThrMma
+        :param tStS: Shared tensor for softmax input/output
+        :type tStS: cute.Tensor
+        :param tStSi: Input tensor containing attention scores
+        :type tStSi: cute.Tensor
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param mma_si_consumer: Pipeline for synchronizing with Si tensors
+        :type mma_si_consumer: pipeline.PipelineConsumer
+        :param si_corr_producer: Pipeline for synchronizing with correction operations
+        :type si_corr_producer: pipeline.PipelineProducer
+        :param pi_mma_producer: Pipeline for synchronizing with Pi tensors
+        :type pi_mma_producer: pipeline.PipelineProducer
+        :param tile_sched_params: Parameters for tile scheduling
+        :type tile_sched_params: fmha_utils.FmhaStaticTileSchedulerParams
+        :param fused_mask: Compute trip counts and apply masking for attention blocks
+        :type fused_mask: fmha_utils.FusedMask
+        """
+        (
+            tStS,
+            tStSi,
+            cum_seqlen_k,
+            cum_seqlen_q,
+            warp_wants_skip_softmax_exchange,
+            skip_softmax_count,
+            total_softmax_count,
+        ) = tensor_args
+        mma_si_consumer, si_corr_producer, pi_mma_producer = pipeline_args
+        inplace_producer, inplace_consumer = inplace_args
+        (
+            seqlen_k,
+            seqlen_q,
+            scale_softmax_log2,
+            skip_softmax_threshold_log2,
+        ) = value_args
+        window_size_left, window_size_right = mask_args
+        tile_sched, work_tile = sched_args
+
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.softmax0_warp_ids))
+
+        cS_base = cute.make_identity_tensor((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+        tilePlikeFP32 = self.qk_mma_tiler[1] // 32 * self.o_dtype.width
+        tScS = qk_thr_mma.partition_C(cS_base)
+        tStS_vec_layout = cute.composition(tStS.layout, cute.make_layout((128, 2)))
+        tmem_vec_offset = self.tmem_vec0_offset if stage == 0 else self.tmem_vec1_offset
+        tStS_vec = cute.make_tensor(tStS.iterator + tmem_vec_offset, tStS_vec_layout)
+        tmem_skip_softmax_offset = (
+            self.tmem_skip_softmax0_offset if stage == 0 else self.tmem_skip_softmax1_offset
+        )
+        tStS_skip_softmax = cute.make_tensor(
+            tStS.iterator + tmem_skip_softmax_offset, tStS_vec_layout
+        )
+        tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
+        tScS_vec = cute.make_tensor(tScS.iterator, tScS_vec_layout)
+        tStS_P_layout = cute.composition(tStS.layout, cute.make_layout((128, tilePlikeFP32)))
+        tmem_p_offset = self.tmem_p0_offset if stage == 0 else self.tmem_p1_offset
+        tStS_P = cute.make_tensor(tStS.iterator + tmem_p_offset, tStS_P_layout)
+        if cutlass.const_expr(self.arch >= Arch.sm_100 and self.arch <= Arch.sm_100f):
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                self.qk_acc_dtype,
+            )
+        else:
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.LdRed32x32bOp(
+                    tcgen05.copy.Repetition(32), redOp=tcgen05.TmemLoadRedOp.MAX
+                ),
+                self.qk_acc_dtype,
+            )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStSi)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        tTMEM_LOADtS = thr_tmem_load.partition_S(tStSi)
+        tmem_store_vec_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(2)),
+            self.qk_acc_dtype,
+        )
+        tiled_tmem_store_vec = tcgen05.make_tmem_copy(tmem_store_vec_atom, tStS_vec)
+        thr_tmem_store_vec = tiled_tmem_store_vec.get_slice(thread_idx)
+        tTMEM_STORE_VECtS = thr_tmem_store_vec.partition_D(tStS_vec)
+        tTMEM_STORE_VECcS = thr_tmem_store_vec.partition_S(tScS_vec)
+        tTMEM_STORE_SKIP_SOFTMAX = thr_tmem_store_vec.partition_D(tStS_skip_softmax)
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)),
+            self.qk_acc_dtype,
+        )
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tStS_P)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+        tTMEM_STOREtS_x4 = thr_tmem_store.partition_D(tStS_P)
+        if cutlass.const_expr(self.enable_sequence_barrier):
+            if cutlass.const_expr(stage == 1):
+                self.sequence_s0_s1_barrier.arrive()
+        while work_tile.is_valid_tile:
+            curr_block_coord = work_tile.tile_idx
+            batch_coord = curr_block_coord[2][1]
+            seqlen_k_ = seqlen_k
+            seqlen_q_ = seqlen_q
+            continue_cond = False
+            cuseqlen_q = Int32(0)
+            seqlen_q_ = seqlen_q
+            if cutlass.const_expr(cum_seqlen_q is not None):
+                cuseqlen_q = cum_seqlen_q[batch_coord]
+                seqlen_q_ = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                continue_cond = (
+                    not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.cta_tiler[0],
+                        curr_block_coord[0],
+                        seqlen_q_,
+                    )
+                )
+            if not continue_cond:
+                if cutlass.const_expr(cum_seqlen_k is not None):
+                    cuseqlen_k = cum_seqlen_k[batch_coord]
+                    seqlen_k_ = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                continue_cond = seqlen_k_ <= 0
+            if not continue_cond:
+                logical_offset = (
+                    curr_block_coord[0] * self.cta_tiler[0] + stage * self.qk_mma_tiler[0],
+                    0,
+                )
+                cS = cute.domain_offset(logical_offset, cS_base)
+                value_args_ = (
+                    seqlen_k_,
+                    seqlen_q_,
+                    scale_softmax_log2,
+                    window_size_left,
+                    window_size_right,
+                    skip_softmax_threshold_log2,
+                    thread_idx,
+                    logical_offset,
+                )
+                atom_args = (
+                    qk_thr_mma,
+                    tiled_tmem_load,
+                    tiled_tmem_store,
+                    tiled_tmem_store_vec,
+                    thr_tmem_load,
+                    thr_tmem_store,
+                    thr_tmem_store_vec,
+                )
+                tensor_args_ = (
+                    tTMEM_LOADtS,
+                    tTMEM_STORE_VECtS,
+                    tTMEM_STORE_SKIP_SOFTMAX,
+                    tTMEM_STOREtS_x4,
+                    warp_wants_skip_softmax_exchange,
+                    skip_softmax_count,
+                    total_softmax_count,
+                )
+                st_cnt, end_cnt, ld_mask_cnt, unmask_cnt, tl_mask_cnt = (
+                    fmha_utils.FusedMask.get_masked_info(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q_,
+                        seqlen_k_,
+                        window_size_left,
+                        window_size_right,
+                    )
+                )
+                row_max = -Float32.inf
+                row_sum = 0.0
+                stats_args = (row_sum, row_max)
+
+                def softmax_loop(
+                    whether_apply_mask: bool,
+                    loop_args: Tuple,
+                    stats_args: Tuple,
+                    pipeline_args: Tuple,
+                    inner_fn: Callable,
+                    value_args: Tuple,
+                    atom_args: Tuple,
+                    tensor_args: Tuple,
+                    cS: cute.Tensor,
+                ) -> Tuple[Tuple, Tuple]:
+                    start_index, iter_num, upper_bound = loop_args
+                    for i in cutlass.range(start_index, start_index + iter_num, 1, unroll=1):
+                        cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
+                        iter_args = (cS_iter, i == upper_bound - 1)
+                        stats_args, pipeline_args = inner_fn(
+                            stage,
+                            whether_apply_mask,
+                            iter_args,
+                            stats_args,
+                            pipeline_args,
+                            value_args,
+                            atom_args,
+                            tensor_args,
+                        )
+                    return stats_args, pipeline_args
+
+                softmax_step_fn = self.softmax_step
+                softmax_loop_fn = partial(
+                    softmax_loop,
+                    inner_fn=softmax_step_fn,
+                    value_args=value_args_,
+                    atom_args=atom_args,
+                    tensor_args=tensor_args_,
+                    cS=cS,
+                )
+                si_peek_status = mma_si_consumer.try_wait()
+                if cutlass.const_expr(stage == 1):
+                    inplace_consumer.wait_and_advance()
+                pipeline_args_ = (
+                    si_peek_status,
+                    mma_si_consumer,
+                    si_corr_producer,
+                    pi_mma_producer,
+                    inplace_producer,
+                    inplace_consumer,
+                )
+                # 1. Leading mask loop
+                loop_args = (st_cnt, ld_mask_cnt, end_cnt)
+                stats_args, pipeline_args_ = softmax_loop_fn(
+                    True, loop_args, stats_args, pipeline_args_
+                )
+                # 2. Unmasked loop
+                loop_args = (st_cnt + ld_mask_cnt, unmask_cnt, end_cnt)
+                stats_args, pipeline_args_ = softmax_loop_fn(
+                    False, loop_args, stats_args, pipeline_args_
+                )
+                # 3. Trailing mask loop
+                loop_args = (st_cnt + ld_mask_cnt + unmask_cnt, tl_mask_cnt, end_cnt)
+                stats_args, pipeline_args_ = softmax_loop_fn(
+                    True, loop_args, stats_args, pipeline_args_
+                )
+
+                # Unpack pipeline_args
+                (
+                    _,
+                    mma_si_consumer,
+                    si_corr_producer,
+                    pi_mma_producer,
+                    inplace_producer,
+                    inplace_consumer,
+                ) = pipeline_args_
+                if cutlass.const_expr(stage == 0):
+                    inplace_producer.commit()
+                    inplace_producer.advance()
+                # 4. Copy the final stats for correction epilog
+                tTMEM_STORE_VECrS = cute.make_rmem_tensor(
+                    tTMEM_STORE_VECcS.shape, self.qk_acc_dtype
+                )
+                tTMEM_STORE_VECrS[0] = stats_args[0]
+                tTMEM_STORE_VECrS[1] = stats_args[1]
+                vec_i_handle = si_corr_producer.acquire_and_advance()
+                cute.copy(tiled_tmem_store_vec, tTMEM_STORE_VECrS, tTMEM_STORE_VECtS)
+                cute.arch.fence_view_async_tmem_store()
+                vec_i_handle.commit()
+            # End of if not continue_cond
+            # Advance to next tile
+            tile_sched.advance_to_next_work()
+            work_tile = tile_sched.get_current_work()
+        # End of persistent scheduler loop
+
+    @cute.jit
+    def correction_rescale(
+        self,
+        thr_mma: cute.ThrMma,
+        tiled_tmem_load_vec: cute.TiledCopy,
+        scale_softmax_log2: Float32,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        oi_peek_status=None,
+    ):
+        """Rescale intermediate attention results based on softmax normalization factor.
+
+        This method performs a crucial correction step in the attention computation pipeline.
+        When processing attention in blocks, the softmax normalization factors may change
+        as new blocks are processed. This method rescales previously computed partial
+        output values to account for updated normalization factors.
+
+        The implementation uses efficient tensor memory operations to:
+        1. Load existing partial attention output from tensor memory
+        2. Apply the scaling factor to all elements
+        3. Store the rescaled results back to tensor memory
+
+        When ``self.enable_correction_double_buffer`` is True, the rescale loop
+        runs as a 2-buffer tensor-memory load / multiply / store pipeline.
+
+        :param thr_mma: Thread MMA operation for the computation
+        :type thr_mma: cute.ThrMma
+        :param tiled_tmem_load_vec: Tiled memory load operation for the vectorized row-wise max
+        :type tiled_tmem_load_vec: cute.TiledCopy
+        :param scale_softmax_log2: Log2 of the softmax factor
+        :type scale_softmax_log2: Float32
+        :param tensor_args: Tuple containing the tensors for the correction
+        :type tensor_args: Tuple[cute.Tensor, cute.Tensor, cute.Tensor]
+        :param pipeline_args: Tuple containing the pipeline arguments for the correction
+        :type pipeline_args: Tuple[pipeline.PipelineConsumer, pipeline.PipelineConsumer]
+        :param oi_peek_status: Optional non-blocking token for the Oi consumer
+            wait. ``None`` or ``False`` falls back to a blocking wait.
+        :return: ``((si_corr_consumer, mma_corr_consumer), next_oi_peek_status)``
+            where ``next_oi_peek_status`` is the peek for the next Oi (only
+            refreshed when a rescale actually ran; otherwise stays
+            ``cutlass.Boolean(False)``).
+        """
+        tOtO, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECcS = tensor_args
+        si_corr_consumer, mma_corr_consumer = pipeline_args
+
+        pv_tiled_mma_shape = (
+            self.pv_mma_tiler[0],
+            self.pv_mma_tiler[1],
+        )
+        cO = cute.make_identity_tensor(pv_tiled_mma_shape)
+        tOcO = thr_mma.partition_C(cO)
+        corr_tile_size = 16  # tuneable parameter
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.pv_acc_dtype,
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.pv_acc_dtype,
+        )
+        tOtO_i_layout = cute.composition(tOtO.layout, cute.make_layout((128, corr_tile_size)))
+        tOcO_i_layout = cute.composition(tOcO.layout, cute.make_layout((128, corr_tile_size)))
+        tOtO_i = cute.make_tensor(tOtO.iterator, tOtO_i_layout)
+        tOcO_i = cute.make_tensor(tOcO.iterator, tOcO_i_layout)
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tOtO_i)
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOtO_i)
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.correction_warp_ids))
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(tOcO_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOtO_i)
+        num_tiles = self.cta_tiler[2] // corr_tile_size
+        if cutlass.const_expr(self.enable_correction_double_buffer):
+            # Double buffer: 2 register buffers to pipeline tensor-memory load / multiply / store.
+            tTMrO = cute.make_rmem_tensor((tTMEM_LOADcO.shape, 2), self.pv_acc_dtype)
+            # Rank-matching views for cute.copy (TMEM partitions are rank-3,
+            # raw tTMrO[None, idx] is rank-1; composition restores the rank).
+            copy_layout = cute.make_layout(tTMrO.shape[0])
+            view_0 = tTMrO[None, 0]
+            view_1 = tTMrO[None, 1]
+            tTMrO_copy = (
+                cute.make_tensor(
+                    view_0.iterator,
+                    cute.composition(view_0.layout, copy_layout),
+                ),
+                cute.make_tensor(
+                    view_1.iterator,
+                    cute.composition(view_1.layout, copy_layout),
+                ),
+            )
+        else:
+            tTMrO = cute.make_rmem_tensor((tTMEM_LOADcO.shape, num_tiles), self.pv_acc_dtype)
+        tTMEM_LOAD_VECrS = cute.make_rmem_tensor(tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype)
+        # Wait for vec_i (row_wise current max & previous max)
+        vec_i_handle = si_corr_consumer.wait_and_advance()
+        cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECrS)
+        cute.arch.fence_view_async_tmem_load()
+        vec_i_handle.release()
+        # Wait for Oi (peek-token aware: None/False falls back to blocking).
+        oi_handle = mma_corr_consumer.wait_and_advance(oi_peek_status)
+        next_oi_peek_status = cutlass.Boolean(False)
+        vote_ballot_cnt = cute.arch.vote_ballot_sync(tTMEM_LOAD_VECrS[0] != tTMEM_LOAD_VECrS[1])
+        should_rescale = vote_ballot_cnt != 0
+        if should_rescale:
+            scale_ = scale_softmax_log2 * (tTMEM_LOAD_VECrS[0] - tTMEM_LOAD_VECrS[1])
+            scale = cute.math.exp2(scale_, fastmath=True)
+            if cutlass.const_expr(self.enable_correction_double_buffer):
+                num_elems = cute.size(tTMrO, mode=[0])
+                # Prologue: load first tile into buffer 0
+                cute.copy(tiled_tmem_load, tTMEM_LOADtO, tTMrO_copy[0])
+                # Steady state. Refresh the next Oi probe near the end of the
+                # current rescale pipeline.
+                for i in cutlass.range_constexpr(1, num_tiles):
+                    cute.copy(
+                        tiled_tmem_load,
+                        cute.make_tensor(
+                            tTMEM_LOADtO.iterator + i * corr_tile_size,
+                            tTMEM_LOADtO.layout,
+                        ),
+                        tTMrO_copy[i % 2],
+                    )
+                    for j in range(0, num_elems, 2):
+                        tTMrO[j, (i - 1) % 2], tTMrO[j + 1, (i - 1) % 2] = (
+                            cute.arch.mul_packed_f32x2(
+                                (
+                                    tTMrO[j, (i - 1) % 2],
+                                    tTMrO[j + 1, (i - 1) % 2],
+                                ),
+                                (scale, scale),
+                            )
+                        )
+                    cute.copy(
+                        tiled_tmem_store,
+                        tTMrO_copy[(i - 1) % 2],
+                        cute.make_tensor(
+                            tTMEM_STOREtO.iterator + (i - 1) * corr_tile_size,
+                            tTMEM_STOREtO.layout,
+                        ),
+                    )
+                next_oi_peek_status = mma_corr_consumer.try_wait()
+                # Epilogue: compute and store last tile
+                last = (num_tiles - 1) % 2
+                for j in range(0, num_elems, 2):
+                    tTMrO[j, last], tTMrO[j + 1, last] = cute.arch.mul_packed_f32x2(
+                        (tTMrO[j, last], tTMrO[j + 1, last]),
+                        (scale, scale),
+                    )
+                cute.copy(
+                    tiled_tmem_store,
+                    tTMrO_copy[last],
+                    cute.make_tensor(
+                        tTMEM_STOREtO.iterator + (num_tiles - 1) * corr_tile_size,
+                        tTMEM_STOREtO.layout,
+                    ),
+                )
+            else:
+                for i in cutlass.range_constexpr(0, num_tiles):
+                    tTMrO_i_ = tTMrO[None, i]
+                    tTMrO_i = cute.make_tensor(
+                        tTMrO_i_.iterator,
+                        cute.composition(tTMrO_i_.layout, cute.make_layout(tTMrO.shape[0])),
+                    )
+                    cute.copy(
+                        tiled_tmem_load,
+                        cute.make_tensor(
+                            tTMEM_LOADtO.iterator + i * corr_tile_size,
+                            tTMEM_LOADtO.layout,
+                        ),
+                        tTMrO_i,
+                    )
+                    for j in range(0, cute.size(tTMrO_i), 2):
+                        tTMrO_i[j], tTMrO_i[j + 1] = cute.arch.mul_packed_f32x2(
+                            (tTMrO_i[j], tTMrO_i[j + 1]),
+                            (scale, scale),
+                        )
+                    cute.copy(
+                        tiled_tmem_store,
+                        tTMrO_i,
+                        cute.make_tensor(
+                            tTMEM_STOREtO.iterator + i * corr_tile_size,
+                            tTMEM_STOREtO.layout,
+                        ),
+                    )
+                next_oi_peek_status = mma_corr_consumer.try_wait()
+        # Release Oi
+        cute.arch.fence_view_async_tmem_store()
+        oi_handle.release()
+        return (si_corr_consumer, mma_corr_consumer), next_oi_peek_status
+
+    @cute.jit
+    def correction_epilog(
+        self,
+        thr_mma: cute.ThrMma,
+        tiled_tmem_load_vec: cute.TiledCopy,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        value_args: Tuple,
+    ):
+        """Apply final scaling and transformation to attention output.
+
+        When use_tma_store=True: writes to shared memory and signals epilogue warp for TMA store.
+        When use_tma_store=False: writes directly to global memory via st.global.
+
+        :param thr_mma: Thread MMA operation for the computation
+        :type thr_mma: cute.ThrMma
+        :param tiled_tmem_load_vec: Tiled memory load operation for the vectorized row-wise max
+        :type tiled_tmem_load_vec: cute.TiledCopy
+        :param tensor_args: Tuple containing (tOtO, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECcS, sO_or_gO, mLSE, mSink)
+        :type tensor_args: Tuple
+        :param pipeline_args: When use_tma_store: (si_corr_consumer, mma_corr_consumer, corr_epi_producer).
+                              When not use_tma_store: (si_corr_consumer, mma_corr_consumer).
+        :type pipeline_args: Tuple
+        :param value_args: Tuple containing (row_idx, cuseqlen_q, seqlen_q, blk_coord, scale_softmax, scale_output)
+        :type value_args: Tuple
+        """
+        tOtO, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECcS, dest_O, mLSE, mSink = tensor_args
+        row_idx, cuseqlen_q, seqlen_q, blk_coord, scale_softmax, scale_output = value_args
+
+        pv_tiled_mma_shape = (
+            self.pv_mma_tiler[0],
+            self.pv_mma_tiler[1],
+        )
+        cO = cute.make_identity_tensor(pv_tiled_mma_shape)
+
+        corr_tile_size = 32 * 8 // self.o_dtype.width
+        tOdO = thr_mma.partition_C(dest_O)
+        tOcO = thr_mma.partition_C(cO)
+        tOtO_i = cute.logical_divide(tOtO, cute.make_layout((128, corr_tile_size)))
+        tOcO_i = cute.logical_divide(tOcO, cute.make_layout((128, corr_tile_size)))
+        tOdO_i = cute.logical_divide(tOdO, cute.make_layout((128, corr_tile_size)))
+
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.correction_warp_ids))
+        epi_subtile = (self.epi_tile[0], corr_tile_size)
+        tmem_copy_atom = sm100_utils.get_tmem_load_op(
+            self.pv_mma_tiler,
+            self.o_layout,
+            self.o_dtype,
+            self.pv_acc_dtype,
+            epi_subtile,
+            use_2cta_instrs=False,
+        )
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_i[(None, None), 0])
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_i[(None, None), None])
+        tTMEM_LOADdO = thr_tmem_load.partition_D(tOdO_i[(None, None), None])
+        tTMEM_LOADoO = thr_tmem_load.partition_D(tOcO_i[(None, None), None])
+
+        if cutlass.const_expr(self.use_tma_store):
+            si_corr_consumer, mma_corr_consumer, corr_epi_producer = pipeline_args
+            smem_copy_atom = sm100_utils.get_smem_store_op(
+                self.o_layout, self.o_dtype, self.pv_acc_dtype, tiled_tmem_load
+            )
+            tiled_smem_store = cute.make_tiled_copy_D(smem_copy_atom, tiled_tmem_load)
+        else:
+            si_corr_consumer, mma_corr_consumer = pipeline_args
+
+        # Wait for vec_i (row_wise global sum)
+        vec_i_handle = si_corr_consumer.wait_and_advance()
+        tTMEM_LOAD_VECrS = cute.make_rmem_tensor(tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype)
+        cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECrS)
+        cute.arch.fence_view_async_tmem_load()
+        vec_i_handle.release()
+
+        # Wait for Oi
+        oi_handle = mma_corr_consumer.wait_and_advance()
+        if cutlass.const_expr(self.use_tma_store):
+            oi_final_handle = corr_epi_producer.acquire_and_advance()
+        row_sum = tTMEM_LOAD_VECrS[0]
+        if cutlass.const_expr(mSink is not None):
+            sink_val = mSink[blk_coord[2]]
+            row_max_raw = tTMEM_LOAD_VECrS[1]
+            # sink is already in scaled logit space, row_max_raw is unscaled
+            # exp2((sink - max_scaled) * log2(e)) = exp(sink - max_scaled)
+            log2_e = Float32(1.4426950408889634)
+            sink_exp = cute.math.exp2(
+                (sink_val - row_max_raw * scale_softmax) * log2_e, fastmath=True
+            )
+            row_sum = row_sum + sink_exp
+        scale = scale_output / row_sum
+
+        for i in range(self.cta_tiler[2] // corr_tile_size):
+            tTMEM_LOADtO_i = tTMEM_LOADtO[None, 0, 0, i]
+            tTMEM_LOADdO_i = tTMEM_LOADdO[None, 0, 0, i]
+            tTMrO = cute.make_rmem_tensor(tTMEM_LOADoO[None, 0, 0, i].shape, self.pv_acc_dtype)
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
+            for j in range(0, cute.size(tTMrO), 2):
+                tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
+                    (tTMrO[j], tTMrO[j + 1]),
+                    (scale, scale),
+                )
+            tDMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
+            o_vec = tTMrO.load()
+            tDMrO.store(o_vec.to(self.o_dtype))
+            if cutlass.const_expr(self.use_tma_store):
+                # TMA store path: write to shared memory
+                cute.copy(tiled_smem_store, tDMrO, tTMEM_LOADdO_i)
+            else:
+                # st.global path: write directly to global memory with bounds check
+                if row_idx < seqlen_q:
+                    cute.autovec_copy(tDMrO, tTMEM_LOADdO_i)
+
+        if cutlass.const_expr(mLSE is not None):
+            scaled_tmp = scale_softmax * tTMEM_LOAD_VECrS[1]
+            # Convert LSE from natural log to log2 space, consistent with flashinfer trtllm-gen backend
+            lse = (cute.math.log(row_sum, fastmath=True) + scaled_tmp) * Float32(1.4426950408889634)
+            # Pre-scale correction: row_sum was inflated by 2^offset, so the
+            # log2-space LSE is too large by exactly `p_fp8_prescale_log2`.
+            if cutlass.const_expr(self.v_dtype.width == 8 and self.p_fp8_prescale_log2 > 0):
+                lse = lse - self.p_fp8_prescale_log2
+            if row_idx < seqlen_q:
+                mLSE[row_idx + cuseqlen_q, blk_coord[2]] = lse
+        if cutlass.const_expr(self.use_tma_store):
+            # fence view async shared
+            cute.arch.fence_view_async_shared()
+            oi_handle.release()
+            oi_final_handle.commit()
+            return (si_corr_consumer, mma_corr_consumer, corr_epi_producer)
+        else:
+            oi_handle.release()
+            return (si_corr_consumer, mma_corr_consumer)
+
+    def check_supported_dtypes(
+        self,
+        qk_dtype: Type[cutlass.Numeric],
+        pv_dtype: Type[cutlass.Numeric],
+        out_dtype: Type[cutlass.Numeric],
+        qk_acc_dtype: Type[cutlass.Numeric],
+        pv_acc_dtype: Type[cutlass.Numeric],
+    ):
+        supported = {cutlass.Float8E4M3FN, cutlass.Float16, cutlass.BFloat16}
+        if qk_dtype not in supported:
+            raise NotImplementedError("Unsupported qk_dtype")
+        if pv_dtype not in supported:
+            raise NotImplementedError("Unsupported pv_dtype")
+        if out_dtype not in {cutlass.Float8E4M3FN, cutlass.Float16, cutlass.BFloat16}:
+            raise NotImplementedError("Unsupported out_dtype")
+        if qk_acc_dtype not in {cutlass.Float32}:
+            raise NotImplementedError("Unsupported qk_acc_dtype")
+        if pv_acc_dtype not in {cutlass.Float32}:
+            raise NotImplementedError("Unsupported pv_acc_dtype")
+
+    def check_invalid_shape(
+        self,
+        qk_dtype: Type[cutlass.Numeric],
+        q_shape: Tuple[int, int, int, int],
+        k_shape: Tuple[int, int, int, int],
+    ):
+        # Shapes are passed around this example as (batch, seq_len, num_heads, head_dim).
+        b, s_q, h_q, d = q_shape
+        b_, s_k, h_k, d_ = k_shape
+
+        if b != b_:
+            raise NotImplementedError("q & k must have the same batch size")
+        if d != d_:
+            raise NotImplementedError("q & k must have the same head dimension")
+        if d not in {32, 64, 128, 192}:
+            raise NotImplementedError("Unsupported head dimension")
+        if h_q % h_k != 0:
+            raise NotImplementedError("h_q must be divisible by h_k")
+        if isinstance(s_q, tuple) and len(s_q) != b:
+            raise NotImplementedError("variable_seqlen s_q must have the length of batch size")
+        if isinstance(s_k, tuple) and len(s_k) != b:
+            raise NotImplementedError("variable_seqlen s_k must have the length of batch size")
+        if d == 192 and qk_dtype not in {cutlass.Float8E4M3FN}:
+            raise NotImplementedError("unimplemented dtypes for headdim 192")
+
+    def can_implement(
+        self,
+        q_shape: Tuple[int, int, int, int],
+        k_shape: Tuple[int, int, int, int],
+        qk_dtype: Type[cutlass.Numeric],
+        pv_dtype: Type[cutlass.Numeric],
+        out_dtype: Type[cutlass.Numeric],
+        qk_acc_dtype: Type[cutlass.Numeric],
+        pv_acc_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        :param q_shape: Shape of the query tensor.
+        :type q_shape: Tuple[int, int, int, int]
+        :param k_shape: Shape of the key tensor.
+        :type k_shape: Tuple[int, int, int, int]
+        :param qk_dtype: Data type for Q and K (Bmm1 inputs).
+        :type qk_dtype: Type[cutlass.Numeric]
+        :param pv_dtype: Data type for P and V (Bmm2 inputs).
+        :type pv_dtype: Type[cutlass.Numeric]
+        :param out_dtype: Data type of the output tensor.
+        :type out_dtype: Type[cutlass.Numeric]
+        :param qk_acc_dtype: Data type of the qk accumulator tensor.
+        :type qk_acc_dtype: Type[cutlass.Numeric]
+        :param pv_acc_dtype: Data type of the pv accumulator tensor.
+        :type pv_acc_dtype: Type[cutlass.Numeric]
+        :return: True if the kernel can be implemented, False otherwise.
+        :rtype: bool
+        """
+        try:
+            # Skip unsupported types
+            self.check_supported_dtypes(
+                qk_dtype,
+                pv_dtype,
+                out_dtype,
+                qk_acc_dtype,
+                pv_acc_dtype,
+            )
+            # Skip invalid shape
+            self.check_invalid_shape(
+                qk_dtype,
+                q_shape,
+                k_shape,
+            )
+        except NotImplementedError:
+            return False
+        return True

--- a/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
@@ -1,0 +1,3763 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# ruff: noqa: I001, E501, F841, E712, E741
+
+import math
+from typing import Callable, Type, Tuple, Union, Optional
+from functools import partial
+
+import torch
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.nvgpu import tcgen05
+from cutlass.cute.nvgpu.common import OperandMajorMode
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.torch as cutlass_torch
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.typing import Int8, Int32, Int64, Float32
+from cutlass.base_dsl.arch import Arch
+from cutlass.cutlass_dsl import BaseDSL
+
+from .helpers import fmha_helpers as fmha_utils
+
+"""
+A fused multi-head attention (FMHA) example where Bmm1(Q@K) is block-scaled with MXFP8 or NVFP4 for
+NVIDIA Blackwell SM100 architecture using CUTE DSL
+
+This example demonstrates an implementation of fused multi-head attention using a TMA + Blackwell SM100
+TensorCore warp-specialized persistent kernel. The implementation integrates the Q*K^T matrix multiplication,
+softmax normalization, and softmax(Q*K^T)*V into a single kernel, avoiding intermediate data movement between
+global memory and shared memory, thus improving computational efficiency.
+
+The kernel implements key optimizations including:
+- Warp specialization for different computation phases (load, MMA, softmax, correction, epilogue)
+- Pipeline stages between different warps for overlapping computation and memory access
+- Support for different precision data types
+- Optional causal masking for autoregressive models
+
+To run this example:
+
+.. code-block:: bash
+
+    python nvidia-internal/fmha_blockscaled.py                            \
+      --qk_mode MXFP8                                                     \
+      --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
+      --mma_tiler_mn 128,128                                              \
+      --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \
+      --is_persistent
+
+The above example runs FMHA with batch size 4, sequence length 1024, 8 attention heads, and head
+dimension 64. The Blackwell tcgen05 MMA tile shape is (128, 128), and the default runner uses BF16
+for V/output with FP32 for accumulation.
+
+To collect performance with NCU profiler:
+
+.. code-block:: bash
+
+    ncu python nvidia-internal/fmha_blockscaled.py                        \
+      --qk_mode NVFP4                                                     \
+      --qk_acc_dtype Float32 --pv_acc_dtype Float32                       \
+      --mma_tiler_mn 128,128                                              \
+      --q_shape 4,1024,8,64 --k_shape 4,1024,8,64                         \
+      --is_persistent --warmup_iterations 10                              \
+      --iterations 10 --skip_ref_check
+
+Constraints for this example:
+* Q and K use supports two microscaling schema:
+  MXFP8 (qk_dtype in {Float8E4M3FN, Float8E5M2}, qk_sf_dtype=Float8E8M0FNU, qk_sf_vec_size=32)
+  and NVFP4 (qk_dtype=Float4E2M1FN, qk_sf_dtype=Float8E4M3FN, qk_sf_vec_size=16)
+* Bmm2 (P@V) remains dense FP8 or BF16 through pv_dtype
+* Supported QK head dimensions: 128 (due to current limitations in blockscaled_utils)
+* Number of heads in Q must be divisible by number of heads in K
+* mma_tiler_mn must be 128,128
+* Batch size must be the same for Q, K, and V tensors
+* For causal masking, use --is_causal (note: specify without =True/False)
+* For persistent scheduling, use --is_persistent (note: specify without =True/False)
+
+For details on the skip softmax algorithm, please refer to the paper: https://arxiv.org/abs/2512.12087.
+"""
+
+
+def make_thread_cooperative_group(size: int):
+    return pipeline.CooperativeGroup(pipeline.Agent.Thread, size)
+
+
+def create_scale_factor_tensor(
+    mn: int,
+    k: int,
+    l: int,
+    sf_vec_size: int,
+    sf_dtype: Type[cutlass.Numeric],
+):
+    """
+    Create dense reference SFs and blocked device SF storage for QK block-scaled MMA.
+
+    Generates per-position SFs sampled from {0.5, 1.0, 2.0} (which are exactly representable in both
+    E8M0 and E4M3) and arranges them into the blocked storage that tile_atom_to_shape_SF,
+    BlockScaledBasicChunk consume on the kernel side. The SF atom layout is:
+        ((32,4),(sf_vec,4)) : ((16,4),(0,1))
+    so for a logical mn in [0,128) inside an atom, the SF byte lives at offset:
+        (mn % 32) * 16 + (mn // 32) * 4 + k_inner
+    """
+
+    def ceil_div(a: int, b: int) -> int:
+        return (a + b - 1) // b
+
+    atom_m = 32 * 4
+    atom_k = 4
+    m_atoms = ceil_div(mn, atom_m)
+    sf_k = ceil_div(k, sf_vec_size)
+    sf_k_atoms = ceil_div(sf_k, atom_k)
+
+    # Generate SFs in the LOGICAL (mn, sf_k, l) layout first, then re-arrange into the blocked
+    # storage layout explained in docstring above.
+    # CuTe decomposes mn in [0,128) column-major as (mn % 32, mn // 32), so the size-32 axis
+    # gets the LOW 5 bits of mn (stride 16) and the size-4 axis gets the HIGH 2 bits (stride 4).
+    mn_padded = m_atoms * atom_m
+    sf_k_padded = sf_k_atoms * atom_k
+    sf_choices = torch.tensor([0.5, 1.0, 2.0], dtype=torch.float32)
+    sf_logical_padded = sf_choices[torch.randint(0, len(sf_choices), (mn_padded, sf_k_padded, l))]
+    sf_storage_f32 = (
+        # K-mode: k_padded -> (sf_k_atoms, atom_k=4)
+        # MN-mode: mn_padded -> (sf_m_atoms, proton_m=4, neutron_m=32)
+        sf_logical_padded.reshape(m_atoms, 4, 32, sf_k_atoms, atom_k, l)
+        # Arrangement (last-idx-major): (l, sf_m_atoms, sf_k_atoms, neutron_m, proton_m, atom_k)
+        # (l, sf_m_atoms, sf_k_atoms) follows a traditional K-major interblock layout
+        # (atom_k) is the last index -> reproduces (sf_vec,atom_k):(0,1)
+        # (neutron_m, proton_m) -> reproduces
+        #   prod((neutron_m,proton_m):(proton_m:1), 1:atom_k) = (32,4):(16,4)
+        .permute(5, 0, 3, 2, 1, 4)
+        .contiguous()
+    )
+
+    sf_tensor, _ = cutlass_torch.cute_tensor_like(
+        sf_storage_f32,
+        sf_dtype,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+
+    sf_logical = sf_logical_padded[:mn, :sf_k, :]
+    # Broadcast each SF across its sf_vec_size K elements to build a elementwise (mn, k, l)
+    # reference whose (m, j, b) entry is the SF the kernel multiplies into the same logical position
+    ref_elementwise = (
+        sf_logical.unsqueeze(2)
+        .expand(-1, -1, sf_vec_size, -1)
+        .reshape(mn, sf_k * sf_vec_size, l)[:, :k, :]
+        .contiguous()
+    )
+
+    return ref_elementwise, sf_tensor
+
+
+def compact_fp4_data(torch_underlying: torch.Tensor, dtype: Type[cutlass.Numeric]) -> None:
+    """Compact packed FP4 rows to match CuTe's sub-byte stride interpretation."""
+    if dtype is not cutlass.Float4E2M1FN:
+        return
+
+    # torch lacks fill_/copy_ kernels for Float4_e2m1fn_x2 on CUDA, but the
+    # storage is byte-packed (two FP4 per byte), so a uint8 view is a free
+    # reinterpret and supports the in-place primitives we need.
+    d = torch_underlying.shape[-1]
+    packed_size = d // (8 // dtype.width)
+    underlying_u8 = torch_underlying.view(torch.uint8)
+    rows = underlying_u8.reshape(-1, d)
+    packed = rows[:, :packed_size].contiguous()
+    underlying_u8.fill_(0)
+    underlying_u8.flatten()[: packed.numel()].copy_(packed.flatten())
+
+
+class BlackwellFusedMultiHeadBlockScaledAttentionForward:
+    arch_str: str = "sm_100"
+    arch_name: str = "Blackwell SM100"
+
+    def __init__(
+        self,
+        qk_acc_dtype: Type[cutlass.Numeric],
+        pv_acc_dtype: Type[cutlass.Numeric],
+        mma_tiler: Tuple[int, int],
+        head_dim: Union[int, Tuple[int, int]],
+        is_persistent: bool,
+        mask_type: fmha_utils.MaskEnum,
+        enable_ex2_emulation: bool,
+        enable_skip_correction: bool,
+        qk_sf_vec_size: int,
+        use_tma_store: bool = True,
+    ):
+        """Initializes the configuration for a Blackwell Fused Multi-Head Attention (FMHA) kernel.
+
+        This configuration includes several key aspects:
+
+        1.  Data Type Settings:
+            - qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
+            - pv_acc_dtype: Data type for P*V matrix multiplication accumulator
+
+        2.  MMA Instruction Settings:
+            - mma_tiler: The shape of the MMA instruction unit: (M, N) for BMM1 and (M, K) for BMM2
+            - head_dim: The head dimension, it can be a single integer or a tuple of two integers (D, Dv).
+                        If it is a tuple, Dv is the head dimension of the value & output tensors.
+                        It also determines the K dimension of the BMM1's MMA instruction unit
+                        & N dimension of the BMM2's MMA instruction unit.
+            - qk_mma_tiler: MMA shape for Q*K^T computation
+            - pv_mma_tiler: MMA shape for P*V computation
+
+        3.  Kernel Execution Mode:
+            - is_persistent: Boolean indicating whether to use persistent kernel mode
+            - mask_type: Specifies the type of mask to use (no mask, residual mask, or causal mask)
+            - window_size_left/right: Sliding window size for attention masking
+            - enable_ex2_emulation: Whether to enable exp2 emulation
+            - enable_skip_correction: Whether to skip the correction when rowmax is not updated larger than a threshold
+
+        :param qk_acc_dtype: Data type for Q*K^T matrix multiplication accumulator
+        :type qk_acc_dtype: Type[cutlass.Numeric]
+        :param pv_acc_dtype: Data type for P*V matrix multiplication accumulator
+        :type pv_acc_dtype: Type[cutlass.Numeric]
+        :param mma_tiler: The (M, N) shape of the MMA instruction
+        :type mma_tiler: Tuple[int, int]
+        :param head_dim: The head dimension, it can be a single integer or a tuple of two integers (D, Dv).
+        :type head_dim: Union[int, Tuple[int, int]]
+        :param is_persistent: Whether to use persistent kernel mode
+        :type is_persistent: bool
+        :param mask_type: Type of mask to use
+        :type mask_type: fmha_utils.MaskEnum
+        :param window_size_left: Left-side sliding window size for attention masking
+        :type window_size_left: int
+        :param window_size_right: Right-side sliding window size for attention masking
+        :type window_size_right: int
+        """
+
+        self.qk_acc_dtype = qk_acc_dtype
+        self.pv_acc_dtype = pv_acc_dtype
+        if mma_tiler != (128, 128):
+            raise ValueError(
+                "This standalone kernel uses a static TMEM map and currently supports only mma_tiler=(128, 128)"
+            )
+        if isinstance(head_dim, tuple):
+            self.head_dim = head_dim[0]
+            self.head_dim_v = head_dim[1]
+            assert self.head_dim == 192 and self.head_dim_v == 128, (
+                f"When Headdim is a tuple, it's for MLA. Must be (192, 128), but got {head_dim}"
+            )
+        else:
+            self.head_dim = head_dim
+            self.head_dim_v = head_dim
+        self.cta_tiler = (
+            2 * mma_tiler[0],  # 2 O tile per CTA
+            mma_tiler[1],
+            self.head_dim_v,
+        )
+        self.qk_mma_tiler = (
+            *mma_tiler,
+            self.head_dim,
+        )
+        self.pv_mma_tiler = (
+            mma_tiler[0],
+            self.head_dim_v,
+            mma_tiler[1],
+        )
+        self.cluster_shape_mn = (1, 1)
+        self.is_persistent = is_persistent
+        self.mask_type = mask_type
+        self.enable_skip_correction = enable_skip_correction
+        self.enable_ex2_emulation = enable_ex2_emulation
+        self.qk_sf_vec_size = qk_sf_vec_size
+        self.qk_mma_inst_bits_k = 256
+        if qk_sf_vec_size == 16:
+            # NVFP4: a 256-bit MMA operand tile covers 64 logical K values.
+            self.qk_mma_inst_tile_k = self.head_dim // (self.qk_mma_inst_bits_k // 4)
+        elif qk_sf_vec_size == 32:
+            # MXFP8: a 256-bit MMA operand tile covers 32 logical K values.
+            self.qk_mma_inst_tile_k = self.head_dim // (self.qk_mma_inst_bits_k // 8)
+        else:
+            self.qk_mma_inst_tile_k = 0
+        self.use_tma_store = use_tma_store
+
+        self.softmax0_warp_ids = (0, 1, 2, 3)
+        self.softmax1_warp_ids = (4, 5, 6, 7)
+        self.correction_warp_ids = (8, 9, 10, 11)
+        self.mma_warp_id = 12
+        self.load_warp_id = 13
+        self.epilogue_warp_id = 14
+        self.empty_warp_id = 15
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch_str)
+
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * len(
+            (
+                *self.softmax0_warp_ids,
+                *self.softmax1_warp_ids,
+                *self.correction_warp_ids,
+                self.mma_warp_id,
+                self.load_warp_id,
+                self.epilogue_warp_id,
+                self.empty_warp_id,
+            )
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_warp
+            * sum(
+                (
+                    len((self.mma_warp_id,)),
+                    len(self.softmax0_warp_ids),
+                    len(self.softmax1_warp_ids),
+                    len(self.correction_warp_ids),
+                )
+            ),
+        )
+        self.sequence_s0_s1_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=self.threads_per_warp
+            * len((*self.softmax0_warp_ids, *self.softmax1_warp_ids)),
+        )
+        self.sequence_s1_s0_barrier = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=self.threads_per_warp
+            * len((*self.softmax0_warp_ids, *self.softmax1_warp_ids)),
+        )
+        self.s0_warpgroup_barrier = pipeline.NamedBarrier(
+            barrier_id=5,
+            num_threads=self.threads_per_warp * len(self.softmax0_warp_ids),
+        )
+        self.s1_warpgroup_barrier = pipeline.NamedBarrier(
+            barrier_id=6,
+            num_threads=self.threads_per_warp * len(self.softmax1_warp_ids),
+        )
+        self.tmem_dealloc_barrier = pipeline.NamedBarrier(
+            barrier_id=7,
+            num_threads=self.threads_per_warp * len(self.correction_warp_ids),
+        )
+
+        self.tmem_s0_offset = 0
+        self.tmem_s1_offset = 128
+        self.tmem_o0_offset = 256
+        self.tmem_o1_offset = 384
+        # inplaced with s1
+        self.tmem_p0_offset = 160
+        # inplaced with s0
+        self.tmem_p1_offset = 32
+        # Block-scaled QK scale factors are live only while issuing QK MMA.
+        # Keep each stage's scale buffers in the opposite S/P tile's tail columns.
+        self.tmem_qk0_sf_offset = 224
+        self.tmem_qk1_sf_offset = 96
+        # vec buffer for row_max & row_sum
+        # inplaced with s0
+        self.tmem_vec0_offset = 0
+        # inplaced with s1
+        self.tmem_vec1_offset = 128
+        # skip mma pv flag offset regarding to the vec buffer
+        # inplaced with s1
+        self.tmem_skip_softmax0_offset = 136
+        # inplaced with s0
+        self.tmem_skip_softmax1_offset = 8
+
+        self.num_regs_softmax = 192
+        self.num_regs_correction = 96
+        self.num_regs_other = 32
+        self.buffer_align_bytes = 1024
+        self.arch = BaseDSL._get_dsl().get_arch_enum()
+
+        if self.arch >= Arch.sm_103:
+            assert self.enable_ex2_emulation == False, (
+                f"Don't enable exp2 emulation for {self.arch}, it doesn't help performance"
+            )
+
+        num_warps_per_warpgroup = 4
+        self.softmax_warpgroup_count = (
+            len((*self.softmax0_warp_ids, *self.softmax1_warp_ids)) // num_warps_per_warpgroup
+        )
+
+    def _make_qk_tiled_mma(self, cta_group):
+        """Build the QK tiled MMA. Override in subclasses to target a different arch."""
+        return sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.q_dtype,
+            self.k_dtype,
+            self.q_major_mode,
+            self.k_major_mode,
+            self.qk_sf_dtype,
+            self.qk_sf_vec_size,
+            cta_group,
+            self.qk_mma_tiler[:2],
+        )
+
+    def _make_pv_tiled_mma(self, cta_group, p_major_mode, p_source):
+        """Build the PV tiled MMA. Override in subclasses to target a different arch."""
+        return sm100_utils.make_trivial_tiled_mma(
+            self.v_dtype,
+            self.v_dtype,
+            p_major_mode,
+            self.v_major_mode,
+            self.pv_acc_dtype,
+            cta_group,
+            self.pv_mma_tiler[:2],
+            p_source,
+        )
+
+    def _setup_attributes(self):
+        """Set up configurations and parameters for the FMHA kernel operation.
+
+        This method initializes and configures various attributes required for the
+        execution of the fused multi-head attention kernel, mainly about the pipeline stages:
+
+        - Sets up staging parameters for Q, K, V inputs and accumulator data
+        - Configures pipeline stages for softmax, correction, and epilogue operations
+        """
+
+        self.q_stage = 2
+        k_stage = 4 if self.q_dtype.width == 8 else 3
+        v_stage = 4 if self.v_dtype.width == 8 else 3
+        self.kv_stage = min(k_stage, v_stage)
+        # For D192, the smem usage of Q & K is larger. So, we need to reduce the stage count.
+        if self.head_dim == 192 and self.q_dtype.width == 16:
+            self.kv_stage = 2
+        self.p_mma_stage = 1
+        self.acc_stage = 1
+        self.softmax_corr_stage = 1
+        self.mma_corr_stage = 2
+        self.mma_softmax_stage = 1
+        self.epi_stage = 2
+
+        # Tunable parameters
+        self.rescale_threshold = 8.0 if self.enable_skip_correction else 0.0
+        # FP8 P pre-scale: offset added to exp2 exponent so that P*2^offset fills
+        # more of E4M3's [0, 448] range, improving quantization precision.
+        # Derived from rescale_threshold to guarantee P*2^offset <= 448.
+        self.p_fp8_prescale_log2 = max(0.0, math.floor(math.log2(448) - self.rescale_threshold))
+        # ln(2) * offset correction for LSE when pre-scale is active
+        self.p_fp8_prescale_lse_correction = self.p_fp8_prescale_log2 * math.log(2)
+        # For most cases, seq barrier is needed to help keep the pipeline stable
+        # But sometimes, compiler will schedule the barrier at an unexpected place
+        # if it hurts perf a lot, try to quickly fix it by disabling seq barrier
+        self.enable_sequence_barrier = False
+        # Optional double buffering for correction rescale.
+        self.enable_correction_double_buffer = False
+
+    @cute.jit
+    def __call__(
+        self,
+        q_tensor: cute.Tensor,
+        k_tensor: cute.Tensor,
+        q_sf_tensor: cute.Tensor,
+        k_sf_tensor: cute.Tensor,
+        v_tensor: cute.Tensor,
+        o_tensor: cute.Tensor,
+        problem_size: Tuple[Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32],
+        cum_seqlen_q: Optional[cute.Tensor],
+        cum_seqlen_k: Optional[cute.Tensor],
+        lse_tensor: Optional[cute.Tensor],
+        sink_tensor: Optional[cute.Tensor],
+        scale_softmax_log2: Float32,
+        scale_softmax: Float32,
+        scale_output: Float32,
+        scale_v_channels: Optional[cute.Tensor],
+        skip_softmax_threshold_log2: Optional[Float32],
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        skip_softmax_count: Optional[cute.Tensor],
+        total_softmax_count: Optional[cute.Tensor],
+        stream: cuda.CUstream,
+        use_pdl: bool,
+    ):
+        """Execute the Fused Multi-Head Attention operation on the provided tensors.
+
+        This method prepares the input tensors for processing, validates their shapes and types,
+        configures the computation parameters, and launches the CUDA kernel.
+
+        The method handles:
+        1. Tensor layout transformations for specific memory access patterns
+        2. Validation of tensor shapes and data types
+        3. Initialization of hardware-specific parameters and memory layouts
+        4. Configuration of TMA (Tensor Memory Access) operations
+        5. Grid and work scheduling computation
+        6. Kernel launch with appropriate parameters
+
+        :param q_tensor: The query tensor with shape (b, s_q, h_k, h_r, d)
+        :type q_tensor: cute.Tensor
+        :param k_tensor: The key tensor with shape (b, s_k, h_k, 1, d)
+        :type k_tensor: cute.Tensor
+        :param v_tensor: The value tensor with shape (b, s_v, h_k, 1, dv)
+        :type v_tensor: cute.Tensor
+        :param o_tensor: The output tensor with shape (b, s_q, h_k, h_r, dv)
+        :type o_tensor: cute.Tensor
+        :param problem_size: The problem size with shape [b, s_q_max, s_lse_max, s_k_max, h_q, h_k, d, dv]. If cum_seqlen_q or cum_seqlen_k is not None, s_q_max and s_k_max are the max of the per-batch sequence lengths respectively.
+        :type problem_size: Tuple[Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32]
+        :param cum_seqlen_q: The cumulative sequence length tensor for query
+        :type cum_seqlen_q: Optional[cute.Tensor]
+        :param cum_seqlen_k: The cumulative sequence length tensor for key
+        :type cum_seqlen_k: Optional[cute.Tensor]
+        :param scale_softmax_log2: The log2 scale factor for softmax
+        :type scale_softmax_log2: Float32
+        :param scale_softmax: The scale factor for softmax
+        :type scale_softmax: Float32
+        :param scale_output: The scale factor for the output
+        :type scale_output: Float32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param stream: The CUDA stream to execute the kernel on
+        :type stream: cuda.CUstream
+        :raises TypeError: If tensor data types don't match or aren't supported
+        :raises RuntimeError: If tensor layouts aren't in supported formats
+        """
+        b, s_q_max, s_lse_max, s_k_max, h_q, h_k, d_, dv_ = problem_size
+        h_r = h_q // h_k
+        # setup static attributes before smem/grid/tma computation
+        self.q_dtype = q_tensor.element_type
+        self.k_dtype = k_tensor.element_type
+        self.qk_sf_dtype = q_sf_tensor.element_type
+        self.v_dtype = v_tensor.element_type
+        self.o_dtype = o_tensor.element_type
+
+        # s_q, s_k, s_v are the actual tensor dimensions (total seqlen for varlen)
+        s_q = q_tensor.shape[1]
+        s_k = k_tensor.shape[1]
+        s_v = v_tensor.shape[1]
+        s_lse = s_lse_max
+        d = self.head_dim
+        dv = self.head_dim_v
+        # Important for performance
+        align = 256 // self.o_dtype.width
+        assert d % align == 0, f"head_dim must be multiple of {align} for the given datatypes."
+        assert dv % align == 0, f"head_dim_v must be multiple of {align} for the given datatypes."
+
+        stride_b_q = h_r * h_k * s_q * d if cum_seqlen_q is None else 0
+        stride_b_o = h_r * h_k * s_q * dv if cum_seqlen_q is None else 0
+        stride_b_k = h_k * s_k * d if cum_seqlen_k is None else 0
+        stride_b_v = h_k * s_v * dv if cum_seqlen_k is None else 0
+        stride_b_lse = h_r * h_k * s_lse if cum_seqlen_q is None else 0
+
+        # (b, s_q, h_k, h_r, d) -> (s_q, d, ((h_r, h_k), b))
+        q_layout = cute.make_layout(
+            (s_q, d, ((h_r, h_k), b)),
+            stride=(d * h_r * h_k, 1, ((d, d * h_r), stride_b_q)),
+        )
+        q = cute.make_tensor(q_tensor.iterator, q_layout)
+        # (b, s_k, h_k, 1, d) -> (s_k, d, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        k_layout = cute.make_layout(
+            (s_k, d, ((h_r, h_k), b)),
+            stride=(d * h_k, 1, ((0, d), stride_b_k)),
+        )
+        k = cute.make_tensor(k_tensor.iterator, k_layout)
+        q_sf_layout = blockscaled_utils.tile_atom_to_shape_SF(q.shape, self.qk_sf_vec_size)
+        q_sf = cute.make_tensor(q_sf_tensor.iterator, q_sf_layout)
+        k_sf_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            (s_k, d, (h_k, b)), self.qk_sf_vec_size
+        )
+        k_sf = cute.make_tensor(k_sf_tensor.iterator, k_sf_layout)
+        # (b, s_v, h_k, 1, dv) -> (dv, s_v, ((h_r, h_k), b)), 0-stride for h_r to broadcast
+        v_layout = cute.make_layout(
+            (dv, s_v, ((h_r, h_k), b)),
+            stride=(1, dv * h_k, ((0, dv), stride_b_v)),
+        )
+        v = cute.make_tensor(v_tensor.iterator, v_layout)
+        # (b, s_q, h_k, h_r, dv) -> (s_q, dv, ((h_r, h_k), b))
+        o_layout = cute.make_layout(
+            (s_q, dv, ((h_r, h_k), b)),
+            stride=(dv * h_r * h_k, 1, ((dv, dv * h_r), stride_b_o)),
+        )
+        o = cute.make_tensor(o_tensor.iterator, o_layout)
+        if cutlass.const_expr(lse_tensor is not None):
+            # (s, ((h_r, h_k), b)) - head stride=1 to match FlashInfer (total_q, h_q) convention
+            lse_layout = cute.make_layout(
+                (s_lse, ((h_r, h_k), b)),
+                stride=(h_r * h_k, ((1, h_r), stride_b_lse)),
+            )
+            lse = cute.make_tensor(lse_tensor.iterator, lse_layout)
+        else:
+            lse = None
+
+        if cutlass.const_expr(sink_tensor is not None):
+            # sink_tensor is 1D with shape (h_q,) = (h_k * h_r,)
+            # Create layout ((h_r, h_k), b) with stride 0 for batch so blk_coord[2] works
+            sink_layout = cute.make_layout(
+                ((h_r, h_k), b),
+                stride=((1, h_r), 0),
+            )
+            sink = cute.make_tensor(sink_tensor.iterator, sink_layout)
+        else:
+            sink = None
+
+        if cutlass.const_expr(scale_v_channels is not None):
+            # scale_v_channels is per (h_k, dv): shape (h_k * dv,) row-major.
+            # Expose as (dv, ((h_r, h_k), b)) where h_r and b are 0-stride broadcasts.
+            scale_v_channels_layout = cute.make_layout(
+                (dv, ((h_r, h_k), b)),
+                stride=(1, ((0, dv), 0)),
+            )
+            m_scale_v_channels = cute.make_tensor(
+                scale_v_channels.iterator, scale_v_channels_layout
+            )
+        else:
+            m_scale_v_channels = None
+
+        self.tile_sched_params, grid = fmha_utils.compute_grid(
+            cute.shape((s_q_max, d, ((h_r, h_k), b))),
+            self.cta_tiler,
+            self.is_persistent,
+        )
+        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = utils.LayoutEnum.from_tensor(o)
+
+        if cutlass.const_expr(self.q_major_mode != OperandMajorMode.K):
+            raise RuntimeError("The layout of q is not supported")
+        if cutlass.const_expr(self.k_major_mode != OperandMajorMode.K):
+            raise RuntimeError("The layout of k is not supported")
+        if cutlass.const_expr(self.v_major_mode != OperandMajorMode.MN):
+            raise RuntimeError("The layout of v is not supported")
+
+        # check type consistency: Q and K must share the same dtype (qk_dtype);
+        # V may use a different dtype (pv_dtype) to allow qk_dtype != pv_dtype.
+        if cutlass.const_expr(self.q_dtype != self.k_dtype):
+            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
+        if cutlass.const_expr(self.qk_sf_dtype != k_sf_tensor.element_type):
+            raise TypeError(
+                f"Q/K scale type mismatch: {self.qk_sf_dtype} != {k_sf_tensor.element_type}"
+            )
+        if cutlass.const_expr(self.qk_mma_inst_tile_k <= 0):
+            raise RuntimeError(
+                f"Invalid QK scale-factor tiling for head_dim={self.head_dim}, qk_sf_vec_size={self.qk_sf_vec_size}"
+            )
+        # SFQ + SFK share one 32-column TMEM slot per stage (see kernel TMEM layout
+        # below). Validate the static footprint on the host so we don't smuggle a
+        # `raise` into @cute.kernel.
+        _sf_atom_mn = 32
+        _qk_sf_tmem_cols = (self.qk_mma_tiler[0] // _sf_atom_mn) * self.qk_mma_inst_tile_k
+        _kqk_sf_tmem_cols = (
+            ((self.qk_mma_tiler[1] + 127) // 128 * 128) // _sf_atom_mn
+        ) * self.qk_mma_inst_tile_k
+        if cutlass.const_expr(_qk_sf_tmem_cols + _kqk_sf_tmem_cols > 32):
+            raise RuntimeError(
+                "QK scale-factor TMEM footprint exceeds the static 32-column slot "
+                f"(qk_sf_tmem_cols={_qk_sf_tmem_cols}, k_sf_tmem_cols={_kqk_sf_tmem_cols})"
+            )
+        self._setup_attributes()
+
+        cta_group = tcgen05.CtaGroup.ONE
+        # the intermediate tensor p is from tmem & k-major
+        p_source = tcgen05.OperandSource.TMEM
+        p_major_mode = cute.nvgpu.OperandMajorMode.K
+        qk_tiled_mma = self._make_qk_tiled_mma(cta_group)
+        pv_tiled_mma = self._make_pv_tiled_mma(cta_group, p_major_mode, p_source)
+
+        self.cluster_shape_mnk = (*self.cluster_shape_mn, 1)
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout(self.cluster_shape_mnk),
+            (qk_tiled_mma.thr_id.shape,),
+        )
+        self.epi_tile = self.pv_mma_tiler[:2]
+
+        q_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.q_dtype,
+            self.q_stage,
+        )
+        k_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.k_dtype,
+            self.kv_stage,
+        )
+        q_sf_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.qk_sf_vec_size,
+            self.q_stage,
+        )
+        k_sf_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            qk_tiled_mma,
+            self.qk_mma_tiler,
+            self.qk_sf_vec_size,
+            self.kv_stage,
+        )
+        p_tmem_layout_staged = sm100_utils.make_smem_layout_a(
+            pv_tiled_mma,
+            self.pv_mma_tiler,
+            self.v_dtype,
+            self.acc_stage,
+        )
+        v_smem_layout_staged_origin = sm100_utils.make_smem_layout_b(
+            pv_tiled_mma,
+            self.pv_mma_tiler,
+            self.v_dtype,
+            self.kv_stage,
+        )
+        # k & v share the same smem buffer. Pad the smaller-tile operand's stage stride to
+        # match the larger tile. Stride is scaled to the target operand's element width.
+        # sK_cosize covers all kv_stage slots at the larger tile's byte footprint.
+        if cutlass.const_expr(self.k_dtype.width >= self.v_dtype.width):
+            # k tile >= v tile: give v k's stage stride in v_dtype units
+            k_tile_cosize = cute.cosize(cute.select(k_smem_layout_staged, mode=[0, 1, 2]))
+            v_stage_stride = k_tile_cosize * self.k_dtype.width // self.v_dtype.width
+            v_smem_layout_staged = cute.append(
+                cute.select(v_smem_layout_staged_origin, mode=[0, 1, 2]),
+                cute.make_layout(self.kv_stage, stride=v_stage_stride),
+            )
+            sK_cosize = cute.cosize(k_smem_layout_staged)
+        else:
+            # v tile > k tile: give k v's stage stride in k_dtype units
+            v_tile_cosize = cute.cosize(cute.select(v_smem_layout_staged_origin, mode=[0, 1, 2]))
+            k_stage_stride = v_tile_cosize * self.v_dtype.width // self.k_dtype.width
+            k_smem_layout_staged = cute.append(
+                cute.select(k_smem_layout_staged, mode=[0, 1, 2]),
+                cute.make_layout(self.kv_stage, stride=k_stage_stride),
+            )
+            v_smem_layout_staged = v_smem_layout_staged_origin
+            # cute.cosize gives (kv_stage-1)*k_stage_stride + k_tile_cosize, but the
+            # last stage must also accommodate a full V tile, so size for kv_stage slots.
+            sK_cosize = self.kv_stage * k_stage_stride
+
+        o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.o_dtype,
+            self.o_layout,
+            self.epi_tile,
+            self.epi_stage,
+        )
+
+        # TMA load for Q
+        tma_load_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_store_op = cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+
+        q_smem_layout = cute.select(q_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_q, tma_tensor_q = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            q,
+            q_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        q_sf_smem_layout = cute.slice_(q_sf_smem_layout_staged, (None, None, None, 0))
+        tma_atom_q_sf, tma_tensor_q_sf = cute.nvgpu.make_tiled_tma_atom_A(
+            tma_load_op,
+            q_sf,
+            q_sf_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        # TMA load for K
+        k_smem_layout = cute.select(k_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_k, tma_tensor_k = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k,
+            k_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        k_sf_smem_layout = cute.slice_(k_sf_smem_layout_staged, (None, None, None, 0))
+        tma_atom_k_sf, tma_tensor_k_sf = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            k_sf,
+            k_sf_smem_layout,
+            self.qk_mma_tiler,
+            qk_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+        # TMA load for V
+        v_smem_layout = cute.select(v_smem_layout_staged, mode=[0, 1, 2])
+        tma_atom_v, tma_tensor_v = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            v,
+            v_smem_layout,
+            self.pv_mma_tiler,
+            pv_tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        o_smem_layout = cute.select(o_smem_layout_staged, mode=[0, 1])
+        tma_atom_o, tma_tensor_o = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_store_op,
+            o,
+            o_smem_layout,
+            self.epi_tile,
+        )
+
+        q_copy_size = cute.size_in_bytes(self.q_dtype, q_smem_layout)
+        k_copy_size = cute.size_in_bytes(self.k_dtype, k_smem_layout)
+        q_sf_copy_size = cute.size_in_bytes(self.qk_sf_dtype, q_sf_smem_layout)
+        k_sf_copy_size = cute.size_in_bytes(self.qk_sf_dtype, k_sf_smem_layout)
+        v_copy_size = cute.size_in_bytes(self.v_dtype, v_smem_layout)
+        self.tma_copy_q_bytes = q_copy_size + q_sf_copy_size
+        self.tma_copy_k_bytes = k_copy_size + k_sf_copy_size
+        self.tma_copy_v_bytes = v_copy_size
+
+        @cute.struct
+        class SharedStorage:
+            # Pipeline barriers
+            load_q_mbar_ptr: cute.struct.MemRange[Int64, self.q_stage * 2]
+            load_kv_mbar_ptr: cute.struct.MemRange[Int64, self.kv_stage * 2]
+            mma_s0_mbar_ptr: cute.struct.MemRange[Int64, self.mma_softmax_stage * 2]
+            mma_s1_mbar_ptr: cute.struct.MemRange[Int64, self.mma_softmax_stage * 2]
+            p0_mma_mbar_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            p1_mma_mbar_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            s0_corr_mbar_ptr: cute.struct.MemRange[Int64, self.softmax_corr_stage * 2]
+            s1_corr_mbar_ptr: cute.struct.MemRange[Int64, self.softmax_corr_stage * 2]
+            corr_epi_mbar_ptr: cute.struct.MemRange[Int64, self.epi_stage * 2]
+            mma_corr_mbar_ptr: cute.struct.MemRange[Int64, self.mma_corr_stage * 2]
+            s0_p1_inplace_barrier_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            s1_p0_inplace_barrier_ptr: cute.struct.MemRange[Int64, self.p_mma_stage * 2]
+            # Softmax_{1-j} signals MMA that S_{1-j}'s TMEM region (whose tail
+            # columns hold SFQ_j / SFK_j) is no longer being read, so mma_qk's
+            # SFQ/SFK S2T copy is safe to issue. One pipeline per QK stage.
+            qk_sf_inplace_0_barrier_ptr: cute.struct.MemRange[Int64, 1 * 2]
+            qk_sf_inplace_1_barrier_ptr: cute.struct.MemRange[Int64, 1 * 2]
+            # Tmem holding buffer
+            tmem_holding_buf: Int32
+            # Smem tensors
+            sO: cute.struct.Align[
+                cute.struct.MemRange[self.o_dtype, cute.cosize(o_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sQ: cute.struct.Align[
+                cute.struct.MemRange[self.q_dtype, cute.cosize(q_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sQSF: cute.struct.Align[
+                cute.struct.MemRange[self.qk_sf_dtype, cute.cosize(q_sf_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            sK: cute.struct.Align[
+                cute.struct.MemRange[self.k_dtype, sK_cosize],
+                self.buffer_align_bytes,
+            ]
+            sKSF: cute.struct.Align[
+                cute.struct.MemRange[self.qk_sf_dtype, cute.cosize(k_sf_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
+            # Skip softmax and PV warpgroup votes
+            s0_warp_wants_skip_softmax_exchange: cute.struct.MemRange[Int8, 4]
+            s1_warp_wants_skip_softmax_exchange: cute.struct.MemRange[Int8, 4]
+
+        self.shared_storage = SharedStorage
+
+        # Launch the kernel synchronously
+        self.kernel(
+            qk_tiled_mma,
+            pv_tiled_mma,
+            tma_atom_q,
+            tma_tensor_q,
+            tma_atom_q_sf,
+            tma_tensor_q_sf,
+            tma_atom_k,
+            tma_tensor_k,
+            tma_atom_k_sf,
+            tma_tensor_k_sf,
+            tma_atom_v,
+            tma_tensor_v,
+            tma_atom_o,
+            tma_tensor_o,
+            o,
+            cum_seqlen_q,
+            cum_seqlen_k,
+            lse,
+            sink,
+            scale_softmax_log2,
+            scale_softmax,
+            scale_output,
+            m_scale_v_channels,
+            skip_softmax_threshold_log2,
+            window_size_left,
+            window_size_right,
+            q_smem_layout_staged,
+            k_smem_layout_staged,
+            q_sf_smem_layout_staged,
+            k_sf_smem_layout_staged,
+            p_tmem_layout_staged,
+            v_smem_layout_staged,
+            o_smem_layout_staged,
+            skip_softmax_count,
+            total_softmax_count,
+            self.tile_sched_params,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=self.cluster_shape_mnk,
+            stream=stream,
+            min_blocks_per_mp=1,
+            use_pdl=use_pdl,
+        )
+
+    #  GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        qk_tiled_mma: cute.TiledMma,
+        pv_tiled_mma: cute.TiledMma,
+        tma_atom_q: cute.CopyAtom,
+        mQ_qdl: cute.Tensor,
+        tma_atom_q_sf: cute.CopyAtom,
+        mQSF_qdl: cute.Tensor,
+        tma_atom_k: cute.CopyAtom,
+        mK_kdl: cute.Tensor,
+        tma_atom_k_sf: cute.CopyAtom,
+        mKSF_kdl: cute.Tensor,
+        tma_atom_v: cute.CopyAtom,
+        mV_dkl: cute.Tensor,
+        tma_atom_o: cute.CopyAtom,
+        mO_qdl: cute.Tensor,
+        mO: cute.Tensor,
+        cum_seqlen_q: Optional[cute.Tensor],
+        cum_seqlen_k: Optional[cute.Tensor],
+        mLSE: Optional[cute.Tensor],
+        mSink: Optional[cute.Tensor],
+        scale_softmax_log2: Float32,
+        scale_softmax: Float32,
+        scale_output: Float32,
+        m_scale_v_channels: Optional[cute.Tensor],
+        skip_softmax_threshold_log2: Optional[Float32],
+        window_size_left: Optional[Int32],
+        window_size_right: Optional[Int32],
+        q_smem_layout_staged: cute.ComposedLayout,
+        k_smem_layout_staged: cute.ComposedLayout,
+        q_sf_smem_layout_staged: cute.Layout,
+        k_sf_smem_layout_staged: cute.Layout,
+        p_tmem_layout_staged: cute.ComposedLayout,
+        v_smem_layout_staged: cute.ComposedLayout,
+        o_smem_layout_staged: cute.ComposedLayout,
+        skip_softmax_count: Optional[cute.Tensor],
+        total_softmax_count: Optional[cute.Tensor],
+        tile_sched_params: fmha_utils.FmhaStaticTileSchedulerParams,
+    ):
+        """The device kernel implementation of the Fused Multi-Head Attention.
+
+        This kernel coordinates multiple specialized warps to perform different phases of the FMHA computation:
+        1. Load warp: Loads Q, K, V data from global memory to shared memory using TMA
+        2. MMA warp: Performs matrix multiplications (Q*K^T and P*V)
+        3. Softmax warps: Compute softmax normalization on attention scores
+        4. Correction warps: Apply adjustments to intermediate results
+        5. Epilogue warp: Handles final output transformation and storage
+
+        The kernel implements a complex pipeline with overlapping computation and memory operations,
+        using tensor memory access (TMA) for efficient data loading, warp specialization for different
+        computation phases, and optional attention masking.
+
+        :param qk_tiled_mma: Tiled MMA for Q*K^T
+        :type qk_tiled_mma: cute.TiledMma
+        :param pv_tiled_mma: Tiled MMA for P*V
+        :type pv_tiled_mma: cute.TiledMma
+        :param tma_atom_q: TMA copy atom for query tensor
+        :type tma_atom_q: cute.CopyAtom
+        :param mQ_qdl: Partitioned query tensor
+        :type mQ_qdl: cute.Tensor
+        :param tma_atom_k: TMA copy atom for key tensor
+        :type tma_atom_k: cute.CopyAtom
+        :param mK_kdl: Partitioned key tensor
+        :type mK_kdl: cute.Tensor
+        :param tma_atom_v: TMA copy atom for value tensor
+        :type tma_atom_v: cute.CopyAtom
+        :param mV_dkl: Partitioned value tensor
+        :type mV_dkl: cute.Tensor
+        :param tma_atom_o: TMA copy atom for output tensor
+        :type tma_atom_o: cute.CopyAtom
+        :param mO_qdl: Partitioned output tensor
+        :type mO_qdl: cute.Tensor
+        :param mO: Non-partitioned output tensor
+        :type mO: cute.Tensor
+        :param scale_softmax_log2: The log2 scale factor for softmax
+        :type scale_softmax_log2: Float32
+        :param scale_output: The scale factor for the output
+        :type scale_output: Float32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param q_smem_layout_staged: Shared memory layout for query tensor
+        :type q_smem_layout_staged: cute.ComposedLayout
+        :param k_smem_layout_staged: Shared memory layout for key tensor
+        :type k_smem_layout_staged: cute.ComposedLayout
+        :param p_tmem_layout_staged: Tensor memory layout for probability matrix
+        :type p_tmem_layout_staged: cute.ComposedLayout
+        :param v_smem_layout_staged: Shared memory layout for value tensor
+        :type v_smem_layout_staged: cute.ComposedLayout
+        :param o_smem_layout_staged: Shared memory layout for output tensor
+        :type o_smem_layout_staged: cute.ComposedLayout
+        :param tile_sched_params: Scheduling parameters for work distribution
+        :type tile_sched_params: fmha_utils.FmhaStaticTileSchedulerParams
+        """
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        # coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.load_warp_id:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_q_sf)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_k_sf)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
+            if cutlass.const_expr(self.use_tma_store):
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
+
+        # Alloc
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.q_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_q_bytes,
+            barrier_storage=storage.load_q_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        load_kv_producer, load_kv_consumer = pipeline.PipelineTmaUmma.create(
+            num_stages=self.kv_stage,
+            producer_group=make_thread_cooperative_group(len([self.load_warp_id])),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            tx_count=self.tma_copy_k_bytes,
+            barrier_storage=storage.load_kv_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        load_kv_full_mbar_ptr = storage.load_kv_mbar_ptr.data_ptr()
+        load_kv_empty_mbar_ptr = load_kv_full_mbar_ptr + self.kv_stage
+        mma_s0_producer, mma_s0_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_softmax_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            barrier_storage=storage.mma_s0_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        mma_s1_producer, mma_s1_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_softmax_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            barrier_storage=storage.mma_s1_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        p0_mma_producer, p0_mma_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.p_mma_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.p0_mma_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        p1_mma_producer, p1_mma_consumer = pipeline.PipelineAsyncUmma.create(
+            num_stages=self.p_mma_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.p1_mma_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        s0_corr_producer, s0_corr_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.softmax_corr_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len((*self.softmax0_warp_ids, self.mma_warp_id))
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            barrier_storage=storage.s0_corr_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        s1_corr_producer, s1_corr_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.softmax_corr_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len((*self.softmax1_warp_ids, self.mma_warp_id))
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            barrier_storage=storage.s1_corr_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        corr_epi_producer, corr_epi_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.epi_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len([self.epilogue_warp_id])
+            ),
+            barrier_storage=storage.corr_epi_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        mma_corr_producer, mma_corr_consumer = pipeline.PipelineUmmaAsync.create(
+            num_stages=self.mma_corr_stage,
+            producer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.correction_warp_ids)
+            ),
+            barrier_storage=storage.mma_corr_mbar_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        s0_p1_inplace_producer, s0_p1_inplace_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.p_mma_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            barrier_storage=storage.s0_p1_inplace_barrier_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        s1_p0_inplace_producer, s1_p0_inplace_consumer = pipeline.PipelineAsync.create(
+            num_stages=self.p_mma_stage,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            barrier_storage=storage.s1_p0_inplace_barrier_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        # QK SF TMEM-slot release pipelines: softmax_{1-j} (producer) signals
+        # MMA (consumer) once its T2R-load of S_{1-j} is done, so mma_qk(j)'s
+        # SFQ/SFK S2T copy is safe to overwrite the tail of TMEM[S_{1-j}].
+        qk_sf_inplace_0_producer, qk_sf_inplace_0_consumer = pipeline.PipelineAsync.create(
+            num_stages=1,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax1_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.qk_sf_inplace_0_barrier_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        qk_sf_inplace_1_producer, qk_sf_inplace_1_consumer = pipeline.PipelineAsync.create(
+            num_stages=1,
+            producer_group=make_thread_cooperative_group(
+                self.threads_per_warp * len(self.softmax0_warp_ids)
+            ),
+            consumer_group=make_thread_cooperative_group(len([self.mma_warp_id])),
+            barrier_storage=storage.qk_sf_inplace_1_barrier_ptr.data_ptr(),
+            defer_sync=True,
+        ).make_participants()
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            # Correction warp is the last one that accesses tmem
+            allocator_warp_id=self.correction_warp_ids[0],
+            arch=self.arch_str,
+        )
+        pipeline_init_arrive(is_relaxed=True)
+
+        #  Generate smem tensor Q/K/V/O
+        # (MMA, MMA_Q, MMA_D, PIPE)
+        sQ = storage.sQ.get_tensor(q_smem_layout_staged.outer, swizzle=q_smem_layout_staged.inner)
+        # (MMA, MMA_Q, MMA_D, PIPE)
+        sQSF = storage.sQSF.get_tensor(q_sf_smem_layout_staged)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        sK = storage.sK.get_tensor(k_smem_layout_staged.outer, swizzle=k_smem_layout_staged.inner)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        sKSF = storage.sKSF.get_tensor(k_sf_smem_layout_staged)
+        # (MMA, MMA_K, MMA_D, PIPE)
+        # Reuse k's smem buffer for v. Recast element type so MMA descriptor matches v_dtype.
+        sV_ptr = cute.recast_ptr(
+            cute.recast_ptr(sK.iterator, dtype=self.v_dtype),
+            v_smem_layout_staged.inner,
+        )
+        sV = cute.make_tensor(sV_ptr, v_smem_layout_staged.outer)
+        sO = storage.sO.get_tensor(o_smem_layout_staged.outer, swizzle=o_smem_layout_staged.inner)
+        s0_warp_wants_skip_softmax_exchange = (
+            storage.s0_warp_wants_skip_softmax_exchange.get_tensor(cute.make_layout((4,)))
+        )
+        s1_warp_wants_skip_softmax_exchange = (
+            storage.s1_warp_wants_skip_softmax_exchange.get_tensor(cute.make_layout((4,)))
+        )
+
+        qk_thr_mma = qk_tiled_mma.get_slice(0)  # default 1sm
+        pv_thr_mma = pv_tiled_mma.get_slice(0)  # default 1sm
+        tSrQ = qk_thr_mma.make_fragment_A(sQ)
+        tSrK = qk_thr_mma.make_fragment_B(sK)
+        tOrV = pv_thr_mma.make_fragment_B(sV)
+
+        def make_tmem_tensors(
+            self,
+            qk_thr_mma: cute.TiledMma,
+            pv_thr_mma: cute.TiledMma,
+            p_tmem_layout_staged: cute.Layout,
+            tmem_ptr: cute.Pointer,
+        ):
+            qk_acc_shape = qk_thr_mma.partition_shape_C(
+                (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
+            )
+            tStS_fake = qk_thr_mma.make_fragment_C(qk_acc_shape)
+            tStS = cute.make_tensor(tmem_ptr + self.tmem_s0_offset, tStS_fake.layout)
+            pv_acc_shape = pv_thr_mma.partition_shape_C(
+                (self.pv_mma_tiler[0], self.pv_mma_tiler[1])
+            )
+            tOtO = pv_thr_mma.make_fragment_C(pv_acc_shape)
+            tStS0 = cute.make_tensor(tmem_ptr + self.tmem_s0_offset, tStS.layout)
+            tStS1 = cute.make_tensor(tmem_ptr + self.tmem_s1_offset, tStS.layout)
+            tOtO0 = cute.make_tensor(tmem_ptr + self.tmem_o0_offset, tOtO.layout)
+            tOtO1 = cute.make_tensor(tmem_ptr + self.tmem_o1_offset, tOtO.layout)
+            tP = cute.make_tensor(tStS.iterator, p_tmem_layout_staged.outer)
+            tOrP = pv_thr_mma.make_fragment_A(tP)[None, None, None, 0]
+            tOrP0 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr + self.tmem_p0_offset,
+                    dtype=tOrP.dtype,
+                ),
+                tOrP.layout,
+            )
+            tOrP1 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr + self.tmem_p1_offset,
+                    dtype=tOrP.dtype,
+                ),
+                tOrP.layout,
+            )
+            return tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1
+
+        tile_sched = fmha_utils.create_fmha_static_tile_scheduler(
+            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+        pipeline_init_wait()
+        softmax_fn = partial(
+            self.softmax,
+            qk_thr_mma=qk_thr_mma,
+            value_args=(
+                mK_kdl.shape[0],
+                mQ_qdl.shape[0],
+                scale_softmax_log2,
+                skip_softmax_threshold_log2,
+            ),
+            mask_args=(window_size_left, window_size_right),
+            sched_args=(tile_sched, work_tile),
+            # Each softmax warpgroup picks its producer by stage: softmax0
+            # (stage=0) produces on qk_sf_inplace_1, softmax1 (stage=1) on
+            # qk_sf_inplace_0.
+            qk_sf_inplace_producers=(
+                qk_sf_inplace_1_producer,
+                qk_sf_inplace_0_producer,
+            ),
+        )
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  EMPTY
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.empty_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  LOAD
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.load_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            cute.arch.griddepcontrol_wait()
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cum_seqlen_k[batch_coord]
+                    continue_cond = seqlen_k <= 0
+                if not continue_cond:
+                    mQ_qdl_ = mQ_qdl
+                    mK_kdl_ = mK_kdl
+                    mQSF_qdl_ = mQSF_qdl
+                    mKSF_kdl_ = mKSF_kdl
+                    mV_dkl_ = mV_dkl
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        mQ_qdl_ = cute.domain_offset(
+                            (cum_seqlen_q[batch_coord], 0, ((0, 0), 0)), mQ_qdl
+                        )
+                        mQSF_qdl_ = cute.domain_offset(
+                            (cum_seqlen_q[batch_coord], 0, (0, 0)), mQSF_qdl
+                        )
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        mK_kdl_ = cute.domain_offset(
+                            (cum_seqlen_k[batch_coord], 0, ((0, 0), 0)), mK_kdl
+                        )
+                        mKSF_kdl_ = cute.domain_offset(
+                            (cum_seqlen_k[batch_coord], 0, (0, 0)), mKSF_kdl
+                        )
+                        mV_dkl_ = cute.domain_offset(
+                            (0, cum_seqlen_k[batch_coord], ((0, 0), 0)), mV_dkl
+                        )
+                    # Local tile partition global tensors
+                    gQ_qdl = cute.flat_divide(mQ_qdl_, cute.select(self.qk_mma_tiler, mode=[0, 2]))
+                    tSgQ_qdl = qk_thr_mma.partition_A(gQ_qdl)
+                    tQsQ, tQgQ_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_q,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sQ, 0, 3),
+                        cute.group_modes(tSgQ_qdl, 0, 3),
+                    )
+                    tQgQ = tQgQ_qdl[None, None, 0, curr_block_coord[2]]
+                    gQSF_qdl = cute.local_tile(
+                        mQSF_qdl_,
+                        cute.select(self.qk_mma_tiler, mode=[0, 2]),
+                        (None, None, None),
+                    )
+                    tSgQSF_qdl = qk_thr_mma.partition_A(gQSF_qdl)
+                    tQsQSF, tQgQSF_qdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_q_sf,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sQSF, 0, 3),
+                        cute.group_modes(tSgQSF_qdl, 0, 3),
+                    )
+                    tQsQSF = cute.filter_zeros(tQsQSF)
+                    tQgQSF_qdl = cute.filter_zeros(tQgQSF_qdl)
+                    # tile_atom_to_shape_SF coalesces Q's ((h_r, h_k), b) mode into (1, h_r*h_k*b),
+                    # One needs to reconstruct the correct layout here to correctly map block_coord
+                    # onto this linearlized L-like mode.
+                    sf_l_q = cute.make_layout(
+                        mQ_qdl.shape[2],
+                        stride=(
+                            (1, mQ_qdl.shape[2][0][0]),
+                            cute.size(mQ_qdl.shape[2][0]),
+                        ),
+                    )(curr_block_coord[2])
+                    tQgQSF = tQgQSF_qdl[None, None, 0, sf_l_q]
+                    gK_kdl = cute.flat_divide(mK_kdl_, cute.select(self.qk_mma_tiler, mode=[1, 2]))
+                    tSgK_kdl = qk_thr_mma.partition_B(gK_kdl)
+                    tKsK, tKgK_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sK, 0, 3),
+                        cute.group_modes(tSgK_kdl, 0, 3),
+                    )
+                    tKgK = tKgK_kdl[None, None, 0, curr_block_coord[2]]
+                    gKSF_kdl = cute.local_tile(
+                        mKSF_kdl_,
+                        cute.select(self.qk_mma_tiler, mode=[1, 2]),
+                        (None, None, None),
+                    )
+                    tSgKSF_kdl = qk_thr_mma.partition_B(gKSF_kdl)
+                    tKsKSF, tKgKSF_kdl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_k_sf,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sKSF, 0, 3),
+                        cute.group_modes(tSgKSF_kdl, 0, 3),
+                    )
+                    tKsKSF = cute.filter_zeros(tKsKSF)
+                    tKgKSF_kdl = cute.filter_zeros(tKgKSF_kdl)
+                    # Same L-mode trick as Q's SF (see comment above). K's SF is shared across h_r heads
+                    # (it indexes h_k, not h_q), which we express by a 0-stride for the h_r sub-mode.
+                    sf_l_k = cute.make_layout(
+                        mK_kdl.shape[2],
+                        stride=((0, 1), mK_kdl.shape[2][0][1]),
+                    )(curr_block_coord[2])
+                    tKgKSF = tKgKSF_kdl[None, None, 0, sf_l_k]
+                    gV_dkl = cute.flat_divide(mV_dkl_, cute.select(self.pv_mma_tiler, mode=[1, 2]))
+                    tSgV_dkl = pv_thr_mma.partition_B(gV_dkl)
+                    tVsV, tVgV_dkl = cute.nvgpu.cpasync.tma_partition(
+                        tma_atom_v,
+                        0,  # no multicast
+                        cute.make_layout(1),
+                        cute.group_modes(sV, 0, 3),
+                        cute.group_modes(tSgV_dkl, 0, 3),
+                    )
+                    tVgV = tVgV_dkl[None, 0, None, curr_block_coord[2]]
+                    seqlen_kv_loop_start = fmha_utils.FusedMask.get_trip_start(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        window_size_left,
+                    )
+                    # Q0
+                    q0_coord = 2 * curr_block_coord[0]
+                    q0_handle = load_q_producer.acquire_and_advance()
+                    cute.copy(
+                        tma_atom_q,
+                        tQgQ[None, q0_coord],
+                        tQsQ[None, q0_handle.index],
+                        tma_bar_ptr=q0_handle.barrier,
+                    )
+                    cute.copy(
+                        tma_atom_q_sf,
+                        tQgQSF[None, q0_coord],
+                        tQsQSF[None, q0_handle.index],
+                        tma_bar_ptr=q0_handle.barrier,
+                    )
+                    seqlen_kv_loop_steps = fmha_utils.FusedMask.get_trip_count(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    # K0
+                    kv_coord = seqlen_kv_loop_start
+                    k_handle = load_kv_producer.acquire_and_advance()
+                    cute.copy(
+                        tma_atom_k,
+                        tKgK[None, kv_coord],
+                        tKsK[None, k_handle.index],
+                        tma_bar_ptr=k_handle.barrier,
+                    )
+                    cute.copy(
+                        tma_atom_k_sf,
+                        tKgKSF[None, kv_coord],
+                        tKsKSF[None, k_handle.index],
+                        tma_bar_ptr=k_handle.barrier,
+                    )
+                    # Q1
+                    q1_coord = q0_coord + 1
+                    q1_handle = load_q_producer.acquire_and_advance()
+                    cute.copy(
+                        tma_atom_q,
+                        tQgQ[None, q1_coord],
+                        tQsQ[None, q1_handle.index],
+                        tma_bar_ptr=q1_handle.barrier,
+                    )
+                    cute.copy(
+                        tma_atom_q_sf,
+                        tQgQSF[None, q1_coord],
+                        tQsQSF[None, q1_handle.index],
+                        tma_bar_ptr=q1_handle.barrier,
+                    )
+                    kv_coord += 1
+
+                    for i in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Ki
+                        k_handle = load_kv_producer.acquire_and_advance()
+                        cute.copy(
+                            tma_atom_k,
+                            tKgK[None, kv_coord],
+                            tKsK[None, k_handle.index],
+                            tma_bar_ptr=k_handle.barrier,
+                        )
+                        cute.copy(
+                            tma_atom_k_sf,
+                            tKgKSF[None, kv_coord],
+                            tKsKSF[None, k_handle.index],
+                            tma_bar_ptr=k_handle.barrier,
+                        )
+                        # Vi-1
+                        v_handle, load_kv_producer = self.kv_producer_update_tx_acquire_and_advance(
+                            load_kv_producer,
+                            load_kv_empty_mbar_ptr,
+                            load_kv_full_mbar_ptr,
+                            self.tma_copy_v_bytes,
+                        )
+                        cute.copy(
+                            tma_atom_v,
+                            tVgV[None, kv_coord - 1],
+                            tVsV[None, v_handle.index],
+                            tma_bar_ptr=load_kv_full_mbar_ptr + v_handle.index,
+                        )
+                        kv_coord += 1
+                    # End of seqlen_kv loop
+                    # Vi_end
+                    v_handle, load_kv_producer = self.kv_producer_update_tx_acquire_and_advance(
+                        load_kv_producer,
+                        load_kv_empty_mbar_ptr,
+                        load_kv_full_mbar_ptr,
+                        self.tma_copy_v_bytes,
+                    )
+                    cute.copy(
+                        tma_atom_v,
+                        tVgV[None, kv_coord - 1],
+                        tVsV[None, v_handle.index],
+                        tma_bar_ptr=load_kv_full_mbar_ptr + v_handle.index,
+                    )
+                # End of if not continue_cond
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                # End of persistent scheduler loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  MMA
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
+                self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            q_sf_tmem_layout = blockscaled_utils.make_tmem_layout_sfa(
+                qk_tiled_mma,
+                self.qk_mma_tiler,
+                self.qk_sf_vec_size,
+                cute.slice_(q_sf_smem_layout_staged, (None, None, None, 0)),
+            )
+            k_sf_tmem_layout = blockscaled_utils.make_tmem_layout_sfb(
+                qk_tiled_mma,
+                self.qk_mma_tiler,
+                self.qk_sf_vec_size,
+                cute.slice_(k_sf_smem_layout_staged, (None, None, None, 0)),
+            )
+            # TMEM offsets are in u32 columns. Follow FA4's explicit SFQ footprint
+            # calculation instead of deriving the offset from the recast FP8 tensor
+            # view, which can under-count for block-scaled layouts.
+            sf_atom_mn = 32
+            q_sf_tmem_cols = (self.qk_mma_tiler[0] // sf_atom_mn) * self.qk_mma_inst_tile_k
+            k_sf_tmem_cols = (
+                ((self.qk_mma_tiler[1] + 127) // 128 * 128) // sf_atom_mn
+            ) * self.qk_mma_inst_tile_k
+            tCtQSF0 = cute.make_tensor(
+                cute.recast_ptr(tmem_ptr + self.tmem_qk0_sf_offset, dtype=self.qk_sf_dtype),
+                q_sf_tmem_layout,
+            )
+            tCtKSF0 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr + self.tmem_qk0_sf_offset + q_sf_tmem_cols,
+                    dtype=self.qk_sf_dtype,
+                ),
+                k_sf_tmem_layout,
+            )
+            tCtQSF1 = cute.make_tensor(
+                cute.recast_ptr(tmem_ptr + self.tmem_qk1_sf_offset, dtype=self.qk_sf_dtype),
+                q_sf_tmem_layout,
+            )
+            tCtKSF1 = cute.make_tensor(
+                cute.recast_ptr(
+                    tmem_ptr + self.tmem_qk1_sf_offset + q_sf_tmem_cols,
+                    dtype=self.qk_sf_dtype,
+                ),
+                k_sf_tmem_layout,
+            )
+            tiled_copy_s2t_qsf0, tCsQSF_s2t, tCtQSF0_s2t = self.mainloop_s2t_copy_and_partition(
+                sQSF, tCtQSF0
+            )
+            tiled_copy_s2t_ksf0, tCsKSF_s2t, tCtKSF0_s2t = self.mainloop_s2t_copy_and_partition(
+                sKSF, tCtKSF0
+            )
+            tiled_copy_s2t_qsf1, tCsQSF1_s2t, tCtQSF1_s2t = self.mainloop_s2t_copy_and_partition(
+                sQSF, tCtQSF1
+            )
+            tiled_copy_s2t_ksf1, tCsKSF1_s2t, tCtKSF1_s2t = self.mainloop_s2t_copy_and_partition(
+                sKSF, tCtKSF1
+            )
+            enable_skip_softmax = skip_softmax_threshold_log2 is not None
+            tiled_tmem_load_v = None
+            tTMEM_LOADtS_v0, tTMEM_LOADtS_v1 = None, None
+            tTMEM_LOADrS_v0, tTMEM_LOADrS_v1 = None, None
+            if cutlass.const_expr(enable_skip_softmax):
+                cS = cute.make_identity_tensor(cute.select(self.qk_mma_tiler, mode=[0, 1]))
+                tScS = qk_thr_mma.partition_C(cS)
+                tStS_v = cute.composition(tStS, cute.make_layout((self.threads_per_warp, 1)))
+                tScS_v = cute.composition(tScS, cute.make_layout((self.threads_per_warp, 1)))
+                tmem_load_v_atom = cute.make_copy_atom(
+                    tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(1)),
+                    self.qk_acc_dtype,
+                )
+                thread_idx = tidx % self.threads_per_warp
+
+                tiled_tmem_load_v = tcgen05.make_tmem_copy(tmem_load_v_atom, tStS_v)
+                thr_tmem_load_v = tiled_tmem_load_v.get_slice(thread_idx)
+                tTMEM_LOADtS_v = thr_tmem_load_v.partition_S(tStS_v)
+                tTMEM_LOADcS_v = thr_tmem_load_v.partition_D(tScS_v)
+                tTMEM_LOADrS_v0 = cute.make_rmem_tensor(tTMEM_LOADcS_v.shape, self.qk_acc_dtype)
+                tTMEM_LOADrS_v1 = cute.make_rmem_tensor(tTMEM_LOADcS_v.shape, self.qk_acc_dtype)
+                tTMEM_LOADtS_v0 = cute.make_tensor(
+                    tTMEM_LOADtS_v.iterator + self.tmem_skip_softmax0_offset,
+                    tTMEM_LOADtS_v.layout,
+                )
+                tTMEM_LOADtS_v1 = cute.make_tensor(
+                    tTMEM_LOADtS_v.iterator + self.tmem_skip_softmax1_offset,
+                    tTMEM_LOADtS_v.layout,
+                )
+
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                batch_coord = curr_block_coord[2][1]
+                continue_cond = False
+                seqlen_q = mQ_qdl.shape[0]
+                seqlen_k = mK_kdl.shape[0]
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+                if not continue_cond:
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    continue_cond = seqlen_k <= 0
+                if not continue_cond:
+                    # Wait for Q0
+                    q0_handle = load_q_consumer.wait_and_advance()
+                    tSrQ0 = tSrQ[None, None, None, q0_handle.index]
+                    # Wait for K0
+                    k_handle = load_kv_consumer.wait_and_advance()
+                    tSrK0 = tSrK[None, None, None, k_handle.index]
+                    q0_sf_stage = (None, None, None, None, q0_handle.index)
+                    k_sf_stage = (None, None, None, None, k_handle.index)
+                    # GEMM_QK00 (Q0 * K0 -> S0)
+                    mma_s0_producer, s0_corr_producer, qk_sf_inplace_0_consumer = self.mma_qk(
+                        qk_tiled_mma,
+                        (tSrQ0, tSrK0, tStS0),
+                        (
+                            tiled_copy_s2t_qsf0,
+                            tCsQSF_s2t[q0_sf_stage],
+                            tCtQSF0_s2t,
+                            tCtQSF0,
+                            tiled_copy_s2t_ksf0,
+                            tCsKSF_s2t[k_sf_stage],
+                            tCtKSF0_s2t,
+                            tCtKSF0,
+                        ),
+                        (mma_s0_producer, s0_corr_producer),
+                        qk_sf_inplace_0_consumer,
+                    )
+                    # Wait for Q1
+                    q1_handle = load_q_consumer.wait_and_advance()
+                    tSrQ1 = tSrQ[None, None, None, q1_handle.index]
+                    q1_sf_stage = (None, None, None, None, q1_handle.index)
+                    # GEMM_QK10 (Q1 * K0 -> S1), K0 is ready in GEMM_QK00
+                    mma_s1_producer, s1_corr_producer, qk_sf_inplace_1_consumer = self.mma_qk(
+                        qk_tiled_mma,
+                        (tSrQ1, tSrK0, tStS1),
+                        (
+                            tiled_copy_s2t_qsf1,
+                            tCsQSF1_s2t[q1_sf_stage],
+                            tCtQSF1_s2t,
+                            tCtQSF1,
+                            tiled_copy_s2t_ksf1,
+                            tCsKSF1_s2t[k_sf_stage],
+                            tCtKSF1_s2t,
+                            tCtKSF1,
+                        ),
+                        (mma_s1_producer, s1_corr_producer),
+                        qk_sf_inplace_1_consumer,
+                    )
+                    # Release K0
+                    k_handle.release()
+                    # Note: Q0 & Q1 are still needed in the seqlen_kv loop
+                    # so we need to release them after the seqlen_kv loop
+                    seqlen_kv_loop_steps = fmha_utils.FusedMask.get_trip_count(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    # O1 hasn't been accumulated yet, its first MMA calculation doesn't need to accumulate
+                    pv_whether_acc = False
+                    for i in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Wait for Ki
+                        k_handle = load_kv_consumer.wait_and_advance()
+                        tSrKi = tSrK[None, None, None, k_handle.index]
+                        k_sf_stage = (None, None, None, None, k_handle.index)
+                        # GEMM_QK0i (Q0 * Ki -> S0)
+                        mma_s0_producer, s0_corr_producer, qk_sf_inplace_0_consumer = self.mma_qk(
+                            qk_tiled_mma,
+                            (tSrQ0, tSrKi, tStS0),
+                            (
+                                tiled_copy_s2t_qsf0,
+                                tCsQSF_s2t[q0_sf_stage],
+                                tCtQSF0_s2t,
+                                tCtQSF0,
+                                tiled_copy_s2t_ksf0,
+                                tCsKSF_s2t[k_sf_stage],
+                                tCtKSF0_s2t,
+                                tCtKSF0,
+                            ),
+                            (mma_s0_producer, s0_corr_producer),
+                            qk_sf_inplace_0_consumer,
+                        )
+                        # Wait for Vi-1
+                        v_handle = load_kv_consumer.wait_and_advance()
+                        tOrVi = tOrV[None, None, None, v_handle.index]
+                        # GEMM_PV0(i-1) (P0 * Vi-1 -> O0_partial)
+                        mma_corr_producer, p0_mma_consumer = self.mma_pv(
+                            pv_tiled_mma,
+                            pv_whether_acc,
+                            (tOrP0, tOrVi, tOtO0),
+                            (mma_corr_producer, p0_mma_consumer),
+                            (
+                                enable_skip_softmax,
+                                tiled_tmem_load_v,
+                                tTMEM_LOADtS_v0,
+                                tTMEM_LOADrS_v0,
+                            ),
+                        )
+                        # GEMM_QK1i (Q1 * Ki -> S1)
+                        mma_s1_producer, s1_corr_producer, qk_sf_inplace_1_consumer = self.mma_qk(
+                            qk_tiled_mma,
+                            (tSrQ1, tSrKi, tStS1),
+                            (
+                                tiled_copy_s2t_qsf1,
+                                tCsQSF1_s2t[q1_sf_stage],
+                                tCtQSF1_s2t,
+                                tCtQSF1,
+                                tiled_copy_s2t_ksf1,
+                                tCsKSF1_s2t[k_sf_stage],
+                                tCtKSF1_s2t,
+                                tCtKSF1,
+                            ),
+                            (mma_s1_producer, s1_corr_producer),
+                            qk_sf_inplace_1_consumer,
+                        )
+                        # Release Ki
+                        k_handle.release()
+                        # GEMM_PV1(i-1) (P1 * Vi-1 -> O1_partial)
+                        mma_corr_producer, p1_mma_consumer = self.mma_pv(
+                            pv_tiled_mma,
+                            pv_whether_acc,
+                            (tOrP1, tOrVi, tOtO1),
+                            (mma_corr_producer, p1_mma_consumer),
+                            (
+                                enable_skip_softmax,
+                                tiled_tmem_load_v,
+                                tTMEM_LOADtS_v1,
+                                tTMEM_LOADrS_v1,
+                            ),
+                        )
+                        pv_whether_acc = True
+                        # Release Vi-1
+                        v_handle.release()
+                    # End of seqlen_kv loop
+                    # release Q0 & Q1
+                    q0_handle.release()
+                    q1_handle.release()
+                    # Wait for Vi_end
+                    v_handle = load_kv_consumer.wait_and_advance()
+                    tOrVi = tOrV[None, None, None, v_handle.index]
+                    # GEMM_PV0(i_end) (P0 * Vi_end -> O0)
+                    mma_corr_producer, p0_mma_consumer = self.mma_pv(
+                        pv_tiled_mma,
+                        pv_whether_acc,
+                        (tOrP0, tOrVi, tOtO0),
+                        (mma_corr_producer, p0_mma_consumer),
+                        (
+                            enable_skip_softmax,
+                            tiled_tmem_load_v,
+                            tTMEM_LOADtS_v0,
+                            tTMEM_LOADrS_v0,
+                        ),
+                    )
+                    # GEMM_PV1(i_end) (P1 * Vi_end -> O1)
+                    mma_corr_producer, p1_mma_consumer = self.mma_pv(
+                        pv_tiled_mma,
+                        pv_whether_acc,
+                        (tOrP1, tOrVi, tOtO1),
+                        (mma_corr_producer, p1_mma_consumer),
+                        (
+                            enable_skip_softmax,
+                            tiled_tmem_load_v,
+                            tTMEM_LOADtS_v1,
+                            tTMEM_LOADrS_v1,
+                        ),
+                    )
+                    # Release Vi_end
+                    v_handle.release()
+                    # Empty step for correction epilog
+                    vec0_handle = s0_corr_producer.acquire_and_advance()
+                    vec0_handle.commit()
+                    vec1_handle = s1_corr_producer.acquire_and_advance()
+                    vec1_handle.commit()
+                # End of if not continue_cond
+                # Advance to next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+            # End of persistent scheduler loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Epilogue (TMA store path only)
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx == self.epilogue_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_other)
+            if cutlass.const_expr(self.use_tma_store):
+                while work_tile.is_valid_tile:
+                    curr_block_coord = work_tile.tile_idx
+                    batch_coord = curr_block_coord[2][1]
+                    continue_cond = False
+                    cuseqlen_q = Int32(0)
+                    seqlen_q = mQ_qdl.shape[0]
+
+                    if cutlass.const_expr(cum_seqlen_q is not None):
+                        cuseqlen_q = cum_seqlen_q[batch_coord]
+                        seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                        continue_cond = (
+                            not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                                self.cta_tiler[0],
+                                curr_block_coord[0],
+                                seqlen_q,
+                            )
+                        )
+                    if not continue_cond:
+                        mO_qdl_ = mO_qdl
+                        if cutlass.const_expr(cum_seqlen_q is not None):
+                            mO_qdl_ = cute.domain_offset(
+                                (cum_seqlen_q[batch_coord], 0, ((0, 0), 0)), mO_qdl
+                            )
+
+                        o0_coord = 2 * curr_block_coord[0]
+                        o1_coord = o0_coord + 1
+                        gO_qdl = cute.flat_divide(
+                            mO_qdl_, cute.select(self.pv_mma_tiler, mode=[0, 1])
+                        )
+                        gO = gO_qdl[None, None, None, 0, curr_block_coord[2]]
+                        tOsO, tOgO = cute.nvgpu.cpasync.tma_partition(
+                            tma_atom_o,
+                            0,
+                            cute.make_layout(1),
+                            cute.group_modes(sO, 0, 2),
+                            cute.group_modes(gO, 0, 2),
+                        )
+
+                        # O0 O1 using the same pipeline
+                        # wait from corr, issue tma store on smem
+                        # O0
+                        # 1. Wait for O0 final
+                        o0_handle = corr_epi_consumer.wait_and_advance()
+                        # 2. Copy O0 to gmem
+                        cute.copy(tma_atom_o, tOsO[None, 0], tOgO[None, o0_coord])
+                        cute.arch.cp_async_bulk_commit_group()
+                        # O1
+                        # 1. Wait for O1 final
+                        o1_handle = corr_epi_consumer.wait_and_advance()
+                        # 2. Copy O1 to gmem
+                        cute.copy(tma_atom_o, tOsO[None, 1], tOgO[None, o1_coord])
+                        cute.arch.cp_async_bulk_commit_group()
+
+                        # Ensure O0 buffer is ready to be released
+                        cute.arch.cp_async_bulk_wait_group(1, read=True)
+                        o0_handle.release()
+                        # Ensure O1 buffer is ready to be released
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
+                        o1_handle.release()
+
+                    # Advance to next tile
+                    tile_sched.advance_to_next_work()
+                    work_tile = tile_sched.get_current_work()
+                cute.arch.griddepcontrol_launch_dependents()
+            # End of persistent scheduler loop
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Softmax0
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx < self.softmax1_warp_ids[0]:
+            cute.arch.setmaxregister_increase(self.num_regs_softmax)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
+                self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            softmax_fn(
+                stage=0,
+                tensor_args=(
+                    tStS,
+                    tStS0,
+                    cum_seqlen_k,
+                    cum_seqlen_q,
+                    s0_warp_wants_skip_softmax_exchange,
+                    skip_softmax_count,
+                    total_softmax_count,
+                ),
+                pipeline_args=(mma_s0_consumer, s0_corr_producer, p0_mma_producer),
+                inplace_args=(s0_p1_inplace_producer, s1_p0_inplace_consumer),
+            )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Softmax1
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx < self.correction_warp_ids[0] and warp_idx >= self.softmax1_warp_ids[0]:
+            cute.arch.setmaxregister_increase(self.num_regs_softmax)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
+                self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            softmax_fn(
+                stage=1,
+                tensor_args=(
+                    tStS,
+                    tStS1,
+                    cum_seqlen_k,
+                    cum_seqlen_q,
+                    s1_warp_wants_skip_softmax_exchange,
+                    skip_softmax_count,
+                    total_softmax_count,
+                ),
+                pipeline_args=(mma_s1_consumer, s1_corr_producer, p1_mma_producer),
+                inplace_args=(s1_p0_inplace_producer, s0_p1_inplace_consumer),
+            )
+
+        # ///////////////////////////////////////////////////////////////////////////////
+        #  Correction
+        # ///////////////////////////////////////////////////////////////////////////////
+        if warp_idx >= self.correction_warp_ids[0] and warp_idx < self.mma_warp_id:
+            cute.arch.setmaxregister_decrease(self.num_regs_correction)
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
+            tStS, tStS0, tStS1, tOtO0, tOtO1, tOrP0, tOrP1 = make_tmem_tensors(
+                self, qk_thr_mma, pv_thr_mma, p_tmem_layout_staged, tmem_ptr
+            )
+            cS = cute.make_identity_tensor((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+            tScS = qk_thr_mma.partition_C(cS)
+
+            tStS_vec_layout = cute.composition(tStS.layout, cute.make_layout((128, 2)))
+
+            tStS_vec0 = cute.make_tensor(tStS.iterator + self.tmem_vec0_offset, tStS_vec_layout)
+            tStS_vec1 = cute.make_tensor(tStS.iterator + self.tmem_vec1_offset, tStS_vec_layout)
+
+            tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
+            tScS_vec = cute.make_tensor(tScS.iterator, tScS_vec_layout)
+            tmem_load_v_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(2)),
+                self.qk_acc_dtype,
+            )
+            tiled_tmem_load_vec = tcgen05.make_tmem_copy(tmem_load_v_atom, tStS_vec0)
+            thread_idx = tidx % (self.threads_per_warp * len(self.correction_warp_ids))
+            thr_tmem_load_vec = tiled_tmem_load_vec.get_slice(thread_idx)
+            tTMEM_LOAD_VECtS0 = thr_tmem_load_vec.partition_S(tStS_vec0)
+            tTMEM_LOAD_VECtS1 = thr_tmem_load_vec.partition_S(tStS_vec1)
+            tTMEM_LOAD_VECcS = thr_tmem_load_vec.partition_D(tScS_vec)
+            while work_tile.is_valid_tile:
+                curr_block_coord = work_tile.tile_idx
+                batch_coord = curr_block_coord[2][1]
+                seqlen_k = mK_kdl.shape[0]
+                row_idx = Int32(0)
+                continue_cond = False
+                cuseqlen_q = Int32(0)
+                seqlen_q = mQ_qdl.shape[0]
+
+                if cutlass.const_expr(cum_seqlen_q is not None):
+                    cuseqlen_q = cum_seqlen_q[batch_coord]
+                    seqlen_q = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                    continue_cond = (
+                        not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                            self.cta_tiler[0],
+                            curr_block_coord[0],
+                            seqlen_q,
+                        )
+                    )
+                if not continue_cond:
+                    row_idx = curr_block_coord[0] * self.cta_tiler[0] + tTMEM_LOAD_VECcS[0][0]
+                    if cutlass.const_expr(cum_seqlen_k is not None):
+                        cuseqlen_k = cum_seqlen_k[batch_coord]
+                        seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                    continue_cond = seqlen_k <= 0
+                if not continue_cond:
+                    # Ignore first signal from softmax as no correction is required
+                    vec0_handle = s0_corr_consumer.wait_and_advance()
+                    vec0_handle.release()
+                    vec1_handle = s1_corr_consumer.wait_and_advance()
+                    vec1_handle.release()
+                    # O0/O1 share the same mma_corr consumer state, so the Oi
+                    # peek token rolls from O0 -> O1 -> next O0. Seed with a
+                    # blocking token; the rescale helper refreshes it near the
+                    # end of each iteration.
+                    oi_peek_status = cutlass.Boolean(False)
+                    seqlen_kv_loop_steps = fmha_utils.FusedMask.get_trip_count(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q,
+                        seqlen_k,
+                        window_size_left,
+                        window_size_right,
+                    )
+                    for i in cutlass.range(1, seqlen_kv_loop_steps, 1, unroll=1):
+                        # Rescale O0
+                        (
+                            (s0_corr_consumer, mma_corr_consumer),
+                            oi_peek_status,
+                        ) = self.correction_rescale(
+                            pv_thr_mma,
+                            tiled_tmem_load_vec,
+                            scale_softmax_log2,
+                            (tOtO0, tTMEM_LOAD_VECtS0, tTMEM_LOAD_VECcS),
+                            (s0_corr_consumer, mma_corr_consumer),
+                            oi_peek_status,
+                        )
+                        # Rescale O1
+                        (
+                            (s1_corr_consumer, mma_corr_consumer),
+                            oi_peek_status,
+                        ) = self.correction_rescale(
+                            pv_thr_mma,
+                            tiled_tmem_load_vec,
+                            scale_softmax_log2,
+                            (tOtO1, tTMEM_LOAD_VECtS1, tTMEM_LOAD_VECcS),
+                            (s1_corr_consumer, mma_corr_consumer),
+                            oi_peek_status,
+                        )
+                    # End of seqlen_corr_loop_steps
+                    value_args = (
+                        cuseqlen_q,
+                        seqlen_q,
+                        curr_block_coord,
+                        scale_softmax,
+                        scale_output,
+                    )
+                    if cutlass.const_expr(self.use_tma_store):
+                        # TMA store path: write to sO, signal epilogue warp
+                        # Normalize O0
+                        s0_corr_consumer, mma_corr_consumer, corr_epi_producer = (
+                            self.correction_epilog(
+                                pv_thr_mma,
+                                tiled_tmem_load_vec,
+                                (
+                                    tOtO0,
+                                    tTMEM_LOAD_VECtS0,
+                                    tTMEM_LOAD_VECcS,
+                                    sO[None, None, 0],
+                                    mLSE,
+                                    mSink,
+                                    m_scale_v_channels,
+                                ),
+                                (
+                                    s0_corr_consumer,
+                                    mma_corr_consumer,
+                                    corr_epi_producer,
+                                ),
+                                (row_idx, *value_args),
+                            )
+                        )
+                        row_idx += self.qk_mma_tiler[0]
+                        # Normalize O1
+                        s1_corr_consumer, mma_corr_consumer, corr_epi_producer = (
+                            self.correction_epilog(
+                                pv_thr_mma,
+                                tiled_tmem_load_vec,
+                                (
+                                    tOtO1,
+                                    tTMEM_LOAD_VECtS1,
+                                    tTMEM_LOAD_VECcS,
+                                    sO[None, None, 1],
+                                    mLSE,
+                                    mSink,
+                                    m_scale_v_channels,
+                                ),
+                                (
+                                    s1_corr_consumer,
+                                    mma_corr_consumer,
+                                    corr_epi_producer,
+                                ),
+                                (row_idx, *value_args),
+                            )
+                        )
+                    else:
+                        # st.global path: store directly to global memory
+                        block_offset_o = Int32(0)
+                        if cutlass.const_expr(cum_seqlen_q is not None):
+                            block_offset_o = cum_seqlen_q[batch_coord]
+                        mO_ = cute.make_tensor(
+                            mO.iterator + block_offset_o * mO.stride[0],
+                            cute.make_layout(
+                                (seqlen_q, mO.shape[1], mO.shape[2]),
+                                stride=mO.stride,
+                            ),
+                        )
+                        o0_coord = 2 * curr_block_coord[0]
+                        o1_coord = o0_coord + 1
+                        gO_stg = cute.local_tile(
+                            mO_,
+                            (self.pv_mma_tiler[0], self.pv_mma_tiler[1]),
+                            (None, None, None),
+                        )
+                        gO0 = gO_stg[None, None, o0_coord, 0, curr_block_coord[2]]
+                        gO1 = gO_stg[None, None, o1_coord, 0, curr_block_coord[2]]
+                        # Normalize O0 and store to global memory
+                        s0_corr_consumer, mma_corr_consumer = self.correction_epilog(
+                            pv_thr_mma,
+                            tiled_tmem_load_vec,
+                            (
+                                tOtO0,
+                                tTMEM_LOAD_VECtS0,
+                                tTMEM_LOAD_VECcS,
+                                gO0,
+                                mLSE,
+                                mSink,
+                                m_scale_v_channels,
+                            ),
+                            (s0_corr_consumer, mma_corr_consumer),
+                            (row_idx, *value_args),
+                        )
+                        row_idx += self.qk_mma_tiler[0]
+                        # Normalize O1 and st.global to global memory
+                        s1_corr_consumer, mma_corr_consumer = self.correction_epilog(
+                            pv_thr_mma,
+                            tiled_tmem_load_vec,
+                            (
+                                tOtO1,
+                                tTMEM_LOAD_VECtS1,
+                                tTMEM_LOAD_VECcS,
+                                gO1,
+                                mLSE,
+                                mSink,
+                                m_scale_v_channels,
+                            ),
+                            (s1_corr_consumer, mma_corr_consumer),
+                            (row_idx, *value_args),
+                        )
+                # End of if not continue_cond
+                # Advance to next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+            if cutlass.const_expr(not self.use_tma_store):
+                cute.arch.griddepcontrol_launch_dependents()
+            # End of persistent scheduler loop
+            tmem.relinquish_alloc_permit()
+            # Synchronize before TMEM dealloc (done by the caller)
+            self.tmem_dealloc_barrier.arrive_and_wait()
+            tmem.free(tmem_ptr)
+        return
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """Partition one block-scaled QK scale-factor tensor for SMEM to TMEM copy."""
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(tcgen05.CtaGroup.ONE),
+            self.qk_sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(tiled_copy_s2t, tCsSF_compact_s2t_)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    @cute.jit
+    def kv_producer_update_tx_acquire_and_advance(
+        self, tma_producer, empty_mbar_ptr, full_mbar_ptr, tx_bytes
+    ):
+        # This utility function is a special version of tma_producer.acquire_and_advance().
+        # This is used to customize the tx bytes which is different from
+        # the initialized tx bytes of tma_producer.
+        state = tma_producer._PipelineProducer__state.clone()
+        cute.arch.mbarrier_wait(empty_mbar_ptr + state.index, state.phase)
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_arrive_and_expect_tx(
+                full_mbar_ptr + state.index,
+                tx_bytes,
+            )
+        tma_producer.advance()
+        return state, tma_producer
+
+    @cute.jit
+    def get_skip_softmax_flag(self, tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v):
+        cute.copy(tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v)
+        tTMEM_LOADrS_v_i32 = cute.recast_tensor(tTMEM_LOADrS_v, dtype=cutlass.Int32)
+        skip_softmax_flag = cute.arch.make_warp_uniform(tTMEM_LOADrS_v_i32[0])
+        return skip_softmax_flag
+
+    @cute.jit
+    def mma_qk(
+        self,
+        tiled_mma: cute.TiledMma,
+        tensor_args: Tuple,
+        scale_args: Tuple,
+        pipeline_args: Tuple,
+        qk_sf_inplace_consumer: pipeline.PipelineConsumer,
+        pipeline_tokens: Tuple = (None, None),
+    ) -> Tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Perform a single step of the QK GEMM computation on a block of attention scores.
+
+        :param tiled_mma: Tiled MMA for QK GEMM
+        :type tiled_mma: cute.TiledMma
+        :param tensor_args: Tuple containing Qi, K, and Si
+        :type tensor_args: Tuple
+        :param pipeline_args: Tuple containing mma_si_producer and si_corr_producer
+        :type pipeline_args: Tuple
+        :param qk_sf_inplace_consumer: PipelineAsync consumer guarding the SFQ/SFK TMEM slot
+            (the tail of the OPPOSITE-stage S region).
+        :type qk_sf_inplace_consumer: pipeline.PipelineConsumer
+        :param pipeline_tokens: Optional non-blocking peek tokens for the Si and
+            vec_i producers, in the form ``(si_peek_status, veci_peek_status)``.
+            ``None`` for either token falls back to a blocking acquire.
+        :type pipeline_tokens: Tuple
+        :return: Tuple containing mma_si_producer, si_corr_producer, and the
+            (advanced) qk_sf_inplace_consumer.
+        :rtype: Tuple[pipeline.PipelineProducer, pipeline.PipelineProducer,
+            pipeline.PipelineConsumer]
+        """
+        tSrQi, tSrK, tStSi = tensor_args
+        (
+            tiled_copy_s2t_qsf,
+            tCsQSF_stage,
+            tCtQSF_s2t,
+            tCtQSF,
+            tiled_copy_s2t_ksf,
+            tCsKSF_stage,
+            tCtKSF_s2t,
+            tCtKSF,
+        ) = scale_args
+        mma_si_producer, si_corr_producer = pipeline_args
+        si_peek_status, veci_peek_status = pipeline_tokens
+        qk_tiled_mma = cutlass.new_from_mlir_values(
+            tiled_mma, cutlass.extract_mlir_values(tiled_mma)
+        )
+        # 0. Make sure Qi & K are ready when calling mma_qk
+        # 1. acquire S0
+        si_handle = mma_si_producer.acquire_and_advance(si_peek_status)
+        # 2. make sure vec is already released in corr
+        veci_handle = si_corr_producer.acquire_and_advance(veci_peek_status)
+        veci_handle.commit()
+        # 3. Wait until softmax_{1-j} has finished T2R-loading S_{1-j} to avoid SFQK_j race cond
+        qk_sf_inplace_consumer.wait_and_advance()
+        # 4. Copy MXFP8 scale factors and issue block-scaled gemm
+        cute.copy(tiled_copy_s2t_qsf, tCsQSF_stage, tCtQSF_s2t)
+        cute.copy(tiled_copy_s2t_ksf, tCsKSF_stage, tCtKSF_s2t)
+        qk_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+        cute.gemm(
+            qk_tiled_mma,
+            tStSi,
+            [tSrQi, tCtQSF],
+            [tSrK, tCtKSF],
+            tStSi,
+        )
+        # 4. release S0
+        si_handle.commit()
+        return mma_si_producer, si_corr_producer, qk_sf_inplace_consumer
+
+    @cute.jit
+    def mma_pv(
+        self,
+        tiled_mma: cute.TiledMma,
+        whether_acc: bool,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        skip_pv_args: Tuple,
+    ) -> Tuple[
+        pipeline.PipelineProducer,
+        pipeline.PipelineConsumer,
+    ]:
+        """Perform a single step of the PV GEMM computation on accumulating O.
+
+        :param tiled_mma: Tiled MMA for PV GEMM
+        :type tiled_mma: cute.TiledMma
+        :param whether_acc: Whether to accumulate O
+        :type whether_acc: bool
+        :param tensor_args: Tuple containing Pi, Vi, and Oi
+        :type tensor_args: Tuple
+        :param pipeline_args: Tuple containing mma_corr_producer and pi_mma_consumer
+        :type pipeline_args: Tuple
+        :param skip_pv_args: Tuple containing enable_skip_softmax, tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v
+        :type skip_pv_args: Tuple
+        :return: Tuple containing mma_corr_producer and pi_mma_consumer
+        :rtype: Tuple[pipeline.PipelineProducer, pipeline.PipelineConsumer]
+        """
+        tOrPi, tOrVi, tOtOi = tensor_args
+        mma_corr_producer, pi_mma_consumer = pipeline_args
+        enable_skip_softmax, tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v = skip_pv_args
+        # 0. Make sure Vi is ready when calling mma_pv
+        # 1. acquire Oi
+        oi_handle = mma_corr_producer.acquire_and_advance()
+        # 2. wait for Pi
+        pi_handle = pi_mma_consumer.wait_and_advance()
+        # 3. gemm
+        num_kphases = cute.size(tOrPi, mode=[2])
+        if cutlass.const_expr(enable_skip_softmax):
+            skip_pv = self.get_skip_softmax_flag(tiled_tmem_load_v, tTMEM_LOADtS_v, tTMEM_LOADrS_v)
+            if not skip_pv:
+                for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                    kphase_coord = (None, None, kphase_idx)
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, whether_acc or kphase_idx != 0)
+                    cute.gemm(
+                        tiled_mma,
+                        tOtOi,
+                        tOrPi[kphase_coord],
+                        tOrVi[kphase_coord],
+                        tOtOi,
+                    )
+        else:
+            for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                kphase_coord = (None, None, kphase_idx)
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, whether_acc or kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma,
+                    tOtOi,
+                    tOrPi[kphase_coord],
+                    tOrVi[kphase_coord],
+                    tOtOi,
+                )
+        # 4. commit Pi
+        pi_handle.release()
+        # 5. commit Oi
+        oi_handle.commit()
+        return mma_corr_producer, pi_mma_consumer
+
+    @cute.jit
+    def calculate_skip_softmax_flag(
+        self,
+        row_max,
+        tile_row_max,
+        scale_softmax_log2,
+        skip_softmax_threshold_log2,
+        seqlen_q,
+        thread_idx,
+        logical_offset,
+        warp_wants_skip_softmax_exchange,
+        stage,
+        skip_softmax_count,
+        total_softmax_count,
+    ) -> Tuple[bool, float]:
+        """Calculate the skip softmax flag and the row maximum.
+
+        :param row_max: The row maximum.
+        :type row_max: float
+        :param tile_row_max: The tile row maximum.
+        :type tile_row_max: float
+        :param scale_softmax_log2: The scale softmax log2.
+        :type scale_softmax_log2: float
+        :param skip_softmax_threshold_log2: The skip softmax threshold log2.
+        :type skip_softmax_threshold_log2: float
+        :param seqlen_q: The sequence length q.
+        :type seqlen_q: int
+        :param thread_idx: The thread index.
+        :type thread_idx: int
+        :param logical_offset: The logical offset.
+        :type logical_offset: Tuple[int, int]
+        :param warp_wants_skip_softmax_exchange: The warp wants skip softmax exchange.
+        :type warp_wants_skip_softmax_exchange: cute.Tensor
+        :param stage: The stage.
+        :type stage: int
+        :param skip_softmax_count: The skip softmax count.
+        :type skip_softmax_count: cute.Tensor
+        :param total_softmax_count: The total softmax count.
+        :type total_softmax_count: cute.Tensor
+        :return: Tuple containing the skip softmax flag and the row maximum.
+        :rtype: Tuple[bool, float]
+        """
+        thread_wants_skip = (
+            tile_row_max * scale_softmax_log2 - row_max * scale_softmax_log2
+        ) < skip_softmax_threshold_log2
+        thread_wants_skip = thread_wants_skip or ((logical_offset[0] + thread_idx) >= seqlen_q)
+        warp_wants_skip = cute.arch.vote_all_sync(thread_wants_skip)
+
+        with cute.arch.elect_one():
+            warp_wants_skip_softmax_exchange[cute.arch.warp_idx() % 4] = warp_wants_skip
+        softmax_barrier = self.s0_warpgroup_barrier if stage == 0 else self.s1_warpgroup_barrier
+        softmax_barrier.arrive_and_wait()
+        warp_wants_skip_softmax_exchange_i32 = cute.make_tensor(
+            cute.recast_ptr(warp_wants_skip_softmax_exchange.iterator, dtype=cutlass.Int32),
+            cute.make_layout((1,)),
+        )
+        skip_softmax = cute.arch.popc(warp_wants_skip_softmax_exchange_i32[0]) == 4
+
+        if not skip_softmax:
+            row_max = max(row_max, tile_row_max)
+
+        if cutlass.const_expr(skip_softmax_count is not None):
+            if thread_idx == 0:
+                if skip_softmax:
+                    cute.arch.atomic_add(skip_softmax_count.iterator.llvm_ptr, Int32(1))
+                cute.arch.atomic_add(total_softmax_count.iterator.llvm_ptr, Int32(1))
+        return skip_softmax, row_max
+
+    @cute.jit
+    def apply_exp_and_cvt(
+        self,
+        tTMEM_LOADrS,
+        tTMEM_LOADrS_cvt,
+        tTMEM_STORErS_x4_e_cvt,
+        stage,
+        scale,
+        minus_row_max_scale,
+        local_row_sum,
+        inplace_consumer,
+        EXP2_EMULATION_OFFSET,
+        EXP2_EMULATION_COUNT,
+        CVT_COUNT,
+        CVT_PER_STEP,
+        FMA_COUNT,
+        ARV_COUNT,
+    ):
+        """Apply the exp and conversion to the P data type on fragment.
+
+        :param tTMEM_LOADrS: The tTMEM_LOADrS tensor.
+        :type tTMEM_LOADrS: cute.Tensor
+        :param tTMEM_LOADrS_cvt: The tTMEM_LOADrS_cvt tensor.
+        :type tTMEM_LOADrS_cvt: cute.Tensor
+        :param tTMEM_STORErS_x4_e_cvt: The tTMEM_STORErS_x4_e_cvt tensor.
+        :type tTMEM_STORErS_x4_e_cvt: cute.Tensor
+        :param stage: The stage.
+        :type stage: int
+        :param scale: The scale.
+        :type scale: float
+        :param minus_row_max_scale: The minus row maximum scale.
+        :type minus_row_max_scale: float
+        :param local_row_sum: The local row sum.
+        :type local_row_sum: float
+        :param inplace_consumer: The inplace consumer.
+        :type inplace_consumer: cute.Tensor
+        :param EXP2_EMULATION_OFFSET: The exp2 emulation offset.
+        :type EXP2_EMULATION_OFFSET: int
+        :param EXP2_EMULATION_COUNT: The exp2 emulation count.
+        :type EXP2_EMULATION_COUNT: int
+        :param CVT_COUNT: The cvt count.
+        :type CVT_COUNT: int
+        :param CVT_PER_STEP: The cvt per step.
+        :type CVT_PER_STEP: int
+        :param FMA_COUNT: The fma count.
+        :type FMA_COUNT: int
+        :param ARV_COUNT: The arv count.
+        :type ARV_COUNT: int
+        :return: The local row sum and the inplace consumer.
+        :rtype: Tuple[float, cute.Tensor]
+        """
+        for i in cutlass.range_constexpr(0, EXP2_EMULATION_OFFSET, 2):
+            if cutlass.const_expr(i >= CVT_COUNT):
+                if cutlass.const_expr(i % CVT_PER_STEP == 0):
+                    if cutlass.const_expr(self.v_dtype.width == 8):
+                        fmha_utils.cvt_f32x4_to_f8x4(
+                            tTMEM_LOADrS_cvt[None, (i - CVT_COUNT) // CVT_PER_STEP],
+                            tTMEM_STORErS_x4_e_cvt[None, (i - CVT_COUNT) // CVT_PER_STEP],
+                        )
+                    else:
+                        s_vec = tTMEM_LOADrS_cvt[None, (i - CVT_COUNT) // CVT_PER_STEP].load()
+                        tTMEM_STORErS_x4_e_cvt[None, (i - CVT_COUNT) // CVT_PER_STEP].store(
+                            s_vec.to(self.v_dtype)
+                        )
+                local_row_sum = cute.arch.add_packed_f32x2(
+                    local_row_sum,
+                    (
+                        tTMEM_LOADrS[i - CVT_COUNT],
+                        tTMEM_LOADrS[i - CVT_COUNT + 1],
+                    ),
+                )
+            tTMEM_LOADrS[i] = cute.math.exp2(tTMEM_LOADrS[i], fastmath=True)
+            if cutlass.const_expr(i + FMA_COUNT < EXP2_EMULATION_OFFSET):
+                (
+                    tTMEM_LOADrS[i + FMA_COUNT],
+                    tTMEM_LOADrS[i + FMA_COUNT + 1],
+                ) = cute.arch.fma_packed_f32x2(
+                    (
+                        tTMEM_LOADrS[i + FMA_COUNT],
+                        tTMEM_LOADrS[i + FMA_COUNT + 1],
+                    ),
+                    (scale, scale),
+                    (minus_row_max_scale, minus_row_max_scale),
+                )
+            tTMEM_LOADrS[i + 1] = cute.math.exp2(tTMEM_LOADrS[i + 1], fastmath=True)
+            if cutlass.const_expr(i == EXP2_EMULATION_OFFSET - ARV_COUNT):
+                if cutlass.const_expr(self.enable_sequence_barrier):
+                    if cutlass.const_expr(stage == 0):
+                        self.sequence_s1_s0_barrier.arrive()
+                    else:
+                        self.sequence_s0_s1_barrier.arrive()
+
+        # The remaining conversion steps
+        for i in cutlass.range_constexpr(
+            EXP2_EMULATION_OFFSET - CVT_COUNT,
+            EXP2_EMULATION_OFFSET,
+            2,
+        ):
+            if cutlass.const_expr(i % CVT_PER_STEP == 0):
+                if cutlass.const_expr(self.v_dtype.width == 8):
+                    fmha_utils.cvt_f32x4_to_f8x4(
+                        tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP],
+                        tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP],
+                    )
+                else:
+                    s_vec = tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP].load()
+                    tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP].store(s_vec.to(self.v_dtype))
+            local_row_sum = cute.arch.add_packed_f32x2(
+                local_row_sum, (tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1])
+            )
+        for i in cutlass.range_constexpr(
+            EXP2_EMULATION_OFFSET, EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT // 2, 2
+        ):
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = cute.arch.fma_packed_f32x2(
+                (tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]),
+                (scale, scale),
+                (minus_row_max_scale, minus_row_max_scale),
+            )
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = fmha_utils.ex2_emulation_packed_f32x2(
+                tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]
+            )
+            if cutlass.const_expr((i + 2) % CVT_PER_STEP == 0):
+                if cutlass.const_expr(self.v_dtype.width == 8):
+                    fmha_utils.cvt_f32x4_to_f8x4(
+                        tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP],
+                        tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP],
+                    )
+                else:
+                    s_vec = tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP].load()
+                    tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP].store(s_vec.to(self.v_dtype))
+
+        inplace_peek_status = inplace_consumer.try_wait()
+        for i in cutlass.range_constexpr(
+            EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT // 2,
+            EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT,
+            2,
+        ):
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = cute.arch.fma_packed_f32x2(
+                (tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]),
+                (scale, scale),
+                (minus_row_max_scale, minus_row_max_scale),
+            )
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = fmha_utils.ex2_emulation_packed_f32x2(
+                tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]
+            )
+            if cutlass.const_expr((i + 2) % CVT_PER_STEP == 0):
+                if cutlass.const_expr(self.v_dtype.width == 8):
+                    fmha_utils.cvt_f32x4_to_f8x4(
+                        tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP],
+                        tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP],
+                    )
+                else:
+                    s_vec = tTMEM_LOADrS_cvt[None, i // CVT_PER_STEP].load()
+                    tTMEM_STORErS_x4_e_cvt[None, i // CVT_PER_STEP].store(s_vec.to(self.v_dtype))
+        inplace_consumer.wait_and_advance(inplace_peek_status)
+        return local_row_sum, inplace_consumer
+
+    @cute.jit
+    def softmax_step(
+        self,
+        stage: int,
+        whether_apply_mask: bool,
+        iter_args: Tuple,
+        stats_args: Tuple,
+        pipeline_args: Tuple,
+        value_args: Tuple,
+        atom_args: Tuple,
+        tensor_args: Tuple,
+    ) -> Tuple[Tuple, Tuple]:
+        """Perform a single step of the softmax computation on a block of attention scores.
+
+        This method processes one block of the attention matrix, computing numerically stable
+        softmax by first finding the row maximum, subtracting it from all elements, applying
+        exponential function, and then normalizing by the sum of exponentials. It also handles
+        optional masking of attention scores.
+
+        The method involves several key operations:
+        1. Loading attention scores from tensor memory
+        2. Applying optional masking based on position
+        3. Computing row-wise maximum values for numerical stability
+        4. Transforming scores using exp2(x*scale - max*scale)
+        5. Computing row sums for normalization
+        6. Coordinating pipeline synchronization between different processing stages
+
+        :param stage: Processing stage (0 for first half, 1 for second half)
+        :type stage: int
+        :param whether_apply_mask: Whether to apply attention masking
+        :type whether_apply_mask: bool
+        :param iter_args: Tuple containing the counting tensor, row_max, row_sum, and vector buffer's handle for current iteration
+        :type iter_args: Tuple
+        :param stats_args: Tuple containing row_sum and row_max
+        :type stats_args: Tuple
+        :param pipeline_args: Tuple containing pipeline related arguments for MMA, correction, and sequence synchronization
+        :type pipeline_args: Tuple
+        :param value_args: Tuple containing seqlen_k, seqlen_q, and scale_softmax_log2
+        :type value_args: Tuple
+        :param atom_args: Tuple containing mma & copy atoms
+        :type atom_args: Tuple
+        :param tensor_args: Tuple containing softmax related tensors
+        :type tensor_args: Tuple
+        :param fused_mask: Compute trip counts and apply masking for attention blocks
+        :type fused_mask: fmha_utils.FusedMask
+        :return: Updated stats_args and pipeline_args
+        :rtype: Tuple[Tuple, Tuple]
+        """
+        row_sum, row_max = stats_args
+        cS, is_last_iter = iter_args
+        (
+            seqlen_k,
+            seqlen_q,
+            scale_softmax_log2,
+            window_size_left,
+            window_size_right,
+            skip_softmax_threshold_log2,
+            thread_idx,
+            logical_offset,
+            qk_sf_inplace_producer,
+        ) = value_args
+        (
+            si_peek_status,
+            mma_si_consumer,
+            si_corr_producer,
+            pi_mma_producer,
+            inplace_producer,
+            inplace_consumer,
+        ) = pipeline_args
+        (
+            qk_thr_mma,
+            tiled_tmem_load,
+            tiled_tmem_store,
+            tiled_tmem_store_vec,
+            thr_tmem_load,
+            thr_tmem_store,
+            thr_tmem_store_vec,
+        ) = atom_args
+        (
+            tTMEM_LOADtS,
+            tTMEM_STORE_VECtS,
+            tTMEM_STORE_SKIP_SOFTMAX,
+            tTMEM_STOREtS_x4,
+            warp_wants_skip_softmax_exchange,
+            skip_softmax_count,
+            total_softmax_count,
+        ) = tensor_args
+        tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.o_dtype.width
+        tScS = qk_thr_mma.partition_C(cS)
+        enable_skip_softmax = skip_softmax_threshold_log2 is not None
+        tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
+        tScS_vec = cute.make_tensor(tScS.iterator, tScS_vec_layout)
+        tScS_P_layout = cute.composition(tScS.layout, cute.make_layout((128, tilePlikeFP32)))
+        tScS_P = cute.make_tensor(tScS.iterator, tScS_P_layout)
+        tTMEM_LOADcS = thr_tmem_load.partition_D(tScS)
+        tTMEM_STORE_VECcS = thr_tmem_store_vec.partition_S(tScS_vec)
+        tTMEM_STOREcS = thr_tmem_store.partition_S(tScS_P)
+        # Wait for Si
+        si_handle = mma_si_consumer.wait_and_advance(si_peek_status)
+        tTMEM_LOADrS = cute.make_rmem_tensor(tTMEM_LOADcS.shape, self.qk_acc_dtype)
+        old_row_max = row_max
+        skip_softmax = cutlass.Boolean(False)
+        if whether_apply_mask:
+            if cutlass.const_expr(self.arch >= Arch.sm_100 and self.arch <= Arch.sm_100f):
+                cute.copy(tiled_tmem_load, tTMEM_LOADtS, tTMEM_LOADrS)
+            else:
+                tTMEM_LOADrMax = cute.make_rmem_tensor(
+                    cute.make_layout((1, cute.size(tTMEM_LOADrS, mode=[1]))),
+                    self.qk_acc_dtype,
+                )
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[1])):
+                    cute.copy_atom_call(
+                        tiled_tmem_load,
+                        tTMEM_LOADtS[None, i, 0, 0],
+                        (tTMEM_LOADrS[None, i, 0, 0], tTMEM_LOADrMax[None, i]),
+                    )
+            fmha_utils.FusedMask.apply_mask(
+                self.mask_type,
+                tTMEM_LOADrS,
+                tTMEM_LOADcS,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            tile_row_max = tTMEM_LOADrS.load().reduce(cute.ReductionOp.MAX, -cutlass.Float32.inf, 0)
+            if cutlass.const_expr(not enable_skip_softmax):
+                row_max = cute.arch.fmax(row_max, tile_row_max)
+            else:
+                skip_softmax, row_max = self.calculate_skip_softmax_flag(
+                    row_max,
+                    tile_row_max,
+                    scale_softmax_log2,
+                    skip_softmax_threshold_log2,
+                    seqlen_q,
+                    thread_idx,
+                    logical_offset,
+                    warp_wants_skip_softmax_exchange,
+                    stage,
+                    skip_softmax_count,
+                    total_softmax_count,
+                )
+            # Fence the T2R load above, then signal MMA that the opposite-stage S is loaded.
+            cute.arch.fence_view_async_tmem_load()
+            qk_sf_inplace_producer.commit()
+            qk_sf_inplace_producer.advance()
+            si_handle.release()
+            # S0 -> P1 / S1 -> P0
+            inplace_producer.commit()
+            inplace_producer.advance()
+        else:
+            if cutlass.const_expr(self.arch >= Arch.sm_100 and self.arch <= Arch.sm_100f):
+                cute.copy(
+                    tiled_tmem_load,
+                    tTMEM_LOADtS[None, 0, None, None],
+                    tTMEM_LOADrS[None, 0, None, None],
+                )
+                cute.copy(
+                    tiled_tmem_load,
+                    tTMEM_LOADtS[None, 1, None, None],
+                    tTMEM_LOADrS[None, 1, None, None],
+                )
+                tile_row_max = -cutlass.Float32.inf
+                tile_row_max_ = tile_row_max
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[0]), 4):
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i, 0, 0, 0])
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i + 1, 0, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 0, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 0, 0, 0])
+                cute.copy(
+                    tiled_tmem_load,
+                    tTMEM_LOADtS[None, 2, None, None],
+                    tTMEM_LOADrS[None, 2, None, None],
+                )
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[0]), 4):
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i, 1, 0, 0])
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i + 1, 1, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 1, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 1, 0, 0])
+                cute.copy(
+                    tiled_tmem_load,
+                    tTMEM_LOADtS[None, 3, None, None],
+                    tTMEM_LOADrS[None, 3, None, None],
+                )
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[0]), 4):
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i, 2, 0, 0])
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i + 1, 2, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 2, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 2, 0, 0])
+                cute.arch.fence_view_async_tmem_store()
+                # Fence T2R loads then release the QK SF TMEM slot before we release S to MMA
+                cute.arch.fence_view_async_tmem_load()
+                qk_sf_inplace_producer.commit()
+                qk_sf_inplace_producer.advance()
+                si_handle.release()
+                # S0 -> P1 / S1 -> P0
+                inplace_producer.commit()
+                inplace_producer.advance()
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[0]), 4):
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i, 3, 0, 0])
+                    tile_row_max = cute.arch.fmax(tile_row_max, tTMEM_LOADrS[i + 1, 3, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 2, 3, 0, 0])
+                    tile_row_max_ = cute.arch.fmax(tile_row_max_, tTMEM_LOADrS[i + 3, 3, 0, 0])
+                tile_row_max = cute.arch.fmax(tile_row_max, tile_row_max_)
+                if cutlass.const_expr(not enable_skip_softmax):
+                    row_max = cute.arch.fmax(tile_row_max, row_max)
+                else:
+                    skip_softmax, row_max = self.calculate_skip_softmax_flag(
+                        row_max,
+                        tile_row_max,
+                        scale_softmax_log2,
+                        skip_softmax_threshold_log2,
+                        seqlen_q,
+                        thread_idx,
+                        logical_offset,
+                        warp_wants_skip_softmax_exchange,
+                        stage,
+                        skip_softmax_count,
+                        total_softmax_count,
+                    )
+            else:
+                tTMEM_LOADrMax = cute.make_rmem_tensor(
+                    cute.make_layout((1, cute.size(tTMEM_LOADrS, mode=[1]))),
+                    self.qk_acc_dtype,
+                )
+                for i in cutlass.range_constexpr(0, cute.size(tTMEM_LOADrS, mode=[1])):
+                    cute.copy_atom_call(
+                        tiled_tmem_load,
+                        tTMEM_LOADtS[None, i, 0, 0],
+                        (tTMEM_LOADrS[None, i, 0, 0], tTMEM_LOADrMax[None, i]),
+                    )
+                cute.arch.fence_view_async_tmem_store()
+                tile_row_max = tTMEM_LOADrMax.load().reduce(
+                    cute.ReductionOp.MAX, -cutlass.Float32.inf, 0
+                )
+                if cutlass.const_expr(not enable_skip_softmax):
+                    row_max = cute.arch.fmax(tile_row_max, row_max)
+                else:
+                    skip_softmax, row_max = self.calculate_skip_softmax_flag(
+                        row_max,
+                        tile_row_max,
+                        scale_softmax_log2,
+                        skip_softmax_threshold_log2,
+                        seqlen_q,
+                        thread_idx,
+                        logical_offset,
+                        warp_wants_skip_softmax_exchange,
+                        stage,
+                        skip_softmax_count,
+                        total_softmax_count,
+                    )
+                # Fence the T2R loads then release the QK SF TMEM slot.
+                cute.arch.fence_view_async_tmem_load()
+                qk_sf_inplace_producer.commit()
+                qk_sf_inplace_producer.advance()
+                si_handle.release()
+                # S0 -> P1 / S1 -> P0
+                inplace_producer.commit()
+                inplace_producer.advance()
+
+        row_max_safe = row_max
+        if row_max == -cutlass.Float32.inf:
+            row_max_safe = 0.0
+        if cutlass.const_expr(self.rescale_threshold > 0.0):
+            if (row_max_safe - old_row_max) * scale_softmax_log2 <= self.rescale_threshold:
+                row_max_safe = old_row_max
+        tTMEM_STORE_VECrS = cute.make_rmem_tensor(tTMEM_STORE_VECcS.shape, self.qk_acc_dtype)
+        tTMEM_STORE_VECrS[0] = old_row_max
+        tTMEM_STORE_VECrS[1] = row_max_safe
+        vec_i_peek_status = si_corr_producer.try_acquire()
+        tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.qk_acc_dtype)
+        tTMEM_STORErS_x4_e = cute.make_tensor(
+            cute.recast_ptr(tTMEM_STORErS_x4.iterator, dtype=self.v_dtype),
+            tTMEM_LOADrS.layout,
+        )
+        scale = scale_softmax_log2
+        minus_row_max_scale = (0.0 - row_max_safe) * scale
+        if cutlass.const_expr(self.v_dtype.width == 8 and self.p_fp8_prescale_log2 > 0):
+            minus_row_max_scale = minus_row_max_scale + self.p_fp8_prescale_log2
+
+        ARV_COUNT = 4
+        FMA_COUNT = 8
+        CVT_COUNT = 8 if self.v_dtype.width == 8 else 4
+        CVT_PER_STEP = 4 if self.v_dtype.width == 8 else 2
+        assert CVT_COUNT % CVT_PER_STEP == 0, (
+            f"CVT_COUNT {CVT_COUNT} must be divisible by CVT_PER_STEP {CVT_PER_STEP}"
+        )
+        tTMEM_LOADrS_cvt = cute.logical_divide(tTMEM_LOADrS, cute.make_layout(CVT_PER_STEP))
+        tTMEM_STORErS_x4_e_cvt = cute.logical_divide(
+            tTMEM_STORErS_x4_e, cute.make_layout(CVT_PER_STEP)
+        )
+        for i in cutlass.range_constexpr(0, FMA_COUNT, 2):
+            tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1] = cute.arch.fma_packed_f32x2(
+                (tTMEM_LOADrS[i], tTMEM_LOADrS[i + 1]),
+                (scale, scale),
+                (minus_row_max_scale, minus_row_max_scale),
+            )
+        vec_i_handle = si_corr_producer.acquire_and_advance(vec_i_peek_status)
+        cute.copy(tiled_tmem_store_vec, tTMEM_STORE_VECrS, tTMEM_STORE_VECtS)
+        cute.arch.fence_view_async_tmem_store()
+        # Notify correction wg that row_max is ready
+        vec_i_handle.commit()
+
+        EXP2_EMULATION_COUNT = 20 if self.enable_ex2_emulation and not whether_apply_mask else 0
+        EXP2_EMULATION_OFFSET = cute.size(tTMEM_LOADrS) - EXP2_EMULATION_COUNT
+        acc_scale_ = scale * (old_row_max - row_max_safe)
+        acc_scale = cute.math.exp2(acc_scale_, fastmath=True) * 0.5
+        if cutlass.const_expr(self.enable_sequence_barrier):
+            if cutlass.const_expr(stage == 0):
+                self.sequence_s0_s1_barrier.arrive_and_wait()
+            else:
+                self.sequence_s1_s0_barrier.arrive_and_wait()
+
+        if cutlass.const_expr(enable_skip_softmax):
+            if not skip_softmax:
+                row_sum *= acc_scale
+                local_row_sum = (row_sum, row_sum)
+                local_row_sum, inplace_consumer = self.apply_exp_and_cvt(
+                    tTMEM_LOADrS,
+                    tTMEM_LOADrS_cvt,
+                    tTMEM_STORErS_x4_e_cvt,
+                    stage,
+                    scale,
+                    minus_row_max_scale,
+                    local_row_sum,
+                    inplace_consumer,
+                    EXP2_EMULATION_OFFSET,
+                    EXP2_EMULATION_COUNT,
+                    CVT_COUNT,
+                    CVT_PER_STEP,
+                    FMA_COUNT,
+                    ARV_COUNT,
+                )
+                tTMEM_STORE_VECrS_i32 = cute.recast_tensor(tTMEM_STORE_VECrS, dtype=cutlass.Int32)
+                tTMEM_STORE_VECrS_i32[0] = 0
+                pi_handle = pi_mma_producer.acquire_and_advance()
+                # store skip softmax flag
+                cute.copy(
+                    tiled_tmem_store_vec,
+                    tTMEM_STORE_VECrS_i32,
+                    tTMEM_STORE_SKIP_SOFTMAX,
+                )
+                # store P
+                cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
+                cute.arch.fence_view_async_tmem_store()
+                pi_handle.commit()
+                for j in cutlass.range_constexpr(
+                    EXP2_EMULATION_OFFSET,
+                    EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT,
+                    2,
+                ):
+                    local_row_sum = cute.arch.add_packed_f32x2(
+                        (tTMEM_LOADrS[j], tTMEM_LOADrS[j + 1]),
+                        local_row_sum,
+                    )
+                row_sum = local_row_sum[0] + local_row_sum[1]
+                cute.arch.fence_view_async_tmem_store()
+            else:
+                if cutlass.const_expr(self.enable_sequence_barrier):
+                    if cutlass.const_expr(stage == 0):
+                        self.sequence_s1_s0_barrier.arrive()
+                    else:
+                        self.sequence_s0_s1_barrier.arrive()
+                inplace_peek_status = inplace_consumer.try_wait()
+                inplace_consumer.wait_and_advance(inplace_peek_status)
+                tTMEM_STORE_VECrS_i32 = cute.recast_tensor(tTMEM_STORE_VECrS, dtype=cutlass.Int32)
+                tTMEM_STORE_VECrS_i32[0] = 1
+                pi_handle = pi_mma_producer.acquire_and_advance()
+                # store skip softmax flag
+                cute.copy(
+                    tiled_tmem_store_vec,
+                    tTMEM_STORE_VECrS_i32,
+                    tTMEM_STORE_SKIP_SOFTMAX,
+                )
+                cute.arch.fence_view_async_tmem_store()
+                pi_handle.commit()
+        else:
+            row_sum *= acc_scale
+            local_row_sum = (row_sum, row_sum)
+            local_row_sum, inplace_consumer = self.apply_exp_and_cvt(
+                tTMEM_LOADrS,
+                tTMEM_LOADrS_cvt,
+                tTMEM_STORErS_x4_e_cvt,
+                stage,
+                scale,
+                minus_row_max_scale,
+                local_row_sum,
+                inplace_consumer,
+                EXP2_EMULATION_OFFSET,
+                EXP2_EMULATION_COUNT,
+                CVT_COUNT,
+                CVT_PER_STEP,
+                FMA_COUNT,
+                ARV_COUNT,
+            )
+            pi_handle = pi_mma_producer.acquire_and_advance()
+            # store P
+            cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
+            cute.arch.fence_view_async_tmem_store()
+            for j in cutlass.range_constexpr(
+                EXP2_EMULATION_OFFSET,
+                EXP2_EMULATION_OFFSET + EXP2_EMULATION_COUNT,
+                2,
+            ):
+                local_row_sum = cute.arch.add_packed_f32x2(
+                    (tTMEM_LOADrS[j], tTMEM_LOADrS[j + 1]),
+                    local_row_sum,
+                )
+            row_sum = local_row_sum[0] + local_row_sum[1]
+            cute.arch.fence_view_async_tmem_store()
+            # Notify tensor core warp that softmax(S->P) is ready
+            pi_handle.commit()
+        if not is_last_iter:
+            si_peek_status = mma_si_consumer.try_wait()
+
+        stats_args = (row_sum, row_max_safe)
+        pipeline_args = (
+            si_peek_status,
+            mma_si_consumer,
+            si_corr_producer,
+            pi_mma_producer,
+            inplace_producer,
+            inplace_consumer,
+        )
+        return stats_args, pipeline_args
+
+    # For both softmax0 and softmax1 warp group
+    @cute.jit
+    def softmax(
+        self,
+        stage: int,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        inplace_args: Tuple,
+        qk_thr_mma: cute.ThrMma,
+        value_args: Tuple,
+        mask_args: Tuple,
+        sched_args: Tuple,
+        qk_sf_inplace_producers: Tuple[pipeline.PipelineProducer, pipeline.PipelineProducer],
+    ):
+        """Compute softmax on attention scores from QK matrix multiplication.
+
+        This method handles the softmax computation for either the first or second half of the
+        attention matrix, depending on the 'stage' parameter. It calculates row-wise maximum
+        and sum values needed for stable softmax computation, applies optional masking, and
+        transforms raw attention scores into probability distributions.
+
+        The implementation uses specialized memory access patterns and efficient math operations
+        for computing exp(x) using exp2 functions. It also coordinates pipeline
+        synchronization between MMA, correction, and sequence processing stages.
+
+        :param stage: Processing stage (0 for first half, 1 for second half of attention matrix)
+        :type stage: int
+        :param seqlen_k: Length of the key sequence
+        :type seqlen_k: Int32
+        :param seqlen_q: Length of the query sequence
+        :type seqlen_q: Int32
+        :param cum_seqlen_q: Cumulative sequence lengths for queries
+        :type cum_seqlen_q: cute.Tensor | None
+        :param cum_seqlen_k: Cumulative sequence lengths for keys
+        :type cum_seqlen_k: cute.Tensor | None
+        :param scale_softmax_log2: Log2 scale factor for softmax operation
+        :type scale_softmax_log2: Float32
+        :param qk_thr_mma: Thread MMA operation for QK matrix multiplication
+        :type qk_thr_mma: cute.ThrMma
+        :param tStS: Shared tensor for softmax input/output
+        :type tStS: cute.Tensor
+        :param tStSi: Input tensor containing attention scores
+        :type tStSi: cute.Tensor
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param mma_si_consumer: Pipeline for synchronizing with Si tensors
+        :type mma_si_consumer: pipeline.PipelineConsumer
+        :param si_corr_producer: Pipeline for synchronizing with correction operations
+        :type si_corr_producer: pipeline.PipelineProducer
+        :param pi_mma_producer: Pipeline for synchronizing with Pi tensors
+        :type pi_mma_producer: pipeline.PipelineProducer
+        :param tile_sched_params: Parameters for tile scheduling
+        :type tile_sched_params: fmha_utils.FmhaStaticTileSchedulerParams
+        :param fused_mask: Compute trip counts and apply masking for attention blocks
+        :type fused_mask: fmha_utils.FusedMask
+        """
+        (
+            tStS,
+            tStSi,
+            cum_seqlen_k,
+            cum_seqlen_q,
+            warp_wants_skip_softmax_exchange,
+            skip_softmax_count,
+            total_softmax_count,
+        ) = tensor_args
+        mma_si_consumer, si_corr_producer, pi_mma_producer = pipeline_args
+        inplace_producer, inplace_consumer = inplace_args
+        (
+            seqlen_k,
+            seqlen_q,
+            scale_softmax_log2,
+            skip_softmax_threshold_log2,
+        ) = value_args
+        window_size_left, window_size_right = mask_args
+        tile_sched, work_tile = sched_args
+
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.softmax0_warp_ids))
+
+        cS_base = cute.make_identity_tensor((self.qk_mma_tiler[0], self.qk_mma_tiler[1]))
+        tilePlikeFP32 = self.qk_mma_tiler[1] // 32 * self.o_dtype.width
+        tScS = qk_thr_mma.partition_C(cS_base)
+        tStS_vec_layout = cute.composition(tStS.layout, cute.make_layout((128, 2)))
+        tmem_vec_offset = self.tmem_vec0_offset if stage == 0 else self.tmem_vec1_offset
+        tStS_vec = cute.make_tensor(tStS.iterator + tmem_vec_offset, tStS_vec_layout)
+        tmem_skip_softmax_offset = (
+            self.tmem_skip_softmax0_offset if stage == 0 else self.tmem_skip_softmax1_offset
+        )
+        tStS_skip_softmax = cute.make_tensor(
+            tStS.iterator + tmem_skip_softmax_offset, tStS_vec_layout
+        )
+        tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
+        tScS_vec = cute.make_tensor(tScS.iterator, tScS_vec_layout)
+        tStS_P_layout = cute.composition(tStS.layout, cute.make_layout((128, tilePlikeFP32)))
+        tmem_p_offset = self.tmem_p0_offset if stage == 0 else self.tmem_p1_offset
+        tStS_P = cute.make_tensor(tStS.iterator + tmem_p_offset, tStS_P_layout)
+        if cutlass.const_expr(self.arch >= Arch.sm_100 and self.arch <= Arch.sm_100f):
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                self.qk_acc_dtype,
+            )
+        else:
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.LdRed32x32bOp(
+                    tcgen05.copy.Repetition(32), redOp=tcgen05.TmemLoadRedOp.MAX
+                ),
+                self.qk_acc_dtype,
+            )
+
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStSi)
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        tTMEM_LOADtS = thr_tmem_load.partition_S(tStSi)
+        tmem_store_vec_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(2)),
+            self.qk_acc_dtype,
+        )
+        tiled_tmem_store_vec = tcgen05.make_tmem_copy(tmem_store_vec_atom, tStS_vec)
+        thr_tmem_store_vec = tiled_tmem_store_vec.get_slice(thread_idx)
+        tTMEM_STORE_VECtS = thr_tmem_store_vec.partition_D(tStS_vec)
+        tTMEM_STORE_VECcS = thr_tmem_store_vec.partition_S(tScS_vec)
+        tTMEM_STORE_SKIP_SOFTMAX = thr_tmem_store_vec.partition_D(tStS_skip_softmax)
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(32)),
+            self.qk_acc_dtype,
+        )
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tStS_P)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+        tTMEM_STOREtS_x4 = thr_tmem_store.partition_D(tStS_P)
+        # Each softmax warpgroup releases the OPPOSITE-stage S region (where
+        # SFQ_{1-stage}/SFK_{1-stage} live in the tail) by committing to its qk_sf_inplace producer
+        # once per kv block:
+        # softmax0 (stage=0) drives qk_sf_inplace_1
+        # softmax1 (stage=1) drives qk_sf_inplace_0
+        qk_sf_inplace_producer = qk_sf_inplace_producers[stage]
+        # Bootstrap: MMA's first mma_qk(stage=0) waits on qk_sf_inplace_0 before
+        # softmax1 has produced any in-loop commit. Each thread of softmax1
+        # pre-commits once so the first wait succeeds. qk_sf_inplace_1 needs no
+        # pre-commit because mma_qk(stage=1) runs after mma_qk(stage=0),
+        # giving softmax0 enough time to consume S0 and commit naturally.
+        if cutlass.const_expr(stage == 1):
+            qk_sf_inplace_producer.commit()
+            qk_sf_inplace_producer.advance()
+        if cutlass.const_expr(self.enable_sequence_barrier):
+            if cutlass.const_expr(stage == 1):
+                self.sequence_s0_s1_barrier.arrive()
+        while work_tile.is_valid_tile:
+            curr_block_coord = work_tile.tile_idx
+            batch_coord = curr_block_coord[2][1]
+            seqlen_k_ = seqlen_k
+            seqlen_q_ = seqlen_q
+            continue_cond = False
+            cuseqlen_q = Int32(0)
+            seqlen_q_ = seqlen_q
+            if cutlass.const_expr(cum_seqlen_q is not None):
+                cuseqlen_q = cum_seqlen_q[batch_coord]
+                seqlen_q_ = cum_seqlen_q[batch_coord + 1] - cuseqlen_q
+                continue_cond = (
+                    not fmha_utils.FmhaStaticTileScheduler.check_valid_work_for_seqlen_q(
+                        self.cta_tiler[0],
+                        curr_block_coord[0],
+                        seqlen_q_,
+                    )
+                )
+            if not continue_cond:
+                if cutlass.const_expr(cum_seqlen_k is not None):
+                    cuseqlen_k = cum_seqlen_k[batch_coord]
+                    seqlen_k_ = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
+                continue_cond = seqlen_k_ <= 0
+            if not continue_cond:
+                logical_offset = (
+                    curr_block_coord[0] * self.cta_tiler[0] + stage * self.qk_mma_tiler[0],
+                    0,
+                )
+                cS = cute.domain_offset(logical_offset, cS_base)
+                value_args_ = (
+                    seqlen_k_,
+                    seqlen_q_,
+                    scale_softmax_log2,
+                    window_size_left,
+                    window_size_right,
+                    skip_softmax_threshold_log2,
+                    thread_idx,
+                    logical_offset,
+                    qk_sf_inplace_producer,
+                )
+                atom_args = (
+                    qk_thr_mma,
+                    tiled_tmem_load,
+                    tiled_tmem_store,
+                    tiled_tmem_store_vec,
+                    thr_tmem_load,
+                    thr_tmem_store,
+                    thr_tmem_store_vec,
+                )
+                tensor_args_ = (
+                    tTMEM_LOADtS,
+                    tTMEM_STORE_VECtS,
+                    tTMEM_STORE_SKIP_SOFTMAX,
+                    tTMEM_STOREtS_x4,
+                    warp_wants_skip_softmax_exchange,
+                    skip_softmax_count,
+                    total_softmax_count,
+                )
+                st_cnt, end_cnt, ld_mask_cnt, unmask_cnt, tl_mask_cnt = (
+                    fmha_utils.FusedMask.get_masked_info(
+                        self.mask_type,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_q_,
+                        seqlen_k_,
+                        window_size_left,
+                        window_size_right,
+                    )
+                )
+                row_max = -Float32.inf
+                row_sum = 0.0
+                stats_args = (row_sum, row_max)
+
+                def softmax_loop(
+                    whether_apply_mask: bool,
+                    loop_args: Tuple,
+                    stats_args: Tuple,
+                    pipeline_args: Tuple,
+                    inner_fn: Callable,
+                    value_args: Tuple,
+                    atom_args: Tuple,
+                    tensor_args: Tuple,
+                    cS: cute.Tensor,
+                ) -> Tuple[Tuple, Tuple]:
+                    start_index, iter_num, upper_bound = loop_args
+                    for i in cutlass.range(start_index, start_index + iter_num, 1, unroll=1):
+                        cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
+                        iter_args = (cS_iter, i == upper_bound - 1)
+                        stats_args, pipeline_args = inner_fn(
+                            stage,
+                            whether_apply_mask,
+                            iter_args,
+                            stats_args,
+                            pipeline_args,
+                            value_args,
+                            atom_args,
+                            tensor_args,
+                        )
+                    return stats_args, pipeline_args
+
+                softmax_step_fn = self.softmax_step
+                softmax_loop_fn = partial(
+                    softmax_loop,
+                    inner_fn=softmax_step_fn,
+                    value_args=value_args_,
+                    atom_args=atom_args,
+                    tensor_args=tensor_args_,
+                    cS=cS,
+                )
+                si_peek_status = mma_si_consumer.try_wait()
+                if cutlass.const_expr(stage == 1):
+                    inplace_consumer.wait_and_advance()
+                pipeline_args_ = (
+                    si_peek_status,
+                    mma_si_consumer,
+                    si_corr_producer,
+                    pi_mma_producer,
+                    inplace_producer,
+                    inplace_consumer,
+                )
+                # 1. Leading mask loop
+                loop_args = (st_cnt, ld_mask_cnt, end_cnt)
+                stats_args, pipeline_args_ = softmax_loop_fn(
+                    True, loop_args, stats_args, pipeline_args_
+                )
+                # 2. Unmasked loop
+                loop_args = (st_cnt + ld_mask_cnt, unmask_cnt, end_cnt)
+                stats_args, pipeline_args_ = softmax_loop_fn(
+                    False, loop_args, stats_args, pipeline_args_
+                )
+                # 3. Trailing mask loop
+                loop_args = (st_cnt + ld_mask_cnt + unmask_cnt, tl_mask_cnt, end_cnt)
+                stats_args, pipeline_args_ = softmax_loop_fn(
+                    True, loop_args, stats_args, pipeline_args_
+                )
+
+                # Unpack pipeline_args
+                (
+                    _,
+                    mma_si_consumer,
+                    si_corr_producer,
+                    pi_mma_producer,
+                    inplace_producer,
+                    inplace_consumer,
+                ) = pipeline_args_
+                if cutlass.const_expr(stage == 0):
+                    inplace_producer.commit()
+                    inplace_producer.advance()
+                # 4. Copy the final stats for correction epilog
+                tTMEM_STORE_VECrS = cute.make_rmem_tensor(
+                    tTMEM_STORE_VECcS.shape, self.qk_acc_dtype
+                )
+                tTMEM_STORE_VECrS[0] = stats_args[0]
+                tTMEM_STORE_VECrS[1] = stats_args[1]
+                vec_i_handle = si_corr_producer.acquire_and_advance()
+                cute.copy(tiled_tmem_store_vec, tTMEM_STORE_VECrS, tTMEM_STORE_VECtS)
+                cute.arch.fence_view_async_tmem_store()
+                vec_i_handle.commit()
+            # End of if not continue_cond
+            # Advance to next tile
+            tile_sched.advance_to_next_work()
+            work_tile = tile_sched.get_current_work()
+        # End of persistent scheduler loop
+
+    @cute.jit
+    def correction_rescale(
+        self,
+        thr_mma: cute.ThrMma,
+        tiled_tmem_load_vec: cute.TiledCopy,
+        scale_softmax_log2: Float32,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        oi_peek_status=None,
+    ):
+        """Rescale intermediate attention results based on softmax normalization factor.
+
+        This method performs a crucial correction step in the attention computation pipeline.
+        When processing attention in blocks, the softmax normalization factors may change
+        as new blocks are processed. This method rescales previously computed partial
+        output values to account for updated normalization factors.
+
+        The implementation uses efficient tensor memory operations to:
+        1. Load existing partial attention output from tensor memory
+        2. Apply the scaling factor to all elements
+        3. Store the rescaled results back to tensor memory
+
+        When ``self.enable_correction_double_buffer`` is True, the rescale loop
+        runs as a 2-buffer tensor-memory load / multiply / store pipeline.
+
+        :param thr_mma: Thread MMA operation for the computation
+        :type thr_mma: cute.ThrMma
+        :param tiled_tmem_load_vec: Tiled memory load operation for the vectorized row-wise max
+        :type tiled_tmem_load_vec: cute.TiledCopy
+        :param scale_softmax_log2: Log2 of the softmax factor
+        :type scale_softmax_log2: Float32
+        :param tensor_args: Tuple containing the tensors for the correction
+        :type tensor_args: Tuple[cute.Tensor, cute.Tensor, cute.Tensor]
+        :param pipeline_args: Tuple containing the pipeline arguments for the correction
+        :type pipeline_args: Tuple[pipeline.PipelineConsumer, pipeline.PipelineConsumer]
+        :param oi_peek_status: Optional non-blocking token for the Oi consumer
+            wait. ``None`` or ``False`` falls back to a blocking wait.
+        :return: ``((si_corr_consumer, mma_corr_consumer), next_oi_peek_status)``
+            where ``next_oi_peek_status`` is the peek for the next Oi (only
+            refreshed when a rescale actually ran; otherwise stays
+            ``cutlass.Boolean(False)``).
+        """
+        tOtO, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECcS = tensor_args
+        si_corr_consumer, mma_corr_consumer = pipeline_args
+
+        pv_tiled_mma_shape = (
+            self.pv_mma_tiler[0],
+            self.pv_mma_tiler[1],
+        )
+        cO = cute.make_identity_tensor(pv_tiled_mma_shape)
+        tOcO = thr_mma.partition_C(cO)
+        corr_tile_size = 16  # tuneable parameter
+        tmem_load_atom = cute.make_copy_atom(
+            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.pv_acc_dtype,
+        )
+        tmem_store_atom = cute.make_copy_atom(
+            tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(corr_tile_size)),
+            self.pv_acc_dtype,
+        )
+        tOtO_i_layout = cute.composition(tOtO.layout, cute.make_layout((128, corr_tile_size)))
+        tOcO_i_layout = cute.composition(tOcO.layout, cute.make_layout((128, corr_tile_size)))
+        tOtO_i = cute.make_tensor(tOtO.iterator, tOtO_i_layout)
+        tOcO_i = cute.make_tensor(tOcO.iterator, tOcO_i_layout)
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tOtO_i)
+        tiled_tmem_store = tcgen05.make_tmem_copy(tmem_store_atom, tOtO_i)
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.correction_warp_ids))
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        thr_tmem_store = tiled_tmem_store.get_slice(thread_idx)
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_i)
+        tTMEM_LOADcO = thr_tmem_load.partition_D(tOcO_i)
+        tTMEM_STOREtO = thr_tmem_store.partition_D(tOtO_i)
+        num_tiles = self.cta_tiler[2] // corr_tile_size
+        if cutlass.const_expr(self.enable_correction_double_buffer):
+            # Double buffer: 2 register buffers to pipeline tensor-memory load / multiply / store.
+            tTMrO = cute.make_rmem_tensor((tTMEM_LOADcO.shape, 2), self.pv_acc_dtype)
+            # Rank-matching views for cute.copy (TMEM partitions are rank-3,
+            # raw tTMrO[None, idx] is rank-1; composition restores the rank).
+            copy_layout = cute.make_layout(tTMrO.shape[0])
+            view_0 = tTMrO[None, 0]
+            view_1 = tTMrO[None, 1]
+            tTMrO_copy = (
+                cute.make_tensor(
+                    view_0.iterator,
+                    cute.composition(view_0.layout, copy_layout),
+                ),
+                cute.make_tensor(
+                    view_1.iterator,
+                    cute.composition(view_1.layout, copy_layout),
+                ),
+            )
+        else:
+            tTMrO = cute.make_rmem_tensor((tTMEM_LOADcO.shape, num_tiles), self.pv_acc_dtype)
+        tTMEM_LOAD_VECrS = cute.make_rmem_tensor(tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype)
+        # Wait for vec_i (row_wise current max & previous max)
+        vec_i_handle = si_corr_consumer.wait_and_advance()
+        cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECrS)
+        cute.arch.fence_view_async_tmem_load()
+        vec_i_handle.release()
+        # Wait for Oi (peek-token aware: None/False falls back to blocking).
+        oi_handle = mma_corr_consumer.wait_and_advance(oi_peek_status)
+        next_oi_peek_status = cutlass.Boolean(False)
+        vote_ballot_cnt = cute.arch.vote_ballot_sync(tTMEM_LOAD_VECrS[0] != tTMEM_LOAD_VECrS[1])
+        should_rescale = vote_ballot_cnt != 0
+        if should_rescale:
+            scale_ = scale_softmax_log2 * (tTMEM_LOAD_VECrS[0] - tTMEM_LOAD_VECrS[1])
+            scale = cute.math.exp2(scale_, fastmath=True)
+            if cutlass.const_expr(self.enable_correction_double_buffer):
+                num_elems = cute.size(tTMrO, mode=[0])
+                # Prologue: load first tile into buffer 0
+                cute.copy(tiled_tmem_load, tTMEM_LOADtO, tTMrO_copy[0])
+                # Steady state. Refresh the next Oi probe near the end of the
+                # current rescale pipeline.
+                for i in cutlass.range_constexpr(1, num_tiles):
+                    cute.copy(
+                        tiled_tmem_load,
+                        cute.make_tensor(
+                            tTMEM_LOADtO.iterator + i * corr_tile_size,
+                            tTMEM_LOADtO.layout,
+                        ),
+                        tTMrO_copy[i % 2],
+                    )
+                    for j in range(0, num_elems, 2):
+                        tTMrO[j, (i - 1) % 2], tTMrO[j + 1, (i - 1) % 2] = (
+                            cute.arch.mul_packed_f32x2(
+                                (
+                                    tTMrO[j, (i - 1) % 2],
+                                    tTMrO[j + 1, (i - 1) % 2],
+                                ),
+                                (scale, scale),
+                            )
+                        )
+                    cute.copy(
+                        tiled_tmem_store,
+                        tTMrO_copy[(i - 1) % 2],
+                        cute.make_tensor(
+                            tTMEM_STOREtO.iterator + (i - 1) * corr_tile_size,
+                            tTMEM_STOREtO.layout,
+                        ),
+                    )
+                next_oi_peek_status = mma_corr_consumer.try_wait()
+                # Epilogue: compute and store last tile
+                last = (num_tiles - 1) % 2
+                for j in range(0, num_elems, 2):
+                    tTMrO[j, last], tTMrO[j + 1, last] = cute.arch.mul_packed_f32x2(
+                        (tTMrO[j, last], tTMrO[j + 1, last]),
+                        (scale, scale),
+                    )
+                cute.copy(
+                    tiled_tmem_store,
+                    tTMrO_copy[last],
+                    cute.make_tensor(
+                        tTMEM_STOREtO.iterator + (num_tiles - 1) * corr_tile_size,
+                        tTMEM_STOREtO.layout,
+                    ),
+                )
+            else:
+                for i in cutlass.range_constexpr(0, num_tiles):
+                    tTMrO_i_ = tTMrO[None, i]
+                    tTMrO_i = cute.make_tensor(
+                        tTMrO_i_.iterator,
+                        cute.composition(tTMrO_i_.layout, cute.make_layout(tTMrO.shape[0])),
+                    )
+                    cute.copy(
+                        tiled_tmem_load,
+                        cute.make_tensor(
+                            tTMEM_LOADtO.iterator + i * corr_tile_size,
+                            tTMEM_LOADtO.layout,
+                        ),
+                        tTMrO_i,
+                    )
+                    for j in range(0, cute.size(tTMrO_i), 2):
+                        tTMrO_i[j], tTMrO_i[j + 1] = cute.arch.mul_packed_f32x2(
+                            (tTMrO_i[j], tTMrO_i[j + 1]),
+                            (scale, scale),
+                        )
+                    cute.copy(
+                        tiled_tmem_store,
+                        tTMrO_i,
+                        cute.make_tensor(
+                            tTMEM_STOREtO.iterator + i * corr_tile_size,
+                            tTMEM_STOREtO.layout,
+                        ),
+                    )
+                next_oi_peek_status = mma_corr_consumer.try_wait()
+        # Release Oi
+        cute.arch.fence_view_async_tmem_store()
+        oi_handle.release()
+        return (si_corr_consumer, mma_corr_consumer), next_oi_peek_status
+
+    @cute.jit
+    def correction_epilog(
+        self,
+        thr_mma: cute.ThrMma,
+        tiled_tmem_load_vec: cute.TiledCopy,
+        tensor_args: Tuple,
+        pipeline_args: Tuple,
+        value_args: Tuple,
+    ):
+        """Apply final scaling and transformation to attention output.
+
+        When use_tma_store=True: writes to shared memory and signals epilogue warp for TMA store.
+        When use_tma_store=False: writes directly to global memory via st.global.
+
+        :param thr_mma: Thread MMA operation for the computation
+        :type thr_mma: cute.ThrMma
+        :param tiled_tmem_load_vec: Tiled memory load operation for the vectorized row-wise max
+        :type tiled_tmem_load_vec: cute.TiledCopy
+        :param tensor_args: Tuple containing (tOtO, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECcS, sO_or_gO, mLSE, mSink)
+        :type tensor_args: Tuple
+        :param pipeline_args: When use_tma_store: (si_corr_consumer, mma_corr_consumer, corr_epi_producer).
+                              When not use_tma_store: (si_corr_consumer, mma_corr_consumer).
+        :type pipeline_args: Tuple
+        :param value_args: Tuple containing (row_idx, cuseqlen_q, seqlen_q, blk_coord, scale_softmax, scale_output)
+        :type value_args: Tuple
+        """
+        (
+            tOtO,
+            tTMEM_LOAD_VECtSi,
+            tTMEM_LOAD_VECcS,
+            dest_O,
+            mLSE,
+            mSink,
+            m_scale_v_channels,
+        ) = tensor_args
+        row_idx, cuseqlen_q, seqlen_q, blk_coord, scale_softmax, scale_output = value_args
+
+        pv_tiled_mma_shape = (
+            self.pv_mma_tiler[0],
+            self.pv_mma_tiler[1],
+        )
+        cO = cute.make_identity_tensor(pv_tiled_mma_shape)
+
+        corr_tile_size = 32 * 8 // self.o_dtype.width
+        tOdO = thr_mma.partition_C(dest_O)
+        tOcO = thr_mma.partition_C(cO)
+        tOtO_i = cute.logical_divide(tOtO, cute.make_layout((128, corr_tile_size)))
+        tOcO_i = cute.logical_divide(tOcO, cute.make_layout((128, corr_tile_size)))
+        tOdO_i = cute.logical_divide(tOdO, cute.make_layout((128, corr_tile_size)))
+
+        tidx, _, _ = cute.arch.thread_idx()
+        thread_idx = tidx % (self.threads_per_warp * len(self.correction_warp_ids))
+        epi_subtile = (self.epi_tile[0], corr_tile_size)
+        tmem_copy_atom = sm100_utils.get_tmem_load_op(
+            self.pv_mma_tiler,
+            self.o_layout,
+            self.o_dtype,
+            self.pv_acc_dtype,
+            epi_subtile,
+            use_2cta_instrs=False,
+        )
+        tiled_tmem_load = tcgen05.make_tmem_copy(tmem_copy_atom, tOtO_i[(None, None), 0])
+        thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
+        tTMEM_LOADtO = thr_tmem_load.partition_S(tOtO_i[(None, None), None])
+        tTMEM_LOADdO = thr_tmem_load.partition_D(tOdO_i[(None, None), None])
+        tTMEM_LOADoO = thr_tmem_load.partition_D(tOcO_i[(None, None), None])
+
+        if cutlass.const_expr(self.use_tma_store):
+            si_corr_consumer, mma_corr_consumer, corr_epi_producer = pipeline_args
+            smem_copy_atom = sm100_utils.get_smem_store_op(
+                self.o_layout, self.o_dtype, self.pv_acc_dtype, tiled_tmem_load
+            )
+            tiled_smem_store = cute.make_tiled_copy_D(smem_copy_atom, tiled_tmem_load)
+        else:
+            si_corr_consumer, mma_corr_consumer = pipeline_args
+
+        # Wait for vec_i (row_wise global sum)
+        vec_i_handle = si_corr_consumer.wait_and_advance()
+        tTMEM_LOAD_VECrS = cute.make_rmem_tensor(tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype)
+        cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtSi, tTMEM_LOAD_VECrS)
+        cute.arch.fence_view_async_tmem_load()
+        vec_i_handle.release()
+
+        # Wait for Oi
+        oi_handle = mma_corr_consumer.wait_and_advance()
+        if cutlass.const_expr(self.use_tma_store):
+            oi_final_handle = corr_epi_producer.acquire_and_advance()
+        row_sum = tTMEM_LOAD_VECrS[0]
+        if cutlass.const_expr(mSink is not None):
+            sink_val = mSink[blk_coord[2]]
+            row_max_raw = tTMEM_LOAD_VECrS[1]
+            # sink is already in scaled logit space, row_max_raw is unscaled
+            # exp2((sink - max_scaled) * log2(e)) = exp(sink - max_scaled)
+            log2_e = Float32(1.4426950408889634)
+            sink_exp = cute.math.exp2(
+                (sink_val - row_max_raw * scale_softmax) * log2_e, fastmath=True
+            )
+            row_sum = row_sum + sink_exp
+        scale = scale_output / row_sum
+
+        if cutlass.const_expr(m_scale_v_channels is not None):
+            scale_v_ch_h = m_scale_v_channels[None, blk_coord[2]]
+        for i in range(self.cta_tiler[2] // corr_tile_size):
+            tTMEM_LOADtO_i = tTMEM_LOADtO[None, 0, 0, i]
+            tTMEM_LOADdO_i = tTMEM_LOADdO[None, 0, 0, i]
+            tTMEM_LOADoO_i = tTMEM_LOADoO[None, 0, 0, i]
+            tTMrO = cute.make_rmem_tensor(tTMEM_LOADoO_i.shape, self.pv_acc_dtype)
+            cute.copy(tiled_tmem_load, tTMEM_LOADtO_i, tTMrO)
+            for j in range(0, cute.size(tTMrO), 2):
+                tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
+                    (tTMrO[j], tTMrO[j + 1]),
+                    (scale, scale),
+                )
+            if cutlass.const_expr(m_scale_v_channels is not None):
+                for j in range(0, cute.size(tTMrO), 2):
+                    _, n0 = tTMEM_LOADoO_i[j]
+                    _, n1 = tTMEM_LOADoO_i[j + 1]
+                    tTMrO[j], tTMrO[j + 1] = cute.arch.mul_packed_f32x2(
+                        (tTMrO[j], tTMrO[j + 1]),
+                        (scale_v_ch_h[n0], scale_v_ch_h[n1]),
+                    )
+            tDMrO = cute.make_rmem_tensor(tTMrO.shape, self.o_dtype)
+            o_vec = tTMrO.load()
+            tDMrO.store(o_vec.to(self.o_dtype))
+            if cutlass.const_expr(self.use_tma_store):
+                # TMA store path: write to shared memory
+                cute.copy(tiled_smem_store, tDMrO, tTMEM_LOADdO_i)
+            else:
+                # st.global path: write directly to global memory with bounds check
+                if row_idx < seqlen_q:
+                    cute.autovec_copy(tDMrO, tTMEM_LOADdO_i)
+
+        if cutlass.const_expr(mLSE is not None):
+            scaled_tmp = scale_softmax * tTMEM_LOAD_VECrS[1]
+            # Convert LSE from natural log to log2 space, consistent with flashinfer trtllm-gen backend
+            lse = (cute.math.log(row_sum, fastmath=True) + scaled_tmp) * Float32(1.4426950408889634)
+            # Pre-scale correction: row_sum was inflated by 2^offset, so the
+            # log2-space LSE is too large by exactly `p_fp8_prescale_log2`.
+            if cutlass.const_expr(self.v_dtype.width == 8 and self.p_fp8_prescale_log2 > 0):
+                lse = lse - self.p_fp8_prescale_log2
+            if row_idx < seqlen_q:
+                mLSE[row_idx + cuseqlen_q, blk_coord[2]] = lse
+        if cutlass.const_expr(self.use_tma_store):
+            # fence view async shared
+            cute.arch.fence_view_async_shared()
+            oi_handle.release()
+            oi_final_handle.commit()
+            return (si_corr_consumer, mma_corr_consumer, corr_epi_producer)
+        else:
+            oi_handle.release()
+            return (si_corr_consumer, mma_corr_consumer)
+
+    def check_supported_dtypes(
+        self,
+        qk_dtype: Type[cutlass.Numeric],
+        pv_dtype: Type[cutlass.Numeric],
+        out_dtype: Type[cutlass.Numeric],
+        qk_sf_dtype: Type[cutlass.Numeric],
+        qk_sf_vec_size: int,
+        qk_acc_dtype: Type[cutlass.Numeric],
+        pv_acc_dtype: Type[cutlass.Numeric],
+    ):
+        if qk_dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}:
+            if qk_sf_dtype is not cutlass.Float8E8M0FNU:
+                raise NotImplementedError("MXFP8 QK requires qk_sf_dtype Float8E8M0FNU")
+            if qk_sf_vec_size != 32:
+                raise NotImplementedError("MXFP8 QK requires qk_sf_vec_size 32")
+        elif qk_dtype is cutlass.Float4E2M1FN:
+            if qk_sf_dtype is not cutlass.Float8E4M3FN:
+                raise NotImplementedError("NVFP4 QK requires qk_sf_dtype Float8E4M3FN")
+            if qk_sf_vec_size != 16:
+                raise NotImplementedError("NVFP4 QK requires qk_sf_vec_size 16")
+        else:
+            raise NotImplementedError(
+                "qk_dtype must be Float8E4M3FN/Float8E5M2 for MXFP8 or Float4E2M1FN for NVFP4"
+            )
+
+        if pv_dtype not in {cutlass.Float8E4M3FN, cutlass.BFloat16}:
+            raise NotImplementedError("pv_dtype must be Float8E4M3FN or BFloat16")
+        if out_dtype not in {cutlass.Float8E4M3FN, cutlass.Float16, cutlass.BFloat16}:
+            raise NotImplementedError("Unsupported out_dtype")
+        if qk_acc_dtype not in {cutlass.Float32}:
+            raise NotImplementedError("Unsupported qk_acc_dtype")
+        if pv_acc_dtype not in {cutlass.Float32}:
+            raise NotImplementedError("Unsupported pv_acc_dtype")
+
+    def check_invalid_shape(
+        self,
+        qk_dtype: Type[cutlass.Numeric],
+        qk_sf_vec_size: int,
+        q_shape: Tuple[int, int, int, int],
+        k_shape: Tuple[int, int, int, int],
+    ):
+        # Shapes are passed around this example as (batch, seq_len, num_heads, head_dim).
+        b, s_q, h_q, d = q_shape
+        b_, s_k, h_k, d_ = k_shape
+
+        if b != b_:
+            raise NotImplementedError("q & k must have the same batch size")
+        if d != d_:
+            raise NotImplementedError("q & k must have the same head dimension")
+        if qk_dtype is cutlass.Float4E2M1FN:
+            if d not in {64, 128}:
+                raise NotImplementedError("NVFP4 QK supports headdim 64 or 128")
+        elif d not in {32, 64, 128}:
+            raise NotImplementedError("MXFP8 QK supports headdim 32, 64, or 128")
+        if d % qk_sf_vec_size != 0:
+            raise NotImplementedError("head dimension must be divisible by qk_sf_vec_size")
+        if h_q % h_k != 0:
+            raise NotImplementedError("h_q must be divisible by h_k")
+        if isinstance(s_q, tuple) and len(s_q) != b:
+            raise NotImplementedError("variable_seqlen s_q must have the length of batch size")
+        if isinstance(s_k, tuple) and len(s_k) != b:
+            raise NotImplementedError("variable_seqlen s_k must have the length of batch size")
+
+    def can_implement(
+        self,
+        q_shape: Tuple[int, int, int, int],
+        k_shape: Tuple[int, int, int, int],
+        qk_dtype: Type[cutlass.Numeric],
+        pv_dtype: Type[cutlass.Numeric],
+        out_dtype: Type[cutlass.Numeric],
+        qk_sf_dtype: Type[cutlass.Numeric],
+        qk_sf_vec_size: int,
+        qk_acc_dtype: Type[cutlass.Numeric],
+        pv_acc_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        :param q_shape: Shape of the query tensor.
+        :type q_shape: Tuple[int, int, int, int]
+        :param k_shape: Shape of the key tensor.
+        :type k_shape: Tuple[int, int, int, int]
+        :param qk_dtype: Data type for Q and K (Bmm1 inputs).
+        :type qk_dtype: Type[cutlass.Numeric]
+        :param pv_dtype: Data type for P and V (Bmm2 inputs).
+        :type pv_dtype: Type[cutlass.Numeric]
+        :param out_dtype: Data type of the output tensor.
+        :type out_dtype: Type[cutlass.Numeric]
+        :param qk_acc_dtype: Data type of the qk accumulator tensor.
+        :type qk_acc_dtype: Type[cutlass.Numeric]
+        :param pv_acc_dtype: Data type of the pv accumulator tensor.
+        :type pv_acc_dtype: Type[cutlass.Numeric]
+        :return: True if the kernel can be implemented, False otherwise.
+        :rtype: bool
+        """
+        try:
+            # Skip unsupported types
+            self.check_supported_dtypes(
+                qk_dtype,
+                pv_dtype,
+                out_dtype,
+                qk_sf_dtype,
+                qk_sf_vec_size,
+                qk_acc_dtype,
+                pv_acc_dtype,
+            )
+            # Skip invalid shape
+            self.check_invalid_shape(
+                qk_dtype,
+                qk_sf_vec_size,
+                q_shape,
+                k_shape,
+            )
+        except NotImplementedError:
+            return False
+        return True

--- a/flashinfer/cute_dsl/attention/fmha/helpers/__init__.py
+++ b/flashinfer/cute_dsl/attention/fmha/helpers/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/flashinfer/cute_dsl/attention/fmha/helpers/fmha_helpers.py
+++ b/flashinfer/cute_dsl/attention/fmha/helpers/fmha_helpers.py
@@ -1,0 +1,1176 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# ruff: noqa: I001, E501, F841
+
+import enum
+from typing import Tuple, Optional
+import cutlass
+from cutlass.cute.typing import Boolean
+from cutlass._mlir.dialects import llvm, vector
+
+from cutlass.cutlass_dsl import (
+    Int32,
+    Float32,
+    T,
+    min,
+    extract_mlir_values,
+    new_from_mlir_values,
+    dsl_user_op,
+)
+from cutlass.utils.hardware_info import HardwareInfo
+from .static_persistent_tile_scheduler import WorkTileInfo
+import cutlass.cute as cute
+
+
+##############################################################################
+# Fmha static tile scheduler
+##############################################################################
+
+
+class FmhaStaticTileSchedulerParams:
+    """A class to represent parameters for the FMHA (Fused Multi-Head Attention) static tile scheduler.
+
+    This class holds the configuration parameters needed to initialize and configure
+    the tile scheduler for FMHA operations.
+
+    :ivar is_persistent: Whether to use persistent kernel mode.
+    :type is_persistent: bool
+    :ivar problem_shape_mhb: Problem shape in (M, H, B) format.
+    :type problem_shape_mhb: cute.Shape
+    """
+
+    def __init__(
+        self,
+        is_persistent: bool,
+        problem_shape_mhb: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        Initializes the FmhaStaticTileSchedulerParams with the given parameters.
+
+        :param is_persistent: Whether to use persistent kernel mode.
+        :type is_persistent: bool
+        :param problem_shape_mhb: Problem shape in (M, H, B) format.
+        :type problem_shape_mhb: cute.Shape
+        """
+        self.is_persistent = is_persistent
+        self.problem_shape_mhb = problem_shape_mhb
+        self._loc = loc
+        self._ip = ip
+
+    def __extract_mlir_values__(self):
+        values, self._values_pos = [], []
+        for obj in [self.problem_shape_mhb]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        obj_list = []
+        for obj, n_items in zip([self.problem_shape_mhb], self._values_pos):
+            obj_list.append(new_from_mlir_values(obj, values[:n_items]))
+            values = values[n_items:]
+        return FmhaStaticTileSchedulerParams(self.is_persistent, *(tuple(obj_list)), loc=self._loc)
+
+
+class FmhaStaticTileScheduler:
+    """A static tile scheduler for FMHA (Fused Multi-Head Attention) operations.
+
+    This class manages the scheduling of work tiles for FMHA kernels, supporting
+    both persistent and non-persistent kernel modes. It tracks the current work
+    position and advances through the problem space efficiently.
+
+    :ivar _params: Scheduler parameters.
+    :type _params: FmhaStaticTileSchedulerParams
+    :ivar _blk_coord: Block coordinates.
+    :type _blk_coord: cute.Coord
+    :ivar _grid_shape: Grid shape for the kernel.
+    :type _grid_shape: cute.Shape
+    :ivar _is_persistent: Whether to use persistent kernel mode.
+    :type _is_persistent: bool
+    :ivar _current_work_linear_idx: Current linear work index.
+    :type _current_work_linear_idx: Int32
+    :ivar _problem_shape_mhb: Problem shape in (M, H, B) format.
+    :type _problem_shape_mhb: cute.Layout
+    :ivar _num_blocks: Number of blocks in the problem.
+    :type _num_blocks: Int32
+    :ivar _is_first_block: Whether this is the first block.
+    :type _is_first_block: bool
+    :ivar num_persistent_sm: Number of persistent SMs.
+    :type num_persistent_sm: Int32
+    """
+
+    def __init__(
+        self,
+        params: FmhaStaticTileSchedulerParams,
+        current_work_linear_idx: Int32,
+        blk_coord: cute.Coord,
+        grid_shape: cute.Shape,
+        *,
+        loc=None,
+        ip=None,
+    ):
+        """
+        Initializes the FmhaStaticTileScheduler with the given parameters.
+
+        :param params: Scheduler parameters.
+        :type params: FmhaStaticTileSchedulerParams
+        :param current_work_linear_idx: Current linear work index.
+        :type current_work_linear_idx: Int32
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param grid_shape: Grid shape for the kernel.
+        :type grid_shape: cute.Shape
+        """
+        self._params = params
+        self._blk_coord = blk_coord
+        self._grid_shape = grid_shape
+        self._is_persistent = params.is_persistent
+        self._current_work_linear_idx = current_work_linear_idx
+        self._problem_shape_mhb = cute.make_layout(params.problem_shape_mhb, loc=loc, ip=ip)
+        self._num_blocks = cute.size(self._problem_shape_mhb, loc=loc, ip=ip)
+        self._is_first_block = True
+        self.num_persistent_sm = cute.size(grid_shape, loc=loc, ip=ip)
+        self._loc = loc
+        self._ip = ip
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: FmhaStaticTileSchedulerParams,
+        *,
+        loc=None,
+        ip=None,
+    ) -> cute.Shape:
+        """
+        Determine the grid shape for the FMHA kernel.
+
+        For persistent kernels, the grid shape is limited by the number of SMs
+        (Streaming Multiprocessors) available on the device. For non-persistent
+        kernels, the grid shape matches the problem shape.
+
+        :param params: Scheduler parameters.
+        :type params: FmhaStaticTileSchedulerParams
+
+        :return: Grid shape as (M, H, B) tuple.
+        :rtype: cute.Shape
+        """
+        if params.is_persistent:
+            hardware_info = HardwareInfo()
+            sm_count = hardware_info.get_device_multiprocessor_count()
+            return (
+                min(sm_count, cute.size(params.problem_shape_mhb, loc=loc, ip=ip)),
+                1,
+                1,
+            )
+        else:
+            return params.problem_shape_mhb
+
+    @staticmethod
+    def check_valid_work_for_seqlen_q(
+        q_tiler: int,
+        current_idx: Int32,
+        seqlen_q: Int32,
+    ) -> Boolean:
+        """
+        Check if the current work index is valid for the given query sequence length.
+
+        This method verifies that the current work tile index multiplied by the
+        query tiler size is within the bounds of the query sequence length.
+
+        :param q_tiler: Query tiler size.
+        :type q_tiler: int
+        :param current_idx: Current work index.
+        :type current_idx: Int32
+        :param seqlen_q: Query sequence length.
+        :type seqlen_q: Int32
+
+        :return: True if the work is valid, False otherwise.
+        :rtype: Boolean
+        """
+        return current_idx * q_tiler < seqlen_q
+
+    def get_current_work(self, *, loc=None, ip=None) -> WorkTileInfo:
+        """
+        Get information about the current work tile.
+
+        Determines if the current work is valid and computes the tile coordinates
+        based on whether the kernel is persistent or non-persistent.
+
+        :return: WorkTileInfo containing tile coordinates and validity flag.
+        :rtype: WorkTileInfo
+        """
+        is_valid = (
+            self._current_work_linear_idx < self._num_blocks
+            if self._is_persistent
+            else self._is_first_block
+        )
+
+        blk_coord = (0, 0, 0)
+        if self._is_persistent:
+            blk_coord = self._problem_shape_mhb.get_hier_coord(
+                self._current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            blk_coord = self._blk_coord
+
+        # cur_tile_coord is (mid, 0, (bid, hid))
+        cur_tile_coord = (
+            blk_coord[0],
+            0,
+            (blk_coord[1], blk_coord[2]),
+        )
+
+        return WorkTileInfo(cur_tile_coord, is_valid)
+
+    def initial_work_tile_info(self, *, loc=None, ip=None):
+        """
+        Get the initial work tile information.
+
+        :return: Initial WorkTileInfo.
+        :rtype: WorkTileInfo
+        """
+        return self.get_current_work(loc=loc, ip=ip)
+
+    def advance_to_next_work(self, *, advance_count=1, loc=None, ip=None):
+        """
+        Advance to the next work tile.
+
+        For persistent kernels, advances by the number of persistent SMs.
+        For non-persistent kernels, marks that the first block has been processed.
+
+        :param advance_count: Number of steps to advance (default: 1).
+        :type advance_count: int
+        """
+        if self._is_persistent:
+            self._current_work_linear_idx += advance_count * self.num_persistent_sm
+        self._is_first_block = False
+
+    def __extract_mlir_values__(self):
+        # Only pass mutable per-iteration state as scf.while block arguments.
+        # _params and _grid_shape are loop-invariant and captured from outer
+        # scope, keeping block arg count low (4 instead of 10).
+        values = extract_mlir_values(self._current_work_linear_idx)
+        values.extend(extract_mlir_values(self._blk_coord))
+        return values
+
+    def __new_from_mlir_values__(self, values):
+        assert len(values) == 4
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[0]]
+        )
+        new_blk_coord = new_from_mlir_values(self._blk_coord, values[1:4])
+        return FmhaStaticTileScheduler(
+            self._params, new_current_work_linear_idx, new_blk_coord, self._grid_shape
+        )
+
+
+def create_fmha_static_tile_scheduler(
+    params: FmhaStaticTileSchedulerParams,
+    blk_coord: cute.Coord,
+    grid_shape: cute.Shape,
+) -> FmhaStaticTileScheduler:
+    """
+    Create a new FMHA static tile scheduler.
+
+    :param params: Scheduler parameters.
+    :type params: FmhaStaticTileSchedulerParams
+    :param blk_coord: Block coordinates.
+    :type blk_coord: cute.Coord
+    :param grid_shape: Grid shape.
+    :type grid_shape: cute.Shape
+
+    :return: New FmhaStaticTileScheduler instance.
+    :rtype: FmhaStaticTileScheduler
+    """
+    return FmhaStaticTileScheduler(params, blk_coord[0], blk_coord, grid_shape)
+
+
+def create_fmha_static_tile_scheduler_params(
+    is_persistent: bool,
+    problem_shape_mhb: cute.Shape,
+) -> FmhaStaticTileSchedulerParams:
+    """
+    Create FMHA static tile scheduler parameters.
+
+    :param is_persistent: Whether to use persistent kernel mode.
+    :type is_persistent: bool
+    :param problem_shape_mhb: Problem shape in (M, H, B) format.
+    :type problem_shape_mhb: cute.Shape
+
+    :return: New FmhaStaticTileSchedulerParams instance.
+    :rtype: FmhaStaticTileSchedulerParams
+    """
+    return FmhaStaticTileSchedulerParams(is_persistent, problem_shape_mhb)
+
+
+def compute_grid(
+    o_shape: cute.Shape,
+    cta_tiler: Tuple[int, int, int],
+    is_persistent: bool,
+    is_2cta: bool = False,
+) -> Tuple[FmhaStaticTileSchedulerParams, Tuple[int, int, int]]:
+    """
+    Compute grid parameters for FMHA operation.
+
+    This function calculates the appropriate grid shape and scheduler parameters
+    based on the output tensor shape, CTA (Cooperative Thread Array) tiler,
+    and whether to use persistent kernel mode.
+
+    The output tensor o has shape (s, d, ((h_r, h_k), b)) where:
+    - s: sequence length
+    - d: head dimension
+    - h_r: number of heads for query
+    - h_k: number of heads for key
+    - b: batch size
+
+    :param o_shape: Output tensor shape for grid computation.
+    :type o_shape: cute.Shape
+    :param cta_tiler: CTA tiler dimensions (M, N, K).
+    :type cta_tiler: Tuple[int, int, int]
+    :param is_persistent: Whether to use persistent kernel mode.
+    :type is_persistent: bool
+    :param is_2cta: Whether to use 2CTA mode.
+    :type is_2cta: bool
+
+    :return: Tuple of (scheduler_params, grid_shape).
+    :rtype: Tuple[FmhaStaticTileSchedulerParams, Tuple[int, int, int]]
+    """
+    tile_sched_params = create_fmha_static_tile_scheduler_params(
+        is_persistent,
+        (
+            cute.round_up(cute.ceil_div(cute.size(o_shape[0]), cta_tiler[0]), 2 if is_2cta else 1),
+            cute.size(o_shape[2][0]),
+            cute.size(o_shape[2][1]),
+        ),
+    )
+    grid = FmhaStaticTileScheduler.get_grid_shape(tile_sched_params)
+
+    return tile_sched_params, grid
+
+
+##############################################################################
+# Fused Mask
+##############################################################################
+
+
+class MaskEnum(enum.Enum):
+    """Enumeration of mask types for FMHA operations.
+
+    - RESIDUAL_MASK: Residual mask for handling variable sequence lengths
+    - WINDOW_MASK: Window mask for attention which also includes causal and no mask
+    - WINDOW_MASK_INFERENCE: Same as the window mask, but has the limitation that the end of q is aligned with the end of k
+    - WINDOW_MASK_BWD: Window mask for backward pass
+    - WINDOW_MASK_BWD_INFERENCE: Same as the window mask for backward pass, but has the limitation that the end of q is aligned with the end of k
+    """
+
+    RESIDUAL_MASK = enum.auto()
+    RESIDUAL_MASK_BWD = enum.auto()
+    WINDOW_MASK = enum.auto()
+    WINDOW_MASK_INFERENCE = enum.auto()
+    WINDOW_MASK_BWD = enum.auto()
+    WINDOW_MASK_BWD_INFERENCE = enum.auto()
+
+
+class FusedMask:
+    """A fused mask implementation for FMHA operations.
+
+    This class handles different types of attention masks including no mask,
+    residual mask for variable sequence lengths, and causal mask for
+    autoregressive attention patterns.
+
+    The class provides methods to:
+    - Calculate trip counts for different mask types
+    - Apply masks to attention scores
+    - Handle masked and unmasked trip calculations
+    """
+
+    def get_trip_count(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of trips needed for the current block.
+
+        The trip count depends on the mask type and the block coordinates.
+        For causal masks, it considers the autoregressive constraint.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of trips needed.
+        :rtype: Int32
+        """
+        result = 0
+        offset = 0
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        if cutlass.const_expr(mask_type == MaskEnum.RESIDUAL_MASK):
+            result = cute.ceil_div(seqlen_k, tile_shape[1])
+        if cutlass.const_expr(mask_type is MaskEnum.RESIDUAL_MASK_BWD):
+            result = cute.ceil_div(seqlen_q, tile_shape[0])
+        if cutlass.const_expr(
+            mask_type == MaskEnum.WINDOW_MASK or mask_type == MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is None):
+                result = cute.ceil_div(seqlen_k, tile_shape[1])
+            else:
+                max_idx_q = (blk_coord[0] + 1) * tile_shape[0]
+                idx_k = max_idx_q + offset + window_size_right
+                tmp_blocks_k = cute.ceil_div(idx_k, tile_shape[1])
+                max_blocks_k = cute.ceil_div(seqlen_k, tile_shape[1])
+                result = min(max_blocks_k, tmp_blocks_k)
+        if cutlass.const_expr(
+            mask_type == MaskEnum.WINDOW_MASK_BWD or mask_type == MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is None):
+                result = cute.ceil_div(seqlen_q, tile_shape[0])
+            else:
+                max_idx_k = (blk_coord[1] + 1) * tile_shape[1]
+                idx_k = max_idx_k + offset + window_size_left
+                tmp_blocks_q = cute.ceil_div(idx_k, tile_shape[0])
+                max_blocks_q = cute.ceil_div(seqlen_q, tile_shape[0])
+                result = min(max_blocks_q, tmp_blocks_q)
+        start_block = FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        result = result - start_block
+        return result
+
+    @cute.jit
+    def get_trip_start(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Get the start of the trip for the current block.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        """
+        result = 0
+        offset = 0
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        if cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK or mask_type is MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_q = blk_coord[0] * tile_shape[0]
+                idx_k = min_idx_q + offset - window_size_left
+                tmp_blocks_k = idx_k // tile_shape[1]
+                result = max(tmp_blocks_k, result)
+        if cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK_BWD or mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_k = blk_coord[1] * tile_shape[1]
+                idx_q = min_idx_k + offset - window_size_right
+                tmp_blocks_q = idx_q // tile_shape[0]
+                result = max(tmp_blocks_q, result)
+        return result
+
+    @cute.jit
+    def get_leading_mask_id(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Int32, Int32]:
+        """
+        Get the begin and end tile idx for the leading mask.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Tuple of (begin, end) tile idx for the leading mask.
+        :rtype: Tuple[Int32, Int32]
+        """
+        offset = 0
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        leading_mask_begin = FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trip_count = FusedMask.get_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+
+        leading_mask_end = leading_mask_begin
+        if cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK or mask_type is MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_q = (blk_coord[0] + 1) * tile_shape[0] + offset - window_size_left
+                leading_mask_end = min(
+                    cute.ceil_div(min_idx_q, tile_shape[1]) - 1,
+                    trip_count + leading_mask_begin - 1,
+                )
+            else:
+                leading_mask_end = leading_mask_begin - 1
+        elif cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK_BWD or mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_k = (blk_coord[1] + 1) * tile_shape[1] + offset - window_size_right
+                leading_mask_end = cute.ceil_div(min_idx_k, tile_shape[0]) - 1
+            else:
+                leading_mask_end = leading_mask_begin - 1
+        return leading_mask_begin, leading_mask_end
+
+    @cute.jit
+    def get_trailing_mask_id(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Tuple[Optional[Int32], Optional[Int32]]:
+        """
+        Get the begin and end tile idx for the trailing mask.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Tuple of (begin, end) tile idx for the trailing mask.
+        :rtype: Tuple[Int32, Int32]
+        """
+        offset = 0
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_INFERENCE):
+            offset = seqlen_k - seqlen_q
+        if cutlass.const_expr(mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE):
+            offset = seqlen_q - seqlen_k
+        trip_start = FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trip_count = FusedMask.get_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+
+        trailing_mask_begin, trailing_mask_end = None, None
+        if cutlass.const_expr(
+            mask_type is MaskEnum.WINDOW_MASK or mask_type is MaskEnum.WINDOW_MASK_INFERENCE
+        ):
+            if cutlass.const_expr(window_size_right is not None):
+                min_idx_q = blk_coord[0] * tile_shape[0] + offset + window_size_right
+                trailing_mask_begin = min(min_idx_q // tile_shape[1], trip_count + trip_start - 1)
+                trailing_mask_end = trip_count + trip_start - 1
+            else:
+                # last tile, we always apply mask on it regardless whether it's a residual tile
+                trailing_mask_begin = trip_count + trip_start - 1
+                trailing_mask_end = trip_count + trip_start - 1
+        else:
+            if cutlass.const_expr(window_size_left is not None):
+                min_idx_k = blk_coord[1] * tile_shape[1] + offset + window_size_left + 1
+                max_idx_k = (blk_coord[1] + 1) * tile_shape[1] + offset + window_size_left
+                trailing_mask_begin = min(
+                    cute.ceil_div(min_idx_k, tile_shape[0]) - 1,
+                    trip_count + trip_start - 1,
+                )
+                trailing_mask_end = min(
+                    cute.ceil_div(max_idx_k, tile_shape[0]) - 1,
+                    trip_count + trip_start - 1,
+                )
+            else:
+                # last tile, we always apply mask on it regardless whether it's a residual tile
+                trailing_mask_begin = trip_count + trip_start - 1
+                trailing_mask_end = trip_count + trip_start - 1
+
+        return trailing_mask_begin, trailing_mask_end
+
+    @cute.jit
+    def get_masked_leading_count(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of masked trips for the leading mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of masked trips.
+        :rtype: Int32
+        """
+        result = 0
+        if cutlass.const_expr(
+            mask_type is not MaskEnum.RESIDUAL_MASK and mask_type is not MaskEnum.RESIDUAL_MASK_BWD
+        ):
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                leading_mask_begin, leading_mask_end = FusedMask.get_leading_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                result = max(leading_mask_end - leading_mask_begin + 1, 0)
+
+        return result
+
+    @cute.jit
+    def get_masked_trailing_count(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+        rem_count: Optional[Int32] = 0,
+    ) -> Int32:
+        """
+        Calculate the number of masked trips for the trailing mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param rem_count: Remaining count from previous calculations.
+        :type rem_count: Int32
+
+        :return: Number of masked trips.
+        :rtype: Int32
+        """
+        result = 0
+
+        if cutlass.const_expr(
+            mask_type is not MaskEnum.RESIDUAL_MASK and mask_type is not MaskEnum.RESIDUAL_MASK_BWD
+        ):
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                trailing_mask_begin, trailing_mask_end = FusedMask.get_trailing_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                leading_mask_begin, leading_mask_end = FusedMask.get_leading_mask_id(
+                    mask_type,
+                    blk_coord,
+                    tile_shape,
+                    seqlen_q,
+                    seqlen_k,
+                    window_size_left,
+                    window_size_right,
+                )
+                if cutlass.const_expr(
+                    trailing_mask_begin is not None and trailing_mask_end is not None
+                ):
+                    if trailing_mask_begin <= leading_mask_end:
+                        result = max(trailing_mask_end - leading_mask_end, 0)
+                    else:
+                        result = max(trailing_mask_end - trailing_mask_begin + 1, 0)
+        else:
+            if seqlen_k % tile_shape[1] != 0:
+                result = 1
+            else:
+                result = 0
+
+        return result + rem_count
+
+    @cute.jit
+    def get_unmasked_trip_count(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+    ) -> Int32:
+        """
+        Calculate the number of unmasked trips for the current block.
+
+        This represents the number of trips that don't require special
+        masking treatment.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+
+        :return: Number of unmasked trips.
+        :rtype: Int32
+        """
+        result = (
+            FusedMask.get_trip_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            - FusedMask.get_masked_leading_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+            )
+            - FusedMask.get_masked_trailing_count(
+                mask_type,
+                blk_coord,
+                tile_shape,
+                seqlen_q,
+                seqlen_k,
+                window_size_left,
+                window_size_right,
+                0,
+            )
+        )
+        return result
+
+    @cute.jit
+    def get_masked_info(
+        mask_type: MaskEnum,
+        blk_coord: cute.Coord,
+        tile_shape: cute.Shape,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[Int32] = None,
+        window_size_right: Optional[Int32] = None,
+        rem_count: Optional[Int32] = 0,
+    ) -> Tuple[Int32, Int32, Int32, Int32, Int32]:
+        """
+        Calculate the number of masked trips for the trailing mask.
+
+        This is used for blocks that need special handling due to masking.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param blk_coord: Block coordinates.
+        :type blk_coord: cute.Coord
+        :param tile_shape: Shape of the tile.
+        :type tile_shape: cute.Shape
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Int32
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[Int32]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[Int32]
+        :param rem_count: Remaining count from previous calculations.
+        :type rem_count: Int32
+
+        :return: Number of masked info.
+        :rtype: Tuple[Int32, Int32, Int32, Int32, Int32]
+        """
+        start_count = FusedMask.get_trip_start(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        leading_mask_count = FusedMask.get_masked_leading_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        unmask_count = FusedMask.get_unmasked_trip_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+        )
+        trailing_mask_count = FusedMask.get_masked_trailing_count(
+            mask_type,
+            blk_coord,
+            tile_shape,
+            seqlen_q,
+            seqlen_k,
+            window_size_left,
+            window_size_right,
+            rem_count,
+        )
+        end_count = start_count + leading_mask_count + unmask_count + trailing_mask_count
+        return (
+            start_count,
+            end_count,
+            leading_mask_count,
+            unmask_count,
+            trailing_mask_count,
+        )
+
+    @cute.jit
+    def apply_mask(
+        mask_type: MaskEnum,
+        acc_qk: cute.Tensor,
+        index_qk: cute.Tensor,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        window_size_left: Optional[int] = None,
+        window_size_right: Optional[int] = None,
+        index_transform: cutlass.Constexpr = lambda index_q, index_k: (
+            index_q,
+            index_k,
+        ),
+    ):
+        """
+        Apply the appropriate mask to the attention scores.
+
+        This method modifies the attention scores (acc_qk) based on the mask type
+        and the positions in the index tensor.
+
+        :param mask_type: Type of mask to use
+        :type mask_type: utils.MaskEnum
+        :param acc_qk: Accumulated QK attention scores tensor.
+        :type acc_qk: cute.Tensor
+        :param index_qk: Index tensor containing position information.
+        :type index_qk: cute.Tensor
+        :param seqlen_k: Key sequence length for attention computation.
+        :type seqlen_k: Int32
+        :param seqlen_q: Query sequence length for attention computation.
+        :type seqlen_q: Optional[int]
+        :param window_size_left: Left-side sliding window size for attention masking.
+        :type window_size_left: Optional[int]
+        :param window_size_right: Right-side sliding window size for attention masking.
+        :type window_size_right: Optional[int]
+        """
+
+        tidx, tidy, tidx = cute.arch.thread_idx()
+        offset = 0
+        offset = (
+            seqlen_k - seqlen_q
+            if cutlass.const_expr(
+                mask_type is MaskEnum.WINDOW_MASK_INFERENCE
+                or mask_type is MaskEnum.WINDOW_MASK_BWD_INFERENCE
+            )
+            else 0
+        )
+        for i in cutlass.range(cute.size(acc_qk), unroll_full=True):
+            index_q, index_k = index_transform(*index_qk[i])
+            if cutlass.const_expr(window_size_left is not None or window_size_right is not None):
+                if cutlass.const_expr(window_size_left is None):
+                    if index_q + offset + window_size_right < index_k:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+                elif cutlass.const_expr(window_size_right is None):
+                    if index_q + offset - window_size_left > index_k:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+                else:
+                    max_K_index = min(index_q + offset + window_size_right, seqlen_k)
+                    min_K_index = max(0, index_q + offset - window_size_left)
+                    if index_k > max_K_index or index_k < min_K_index:
+                        acc_qk[i] = -Float32.inf
+                    if index_k >= seqlen_k or index_q >= seqlen_q:  # residual mask
+                        acc_qk[i] = -Float32.inf
+
+            if cutlass.const_expr(
+                mask_type == MaskEnum.RESIDUAL_MASK or mask_type == MaskEnum.RESIDUAL_MASK_BWD
+            ):
+                if index_k >= seqlen_k or index_q >= seqlen_q:
+                    acc_qk[i] = -Float32.inf
+
+
+@dsl_user_op
+def ex2_emulation_packed_f32x2(
+    x: Float32, y: Float32, *, loc=None, ip=None
+) -> Tuple[Float32, Float32]:
+    # Clamp the xy so they fit within the FP32 exponent range
+    # The upper side is ensured by the (s - row_max)
+    xy_clamped = (cute.arch.fmax(x, -127.0), cute.arch.fmax(y, -127.0))
+
+    fp32_round_int = float(2**23 + 2**22)
+    # |  0   | 10010110 | 10000000000000000000000 |
+    # | sign | exponent |        mantissa         |
+    #                                           ^
+    #                                           |
+    #                                  digit of ones place
+    # During FP32 addition, any number that smaller than this will be
+    # aligned the exponent to 2^23, so that the digit of ones
+    # is at the rightest place
+    # We want to round down here, so that the fractional part is in [0, 1)
+    xy_rounded = cute.arch.add_packed_f32x2(xy_clamped, (fp32_round_int, fp32_round_int), rnd="rm")
+    # The integer floor of x & y are now in the last 8 bits of xy_rounded
+    # We want the next 2 ops to round to nearest even. The rounding mode is important.
+    xy_rounded_back = cute.arch.sub_packed_f32x2(xy_rounded, (fp32_round_int, fp32_round_int))
+    xy_frac = cute.arch.sub_packed_f32x2(xy_clamped, xy_rounded_back)
+
+    @dsl_user_op
+    @cute.jit
+    def polynomial_deg3_packed_f32x2(
+        x: Float32, y: Float32, *, loc=None, ip=None
+    ) -> Tuple[Float32, Float32]:
+        # 2^x ~= (0.077 * x + 0.228) * x + 0.695) * x + 1, for x in [0, 1)
+        coeff = (
+            1.0,  # coeff of deg0
+            0.695146143436431884765625,  # coeff of deg1
+            0.227564394474029541015625,  # coeff of deg2
+            0.077119089663028717041015625,  # coeff of deg3
+        )
+        deg = len(coeff) - 1  # started with highest degree
+        out = (coeff[deg], coeff[deg])
+        for i in cutlass.range_constexpr(deg - 1, -1, -1):
+            out = cute.arch.fma_packed_f32x2(out, (x, y), (coeff[i], coeff[i]), loc=loc, ip=ip)
+        return out
+
+    xy_frac_ex2 = polynomial_deg3_packed_f32x2(*xy_frac, loc=loc, ip=ip)
+
+    @dsl_user_op
+    def combine_int_frac_ex2(
+        x_rounded: Float32, frac_ex2: Float32, *, loc=None, ip=None
+    ) -> Float32:
+        return cutlass.Float32(
+            llvm.inline_asm(
+                T.f32(),
+                [
+                    Float32(x_rounded).ir_value(loc=loc, ip=ip),
+                    Float32(frac_ex2).ir_value(loc=loc, ip=ip),
+                ],
+                "{\n\t"
+                ".reg .s32 x_rounded_i, frac_ex_i, x_rounded_e, out_i;\n\t"
+                "mov.b32 x_rounded_i, $1;\n\t"
+                "mov.b32 frac_ex_i, $2;\n\t"
+                "shl.b32 x_rounded_e, x_rounded_i, 23;\n\t"
+                "add.s32 out_i, x_rounded_e, frac_ex_i;\n\t"
+                "mov.b32 $0, out_i;\n\t"
+                "}\n",
+                "=f,f,f",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            )
+        )
+
+    x_out = combine_int_frac_ex2(xy_rounded[0], xy_frac_ex2[0], loc=loc, ip=ip)
+    y_out = combine_int_frac_ex2(xy_rounded[1], xy_frac_ex2[1], loc=loc, ip=ip)
+
+    return x_out, y_out
+
+
+@cute.jit
+def cvt_f32x4_to_f8x4_pack_i32(fp32x4, fp8_type, *, loc=None, ip=None):
+    fp32x4 = fp32x4.load()
+    src_vec4 = fp32x4.ir_value(loc=loc, ip=ip) if hasattr(fp32x4, "ir_value") else fp32x4
+
+    src0 = Float32(vector.extract(src_vec4, [], [0])).ir_value(loc=loc, ip=ip)
+    src1 = Float32(vector.extract(src_vec4, [], [1])).ir_value(loc=loc, ip=ip)
+    src2 = Float32(vector.extract(src_vec4, [], [2])).ir_value(loc=loc, ip=ip)
+    src3 = Float32(vector.extract(src_vec4, [], [3])).ir_value(loc=loc, ip=ip)
+
+    cvt_instruction = ""
+    if cutlass.const_expr(fp8_type == cutlass.Float8E4M3FN):
+        cvt_instruction = "cvt.rn.satfinite.e4m3x2.f32"
+    else:
+        assert False, "Unsupported fp8 element type"
+
+    asm_tmpl = (
+        "{\n"
+        "  .reg .b16 lo;\n"
+        "  .reg .b16 hi;\n"
+        f"  {cvt_instruction} lo, $2, $1;\n"
+        f"  {cvt_instruction} hi, $4, $3;\n"
+        "  mov.b32 $0, {lo, hi};\n"
+        "}"
+    )
+    packed_i32 = llvm.inline_asm(
+        T.i32(),
+        [src0, src1, src2, src3],
+        asm_tmpl,
+        "=r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+    return packed_i32
+
+
+@cute.jit
+def cvt_f32x4_to_f8x4(fp32x4, fp8x4, *, loc=None, ip=None):
+    packed_i32 = cvt_f32x4_to_f8x4_pack_i32(fp32x4, fp8x4.element_type)
+    fp8x4_i32 = cute.recast_tensor(fp8x4, cutlass.Int32)
+    fp8x4_i32[0] = cutlass.Int32(packed_i32)
+    return

--- a/flashinfer/cute_dsl/attention/fmha/helpers/static_persistent_tile_scheduler.py
+++ b/flashinfer/cute_dsl/attention/fmha/helpers/static_persistent_tile_scheduler.py
@@ -1,0 +1,814 @@
+# Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# ruff: noqa: I001, E501
+
+import inspect
+from typing import Optional, Tuple
+
+from cutlass.cutlass_dsl import (
+    Boolean,
+    Integer,
+    Int32,
+    min,
+    extract_mlir_values,
+    new_from_mlir_values,
+    dsl_user_op,
+    const_expr,
+)
+from cutlass._mlir import ir
+import cutlass.cute as cute
+
+##############################################################################
+# Static persistent tile scheduler
+##############################################################################
+
+
+class WorkTileInfo:
+    """A class to represent information about a work tile.
+
+    :ivar tile_idx: The index of the tile.
+    :type tile_idx: cute.Coord
+    :ivar is_valid_tile: Whether the tile is valid.
+    :type is_valid_tile: Boolean
+    """
+
+    def __init__(self, tile_idx: cute.Coord, is_valid_tile: Boolean):
+        self._tile_idx = tile_idx
+        self._is_valid_tile = Boolean(is_valid_tile)
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values = extract_mlir_values(self.tile_idx)
+        values.extend(extract_mlir_values(self.is_valid_tile))
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "WorkTileInfo":
+        assert len(values) == 4
+        new_tile_idx = new_from_mlir_values(self._tile_idx, values[:-1])
+        new_is_valid_tile = new_from_mlir_values(self._is_valid_tile, [values[-1]])
+        return WorkTileInfo(new_tile_idx, new_is_valid_tile)
+
+    @property
+    @cute.jit
+    def is_valid_tile(self) -> Boolean:
+        """Check latest tile returned by the scheduler is valid or not. Any scheduling
+        requests after all tasks completed will return an invalid tile.
+
+        :return: The validity of the tile.
+        :rtype: Boolean
+        """
+        return self._is_valid_tile
+
+    @property
+    @cute.jit
+    def tile_idx(self) -> cute.Coord:
+        """
+        Get the index of the tile.
+
+        :return: The index of the tile.
+        :rtype: cute.Coord
+        """
+        return self._tile_idx
+
+
+class PersistentTileSchedulerParams:
+    """A class to represent parameters for a persistent tile scheduler.
+
+    This class is designed to manage and compute the layout of clusters and tiles
+    in a batched gemm problem.
+
+    :ivar cluster_shape_mn: Shape of the cluster in (m, n) dimensions (K dimension cta count must be 1).
+    :type cluster_shape_mn: tuple
+    :ivar problem_layout_ncluster_mnl: Layout of the problem in terms of
+        number of clusters in (m, n, l) dimensions.
+    :type problem_layout_ncluster_mnl: cute.Layout
+    """
+
+    @dsl_user_op
+    def __init__(
+        self,
+        problem_shape_ntile_mnl: cute.Shape,
+        cluster_shape_mnk: cute.Shape,
+        swizzle_size: int = 1,
+        raster_along_m: bool = True,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """
+        Initializes the PersistentTileSchedulerParams with the given parameters.
+
+        :param problem_shape_ntile_mnl: The shape of the problem in terms of
+            number of CTA (Cooperative Thread Array) in (m, n, l) dimensions.
+        :type problem_shape_ntile_mnl: cute.Shape
+        :param cluster_shape_mnk: The shape of the cluster in (m, n) dimensions.
+        :type cluster_shape_mnk: cute.Shape
+        :param swizzle_size: Swizzling size in the unit of cluster. 1 means no swizzle
+        :type swizzle_size: int
+        :param raster_along_m: Rasterization order of clusters. Only used when swizzle_size > 1.
+            True means along M, false means along N.
+        :type raster_along_m: bool
+
+        :raises ValueError: If cluster_shape_k is not 1.
+        """
+
+        if cluster_shape_mnk[2] != 1:  # type: ignore[index]
+            raise ValueError(f"unsupported cluster_shape_k {cluster_shape_mnk[2]}")  # type: ignore[index]
+        if swizzle_size < 1:
+            raise ValueError(f"expect swizzle_size >= 1, but get {swizzle_size}")
+
+        self.problem_shape_ntile_mnl = problem_shape_ntile_mnl
+        # cluster_shape_mnk is kept for reconstruction
+        self._cluster_shape_mnk = cluster_shape_mnk
+        self.cluster_shape_mn = cluster_shape_mnk[:2]  # type: ignore[index]
+        self.swizzle_size = swizzle_size
+        self.raster_along_m = raster_along_m
+        self._loc = loc
+
+        # By default, we follow m major (col-major) raster order, so make a col-major layout
+        self.problem_layout_ncluster_mnl = cute.make_layout(
+            cute.ceil_div(
+                self.problem_shape_ntile_mnl,
+                cluster_shape_mnk[:2],  # type: ignore[index]
+                loc=loc,
+                ip=ip,
+            ),
+            loc=loc,
+            ip=ip,
+        )
+
+        # Apply swizzle if swizzle_size > 1
+        if swizzle_size > 1:
+            problem_shape_ncluster_mnl = cute.round_up(
+                self.problem_layout_ncluster_mnl.shape,
+                (1, swizzle_size, 1) if raster_along_m else (swizzle_size, 1, 1),
+            )
+
+            if raster_along_m:
+                self.problem_layout_ncluster_mnl = cute.make_layout(
+                    (
+                        problem_shape_ncluster_mnl[0],  # type: ignore[index]
+                        (swizzle_size, problem_shape_ncluster_mnl[1] // swizzle_size),  # type: ignore[index, operator]
+                        problem_shape_ncluster_mnl[2],  # type: ignore[index]
+                    ),
+                    stride=(
+                        swizzle_size,
+                        (1, swizzle_size * problem_shape_ncluster_mnl[0]),  # type: ignore[index]
+                        problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],  # type: ignore[index, operator]
+                    ),
+                    loc=loc,
+                    ip=ip,
+                )
+            else:
+                self.problem_layout_ncluster_mnl = cute.make_layout(
+                    (
+                        (swizzle_size, problem_shape_ncluster_mnl[0] // swizzle_size),  # type: ignore[index, operator]
+                        problem_shape_ncluster_mnl[1],  # type: ignore[index]
+                        problem_shape_ncluster_mnl[2],  # type: ignore[index]
+                    ),
+                    stride=(
+                        (1, swizzle_size * problem_shape_ncluster_mnl[1]),  # type: ignore[index]
+                        swizzle_size,
+                        problem_shape_ncluster_mnl[0] * problem_shape_ncluster_mnl[1],  # type: ignore[index, operator]
+                    ),
+                    loc=loc,
+                    ip=ip,
+                )
+
+        # Create FastDivmod divisors (only when swizzle_size == 1 for correctness)
+        # FastDivmod assumes simple col-major layout, incompatible with swizzled layouts
+        if swizzle_size == 1:
+            _problem_layout_size = cute.size(self.problem_layout_ncluster_mnl, loc=loc, ip=ip)
+            cluster_count_m = self.problem_layout_ncluster_mnl.shape[0]
+            cluster_count_n = self.problem_layout_ncluster_mnl.shape[1]
+
+            if raster_along_m:
+                cluster_count_major = cluster_count_m
+                cluster_count_minor = cluster_count_n
+            else:
+                cluster_count_major = cluster_count_n
+                cluster_count_minor = cluster_count_m
+
+            # cluster_shape_major_fdd: Used to decode work_unit_id to cluster coordinates
+            self.cluster_shape_major_fdd = cute.fast_divmod_create_divisor(
+                cluster_count_major, loc=loc, ip=ip
+            )
+
+            # cluster_shape_minor_fdd: Used for the second level decomposition
+            self.cluster_shape_minor_fdd = cute.fast_divmod_create_divisor(
+                cluster_count_minor, loc=loc, ip=ip
+            )
+        else:
+            # FastDivmod not applicable with swizzling, set to None
+            self.cluster_shape_major_fdd = None
+            self.cluster_shape_minor_fdd = None
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values, self._values_pos = [], []
+        for obj in [
+            self.problem_shape_ntile_mnl,
+            self._cluster_shape_mnk,
+            self.swizzle_size,
+            self.raster_along_m,
+        ]:
+            obj_values = extract_mlir_values(obj)
+            values += obj_values
+            self._values_pos.append(len(obj_values))
+
+        # Add FastDivmod divisors to MLIR values for Host->Device transfer
+        # Only add non-None values to avoid MLIR type errors
+        fastdivmod_values = []
+        fastdivmod_indices = []  # Track which FastDivmod objects are present
+        fastdivmod_lengths = []  # Track serialized MLIR value count per FDD
+
+        for i, (fdd_name, fdd_obj) in enumerate(
+            [
+                ("cluster_shape_major_fdd", self.cluster_shape_major_fdd),
+                ("cluster_shape_minor_fdd", self.cluster_shape_minor_fdd),
+            ]
+        ):
+            if fdd_obj is not None:
+                # Extract MLIR values from FastDivmodDivisor objects
+                fdd_values = extract_mlir_values(fdd_obj)
+                fastdivmod_values.extend(fdd_values)
+                fastdivmod_indices.append(i)
+                fastdivmod_lengths.append(len(fdd_values))
+
+        values += fastdivmod_values
+        self._values_pos.append(
+            len(fastdivmod_indices)
+        )  # Store count of FastDivmod objects, not values
+        self._fastdivmod_indices = fastdivmod_indices  # Store for reconstruction
+        self._fastdivmod_lengths = fastdivmod_lengths  # Per-FDD value count
+
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "PersistentTileSchedulerParams":
+        obj_list = []
+        values_copy = list(values)  # Make a copy to avoid modifying original
+
+        # Reconstruct original objects from MLIR values
+        for obj, n_items in zip(
+            [
+                self.problem_shape_ntile_mnl,
+                self._cluster_shape_mnk,
+                self.swizzle_size,
+                self.raster_along_m,
+            ],
+            self._values_pos[:-1],  # Exclude FastDivmod count
+        ):
+            obj_list.append(new_from_mlir_values(obj, values_copy[:n_items]))
+            values_copy = values_copy[n_items:]
+
+        # Create new params object by calling __init__ with reconstructed values
+        # This properly recreates layouts and other derived attributes in the device context
+        new_params = PersistentTileSchedulerParams(*(tuple(obj_list)), loc=self._loc)
+
+        # Restore FastDivmod divisors from remaining values
+        fdd_names = ["cluster_shape_major_fdd", "cluster_shape_minor_fdd"]
+
+        if hasattr(self, "_fastdivmod_indices") and len(self._fastdivmod_indices) > 0:
+            # Override the FastDivmod divisors created by __init__ with reconstructed ones.
+            # FastDivmodDivisor now emits multiple MLIR values per object (see issue #3243);
+            # use the per-FDD length recorded during __extract_mlir_values__ to slice the
+            # tail of values_copy without re-emitting IR.
+            fdd_tail_offset = 0
+            for original_index, n_fdd in zip(self._fastdivmod_indices, self._fastdivmod_lengths):
+                fdd_name = fdd_names[original_index]
+                original_fdd = getattr(self, fdd_name)
+                if original_fdd is None:
+                    continue
+                end = fdd_tail_offset + n_fdd
+                if end > len(values_copy):
+                    raise ValueError(
+                        f"FastDivmod values out of range for {fdd_name}: "
+                        f"need {end}, have {len(values_copy)}"
+                    )
+                reconstructed_fdd = new_from_mlir_values(
+                    original_fdd, values_copy[fdd_tail_offset:end]
+                )
+                setattr(new_params, fdd_name, reconstructed_fdd)
+                fdd_tail_offset = end
+            if fdd_tail_offset != len(values_copy):
+                raise ValueError(
+                    "Unexpected trailing FastDivmod MLIR values: "
+                    f"consumed {fdd_tail_offset}, have {len(values_copy)}"
+                )
+
+        return new_params
+
+    @dsl_user_op
+    def get_grid_shape(
+        self,
+        max_active_clusters: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Integer, Integer, Integer]:
+        """
+        Computes the grid shape based on the maximum active clusters allowed.
+
+        :param max_active_clusters: The maximum number of active clusters that
+            can run in one wave.
+        :type max_active_clusters: Int32
+
+        :return: A tuple containing the grid shape in (m, n, persistent_clusters).
+            - m: self.cluster_shape_m.
+            - n: self.cluster_shape_n.
+            - persistent_clusters: Number of persistent clusters that can run.
+        """
+
+        # Total ctas in problem size
+        num_ctas_mnl = tuple(
+            cute.size(x) * y
+            for x, y in zip(self.problem_layout_ncluster_mnl.shape, self.cluster_shape_mn)
+        ) + (self.problem_layout_ncluster_mnl.shape[2],)
+
+        num_ctas_in_problem = cute.size(num_ctas_mnl, loc=loc, ip=ip)
+
+        num_ctas_per_cluster = cute.size(self.cluster_shape_mn, loc=loc, ip=ip)
+        # Total ctas that can run in one wave
+        num_ctas_per_wave = max_active_clusters * num_ctas_per_cluster
+
+        num_persistent_ctas = min(num_ctas_in_problem, num_ctas_per_wave)
+        num_persistent_clusters = num_persistent_ctas // num_ctas_per_cluster
+
+        return (*self.cluster_shape_mn, num_persistent_clusters)
+
+
+# Set explicit signature for Sphinx documentation to avoid issues with @dsl_user_op decorator
+PersistentTileSchedulerParams.__init__.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+    [
+        inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD),
+    ]
+)
+
+
+class StaticPersistentTileScheduler:
+    """A scheduler for static persistent tile execution in CUTLASS/CuTe kernels.
+
+    :ivar params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl
+    :type params: PersistentTileSchedulerParams
+    :ivar num_persistent_clusters: Number of persistent clusters that can be launched
+    :type num_persistent_clusters: Int32
+    :ivar cta_id_in_cluster: ID of the CTA within its cluster
+    :type cta_id_in_cluster: cute.Coord
+    :ivar _num_tiles_executed: Counter for executed tiles
+    :type _num_tiles_executed: Int32
+    :ivar _current_work_linear_idx: Current cluster index
+    :type _current_work_linear_idx: Int32
+    """
+
+    def __init__(
+        self,
+        params: PersistentTileSchedulerParams,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+    ):
+        """
+        Initializes the StaticPersistentTileScheduler with the given parameters.
+
+        :param params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl.
+        :type params: PersistentTileSchedulerParams
+        :param num_persistent_clusters: Number of persistent clusters that can be launched.
+        :type num_persistent_clusters: Int32
+        :param current_work_linear_idx: Current cluster index.
+        :type current_work_linear_idx: Int32
+        :param cta_id_in_cluster: ID of the CTA within its cluster.
+        :type cta_id_in_cluster: cute.Coord
+        :param num_tiles_executed: Counter for executed tiles.
+        :type num_tiles_executed: Int32
+        """
+        self.params = params
+        self.num_persistent_clusters = num_persistent_clusters
+        self._current_work_linear_idx = current_work_linear_idx
+        self.cta_id_in_cluster = cta_id_in_cluster
+        self._num_tiles_executed = num_tiles_executed
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values = extract_mlir_values(self.num_persistent_clusters)
+        values.extend(extract_mlir_values(self._current_work_linear_idx))
+        values.extend(extract_mlir_values(self.cta_id_in_cluster))
+        values.extend(extract_mlir_values(self._num_tiles_executed))
+
+        # CRITICAL: Also extract FastDivmod divisors from params
+        values.extend(extract_mlir_values(self.params))
+
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> "StaticPersistentTileScheduler":
+        assert len(values) >= 6
+        new_num_persistent_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[0]]
+        )
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[1]]
+        )
+        new_cta_id_in_cluster = new_from_mlir_values(self.cta_id_in_cluster, values[2:5])
+        new_num_tiles_executed = new_from_mlir_values(self._num_tiles_executed, [values[5]])
+
+        # Reconstruct params with FastDivmod divisors
+        params_values = values[6:]  # Remaining values are from params
+        new_params = new_from_mlir_values(self.params, params_values)
+
+        return StaticPersistentTileScheduler(
+            new_params,  # Use reconstructed params with FastDivmod divisors
+            new_num_persistent_clusters,
+            new_current_work_linear_idx,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+        )
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: PersistentTileSchedulerParams,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "StaticPersistentTileScheduler":
+        """Initialize the static persistent tile scheduler.
+
+        :param params: Parameters for the persistent
+            tile scheduler.
+        :type params: PersistentTileSchedulerParams
+        :param block_idx: The 3d block index in the format (bidx, bidy, bidz).
+        :type block_idx: Tuple[Integer, Integer, Integer]
+        :param grid_dim: The 3d grid dimensions for kernel launch.
+        :type grid_dim: Tuple[Integer, Integer, Integer]
+
+        :return: A StaticPersistentTileScheduler object.
+        :rtype: StaticPersistentTileScheduler
+        """
+
+        # Calculate the number of persistent clusters by dividing the total grid size
+        # by the number of CTAs per cluster
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+
+        bidx, bidy, bidz = block_idx
+
+        # Initialize workload index equals to the cluster index in the grid
+        current_work_linear_idx = Int32(bidz)
+
+        # CTA id in the cluster
+        cta_id_in_cluster = (
+            Int32(bidx % params.cluster_shape_mn[0]),
+            Int32(bidy % params.cluster_shape_mn[1]),
+            Int32(0),
+        )
+        # Initialize number of tiles executed to zero
+        num_tiles_executed = Int32(0)
+        return StaticPersistentTileScheduler(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+        )
+
+    # called by host
+    @staticmethod
+    def get_grid_shape(
+        params: PersistentTileSchedulerParams,
+        max_active_clusters: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Integer, Integer, Integer]:
+        """Calculates the grid shape to be launched on GPU using problem shape,
+        threadblock shape, and active cluster size.
+
+        :param params: Parameters for grid shape calculation.
+        :type params: PersistentTileSchedulerParams
+        :param max_active_clusters: Maximum active clusters allowed.
+        :type max_active_clusters: Int32
+
+        :return: The calculated 3d grid shape.
+        :rtype: Tuple[Integer, Integer, Integer]
+        """
+
+        return params.get_grid_shape(max_active_clusters, loc=loc, ip=ip)
+
+    # private method
+    def _get_current_work_for_linear_idx(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        """Compute current tile coord given current_work_linear_idx and cta_id_in_cluster.
+
+        :param current_work_linear_idx: The linear index of the current work.
+        :type current_work_linear_idx: Int32
+
+        :return: An object containing information about the current tile coordinates
+            and validity status.
+        :rtype: WorkTileInfo
+        """
+
+        is_valid = current_work_linear_idx < cute.size(
+            self.params.problem_layout_ncluster_mnl, loc=loc, ip=ip
+        )
+
+        # Choose coordinate calculation method based on swizzle configuration
+        if self.params.swizzle_size == 1:
+            # Use FastDivmod optimization for non-swizzled layouts
+            cur_cluster_coord = self._get_cluster_work_idx_with_fastdivmod(
+                current_work_linear_idx, loc=loc, ip=ip
+            )
+        else:
+            # Use get_flat_coord for swizzled layouts (FastDivmod doesn't support them)
+            cur_cluster_coord = self.params.problem_layout_ncluster_mnl.get_flat_coord(
+                current_work_linear_idx, loc=loc, ip=ip
+            )
+
+        cur_tile_coord = tuple(
+            cute.arch.make_warp_uniform(Int32(x) * Int32(z) + Int32(y))
+            for x, y, z in zip(
+                cur_cluster_coord,
+                self.cta_id_in_cluster,  # type: ignore[arg-type]
+                (*self.params.cluster_shape_mn, Int32(1)),
+            )
+        )
+
+        return WorkTileInfo(cur_tile_coord, cute.arch.make_warp_uniform(is_valid))
+
+    def _get_cluster_work_idx_with_fastdivmod(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Int32, Int32, Int32]:
+        """
+        FastDivmod optimized CLUSTER coordinate calculation.
+
+        CRITICAL: This should mimic problem_layout_ncluster_mnl.get_hier_coord()
+        which returns CLUSTER coordinates, not tile coordinates!
+
+        :param current_work_linear_idx: Linear index in the work space
+        :type current_work_linear_idx: Int32
+        :return: Cluster coordinates (m, n, l) or None if FastDivmod not available
+        :rtype: Tuple[Int32, Int32, Int32] or None
+        """
+
+        # Step 1: Decode current_work_linear_idx using FastDivmod objects
+        # The layout structure is: problem_layout_ncluster_mnl has shape (cluster_count_m, cluster_count_n, batch_count)
+        # current_work_linear_idx needs to be decomposed into (batch_l, cluster_minor, cluster_major) in little-endian order
+
+        # First, get cluster_major using cluster_shape_major_fdd
+        cluster_minor_batch, cluster_major = divmod(
+            current_work_linear_idx, self.params.cluster_shape_major_fdd
+        )
+
+        # Then decode cluster_minor_batch to get cluster_minor and batch_l using FastDivmod
+        batch_l, cluster_minor = divmod(cluster_minor_batch, self.params.cluster_shape_minor_fdd)
+
+        if self.params.raster_along_m:
+            cluster_m = cluster_major
+            cluster_n = cluster_minor
+        else:
+            cluster_m = cluster_minor
+            cluster_n = cluster_major
+
+        return (cluster_m, cluster_n, batch_l)
+
+    @dsl_user_op
+    @cute.jit
+    def get_current_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        return self._get_current_work_for_linear_idx(self._current_work_linear_idx, loc=loc, ip=ip)
+
+    @dsl_user_op
+    @cute.jit
+    def initial_work_tile_info(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        return self.get_current_work(loc=loc, ip=ip)
+
+    @dsl_user_op
+    @cute.jit
+    def advance_to_next_work(
+        self,
+        *,
+        advance_count: int = 1,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        self._current_work_linear_idx += Int32(advance_count) * Int32(self.num_persistent_clusters)
+        self._num_tiles_executed += Int32(1)
+
+    @property
+    @cute.jit
+    def num_tiles_executed(self) -> Int32:
+        return self._num_tiles_executed
+
+
+class StaticPersistentRuntimeTileScheduler(StaticPersistentTileScheduler):
+    """A scheduler for static persistent runtime tile execution in CUTLASS/CuTe kernels.
+    This scheduler will always launch all the SMs and the scheduler will generate the real tile info for each SM.
+
+    :ivar params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl
+    :type params: PersistentTileSchedulerParams
+    :ivar num_persistent_clusters: Number of persistent clusters that can be launched
+    :type num_persistent_clusters: Int32
+    :ivar cta_id_in_cluster: ID of the CTA within its cluster
+    :type cta_id_in_cluster: cute.Coord
+    :ivar _num_tiles_executed: Counter for executed tiles
+    :type _num_tiles_executed: Int32
+    :ivar _current_work_linear_idx: Current cluster index
+    :type _current_work_linear_idx: Int32
+    """
+
+    def __init__(
+        self,
+        params: PersistentTileSchedulerParams,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+        num_tiles_executed: Int32,
+        inner_mode: int = 1,
+    ):
+        """
+        Initializes the StaticPersistentRuntimeTileScheduler with the given parameters.
+
+        :param params: Tile schedule related params, including cluster shape and problem_layout_ncluster_mnl.
+        :type params: PersistentTileSchedulerParams
+        :param num_persistent_clusters: Number of persistent clusters that can be launched.
+        :type num_persistent_clusters: Int32
+        :param current_work_linear_idx: Current cluster index.
+        :type current_work_linear_idx: Int32
+        :param cta_id_in_cluster: ID of the CTA within its cluster.
+        :type cta_id_in_cluster: cute.Coord
+        :param num_tiles_executed: Counter for executed tiles.
+        :type num_tiles_executed: Int32
+        :param inner_mode: The inner mode along which the linear index will be decomposed first.
+        :type inner_mode: int
+        """
+        super().__init__(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+        )
+        if inner_mode not in [0, 1]:
+            raise ValueError(
+                f"inner_mode must be 0(for M mode) or 1(for N mode), but got {inner_mode}"
+            )
+        self.inner_mode = inner_mode
+
+    def __new_from_mlir_values__(
+        self, values: list[ir.Value]
+    ) -> "StaticPersistentRuntimeTileScheduler":
+        assert len(values) >= 6
+        new_num_persistent_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[0]]
+        )
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[1]]
+        )
+        new_cta_id_in_cluster = new_from_mlir_values(self.cta_id_in_cluster, values[2:5])
+        new_num_tiles_executed = new_from_mlir_values(self._num_tiles_executed, [values[5]])
+
+        # Reconstruct params with FastDivmod divisors (same as parent class)
+        params_values = values[6:]  # Remaining values are from params
+        new_params = new_from_mlir_values(self.params, params_values)
+
+        return StaticPersistentRuntimeTileScheduler(
+            new_params,  # Use reconstructed params with FastDivmod divisors
+            new_num_persistent_clusters,
+            new_current_work_linear_idx,
+            new_cta_id_in_cluster,
+            new_num_tiles_executed,
+            self.inner_mode,
+        )
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: PersistentTileSchedulerParams,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        inner_mode: int = 1,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "StaticPersistentRuntimeTileScheduler":
+        """Initialize the static persistent tile scheduler.
+
+        :param params: Parameters for the persistent
+            tile scheduler.
+        :type params: PersistentTileSchedulerParams
+        :param block_idx: The 3d block index in the format (bidx, bidy, bidz).
+        :type block_idx: Tuple[Integer, Integer, Integer]
+        :param grid_dim: The 3d grid dimensions for kernel launch.
+        :type grid_dim: Tuple[Integer, Integer, Integer]
+        :param inner_mode: The inner mode along which the linear index will be decomposed first.
+        :type inner_mode: int
+
+        :return: A StaticPersistentRuntimeTileScheduler object.
+        :rtype: StaticPersistentRuntimeTileScheduler
+        """
+
+        # Calculate the number of persistent clusters by dividing the total grid size
+        # by the number of CTAs per cluster
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+
+        bidx, bidy, bidz = block_idx
+
+        # Initialize workload index equals to the cluster index in the grid
+        current_work_linear_idx = Int32(bidz)
+
+        # CTA id in the cluster
+        cta_id_in_cluster = (
+            Int32(bidx % params.cluster_shape_mn[0]),
+            Int32(bidy % params.cluster_shape_mn[1]),
+            Int32(0),
+        )
+        # Initialize number of tiles executed to zero
+        num_tiles_executed = Int32(0)
+        return StaticPersistentRuntimeTileScheduler(
+            params,
+            num_persistent_clusters,
+            current_work_linear_idx,
+            cta_id_in_cluster,
+            num_tiles_executed,
+            inner_mode,
+        )
+
+    # private method
+    def _get_current_work_for_linear_idx(
+        self,
+        current_work_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> WorkTileInfo:
+        """Compute current tile coord given current_work_linear_idx and cta_id_in_cluster.
+
+        :param current_work_linear_idx: The linear index of the current work.
+        :type current_work_linear_idx: Int32
+
+        :return: An object containing information about the current tile coordinates
+            and validity status.
+        :rtype: WorkTileInfo
+        """
+        ntile_shape = self.params.problem_layout_ncluster_mnl.shape
+        int_max = 2147483647
+        if const_expr(self.inner_mode == 1):
+            ntile_layout = cute.make_layout((int_max, ntile_shape[1]), stride=(ntile_shape[1], 1))
+        else:
+            ntile_layout = cute.make_layout((ntile_shape[0], int_max), stride=(1, ntile_shape[0]))
+        cluster_tile_coord_mn = ntile_layout.get_hier_coord(current_work_linear_idx)
+        cur_tile_coord = (
+            cluster_tile_coord_mn[0],
+            cluster_tile_coord_mn[1],
+            Int32(0),
+        )
+
+        # it is determined by kernel implementation
+        is_valid = Boolean(True)
+
+        return WorkTileInfo(cur_tile_coord, is_valid)

--- a/flashinfer/cute_dsl/attention/fmha/quantize.py
+++ b/flashinfer/cute_dsl/attention/fmha/quantize.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Block-scale Q/K quantization for the trtllm block-scaled FMHA kernel.
+
+Calls FlashInfer's fused ``mxfp8_quantize`` / ``fp4_quantize`` kernels: transpose to
+(B, H, S, D), pad S to a multiple of 128 (the SF atom row size), quantize as a 2D
+``[B*H*S_pad, D]`` matrix, then unpad the *data* back to S. The scale-factor tensor is
+kept at S_pad and passed to the kernel as-is in the swizzled (128x4) layout, which
+matches what the kernel's ``tile_atom_to_shape_SF`` consumes. NVFP4's per-tensor global
+scale is returned to be folded into ``sm_scale``.
+"""
+
+from typing import Tuple
+
+import torch
+
+from flashinfer.quantization import fp4_quantize, mxfp8_quantize
+
+_FP8_E4M3_MAX = 448.0
+_FP4_E2M1_MAX = 6.0
+_SF_VEC = {"mxfp8": 32, "nvfp4": 16}
+
+
+def _quantize_one(
+    x_bshd: torch.Tensor, qk_mode: str, quant_backend: str
+) -> Tuple[torch.Tensor, torch.Tensor, float | torch.Tensor]:
+    """Quantize one (B, S, H, D) bf16/fp16 tensor -> (store, sf, scale)."""
+    b, s, h, d = x_bshd.shape
+    # (B, H, S, D): num_heads is batch-like for the GEMM-style quantizer.
+    x_bhsd = x_bshd.transpose(1, 2).contiguous()
+    s_pad = ((s + 127) // 128) * 128
+    if s_pad != s:
+        pad = torch.zeros(b, h, s_pad - s, d, dtype=x_bhsd.dtype, device=x_bhsd.device)
+        x_bhsd = torch.cat([x_bhsd, pad], dim=2)
+    x_2d = x_bhsd.reshape(b * h * s_pad, d)
+
+    if qk_mode == "mxfp8":
+        data, sf = mxfp8_quantize(
+            x_2d, is_sf_swizzled_layout=True, alignment=32, backend=quant_backend
+        )
+        x_q = data.view(b, h, s_pad, d)[:, :, :s, :].transpose(1, 2).contiguous()
+        # E8M0 scale factors (op returns uint8 storage); kernel reads only the SF pointer.
+        return x_q, sf.view(torch.float8_e8m0fnu), 1.0  # per-tensor scale is trivial
+
+    if qk_mode == "nvfp4":
+        amax = x_2d.float().abs().amax().clamp(min=1e-6)
+        global_sf = (_FP8_E4M3_MAX * _FP4_E2M1_MAX) / amax
+        data, sf = fp4_quantize(
+            x_2d,
+            global_sf.to(torch.float32).reshape(1),
+            sf_vec_size=16,
+            is_sf_swizzled_layout=True,
+            backend=quant_backend,
+        )
+        x_q = (
+            data.view(torch.float4_e2m1fn_x2)
+            .view(b, h, s_pad, d // 2)[:, :, :s, :]
+            .transpose(1, 2)
+            .contiguous()
+        )
+        # Keep the dequant scale as a 0-d tensor (no ``.item()`` -> torch.compile safe);
+        # the runner converts it to a Python float at the eager call boundary.
+        return x_q, sf.view(torch.float8_e4m3fn), amax / (_FP8_E4M3_MAX * _FP4_E2M1_MAX)
+
+    raise ValueError(f"qk_mode must be one of {tuple(_SF_VEC)}, got {qk_mode!r}")
+
+
+def quantize_blockscaled_qk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    qk_mode: str,
+    quant_backend: str = "cute-dsl",
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    float | torch.Tensor,
+    float | torch.Tensor,
+]:
+    """Quantize Q/K ``(B, S, H, D)`` to the block-scaled format the FMHA kernel needs.
+
+    ``quant_backend`` selects the fused quantizer backend (``"cuda"`` stable, or
+    ``"cute-dsl"`` for nvcc-free environments). Returns
+    ``(q_store, k_store, q_sf, k_sf, q_scale, k_scale)``: the quantized Q/K, the padded
+    SF tensors, and the per-tensor dequant scales (fold ``q_scale * k_scale`` into
+    ``sm_scale``; both are 1.0 for MXFP8).
+    """
+    if qk_mode not in _SF_VEC:
+        raise ValueError(f"qk_mode must be one of {tuple(_SF_VEC)}, got {qk_mode!r}")
+    q_store, q_sf, q_scale = _quantize_one(q, qk_mode, quant_backend)
+    k_store, k_sf, k_scale = _quantize_one(k, qk_mode, quant_backend)
+    return q_store, k_store, q_sf, k_sf, q_scale, k_scale

--- a/flashinfer/cute_dsl/attention/fmha/runner.py
+++ b/flashinfer/cute_dsl/attention/fmha/runner.py
@@ -29,6 +29,7 @@ from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
 from cutlass.cute.typing import Float32, Int32
 
 from .fmha import BlackwellFusedMultiHeadAttentionForward
+from .fmha_blockscaled import BlackwellFusedMultiHeadBlockScaledAttentionForward
 from .helpers import fmha_helpers as fmha_utils
 
 # torch dtype -> cutlass dtype
@@ -37,8 +38,6 @@ _CUTLASS_DTYPE = {
     torch.bfloat16: cutlass.BFloat16,
     torch.float8_e4m3fn: cutlass.Float8E4M3FN,
 }
-
-_LOG2_E = math.log2(math.e)
 
 # Block-scaling mode -> (qk cutlass dtype, sf cutlass dtype, sf_vec_size)
 _BLOCKSCALED_MODES = {
@@ -174,7 +173,7 @@ def _get_compiled_fmha(
         cum_k_fake,
         lse_fake,
         sink_fake,
-        scale_softmax * _LOG2_E,
+        scale_softmax * math.log2(math.e),
         scale_softmax,
         1.0,
         skip_threshold_log2,
@@ -202,10 +201,10 @@ def cute_dsl_fmha_prefill(
     window_right: int = -1,
     lse: Optional[torch.Tensor] = None,
     attention_sinks: Optional[torch.Tensor] = None,
-    scale_q: float = 1.0,
-    scale_k: float = 1.0,
-    scale_v: float = 1.0,
-    scale_o: float = 1.0,
+    scale_q: float | torch.Tensor = 1.0,
+    scale_k: float | torch.Tensor = 1.0,
+    scale_v: float | torch.Tensor = 1.0,
+    scale_o: float | torch.Tensor = 1.0,
     max_qo_len: Optional[int] = None,
     max_kv_len: Optional[int] = None,
     skip_softmax_threshold_scale_factor: Optional[float] = None,
@@ -240,8 +239,12 @@ def cute_dsl_fmha_prefill(
 
     if sm_scale is None:
         sm_scale = 1.0 / math.sqrt(D)
+    scale_q, scale_k, scale_v, scale_o = map(
+        lambda x: x.item() if isinstance(x, torch.Tensor) else x,
+        (scale_q, scale_k, scale_v, scale_o),
+    )
     scale_softmax = scale_q * scale_k * sm_scale
-    scale_softmax_log2 = scale_softmax * _LOG2_E
+    scale_softmax_log2 = scale_softmax * math.log2(math.e)
     scale_output = scale_v / scale_o
 
     if max_qo_len is None:
@@ -281,6 +284,234 @@ def cute_dsl_fmha_prefill(
         Float32(scale_softmax_log2),
         Float32(scale_softmax),
         Float32(scale_output),
+        skip_threshold_log2,
+        ws_left,
+        ws_right,
+        None,  # skip_softmax_count
+        None,  # total_softmax_count
+        enable_pdl,
+    )
+
+
+# =============================================================================
+# Block-scaled (MXFP8 / NVFP4)
+# =============================================================================
+
+
+@functools.cache
+def _get_compiled_fmha_blockscaled(
+    qk_mode: str,
+    out_dtype: torch.dtype,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    is_causal: bool,
+    with_lse: bool,
+    enable_skip_softmax: bool,
+    use_pdl: bool,
+    enable_ex2_emulation: bool,
+):
+    """Compile (and cache) the vendored block-scaled FMHA kernel (batched, non-varlen)."""
+    qk, sf_dt, sf_vec = _BLOCKSCALED_MODES[qk_mode]
+    out = _CUTLASS_DTYPE[out_dtype]
+    d = dv = head_dim
+
+    fmha = BlackwellFusedMultiHeadBlockScaledAttentionForward(
+        qk_acc_dtype=cutlass.Float32,
+        pv_acc_dtype=cutlass.Float32,
+        mma_tiler=(128, 128),
+        head_dim=d,
+        is_persistent=False,
+        mask_type=_mask_type(is_causal),
+        enable_ex2_emulation=enable_ex2_emulation,
+        enable_skip_correction=True,
+        qk_sf_vec_size=sf_vec,
+        use_tma_store=True,  # non-varlen
+    )
+
+    sym_b = cute.sym_int()
+    sym_s_q = cute.sym_int()
+    sym_s_k = cute.sym_int()
+    sym_hk = cute.sym_int()
+    sym_hr = cute.sym_int()
+    # Sub-byte (fp4) stride-1 dim must be static.
+    sym_d = d if qk.width < 8 else cute.sym_int()
+    sym_dv = dv if qk.width < 8 else cute.sym_int()
+    q_fake = make_fake_compact_tensor(
+        qk,
+        (sym_b, sym_s_q, sym_hk, sym_hr, sym_d),
+        stride_order=(4, 3, 2, 1, 0),
+        assumed_align=16,
+    )
+    k_fake = make_fake_compact_tensor(
+        qk,
+        (sym_b, sym_s_k, sym_hk, 1, sym_d),
+        stride_order=(4, 3, 2, 1, 0),
+        assumed_align=16,
+    )
+    v_fake = make_fake_compact_tensor(
+        cutlass.Float8E4M3FN,
+        (sym_b, sym_s_k, sym_hk, 1, sym_dv),
+        stride_order=(4, 3, 2, 1, 0),
+        assumed_align=16,
+    )
+    o_fake = make_fake_compact_tensor(
+        out,
+        (sym_b, sym_s_q, sym_hk, sym_hr, sym_dv),
+        stride_order=(4, 3, 2, 1, 0),
+        assumed_align=32,
+    )
+    # SF: the kernel reconstructs the blocked layout from q.shape via
+    # tile_atom_to_shape_SF and only reads the SF pointer, so a flat 1D tensor
+    # (the fused quantizer's SF, flattened) is sufficient.
+    q_sf_fake = make_fake_compact_tensor(sf_dt, (cute.sym_int(),), assumed_align=16)
+    k_sf_fake = make_fake_compact_tensor(sf_dt, (cute.sym_int(),), assumed_align=16)
+    lse_fake = (
+        make_fake_compact_tensor(
+            cutlass.Float32,
+            (sym_b, sym_s_q, sym_hk, sym_hr),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=16,
+        )
+        if with_lse
+        else None
+    )
+
+    problem_size = (1, 1, 1, 1, num_qo_heads, num_kv_heads, d, dv)
+    scale_softmax = 1.0 / math.sqrt(d)
+    skip_threshold_log2 = Float32(0.0) if enable_skip_softmax else None
+    ws_right = Int32(0) if is_causal else None
+    stream_fake = make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    return cute.compile(
+        fmha,
+        q_fake,
+        k_fake,
+        q_sf_fake,
+        k_sf_fake,
+        v_fake,
+        o_fake,
+        problem_size,
+        None,  # cum_seqlen_q (non-varlen)
+        None,  # cum_seqlen_k
+        lse_fake,
+        None,  # sink
+        scale_softmax * math.log2(math.e),
+        scale_softmax,
+        1.0,
+        None,  # scale_v_channels
+        skip_threshold_log2,
+        None,
+        ws_right,
+        None,
+        None,
+        stream_fake,
+        use_pdl,
+        options="--enable-tvm-ffi --opt-level 2",
+    )
+
+
+def cute_dsl_fmha_blockscaled_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_sf: torch.Tensor,
+    k_sf: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    *,
+    qk_mode: str,
+    is_causal: bool = False,
+    sm_scale: Optional[float] = None,
+    window_left: int = -1,
+    window_right: int = -1,
+    lse: Optional[torch.Tensor] = None,
+    scale_q: float | torch.Tensor = 1.0,
+    scale_k: float | torch.Tensor = 1.0,
+    scale_v: float | torch.Tensor = 1.0,
+    scale_o: float | torch.Tensor = 1.0,
+    skip_softmax_threshold_scale_factor: Optional[float] = None,
+    enable_pdl: bool = False,
+) -> None:
+    """Batched (non-varlen) block-scaled prefill via the JIT-compiled vendored kernel.
+
+    Inputs are batched:
+    - q (b, s_q, H_q, D), q_sf (quantized block-scaled format)
+    - k (b, s_k, H_k, D), k_sf (quantized block-scaled format)
+    - v/o: (b, s, H, D_v)
+    """
+    if qk_mode not in _BLOCKSCALED_MODES:
+        raise ValueError(
+            f"qk_mode must be one of {tuple(_BLOCKSCALED_MODES)}, got {qk_mode!r}"
+        )
+    batch_size, s_q, H_q, _ = q.shape
+    _, s_k, H_k, _ = k.shape
+    D = D_v = v.shape[-1]
+    h_r = H_q // H_k
+
+    use_skip = (
+        skip_softmax_threshold_scale_factor is not None
+        and skip_softmax_threshold_scale_factor > 0
+    )
+    kernel_fn = _get_compiled_fmha_blockscaled(
+        qk_mode,
+        o.dtype,
+        H_q,
+        H_k,
+        D,
+        is_causal,
+        lse is not None,
+        use_skip,
+        enable_pdl,
+        _ex2_emulation_enabled(q.device),
+    )
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(D)
+    # The block-scale quantizer returns scales as 0-d tensors (no ``.item()`` sync, so it
+    # stays torch.compile-friendly); materialize to floats here at the eager boundary.
+    scale_q, scale_k, scale_v, scale_o = map(
+        lambda x: x.item() if isinstance(x, torch.Tensor) else x,
+        (scale_q, scale_k, scale_v, scale_o),
+    )
+    scale_softmax = scale_q * scale_k * sm_scale
+    scale_softmax_log2 = scale_softmax * math.log2(math.e)
+    scale_output = scale_v / scale_o
+    problem_size = (batch_size, s_q, s_q, s_k, H_q, H_k, D, D_v)
+
+    skip_threshold_log2 = None
+    if use_skip:
+        skip_threshold_log2 = Float32(
+            math.log2(skip_softmax_threshold_scale_factor / s_k)
+        )
+
+    ws_left = None if window_left == -1 else Int32(window_left)
+    ws_right = None if window_right == -1 else Int32(window_right)
+    if is_causal and ws_right is None:
+        ws_right = Int32(0)
+
+    q_5d = q.reshape(batch_size, s_q, H_k, h_r, q.shape[-1])
+    k_5d = k.reshape(batch_size, s_k, H_k, 1, k.shape[-1])
+    v_5d = v.reshape(batch_size, s_k, H_k, 1, D_v)
+    assert o.data_ptr() % 32 == 0, "o must be 32-byte aligned (256-bit stores)"
+    o_5d = o.reshape(batch_size, s_q, H_k, h_r, D_v)
+    lse_4d = lse.reshape(batch_size, s_q, H_k, h_r) if lse is not None else None
+
+    kernel_fn(
+        q_5d,
+        k_5d,
+        q_sf.reshape(-1),
+        k_sf.reshape(-1),
+        v_5d,
+        o_5d,
+        problem_size,
+        None,  # cum_seqlen_q
+        None,  # cum_seqlen_k
+        lse_4d,
+        None,  # attention_sinks
+        Float32(scale_softmax_log2),
+        Float32(scale_softmax),
+        Float32(scale_output),
+        None,  # scale_v_channels
         skip_threshold_log2,
         ws_left,
         ws_right,

--- a/flashinfer/cute_dsl/attention/fmha/runner.py
+++ b/flashinfer/cute_dsl/attention/fmha/runner.py
@@ -1,0 +1,290 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch runner for the trtllm CuTe DSL FMHA kernels (JIT-compiled).
+
+JIT-compiles the trtllm BlackwellFusedMultiHead[BlockScaled]AttentionForward classes and exposes
+PyTorch-friendly ragged/batched prefill entry points. This is the JIT runner invoked by
+flashinfer.attention.cute_dsl.fmha
+"""
+
+import functools
+import math
+from typing import Optional
+
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_stream
+from cutlass.cute.typing import Float32, Int32
+
+from .fmha import BlackwellFusedMultiHeadAttentionForward
+from .helpers import fmha_helpers as fmha_utils
+
+# torch dtype -> cutlass dtype
+_CUTLASS_DTYPE = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+}
+
+_LOG2_E = math.log2(math.e)
+
+# Block-scaling mode -> (qk cutlass dtype, sf cutlass dtype, sf_vec_size)
+_BLOCKSCALED_MODES = {
+    "mxfp8": (cutlass.Float8E4M3FN, cutlass.Float8E8M0FNU, 32),
+    "nvfp4": (cutlass.Float4E2M1FN, cutlass.Float8E4M3FN, 16),
+}
+
+
+def _mask_type(is_causal: bool):
+    # Bottom-right aligned causal, matching FlashInfer convention.
+    return (
+        fmha_utils.MaskEnum.WINDOW_MASK_INFERENCE
+        if is_causal
+        else fmha_utils.MaskEnum.RESIDUAL_MASK
+    )
+
+
+def _ex2_emulation_enabled(device: torch.device) -> bool:
+    # ex2 emulation is only beneficial / correct on CC 10.0 (sm_100/sm_100a/sm_100f);
+    # not on sm_103 (CC 10.3) or later archs.
+    return torch.cuda.get_device_capability(device) == (10, 0)
+
+
+# =============================================================================
+# Non-block-scaled
+# =============================================================================
+
+
+@functools.cache
+def _get_compiled_fmha(
+    qk_dtype: torch.dtype,
+    v_dtype: torch.dtype,
+    out_dtype: torch.dtype,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    head_dim_v: int,
+    is_causal: bool,
+    with_lse: bool,
+    enable_sink: bool,
+    enable_skip_softmax: bool,
+    use_pdl: bool,
+    enable_ex2_emulation: bool,
+):
+    """Compile (and cache) the vendored FMHA kernel for a static config.
+
+    Uses symbolic batch/seqlen dims (TVM-FFI ABI) so a single compile serves all
+    shapes with the given dtypes / head counts / head_dim / mask.
+    """
+    qk = _CUTLASS_DTYPE[qk_dtype]
+    pv = _CUTLASS_DTYPE[v_dtype]
+    out = _CUTLASS_DTYPE[out_dtype]
+    d = head_dim
+    dv = head_dim_v
+    head_dim_arg = d if d == dv else (d, dv)
+
+    fmha = BlackwellFusedMultiHeadAttentionForward(
+        qk_acc_dtype=cutlass.Float32,
+        pv_acc_dtype=cutlass.Float32,
+        mma_tiler=(128, 128),
+        head_dim=head_dim_arg,
+        is_persistent=False,  # varlen ragged
+        mask_type=_mask_type(is_causal),
+        enable_ex2_emulation=enable_ex2_emulation,
+        enable_skip_correction=True,
+        use_tma_store=False,  # varlen -> STG
+    )
+
+    sym_b = cute.sym_int()
+    sym_s_q = cute.sym_int()
+    sym_s_k = cute.sym_int()
+    sym_hk = cute.sym_int()
+    sym_hr = cute.sym_int()
+    sym_seq = cute.sym_int()
+    q_fake = make_fake_compact_tensor(
+        qk,
+        (sym_b, sym_s_q, sym_hk, sym_hr, d),
+        stride_order=(4, 3, 2, 1, 0),
+        assumed_align=16,
+    )
+    k_fake = make_fake_compact_tensor(
+        qk,
+        (sym_b, sym_s_k, sym_hk, 1, d),
+        stride_order=(4, 3, 2, 1, 0),
+        assumed_align=16,
+    )
+    v_fake = make_fake_compact_tensor(
+        pv,
+        (sym_b, sym_s_k, sym_hk, 1, dv),
+        stride_order=(4, 3, 2, 1, 0),
+        assumed_align=16,
+    )
+    o_fake = make_fake_compact_tensor(
+        out,
+        (sym_b, sym_s_q, sym_hk, sym_hr, dv),
+        stride_order=(4, 3, 2, 1, 0),
+        assumed_align=32,
+    )
+    lse_fake = (
+        make_fake_compact_tensor(
+            cutlass.Float32,
+            (sym_b, sym_s_q, sym_hk, sym_hr),
+            stride_order=(3, 2, 1, 0),
+            assumed_align=16,
+        )
+        if with_lse
+        else None
+    )
+    sink_fake = (
+        make_fake_compact_tensor(
+            cutlass.Float32, (cute.sym_int(),), stride_order=(0,), assumed_align=16
+        )
+        if enable_sink
+        else None
+    )
+    cum_q_fake = make_fake_compact_tensor(Int32, (sym_seq,), assumed_align=16)
+    cum_k_fake = make_fake_compact_tensor(Int32, (sym_seq,), assumed_align=16)
+
+    problem_size = (1, 1, 1, 1, num_qo_heads, num_kv_heads, d, dv)
+    scale_softmax = 1.0 / math.sqrt(d)
+    skip_threshold_log2 = Float32(0.0) if enable_skip_softmax else None
+    ws_right = Int32(0) if is_causal else None
+    stream_fake = make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    return cute.compile(
+        fmha,
+        q_fake,
+        k_fake,
+        v_fake,
+        o_fake,
+        problem_size,
+        cum_q_fake,
+        cum_k_fake,
+        lse_fake,
+        sink_fake,
+        scale_softmax * _LOG2_E,
+        scale_softmax,
+        1.0,
+        skip_threshold_log2,
+        None,
+        ws_right,
+        None,
+        None,
+        stream_fake,
+        use_pdl,
+        options="--enable-tvm-ffi --opt-level 2",
+    )
+
+
+def cute_dsl_fmha_prefill(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    *,
+    is_causal: bool = False,
+    sm_scale: Optional[float] = None,
+    window_left: int = -1,
+    window_right: int = -1,
+    lse: Optional[torch.Tensor] = None,
+    attention_sinks: Optional[torch.Tensor] = None,
+    scale_q: float = 1.0,
+    scale_k: float = 1.0,
+    scale_v: float = 1.0,
+    scale_o: float = 1.0,
+    max_qo_len: Optional[int] = None,
+    max_kv_len: Optional[int] = None,
+    skip_softmax_threshold_scale_factor: Optional[float] = None,
+    enable_pdl: bool = False,
+) -> None:
+    """Ragged (varlen) prefill via the JIT-compiled vendored FMHA kernel."""
+    total_q, H_q, D = q.shape
+    total_kv, H_k, _ = k.shape
+    D_v = v.shape[-1]
+    h_r = H_q // H_k
+    batch_size = len(qo_indptr) - 1
+
+    use_skip = (
+        skip_softmax_threshold_scale_factor is not None
+        and skip_softmax_threshold_scale_factor > 0
+    )
+    kernel_fn = _get_compiled_fmha(
+        q.dtype,
+        v.dtype,
+        o.dtype,
+        H_q,
+        H_k,
+        D,
+        D_v,
+        is_causal,
+        lse is not None,
+        attention_sinks is not None,
+        use_skip,
+        enable_pdl,
+        _ex2_emulation_enabled(q.device),
+    )
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(D)
+    scale_softmax = scale_q * scale_k * sm_scale
+    scale_softmax_log2 = scale_softmax * _LOG2_E
+    scale_output = scale_v / scale_o
+
+    if max_qo_len is None:
+        max_qo_len = int((qo_indptr[1:] - qo_indptr[:-1]).max().item())
+    if max_kv_len is None:
+        max_kv_len = int((kv_indptr[1:] - kv_indptr[:-1]).max().item())
+    problem_size = (batch_size, max_qo_len, total_q, max_kv_len, H_q, H_k, D, D_v)
+
+    skip_threshold_log2 = None
+    if use_skip:
+        skip_threshold_log2 = Float32(
+            math.log2(skip_softmax_threshold_scale_factor / max_kv_len)
+        )
+
+    ws_left = None if window_left == -1 else Int32(window_left)
+    ws_right = None if window_right == -1 else Int32(window_right)
+    if is_causal and ws_right is None:
+        ws_right = Int32(0)
+
+    q_5d = q.view(1, total_q, H_k, h_r, D)
+    k_5d = k.view(1, total_kv, H_k, 1, D)
+    v_5d = v.view(1, total_kv, H_k, 1, D_v)
+    assert o.data_ptr() % 32 == 0, "o must be 32-byte aligned (256-bit stores)"
+    o_5d = o.view(1, total_q, H_k, h_r, D_v)
+    lse_4d = lse.view(1, total_q, H_k, h_r) if lse is not None else None
+
+    kernel_fn(
+        q_5d,
+        k_5d,
+        v_5d,
+        o_5d,
+        problem_size,
+        qo_indptr.to(torch.int32),
+        kv_indptr.to(torch.int32),
+        lse_4d,
+        attention_sinks,
+        Float32(scale_softmax_log2),
+        Float32(scale_softmax),
+        Float32(scale_output),
+        skip_threshold_log2,
+        ws_left,
+        ws_right,
+        None,  # skip_softmax_count
+        None,  # total_softmax_count
+        enable_pdl,
+    )

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3498,22 +3498,42 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     )
                 variant = SoftCappingAttention(cap=logits_soft_cap)
 
-            self._cute_dsl_wrapper.plan(
-                qo_indptr,
-                kv_indptr,
-                num_qo_heads,
-                num_kv_heads,
-                head_dim_qk,
-                head_dim_vo=head_dim_qk,
-                causal=causal,
-                sm_scale=sm_scale
-                if sm_scale is not None
-                else 1.0 / math.sqrt(head_dim_qk),
-                q_data_type=q_data_type,
-                kv_data_type=kv_data_type if kv_data_type is not None else q_data_type,
-                window_left=window_left,
-                variant=variant,
+            _sm_scale = (
+                sm_scale if sm_scale is not None else 1.0 / math.sqrt(head_dim_qk)
             )
+            # Route compatible calls to faster trtllm CuTe DSL FMHA kernels.
+            self._cute_dsl_use_fmha = variant is None and head_dim_qk == 128
+            if self._cute_dsl_use_fmha:
+                q_lens = qo_indptr[1:] - qo_indptr[:-1]
+                k_lens = kv_indptr[1:] - kv_indptr[:-1]
+                self._cute_dsl_fmha_plan = {
+                    "qo_indptr": qo_indptr,
+                    "kv_indptr": kv_indptr,
+                    "seq_lens": k_lens.to(torch.int32),
+                    "batch_size": qo_indptr.shape[0] - 1,
+                    "max_q_len": int(q_lens.max().item()),
+                    "max_kv_len": int(k_lens.max().item()),
+                    "sm_scale": _sm_scale,
+                    "causal": causal,
+                    "window_left": window_left,
+                }
+            else:
+                self._cute_dsl_wrapper.plan(
+                    qo_indptr,
+                    kv_indptr,
+                    num_qo_heads,
+                    num_kv_heads,
+                    head_dim_qk,
+                    head_dim_vo=head_dim_qk,
+                    causal=causal,
+                    sm_scale=_sm_scale,
+                    q_data_type=q_data_type,
+                    kv_data_type=kv_data_type
+                    if kv_data_type is not None
+                    else q_data_type,
+                    window_left=window_left,
+                    variant=variant,
+                )
         elif self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
@@ -3794,16 +3814,39 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 "out",
             )
         if self._backend == "cute-dsl":
-            # These checks live here (not in plan()) because return_lse and
-            # scale parameters are run()-time arguments that can vary between
-            # calls on the same planned wrapper.
-            if return_lse:
-                raise NotImplementedError(
-                    "cute-dsl backend does not support return_lse"
-                )
             if any(s is not None for s in (q_scale, k_scale, v_scale, o_scale)):
                 raise NotImplementedError(
                     "cute-dsl backend does not support FP8 scale parameters"
+                )
+            if self._cute_dsl_use_fmha:
+                # Delegate to the trtllm CuTe DSL FMHA kernel (supports LSE).
+                p = self._cute_dsl_fmha_plan
+                return trtllm_ragged_attention_deepseek(
+                    query=q,
+                    key=k,
+                    value=v,
+                    workspace_buffer=self._float_workspace_buffer,
+                    seq_lens=p["seq_lens"],
+                    max_q_len=p["max_q_len"],
+                    max_kv_len=p["max_kv_len"],
+                    bmm1_scale=p["sm_scale"],
+                    bmm2_scale=1.0,
+                    o_sf_scale=1.0,
+                    batch_size=p["batch_size"],
+                    window_left=p["window_left"],
+                    cum_seq_lens_q=p["qo_indptr"],
+                    cum_seq_lens_kv=p["kv_indptr"],
+                    enable_pdl=enable_pdl,
+                    is_causal=p["causal"],
+                    return_lse=return_lse,
+                    out=out,
+                    lse=lse,
+                    backend="cute-dsl",
+                )
+            # Generic JIT (ALiBi / soft-cap): prefill.py-based wrapper (no LSE).
+            if return_lse:
+                raise NotImplementedError(
+                    "cute-dsl backend does not support return_lse with ALiBi / soft-cap"
                 )
             out = self._cute_dsl_wrapper.run(q, k, v, out=out)
             return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,14 +104,20 @@ exclude = [
   "flashinfer-jit-cache/",
   "3rdparty/",
   "flashinfer/data/cutlass/",
-  "flashinfer/cute_dsl/attention/fmha/",
+  "flashinfer/cute_dsl/attention/fmha/fmha.py",
+  "flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py",
+  "flashinfer/cute_dsl/attention/fmha/helpers/",
   "build/",
 ]
 
 
 # CuTe DSL FMHA kernels from TRTLLM VisualGen; kept as-is for clean re-sync.
 [tool.ruff]
-extend-exclude = ["flashinfer/cute_dsl/attention/fmha/"]
+extend-exclude = [
+  "flashinfer/cute_dsl/attention/fmha/fmha.py",
+  "flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py",
+  "flashinfer/cute_dsl/attention/fmha/helpers",
+]
 force-exclude = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,15 @@ exclude = [
   "flashinfer-jit-cache/",
   "3rdparty/",
   "flashinfer/data/cutlass/",
+  "flashinfer/cute_dsl/attention/fmha/",
   "build/",
 ]
+
+
+# CuTe DSL FMHA kernels from TRTLLM VisualGen; kept as-is for clean re-sync.
+[tool.ruff]
+extend-exclude = ["flashinfer/cute_dsl/attention/fmha/"]
+force-exclude = true
 
 
 [tool.ruff.lint]

--- a/tests/attention/test_cute_dsl_fmha_backend.py
+++ b/tests/attention/test_cute_dsl_fmha_backend.py
@@ -120,3 +120,109 @@ def test_deepseek_cute_dsl(dtype_qk, dtype_vo, Dqk, Dvo):
     ref = _ragged_ref(qr, kr, vr, qo, kv, sm, causal=False)
     atol = 4e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
     torch.testing.assert_close(o.float(), ref.float(), atol=atol, rtol=atol)
+
+
+# =============================================================================
+# BatchPrefillWithRaggedKVCacheWrapper(backend="cute-dsl")
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "dtype_qk,dtype_vo",
+    [
+        (torch.bfloat16, torch.bfloat16),
+        (torch.bfloat16, torch.float8_e4m3fn),
+        (torch.float8_e4m3fn, torch.float8_e4m3fn),
+    ],
+)
+@pytest.mark.parametrize("causal", [False, True])
+def test_batch_prefill_cute_dsl(dtype_qk, dtype_vo, causal):
+    torch.manual_seed(0)
+    b, s, Hq, Hk, D = 2, 1024, 8, 8, 128
+    qo = _indptr([s] * b)
+    kv = qo.clone()
+    total = b * s
+    sm = 1.0 / math.sqrt(D)
+    q, k, v, qr, kr, vr = _make_qkv(total, total, Hq, Hk, dtype_qk, dtype_vo, D, D)
+    ws = torch.empty(128 * 1024 * 1024, device=DEVICE, dtype=torch.uint8)
+
+    w = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+        ws, kv_layout="NHD", backend="cute-dsl"
+    )
+    w.plan(qo, kv, Hq, Hk, D, causal=causal, q_data_type=dtype_qk)
+    o = w.run(q, k, v)
+    ref = _ragged_ref(qr, kr, vr, qo, kv, sm, causal=causal)
+    atol = 4e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
+    torch.testing.assert_close(o.float(), ref.float(), atol=atol, rtol=atol)
+
+    # LSE is now supported for standard attention.
+    o2, lse = w.run(q, k, v, return_lse=True)
+    torch.testing.assert_close(o2.float(), o.float(), atol=1e-2, rtol=1e-2)
+    assert lse.shape == (total, Hq)
+
+
+def test_cute_dsl_jit_fallback(monkeypatch):
+    """When the cubin variant is unavailable, cute_dsl_fmha_ragged_prefill must
+    fall back to the JIT runner and still produce correct results."""
+    import flashinfer.attention.cute_dsl.fmha as cubin_mod
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("forced: cubin unavailable")
+
+    monkeypatch.setattr(cubin_mod, "get_cute_dsl_fmha_kernel", _raise)
+
+    torch.manual_seed(0)
+    b, s, H, D = 2, 256, 4, 128
+    qo = _indptr([s] * b)
+    kv = qo.clone()
+    total = b * s
+    sm = 1.0 / math.sqrt(D)
+    q, k, v, qr, kr, vr = _make_qkv(
+        total, total, H, H, torch.bfloat16, torch.bfloat16, D, D
+    )
+    o = torch.empty(total, H, D, device=DEVICE, dtype=torch.bfloat16)
+
+    cubin_mod.cute_dsl_fmha_ragged_prefill(
+        q=q,
+        k=k,
+        v=v,
+        o=o,
+        qo_indptr=qo,
+        kv_indptr=kv,
+        is_causal=False,
+        sm_scale=sm,
+        max_qo_len=s,
+        max_kv_len=s,
+    )
+    ref = _ragged_ref(qr, kr, vr, qo, kv, sm, causal=False)
+    torch.testing.assert_close(o.float(), ref.float(), atol=3e-2, rtol=3e-2)
+
+
+def test_batch_prefill_cute_dsl_alibi_fallback():
+    """ALiBi is unsupported by the vendored kernel; must fall back to prefill.py."""
+    torch.manual_seed(0)
+    b, s, H, D = 2, 256, 8, 128
+    qo = _indptr([s] * b)
+    kv = qo.clone()
+    total = b * s
+    q = torch.randn(total, H, D, device=DEVICE, dtype=torch.bfloat16)
+    k = torch.randn(total, H, D, device=DEVICE, dtype=torch.bfloat16)
+    v = torch.randn(total, H, D, device=DEVICE, dtype=torch.bfloat16)
+    ws = torch.empty(128 * 1024 * 1024, device=DEVICE, dtype=torch.uint8)
+
+    w = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+        ws, kv_layout="NHD", backend="cute-dsl"
+    )
+    w.plan(
+        qo,
+        kv,
+        H,
+        H,
+        D,
+        causal=False,
+        pos_encoding_mode="ALIBI",
+        q_data_type=torch.bfloat16,
+    )
+    o = w.run(q, k, v)
+    assert o.shape == (total, H, D)
+    assert torch.isfinite(o.float()).all()

--- a/tests/attention/test_cute_dsl_fmha_backend.py
+++ b/tests/attention/test_cute_dsl_fmha_backend.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Frontend tests for the `cute-dsl` backend routed to the trtllm JIT FMHA kernel.
+
+Covers entry points:
+* `trtllm_ragged_attention_deepseek(backend="cute-dsl")` — the shared low-level API.
+* `BatchPrefillWithRaggedKVCacheWrapper(backend="cute-dsl")` — delegates to the former
+  for standard attention, falls back to prefill.py for ALiBi / soft-cap.
+"""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flashinfer
+from flashinfer.cute_dsl.utils import is_cute_dsl_available
+from flashinfer.utils import is_sm100a_supported
+
+if not is_cute_dsl_available():
+    pytest.skip("CuTe DSL not available", allow_module_level=True)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda")),
+    reason="CuTe DSL FMHA requires Blackwell (SM100a+)",
+)
+
+DEVICE = "cuda"
+
+
+def _indptr(lengths):
+    t = torch.tensor(lengths, device=DEVICE, dtype=torch.int32)
+    return torch.cat([torch.zeros(1, device=DEVICE, dtype=torch.int32), t.cumsum(0)])
+
+
+def _ragged_ref(q, k, v, qo_indptr, kv_indptr, sm_scale, causal):
+    """Per-batch float32 ragged attention (top-left causal; equal q/k lengths here)."""
+    pieces = []
+    for i in range(qo_indptr.numel() - 1):
+        qb, qe = int(qo_indptr[i]), int(qo_indptr[i + 1])
+        kb, ke = int(kv_indptr[i]), int(kv_indptr[i + 1])
+        qi = q[qb:qe].transpose(0, 1).unsqueeze(0).float()
+        ki = k[kb:ke].transpose(0, 1).unsqueeze(0).float()
+        vi = v[kb:ke].transpose(0, 1).unsqueeze(0).float()
+        oi = F.scaled_dot_product_attention(
+            qi, ki, vi, scale=sm_scale, is_causal=causal
+        )
+        pieces.append(oi.squeeze(0).transpose(0, 1))
+    return torch.cat(pieces, dim=0)
+
+
+def _make_qkv(total_q, total_kv, Hq, Hk, dtype_qk, dtype_vo, Dqk, Dvo):
+    q = torch.randn(total_q, Hq, Dqk, device=DEVICE, dtype=torch.bfloat16).to(dtype_qk)
+    k = torch.randn(total_kv, Hk, Dqk, device=DEVICE, dtype=torch.bfloat16).to(dtype_qk)
+    v = torch.randn(total_kv, Hk, Dvo, device=DEVICE, dtype=torch.bfloat16).to(dtype_vo)
+    # reference operands (exact stored values)
+    qr = q.float() if dtype_qk.itemsize == 1 else q
+    kr = k.float() if dtype_qk.itemsize == 1 else k
+    vr = v.float() if dtype_vo.itemsize == 1 else v
+    return q, k, v, qr, kr, vr
+
+
+# =============================================================================
+# trtllm_ragged_attention_deepseek(backend="cute-dsl")
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "dtype_qk,dtype_vo,Dqk,Dvo",
+    [
+        (torch.bfloat16, torch.bfloat16, 128, 128),
+        (torch.bfloat16, torch.float8_e4m3fn, 128, 128),
+        (torch.float8_e4m3fn, torch.float8_e4m3fn, 128, 128),
+        (torch.float8_e4m3fn, torch.float8_e4m3fn, 192, 128),  # MLA
+    ],
+)
+def test_deepseek_cute_dsl(dtype_qk, dtype_vo, Dqk, Dvo):
+    torch.manual_seed(0)
+    b, s, H = 2, 256, 8
+    qo = _indptr([s] * b)
+    kv = qo.clone()
+    total = b * s
+    sm = 1.0 / math.sqrt(Dqk)
+    q, k, v, qr, kr, vr = _make_qkv(total, total, H, H, dtype_qk, dtype_vo, Dqk, Dvo)
+    ws = torch.empty(128 * 1024 * 1024, device=DEVICE, dtype=torch.uint8)
+    seq_lens = torch.tensor([s] * b, device=DEVICE, dtype=torch.int32)
+
+    o = flashinfer.prefill.trtllm_ragged_attention_deepseek(
+        query=q,
+        key=k,
+        value=v,
+        workspace_buffer=ws,
+        seq_lens=seq_lens,
+        max_q_len=s,
+        max_kv_len=s,
+        bmm1_scale=sm,
+        bmm2_scale=1.0,
+        o_sf_scale=1.0,
+        batch_size=b,
+        window_left=-1,
+        cum_seq_lens_q=qo,
+        cum_seq_lens_kv=kv,
+        enable_pdl=False,
+        is_causal=False,
+        return_lse=False,
+        backend="cute-dsl",
+    )
+    ref = _ragged_ref(qr, kr, vr, qo, kv, sm, causal=False)
+    atol = 4e-2 if min(dtype_qk.itemsize, dtype_vo.itemsize) == 1 else 6e-3
+    torch.testing.assert_close(o.float(), ref.float(), atol=atol, rtol=atol)

--- a/tests/attention/test_cute_dsl_fmha_backend.py
+++ b/tests/attention/test_cute_dsl_fmha_backend.py
@@ -161,9 +161,10 @@ def test_batch_prefill_cute_dsl(dtype_qk, dtype_vo, causal):
     assert lse.shape == (total, Hq)
 
 
-def test_cute_dsl_jit_fallback(monkeypatch):
+def test_cute_dsl_jit_case(monkeypatch):
     """When the cubin variant is unavailable, cute_dsl_fmha_ragged_prefill must
-    fall back to the JIT runner and still produce correct results."""
+    JIT-compile the kernel and still produce correct results.
+    """
     import flashinfer.attention.cute_dsl.fmha as cubin_mod
 
     def _raise(*args, **kwargs):
@@ -198,8 +199,8 @@ def test_cute_dsl_jit_fallback(monkeypatch):
     torch.testing.assert_close(o.float(), ref.float(), atol=3e-2, rtol=3e-2)
 
 
-def test_batch_prefill_cute_dsl_alibi_fallback():
-    """ALiBi is unsupported by the vendored kernel; must fall back to prefill.py."""
+def test_batch_prefill_cute_dsl_alibi():
+    """ALiBi is unsupported by the trtllm kernel; must use prefill.py instead."""
     torch.manual_seed(0)
     b, s, H, D = 2, 256, 8, 128
     qo = _indptr([s] * b)
@@ -279,7 +280,7 @@ def _blockscaled_dequant(x_bshd, qk_mode):
 def test_blockscaled_quantize_and_prefill(qk_mode, causal):
     """End-to-end block-scaled path: fused quantizer -> SF -> FMHA kernel."""
     from flashinfer.cute_dsl.attention.fmha.quantize import quantize_blockscaled_qk
-    from flashinfer.cute_dsl.attention.fmha.runner import (
+    from flashinfer.attention.cute_dsl.fmha_blockscaled import (
         cute_dsl_fmha_blockscaled_prefill,
     )
 

--- a/tests/attention/test_cute_dsl_fmha_backend.py
+++ b/tests/attention/test_cute_dsl_fmha_backend.py
@@ -226,3 +226,98 @@ def test_batch_prefill_cute_dsl_alibi_fallback():
     o = w.run(q, k, v)
     assert o.shape == (total, H, D)
     assert torch.isfinite(o.float()).all()
+
+
+def _blockscaled_dequant(x_bshd, qk_mode):
+    """Dequantized (f32) logical Q/K values the block-scaled kernel operates on.
+
+    Mirrors quantize.py's pad/transpose, but requests the *linear* SF layout so the
+    per-block scales are directly decodable here (kept out of the production path).
+    """
+    from flashinfer.quantization import fp4_quantize, mxfp8_quantize
+
+    b, s, h, d = x_bshd.shape
+    x_bhsd = x_bshd.transpose(1, 2).contiguous()
+    s_pad = ((s + 127) // 128) * 128
+    if s_pad != s:
+        pad = torch.zeros(b, h, s_pad - s, d, dtype=x_bhsd.dtype, device=x_bhsd.device)
+        x_bhsd = torch.cat([x_bhsd, pad], dim=2)
+    x2d = x_bhsd.reshape(b * h * s_pad, d)
+    m = x2d.shape[0]
+
+    if qk_mode == "mxfp8":
+        data, sf = mxfp8_quantize(
+            x2d, is_sf_swizzled_layout=False, alignment=32, backend="cute-dsl"
+        )
+        vals = data.float()
+        sf_k, vec, glob = d // 32, 32, 1.0
+        sf_lin = sf.view(torch.float8_e8m0fnu).float().reshape(m, sf_k)
+    else:
+        amax = x2d.float().abs().amax().clamp(min=1e-6)
+        glob = float(amax / (448.0 * 6.0))
+        gsf = (448.0 * 6.0 / amax).to(torch.float32).reshape(1)
+        data, sf = fp4_quantize(
+            x2d, gsf, sf_vec_size=16, is_sf_swizzled_layout=False, backend="cute-dsl"
+        )
+        u8 = data.reshape(m, d // 2).to(torch.int32)
+        codes = torch.stack([u8 & 0xF, (u8 >> 4) & 0xF], dim=-1).reshape(m, d)
+        # Brute-force decode e2m1 values.
+        e2m1_levels = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+        vals = (
+            torch.where((codes & 0x8) != 0, -1.0, 1.0)
+            * e2m1_levels.to(x2d.device)[codes & 0x7]
+        )
+        sf_k, vec = d // 16, 16
+        sf_lin = sf.view(torch.float8_e4m3fn).float().reshape(m, sf_k)
+    sf_bcast = sf_lin.unsqueeze(-1).expand(m, sf_k, vec).reshape(m, d)
+    deq = (vals * sf_bcast * glob).reshape(b, h, s_pad, d)
+    return deq[:, :, :s, :].transpose(1, 2).contiguous()
+
+
+@pytest.mark.parametrize("qk_mode", ["mxfp8", "nvfp4"])
+@pytest.mark.parametrize("causal", [False, True])
+def test_blockscaled_quantize_and_prefill(qk_mode, causal):
+    """End-to-end block-scaled path: fused quantizer -> SF -> FMHA kernel."""
+    from flashinfer.cute_dsl.attention.fmha.quantize import quantize_blockscaled_qk
+    from flashinfer.cute_dsl.attention.fmha.runner import (
+        cute_dsl_fmha_blockscaled_prefill,
+    )
+
+    torch.manual_seed(0)
+    b, s, H, D = 2, 128, 4, 128
+    sm = 1.0 / math.sqrt(D)
+    q = torch.randn(b, s, H, D, device=DEVICE, dtype=torch.bfloat16)
+    k = torch.randn(b, s, H, D, device=DEVICE, dtype=torch.bfloat16)
+    v = torch.randn(b, s, H, D, device=DEVICE, dtype=torch.bfloat16)
+
+    q_store, k_store, q_sf, k_sf, q_scale, k_scale = quantize_blockscaled_qk(
+        q, k, qk_mode
+    )
+    v_store = v.to(torch.float8_e4m3fn)
+    v_deq = v_store.float()
+    o = torch.empty(b, s, H, D, device=DEVICE, dtype=torch.bfloat16)
+    cute_dsl_fmha_blockscaled_prefill(
+        q_store,
+        k_store,
+        q_sf,
+        k_sf,
+        v_store,
+        o,
+        qk_mode=qk_mode,
+        is_causal=causal,
+        sm_scale=sm,
+        scale_q=q_scale,
+        scale_k=k_scale,
+    )
+
+    # Reference on the dequantized logical values (matches kernel semantics exactly).
+    q_deq = _blockscaled_dequant(q, qk_mode)
+    k_deq = _blockscaled_dequant(k, qk_mode)
+    s_logits = torch.einsum("bqhd,bkhd->bhqk", q_deq, k_deq) * sm
+    if causal:
+        row = torch.arange(s, device=DEVICE).view(-1, 1)
+        col = torch.arange(s, device=DEVICE).view(1, -1)
+        s_logits = s_logits.masked_fill((col > row).view(1, 1, s, s), float("-inf"))
+    p = torch.softmax(s_logits, dim=-1)
+    o_ref = torch.einsum("bhqk,bkhd->bqhd", p, v_deq)
+    torch.testing.assert_close(o.float(), o_ref, atol=0.1, rtol=1e-2)

--- a/tests/attention/test_cute_dsl_fmha_jit.py
+++ b/tests/attention/test_cute_dsl_fmha_jit.py
@@ -44,6 +44,7 @@ from flashinfer.cute_dsl.attention.fmha.fmha_blockscaled import (
     create_scale_factor_tensor,
 )
 from flashinfer.cute_dsl.attention.fmha.helpers import fmha_helpers as fmha_utils
+from flashinfer.cute_dsl.attention.fmha.compile import _ex2_emulation_enabled
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda")),
@@ -53,6 +54,7 @@ pytestmark = pytest.mark.skipif(
 DEVICE = "cuda"
 MMA_TILER = (128, 128)
 LOG2_E = math.log2(math.e)
+ENABLE_EX2 = _ex2_emulation_enabled(torch.device(DEVICE))
 
 
 def _make_cute(shape, cutlass_dtype, *, zero_out=False):
@@ -238,7 +240,7 @@ def test_cute_dsl_fmha_jit(mode, causal):
         head_dim=d,
         is_persistent=False,
         mask_type=mask_type,
-        enable_ex2_emulation=True,
+        enable_ex2_emulation=ENABLE_EX2,
         enable_skip_correction=True,
         use_tma_store=False,  # varlen
     )
@@ -365,7 +367,7 @@ def test_cute_dsl_fmha_blockscaled_jit(qk_mode, causal, with_lse):
         head_dim=d,
         is_persistent=False,
         mask_type=mask_type,
-        enable_ex2_emulation=True,
+        enable_ex2_emulation=ENABLE_EX2,
         enable_skip_correction=True,
         qk_sf_vec_size=sf_vec,
         use_tma_store=True,  # non-varlen

--- a/tests/attention/test_cute_dsl_fmha_jit.py
+++ b/tests/attention/test_cute_dsl_fmha_jit.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Correctness tests for the JIT-compiled CuTe DSL FMHA kernels vendored into
-flashinfer/cute_dsl/attention/fmha/ (copied from trtllm-oss).
+"""Correctness tests for the JIT-compiled TRTLLM CuTe DSL FMHA kernels.
 
 The kernels are compiled in-process via cute.compile (CuTe native ABI) and checked
 against a torch reference. Covers non-block-scaled (bf16, fp8, split-BMM bf16-QK/E4M3-V,
@@ -186,7 +185,7 @@ _NONBS_MODES = {
 @pytest.mark.parametrize("mode", list(_NONBS_MODES))
 @pytest.mark.parametrize("causal", [False, True])
 def test_cute_dsl_fmha_jit(mode, causal):
-    """Non-block-scaled varlen prefill, JIT-compiled from the vendored kernel."""
+    """Non-block-scaled varlen prefill, JIT-compiled."""
     torch.manual_seed(0)
     qk_dt, v_dt, out_dt, out_torch_dt, atol = _NONBS_MODES[mode]
     d = dv = 128
@@ -328,7 +327,7 @@ def _sf_ref_5d(ref_flat, s, b, h_k, h_r, d):
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("with_lse", [False, True])
 def test_cute_dsl_fmha_blockscaled_jit(qk_mode, causal, with_lse):
-    """Block-scaled (MXFP8 / NVFP4) non-varlen prefill, JIT-compiled from the vendored kernel."""
+    """Block-scaled (MXFP8 / NVFP4) non-varlen prefill, JIT-compiled."""
     torch.manual_seed(0)
     qk_dt, sf_dt, sf_vec = _BS_MODES[qk_mode]
     d = dv = 128

--- a/tests/attention/test_cute_dsl_fmha_jit.py
+++ b/tests/attention/test_cute_dsl_fmha_jit.py
@@ -1,0 +1,439 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Correctness tests for the JIT-compiled CuTe DSL FMHA kernels vendored into
+flashinfer/cute_dsl/attention/fmha/ (copied from trtllm-oss).
+
+The kernels are compiled in-process via cute.compile (CuTe native ABI) and checked
+against a torch reference. Covers non-block-scaled (bf16, fp8, split-BMM bf16-QK/E4M3-V,
+varlen) and block-scaled MXFP8/NVFP4 (non-varlen).
+"""
+
+import math
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl.utils import is_cute_dsl_available
+from flashinfer.utils import is_sm100a_supported
+
+if not is_cute_dsl_available():
+    pytest.skip("CuTe DSL not available", allow_module_level=True)
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.torch as cutlass_torch
+from cutlass.cute.runtime import from_dlpack
+from cutlass.cute.typing import Float32, Int32
+
+from flashinfer.cute_dsl.attention.fmha.fmha import (
+    BlackwellFusedMultiHeadAttentionForward,
+)
+from flashinfer.cute_dsl.attention.fmha.fmha_blockscaled import (
+    BlackwellFusedMultiHeadBlockScaledAttentionForward,
+    compact_fp4_data,
+    create_scale_factor_tensor,
+)
+from flashinfer.cute_dsl.attention.fmha.helpers import fmha_helpers as fmha_utils
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda")),
+    reason="CuTe DSL FMHA requires Blackwell (SM100a+)",
+)
+
+DEVICE = "cuda"
+MMA_TILER = (128, 128)
+LOG2_E = math.log2(math.e)
+
+
+def _make_cute(shape, cutlass_dtype, *, zero_out=False):
+    """Build a device cute tensor of the given dtype and return (f32_ref, cute_tensor).
+
+    f32_ref holds the exact (dequantized) stored values, extracted from the cute
+    tensor via cute.testing.convert, so it matches what the kernel reads. Integer
+    inputs in [-2, 2] are exactly representable in bf16/E4M3/E2M1, so the round-trip
+    is lossless.
+    """
+    if zero_out:
+        f32 = torch.zeros(*shape, dtype=torch.float32)
+    else:
+        f32 = torch.randint(-2, 3, shape, dtype=torch.float32)
+    cute_t, torch_t = cutlass_torch.cute_tensor_like(
+        f32, cutlass_dtype, is_dynamic_layout=True, assumed_align=32
+    )
+    compact_fp4_data(torch_t, cutlass_dtype)
+    ref = f32.cuda()
+    if not zero_out:
+        cute.testing.convert(cute_t, from_dlpack(ref, assumed_align=32))
+    return ref, cute_t
+
+
+def _readback(cute_t, shape):
+    """Convert a device cute tensor back to an f32 CPU tensor for comparison."""
+    f32_cute, f32_torch = cutlass_torch.cute_tensor_like(
+        torch.zeros(*shape, dtype=torch.float32),
+        cutlass.Float32,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+    cute.testing.convert(cute_t, f32_cute)
+    return f32_torch.cpu()
+
+
+def _ref_attention(
+    q5,
+    k5,
+    v5,
+    *,
+    batch,
+    s_q_max,
+    s_k_max,
+    scale_softmax,
+    scale_output,
+    causal,
+    cum_q=None,
+    cum_k=None,
+    q_sf5=None,
+    k_sf5=None,
+):
+    """float32 attention reference over 5D tensors (b, s, h_k, {h_r|1}, d).
+
+    Mirrors the kernel's run_torch_fmha: per (batch, head), optionally scale q/k by
+    the per-block SF, S = qk*scale_softmax, bottom-right causal mask, softmax over
+    s_k, O = P@v*scale_output. Returns (o_ref_f32, lse_ref_f32) with o_ref shaped
+    like q5 (dv last) and lse_ref shaped (b_out, s, h_k, h_r).
+    """
+    h_k, h_r, d = q5.shape[2], q5.shape[3], q5.shape[4]
+    dv = v5.shape[4]
+    o_ref = torch.zeros(*q5.shape[:-1], dv, dtype=torch.float32, device=q5.device)
+    lse_ref = torch.zeros(*q5.shape[:-1], dtype=torch.float32, device=q5.device)
+    for bi in range(batch):
+        bq = 0 if cum_q is not None else bi
+        bk = 0 if cum_k is not None else bi
+        qo = cum_q[bi] if cum_q is not None else 0
+        ko = cum_k[bi] if cum_k is not None else 0
+        sq = (cum_q[bi + 1] - cum_q[bi]) if cum_q is not None else s_q_max
+        sk = (cum_k[bi + 1] - cum_k[bi]) if cum_k is not None else s_k_max
+        cq = q5[bq, qo : qo + sq].float()  # (sq, h_k, h_r, d)
+        ck = k5[bk, ko : ko + sk].float()  # (sk, h_k, 1, d)
+        cv = v5[bk, ko : ko + sk].float()  # (sk, h_k, 1, dv)
+        if q_sf5 is not None:
+            cq = cq * q_sf5[bi, qo : qo + sq].float()
+            ck = ck * k_sf5[bk, ko : ko + sk].float()
+        ck = ck.expand(sk, h_k, h_r, d)
+        cv = cv.expand(sk, h_k, h_r, dv)
+        s = (
+            torch.einsum("qhrd,khrd->qkhr", cq, ck) * scale_softmax
+        )  # (sq, sk, h_k, h_r)
+        if causal:
+            qc = torch.arange(sq, device=q5.device).view(-1, 1)
+            kc = torch.arange(sk, device=q5.device).view(1, -1)
+            masked = kc > (qc + (sk - sq))  # bottom-right aligned
+            s = s.masked_fill(masked.view(sq, sk, 1, 1), float("-inf"))
+        p = torch.softmax(s, dim=1)
+        o = torch.einsum("qkhr,khrd->qhrd", p, cv) * scale_output
+        o_ref[bq, qo : qo + sq] = o
+        lse_ref[bq, qo : qo + sq] = torch.logsumexp(s, dim=1) * LOG2_E
+    return o_ref, lse_ref
+
+
+def _default_stream():
+    return cutlass_torch.default_stream()
+
+
+# =============================================================================
+# Non-block-scaled: bf16, fp8 (e4m3->bf16), split-BMM (bf16 QK / e4m3 V -> bf16)
+# =============================================================================
+
+# mode -> (qk cutlass dtype, v cutlass dtype, out cutlass dtype, out torch dtype, atol)
+_NONBS_MODES = {
+    "bf16": (
+        cutlass.BFloat16,
+        cutlass.BFloat16,
+        cutlass.BFloat16,
+        torch.bfloat16,
+        3e-2,
+    ),
+    # FP8 inputs + bf16 output: a few elements land just past 3e-2 (near-one-hot
+    # softmax on coarse E4M3 logits), so allow a little more headroom.
+    "fp8": (
+        cutlass.Float8E4M3FN,
+        cutlass.Float8E4M3FN,
+        cutlass.BFloat16,
+        torch.bfloat16,
+        5e-2,
+    ),
+    "split": (
+        cutlass.BFloat16,
+        cutlass.Float8E4M3FN,
+        cutlass.BFloat16,
+        torch.bfloat16,
+        5e-2,
+    ),
+}
+
+
+@pytest.mark.parametrize("mode", list(_NONBS_MODES))
+@pytest.mark.parametrize("causal", [False, True])
+def test_cute_dsl_fmha_jit(mode, causal):
+    """Non-block-scaled varlen prefill, JIT-compiled from the vendored kernel."""
+    torch.manual_seed(0)
+    qk_dt, v_dt, out_dt, out_torch_dt, atol = _NONBS_MODES[mode]
+    d = dv = 128
+    h_k, h_r = 4, 1
+    h_q = h_k * h_r
+    seq_lens_q = (64, 128, 32)
+    seq_lens_k = (64, 128, 32)
+    batch = len(seq_lens_q)
+    s_q, s_k = sum(seq_lens_q), sum(seq_lens_k)
+    max_s_q, max_s_k = max(seq_lens_q), max(seq_lens_k)
+
+    q_ref, q_cute = _make_cute((1, s_q, h_k, h_r, d), qk_dt)
+    k_ref, k_cute = _make_cute((1, s_k, h_k, 1, d), qk_dt)
+    v_ref, v_cute = _make_cute((1, s_k, h_k, 1, dv), v_dt)
+    _, o_cute = _make_cute((1, s_q, h_k, h_r, dv), out_dt, zero_out=True)
+
+    def _cum(lens):
+        c = [0]
+        for x in lens:
+            c.append(c[-1] + x)
+        return c
+
+    cum_q, cum_k = _cum(seq_lens_q), _cum(seq_lens_k)
+    cum_q_cute, _ = cutlass_torch.cute_tensor_like(
+        torch.tensor(cum_q, dtype=torch.int32),
+        Int32,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+    cum_k_cute, _ = cutlass_torch.cute_tensor_like(
+        torch.tensor(cum_k, dtype=torch.int32),
+        Int32,
+        is_dynamic_layout=True,
+        assumed_align=16,
+    )
+
+    problem_size = (batch, max_s_q, s_q, max_s_k, h_q, h_k, d, dv)
+    scale_softmax = 1.0 / math.sqrt(d)
+    mask_type = (
+        fmha_utils.MaskEnum.WINDOW_MASK_INFERENCE
+        if causal
+        else fmha_utils.MaskEnum.RESIDUAL_MASK
+    )
+    ws_right = Int32(0) if causal else None
+
+    fmha = BlackwellFusedMultiHeadAttentionForward(
+        qk_acc_dtype=cutlass.Float32,
+        pv_acc_dtype=cutlass.Float32,
+        mma_tiler=MMA_TILER,
+        head_dim=d,
+        is_persistent=False,
+        mask_type=mask_type,
+        enable_ex2_emulation=True,
+        enable_skip_correction=True,
+        use_tma_store=False,  # varlen
+    )
+    stream = _default_stream()
+    compiled = cute.compile(
+        fmha,
+        q_cute,
+        k_cute,
+        v_cute,
+        o_cute,
+        problem_size,
+        cum_q_cute,
+        cum_k_cute,
+        None,
+        None,
+        scale_softmax * LOG2_E,
+        scale_softmax,
+        1.0,
+        None,
+        None,
+        ws_right,
+        None,
+        None,
+        stream,
+        False,
+    )
+    compiled(
+        q_cute,
+        k_cute,
+        v_cute,
+        o_cute,
+        problem_size,
+        cum_q_cute,
+        cum_k_cute,
+        None,
+        None,
+        Float32(scale_softmax * LOG2_E),
+        Float32(scale_softmax),
+        Float32(1.0),
+        None,
+        None,
+        ws_right,
+        None,
+        None,
+        stream,
+        False,
+    )
+    torch.cuda.synchronize()
+
+    o = _readback(o_cute, (1, s_q, h_k, h_r, dv))
+    o_ref, _ = _ref_attention(
+        q_ref,
+        k_ref,
+        v_ref,
+        batch=batch,
+        s_q_max=max_s_q,
+        s_k_max=max_s_k,
+        scale_softmax=scale_softmax,
+        scale_output=1.0,
+        causal=causal,
+        cum_q=cum_q,
+        cum_k=cum_k,
+    )
+    torch.testing.assert_close(o, o_ref.cpu(), atol=atol, rtol=atol)
+
+
+# =============================================================================
+# Block-scaled: MXFP8 / NVFP4 (non-varlen, h_r = 1)
+# =============================================================================
+
+# qk_mode -> (qk dtype, sf dtype, sf_vec_size)
+_BS_MODES = {
+    "mxfp8": (cutlass.Float8E4M3FN, cutlass.Float8E8M0FNU, 32),
+    "nvfp4": (cutlass.Float4E2M1FN, cutlass.Float8E4M3FN, 16),
+}
+
+
+def _sf_ref_5d(ref_flat, s, b, h_k, h_r, d):
+    # create_scale_factor_tensor ref: (mn=s, k=d, l=b*h) -> (b, s, h_k, h_r, d)
+    return (
+        ref_flat.reshape(s, d, b, h_k, h_r).permute(2, 0, 3, 4, 1).contiguous().cuda()
+    )
+
+
+@pytest.mark.parametrize("qk_mode", list(_BS_MODES))
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("with_lse", [False, True])
+def test_cute_dsl_fmha_blockscaled_jit(qk_mode, causal, with_lse):
+    """Block-scaled (MXFP8 / NVFP4) non-varlen prefill, JIT-compiled from the vendored kernel."""
+    torch.manual_seed(0)
+    qk_dt, sf_dt, sf_vec = _BS_MODES[qk_mode]
+    d = dv = 128
+    b, s_q, s_k = 2, 128, 128
+    h_k, h_r = 4, 1
+    h_q = h_k * h_r
+
+    q_ref, q_cute = _make_cute((b, s_q, h_k, h_r, d), qk_dt)
+    k_ref, k_cute = _make_cute((b, s_k, h_k, 1, d), qk_dt)
+    v_ref, v_cute = _make_cute((b, s_k, h_k, 1, dv), cutlass.Float8E4M3FN)
+    _, o_cute = _make_cute((b, s_q, h_k, h_r, dv), cutlass.Float8E4M3FN, zero_out=True)
+
+    q_sf_flat, q_sf_cute = create_scale_factor_tensor(s_q, d, b * h_q, sf_vec, sf_dt)
+    k_sf_flat, k_sf_cute = create_scale_factor_tensor(s_k, d, b * h_k, sf_vec, sf_dt)
+    q_sf5 = _sf_ref_5d(q_sf_flat, s_q, b, h_k, h_r, d)
+    k_sf5 = _sf_ref_5d(k_sf_flat, s_k, b, h_k, 1, d)
+
+    lse_cute = None
+    if with_lse:
+        _, lse_cute = _make_cute((b, s_q, h_k, h_r), cutlass.Float32, zero_out=True)
+
+    problem_size = (b, s_q, s_q, s_k, h_q, h_k, d, dv)
+    scale_softmax = 1.0 / math.sqrt(d)
+    mask_type = (
+        fmha_utils.MaskEnum.WINDOW_MASK_INFERENCE
+        if causal
+        else fmha_utils.MaskEnum.RESIDUAL_MASK
+    )
+    ws_right = Int32(0) if causal else None
+
+    fmha = BlackwellFusedMultiHeadBlockScaledAttentionForward(
+        qk_acc_dtype=cutlass.Float32,
+        pv_acc_dtype=cutlass.Float32,
+        mma_tiler=MMA_TILER,
+        head_dim=d,
+        is_persistent=False,
+        mask_type=mask_type,
+        enable_ex2_emulation=True,
+        enable_skip_correction=True,
+        qk_sf_vec_size=sf_vec,
+        use_tma_store=True,  # non-varlen
+    )
+    stream = _default_stream()
+    args = (
+        q_cute,
+        k_cute,
+        q_sf_cute,
+        k_sf_cute,
+        v_cute,
+        o_cute,
+        problem_size,
+        None,
+        None,
+        lse_cute,
+        None,
+    )
+    compiled = cute.compile(
+        fmha,
+        *args,
+        scale_softmax * LOG2_E,
+        scale_softmax,
+        1.0,
+        None,
+        None,
+        None,
+        ws_right,
+        None,
+        None,
+        stream,
+        False,
+    )
+    compiled(
+        *args,
+        Float32(scale_softmax * LOG2_E),
+        Float32(scale_softmax),
+        Float32(1.0),
+        None,
+        None,
+        None,
+        ws_right,
+        None,
+        None,
+        stream,
+        False,
+    )
+    torch.cuda.synchronize()
+
+    o = _readback(o_cute, (b, s_q, h_k, h_r, dv))
+    o_ref, lse_ref = _ref_attention(
+        q_ref,
+        k_ref,
+        v_ref,
+        batch=b,
+        s_q_max=s_q,
+        s_k_max=s_k,
+        scale_softmax=scale_softmax,
+        scale_output=1.0,
+        causal=causal,
+        q_sf5=q_sf5,
+        k_sf5=k_sf5,
+    )
+    # Compare like the kernel refcheck: round the reference through E4M3.
+    o_ref_q = o_ref.to(torch.float8_e4m3fn).float().cpu()
+    torch.testing.assert_close(o.float(), o_ref_q, atol=0.2, rtol=1e-2)
+
+    if with_lse:
+        lse = _readback(lse_cute, (b, s_q, h_k, h_r))
+        torch.testing.assert_close(lse, lse_ref.cpu(), atol=0.2, rtol=1e-2)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

### Added kernels

- `fmha.py`: high-throughput FMHA kernel in CuTe DSL
  - QK_dtype & V_dtype can independently select BF16, FP16, or FP8.
  - Accepts the same input format as CUBINs wrapped by `flashinfer/attention/cute_dsl/fmha.py`.
  - Substantially faster than `flashinfer/cute_dsl/attention/prefill.py` .
- `fmha_blockscaled.py`: QK can select MXFP8 & NVFP4. V can select BF16, FP16, or FP8.

Added kernel doesn't support decode-phase attention.

### API design

#### Dense FMHA

| Content | Location | API |
| ------- | -------- | --- |
| New JIT source code | `flashinfer/cute_dsl/attention/fmha/fmha.py` | ... |
| Compilation entry   | `flashinfer/cute_dsl/attention/fmha/compile.py` | `compile_cute_dsl_fmha_kernel` |
| Runner (cubin & JIT shares runner) | `flashinfer/attention/cute_dsl/fmha.py` | `cute_dsl_fmha_ragged_prefill` |
| **Frontend** | `flashinfer/prefill.py` | ... |

Here, The **Frontend** changes are independent to JIT compilation & execution: it wires the existing `trtllm_ragged_attention_deepseek` to the `BatchPrefillWithRaggedKVCacheWrapper` generic module to ease use.

#### Block-scaled FMHA

| Content | Location | API |
| ------- | -------- | --- |
| New JIT source code | `flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py` | ... |
| Compilation entry   | `flashinfer/cute_dsl/attention/fmha/compile.py` | `compile_cute_dsl_fmha_blockscaled_kernel` |
| Runner  | `flashinfer/attention/cute_dsl/fmha_blockscaled.py` | `cute_dsl_fmha_blockscaled_prefill` |
| Quantizer | `flashinfer/cute_dsl/attention/fmha/quantize.py`    | `quantize_blockscaled_qk` |

## 🔍 Related Issues

<!-- Link any related issues here -->
N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a block-scaled CuTe DSL FMHA attention path, including block-scaled Q/K quantization to drive it.
  * Improved `cute-dsl` planning/runtime to support `return_lse` for the FMHA route.
  * Expanded end-to-end and JIT FMHA correctness coverage with CUDA/SM100a+ gated tests.

* **Bug Fixes**
  * Improved robustness when prebuilt FMHA kernels are unavailable by falling back to JIT compilation and enforcing consistent input dtypes.

* **Chores**
  * Updated type-checking and linting exclusions to skip generated/unsupported FMHA sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->