### PR TITLE
feat: SM100 CUTLASS NVFP4 SVDQuant fused GEMM (mm_nvfp4_svdquant)

### DIFF
--- a/benchmarks/bench_nvfp4_svdquant_gemm.py
+++ b/benchmarks/bench_nvfp4_svdquant_gemm.py
@@ -2,16 +2,19 @@
 """Benchmark for the SM100 NVFP4 SVDQuant fused GEMM (Qwen-Image linear shapes).
 
 For every (n, k) x m problem this script times three things after autotuning:
-  1. mm_nvfp4_svdquant : fused residual NVFP4 GEMM + rank-32 BF16 LoRA-up + bias
+  1. mm_nvfp4_svdquant : fused residual NVFP4 GEMM + rank-r BF16 LoRA-up + bias
   2. svdquant_linear   : the full chain (nvfp4_quantize_smooth -> bf16 LoRA-down
                          GEMM -> fused GEMM)
   3. mm_fp4 (cutlass)  : the stock NVFP4 GEMM on the same residual operands
                          (no LoRA correction), as the lower-bound baseline
 
+The LoRA rank defaults to 32; pass e.g. --ranks 32,64,96,128 to sweep.
+
 Timing uses flashinfer.testing bench_gpu_time (CUPTI preferred, automatic
 fallback to CUDA events).
 """
 
+import argparse
 import sys
 
 import numpy as np
@@ -25,7 +28,7 @@ from flashinfer import (
     nvfp4_quantize,
     svdquant_linear,
 )
-from flashinfer.gemm.gemm_svdquant import SVDQUANT_LORA_RANK
+from flashinfer.gemm.gemm_svdquant import SVDQUANT_LORA_RANK_GRANULARITY
 from flashinfer.testing.utils import bench_gpu_time
 from flashinfer.utils import get_compute_capability
 
@@ -33,10 +36,8 @@ from flashinfer.utils import get_compute_capability
 NK_SHAPES = [(3072, 3072), (12288, 3072), (3072, 12288)]
 M_VALUES = [4096, 6889, 9216, 16384]
 
-_RANK = SVDQUANT_LORA_RANK
 
-
-def _build_case(m, n, k, device):
+def _build_case(m, n, k, rank, device):
     """Build all operands for one problem once (outside the timed region)."""
     x = torch.randn(m, k, dtype=torch.bfloat16, device=device) / (k**0.25)
     pqs = (
@@ -65,9 +66,9 @@ def _build_case(m, n, k, device):
     xq = xq.view(torch.uint8)
     x_sf = x_sf.view(torch.uint8)
 
-    lora_a = torch.randn(_RANK, k, dtype=torch.bfloat16, device=device) / (k**0.25)
-    l2t_smoothed = (pqs.unsqueeze(1) * lora_a.t()).contiguous()  # [k, RANK]
-    lora_b = torch.randn(n, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    lora_a = torch.randn(rank, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    l2t_smoothed = (pqs.unsqueeze(1) * lora_a.t()).contiguous()  # [k, rank]
+    lora_b = torch.randn(n, rank, dtype=torch.bfloat16, device=device) / (rank**0.25)
     l1_scaled = (lora_b.float() / alpha).to(torch.bfloat16).contiguous()
     d = torch.mm(x, l2t_smoothed)  # LoRA-down output for the fused-GEMM-only path
     bias = torch.randn(n, dtype=torch.bfloat16, device=device).contiguous()
@@ -96,8 +97,8 @@ def _median_us(times_ms):
     return float(np.median(times_ms) * 1000.0)
 
 
-def bench_one(m, n, k, device):
-    c = _build_case(m, n, k, device)
+def bench_one(m, n, k, rank, device):
+    c = _build_case(m, n, k, rank, device)
 
     def run_fused():
         mm_nvfp4_svdquant(
@@ -163,6 +164,15 @@ def bench_one(m, n, k, device):
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ranks",
+        type=lambda s: [int(r) for r in s.split(",")],
+        default=[SVDQUANT_LORA_RANK_GRANULARITY],
+        help="comma-separated LoRA ranks to sweep (positive multiples of 32)",
+    )
+    args = parser.parse_args()
+
     if not torch.cuda.is_available():
         print("CUDA is not available; this benchmark requires an SM100-class GPU.")
         sys.exit(1)
@@ -180,21 +190,22 @@ def main():
     print("Timing: median GPU time in us (CUPTI preferred, CUDA-event fallback)\n")
 
     header = (
-        f"{'n':>6} {'k':>6} {'m':>6} | {'fused GEMM':>12} {'svdq linear':>12} "
-        f"{'mm_fp4':>12} | {'fused/mm_fp4':>12}"
+        f"{'n':>6} {'k':>6} {'m':>6} {'rank':>5} | {'fused GEMM':>12} "
+        f"{'svdq linear':>12} {'mm_fp4':>12} | {'fused/mm_fp4':>12}"
     )
     print(header)
     print("-" * len(header))
 
-    for n, k in NK_SHAPES:
-        for m in M_VALUES:
-            fused_us, linear_us, mm_fp4_us = bench_one(m, n, k, device)
-            ratio = fused_us / mm_fp4_us if mm_fp4_us > 0 else float("nan")
-            print(
-                f"{n:>6} {k:>6} {m:>6} | {fused_us:>12.2f} {linear_us:>12.2f} "
-                f"{mm_fp4_us:>12.2f} | {ratio:>12.3f}"
-            )
-        print("-" * len(header))
+    for rank in args.ranks:
+        for n, k in NK_SHAPES:
+            for m in M_VALUES:
+                fused_us, linear_us, mm_fp4_us = bench_one(m, n, k, rank, device)
+                ratio = fused_us / mm_fp4_us if mm_fp4_us > 0 else float("nan")
+                print(
+                    f"{n:>6} {k:>6} {m:>6} {rank:>5} | {fused_us:>12.2f} "
+                    f"{linear_us:>12.2f} {mm_fp4_us:>12.2f} | {ratio:>12.3f}"
+                )
+            print("-" * len(header))
 
 
 if __name__ == "__main__":

--- a/benchmarks/bench_nvfp4_svdquant_gemm.py
+++ b/benchmarks/bench_nvfp4_svdquant_gemm.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Benchmark for the SM100 NVFP4 SVDQuant fused GEMM (Qwen-Image linear shapes).
+
+For every (n, k) x m problem this script times three things after autotuning:
+  1. mm_nvfp4_svdquant : fused residual NVFP4 GEMM + rank-32 BF16 LoRA-up + bias
+  2. svdquant_linear   : the full chain (nvfp4_quantize_smooth -> bf16 LoRA-down
+                         GEMM -> fused GEMM)
+  3. mm_fp4 (cutlass)  : the stock NVFP4 GEMM on the same residual operands
+                         (no LoRA correction), as the lower-bound baseline
+
+Timing uses flashinfer.testing bench_gpu_time (CUPTI preferred, automatic
+fallback to CUDA events).
+"""
+
+import sys
+
+import numpy as np
+import torch
+
+from flashinfer import (
+    SfLayout,
+    autotune,
+    mm_fp4,
+    mm_nvfp4_svdquant,
+    nvfp4_quantize,
+    svdquant_linear,
+)
+from flashinfer.gemm.gemm_svdquant import SVDQUANT_LORA_RANK
+from flashinfer.testing.utils import bench_gpu_time
+from flashinfer.utils import get_compute_capability
+
+# Qwen-Image DiT linear shapes: (n, k) per layer type, m image-token counts.
+NK_SHAPES = [(3072, 3072), (12288, 3072), (3072, 12288)]
+M_VALUES = [4096, 6889, 9216, 16384]
+
+_RANK = SVDQUANT_LORA_RANK
+
+
+def _build_case(m, n, k, device):
+    """Build all operands for one problem once (outside the timed region)."""
+    x = torch.randn(m, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    pqs = (
+        (1.0 + 0.3 * torch.randn(k, dtype=torch.bfloat16, device=device))
+        .abs()
+        .contiguous()
+    )
+    smoothed = (x * pqs).to(torch.bfloat16)
+    global_sf = (
+        ((448.0 * 6.0) / smoothed.float().abs().nan_to_num().max())
+        .reshape(1)
+        .contiguous()
+    )
+
+    w = torch.randn(n, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    gw = ((448.0 * 6.0) / w.float().abs().nan_to_num().max()).reshape(1)
+    wq, w_sf = nvfp4_quantize(w, gw, sfLayout=SfLayout.layout_128x4, do_shuffle=False)
+    wq = wq.view(torch.uint8)
+    w_sf = w_sf.view(torch.uint8)
+    alpha = (1.0 / (global_sf * gw)).reshape(1).float()
+
+    # Quantized activation (byte-identical to nvfp4_quantize_smooth(x, pqs, gs)).
+    xq, x_sf = nvfp4_quantize(
+        smoothed, global_sf, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    xq = xq.view(torch.uint8)
+    x_sf = x_sf.view(torch.uint8)
+
+    lora_a = torch.randn(_RANK, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    l2t_smoothed = (pqs.unsqueeze(1) * lora_a.t()).contiguous()  # [k, RANK]
+    lora_b = torch.randn(n, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    l1_scaled = (lora_b.float() / alpha).to(torch.bfloat16).contiguous()
+    d = torch.mm(x, l2t_smoothed)  # LoRA-down output for the fused-GEMM-only path
+    bias = torch.randn(n, dtype=torch.bfloat16, device=device).contiguous()
+
+    return {
+        "x": x,
+        "pqs": pqs,
+        "global_sf": global_sf,
+        "xq": xq,
+        "x_sf": x_sf,  # 2-D swizzled layout (mm_fp4 convention)
+        "x_sf_flat": x_sf.reshape(-1),  # 1-D buffer (fused-kernel convention)
+        "wq": wq,
+        "w_sf": w_sf,
+        "w_sf_flat": w_sf.reshape(-1),
+        "alpha": alpha,
+        "l2t_smoothed": l2t_smoothed,
+        "l1_scaled": l1_scaled,
+        "d": d,
+        "bias": bias,
+        "out_fused": torch.empty(m, n, dtype=torch.bfloat16, device=device),
+        "out_fp4": torch.empty(m, n, dtype=torch.bfloat16, device=device),
+    }
+
+
+def _median_us(times_ms):
+    return float(np.median(times_ms) * 1000.0)
+
+
+def bench_one(m, n, k, device):
+    c = _build_case(m, n, k, device)
+
+    def run_fused():
+        mm_nvfp4_svdquant(
+            c["xq"],
+            c["wq"],
+            c["x_sf_flat"],
+            c["w_sf_flat"],
+            c["alpha"],
+            c["d"],
+            c["l1_scaled"],
+            bias=c["bias"],
+            out=c["out_fused"],
+        )
+
+    def run_linear():
+        svdquant_linear(
+            c["x"],
+            c["wq"],
+            c["w_sf_flat"],
+            c["alpha"],
+            c["pqs"],
+            c["l2t_smoothed"],
+            c["l1_scaled"],
+            c["global_sf"],
+            bias=c["bias"],
+        )
+
+    def run_mm_fp4():
+        mm_fp4(
+            c["xq"],
+            c["wq"].T,
+            c["x_sf"],
+            c["w_sf"].T,
+            c["alpha"],
+            torch.bfloat16,
+            c["out_fp4"],
+            block_size=16,
+            use_8x4_sf_layout=False,
+            backend="cutlass",
+            use_nvfp4=True,
+        )
+
+    # Tune once; subsequent calls replay the best tactic from the tuner cache.
+    with autotune(True):
+        for _ in range(3):
+            run_fused()
+            run_linear()
+            run_mm_fp4()
+    torch.cuda.synchronize()
+
+    bench_kwargs = dict(
+        dry_run_time_ms=100,
+        repeat_time_ms=500,
+        use_cuda_graph=True,
+        enable_cupti=True,
+        cold_l2_cache=True,
+    )
+    fused_us = _median_us(bench_gpu_time(run_fused, **bench_kwargs))
+    linear_us = _median_us(bench_gpu_time(run_linear, **bench_kwargs))
+    mm_fp4_us = _median_us(bench_gpu_time(run_mm_fp4, **bench_kwargs))
+
+    return fused_us, linear_us, mm_fp4_us
+
+
+def main():
+    if not torch.cuda.is_available():
+        print("CUDA is not available; this benchmark requires an SM100-class GPU.")
+        sys.exit(1)
+    major, minor = get_compute_capability(torch.device(device="cuda"))
+    if major != 10:
+        print(
+            "NVFP4 SVDQuant kernels require SM100-class GPUs (Blackwell); "
+            f"got SM{major}{minor}. Exiting."
+        )
+        sys.exit(1)
+
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    print(f"Device: {torch.cuda.get_device_name(device)} (SM{major}{minor})")
+    print("Timing: median GPU time in us (CUPTI preferred, CUDA-event fallback)\n")
+
+    header = (
+        f"{'n':>6} {'k':>6} {'m':>6} | {'fused GEMM':>12} {'svdq linear':>12} "
+        f"{'mm_fp4':>12} | {'fused/mm_fp4':>12}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for n, k in NK_SHAPES:
+        for m in M_VALUES:
+            fused_us, linear_us, mm_fp4_us = bench_one(m, n, k, device)
+            ratio = fused_us / mm_fp4_us if mm_fp4_us > 0 else float("nan")
+            print(
+                f"{n:>6} {k:>6} {m:>6} | {fused_us:>12.2f} {linear_us:>12.2f} "
+                f"{mm_fp4_us:>12.2f} | {ratio:>12.3f}"
+            )
+        print("-" * len(header))
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/nvfp4_smooth_quantize_sm100.cu
+++ b/csrc/nvfp4_smooth_quantize_sm100.cu
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "flashinfer/gemm/nvfp4_smooth_quantize_sm100.cuh"
+#include "tvm_ffi_utils.h"
+
+namespace torch_ext {
+
+namespace {
+
+int32_t getMultiProcessorCount(int32_t device_index) {
+  static thread_local int32_t cached_multi_processor_count = -1;
+  static thread_local int32_t cached_device_index = -1;
+
+  if (device_index == cached_device_index && cached_multi_processor_count != -1) {
+    return cached_multi_processor_count;
+  }
+  int32_t count;
+  cudaError_t cudaStatus =
+      cudaDeviceGetAttribute(&count, cudaDevAttrMultiProcessorCount, device_index);
+  TVM_FFI_ICHECK(cudaStatus == cudaSuccess)
+      << "Failed to get device attribute: " << cudaGetErrorString(cudaStatus);
+  cached_multi_processor_count = count;
+  cached_device_index = device_index;
+  return count;
+}
+
+}  // namespace
+
+// (xq, sf) = NVFP4-quantize(x * pqs) in one pass: the per-input-channel pre_quant_scale smoothing
+// is fused into the quantize -- byte-identical to a separate x_hat = x*s elementwise pass followed
+// by fp4_quantize. x [m, n] bf16, pqs [n] bf16, global_scale f32 (numel >= 1, the per-tensor
+// scale). Outputs are caller-allocated: xq [m, n/2] uint8 (packed e2m1), sf uint8 with numel >=
+// ceil(m/128)*128 * ceil((n/16)/4)*4 (swizzled 128x4 UE4M3 block scales, vec size 16). SM100+.
+void nvfp4_quantize_smooth(TensorView x, TensorView pqs, TensorView global_scale, TensorView xq,
+                           TensorView sf, bool enable_pdl) {
+  CHECK_INPUT_AND_TYPE(x, dl_bfloat16);
+  CHECK_INPUT_AND_TYPE(pqs, dl_bfloat16);
+  CHECK_INPUT_AND_TYPE(global_scale, dl_float32);
+  CHECK_INPUT_AND_TYPE(xq, dl_uint8);
+  CHECK_INPUT_AND_TYPE(sf, dl_uint8);
+  CHECK_DEVICE(pqs, x);
+  CHECK_DEVICE(global_scale, x);
+  CHECK_DEVICE(xq, x);
+  CHECK_DEVICE(sf, x);
+
+  TVM_FFI_ICHECK_EQ(x.ndim(), 2) << "x must be [m, n]";
+  int const m = static_cast<int>(x.size(0));
+  int const n = static_cast<int>(x.size(1));
+  TVM_FFI_ICHECK_EQ(n % 16, 0) << "n must be divisible by 16 (NVFP4 SF vector size)";
+  TVM_FFI_ICHECK_EQ(pqs.numel(), n) << "pqs must have n elements";
+  TVM_FFI_ICHECK_GE(global_scale.numel(), 1) << "global_scale must contain at least one element";
+
+  TVM_FFI_ICHECK_EQ(xq.ndim(), 2) << "xq must be [m, n/2]";
+  TVM_FFI_ICHECK_EQ(xq.size(0), m) << "xq must be [m, n/2]";
+  TVM_FFI_ICHECK_EQ(xq.size(1), n / 2) << "xq must be [m, n/2]";
+  // Swizzled 128x4 SF layout: rows padded to a multiple of 128, SF columns (n/16) to a multiple
+  // of 4.
+  int64_t const sfSize =
+      static_cast<int64_t>((m + 128 - 1) / 128 * 128) * ((n / 16 + 4 - 1) / 4 * 4);
+  TVM_FFI_ICHECK_GE(sf.numel(), sfSize)
+      << "sf is smaller than the required swizzled scale layout (" << sfSize << " bytes)";
+
+  int const smCount = getMultiProcessorCount(x.device().device_id);
+  auto stream = get_stream(x.device());
+  flashinfer::gemm::nvfp4_smooth_quantize(
+      xq.data_ptr(), sf.data_ptr(), x.data_ptr(), pqs.data_ptr(),
+      static_cast<float const*>(global_scale.data_ptr()), m, n, smCount, stream, enable_pdl);
+}
+
+}  // namespace torch_ext
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(nvfp4_quantize_smooth, torch_ext::nvfp4_quantize_smooth);

--- a/csrc/nvfp4_svdquant_gemm_cutlass_sm100.cu
+++ b/csrc/nvfp4_svdquant_gemm_cutlass_sm100.cu
@@ -16,8 +16,9 @@
  */
 // TVM-FFI binding for the SM100 SVDQuant fused NVFP4 GEMM:
 //   nvfp4_svdquant_gemm : out = alpha * (A @ Bᵀ) + (D @ L1ᵀ) [+ bias], the residual NVFP4 GEMM
-//                         fused with the rank-32 LoRA-up via a 2nd bf16 tcgen05 MMA in the same
+//                         fused with the rank-r LoRA-up via a 2nd bf16 tcgen05 MMA in the same
 //                         TMEM accumulator (custom CUTLASS SM100 block-scaled collective).
+//                         r is inferred from d/l1 and must be a positive multiple of 32.
 //   nvfp4_svdquant_gemm_tactic_num : number of kernel tactics for the autotuner.
 
 #include <cuda_fp16.h>
@@ -73,42 +74,42 @@ size_t nvfp4_svdquant_gemm_workspace_size(int m, int n, int k, int tactic) {
 // collective. 1/alpha folded into L1 so the epilogue yields alpha*residual + D@L1ᵀ + bias.
 void nvfp4_svdquant_gemm_run(void* out, void const* A, void const* B, void const* sfa,
                              void const* sfb, float const* alpha, void const* D, void const* L1,
-                             void const* bias, int m, int n, int k, char* ws, size_t wsBytes,
-                             cudaStream_t stream, int tactic, bool enable_pdl) {
+                             void const* bias, int m, int n, int k, int lora_rank, char* ws,
+                             size_t wsBytes, cudaStream_t stream, int tactic, bool enable_pdl) {
   RuntimeTactic const runtime_tactic = resolve_tactic(tactic);
   switch (runtime_tactic.kernel_shape) {
     case KernelShape::k1Sm128x256x128:
       return svdquant_detail::run_tactic<svdquant_detail::Tactic1Sm128x256x128Config>(
-          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
-          enable_pdl);
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, lora_rank, ws, wsBytes, stream,
+          runtime_tactic, enable_pdl);
     case KernelShape::k2Sm256x256x128:
       return svdquant_detail::run_tactic<svdquant_detail::Tactic2Sm256x256x128Config>(
-          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
-          enable_pdl);
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, lora_rank, ws, wsBytes, stream,
+          runtime_tactic, enable_pdl);
     case KernelShape::k1Sm128x128x128:
       return svdquant_detail::run_tactic<svdquant_detail::Tactic1Sm128x128x128Config>(
-          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
-          enable_pdl);
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, lora_rank, ws, wsBytes, stream,
+          runtime_tactic, enable_pdl);
     case KernelShape::k2Sm256x192x128:
       return svdquant_detail::run_tactic<svdquant_detail::Tactic2Sm256x192x128Config>(
-          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
-          enable_pdl);
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, lora_rank, ws, wsBytes, stream,
+          runtime_tactic, enable_pdl);
     case KernelShape::k1Sm128x64x128:
       return svdquant_detail::run_tactic<svdquant_detail::Tactic1Sm128x64x128Config>(
-          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
-          enable_pdl);
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, lora_rank, ws, wsBytes, stream,
+          runtime_tactic, enable_pdl);
     case KernelShape::k1Sm128x128x256:
       return svdquant_detail::run_tactic<svdquant_detail::Tactic1Sm128x128x256Config>(
-          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
-          enable_pdl);
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, lora_rank, ws, wsBytes, stream,
+          runtime_tactic, enable_pdl);
     case KernelShape::k2Sm256x128x256:
       return svdquant_detail::run_tactic<svdquant_detail::Tactic2Sm256x128x256Config>(
-          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
-          enable_pdl);
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, lora_rank, ws, wsBytes, stream,
+          runtime_tactic, enable_pdl);
     case KernelShape::k2Sm256x256x256:
       return svdquant_detail::run_tactic<svdquant_detail::Tactic2Sm256x256x256Config>(
-          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
-          enable_pdl);
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, lora_rank, ws, wsBytes, stream,
+          runtime_tactic, enable_pdl);
   }
   throw std::invalid_argument("nvfp4_svdquant_gemm_run: invalid kernel shape");
 }
@@ -133,8 +134,9 @@ inline int64_t swizzled_sf_size(int64_t rows, int64_t sfCols) {
 
 // out = alpha * (A @ Bᵀ) + (D @ L1ᵀ) [+ bias]. a = quant(x_hat) [m, k/2] uint8, b [n, k/2] uint8
 // (packed e2m1), a_sf/b_sf swizzled UE4M3 block scales, alpha f32[1] (residual dequant scale).
-// D [m, 32] = x_hat @ L2ᵀ (bf16) and L1 [n, 32] = svdquant_lora_b / alpha (bf16; 1/alpha folded so
-// the epilogue out = alpha * acc yields the LoRA). out [m, n] bf16, allocated by the caller.
+// D [m, r] = x_hat @ L2ᵀ (bf16) and L1 [n, r] = svdquant_lora_b / alpha (bf16; 1/alpha folded so
+// the epilogue out = alpha * acc yields the LoRA); the LoRA rank r is inferred from d/l1 and must
+// be a positive multiple of 32. out [m, n] bf16, allocated by the caller.
 void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView b_sf,
                          TensorView alpha, TensorView d, TensorView l1,
                          Optional<TensorView> const& bias, TensorView out,
@@ -169,12 +171,15 @@ void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView
       << "a_sf is smaller than the required swizzled scale layout";
   TVM_FFI_ICHECK_GE(b_sf.numel(), swizzled_sf_size(n, k / 16))
       << "b_sf is smaller than the required swizzled scale layout";
-  TVM_FFI_ICHECK(d.ndim() == 2 && d.size(0) == m && d.size(1) == 32)
-      << "d must have shape [m, 32] (rank-32 LoRA-down output)";
+  TVM_FFI_ICHECK(d.ndim() == 2 && d.size(0) == m)
+      << "d must have shape [m, r] (rank-r LoRA-down output)";
+  int64_t const loraRank = d.size(1);
+  TVM_FFI_ICHECK(loraRank >= 32 && loraRank % 32 == 0)
+      << "the LoRA rank (d/l1 inner dimension) must be a positive multiple of 32, got " << loraRank;
   TVM_FFI_ICHECK_EQ(reinterpret_cast<std::uintptr_t>(d.data_ptr()) % 16, 0)
       << "d must be 16-byte aligned for TMA";
-  TVM_FFI_ICHECK(l1.ndim() == 2 && l1.size(0) == n && l1.size(1) == 32)
-      << "l1 must have shape [n, 32] (rank-32 LoRA-up weight, pre-divided by alpha)";
+  TVM_FFI_ICHECK(l1.ndim() == 2 && l1.size(0) == n && l1.size(1) == loraRank)
+      << "l1 must have shape [n, r] with the same LoRA rank as d (pre-divided by alpha)";
   TVM_FFI_ICHECK_EQ(reinterpret_cast<std::uintptr_t>(l1.data_ptr()) % 16, 0)
       << "l1 must be 16-byte aligned for TMA";
   TVM_FFI_ICHECK(out.ndim() == 2 && out.size(0) == m && out.size(1) == n)
@@ -206,7 +211,7 @@ void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView
     flashinfer::gemm::nvfp4_svdquant_gemm_run(
         out.data_ptr(), a.data_ptr(), b.data_ptr(), a_sf.data_ptr(), b_sf.data_ptr(),
         static_cast<float const*>(alpha.data_ptr()), d.data_ptr(), l1.data_ptr(), biasPtr,
-        static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
+        static_cast<int>(m), static_cast<int>(n), static_cast<int>(k), static_cast<int>(loraRank),
         reinterpret_cast<char*>(workspace), requiredWorkspaceBytes, stream, tacticId, enable_pdl);
   };
 

--- a/csrc/nvfp4_svdquant_gemm_cutlass_sm100.cu
+++ b/csrc/nvfp4_svdquant_gemm_cutlass_sm100.cu
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// TVM-FFI binding for the SM100 SVDQuant fused NVFP4 GEMM:
+//   nvfp4_svdquant_gemm : out = alpha * (A @ Bᵀ) + (D @ L1ᵀ) [+ bias], the residual NVFP4 GEMM
+//                         fused with the rank-32 LoRA-up via a 2nd bf16 tcgen05 MMA in the same
+//                         TMEM accumulator (custom CUTLASS SM100 block-scaled collective).
+//   nvfp4_svdquant_gemm_tactic_num : number of kernel tactics for the autotuner.
+
+#include <cuda_fp16.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "flashinfer/gemm/nvfp4_svdquant_gemm_cutlass.h"
+#include "flashinfer/gemm/nvfp4_svdquant_gemm_template_sm100.h"
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::Optional;
+
+namespace flashinfer {
+namespace gemm {
+
+using svdquant_detail::KernelShape;
+using svdquant_detail::resolve_tactic;
+using svdquant_detail::RuntimeTactic;
+
+size_t nvfp4_svdquant_gemm_workspace_size(int m, int n, int k, int tactic) {
+  RuntimeTactic const runtime_tactic = resolve_tactic(tactic);
+  switch (runtime_tactic.kernel_shape) {
+    case KernelShape::k1Sm128x256x128:
+      return svdquant_detail::workspace_size_for_tactic<
+          svdquant_detail::Tactic1Sm128x256x128Config>(m, n, k, runtime_tactic);
+    case KernelShape::k2Sm256x256x128:
+      return svdquant_detail::workspace_size_for_tactic<
+          svdquant_detail::Tactic2Sm256x256x128Config>(m, n, k, runtime_tactic);
+    case KernelShape::k1Sm128x128x128:
+      return svdquant_detail::workspace_size_for_tactic<
+          svdquant_detail::Tactic1Sm128x128x128Config>(m, n, k, runtime_tactic);
+    case KernelShape::k2Sm256x192x128:
+      return svdquant_detail::workspace_size_for_tactic<
+          svdquant_detail::Tactic2Sm256x192x128Config>(m, n, k, runtime_tactic);
+    case KernelShape::k1Sm128x64x128:
+      return svdquant_detail::workspace_size_for_tactic<svdquant_detail::Tactic1Sm128x64x128Config>(
+          m, n, k, runtime_tactic);
+    case KernelShape::k1Sm128x128x256:
+      return svdquant_detail::workspace_size_for_tactic<
+          svdquant_detail::Tactic1Sm128x128x256Config>(m, n, k, runtime_tactic);
+    case KernelShape::k2Sm256x128x256:
+      return svdquant_detail::workspace_size_for_tactic<
+          svdquant_detail::Tactic2Sm256x128x256Config>(m, n, k, runtime_tactic);
+    case KernelShape::k2Sm256x256x256:
+      return svdquant_detail::workspace_size_for_tactic<
+          svdquant_detail::Tactic2Sm256x256x256Config>(m, n, k, runtime_tactic);
+  }
+  throw std::invalid_argument("nvfp4_svdquant_gemm_workspace_size: invalid kernel shape");
+}
+
+// Fused residual NVFP4 GEMM + rank-r LoRA-up: D @ L1ᵀ via the 2nd bf16 tcgen05 MMA in the custom
+// collective. 1/alpha folded into L1 so the epilogue yields alpha*residual + D@L1ᵀ + bias.
+void nvfp4_svdquant_gemm_run(void* out, void const* A, void const* B, void const* sfa,
+                             void const* sfb, float const* alpha, void const* D, void const* L1,
+                             void const* bias, int m, int n, int k, char* ws, size_t wsBytes,
+                             cudaStream_t stream, int tactic, bool enable_pdl) {
+  RuntimeTactic const runtime_tactic = resolve_tactic(tactic);
+  switch (runtime_tactic.kernel_shape) {
+    case KernelShape::k1Sm128x256x128:
+      return svdquant_detail::run_tactic<svdquant_detail::Tactic1Sm128x256x128Config>(
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
+          enable_pdl);
+    case KernelShape::k2Sm256x256x128:
+      return svdquant_detail::run_tactic<svdquant_detail::Tactic2Sm256x256x128Config>(
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
+          enable_pdl);
+    case KernelShape::k1Sm128x128x128:
+      return svdquant_detail::run_tactic<svdquant_detail::Tactic1Sm128x128x128Config>(
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
+          enable_pdl);
+    case KernelShape::k2Sm256x192x128:
+      return svdquant_detail::run_tactic<svdquant_detail::Tactic2Sm256x192x128Config>(
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
+          enable_pdl);
+    case KernelShape::k1Sm128x64x128:
+      return svdquant_detail::run_tactic<svdquant_detail::Tactic1Sm128x64x128Config>(
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
+          enable_pdl);
+    case KernelShape::k1Sm128x128x256:
+      return svdquant_detail::run_tactic<svdquant_detail::Tactic1Sm128x128x256Config>(
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
+          enable_pdl);
+    case KernelShape::k2Sm256x128x256:
+      return svdquant_detail::run_tactic<svdquant_detail::Tactic2Sm256x128x256Config>(
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
+          enable_pdl);
+    case KernelShape::k2Sm256x256x256:
+      return svdquant_detail::run_tactic<svdquant_detail::Tactic2Sm256x256x256Config>(
+          out, A, B, sfa, sfb, alpha, D, L1, bias, m, n, k, ws, wsBytes, stream, runtime_tactic,
+          enable_pdl);
+  }
+  throw std::invalid_argument("nvfp4_svdquant_gemm_run: invalid kernel shape");
+}
+
+}  // namespace gemm
+}  // namespace flashinfer
+
+namespace torch_ext {
+
+namespace {
+
+constexpr auto FLOAT4_E2M1X2 = dl_uint8;  // packed e2m1
+constexpr auto SF_DTYPE = dl_uint8;       // swizzled ue4m3 block scales
+
+// ceil(rows / 128) * 128 * ceil(cols / 4) * 4, the 128x4-swizzled block-scale layout size.
+inline int64_t swizzled_sf_size(int64_t rows, int64_t sfCols) {
+  auto pad = [](int64_t x, int64_t y) { return (x + y - 1) / y * y; };
+  return pad(rows, 128) * pad(sfCols, 4);
+}
+
+}  // namespace
+
+// out = alpha * (A @ Bᵀ) + (D @ L1ᵀ) [+ bias]. a = quant(x_hat) [m, k/2] uint8, b [n, k/2] uint8
+// (packed e2m1), a_sf/b_sf swizzled UE4M3 block scales, alpha f32[1] (residual dequant scale).
+// D [m, 32] = x_hat @ L2ᵀ (bf16) and L1 [n, 32] = svdquant_lora_b / alpha (bf16; 1/alpha folded so
+// the epilogue out = alpha * acc yields the LoRA). out [m, n] bf16, allocated by the caller.
+void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView b_sf,
+                         TensorView alpha, TensorView d, TensorView l1,
+                         Optional<TensorView> const& bias, TensorView out,
+                         TensorView workspace_buffer, int64_t tactic, bool enable_pdl) {
+  CHECK_INPUT_AND_TYPE(a, FLOAT4_E2M1X2);
+  CHECK_INPUT_AND_TYPE(b, FLOAT4_E2M1X2);
+  CHECK_INPUT_AND_TYPE(a_sf, SF_DTYPE);
+  CHECK_INPUT_AND_TYPE(b_sf, SF_DTYPE);
+  CHECK_INPUT_AND_TYPE(alpha, dl_float32);
+  CHECK_INPUT_AND_TYPE(d, dl_bfloat16);
+  CHECK_INPUT_AND_TYPE(l1, dl_bfloat16);
+
+  TVM_FFI_ICHECK_EQ(a.ndim(), 2) << "a must be [m, k/2]";
+  TVM_FFI_ICHECK_EQ(b.ndim(), 2) << "b must be [n, k/2]";
+  int64_t const m = a.size(0);
+  int64_t const kPacked = a.size(1);
+  int64_t const k = kPacked * 2;
+  int64_t const n = b.size(0);
+  TVM_FFI_ICHECK_EQ(b.size(1), kPacked) << "a and b inner dimensions mismatch";
+  TVM_FFI_ICHECK(n % 32 == 0 && k % 32 == 0) << "n and k must be divisible by 32";
+  TVM_FFI_ICHECK_GE(alpha.numel(), 1) << "alpha must contain at least one element";
+  TVM_FFI_ICHECK_GE(a_sf.numel(), swizzled_sf_size(m, k / 16))
+      << "a_sf is smaller than the required swizzled scale layout";
+  TVM_FFI_ICHECK_GE(b_sf.numel(), swizzled_sf_size(n, k / 16))
+      << "b_sf is smaller than the required swizzled scale layout";
+  TVM_FFI_ICHECK(d.ndim() == 2 && d.size(0) == m && d.size(1) == 32)
+      << "d must have shape [m, 32] (rank-32 LoRA-down output)";
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<std::uintptr_t>(d.data_ptr()) % 16, 0)
+      << "d must be 16-byte aligned for TMA";
+  TVM_FFI_ICHECK(l1.ndim() == 2 && l1.size(0) == n && l1.size(1) == 32)
+      << "l1 must have shape [n, 32] (rank-32 LoRA-up weight, pre-divided by alpha)";
+  TVM_FFI_ICHECK(out.ndim() == 2 && out.size(0) == m && out.size(1) == n)
+      << "out must have shape [m, n]";
+  TVM_FFI_ICHECK_EQ(encode_dlpack_dtype(out.dtype()), bfloat16_code)
+      << "nvfp4_svdquant_gemm currently supports bf16 output only";
+
+  void const* biasPtr = nullptr;
+  if (bias.has_value()) {
+    auto const& biasTensor = bias.value();
+    CHECK_INPUT_AND_TYPE(biasTensor, dl_bfloat16);
+    TVM_FFI_ICHECK(biasTensor.ndim() == 1 && biasTensor.size(0) == n) << "bias must have shape [n]";
+    biasPtr = biasTensor.data_ptr();
+  }
+
+  TVM_FFI_ICHECK(tactic >= -1 && tactic < flashinfer::gemm::kNvfp4SvdquantGemmNumTactics)
+      << "invalid NVFP4 SVDQuant tactic: " << tactic;
+  int const tacticId = tactic < 0 ? 0 : static_cast<int>(tactic);
+
+  size_t const requiredWorkspaceBytes = flashinfer::gemm::nvfp4_svdquant_gemm_workspace_size(
+      static_cast<int>(m), static_cast<int>(n), static_cast<int>(k), tacticId);
+  auto stream = get_stream(a.device());
+
+  auto runKernel = [&](void* workspace) {
+    flashinfer::gemm::nvfp4_svdquant_gemm_run(
+        out.data_ptr(), a.data_ptr(), b.data_ptr(), a_sf.data_ptr(), b_sf.data_ptr(),
+        static_cast<float const*>(alpha.data_ptr()), d.data_ptr(), l1.data_ptr(), biasPtr,
+        static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
+        reinterpret_cast<char*>(workspace), requiredWorkspaceBytes, stream, tacticId, enable_pdl);
+  };
+
+  int64_t const provided_workspace_size =
+      workspace_buffer.numel() * get_element_size(workspace_buffer);
+  if (provided_workspace_size < static_cast<int64_t>(requiredWorkspaceBytes)) {
+    Tensor new_workspace = alloc_tensor({static_cast<int64_t>(requiredWorkspaceBytes)},
+                                        DLDataType{kDLInt, 8, 1}, a.device());
+    runKernel(new_workspace.data_ptr());
+  } else {
+    runKernel(workspace_buffer.data_ptr());
+  }
+}
+
+int64_t nvfp4_svdquant_gemm_tactic_num() { return flashinfer::gemm::kNvfp4SvdquantGemmNumTactics; }
+
+}  // namespace torch_ext
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(nvfp4_svdquant_gemm, torch_ext::nvfp4_svdquant_gemm);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(nvfp4_svdquant_gemm_tactic_num,
+                              torch_ext::nvfp4_svdquant_gemm_tactic_num);

--- a/csrc/nvfp4_svdquant_gemm_cutlass_sm100.cu
+++ b/csrc/nvfp4_svdquant_gemm_cutlass_sm100.cu
@@ -146,6 +146,14 @@ void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView
   CHECK_INPUT_AND_TYPE(alpha, dl_float32);
   CHECK_INPUT_AND_TYPE(d, dl_bfloat16);
   CHECK_INPUT_AND_TYPE(l1, dl_bfloat16);
+  CHECK_DEVICE(b, a);
+  CHECK_DEVICE(a_sf, a);
+  CHECK_DEVICE(b_sf, a);
+  CHECK_DEVICE(alpha, a);
+  CHECK_DEVICE(d, a);
+  CHECK_DEVICE(l1, a);
+  CHECK_DEVICE(out, a);
+  CHECK_DEVICE(workspace_buffer, a);
 
   TVM_FFI_ICHECK_EQ(a.ndim(), 2) << "a must be [m, k/2]";
   TVM_FFI_ICHECK_EQ(b.ndim(), 2) << "b must be [n, k/2]";
@@ -154,6 +162,7 @@ void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView
   int64_t const k = kPacked * 2;
   int64_t const n = b.size(0);
   TVM_FFI_ICHECK_EQ(b.size(1), kPacked) << "a and b inner dimensions mismatch";
+  TVM_FFI_ICHECK(n > 0 && k > 0) << "n and k must be positive";
   TVM_FFI_ICHECK(n % 32 == 0 && k % 32 == 0) << "n and k must be divisible by 32";
   TVM_FFI_ICHECK_GE(alpha.numel(), 1) << "alpha must contain at least one element";
   TVM_FFI_ICHECK_GE(a_sf.numel(), swizzled_sf_size(m, k / 16))
@@ -166,6 +175,8 @@ void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView
       << "d must be 16-byte aligned for TMA";
   TVM_FFI_ICHECK(l1.ndim() == 2 && l1.size(0) == n && l1.size(1) == 32)
       << "l1 must have shape [n, 32] (rank-32 LoRA-up weight, pre-divided by alpha)";
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<std::uintptr_t>(l1.data_ptr()) % 16, 0)
+      << "l1 must be 16-byte aligned for TMA";
   TVM_FFI_ICHECK(out.ndim() == 2 && out.size(0) == m && out.size(1) == n)
       << "out must have shape [m, n]";
   TVM_FFI_ICHECK_EQ(encode_dlpack_dtype(out.dtype()), bfloat16_code)
@@ -175,6 +186,7 @@ void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView
   if (bias.has_value()) {
     auto const& biasTensor = bias.value();
     CHECK_INPUT_AND_TYPE(biasTensor, dl_bfloat16);
+    CHECK_DEVICE(biasTensor, a);
     TVM_FFI_ICHECK(biasTensor.ndim() == 1 && biasTensor.size(0) == n) << "bias must have shape [n]";
     biasPtr = biasTensor.data_ptr();
   }
@@ -182,6 +194,9 @@ void nvfp4_svdquant_gemm(TensorView a, TensorView b, TensorView a_sf, TensorView
   TVM_FFI_ICHECK(tactic >= -1 && tactic < flashinfer::gemm::kNvfp4SvdquantGemmNumTactics)
       << "invalid NVFP4 SVDQuant tactic: " << tactic;
   int const tacticId = tactic < 0 ? 0 : static_cast<int>(tactic);
+
+  // Empty batch: out is [0, n], nothing to compute.
+  if (m == 0) return;
 
   size_t const requiredWorkspaceBytes = flashinfer::gemm::nvfp4_svdquant_gemm_workspace_size(
       static_cast<int>(m), static_cast<int>(n), static_cast<int>(k), tacticId);

--- a/csrc/nvfp4_svdquant_gemm_cutlass_sm100.jinja
+++ b/csrc/nvfp4_svdquant_gemm_cutlass_sm100.jinja
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flashinfer/gemm/nvfp4_svdquant_gemm_template_sm100.h"
+
+namespace flashinfer {
+namespace gemm {
+namespace svdquant_detail {
+
+INSTANTIATE_NVFP4_SVDQUANT_GEMM_TACTIC({{ config }})
+
+}  // namespace svdquant_detail
+}  // namespace gemm
+}  // namespace flashinfer

--- a/docs/api/gemm.rst
+++ b/docs/api/gemm.rst
@@ -24,6 +24,16 @@ FP4 GEMM
 
     mm_fp4
 
+SVDQuant NVFP4 GEMM (SM100)
+---------------------------
+
+.. autosummary::
+    :toctree: ../generated
+
+    mm_nvfp4_svdquant
+    nvfp4_quantize_smooth
+    svdquant_linear
+
 BF16 x FP4 GEMM (W4A16)
 -----------------------
 

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -110,6 +110,9 @@ from .gemm import bmm_fp8 as bmm_fp8
 from .gemm import bmm_mxfp8 as bmm_mxfp8
 from .gemm import mm_bf16 as mm_bf16
 from .gemm import mm_fp4 as mm_fp4
+from .gemm import mm_nvfp4_svdquant as mm_nvfp4_svdquant
+from .gemm import nvfp4_quantize_smooth as nvfp4_quantize_smooth
+from .gemm import svdquant_linear as svdquant_linear
 from .gemm import mm_bf16_fp4 as mm_bf16_fp4
 from .gemm import prepare_bf16_fp4_weights as prepare_bf16_fp4_weights
 from .gemm import mm_fp8 as mm_fp8

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -77,6 +77,7 @@ from .jit.gemm import (
     gen_gemm_sm90_module,
     gen_gemm_sm100_module,
     gen_gemm_sm100_module_cutlass_fp4,
+    gen_gemm_sm100_module_cutlass_nvfp4_svdquant,
     gen_gemm_sm100_module_cutlass_fp8,
     gen_gemm_sm100_module_cutlass_mxfp8,
     gen_gemm_sm120_module,
@@ -538,6 +539,7 @@ def gen_all_modules(
             jit_specs.append(gen_cutlass_fused_moe_sm100_module())
             jit_specs.append(gen_gemm_sm100_module())
             jit_specs.append(gen_gemm_sm100_module_cutlass_fp4())
+            jit_specs.append(gen_gemm_sm100_module_cutlass_nvfp4_svdquant())
             jit_specs.append(gen_gemm_sm100_module_cutlass_fp8())
             jit_specs.append(gen_gemm_sm100_module_cutlass_mxfp8())
             # Add TGV GEMM modules for both bf16 and fp16

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -28,6 +28,12 @@ from .gemm_bf16_fp4 import (
     prepare_bf16_fp4_weights as prepare_bf16_fp4_weights,
 )
 
+from .gemm_svdquant import (
+    mm_nvfp4_svdquant as mm_nvfp4_svdquant,
+    nvfp4_quantize_smooth as nvfp4_quantize_smooth,
+    svdquant_linear as svdquant_linear,
+)
+
 from .routergemm import (
     mm_M1_16_K6144_N256 as mm_M1_16_K6144_N256,
     mm_M1_16_K7168_N128 as mm_M1_16_K7168_N128,

--- a/flashinfer/gemm/gemm_svdquant.py
+++ b/flashinfer/gemm/gemm_svdquant.py
@@ -1,0 +1,407 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from typing import List, Literal, Optional, Tuple
+
+import torch
+
+from ..api_logging import flashinfer_api
+from ..autotuner import (
+    AutoTuner,
+    ConstraintSpec,
+    DynamicTensorSpec,
+    OptimizationProfile,
+    TunableRunner,
+    TuningConfig,
+)
+from ..fused_moe.utils import (
+    get_hybrid_num_tokens_buckets,
+    map_to_hybrid_bucket_uncapped,
+)
+from ..jit.gemm import gen_gemm_sm100_module_cutlass_nvfp4_svdquant
+from ..trace.templates.gemm import mm_nvfp4_svdquant_trace
+from ..utils import (
+    _get_cache_buf,
+    backend_requirement,
+    device_support_pdl,
+    supported_compute_capability,
+)
+
+DEFAULT_WORKSPACE_SIZE = 32 * 1024 * 1024
+
+# The fused kernel accumulates the rank-32 BF16 LoRA-up into the NVFP4 residual accumulator; the
+# rank is fixed by the collective (CollectiveMmaLoRA::LoRaK).
+SVDQUANT_LORA_RANK = 32
+
+
+def _pad_up(x: int, y: int) -> int:
+    return (x + y - 1) // y * y
+
+
+def _swizzled_sf_size(rows: int, sf_cols: int) -> int:
+    """Size of the 128x4-swizzled block-scale layout for a [rows, sf_cols] scale matrix."""
+    return _pad_up(rows, 128) * _pad_up(sf_cols, 4)
+
+
+@functools.cache
+def get_nvfp4_svdquant_module():
+    """JIT-build and load the SM100 CUTLASS NVFP4 SVDQuant module."""
+    return gen_gemm_sm100_module_cutlass_nvfp4_svdquant().build_and_load()
+
+
+def _nvfp4_svdquant_gemm_runner(enable_pdl: bool):
+    module = get_nvfp4_svdquant_module()
+
+    class Nvfp4SvdquantGemmRunner(TunableRunner):
+        def get_valid_tactics(
+            self,
+            inputs: List[torch.Tensor],
+            profile: OptimizationProfile,
+        ) -> List[int]:
+            return list(range(module.nvfp4_svdquant_gemm_tactic_num()))
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic: int = -1,
+            do_preparation: bool = False,
+            **kwargs,
+        ):
+            (a, b, a_sf, b_sf, alpha, d, l1, bias, out, workspace_buffer) = inputs
+            module.nvfp4_svdquant_gemm(
+                a,
+                b,
+                a_sf,
+                b_sf,
+                alpha,
+                d,
+                l1,
+                bias,
+                out,
+                workspace_buffer,
+                tactic,
+                enable_pdl,
+            )
+            return out
+
+    return Nvfp4SvdquantGemmRunner()
+
+
+_NVFP4_SVDQUANT_GEMM_TUNING_CONFIG = TuningConfig(
+    use_cuda_graph=True,
+    use_cold_l2_cache=True,
+    dynamic_tensor_specs=(
+        DynamicTensorSpec(
+            (0,),  # a_tensor_index
+            (0,),
+            get_hybrid_num_tokens_buckets,
+            map_to_hybrid_bucket_uncapped,
+        ),
+    ),
+    constraint_specs=(
+        ConstraintSpec(
+            2,  # a_sf tensor index: 1-D 128x4-swizzled scale buffer sized by (m, k/16)
+            0,
+            lambda shapes: _swizzled_sf_size(shapes[0][0], shapes[0][1] * 2 // 16),
+        ),
+        ConstraintSpec(
+            5,  # d tensor index: [m, 32] LoRA-down output
+            0,
+            lambda shapes: shapes[0][0],
+        ),
+        ConstraintSpec(
+            8,  # out tensor index
+            0,
+            lambda shapes: shapes[0][0],
+        ),
+        ConstraintSpec(
+            9,  # workspace_buffer index: scratch; exclude its (resizable) size from the
+            0,  # cache key so a mid-tune resize never causes a silent cache miss.
+            lambda shapes: shapes[9][0],
+        ),
+    ),
+)
+
+
+@supported_compute_capability([100, 103])
+def _cutlass_nvfp4_svdquant_requirement(*args, **kwargs):
+    return True
+
+
+def _check_mm_nvfp4_svdquant_problem(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_sf: torch.Tensor,
+    b_sf: torch.Tensor,
+    alpha: torch.Tensor,
+    d: torch.Tensor,
+    l1: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    backend: Literal["cutlass"] = "cutlass",
+    enable_pdl: Optional[bool] = None,
+):
+    if a.ndim != 2 or b.ndim != 2:
+        raise ValueError("a and b must be 2-D packed-e2m1 (uint8) tensors")
+    if a.dtype != torch.uint8 or b.dtype != torch.uint8:
+        raise ValueError("a and b must be uint8 (two e2m1 values per byte)")
+    m, k_packed = a.shape
+    n = b.shape[0]
+    if b.shape[1] != k_packed:
+        raise ValueError(
+            f"a and b inner dimensions mismatch: a {tuple(a.shape)} vs b {tuple(b.shape)}"
+        )
+    k = k_packed * 2
+    if n % 32 != 0 or k % 32 != 0:
+        raise ValueError(f"n and k must be divisible by 32, got n={n}, k={k}")
+    if d.ndim != 2 or d.shape[0] != m or d.shape[1] != SVDQUANT_LORA_RANK:
+        raise ValueError(
+            f"d must have shape [m, {SVDQUANT_LORA_RANK}] (rank-{SVDQUANT_LORA_RANK} "
+            f"LoRA-down output), got {tuple(d.shape)}"
+        )
+    if l1.ndim != 2 or l1.shape[0] != n or l1.shape[1] != SVDQUANT_LORA_RANK:
+        raise ValueError(
+            f"l1 must have shape [n, {SVDQUANT_LORA_RANK}] (rank-{SVDQUANT_LORA_RANK} "
+            f"LoRA-up weight pre-divided by alpha), got {tuple(l1.shape)}"
+        )
+    if d.dtype != torch.bfloat16 or l1.dtype != torch.bfloat16:
+        raise ValueError("d and l1 must be bf16")
+    return True
+
+
+@backend_requirement(
+    {"cutlass": _cutlass_nvfp4_svdquant_requirement},
+    common_check=_check_mm_nvfp4_svdquant_problem,
+)
+@flashinfer_api(trace=mm_nvfp4_svdquant_trace)
+def mm_nvfp4_svdquant(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_sf: torch.Tensor,
+    b_sf: torch.Tensor,
+    alpha: torch.Tensor,
+    d: torch.Tensor,
+    l1: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    backend: Literal["cutlass"] = "cutlass",
+    enable_pdl: Optional[bool] = None,
+) -> torch.Tensor:
+    r"""SVDQuant fused NVFP4 GEMM (SM100): ``out = alpha * (a @ bᵀ) + d @ l1ᵀ [+ bias]``.
+
+    The block-scaled NVFP4 residual GEMM is fused with the rank-32 BF16 LoRA-up correction
+    ``d @ l1ᵀ``, computed by a second BF16 tcgen05 MMA into the same accumulator after the
+    NVFP4 K-loop, plus an optional fused per-column bias. ``1/alpha`` must be folded into
+    ``l1`` by the caller (``l1 = svdquant_lora_b / alpha``) so the epilogue
+    ``out = alpha * acc + bias`` yields the correction unscaled.
+
+    Parameters
+    ----------
+    a: torch.Tensor
+        Quantized activation, shape ``(m, k // 2)`` uint8 (packed e2m1), row-major. Produce it
+        with :func:`nvfp4_quantize_smooth` (which folds the SVDQuant ``pre_quant_scale`` into
+        the quantization).
+    b: torch.Tensor
+        Quantized residual weight, shape ``(n, k // 2)`` uint8 (packed e2m1), row-major
+        (i.e. the GEMM computes ``a @ bᵀ``).
+    a_sf: torch.Tensor
+        Activation block scales, uint8 (ue4m3) in the 128x4 swizzled layout,
+        ``numel >= ceil(m / 128) * 128 * ceil(k / 16 / 4) * 4``.
+    b_sf: torch.Tensor
+        Weight block scales, same layout as ``a_sf`` with ``n`` rows.
+    alpha: torch.Tensor
+        Per-tensor residual dequantization scale, float32, device scalar (``numel >= 1``).
+    d: torch.Tensor
+        LoRA-down output ``x_hat @ L2ᵀ``, shape ``(m, 32)`` bf16, contiguous and 16-byte
+        aligned (TMA). Compute it as ``x @ (pre_quant_scale[:, None] * L2ᵀ)`` in bf16.
+    l1: torch.Tensor
+        LoRA-up weight pre-divided by alpha, shape ``(n, 32)`` bf16.
+    bias: Optional[torch.Tensor]
+        Optional per-column bias, shape ``(n,)`` bf16, fused in the epilogue.
+    out: Optional[torch.Tensor]
+        Output tensor, shape ``(m, n)`` bf16; allocated when ``None``.
+    backend: Literal["cutlass"]
+        Only the CUTLASS backend exists.
+    enable_pdl: Optional[bool]
+        Whether to launch with Programmatic Dependent Launch. Defaults to the device default.
+
+    Returns
+    -------
+    out: torch.Tensor
+        Output tensor, shape ``(m, n)`` bf16.
+    """
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(a.device)
+    if out is None:
+        out = torch.empty(a.shape[0], b.shape[0], dtype=torch.bfloat16, device=a.device)
+    workspace_buffer = _get_cache_buf(
+        "nvfp4_svdquant_gemm_workspace", DEFAULT_WORKSPACE_SIZE, a.device
+    )
+
+    tuner = AutoTuner.get()
+    runners = [_nvfp4_svdquant_gemm_runner(enable_pdl)]
+    inputs = [a, b, a_sf, b_sf, alpha, d, l1, bias, out, workspace_buffer]
+    runner, tactic = tuner.choose_one(
+        "nvfp4_svdquant_gemm",
+        runners,
+        _NVFP4_SVDQUANT_GEMM_TUNING_CONFIG,
+        inputs,
+    )
+    runner(inputs=inputs, tactic=tactic)
+    return out
+
+
+def _check_nvfp4_quantize_smooth_problem(
+    x: torch.Tensor,
+    pre_quant_scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    enable_pdl: Optional[bool] = None,
+    backend: Literal["cutlass"] = "cutlass",
+):
+    if x.ndim != 2:
+        raise ValueError(f"x must be [m, n], got {tuple(x.shape)}")
+    if x.dtype != torch.bfloat16 or pre_quant_scale.dtype != torch.bfloat16:
+        raise ValueError("x and pre_quant_scale must be bf16")
+    if x.shape[1] % 16 != 0:
+        raise ValueError(
+            f"n must be divisible by 16 (NVFP4 SF vector size), got {x.shape[1]}"
+        )
+    if pre_quant_scale.numel() != x.shape[1]:
+        raise ValueError(
+            f"pre_quant_scale must have n={x.shape[1]} elements, got {pre_quant_scale.numel()}"
+        )
+    return True
+
+
+@backend_requirement(
+    {"cutlass": _cutlass_nvfp4_svdquant_requirement},
+    common_check=_check_nvfp4_quantize_smooth_problem,
+)
+@flashinfer_api
+def nvfp4_quantize_smooth(
+    x: torch.Tensor,
+    pre_quant_scale: torch.Tensor,
+    global_scale: torch.Tensor,
+    enable_pdl: Optional[bool] = None,
+    backend: Literal["cutlass"] = "cutlass",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Fused smooth + NVFP4 quantize: ``(xq, sf) = nvfp4-quantize(x * pre_quant_scale)``.
+
+    Applies the SVDQuant per-input-channel smoothing scale and NVFP4-quantizes in one pass
+    over the input; the result is byte-identical to quantizing ``x * pre_quant_scale`` with
+    the stock NVFP4 quantizer (ue4m3 block scales, 128x4 swizzled layout, SF vector size 16).
+
+    Parameters
+    ----------
+    x: torch.Tensor
+        Input activation, shape ``(m, n)`` bf16.
+    pre_quant_scale: torch.Tensor
+        Per-input-channel smoothing scale, shape ``(n,)`` bf16.
+    global_scale: torch.Tensor
+        Global scale, float32 device scalar: ``(448 * 6) / (x * pre_quant_scale).abs().max()``.
+    enable_pdl: Optional[bool]
+        Whether to launch with Programmatic Dependent Launch. Defaults to the device default.
+    backend: Literal["cutlass"]
+        Only the CUDA backend exists.
+
+    Returns
+    -------
+    xq: torch.Tensor
+        Quantized tensor, shape ``(m, n // 2)`` uint8 (packed e2m1).
+    sf: torch.Tensor
+        Block scales, uint8 (ue4m3), 128x4 swizzled layout, 1-D of size
+        ``ceil(m / 128) * 128 * ceil(n / 16 / 4) * 4``.
+    """
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(x.device)
+    m, n = x.shape
+    module = get_nvfp4_svdquant_module()
+    xq = torch.empty(m, n // 2, dtype=torch.uint8, device=x.device)
+    sf = torch.empty(_swizzled_sf_size(m, n // 16), dtype=torch.uint8, device=x.device)
+    module.nvfp4_quantize_smooth(x, pre_quant_scale, global_scale, xq, sf, enable_pdl)
+    return xq, sf
+
+
+@flashinfer_api
+def svdquant_linear(
+    x: torch.Tensor,
+    weight_fp4: torch.Tensor,
+    weight_sf: torch.Tensor,
+    alpha: torch.Tensor,
+    pre_quant_scale: torch.Tensor,
+    l2t_smoothed: torch.Tensor,
+    l1_scaled: torch.Tensor,
+    global_scale: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    enable_pdl: Optional[bool] = None,
+) -> torch.Tensor:
+    r"""The full SVDQuant linear operator: ``y = x_hat @ (R + L1 @ L2)ᵀ [+ bias]`` where
+    ``x_hat = x * pre_quant_scale`` and ``R`` is the NVFP4-quantized residual weight.
+
+    Runs the three-step chain this library's kernels are designed for:
+
+    1. ``xq, x_sf = nvfp4_quantize_smooth(x, pre_quant_scale, global_scale)``
+    2. ``down = x @ l2t_smoothed``  (plain BF16 GEMM; ``l2t_smoothed = pre_quant_scale[:, None] * L2ᵀ``)
+    3. ``mm_nvfp4_svdquant(xq, weight_fp4, x_sf, weight_sf, alpha, down, l1_scaled, bias)``
+
+    The invariant per-layer transforms must be prepared offline by the caller:
+    ``l2t_smoothed = (pre_quant_scale[:, None] * svdquant_lora_a.T).to(bf16)`` with shape
+    ``(k, 32)`` and ``l1_scaled = (svdquant_lora_b / alpha).to(bf16)`` with shape ``(n, 32)``.
+
+    Parameters
+    ----------
+    x: torch.Tensor
+        Input activation, shape ``(m, k)`` bf16.
+    weight_fp4: torch.Tensor
+        NVFP4 residual weight, shape ``(n, k // 2)`` uint8 (packed e2m1).
+    weight_sf: torch.Tensor
+        Weight block scales, uint8 (ue4m3), 128x4 swizzled layout.
+    alpha: torch.Tensor
+        Per-tensor residual dequantization scale, float32 device scalar.
+    pre_quant_scale: torch.Tensor
+        Per-input-channel smoothing scale, shape ``(k,)`` bf16.
+    l2t_smoothed: torch.Tensor
+        ``pre_quant_scale[:, None] * L2ᵀ``, shape ``(k, 32)`` bf16.
+    l1_scaled: torch.Tensor
+        ``L1 / alpha``, shape ``(n, 32)`` bf16.
+    global_scale: torch.Tensor
+        Activation global scale, float32 device scalar.
+    bias: Optional[torch.Tensor]
+        Optional per-column bias, shape ``(n,)`` bf16.
+    enable_pdl: Optional[bool]
+        Whether to launch with Programmatic Dependent Launch. Defaults to the device default.
+
+    Returns
+    -------
+    out: torch.Tensor
+        Output tensor, shape ``(m, n)`` bf16.
+    """
+    xq, x_sf = nvfp4_quantize_smooth(
+        x, pre_quant_scale, global_scale, enable_pdl=enable_pdl
+    )
+    down = torch.mm(x, l2t_smoothed)
+    return mm_nvfp4_svdquant(
+        xq,
+        weight_fp4,
+        x_sf,
+        weight_sf,
+        alpha,
+        down,
+        l1_scaled,
+        bias=bias,
+        enable_pdl=enable_pdl,
+    )

--- a/flashinfer/gemm/gemm_svdquant.py
+++ b/flashinfer/gemm/gemm_svdquant.py
@@ -33,7 +33,11 @@ from ..fused_moe.utils import (
     map_to_hybrid_bucket_uncapped,
 )
 from ..jit.gemm import gen_gemm_sm100_module_cutlass_nvfp4_svdquant
-from ..trace.templates.gemm import mm_nvfp4_svdquant_trace
+from ..trace.templates.gemm import (
+    mm_nvfp4_svdquant_trace,
+    nvfp4_quantize_smooth_trace,
+    svdquant_linear_trace,
+)
 from ..utils import (
     _get_cache_buf,
     backend_requirement,
@@ -291,7 +295,7 @@ def _check_nvfp4_quantize_smooth_problem(
     {"cutlass": _cutlass_nvfp4_svdquant_requirement},
     common_check=_check_nvfp4_quantize_smooth_problem,
 )
-@flashinfer_api
+@flashinfer_api(trace=nvfp4_quantize_smooth_trace)
 def nvfp4_quantize_smooth(
     x: torch.Tensor,
     pre_quant_scale: torch.Tensor,
@@ -336,7 +340,7 @@ def nvfp4_quantize_smooth(
     return xq, sf
 
 
-@flashinfer_api
+@flashinfer_api(trace=svdquant_linear_trace)
 def svdquant_linear(
     x: torch.Tensor,
     weight_fp4: torch.Tensor,

--- a/flashinfer/gemm/gemm_svdquant.py
+++ b/flashinfer/gemm/gemm_svdquant.py
@@ -47,9 +47,10 @@ from ..utils import (
 
 DEFAULT_WORKSPACE_SIZE = 32 * 1024 * 1024
 
-# The fused kernel accumulates the rank-32 BF16 LoRA-up into the NVFP4 residual accumulator; the
-# rank is fixed by the collective (CollectiveMmaLoRA::LoRaK).
-SVDQUANT_LORA_RANK = 32
+# The fused kernel accumulates the rank-r BF16 LoRA-up into the NVFP4 residual accumulator.
+# The rank is inferred from the d/l1 shapes and must be a positive multiple of the collective's
+# rank granularity (CollectiveMmaLoRA::LoRaK); ranks 32-128 are validated.
+SVDQUANT_LORA_RANK_GRANULARITY = 32
 
 
 def _pad_up(x: int, y: int) -> int:
@@ -123,7 +124,7 @@ _NVFP4_SVDQUANT_GEMM_TUNING_CONFIG = TuningConfig(
             lambda shapes: _swizzled_sf_size(shapes[0][0], shapes[0][1] * 2 // 16),
         ),
         ConstraintSpec(
-            5,  # d tensor index: [m, 32] LoRA-down output
+            5,  # d tensor index: [m, r] LoRA-down output (r kept from the real input)
             0,
             lambda shapes: shapes[0][0],
         ),
@@ -172,15 +173,20 @@ def _check_mm_nvfp4_svdquant_problem(
     k = k_packed * 2
     if n % 32 != 0 or k % 32 != 0:
         raise ValueError(f"n and k must be divisible by 32, got n={n}, k={k}")
-    if d.ndim != 2 or d.shape[0] != m or d.shape[1] != SVDQUANT_LORA_RANK:
+    if d.ndim != 2 or d.shape[0] != m:
         raise ValueError(
-            f"d must have shape [m, {SVDQUANT_LORA_RANK}] (rank-{SVDQUANT_LORA_RANK} "
-            f"LoRA-down output), got {tuple(d.shape)}"
+            f"d must have shape [m, r] (rank-r LoRA-down output), got {tuple(d.shape)}"
         )
-    if l1.ndim != 2 or l1.shape[0] != n or l1.shape[1] != SVDQUANT_LORA_RANK:
+    rank = d.shape[1]
+    if rank < SVDQUANT_LORA_RANK_GRANULARITY or rank % SVDQUANT_LORA_RANK_GRANULARITY:
         raise ValueError(
-            f"l1 must have shape [n, {SVDQUANT_LORA_RANK}] (rank-{SVDQUANT_LORA_RANK} "
-            f"LoRA-up weight pre-divided by alpha), got {tuple(l1.shape)}"
+            f"the LoRA rank (d.shape[1]) must be a positive multiple of "
+            f"{SVDQUANT_LORA_RANK_GRANULARITY}, got {rank}"
+        )
+    if l1.ndim != 2 or l1.shape[0] != n or l1.shape[1] != rank:
+        raise ValueError(
+            f"l1 must have shape [n, {rank}] (rank-{rank} LoRA-up weight pre-divided "
+            f"by alpha, same rank as d), got {tuple(l1.shape)}"
         )
     if d.dtype != torch.bfloat16 or l1.dtype != torch.bfloat16:
         raise ValueError("d and l1 must be bf16")
@@ -207,11 +213,13 @@ def mm_nvfp4_svdquant(
 ) -> torch.Tensor:
     r"""SVDQuant fused NVFP4 GEMM (SM100): ``out = alpha * (a @ bᵀ) + d @ l1ᵀ [+ bias]``.
 
-    The block-scaled NVFP4 residual GEMM is fused with the rank-32 BF16 LoRA-up correction
+    The block-scaled NVFP4 residual GEMM is fused with the rank-r BF16 LoRA-up correction
     ``d @ l1ᵀ``, computed by a second BF16 tcgen05 MMA into the same accumulator after the
-    NVFP4 K-loop, plus an optional fused per-column bias. ``1/alpha`` must be folded into
-    ``l1`` by the caller (``l1 = svdquant_lora_b / alpha``) so the epilogue
-    ``out = alpha * acc + bias`` yields the correction unscaled.
+    NVFP4 K-loop, plus an optional fused per-column bias. The LoRA rank ``r`` is inferred
+    from the ``d``/``l1`` shapes and must be a positive multiple of 32 (ranks 32-128 are
+    validated). ``1/alpha`` must be folded into ``l1`` by the caller
+    (``l1 = svdquant_lora_b / alpha``) so the epilogue ``out = alpha * acc + bias`` yields
+    the correction unscaled.
 
     Parameters
     ----------
@@ -230,10 +238,10 @@ def mm_nvfp4_svdquant(
     alpha: torch.Tensor
         Per-tensor residual dequantization scale, float32, device scalar (``numel >= 1``).
     d: torch.Tensor
-        LoRA-down output ``x_hat @ L2ᵀ``, shape ``(m, 32)`` bf16, contiguous and 16-byte
+        LoRA-down output ``x_hat @ L2ᵀ``, shape ``(m, r)`` bf16, contiguous and 16-byte
         aligned (TMA). Compute it as ``x @ (pre_quant_scale[:, None] * L2ᵀ)`` in bf16.
     l1: torch.Tensor
-        LoRA-up weight pre-divided by alpha, shape ``(n, 32)`` bf16.
+        LoRA-up weight pre-divided by alpha, shape ``(n, r)`` bf16 (same rank as ``d``).
     bias: Optional[torch.Tensor]
         Optional per-column bias, shape ``(n,)`` bf16, fused in the epilogue.
     out: Optional[torch.Tensor]
@@ -364,7 +372,8 @@ def svdquant_linear(
 
     The invariant per-layer transforms must be prepared offline by the caller:
     ``l2t_smoothed = (pre_quant_scale[:, None] * svdquant_lora_a.T).to(bf16)`` with shape
-    ``(k, 32)`` and ``l1_scaled = (svdquant_lora_b / alpha).to(bf16)`` with shape ``(n, 32)``.
+    ``(k, r)`` and ``l1_scaled = (svdquant_lora_b / alpha).to(bf16)`` with shape ``(n, r)``,
+    where the LoRA rank ``r`` is a positive multiple of 32.
 
     Parameters
     ----------
@@ -379,9 +388,9 @@ def svdquant_linear(
     pre_quant_scale: torch.Tensor
         Per-input-channel smoothing scale, shape ``(k,)`` bf16.
     l2t_smoothed: torch.Tensor
-        ``pre_quant_scale[:, None] * L2ᵀ``, shape ``(k, 32)`` bf16.
+        ``pre_quant_scale[:, None] * L2ᵀ``, shape ``(k, r)`` bf16.
     l1_scaled: torch.Tensor
-        ``L1 / alpha``, shape ``(n, 32)`` bf16.
+        ``L1 / alpha``, shape ``(n, r)`` bf16.
     global_scale: torch.Tensor
         Activation global scale, float32 device scalar.
     bias: Optional[torch.Tensor]

--- a/flashinfer/jit/gemm/__init__.py
+++ b/flashinfer/jit/gemm/__init__.py
@@ -17,6 +17,7 @@ limitations under the License.
 from .core import (
     gen_gemm_module,
     gen_gemm_sm100_module_cutlass_fp4,
+    gen_gemm_sm100_module_cutlass_nvfp4_svdquant,
     gen_gemm_sm103_module_cutlass_fp4,
     gen_gemm_sm120_module_cutlass_fp4,
     gen_gemm_sm100_module_cutlass_fp8,
@@ -37,6 +38,7 @@ from .fp8_blockscale import gen_fp8_blockscale_gemm_sm90_module
 __all__ = [
     "gen_gemm_module",
     "gen_gemm_sm100_module_cutlass_fp4",
+    "gen_gemm_sm100_module_cutlass_nvfp4_svdquant",
     "gen_gemm_sm103_module_cutlass_fp4",
     "gen_gemm_sm120_module_cutlass_fp4",
     "gen_gemm_sm100_module_cutlass_fp8",

--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -131,6 +131,55 @@ def gen_gemm_sm100_module_cutlass_fp4() -> JitSpec:
     )
 
 
+def gen_gemm_sm100_module_cutlass_nvfp4_svdquant() -> JitSpec:
+    gen_directory = (
+        jit_env.FLASHINFER_GEN_SRC_DIR / "gen_gemm_sm100_cutlass_nvfp4_svdquant"
+    )
+    os.makedirs(gen_directory, exist_ok=True)
+    source_paths = [
+        jit_env.FLASHINFER_CSRC_DIR / "nvfp4_svdquant_gemm_cutlass_sm100.cu",
+        jit_env.FLASHINFER_CSRC_DIR / "nvfp4_smooth_quantize_sm100.cu",
+    ]
+
+    with open(
+        jit_env.FLASHINFER_CSRC_DIR / "nvfp4_svdquant_gemm_cutlass_sm100.jinja"
+    ) as f:
+        kernel_inst_templ = jinja2.Template(f.read())
+        # One TU per kernel shape (27 runtime tactics = 8 shapes x dynamic clusters).
+        config_list = [
+            "Tactic1Sm128x256x128Config",
+            "Tactic2Sm256x256x128Config",
+            "Tactic1Sm128x128x128Config",
+            "Tactic2Sm256x192x128Config",
+            "Tactic1Sm128x64x128Config",
+            "Tactic1Sm128x128x256Config",
+            "Tactic2Sm256x128x256Config",
+            "Tactic2Sm256x256x256Config",
+        ]
+        for config in config_list:
+            dest_path = gen_directory / f"nvfp4_svdquant_gemm_cutlass_{config}.cu"
+            source_paths.append(dest_path)
+            source = kernel_inst_templ.render(config=config)
+            write_if_different(dest_path, source)
+
+    nvcc_flags = current_compilation_context.get_nvcc_flags_list(
+        supported_major_versions=[10]
+    )
+    return gen_jit_spec(
+        "nvfp4_svdquant_gemm_cutlass",
+        source_paths,
+        extra_cuda_cflags=nvcc_flags
+        + [
+            "-DENABLE_BF16",
+            "-DENABLE_FP4",
+            "-DCUTLASS_ENABLE_GDC_FOR_SM100=1",
+        ],
+        extra_cflags=[
+            "-DFAST_BUILD",
+        ],
+    )
+
+
 def gen_gemm_sm103_module_cutlass_fp4() -> JitSpec:
     gen_directory = jit_env.FLASHINFER_GEN_SRC_DIR / "gen_gemm_sm103_cutlass_fp4"
     os.makedirs(gen_directory, exist_ok=True)

--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -1976,7 +1976,7 @@ mm_nvfp4_svdquant_trace = TraceTemplate(
     op_type="gemm_nvfp4_svdquant",
     description=(
         "SVDQuant fused NVFP4 GEMM (SM100): out = alpha * (a @ bᵀ) + d @ l1ᵀ. "
-        "The block-scaled NVFP4 residual GEMM fused with a rank-32 BF16 LoRA-up "
+        "The block-scaled NVFP4 residual GEMM fused with a rank-r BF16 LoRA-up "
         "correction in the same accumulator; 1/alpha is pre-folded into l1."
     ),
     axes={
@@ -1985,7 +1985,7 @@ mm_nvfp4_svdquant_trace = TraceTemplate(
         "K_packed": Const(description="K / 2 (two e2m1 values per byte)."),
         "SF_A": Const(description="128x4-swizzled activation scale buffer size."),
         "SF_B": Const(description="128x4-swizzled weight scale buffer size."),
-        "rank": Const(description="LoRA rank, fixed at 32 by the kernel."),
+        "rank": Const(description="LoRA rank, a positive multiple of 32."),
     },
     inputs={
         "a": Tensor(
@@ -2135,7 +2135,7 @@ svdquant_linear_trace = TraceTemplate(
     op_type="linear_nvfp4_svdquant",
     description=(
         "Full SVDQuant linear: y = (x * pre_quant_scale) @ (R + L1 @ L2)ᵀ where R is the "
-        "NVFP4-quantized residual weight — smooth-quantize, BF16 rank-32 down-projection, "
+        "NVFP4-quantized residual weight — smooth-quantize, BF16 rank-r down-projection, "
         "and the fused NVFP4 residual + LoRA-up GEMM."
     ),
     axes={
@@ -2144,7 +2144,7 @@ svdquant_linear_trace = TraceTemplate(
         "K": Const(),
         "K_packed": Const(description="K / 2 (two e2m1 values per byte)."),
         "SF_B": Const(description="128x4-swizzled weight scale buffer size."),
-        "rank": Const(description="LoRA rank, fixed at 32 by the kernel."),
+        "rank": Const(description="LoRA rank, a positive multiple of 32."),
     },
     inputs={
         "x": Tensor(["M", "K"], param="x", description="Input activation, bf16."),

--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -2036,10 +2036,13 @@ def _nvfp4_quantize_smooth_init(
     *,
     M: int,
     N: int = 3072,
+    N_half: int = 0,
+    SF: int = 0,
     device: str = "cuda",
     seed: int = 0,
 ):
     """Build inputs for ``flashinfer.nvfp4_quantize_smooth``."""
+    del N_half, SF  # output-only / derived axes
     torch.manual_seed(seed)
     x = torch.randn(M, N, dtype=torch.bfloat16, device=device)
     pqs = torch.rand(N, dtype=torch.bfloat16, device=device) + 0.5

--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -1916,3 +1916,117 @@ trtllm_ragged_attention_deepseek_trace = TraceTemplate(
     reference=_trtllm_ragged_attention_deepseek_reference,
     init=_trtllm_ragged_attention_deepseek_init,
 )
+
+
+# ── SVDQuant fused NVFP4 GEMM (SM100) ────────────────────────────────────────
+
+
+def _mm_nvfp4_svdquant_init(
+    *,
+    M: int,
+    N: int = 3072,
+    K: int = 3072,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build inputs for ``flashinfer.mm_nvfp4_svdquant``.
+
+    Mirrors the SVDQuant linear decomposition W ~= R + L1 @ L2 at Qwen-Image
+    shapes: the residual weight is NVFP4-quantized (via ``nvfp4_quantize_smooth``
+    with a unit smoothing scale, which is byte-identical to the stock NVFP4
+    quantizer), the activation is smooth-quantized, and the rank-32 LoRA factors
+    follow the host-side folding contract (``d = x_hat @ L2ᵀ``, ``l1 = L1 / alpha``).
+    """
+    from flashinfer import nvfp4_quantize_smooth  # noqa: PLC0415
+
+    torch.manual_seed(seed)
+    rank = 32
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    w = torch.randn(N, K, dtype=torch.bfloat16, device=device) / math.sqrt(K)
+    pqs = torch.rand(K, dtype=torch.bfloat16, device=device) + 0.5
+    l1 = torch.randn(N, rank, dtype=torch.bfloat16, device=device) / math.sqrt(rank)
+    l2 = torch.randn(rank, K, dtype=torch.bfloat16, device=device) / math.sqrt(K)
+
+    x_hat = (x.float() * pqs.float()).to(torch.bfloat16)
+    x_gs = (
+        ((448 * 6) / x_hat.float().abs().nan_to_num().max())
+        .to(torch.float32)
+        .reshape(1)
+    )
+    w_gs = ((448 * 6) / w.float().abs().nan_to_num().max()).to(torch.float32).reshape(1)
+    ones = torch.ones(K, dtype=torch.bfloat16, device=device)
+
+    a, a_sf = nvfp4_quantize_smooth(x, pqs, x_gs)
+    b, b_sf = nvfp4_quantize_smooth(w, ones, w_gs)
+    alpha = (1.0 / (x_gs * w_gs)).to(torch.float32).reshape(1)
+    d = torch.mm(x_hat, l2.t().contiguous().to(torch.bfloat16))
+    l1_scaled = (l1.float() / alpha.item()).to(torch.bfloat16)
+    return {
+        "a": a,
+        "b": b,
+        "a_sf": a_sf,
+        "b_sf": b_sf,
+        "alpha": alpha,
+        "d": d,
+        "l1": l1_scaled,
+    }
+
+
+mm_nvfp4_svdquant_trace = TraceTemplate(
+    op_type="gemm_nvfp4_svdquant",
+    description=(
+        "SVDQuant fused NVFP4 GEMM (SM100): out = alpha * (a @ bᵀ) + d @ l1ᵀ. "
+        "The block-scaled NVFP4 residual GEMM fused with a rank-32 BF16 LoRA-up "
+        "correction in the same accumulator; 1/alpha is pre-folded into l1."
+    ),
+    axes={
+        "M": Var(),
+        "N": Const(),
+        "K_packed": Const(description="K / 2 (two e2m1 values per byte)."),
+        "SF_A": Const(description="128x4-swizzled activation scale buffer size."),
+        "SF_B": Const(description="128x4-swizzled weight scale buffer size."),
+        "rank": Const(description="LoRA rank, fixed at 32 by the kernel."),
+    },
+    inputs={
+        "a": Tensor(
+            ["M", "K_packed"],
+            param="a",
+            description="Smooth-quantized activation, packed e2m1 as uint8.",
+        ),
+        "b": Tensor(
+            ["N", "K_packed"],
+            param="b",
+            description="NVFP4 residual weight, packed e2m1 as uint8, row-major.",
+        ),
+        "a_sf": Tensor(
+            ["SF_A"],
+            param="a_sf",
+            description="Activation block scales, ue4m3 as uint8, 128x4 swizzled.",
+        ),
+        "b_sf": Tensor(
+            ["SF_B"],
+            param="b_sf",
+            description="Weight block scales, ue4m3 as uint8, 128x4 swizzled.",
+        ),
+        "alpha": Tensor(
+            ["1"],
+            param="alpha",
+            description="Per-tensor residual dequant scale, float32 device scalar.",
+        ),
+        "d": Tensor(
+            ["M", "rank"],
+            param="d",
+            description="LoRA-down output x_hat @ L2ᵀ, bf16.",
+        ),
+        "l1": Tensor(
+            ["N", "rank"],
+            param="l1",
+            description="LoRA-up weight pre-divided by alpha, bf16.",
+        ),
+    },
+    outputs={
+        "out": Tensor(["M", "N"], dtype="bfloat16"),
+    },
+    tags=["quantization:fp4"],
+    init=_mm_nvfp4_svdquant_init,
+)

--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -2062,8 +2062,8 @@ nvfp4_quantize_smooth_trace = TraceTemplate(
     axes={
         "M": Var(),
         "N": Const(),
-        "N_half": Const(description="N / 2 (two e2m1 values per byte)."),
-        "SF": Const(description="128x4-swizzled scale buffer size."),
+        "N_half": Var(description="N / 2 (two e2m1 values per byte)."),
+        "SF": Var(description="128x4-swizzled scale buffer size derived from M and N."),
     },
     inputs={
         "x": Tensor(["M", "N"], param="x", description="Input activation, bf16."),
@@ -2082,6 +2082,10 @@ nvfp4_quantize_smooth_trace = TraceTemplate(
         "xq": Tensor(["M", "N_half"], dtype="uint8"),
         "sf": Tensor(["SF"], dtype="uint8"),
     },
+    constraints=[
+        "N_half == N // 2",
+        "SF == ((M + 127) // 128) * 128 * ((N // 16 + 3) // 4) * 4",
+    ],
     tags=["quantization:fp4"],
     init=_nvfp4_quantize_smooth_init,
 )

--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -2030,3 +2030,163 @@ mm_nvfp4_svdquant_trace = TraceTemplate(
     tags=["quantization:fp4"],
     init=_mm_nvfp4_svdquant_init,
 )
+
+
+def _nvfp4_quantize_smooth_init(
+    *,
+    M: int,
+    N: int = 3072,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build inputs for ``flashinfer.nvfp4_quantize_smooth``."""
+    torch.manual_seed(seed)
+    x = torch.randn(M, N, dtype=torch.bfloat16, device=device)
+    pqs = torch.rand(N, dtype=torch.bfloat16, device=device) + 0.5
+    x_hat = (x.float() * pqs.float()).to(torch.bfloat16)
+    gs = (
+        ((448 * 6) / x_hat.float().abs().nan_to_num().max())
+        .to(torch.float32)
+        .reshape(1)
+    )
+    return {"x": x, "pre_quant_scale": pqs, "global_scale": gs}
+
+
+nvfp4_quantize_smooth_trace = TraceTemplate(
+    op_type="quantize_nvfp4_smooth",
+    description=(
+        "Fused smooth + NVFP4 quantize: (xq, sf) = nvfp4-quantize(x * pre_quant_scale). "
+        "Byte-identical to smoothing followed by the stock NVFP4 quantizer "
+        "(ue4m3 block scales, 128x4 swizzled layout, SF vector size 16)."
+    ),
+    axes={
+        "M": Var(),
+        "N": Const(),
+        "N_half": Const(description="N / 2 (two e2m1 values per byte)."),
+        "SF": Const(description="128x4-swizzled scale buffer size."),
+    },
+    inputs={
+        "x": Tensor(["M", "N"], param="x", description="Input activation, bf16."),
+        "pre_quant_scale": Tensor(
+            ["N"],
+            param="pre_quant_scale",
+            description="Per-input-channel smoothing scale, bf16.",
+        ),
+        "global_scale": Tensor(
+            ["1"],
+            param="global_scale",
+            description="Global scale, float32 device scalar.",
+        ),
+    },
+    outputs={
+        "xq": Tensor(["M", "N_half"], dtype="uint8"),
+        "sf": Tensor(["SF"], dtype="uint8"),
+    },
+    tags=["quantization:fp4"],
+    init=_nvfp4_quantize_smooth_init,
+)
+
+
+def _svdquant_linear_init(
+    *,
+    M: int,
+    N: int = 3072,
+    K: int = 3072,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build inputs for ``flashinfer.svdquant_linear`` (full SVDQuant linear chain)."""
+    from flashinfer import nvfp4_quantize_smooth  # noqa: PLC0415
+
+    torch.manual_seed(seed)
+    rank = 32
+    x = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    w = torch.randn(N, K, dtype=torch.bfloat16, device=device) / math.sqrt(K)
+    pqs = torch.rand(K, dtype=torch.bfloat16, device=device) + 0.5
+    l1 = torch.randn(N, rank, dtype=torch.bfloat16, device=device) / math.sqrt(rank)
+    l2 = torch.randn(rank, K, dtype=torch.bfloat16, device=device) / math.sqrt(K)
+
+    x_hat = (x.float() * pqs.float()).to(torch.bfloat16)
+    x_gs = (
+        ((448 * 6) / x_hat.float().abs().nan_to_num().max())
+        .to(torch.float32)
+        .reshape(1)
+    )
+    w_gs = ((448 * 6) / w.float().abs().nan_to_num().max()).to(torch.float32).reshape(1)
+    ones = torch.ones(K, dtype=torch.bfloat16, device=device)
+
+    weight_fp4, weight_sf = nvfp4_quantize_smooth(w, ones, w_gs)
+    alpha = (1.0 / (x_gs * w_gs)).to(torch.float32).reshape(1)
+    l2t_smoothed = (pqs.float()[:, None] * l2.float().t()).to(torch.bfloat16)
+    l1_scaled = (l1.float() / alpha.item()).to(torch.bfloat16)
+    return {
+        "x": x,
+        "weight_fp4": weight_fp4,
+        "weight_sf": weight_sf,
+        "alpha": alpha,
+        "pre_quant_scale": pqs,
+        "l2t_smoothed": l2t_smoothed,
+        "l1_scaled": l1_scaled,
+        "global_scale": x_gs,
+    }
+
+
+svdquant_linear_trace = TraceTemplate(
+    op_type="linear_nvfp4_svdquant",
+    description=(
+        "Full SVDQuant linear: y = (x * pre_quant_scale) @ (R + L1 @ L2)ᵀ where R is the "
+        "NVFP4-quantized residual weight — smooth-quantize, BF16 rank-32 down-projection, "
+        "and the fused NVFP4 residual + LoRA-up GEMM."
+    ),
+    axes={
+        "M": Var(),
+        "N": Const(),
+        "K": Const(),
+        "K_packed": Const(description="K / 2 (two e2m1 values per byte)."),
+        "SF_B": Const(description="128x4-swizzled weight scale buffer size."),
+        "rank": Const(description="LoRA rank, fixed at 32 by the kernel."),
+    },
+    inputs={
+        "x": Tensor(["M", "K"], param="x", description="Input activation, bf16."),
+        "weight_fp4": Tensor(
+            ["N", "K_packed"],
+            param="weight_fp4",
+            description="NVFP4 residual weight, packed e2m1 as uint8.",
+        ),
+        "weight_sf": Tensor(
+            ["SF_B"],
+            param="weight_sf",
+            description="Weight block scales, ue4m3 as uint8, 128x4 swizzled.",
+        ),
+        "alpha": Tensor(
+            ["1"],
+            param="alpha",
+            description="Per-tensor residual dequant scale, float32 device scalar.",
+        ),
+        "pre_quant_scale": Tensor(
+            ["K"],
+            param="pre_quant_scale",
+            description="Per-input-channel smoothing scale, bf16.",
+        ),
+        "l2t_smoothed": Tensor(
+            ["K", "rank"],
+            param="l2t_smoothed",
+            description="pre_quant_scale[:, None] * L2ᵀ, bf16.",
+        ),
+        "l1_scaled": Tensor(
+            ["N", "rank"],
+            param="l1_scaled",
+            description="L1 / alpha, bf16.",
+        ),
+        "global_scale": Tensor(
+            ["1"],
+            param="global_scale",
+            description="Activation global scale, float32 device scalar.",
+        ),
+    },
+    outputs={
+        "out": Tensor(["M", "N"], dtype="bfloat16"),
+    },
+    tags=["quantization:fp4"],
+    init=_svdquant_linear_init,
+)

--- a/include/flashinfer/gemm/nvfp4_smooth_quantize_sm100.cuh
+++ b/include/flashinfer/gemm/nvfp4_smooth_quantize_sm100.cuh
@@ -1,0 +1,585 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Fused smooth + NVFP4 quantize: apply the per-input-channel pre_quant_scale AND NVFP4-quantize in
+// ONE pass over the input, eliminating the separate x_hat = x*s elementwise pass. Self-contained
+// port of TensorRT-LLM's kernels/nvfp4SmoothQuantize.cu: the device helpers it reused from
+// trtllm's kernels/quantization.cuh (cvt_warp_fp16_to_fp4, PackedVec, cvt_quant_get_sf_out_offset,
+// get_sf_out_offset_128x4, ...) are copied verbatim below so the xq+SF output stays byte-identical
+// to fp4_quantize(x*s); the only addition is the per-channel multiply before the block-amax +
+// quantize. Differences vs the TRT-LLM original: PDL comes in as a function parameter (instead of
+// an env probe) and the *_SMOOTH_QUANT_THREADS/*_SMOOTH_QUANT_BLOCKS_PER_SM env overrides are
+// dropped (the defaults they fell back to are hardcoded).
+#pragma once
+
+#undef __CUDA_NO_HALF_OPERATORS__
+#undef __CUDA_NO_HALF_CONVERSIONS__
+#undef __CUDA_NO_BFLOAT16_OPERATORS__
+#undef __CUDA_NO_BFLOAT16_CONVERSIONS__
+#undef __CUDA_NO_HALF2_OPERATORS__
+#undef __CUDA_NO_BFLOAT162_OPERATORS__
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+
+namespace flashinfer {
+namespace gemm {
+
+namespace smooth_quantize_detail {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Helpers copied verbatim from TensorRT-LLM common/cudaTypeUtils.cuh (only the variants the
+// kernels below instantiate: bfloat16/bfloat162 plus the generic templates they specialize).
+
+// Get type2 from type or vice versa (applied to half and bfloat16)
+template <typename T>
+struct TypeConverter {
+  using Type = half2;
+};  // keep for generality
+
+template <>
+struct TypeConverter<half2> {
+  using Type = half;
+};
+
+template <>
+struct TypeConverter<half> {
+  using Type = half2;
+};
+
+template <>
+struct TypeConverter<__nv_bfloat162> {
+  using Type = __nv_bfloat16;
+};
+
+template <>
+struct TypeConverter<__nv_bfloat16> {
+  using Type = __nv_bfloat162;
+};
+
+template <typename T>
+__device__ inline T cuda_abs(T val) {
+  assert(false);
+  return {};
+}
+
+#if __CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)
+template <>
+__device__ inline __nv_bfloat16 cuda_abs(__nv_bfloat16 val) {
+  return __habs(val);
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_abs(__nv_bfloat162 val) {
+  return __habs2(val);
+}
+#endif
+
+// Binary maximum: compute the max of two values.
+template <typename T>
+__device__ inline T cuda_max(T val1, T val2) {
+  return (val1 > val2) ? val1 : val2;
+}
+
+template <>
+__device__ inline __nv_bfloat162 cuda_max(__nv_bfloat162 val1, __nv_bfloat162 val2) {
+  return __hmax2(val1, val2);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Helpers copied verbatim from TensorRT-LLM kernels/quantization.cuh (FP4 quantization section).
+
+constexpr int CVT_ELTS_PER_THREAD = 8;
+
+// Convert 4 float2 values into 8 e2m1 values (represented as one uint32_t).
+inline __device__ uint32_t fp32_vec_to_e2m1(float2 (&array)[4]) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint32_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
+      "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+      "}"
+      : "=r"(val)
+      : "f"(array[0].x), "f"(array[0].y), "f"(array[1].x), "f"(array[1].y), "f"(array[2].x),
+        "f"(array[2].y), "f"(array[3].x), "f"(array[3].y));
+  return val;
+#else
+  // static_assert(false, "not supported.");
+  return 0;
+#endif
+}
+
+// Convert 8 float2 values into 16 e2m1 values (represented as one uint64_t).
+inline __device__ uint64_t fp32_vec_to_e2m1(float2 (&array)[8]) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  uint64_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      ".reg .b8 byte4;\n"
+      ".reg .b8 byte5;\n"
+      ".reg .b8 byte6;\n"
+      ".reg .b8 byte7;\n"
+      ".reg .b32 val0;\n"
+      ".reg .b32 val1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0,  %2,  %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1,  %4,  %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2,  %6,  %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3,  %8,  %7;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte4, %10,  %9;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte5, %12, %11;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte6, %14, %13;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte7, %16, %15;\n"
+      "mov.b32 val0, {byte0, byte1, byte2, byte3};\n"
+      "mov.b32 val1, {byte4, byte5, byte6, byte7};\n"
+      "mov.b64 %0, {val0, val1};\n"
+      "}"
+      : "=l"(val)
+      : "f"(array[0].x), "f"(array[0].y), "f"(array[1].x), "f"(array[1].y), "f"(array[2].x),
+        "f"(array[2].y), "f"(array[3].x), "f"(array[3].y), "f"(array[4].x), "f"(array[4].y),
+        "f"(array[5].x), "f"(array[5].y), "f"(array[6].x), "f"(array[6].y), "f"(array[7].x),
+        "f"(array[7].y));
+  return val;
+#else
+  // static_assert(false, "not supported.");
+  return 0;
+#endif
+}
+
+// Fast reciprocal.
+inline __device__ float reciprocal_approximate_ftz(float a) {
+  float b;
+  asm volatile("rcp.approx.ftz.f32 %0, %1;\n" : "=f"(b) : "f"(a));
+  return b;
+}
+
+// Define a 16 bytes packed data type.
+template <class Type>
+struct PackedVec {
+  typename TypeConverter<Type>::Type elts[4];
+  static_assert(sizeof(elts) == sizeof(Type) * CVT_ELTS_PER_THREAD,
+                "Vector size should match the number of elements per thread.");
+};
+
+// Quantizes the provided PackedVec into the uint32_t output.
+// Port note: only the UE4M3 scale-factor path (UE8M0_SF == false) is kept; the removed
+// "if constexpr (UE8M0_SF)" branch emitted no code for the instantiation this port uses.
+template <class Type, int SF_VEC_SIZE, bool UE8M0_SF>
+__device__ uint32_t cvt_warp_fp16_to_fp4(PackedVec<Type>& vec, float SFScaleVal, uint8_t* SFout) {
+  static_assert(!UE8M0_SF, "this port only supports the UE4M3 scale-factor path");
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  // Get absolute maximum values among the local 8 values.
+  auto localMax = cuda_abs(vec.elts[0]);
+
+// Local maximum value.
+#pragma unroll
+  for (int i = 1; i < CVT_ELTS_PER_THREAD / 2; i++) {
+    localMax = cuda_max(localMax, cuda_abs(vec.elts[i]));
+  }
+
+  constexpr int CVT_NUM_THREADS_PER_SF = SF_VEC_SIZE / CVT_ELTS_PER_THREAD;
+  // Get the absolute maximum among all 16 values (two threads for 16, four threads for 32).
+  localMax = cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+  if constexpr (CVT_NUM_THREADS_PER_SF == 4) {
+    localMax = cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 2), localMax);
+  }
+  // Get the final absolute maximum values.
+  float vecMax = float(cuda_max(localMax.x, localMax.y));
+
+  // 8 bits representation of the SF.
+  uint8_t fp8SFVal;
+  float outputScale;
+  // Get the SF (max value of the vector / max value of e2m1).
+  // maximum value of e2m1 = 6.0.
+  // TODO: use half as compute data type.
+  auto SFValue = SFScaleVal * (vecMax * reciprocal_approximate_ftz(6.0f));
+  // Here SFValue is always positive, so E4M3 is the same as UE4M3.
+  __nv_fp8_e4m3 tmp = __nv_fp8_e4m3(SFValue);
+  fp8SFVal = tmp.__x;
+  SFValue = static_cast<float>(tmp);
+  // Get the output scale.
+  // Recipe: final_scale = reciprocal(fp32(fp8(SFValue * SFScaleVal)) * reciprocal(SFScaleVal))
+  outputScale = vecMax != 0
+                    ? reciprocal_approximate_ftz(SFValue * reciprocal_approximate_ftz(SFScaleVal))
+                    : 0.0f;
+
+  if (SFout) {
+    // Write the SF to global memory (STG.8).
+    *SFout = fp8SFVal;
+  }
+
+  // Convert the input to float.
+  float2 fp2Vals[CVT_ELTS_PER_THREAD / 2];
+
+#pragma unroll
+  for (int i = 0; i < CVT_ELTS_PER_THREAD / 2; i++) {
+    if constexpr (std::is_same_v<Type, half>) {
+      fp2Vals[i] = __half22float2(vec.elts[i]);
+    } else {
+      fp2Vals[i] = __bfloat1622float2(vec.elts[i]);
+    }
+    fp2Vals[i].x *= outputScale;
+    fp2Vals[i].y *= outputScale;
+  }
+
+  // Convert to e2m1 values.
+  uint32_t e2m1Vec = fp32_vec_to_e2m1(fp2Vals);
+
+  // Write the e2m1 values to global memory.
+  return e2m1Vec;
+#else
+  return 0;
+#endif
+}
+
+// Port note: batch support dropped -- the original takes std::optional<int> batchIdx/numRows, but
+// every call site of this port passes std::nullopt/0, making the batch term (batchIdx *
+// bTileStride) identically zero. Byte-identical for the single-batch case this port serves.
+inline __host__ __device__ int64_t get_sf_out_offset_128x4(int mIdx, int kIdx, int numColVecs) {
+  // SF layout [numMTiles, numKTiles, 32 (mTile), 4 (mTile), 4(kTile)]
+  // --> index [mTileIdx, kTileIdx, outerMIdx, innerMIdx, innerKIdx]
+
+  int32_t innerKIdx = (kIdx % 4);
+  int64_t innerKStride = 1;
+
+  int32_t innerMIdx = (mIdx % (32 * 4)) / 32;
+  int64_t innerMStride = 4 * innerKStride;  // 4
+
+  // M tile layout [32, 4] is column-major.
+  int32_t outerMIdx = (mIdx % 32);
+  int64_t outerMStride = 4 * innerMStride;  // 16
+
+  int32_t kTileIdx = (kIdx / 4);
+  int64_t kTileStride = 32 * outerMStride;  // 512
+
+  // SF vector size 16 or 32. We round the "numCols" up to a multiple of 64 or 128.
+  // It is the same as rounding the "numColVecs" up to a multiple of 4.
+  int32_t numKTiles = (numColVecs + 4 - 1) / 4;
+  int32_t mTileIdx = mIdx / (32 * 4);
+  int64_t mTileStride = numKTiles * kTileStride;
+
+  // Compute the global offset.
+  int64_t SFOffset = mTileIdx * mTileStride + kTileIdx * kTileStride + outerMIdx * outerMStride +
+                     innerMIdx * innerMStride + innerKIdx * innerKStride;
+
+  return SFOffset;
+}
+
+// Port note: hardcoded to the SWIZZLED 128x4 layout (the only layout this port dispatches on) and
+// batch support dropped as above; otherwise verbatim.
+template <class SFType, int CVT_NUM_THREADS_PER_SF>
+__device__ uint8_t* cvt_quant_get_sf_out_offset(int rowIdx, int colVecIdx, int numColVecs,
+                                                SFType* SFout) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  // Each thread holds one vector.
+  static_assert(CVT_NUM_THREADS_PER_SF == 1 || CVT_NUM_THREADS_PER_SF == 2 ||
+                CVT_NUM_THREADS_PER_SF == 4);
+
+  // One pair of threads write one SF to global memory.
+  // TODO: stage through smem for packed STG.32
+  // is it better than STG.8 from 4 threads ?
+  if (threadIdx.x % CVT_NUM_THREADS_PER_SF == 0) {
+    // SF vector index (16 elements share one SF in the K dimension).
+    // numRows and numCols are unpadded.
+    int32_t kIdx = colVecIdx / CVT_NUM_THREADS_PER_SF;
+    int32_t mIdx = rowIdx;
+
+    auto SFOffset = get_sf_out_offset_128x4(mIdx, kIdx, numColVecs);
+    return reinterpret_cast<uint8_t*>(SFout) + SFOffset;
+  }
+#endif
+  return nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// The fused smooth-quantize kernels, ported from TensorRT-LLM kernels/nvfp4SmoothQuantize.cu.
+
+// bf16, NVFP4 (UE4M3 SF, SF_VEC_SIZE=16), swizzled layout, single batch.
+constexpr int SF_VEC_SIZE = 16;
+using Type = __nv_bfloat16;
+constexpr int ELTS_PER_THREAD = CVT_ELTS_PER_THREAD;
+using SmoothPackedVec = PackedVec<Type>;
+constexpr int CVT_NUM_THREADS_PER_SF = SF_VEC_SIZE / ELTS_PER_THREAD;
+constexpr int FAST_ELTS_PER_THREAD = SF_VEC_SIZE;
+
+// Two of these make one complete 16-element NVFP4 scale block. Keeping the load granularity at
+// 128 bits avoids imposing a stronger alignment requirement than the stock quantizer.
+union alignas(16) Bf16x8 {
+  uint4 bits;
+  __nv_bfloat162 elts[4];
+};
+
+static_assert(sizeof(Bf16x8) == 16);
+
+// trtllm's PadUpFn is a function-like macro (quantization.h); use a plain
+// host+device helper here instead.
+__host__ __device__ inline int padUp(int x, int y) { return (x + y - 1) / y * y; }
+
+__device__ __forceinline__ void loadBf16x8(Type const* ptr, Bf16x8& result) {
+  result.bits = *reinterpret_cast<uint4 const*>(ptr);
+}
+
+__device__ __forceinline__ uint64_t quantizeSmoothed16(Bf16x8& lo, Bf16x8& hi, Bf16x8 const& pqsLo,
+                                                       Bf16x8 const& pqsHi, float SFScaleVal,
+                                                       uint8_t* SFout) {
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    lo.elts[i] = __hmul2(lo.elts[i], pqsLo.elts[i]);
+    hi.elts[i] = __hmul2(hi.elts[i], pqsHi.elts[i]);
+  }
+
+  // Match the legacy even lane's reduction order: reduce each 8-element half independently, then
+  // merge the high half into the low half. For finite BF16 values this produces the same scale for
+  // both halves.
+  auto loMax = cuda_abs(lo.elts[0]);
+  auto hiMax = cuda_abs(hi.elts[0]);
+#pragma unroll
+  for (int i = 1; i < 4; ++i) {
+    loMax = cuda_max(loMax, cuda_abs(lo.elts[i]));
+    hiMax = cuda_max(hiMax, cuda_abs(hi.elts[i]));
+  }
+  auto const localMax = cuda_max(hiMax, loMax);
+  float const vecMax = float(cuda_max(localMax.x, localMax.y));
+
+  // This is deliberately kept instruction-for-instruction equivalent to cvt_warp_fp16_to_fp4's
+  // UE4M3 path.
+  auto SFValue = SFScaleVal * (vecMax * reciprocal_approximate_ftz(6.0f));
+  __nv_fp8_e4m3 tmp = __nv_fp8_e4m3(SFValue);
+  uint8_t const fp8SFVal = tmp.__x;
+  SFValue = static_cast<float>(tmp);
+  float const outputScale =
+      vecMax != 0 ? reciprocal_approximate_ftz(SFValue * reciprocal_approximate_ftz(SFScaleVal))
+                  : 0.0f;
+
+  if (SFout != nullptr) *SFout = fp8SFVal;
+
+  float2 fp2Vals[FAST_ELTS_PER_THREAD / 2];
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    fp2Vals[i] = __bfloat1622float2(lo.elts[i]);
+    fp2Vals[i + 4] = __bfloat1622float2(hi.elts[i]);
+    fp2Vals[i].x *= outputScale;
+    fp2Vals[i].y *= outputScale;
+    fp2Vals[i + 4].x *= outputScale;
+    fp2Vals[i + 4].y *= outputScale;
+  }
+  return fp32_vec_to_e2m1(fp2Vals);
+}
+
+template <int NumCols, int RowsPerCta>
+__global__ void __launch_bounds__(512, 4)
+    smooth_quantize_fast_kernel(int numRows, Type const* __restrict__ in,
+                                Type const* __restrict__ pqs, float const* __restrict__ SFScale,
+                                uint64_t* __restrict__ out, uint8_t* __restrict__ SFout) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  static_assert(NumCols % (4 * SF_VEC_SIZE) == 0);
+  constexpr int NumSfCols = NumCols / SF_VEC_SIZE;
+  constexpr int NumSfGroups = NumSfCols / 4;
+  float const SFScaleVal = SFScale == nullptr ? 1.0f : SFScale[0];
+
+  cudaGridDependencySynchronize();
+
+  // Hot path: map a fixed number of complete rows onto each CTA. K=3072 uses two rows and 384
+  // threads, so every thread owns exactly one 16-value scale block without a warp shuffle.
+  for (int rowBase = blockIdx.x * RowsPerCta; rowBase < numRows;
+       rowBase += gridDim.x * RowsPerCta) {
+    int const rowsRemaining = numRows - rowBase;
+    int const rowsThisCta = rowsRemaining < RowsPerCta ? rowsRemaining : RowsPerCta;
+    int const workItems = rowsThisCta * NumSfCols;
+    for (int item = threadIdx.x; item < workItems; item += blockDim.x) {
+      int const rowOffset = item / NumSfCols;
+      int const sfCol = item - rowOffset * NumSfCols;
+      int const row = rowBase + rowOffset;
+      int64_t const vecOffset = static_cast<int64_t>(row) * NumSfCols + sfCol;
+
+      Type const* xPtr = in + vecOffset * FAST_ELTS_PER_THREAD;
+      Type const* pqsPtr = pqs + sfCol * FAST_ELTS_PER_THREAD;
+      Bf16x8 xLo;
+      Bf16x8 xHi;
+      Bf16x8 pqsLo;
+      Bf16x8 pqsHi;
+      loadBf16x8(xPtr, xLo);
+      loadBf16x8(xPtr + 8, xHi);
+      loadBf16x8(pqsPtr, pqsLo);
+      loadBf16x8(pqsPtr + 8, pqsHi);
+
+      int64_t const sfOffset = get_sf_out_offset_128x4(row, sfCol, NumSfCols);
+      out[vecOffset] = quantizeSmoothed16(xLo, xHi, pqsLo, pqsHi, SFScaleVal, SFout + sfOffset);
+    }
+  }
+
+  // Cold path: only scale factors have padded rows. Four consecutive SF columns are contiguous in
+  // the 128x4 layout, so initialize them with one aligned 32-bit store instead of four byte stores.
+  int const numPaddedRows = padUp(numRows, 128);
+  int64_t const numPaddingStores = static_cast<int64_t>(numPaddedRows - numRows) * NumSfGroups;
+  for (int64_t item = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+       item < numPaddingStores; item += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    int const paddingRow = static_cast<int>(item / NumSfGroups);
+    int const sfGroup = static_cast<int>(item - static_cast<int64_t>(paddingRow) * NumSfGroups);
+    int const row = numRows + paddingRow;
+    int const sfCol = sfGroup * 4;
+    int64_t const sfOffset = get_sf_out_offset_128x4(row, sfCol, NumSfCols);
+    *reinterpret_cast<uint32_t*>(SFout + sfOffset) = 0u;
+  }
+
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+__global__ void __launch_bounds__(512, 4)
+    smooth_quantize_legacy_kernel(int numRows, int numCols, int numPaddedCols, Type const* in,
+                                  Type const* pqs, float const* SFScale, uint32_t* out,
+                                  uint32_t* SFout) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  float const SFScaleVal = SFScale == nullptr ? 1.0f : SFScale[0];
+  int const numPaddedRowsForSf = padUp(numRows, 128);
+  int const numColsForSf = padUp(numPaddedCols, 4 * SF_VEC_SIZE);
+  int const numColThreads = numCols / ELTS_PER_THREAD;
+  int const numPaddedColThreads = numPaddedCols / ELTS_PER_THREAD;
+  int const numColThreadsForSf = numColsForSf / ELTS_PER_THREAD;
+
+  cudaGridDependencySynchronize();
+  for (int rowIdx = blockIdx.x; rowIdx < numPaddedRowsForSf; rowIdx += gridDim.x) {
+    bool const isRowPadding = (rowIdx >= numRows);
+    for (int colIdx = threadIdx.x; colIdx < numColThreadsForSf; colIdx += blockDim.x) {
+      auto sf_out = cvt_quant_get_sf_out_offset<uint32_t, CVT_NUM_THREADS_PER_SF>(
+          rowIdx, colIdx, numPaddedCols / SF_VEC_SIZE, SFout);
+
+      if (isRowPadding || colIdx >= numColThreads) {
+        if (sf_out != nullptr) sf_out[0] = 0x00;
+        if (!isRowPadding && colIdx >= numColThreads && colIdx < numPaddedColThreads)
+          reinterpret_cast<uint32_t*>(
+              out)[static_cast<int64_t>(rowIdx) * numPaddedColThreads + colIdx] = 0u;
+        continue;
+      }
+
+      int64_t const inOffset = static_cast<int64_t>(rowIdx) * numColThreads + colIdx;
+      int64_t const outOffset = static_cast<int64_t>(rowIdx) * numPaddedColThreads + colIdx;
+      SmoothPackedVec in_vec = reinterpret_cast<SmoothPackedVec const*>(in)[inOffset];
+      // --- the fusion: smooth by the per-channel pre_quant_scale (broadcast over rows) ---
+      SmoothPackedVec p_vec = reinterpret_cast<SmoothPackedVec const*>(pqs)[colIdx];
+#pragma unroll
+      for (int i = 0; i < ELTS_PER_THREAD / 2; i++)
+        in_vec.elts[i] = __hmul2(in_vec.elts[i], p_vec.elts[i]);
+      reinterpret_cast<uint32_t*>(out)[outOffset] =
+          cvt_warp_fp16_to_fp4<Type, SF_VEC_SIZE, false>(in_vec, SFScaleVal, sf_out);
+    }
+  }
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+template <int NumCols, int RowsPerCta>
+void launchSmoothQuantizeFast(void* out, void* sfOut, void const* in, void const* pqs,
+                              float const* sfScale, int numRows, int multiProcessorCount,
+                              int blockThreads, int blocksPerSm, bool enablePDL,
+                              cudaStream_t stream) {
+  constexpr int NumSfGroups = NumCols / (4 * SF_VEC_SIZE);
+  int const numPaddedRows = padUp(numRows, 128);
+  int64_t const hotCtas = (static_cast<int64_t>(numRows) + RowsPerCta - 1) / RowsPerCta;
+  int64_t const numPaddingStores = static_cast<int64_t>(numPaddedRows - numRows) * NumSfGroups;
+  int64_t const paddingCtas = (numPaddingStores + blockThreads - 1) / blockThreads;
+  int64_t const wantedCtas = std::max(hotCtas, paddingCtas);
+  int64_t const maxCtas = static_cast<int64_t>(multiProcessorCount) * blocksPerSm;
+
+  cudaLaunchConfig_t cfg = {};
+  cfg.gridDim = dim3(static_cast<unsigned int>(std::min(wantedCtas, maxCtas)));
+  cfg.blockDim = dim3(blockThreads);
+  cfg.dynamicSmemBytes = 0;
+  cfg.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = enablePDL ? 1 : 0;
+  cfg.attrs = attrs;
+  cfg.numAttrs = 1;
+
+  auto* kernel = &smooth_quantize_fast_kernel<NumCols, RowsPerCta>;
+  cudaLaunchKernelEx(&cfg, kernel, numRows, reinterpret_cast<Type const*>(in),
+                     reinterpret_cast<Type const*>(pqs), sfScale, reinterpret_cast<uint64_t*>(out),
+                     reinterpret_cast<uint8_t*>(sfOut));
+}
+
+}  // namespace smooth_quantize_detail
+
+// Fused smooth + NVFP4 quantize: (out, sf_out) = NVFP4-quantize(in * pqs) in a single pass over
+// in, folding the per-input-channel pre_quant_scale smoothing into the quantize. Byte-identical to
+// fp4_quantize(in * pqs) (same cvt_warp_fp16_to_fp4 + swizzled SF layout), so the residual GEMM
+// consumes the output unchanged. in [m, n] bf16, pqs [n] bf16, sf_scale f32[1] (the per-tensor
+// global scale). out [m, n/2] uint8 (packed e2m1), sf_out swizzled UE4M3 block scales (vec size
+// 16). SM100+ only.
+inline void nvfp4_smooth_quantize(void* out, void* sf_out, void const* in, void const* pqs,
+                                  float const* sf_scale, int m, int n, int multiProcessorCount,
+                                  cudaStream_t stream, bool enable_pdl) {
+  using namespace smooth_quantize_detail;
+
+  if (m == 0) return;
+
+  bool const enablePDL = enable_pdl;
+  bool const useFastPath = (n == 3072 || n == 12288);
+  if (useFastPath) {
+    // Same-node SM100 sweeps over the Qwen image-token M values select 192 threads for K=3072
+    // and 256 for K=12288. A grid cap of eight CTAs per SM is best for both.
+    int const blockThreads = n == 3072 ? 192 : 256;
+    int const blocksPerSm = 8;
+
+    if (n == 3072)
+      launchSmoothQuantizeFast<3072, 2>(out, sf_out, in, pqs, sf_scale, m, multiProcessorCount,
+                                        blockThreads, blocksPerSm, enablePDL, stream);
+    else
+      launchSmoothQuantizeFast<12288, 1>(out, sf_out, in, pqs, sf_scale, m, multiProcessorCount,
+                                         blockThreads, blocksPerSm, enablePDL, stream);
+    return;
+  }
+
+  dim3 block(std::min(n / ELTS_PER_THREAD, 512));
+  int const numBlocksPerSM = std::max(1, 2048 / int(block.x));
+  dim3 grid(std::min(padUp(m, 128), multiProcessorCount * numBlocksPerSM));
+  cudaLaunchConfig_t cfg = {};
+  cfg.gridDim = grid;
+  cfg.blockDim = block;
+  cfg.dynamicSmemBytes = 0;
+  cfg.stream = stream;
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = enablePDL ? 1 : 0;
+  cfg.attrs = attrs;
+  cfg.numAttrs = 1;
+  // No column padding here (n is the padded width); the residual GEMM and the SF layout use n.
+  cudaLaunchKernelEx(&cfg, smooth_quantize_legacy_kernel, m, n, n,
+                     reinterpret_cast<Type const*>(in), reinterpret_cast<Type const*>(pqs),
+                     sf_scale, reinterpret_cast<uint32_t*>(out),
+                     reinterpret_cast<uint32_t*>(sf_out));
+}
+
+}  // namespace gemm
+}  // namespace flashinfer

--- a/include/flashinfer/gemm/nvfp4_smooth_quantize_sm100.cuh
+++ b/include/flashinfer/gemm/nvfp4_smooth_quantize_sm100.cuh
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <type_traits>
 
 namespace flashinfer {
@@ -453,6 +454,13 @@ __global__ void __launch_bounds__(512, 4)
   }
 
   cudaTriggerProgrammaticLaunchCompletion();
+#else
+  // Fail loudly instead of silently leaving out/SFout uninitialized if a build for an
+  // unsupported architecture is ever launched.
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    printf("nvfp4_smooth_quantize requires SM100 or newer\n");
+    __trap();
+  }
 #endif
 }
 
@@ -496,6 +504,11 @@ __global__ void __launch_bounds__(512, 4)
     }
   }
   cudaTriggerProgrammaticLaunchCompletion();
+#else
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    printf("nvfp4_smooth_quantize requires SM100 or newer\n");
+    __trap();
+  }
 #endif
 }
 
@@ -542,7 +555,7 @@ inline void nvfp4_smooth_quantize(void* out, void* sf_out, void const* in, void 
                                   cudaStream_t stream, bool enable_pdl) {
   using namespace smooth_quantize_detail;
 
-  if (m == 0) return;
+  if (m == 0 || n == 0) return;
 
   bool const enablePDL = enable_pdl;
   bool const useFastPath = (n == 3072 || n == 12288);

--- a/include/flashinfer/gemm/nvfp4_svdquant_gemm_collective_sm100.h
+++ b/include/flashinfer/gemm/nvfp4_svdquant_gemm_collective_sm100.h
@@ -1,0 +1,1352 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include "cute/algorithm/functional.hpp"
+#include "cute/algorithm/gemm.hpp"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cute/numeric/arithmetic_tuple.hpp"
+#include "cutlass/cutlass.h"
+#include "cutlass/detail/cluster.hpp"
+#include "cutlass/detail/collective.hpp"
+#include "cutlass/detail/sm100_blockscaled_layout.hpp"
+#include "cutlass/detail/sm100_tmem_helper.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/kernel_hardware_info.hpp"
+#include "cutlass/numeric_types.h"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "cutlass/trace.h"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::collective {
+using namespace cute;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// SVDQuant LoRA-fused mainloop: a copy of the SM100 block-scaled warp-specialized CollectiveMma,
+// renamed CollectiveMmaLoRA so it coexists with the unmodified original (a distinct type, not a
+// CollectiveMma specialization, so there is no ODR clash). The stock nvfp4 GEMM template is
+// untouched. It is instantiated via extract-from-Builder: each of the 15 template args is a public
+// typedef on the standard Builder's CollectiveOp (DispatchPolicy / TileShape / ElementPairA / ...),
+// so the launcher re-instantiates CollectiveMmaLoRA<BC::DispatchPolicy, BC::TileShape, ...>.
+// The only functional change vs the base collective is the rank-r LoRA-up: D @ L1ᵀ is accumulated
+// by a 2nd bf16 tcgen05 MMA (K = r) into the same TMEM accumulator after the NVFP4 K-loop, with
+// D/L1 riding the residual stage buffers (no dedicated smem). The LoRA-up is always applied.
+template <class DispatchPolicy, class TileShape_, class ElementPairA_, class StridePairA_,
+          class ElementPairB_, class StridePairB_, class TiledMma_, class GmemTiledCopyPairA_,
+          class SmemLayoutAtomPairA_, class SmemCopyAtomA_, class TransformA_,
+          class GmemTiledCopyPairB_, class SmemLayoutAtomPairB_, class SmemCopyAtomB_,
+          class TransformB_>
+struct CollectiveMmaLoRA;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// WarpSpecialized Mainloop
+// Both DMA Load and MMA methods of this class must be run by a single thread that's picked by
+// elect_one
+template <int Stages, int SchedulerPipelineStageCount, int AccumulatorPipelineStageCount,
+          class ClusterShape,  // Static cluster shape or dynamic (int, int, _1)
+          class TileShape_,    // (MmaAtomShapeM, MmaAtomShapeN, TileK)
+          class ElementPairA_, class StridePairA_, class ElementPairB_, class StridePairB_,
+          class TiledMma_, class GmemTiledCopyPairA_, class SmemLayoutAtomPairA_,
+          class SmemCopyAtomA_, class TransformA_, class GmemTiledCopyPairB_,
+          class SmemLayoutAtomPairB_, class SmemCopyAtomB_, class TransformB_>
+struct CollectiveMmaLoRA<
+    MainloopSm100TmaUmmaWarpSpecializedBlockScaled<Stages, SchedulerPipelineStageCount,
+                                                   AccumulatorPipelineStageCount, ClusterShape>,
+    TileShape_, ElementPairA_, StridePairA_, ElementPairB_, StridePairB_, TiledMma_,
+    GmemTiledCopyPairA_, SmemLayoutAtomPairA_, SmemCopyAtomA_, TransformA_, GmemTiledCopyPairB_,
+    SmemLayoutAtomPairB_, SmemCopyAtomB_, TransformB_> {
+  //
+  // Type Aliases
+  //
+  using TiledMma = TiledMma_;
+  using AtomThrShapeMNK = Shape<decltype(shape<0>(typename TiledMma::ThrLayoutVMNK{})), _1, _1>;
+
+  using DispatchPolicy =
+      MainloopSm100TmaUmmaWarpSpecializedBlockScaled<Stages, SchedulerPipelineStageCount,
+                                                     AccumulatorPipelineStageCount, ClusterShape>;
+  using TileShape = TileShape_;
+  using TiledMMA_SF = TiledMMA<MMA_Atom<typename TiledMma::MMA_ScaleFactor>,
+                               Layout<Shape<_1, _1, _1>>, Tile<Underscore, Underscore, Underscore>>;
+
+  static constexpr bool IsDynamicCluster = not cute::is_static_v<ClusterShape>;
+  static constexpr int SFVecSize = TiledMma::SFVecSize;
+  static constexpr bool IsOverlappingAccum = DispatchPolicy::IsOverlappingAccum;
+
+  CUTE_STATIC_ASSERT_V(evenly_divides(TileShape{}, tile_shape(TiledMma{})),
+                       "Static cluster shape used: TileShape should be evenly divided by TiledMma");
+
+  using CtaShape_MNK = decltype(shape_div(TileShape{}, AtomThrShapeMNK{}));
+
+  // === LoRA-up: a bf16 tcgen05 MMA of D@L1ᵀ (K=rank) accumulated into the
+  // SAME f32 TMEM accumulator after the NVFP4 K-loop. Build the bf16 TiledMMA via CUTLASS's
+  // own SM100 helper (matches the residual cta_group; SS = both operands SMEM-sourced, as
+  // the residual mainloop requires). The MMA tile is the full CTA-group tile, while the
+  // SMEM layouts below are explicitly reduced to each CTA's partition. ===
+  static constexpr int LoRaK = 32;  // Logical SVDQuant rank r=32 = 2 bf16 16-wide K-atoms.
+  using ResidualElementA = remove_cvref_t<decltype(get<0>(ElementPairA_{}))>;
+  static_assert((cute::size<2>(TileShape{}) * cute::sizeof_bits_v<ResidualElementA>) %
+                    cute::sizeof_bits_v<cutlass::bfloat16_t> ==
+                0);
+  // Match one residual A/B stage exactly: FP4 K128 -> BF16 K32, FP4 K256 -> BF16 K64.
+  // The global D/L1 tensors remain logical K32; TMA zero-fills the upper half of a K64 box.
+  static constexpr int LoRaStorageK = cute::size<2>(TileShape{}) *
+                                      cute::sizeof_bits_v<ResidualElementA> /
+                                      cute::sizeof_bits_v<cutlass::bfloat16_t>;
+  static_assert(LoRaStorageK >= LoRaK);
+  using LoRaMmaTileShape = decltype(make_shape(
+      cute::size<0>(TileShape{}), cute::size<1>(TileShape{}), cute::Int<LoRaStorageK>{}));
+
+  static constexpr auto make_lora_mma() {
+    static_assert(cute::size(AtomThrShapeMNK{}) == 1 || cute::size(AtomThrShapeMNK{}) == 2,
+                  "LoRaMma only supports one- or two-CTA MMA groups");
+    if constexpr (cute::size(AtomThrShapeMNK{}) == 2) {
+      return cutlass::gemm::collective::detail::sm100_make_2sm_trivial_tiled_mma<
+          cutlass::bfloat16_t, cutlass::bfloat16_t, float, LoRaMmaTileShape, ClusterShape,
+          cute::UMMA::Major::K, cute::UMMA::Major::K>();
+    } else {
+      return cutlass::gemm::collective::detail::sm100_make_1sm_trivial_tiled_mma<
+          cutlass::bfloat16_t, cutlass::bfloat16_t, float, LoRaMmaTileShape, ClusterShape,
+          cute::UMMA::Major::K, cute::UMMA::Major::K>();
+    }
+  }
+
+  using LoRaMma = decltype(make_lora_mma());
+  static_assert(cute::size(typename LoRaMma::ThrLayoutVMNK{}) >= 1, "LoRaMma constructed");
+  static_assert(cute::size(typename LoRaMma::AtomThrID{}) ==
+                    cute::size(typename TiledMma::AtomThrID{}),
+                "LoRA and residual MMA CTA groups must match");
+  static_assert(shape<1>(CtaShape_MNK{}) == 192 or shape<1>(CtaShape_MNK{}) == 64 or
+                    shape<1>(CtaShape_MNK{}) == 128 or shape<1>(CtaShape_MNK{}) == 256,
+                "Cta N should be one of 64/128/192/256");
+
+  using ClusterTileShape = decltype(make_shape(get<0>(TileShape{}) * get<0>(ClusterShape{}),
+                                               get<1>(TileShape{}) * get<1>(ClusterShape{}),
+                                               get<2>(TileShape{}) * get<2>(ClusterShape{})));
+  using Sm1xxBlkScaledConfig = cutlass::detail::Sm1xxBlockScaledConfig<SFVecSize>;
+  using Blk_MN = typename Sm1xxBlkScaledConfig::Blk_MN;
+  static constexpr int IsCtaN192 = shape<1>(CtaShape_MNK{}) == 192;
+  static constexpr int IsCtaN64 = shape<1>(CtaShape_MNK{}) == 64;
+  static int constexpr CTA_N_SF = cutlass::ceil_div(size<1>(CtaShape_MNK{}), Blk_MN{}) * Blk_MN{};
+  // Tile shape used for partitioning Scale Factor B.
+  // The M-dim does not affect the SFB, so just set it as the original TileShape;
+  using TileShape_SF = decltype(make_shape(
+      get<0>(CtaShape_MNK{}), Int<CTA_N_SF>{} * shape<2>(typename TiledMma::ThrLayoutVMNK()),
+      get<2>(TileShape{})));
+
+  // Define A and B block shapes for reduced size TMA_LOADs
+  using MmaShapeA_MK = decltype(partition_shape_A(
+      TiledMma{}, make_shape(size<0>(TileShape{}), size<2>(TileShape{}))));
+  using MmaShapeB_NK = decltype(partition_shape_B(
+      TiledMma{}, make_shape(size<1>(TileShape{}), size<2>(TileShape{}))));
+
+  using ElementPairA = ElementPairA_;
+  using ElementPairB = ElementPairB_;
+  using ElementAMma = typename TiledMma::ValTypeA;
+  using ElementBMma = typename TiledMma::ValTypeB;
+  using StridePairA = StridePairA_;
+  using StridePairB = StridePairB_;
+  using SmemLayoutAtomPairA = SmemLayoutAtomPairA_;
+  using SmemLayoutAtomPairB = SmemLayoutAtomPairB_;
+  static_assert(cute::is_same_v<remove_cvref_t<decltype(get<1>(ElementPairA{}))>,
+                                remove_cvref_t<decltype(get<1>(ElementPairB{}))>>,
+                "SFA and SFB data types should be the same");
+
+  // A and B matrices
+  using ElementA = remove_cvref_t<decltype(get<0>(ElementPairA{}))>;
+  using StrideA = remove_cvref_t<decltype(get<0>(StridePairA{}))>;
+
+  using ElementB = remove_cvref_t<decltype(get<0>(ElementPairB{}))>;
+  using StrideB = remove_cvref_t<decltype(get<0>(StridePairB{}))>;
+
+  static constexpr bool IsRuntimeDataTypeA =
+      cutlass::gemm::collective::detail::is_sm10x_runtime_f8f6f4<ElementA>();
+  static constexpr bool IsRuntimeDataTypeB =
+      cutlass::gemm::collective::detail::is_sm10x_runtime_f8f6f4<ElementB>();
+
+  static_assert((IsRuntimeDataTypeA && IsRuntimeDataTypeB) ||
+                    (!IsRuntimeDataTypeA && !IsRuntimeDataTypeB),
+                "ElementA and ElementB should be both runtime or both static.");
+
+  static constexpr bool IsRuntimeDataType = IsRuntimeDataTypeA && IsRuntimeDataTypeB;
+
+  // SFA and SFB
+  using ElementSF = remove_cvref_t<decltype(get<1>(ElementPairA{}))>;
+  using LayoutSFA = remove_cvref_t<decltype(get<1>(StridePairA{}))>;
+  using LayoutSFB = remove_cvref_t<decltype(get<1>(StridePairB{}))>;
+
+  using ElementAccumulator = typename TiledMma::ValTypeC;
+  using GmemTiledCopyPairA = GmemTiledCopyPairA_;
+  using GmemTiledCopyPairB = GmemTiledCopyPairB_;
+  using GmemTiledCopyA = remove_cvref_t<decltype(get<0>(GmemTiledCopyPairA{}))>;
+  using GmemTiledCopySFA = remove_cvref_t<decltype(get<1>(GmemTiledCopyPairA{}))>;
+  using GmemTiledCopyB = remove_cvref_t<decltype(get<0>(GmemTiledCopyPairB{}))>;
+  using GmemTiledCopySFB = remove_cvref_t<decltype(get<1>(GmemTiledCopyPairB{}))>;
+
+  using SmemLayoutAtomA = remove_cvref_t<decltype(get<0>(SmemLayoutAtomPairA{}))>;
+  using SmemLayoutAtomSFA = remove_cvref_t<decltype(get<1>(SmemLayoutAtomPairA{}))>;
+  using SmemLayoutAtomB = remove_cvref_t<decltype(get<0>(SmemLayoutAtomPairB{}))>;
+  using SmemLayoutAtomSFB = remove_cvref_t<decltype(get<1>(SmemLayoutAtomPairB{}))>;
+
+  using SmemCopyAtomA = SmemCopyAtomA_;
+  using SmemCopyAtomB = SmemCopyAtomB_;
+  using TransformA = TransformA_;
+  using TransformB = TransformB_;
+  using ArchTag = typename DispatchPolicy::ArchTag;
+
+  using MainloopPipeline =
+      cutlass::PipelineTmaUmmaAsync<DispatchPolicy::Stages, ClusterShape, AtomThrShapeMNK>;
+  using MainloopPipelineState = typename MainloopPipeline::PipelineState;
+
+  static_assert(rank(SmemLayoutAtomA{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
+  static_assert((size<0>(TileShape{}) % size<0>(SmemLayoutAtomA{})) == 0,
+                "SmemLayoutAtomA must evenly divide the tile shape.");
+  static_assert((size<2>(TileShape{}) % size<1>(SmemLayoutAtomA{})) == 0,
+                "SmemLayoutAtomA must evenly divide the tile shape.");
+  static_assert(cute::is_void_v<SmemCopyAtomA>,
+                "SM100 UMMA cannot have a non-void copy atom for smem sourced instructions.");
+
+  static_assert(rank(SmemLayoutAtomB{}) == 2, "SmemLayoutAtom must be rank 2 (M/N, K)");
+  static_assert((size<1>(TileShape{}) % size<0>(SmemLayoutAtomB{})) == 0,
+                "SmemLayoutAtomB must evenly divide the tile shape.");
+  static_assert((size<2>(TileShape{}) % size<1>(SmemLayoutAtomB{})) == 0,
+                "SmemLayoutAtomB must evenly divide the tile shape.");
+  static_assert(cute::is_void_v<SmemCopyAtomB>,
+                "SM100 UMMA cannot have a non-void copy atom for smem sourced instructions.");
+
+  // Tile along K mode first before tiling over MN. PIPE mode last as usual.
+  // This maximizes TMA boxes due to better smem-K vectorization, reducing total issued TMAs.
+  // (MMA_TILE_M,MMA_TILE_K),MMA_M,MMA_K,PIPE)
+  using SmemLayoutA = decltype(UMMA::tile_to_mma_shape(
+      SmemLayoutAtomA{}, append(MmaShapeA_MK{}, Int<DispatchPolicy::Stages>{}),
+      cute::conditional_t<cutlass::gemm::detail::is_mn_major<StrideA>(), Step<_2, _1, _3>,
+                          Step<_1, _2, _3>>{}));
+  // (MMA_TILE_N,MMA_TILE_K),MMA_N,MMA_K,PIPE)
+  using SmemLayoutB = decltype(UMMA::tile_to_mma_shape(
+      SmemLayoutAtomB{}, append(MmaShapeB_NK{}, Int<DispatchPolicy::Stages>{}),
+      cute::conditional_t<cutlass::gemm::detail::is_mn_major<StrideB>(), Step<_2, _1, _3>,
+                          Step<_1, _2, _3>>{}));
+
+  // --- LoRA operand smem layouts: bf16 D[M,LoRaK] (A-side) + L1[N,LoRaK] (B-side).
+  // D/L1 are loaded once per output tile, not per k_tile. Build the SMEM selector from the
+  // partitioned MMA shape so a 2SM 256x256 MMA stores only its 128x256 per-CTA partition. ---
+  using MmaShapeD_MK = decltype(partition_shape_A(
+      LoRaMma{}, make_shape(cute::size<0>(LoRaMmaTileShape{}), cute::size<2>(LoRaMmaTileShape{}))));
+  using MmaShapeL1_NK = decltype(partition_shape_B(
+      LoRaMma{}, make_shape(cute::size<1>(LoRaMmaTileShape{}), cute::size<2>(LoRaMmaTileShape{}))));
+  using BlockTileD_M = decltype(cute::size<0, 0>(MmaShapeD_MK{}) * cute::size<1>(MmaShapeD_MK{}));
+  using BlockTileD_K = decltype(cute::size<0, 1>(MmaShapeD_MK{}) * cute::size<2>(MmaShapeD_MK{}));
+  using BlockTileL1_N =
+      decltype(cute::size<0, 0>(MmaShapeL1_NK{}) * cute::size<1>(MmaShapeL1_NK{}));
+  using BlockTileL1_K =
+      decltype(cute::size<0, 1>(MmaShapeL1_NK{}) * cute::size<2>(MmaShapeL1_NK{}));
+  using SmemLayoutAtomD =
+      decltype(cutlass::gemm::collective::detail::sm100_smem_selector<
+               cute::UMMA::Major::K, cutlass::bfloat16_t, BlockTileD_M, BlockTileD_K>());
+  using SmemLayoutAtomL1 =
+      decltype(cutlass::gemm::collective::detail::sm100_smem_selector<
+               cute::UMMA::Major::K, cutlass::bfloat16_t, BlockTileL1_N, BlockTileL1_K>());
+  // D/L1 smem layouts are MULTI-STAGE (Stages, == smem_A/smem_B) so D/L1 RIDE the
+  // residual stage buffers (smem_A[ws]/smem_B[ws]) instead of dedicated sD/sL1 -> no carveout,
+  // residual regains its full stages. Byte-exact overlay: D-tile = M*LoRaStorageK*bf16 == A-stage
+  // (M*K*fp4) and L1-tile = N*LoRaStorageK*bf16 == B-stage; stage stride matches smem_A/B.
+  using SmemLayoutD = decltype(UMMA::tile_to_mma_shape(
+      SmemLayoutAtomD{}, append(MmaShapeD_MK{}, cute::Int<DispatchPolicy::Stages>{})));
+  using SmemLayoutL1 = decltype(UMMA::tile_to_mma_shape(
+      SmemLayoutAtomL1{}, append(MmaShapeL1_NK{}, cute::Int<DispatchPolicy::Stages>{})));
+  static_assert(cute::cosize(SmemLayoutD{}) > 0 && cute::cosize(SmemLayoutL1{}) > 0,
+                "LoRA smem layouts constructed");
+  static_assert(cute::cosize(take<0, 3>(SmemLayoutD{})) *
+                        cute::sizeof_bits_v<cutlass::bfloat16_t> ==
+                    cute::cosize(take<0, 3>(SmemLayoutA{})) * cute::sizeof_bits_v<ElementA>,
+                "Each CTA's LoRA D tile must exactly overlay one residual A stage");
+  static_assert(cute::cosize(take<0, 3>(SmemLayoutL1{})) *
+                        cute::sizeof_bits_v<cutlass::bfloat16_t> ==
+                    cute::cosize(take<0, 3>(SmemLayoutB{})) * cute::sizeof_bits_v<ElementB>,
+                "Each CTA's LoRA L1 tile must exactly overlay one residual B stage");
+  using StrideD = cute::Stride<int64_t, cute::_1, int64_t>;   // D  [M, LoRaK, L] (K-contig)
+  using StrideL1 = cute::Stride<int64_t, cute::_1, int64_t>;  // L1 [N, LoRaK, L] (K-contig)
+  // CTA-group bytes for one stage -- the post-loop TMA loads one D/L1 tile per output tile.
+  // (Unused in the post-loop, which relies on D/L1 arriving the armed A/B byte budget, but
+  // kept correct in case of an expect_transaction path.)
+  static constexpr uint32_t LoRaTmaBytes =
+      cutlass::bits_to_bytes(cute::size(AtomThrShapeMNK{}) *
+                             cute::cosize(take<0, 3>(SmemLayoutD{})) *
+                             cute::sizeof_bits_v<cutlass::bfloat16_t>) +
+      cutlass::bits_to_bytes(cute::size(AtomThrShapeMNK{}) *
+                             cute::cosize(take<0, 3>(SmemLayoutL1{})) *
+                             cute::sizeof_bits_v<cutlass::bfloat16_t>);
+
+  // SmemLayoutAtomSFA and SmemLayoutAtomSFB are for whole CTA tiles. We add the number of pipeline
+  // stages here. The number of pipeline stages is the same as the number of pipeline stages from AB
+  // Load <-> MainLoop
+  using SmemLayoutSFA = decltype(make_layout(
+      append(shape(SmemLayoutAtomSFA{}), Int<DispatchPolicy::Stages>{}),
+      append(stride(SmemLayoutAtomSFA{}), size(filter_zeros(SmemLayoutAtomSFA{})))));
+  using SmemLayoutSFB = decltype(make_layout(
+      append(shape(SmemLayoutAtomSFB{}), Int<DispatchPolicy::Stages>{}),
+      append(stride(SmemLayoutAtomSFB{}), size(filter_zeros(SmemLayoutAtomSFB{})))));
+
+  static_assert(
+      cute::is_base_of<cute::UMMA::DescriptorIterator, typename TiledMma::FrgTypeA>::value &&
+          cute::is_base_of<cute::UMMA::DescriptorIterator, typename TiledMma::FrgTypeB>::value,
+      "MMA atom must source both A and B operand from smem_desc for this mainloop.");
+  static_assert((size(AtomThrShapeMNK{}) == 1 &&
+                 (cute::is_same_v<GmemTiledCopyA, SM90_TMA_LOAD> ||
+                  cute::is_same_v<GmemTiledCopyA, SM90_TMA_LOAD_MULTICAST>)) ||
+                    (size(AtomThrShapeMNK{}) == 2 &&
+                     (cute::is_same_v<GmemTiledCopyA, SM100_TMA_2SM_LOAD> ||
+                      cute::is_same_v<GmemTiledCopyA, SM100_TMA_2SM_LOAD_MULTICAST>)),
+                "GmemTiledCopy - invalid TMA copy atom specified.");
+  static_assert((size(AtomThrShapeMNK{}) == 1 &&
+                 (cute::is_same_v<GmemTiledCopyB, SM90_TMA_LOAD> ||
+                  cute::is_same_v<GmemTiledCopyB, SM90_TMA_LOAD_MULTICAST>)) ||
+                    (size(AtomThrShapeMNK{}) == 2 &&
+                     (cute::is_same_v<GmemTiledCopyB, SM100_TMA_2SM_LOAD> ||
+                      cute::is_same_v<GmemTiledCopyB, SM100_TMA_2SM_LOAD_MULTICAST>)),
+                "GmemTiledCopy -  invalid TMA copy atom specified.");
+
+  static constexpr bool IsF8F6F4 = detail::is_sm100_mma_f8f6f4<TiledMma, ElementA, ElementB>();
+
+  using TmaInternalElementA = cute::conditional_t<IsF8F6F4, ElementAMma, ElementA>;
+  using TmaInternalElementB = cute::conditional_t<IsF8F6F4, ElementBMma, ElementB>;
+
+  using SmemAllocTypeA =
+      cute::conditional_t < IsF8F6F4&& cute::sizeof_bits_v<ElementAMma><8, uint8_t, ElementAMma>;
+  using SmemAllocTypeB =
+      cute::conditional_t < IsF8F6F4&& cute::sizeof_bits_v<ElementBMma><8, uint8_t, ElementBMma>;
+
+  using BitTypeElementA = cute::uint_bit_t<cute::sizeof_bits_v<ElementA>>;
+  using BitTypeElementB = cute::uint_bit_t<cute::sizeof_bits_v<ElementB>>;
+
+  using ArrayElementA = cute::conditional_t<IsRuntimeDataTypeA, BitTypeElementA, ElementA>;
+  using ArrayElementB = cute::conditional_t<IsRuntimeDataTypeB, BitTypeElementB, ElementB>;
+
+  using RuntimeDataTypeA =
+      typename detail::sm10x_block_scale_runtime_input_t<ElementAMma, IsRuntimeDataTypeA>::Type;
+  using RuntimeDataTypeB =
+      typename detail::sm10x_block_scale_runtime_input_t<ElementBMma, IsRuntimeDataTypeB>::Type;
+
+  struct SharedStorage {
+    struct TensorStorage : cute::aligned_struct<128, _0> {
+      cute::ArrayEngine<SmemAllocTypeA, cute::cosize_v<SmemLayoutA>> smem_A;
+      cute::ArrayEngine<SmemAllocTypeB, cute::cosize_v<SmemLayoutB>> smem_B;
+      cute::ArrayEngine<ElementSF, cute::cosize_v<SmemLayoutSFA>> smem_SFA;
+      cute::ArrayEngine<ElementSF, cute::cosize_v<SmemLayoutSFB>> smem_SFB;
+      // NO dedicated LoRA smem -- D/L1 reinterpret smem_A/smem_B's stage buffers
+      // (byte-exact overlay) post-K-loop. This frees the ~24KB + carveout -> +1 mainloop stage.
+    } tensors;
+
+    using PipelineStorage = typename MainloopPipeline::SharedStorage;
+    PipelineStorage pipeline;
+  };
+
+  // Expose shared storage for tensors/pipelines separately to allow kernel layer to reorder them.
+  using TensorStorage = typename SharedStorage::TensorStorage;
+  using PipelineStorage = typename SharedStorage::PipelineStorage;
+
+  // Only one thread issues the TMA and updates the barriers in a 2SM MMA, adjust bytes accordingly
+  static constexpr uint32_t SFTransactionBytes =
+      cutlass::bits_to_bytes(size(AtomThrShapeMNK{}) * cosize(take<0, 3>(SmemLayoutSFA{})) *
+                             cute::sizeof_bits_v<ElementSF>) +
+      cutlass::bits_to_bytes(size(AtomThrShapeMNK{}) * cosize(take<0, 3>(SmemLayoutSFB{})) *
+                             cute::sizeof_bits_v<ElementSF>);
+  static constexpr uint32_t ABTmaTransactionBytes =
+      cutlass::bits_to_bytes(size(AtomThrShapeMNK{}) * cosize(take<0, 3>(SmemLayoutA{})) *
+                             cute::sizeof_bits_v<ElementA>) +
+      cutlass::bits_to_bytes(size(AtomThrShapeMNK{}) * cosize(take<0, 3>(SmemLayoutB{})) *
+                             cute::sizeof_bits_v<ElementB>);
+  static_assert(LoRaTmaBytes == ABTmaTransactionBytes,
+                "LoRA storage/TMA box must exactly replace the residual A/B stage");
+  static constexpr uint32_t TmaTransactionBytes = ABTmaTransactionBytes + SFTransactionBytes;
+
+  template <class AccTensor, class SfaTensor, class SfbTensor>
+  struct TmemStorage {
+    AccTensor accumulators;
+    SfaTensor tCtSFA;
+    SfbTensor tCtSFB;
+  };
+
+  template <class KTileCount, class GTensorPartitionedA, class GTensorPartitionedB, class STensorA,
+            class STensorB, class GTensorPartitionedSFA, class GTensorPartitionedSFB,
+            class STensorSFA, class STensorSFB, class GTensorPartitionedD, class STensorD,
+            class GTensorPartitionedL1, class STensorL1>
+  struct LoadParams {
+    // for scheduler
+    KTileCount k_tiles;
+    // for input tensor values
+    GTensorPartitionedA tAgA_mkl;
+    GTensorPartitionedB tBgB_nkl;
+    STensorA tAsA;
+    STensorB tBsB;
+    // for scale factor tensor values
+    GTensorPartitionedSFA tAgSFA_mkl;
+    GTensorPartitionedSFB tBgSFB_nkl;
+    STensorSFA tAsSFA;
+    STensorSFB tBsSFB;
+    // the TMA multicast masks
+    uint16_t mcast_mask_a;
+    uint16_t mcast_mask_b;
+    uint16_t mcast_mask_sfa;
+    uint16_t mcast_mask_sfb;
+    // LoRA D/L1 partitioned gmem + smem + masks (D like A [M-indexed], L1 like B [N-indexed]).
+    GTensorPartitionedD tDgD_mkl;
+    STensorD tDsD;
+    GTensorPartitionedL1 tL1gL1_nkl;
+    STensorL1 tL1sL1;
+    uint16_t mcast_mask_d;
+    uint16_t mcast_mask_l1;
+
+    CUTLASS_DEVICE
+    LoadParams(KTileCount k_tiles_, GTensorPartitionedA tAgA_mkl_, GTensorPartitionedB tBgB_nkl_,
+               STensorA tAsA_, STensorB tBsB_, GTensorPartitionedSFA tAgSFA_mkl_,
+               GTensorPartitionedSFB tBgSFB_nkl_, STensorSFA tAsSFA_, STensorSFB tBsSFB_,
+               uint16_t mcast_mask_a_, uint16_t mcast_mask_b_, uint16_t mcast_mask_sfa_,
+               uint16_t mcast_mask_sfb_, GTensorPartitionedD tDgD_mkl_, STensorD tDsD_,
+               GTensorPartitionedL1 tL1gL1_nkl_, STensorL1 tL1sL1_, uint16_t mcast_mask_d_,
+               uint16_t mcast_mask_l1_)
+        : k_tiles(k_tiles_),
+          tAgA_mkl(tAgA_mkl_),
+          tBgB_nkl(tBgB_nkl_),
+          tAsA(tAsA_),
+          tBsB(tBsB_),
+          tAgSFA_mkl(tAgSFA_mkl_),
+          tBgSFB_nkl(tBgSFB_nkl_),
+          tAsSFA(tAsSFA_),
+          tBsSFB(tBsSFB_),
+          mcast_mask_a(mcast_mask_a_),
+          mcast_mask_b(mcast_mask_b_),
+          mcast_mask_sfa(mcast_mask_sfa_),
+          mcast_mask_sfb(mcast_mask_sfb_),
+          tDgD_mkl(tDgD_mkl_),
+          tDsD(tDsD_),
+          tL1gL1_nkl(tL1gL1_nkl_),
+          tL1sL1(tL1sL1_),
+          mcast_mask_d(mcast_mask_d_),
+          mcast_mask_l1(mcast_mask_l1_) {}
+  };
+
+  template <class TiledMma, class FragmentA, class FragmentB, class FragmentSFA, class FragmentSFB,
+            class SFATiledCopy, class SmemFrgSFA, class TmemFrgSFA, class SFBTiledCopy,
+            class SmemFrgSFB, class TmemFrgSFB, class FragmentD, class FragmentL1>
+  struct MmaParams {
+    TiledMma tiled_mma;
+    FragmentA tCrA;
+    FragmentB tCrB;
+    FragmentSFA tCtSFA;
+    FragmentSFB tCtSFB;
+    SFATiledCopy tiled_copy_s2t_SFA;
+    SmemFrgSFA thr_tCsSFA_s2t;
+    TmemFrgSFA thr_tCtSFA_s2t;
+    SFBTiledCopy tiled_copy_s2t_SFB;
+    SmemFrgSFB thr_tCsSFB_s2t;
+    TmemFrgSFB thr_tCtSFB_s2t;
+    FragmentD tCrD;    // LoRA D fragment (MMA,MMA_M,MMA_K)
+    FragmentL1 tCrL1;  // LoRA L1 fragment (MMA,MMA_N,MMA_K)
+
+    CUTLASS_DEVICE
+    MmaParams(TiledMma tiled_mma_, FragmentA tCrA_, FragmentB tCrB_, FragmentSFA tCtSFA_,
+              FragmentSFB tCtSFB_, SFATiledCopy tiled_copy_s2t_SFA_, SmemFrgSFA thr_tCsSFA_s2t_,
+              TmemFrgSFA thr_tCtSFA_s2t_, SFBTiledCopy tiled_copy_s2t_SFB_,
+              SmemFrgSFB thr_tCsSFB_s2t_, TmemFrgSFB thr_tCtSFB_s2t_, FragmentD tCrD_,
+              FragmentL1 tCrL1_)
+        : tiled_mma(tiled_mma_),
+          tCrA(tCrA_),
+          tCrB(tCrB_),
+          tCtSFA(tCtSFA_),
+          tCtSFB(tCtSFB_),
+          tiled_copy_s2t_SFA(tiled_copy_s2t_SFA_),
+          thr_tCsSFA_s2t(thr_tCsSFA_s2t_),
+          thr_tCtSFA_s2t(thr_tCtSFA_s2t_),
+          tiled_copy_s2t_SFB(tiled_copy_s2t_SFB_),
+          thr_tCsSFB_s2t(thr_tCsSFB_s2t_),
+          thr_tCtSFB_s2t(thr_tCtSFB_s2t_),
+          tCrD(tCrD_),
+          tCrL1(tCrL1_) {}
+  };
+
+  // Host side kernel arguments
+  struct Arguments {
+    ArrayElementA const* ptr_A{nullptr};
+    StrideA dA{};
+    ArrayElementB const* ptr_B{nullptr};
+    StrideB dB{};
+    ElementSF const* ptr_SFA{nullptr};
+    LayoutSFA layout_SFA{};
+    ElementSF const* ptr_SFB{nullptr};
+    LayoutSFB layout_SFB{};
+    RuntimeDataTypeA runtime_data_type_a{};
+    RuntimeDataTypeB runtime_data_type_b{};
+    // LoRA-up: D [M, LoRaK] (1/alpha NOT here), L1 [N, LoRaK] (1/alpha folded in). bf16.
+    cutlass::bfloat16_t const* ptr_D{nullptr};
+    StrideD dD{};
+    cutlass::bfloat16_t const* ptr_L1{nullptr};
+    StrideL1 dL1{};
+  };
+
+  // Device side kernel params
+  struct Params {
+    using ClusterLayout_VMNK =
+        decltype(tiled_divide(make_layout(conditional_return<IsDynamicCluster>(
+                                  make_shape(uint32_t(0), uint32_t(0), Int<1>{}), ClusterShape{})),
+                              make_tile(typename TiledMma::AtomThrID{})));
+
+    using ClusterLayoutSfb_VMNK =
+        decltype(tiled_divide(make_layout(conditional_return<IsDynamicCluster>(
+                                  make_shape(uint32_t(0), uint32_t(0), Int<1>{}), ClusterShape{})),
+                              make_tile(typename TiledMMA_SF::AtomThrID{})));
+
+    using TMA_A = decltype(make_tma_atom_A_sm100<TmaInternalElementA>(
+        GmemTiledCopyA{},
+        make_tensor(recast_ptr<TmaInternalElementA>(nullptr), repeat_like(StrideA{}, int32_t(0)),
+                    StrideA{}),
+        SmemLayoutA{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{}, ClusterLayout_VMNK{}));
+
+    using TMA_B = decltype(make_tma_atom_B_sm100<TmaInternalElementB>(
+        GmemTiledCopyB{},
+        make_tensor(recast_ptr<TmaInternalElementB>(nullptr), repeat_like(StrideB{}, int32_t(0)),
+                    StrideB{}),
+        SmemLayoutB{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{}, ClusterLayout_VMNK{}));
+
+    using TMA_SFA = decltype(make_tma_atom_A_sm100<uint16_t>(
+        GmemTiledCopySFA{}, make_tensor(static_cast<ElementSF const*>(nullptr), LayoutSFA{}),
+        SmemLayoutSFA{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{}, ClusterLayout_VMNK{}));
+
+    using TMA_SFB = decltype(make_tma_atom_B_sm100<uint16_t>(
+        GmemTiledCopySFB{}, make_tensor(static_cast<ElementSF const*>(nullptr), LayoutSFB{}),
+        SmemLayoutSFB{}(_, _, _, cute::Int<0>{}), TileShape_SF{}, TiledMMA_SF{},
+        ClusterLayoutSfb_VMNK{}));
+
+    // LoRA D/L1 TMA atoms (bf16; D mcast like A [M-indexed], L1 like B [N-indexed]).
+    using TMA_D = decltype(make_tma_atom_A_sm100<cutlass::bfloat16_t>(
+        GmemTiledCopyA{},
+        make_tensor(static_cast<cutlass::bfloat16_t const*>(nullptr),
+                    repeat_like(StrideD{}, int32_t(0)), StrideD{}),
+        SmemLayoutD{}(_, _, _, cute::Int<0>{}), LoRaMmaTileShape{}, LoRaMma{},
+        ClusterLayout_VMNK{}));
+    using TMA_L1 = decltype(make_tma_atom_B_sm100<cutlass::bfloat16_t>(
+        GmemTiledCopyB{},
+        make_tensor(static_cast<cutlass::bfloat16_t const*>(nullptr),
+                    repeat_like(StrideL1{}, int32_t(0)), StrideL1{}),
+        SmemLayoutL1{}(_, _, _, cute::Int<0>{}), LoRaMmaTileShape{}, LoRaMma{},
+        ClusterLayout_VMNK{}));
+
+    TMA_A tma_load_a;
+    TMA_B tma_load_b;
+    TMA_SFA tma_load_sfa;
+    TMA_SFB tma_load_sfb;
+    TMA_A tma_load_a_fallback;
+    TMA_B tma_load_b_fallback;
+    TMA_SFA tma_load_sfa_fallback;
+    TMA_SFB tma_load_sfb_fallback;
+    TMA_D tma_load_d;
+    TMA_L1 tma_load_l1;
+    TMA_D tma_load_d_fallback;
+    TMA_L1 tma_load_l1_fallback;
+    LayoutSFA layout_SFA;
+    LayoutSFB layout_SFB;
+    dim3 cluster_shape_fallback;
+    RuntimeDataTypeA runtime_data_type_a;
+    RuntimeDataTypeB runtime_data_type_b;
+  };
+
+  CUTLASS_DEVICE
+  CollectiveMmaLoRA(Params const& params, ClusterShape cluster_shape,
+                    uint32_t block_rank_in_cluster)
+      : cluster_shape_(cluster_shape),
+        block_rank_in_cluster_(block_rank_in_cluster),
+        layout_SFA_(params.layout_SFA),
+        layout_SFB_(params.layout_SFB),
+        runtime_data_type_a_(params.runtime_data_type_a),
+        runtime_data_type_b_(params.runtime_data_type_b) {
+    if constexpr (IsDynamicCluster) {
+      bool const is_fallback_cluster =
+          (cute::size<0>(cluster_shape_) == params.cluster_shape_fallback.x &&
+           cute::size<1>(cluster_shape_) == params.cluster_shape_fallback.y);
+      observed_tma_load_a_ = is_fallback_cluster ? &params.tma_load_a_fallback : &params.tma_load_a;
+      observed_tma_load_b_ = is_fallback_cluster ? &params.tma_load_b_fallback : &params.tma_load_b;
+      observed_tma_load_sfa_ =
+          is_fallback_cluster ? &params.tma_load_sfa_fallback : &params.tma_load_sfa;
+      observed_tma_load_sfb_ =
+          is_fallback_cluster ? &params.tma_load_sfb_fallback : &params.tma_load_sfb;
+      observed_tma_load_d_ = is_fallback_cluster ? &params.tma_load_d_fallback : &params.tma_load_d;
+      observed_tma_load_l1_ =
+          is_fallback_cluster ? &params.tma_load_l1_fallback : &params.tma_load_l1;
+    } else {
+      observed_tma_load_a_ = &params.tma_load_a;
+      observed_tma_load_b_ = &params.tma_load_b;
+      observed_tma_load_sfa_ = &params.tma_load_sfa;
+      observed_tma_load_sfb_ = &params.tma_load_sfb;
+      observed_tma_load_d_ = &params.tma_load_d;
+      observed_tma_load_l1_ = &params.tma_load_l1;
+    }
+  }
+
+  template <class ProblemShape>
+  static constexpr Params to_underlying_arguments(
+      ProblemShape const& problem_shape, Arguments const& args, [[maybe_unused]] void* workspace,
+      cutlass::KernelHardwareInfo const& hw_info = cutlass::KernelHardwareInfo{}) {
+    // Optionally append 1s until problem shape is rank-4 (MNKL), in case it is only rank-3 (MNK)
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    auto ptr_A = recast_ptr<TmaInternalElementA>(args.ptr_A);
+    auto ptr_B = recast_ptr<TmaInternalElementB>(args.ptr_B);
+
+    Tensor tensor_a = make_tensor(ptr_A, make_layout(make_shape(M, K, L), args.dA));
+    Tensor tensor_b = make_tensor(ptr_B, make_layout(make_shape(N, K, L), args.dB));
+    auto cluster_shape =
+        cutlass::detail::select_cluster_shape(ClusterShape{}, hw_info.cluster_shape);
+
+    // Cluster layout for TMA construction
+    auto cluster_layout_vmnk =
+        tiled_divide(make_layout(cluster_shape), make_tile(typename TiledMma::AtomThrID{}));
+    auto cluster_shape_fallback =
+        cutlass::detail::select_cluster_shape(ClusterShape{}, hw_info.cluster_shape_fallback);
+    auto cluster_layout_vmnk_fallback = tiled_divide(make_layout(cluster_shape_fallback),
+                                                     make_tile(typename TiledMma::AtomThrID{}));
+    Tensor tensor_sfa = make_tensor(args.ptr_SFA, args.layout_SFA);
+    Tensor tensor_sfb = make_tensor(args.ptr_SFB, args.layout_SFB);
+
+    // Cluster layout for TMA construction of SFB
+    auto cluster_layout_sfb_vmnk =
+        tiled_divide(make_layout(cluster_shape), make_tile(typename TiledMMA_SF::AtomThrID{}));
+    auto cluster_layout_sfb_vmnk_fallback = tiled_divide(
+        make_layout(cluster_shape_fallback), make_tile(typename TiledMMA_SF::AtomThrID{}));
+
+    typename Params::TMA_A tma_load_a = make_tma_atom_A_sm100<TmaInternalElementA>(
+        GmemTiledCopyA{}, tensor_a, SmemLayoutA{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{},
+        cluster_layout_vmnk);
+
+    typename Params::TMA_B tma_load_b = make_tma_atom_B_sm100<TmaInternalElementB>(
+        GmemTiledCopyB{}, tensor_b, SmemLayoutB{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{},
+        cluster_layout_vmnk);
+
+    typename Params::TMA_A tma_load_a_fallback = make_tma_atom_A_sm100<TmaInternalElementA>(
+        GmemTiledCopyA{}, tensor_a, SmemLayoutA{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{},
+        cluster_layout_vmnk_fallback);
+
+    typename Params::TMA_B tma_load_b_fallback = make_tma_atom_B_sm100<TmaInternalElementB>(
+        GmemTiledCopyB{}, tensor_b, SmemLayoutB{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{},
+        cluster_layout_vmnk_fallback);
+
+    typename Params::TMA_SFA tma_load_sfa = make_tma_atom_A_sm100<uint16_t>(
+        GmemTiledCopySFA{}, tensor_sfa, SmemLayoutSFA{}(_, _, _, cute::Int<0>{}), TileShape{},
+        TiledMma{}, cluster_layout_vmnk);
+
+    typename Params::TMA_SFB tma_load_sfb = make_tma_atom_B_sm100<uint16_t>(
+        GmemTiledCopySFB{}, tensor_sfb, SmemLayoutSFB{}(_, _, _, cute::Int<0>{}), TileShape_SF{},
+        TiledMMA_SF{}, cluster_layout_sfb_vmnk);
+
+    typename Params::TMA_SFA tma_load_sfa_fallback = make_tma_atom_A_sm100<uint16_t>(
+        GmemTiledCopySFA{}, tensor_sfa, SmemLayoutSFA{}(_, _, _, cute::Int<0>{}), TileShape{},
+        TiledMma{}, cluster_layout_vmnk_fallback);
+
+    typename Params::TMA_SFB tma_load_sfb_fallback = make_tma_atom_B_sm100<uint16_t>(
+        GmemTiledCopySFB{}, tensor_sfb, SmemLayoutSFB{}(_, _, _, cute::Int<0>{}), TileShape_SF{},
+        TiledMMA_SF{}, cluster_layout_sfb_vmnk_fallback);
+
+    // LoRA D/L1 TMA atoms (bf16; [M,LoRaK,L] / [N,LoRaK,L], K-contiguous).
+    Tensor tensor_d =
+        make_tensor(args.ptr_D, make_layout(make_shape(M, cute::Int<LoRaK>{}, L), args.dD));
+    Tensor tensor_l1 =
+        make_tensor(args.ptr_L1, make_layout(make_shape(N, cute::Int<LoRaK>{}, L), args.dL1));
+    typename Params::TMA_D tma_load_d = make_tma_atom_A_sm100<cutlass::bfloat16_t>(
+        GmemTiledCopyA{}, tensor_d, SmemLayoutD{}(_, _, _, cute::Int<0>{}), LoRaMmaTileShape{},
+        LoRaMma{}, cluster_layout_vmnk);
+    typename Params::TMA_L1 tma_load_l1 = make_tma_atom_B_sm100<cutlass::bfloat16_t>(
+        GmemTiledCopyB{}, tensor_l1, SmemLayoutL1{}(_, _, _, cute::Int<0>{}), LoRaMmaTileShape{},
+        LoRaMma{}, cluster_layout_vmnk);
+    typename Params::TMA_D tma_load_d_fallback = make_tma_atom_A_sm100<cutlass::bfloat16_t>(
+        GmemTiledCopyA{}, tensor_d, SmemLayoutD{}(_, _, _, cute::Int<0>{}), LoRaMmaTileShape{},
+        LoRaMma{}, cluster_layout_vmnk_fallback);
+    typename Params::TMA_L1 tma_load_l1_fallback = make_tma_atom_B_sm100<cutlass::bfloat16_t>(
+        GmemTiledCopyB{}, tensor_l1, SmemLayoutL1{}(_, _, _, cute::Int<0>{}), LoRaMmaTileShape{},
+        LoRaMma{}, cluster_layout_vmnk_fallback);
+
+    return {tma_load_a,
+            tma_load_b,
+            tma_load_sfa,
+            tma_load_sfb,
+            tma_load_a_fallback,
+            tma_load_b_fallback,
+            tma_load_sfa_fallback,
+            tma_load_sfb_fallback,
+            tma_load_d,
+            tma_load_l1,
+            tma_load_d_fallback,
+            tma_load_l1_fallback,
+            args.layout_SFA,
+            args.layout_SFB,
+            hw_info.cluster_shape_fallback,
+            args.runtime_data_type_a,
+            args.runtime_data_type_b};
+  }
+
+  template <class ProblemShape>
+  static bool can_implement(ProblemShape const& problem_shape,
+                            [[maybe_unused]] Arguments const& args) {
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    constexpr int tma_alignment_bits_A =
+        cutlass::detail::get_input_alignment_bits<ElementA, IsF8F6F4>();
+    constexpr int tma_alignment_bits_B =
+        cutlass::detail::get_input_alignment_bits<ElementB, IsF8F6F4>();
+
+    bool implementable = true;
+    constexpr int min_tma_aligned_elements_A =
+        tma_alignment_bits_A / cute::sizeof_bits<ElementA>::value;
+    implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_A>(
+                                         cute::make_shape(M, K, L), StrideA{});
+    constexpr int min_tma_aligned_elements_B =
+        tma_alignment_bits_B / cute::sizeof_bits<ElementB>::value;
+    implementable = implementable && cutlass::detail::check_alignment<min_tma_aligned_elements_B>(
+                                         cute::make_shape(N, K, L), StrideB{});
+
+    // Check for SFA SFB layout requirement
+    auto const layout_sfa_ref =
+        take<0, 2>(Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(problem_shape_MNKL));
+    auto const layout_sfb_ref =
+        take<0, 2>(Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(problem_shape_MNKL));
+
+    implementable = implementable && (layout_sfa_ref == take<0, 2>(args.layout_SFA));
+    if (!implementable) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: layout_SFA mismatch, layout_SFA needs to be K-major\n");
+    }
+
+    implementable = implementable && (layout_sfb_ref == take<0, 2>(args.layout_SFB));
+    if (!implementable) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: layout_SFB mismatch, layout_SFB needs to be K-major\n");
+    }
+
+    if (!implementable) {
+      CUTLASS_TRACE_HOST(
+          "  CAN IMPLEMENT: Problem Size doesn't meet the minimum alignment requirements for "
+          "TMA.\n");
+    }
+    return implementable;
+  }
+
+  /// Issue Tma Descriptor Prefetch -- ideally from a single thread for best performance
+  CUTLASS_DEVICE void prefetch_tma_descriptors() {
+    cute::prefetch_tma_descriptor(observed_tma_load_a_->get_tma_descriptor());
+    cute::prefetch_tma_descriptor(observed_tma_load_b_->get_tma_descriptor());
+    cute::prefetch_tma_descriptor(observed_tma_load_sfa_->get_tma_descriptor());
+    cute::prefetch_tma_descriptor(observed_tma_load_sfb_->get_tma_descriptor());
+    cute::prefetch_tma_descriptor(observed_tma_load_d_->get_tma_descriptor());
+    cute::prefetch_tma_descriptor(observed_tma_load_l1_->get_tma_descriptor());
+  }
+
+  /// Construct A Single Stage's Accumulator Shape
+  CUTLASS_DEVICE static auto partition_accumulator_shape() {
+    auto acc_shape = partition_shape_C(
+        TiledMma{}, take<0, 2>(TileShape{}));  // ((MMA_TILE_M,MMA_TILE_N),MMA_M,MMA_N)
+
+    return acc_shape;
+  }
+
+  template <class TmemStorage>
+  CUTLASS_DEVICE static auto slice_accumulator(TmemStorage tmem_storage, int stage) {
+    return cute::make_tuple(tmem_storage.accumulators(_, _, _, stage));
+  }
+
+  template <class EpilogueTile, bool IsOverlappingAccum = false>
+  CUTLASS_DEVICE static auto init_tmem_tensors(EpilogueTile epi_tile) {
+    TiledMma tiled_mma;
+    auto acc_shape = partition_accumulator_shape();
+    // ((MMA_TILE_M,MMA_TILE_N),MMA_M,MMA_N,ACC_PIPE) where ACC_PIPE=2 so we can double buffer our
+    // accumulators for mainloop and epilogue.
+    Tensor accumulators =
+        cutlass::detail::make_sm100_accumulator<AccumulatorPipelineStageCount, IsOverlappingAccum>(
+            tiled_mma, acc_shape, EpilogueTile{});
+    Tensor tCtSFA = make_tensor<typename TiledMma::FrgTypeSFA>(shape(SmemLayoutAtomSFA{}));
+    Tensor tCtSFB = make_tensor<typename TiledMma::FrgTypeSFB>(shape(SmemLayoutAtomSFB{}));
+
+    TmemStorage<decltype(accumulators), decltype(tCtSFA), decltype(tCtSFB)> tmem_storage;
+    tmem_storage.accumulators = accumulators;
+    tmem_storage.tCtSFA = tCtSFA;
+    tmem_storage.tCtSFB = tCtSFB;
+
+    return tmem_storage;
+  }
+
+  template <class TmemStorage>
+  CUTLASS_DEVICE static void set_tmem_offsets(TmemStorage& tmem_storage, uint32_t tmem_base_addr) {
+    tmem_storage.accumulators.data() = tmem_base_addr;
+    tmem_storage.tCtSFA.data() =
+        tmem_storage.accumulators.data().get() +
+        cutlass::detail::find_tmem_tensor_col_offset(tmem_storage.accumulators);
+    tmem_storage.tCtSFB.data() = tmem_storage.tCtSFA.data().get() +
+                                 cutlass::detail::find_tmem_tensor_col_offset(tmem_storage.tCtSFA);
+  }
+
+  /// Set up the data needed by this collective for load.
+  /// Return tuple element contain
+  /// gA_mkl - The tiled tma tensor for input A
+  /// gB_nkl - The tiled tma tensor for input B
+  /// tAgA_mkl - partitioned gmem tensor for A
+  /// tBgB_nkl - partitioned gmem tensor for B
+  /// tAsA - partitioned smem tensor for A
+  /// tBsB - partitioned smem tensor for B
+  /// tAgSFA_mkl - partitioned gmem tensor for SFA
+  /// tBgSFB_nkl - partitioned gmem tensor for SFB
+  /// tAsSFA - partitioned tmem tensor for SFA
+  /// tAsSFB - partitioned tmem tensor for SFB
+  /// mcast_mask_a - tma multicast mask for A
+  /// mcast_mask_b - tma multicast mask for B
+  /// mcast_mask_sfa - tma multicast mask for SFA
+  /// mcast_mask_sfb - tma multicast mask for SFB
+  template <class ProblemShape_MNKL>
+  CUTLASS_DEVICE auto load_init(ProblemShape_MNKL const& problem_shape_MNKL,
+                                TensorStorage& shared_tensors) const {
+    using X = Underscore;
+
+    // Separate out problem shape for convenience
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    // Represent the full tensors -- get these from TMA
+    Tensor mA_mkl = observed_tma_load_a_->get_tma_tensor(make_shape(M, K, L));
+    Tensor mB_nkl = observed_tma_load_b_->get_tma_tensor(make_shape(N, K, L));
+
+    // Tile the tensors and defer the slice
+    Tensor gA_mkl = local_tile(mA_mkl, TileShape{}, make_coord(_, _, _),
+                               Step<_1, X, _1>{});  // (BLK_M, BLK_K, m, k, l)
+    Tensor gB_nkl = local_tile(mB_nkl, TileShape{}, make_coord(_, _, _),
+                               Step<X, _1, _1>{});  // (BLK_N, BLK_K, n, k, l)
+
+    // Represent the full tensor of Scale factors
+    Tensor mSFA_mkl = observed_tma_load_sfa_->get_tma_tensor(shape(layout_SFA_));
+    auto mSFB_nkl = [=]() {
+      if constexpr (IsCtaN192) {
+        Tensor mSFB_tmp = observed_tma_load_sfb_->get_tma_tensor(shape(layout_SFB_));
+        auto x = stride<0, 1>(mSFB_tmp);
+        auto y = ceil_div(shape<0, 1>(mSFB_tmp), 4);
+        auto new_shape =
+            make_shape(make_shape(shape<0, 0>(mSFB_tmp), make_shape(make_shape(_2{}, _2{}), y)),
+                       shape<1>(mSFB_tmp), shape<2>(mSFB_tmp));
+        auto new_stride =
+            make_stride(make_stride(stride<0, 0>(mSFB_tmp), make_stride(make_stride(x, x), x * 3)),
+                        stride<1>(mSFB_tmp), stride<2>(mSFB_tmp));
+        return make_tensor(mSFB_tmp.data(), make_layout(new_shape, new_stride));
+      } else if constexpr (IsCtaN64) {
+        Tensor mSFB_tmp = observed_tma_load_sfb_->get_tma_tensor(shape(layout_SFB_));
+        auto new_shape =
+            make_shape(make_shape(shape<0, 0>(mSFB_tmp), make_shape(_2{}, shape<0, 1>(mSFB_tmp))),
+                       shape<1>(mSFB_tmp), shape<2>(mSFB_tmp));
+        auto new_stride = make_stride(
+            make_stride(stride<0, 0>(mSFB_tmp), make_stride(_0{}, stride<0, 1>(mSFB_tmp))),
+            stride<1>(mSFB_tmp), stride<2>(mSFB_tmp));
+        return make_tensor(mSFB_tmp.data(), make_layout(new_shape, new_stride));
+      } else {
+        return observed_tma_load_sfb_->get_tma_tensor(shape(layout_SFB_));
+      }
+    }();
+
+    Tensor gSFA_mkl = local_tile(mSFA_mkl, TileShape{}, make_coord(_, _, _),
+                                 Step<_1, X, _1>{});  // (TILE_M,TILE_K,m,k,l)
+    Tensor gSFB_nkl = local_tile(mSFB_nkl, TileShape_SF{}, make_coord(_, _, _),
+                                 Step<X, _1, _1>{});  // (TILE_N,TILE_K,n,k,l)
+
+    // Partition for this CTA
+    ThrMMA cta_mma = TiledMma{}.get_slice(blockIdx.x % size(typename TiledMma::AtomThrID{}));
+
+    Tensor tCgA_mkl = cta_mma.partition_A(gA_mkl);  // (MMA, MMA_M, MMA_K, m, k, l)
+    Tensor tCgB_nkl = cta_mma.partition_B(gB_nkl);  // (MMA, MMA_N, MMA_K, n, k, l)
+
+    Tensor sA = make_tensor(make_smem_ptr(shared_tensors.smem_A.begin()),
+                            SmemLayoutA{});  // (MMA,MMA_M,MMA_K,PIPE)
+    Tensor sB = make_tensor(make_smem_ptr(shared_tensors.smem_B.begin()),
+                            SmemLayoutB{});  // (MMA,MMA_N,MMA_K,PIPE)
+
+    ThrMMA cta_mma_sfb =
+        TiledMMA_SF{}.get_slice(blockIdx.x % size(typename TiledMMA_SF::AtomThrID{}));
+    Tensor tCgSFA_mkl = cta_mma.partition_A(gSFA_mkl);      // (MMA, MMA_M, MMA_K, m, k, l)
+    Tensor tCgSFB_nkl = cta_mma_sfb.partition_B(gSFB_nkl);  // (MMA, MMA_N, MMA_K, n, k, l)
+
+    Tensor sSFA = make_tensor(make_smem_ptr(shared_tensors.smem_SFA.begin()), SmemLayoutSFA{});
+    Tensor sSFB = make_tensor(make_smem_ptr(shared_tensors.smem_SFB.begin()), SmemLayoutSFB{});
+
+    // Define the CTA-in-cluster Layout and Coord
+    Layout cta_layout_mnk = make_layout(cluster_shape_);
+    Layout cta_layout_vmnk =
+        tiled_divide(cta_layout_mnk, make_tile(typename TiledMma::AtomThrID{}));
+    auto cta_coord_vmnk = cta_layout_vmnk.get_flat_coord(block_rank_in_cluster_);
+
+    Layout cta_layout_sfb_vmnk =
+        tiled_divide(cta_layout_mnk, make_tile(typename TiledMMA_SF::AtomThrID{}));
+    auto cta_coord_sfb_vmnk = cta_layout_sfb_vmnk.get_flat_coord(block_rank_in_cluster_);
+
+    // Project the cta_layout for tma_a along the n-modes
+    auto [tAgA_mkl, tAsA] = tma_partition(*observed_tma_load_a_, get<2>(cta_coord_vmnk),
+                                          make_layout(size<2>(cta_layout_vmnk)),
+                                          group_modes<0, 3>(sA), group_modes<0, 3>(tCgA_mkl));
+
+    // Project the cta_layout for tma_b along the m-modes
+    auto [tBgB_nkl, tBsB] = tma_partition(*observed_tma_load_b_, get<1>(cta_coord_vmnk),
+                                          make_layout(size<1>(cta_layout_vmnk)),
+                                          group_modes<0, 3>(sB), group_modes<0, 3>(tCgB_nkl));
+
+    // Project the cta_layout for tma_a along the n-modes
+    auto [tAgSFA_mkl, tAsSFA] = tma_partition(
+        *observed_tma_load_sfa_, get<2>(cta_coord_vmnk), make_layout(size<2>(cta_layout_vmnk)),
+        group_modes<0, 3>(sSFA), group_modes<0, 3>(tCgSFA_mkl));
+
+    // Project the cta_layout for tma_b along the m-modes
+    auto [tBgSFB_nkl, tBsSFB] =
+        tma_partition(*observed_tma_load_sfb_, get<1>(cta_coord_sfb_vmnk),
+                      make_layout(size<1>(cta_layout_sfb_vmnk)), group_modes<0, 3>(sSFB),
+                      group_modes<0, 3>(tCgSFB_nkl));
+
+    // TMA Multicast Masks
+    uint16_t mcast_mask_a = create_tma_multicast_mask<2>(cta_layout_vmnk, cta_coord_vmnk);
+    uint16_t mcast_mask_b = create_tma_multicast_mask<1>(cta_layout_vmnk, cta_coord_vmnk);
+    uint16_t mcast_mask_sfa = create_tma_multicast_mask<2>(cta_layout_vmnk, cta_coord_vmnk);
+    uint16_t mcast_mask_sfb = create_tma_multicast_mask<1>(cta_layout_sfb_vmnk, cta_coord_sfb_vmnk);
+
+    // LoRA D[M,LoRaK]/L1[N,LoRaK]: partition like A/B (D along M, L1 along N), single k-tile.
+    Tensor mD_mkl = observed_tma_load_d_->get_tma_tensor(make_shape(M, cute::Int<LoRaK>{}, L));
+    Tensor mL1_nkl = observed_tma_load_l1_->get_tma_tensor(make_shape(N, cute::Int<LoRaK>{}, L));
+    Tensor gD_mkl = local_tile(mD_mkl, LoRaMmaTileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});
+    Tensor gL1_nkl =
+        local_tile(mL1_nkl, LoRaMmaTileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
+    ThrMMA cta_mma_lora = LoRaMma{}.get_slice(blockIdx.x % size(typename LoRaMma::AtomThrID{}));
+    Tensor tCgD_mkl = cta_mma_lora.partition_A(gD_mkl);
+    Tensor tCgL1_nkl = cta_mma_lora.partition_B(gL1_nkl);
+    // D/L1 SMEM = the residual stage buffers reinterpreted as bf16 (byte-exact, multi-stage).
+    Tensor sD =
+        make_tensor(recast_ptr<cutlass::bfloat16_t>(make_smem_ptr(shared_tensors.smem_A.begin())),
+                    SmemLayoutD{});
+    Tensor sL1 =
+        make_tensor(recast_ptr<cutlass::bfloat16_t>(make_smem_ptr(shared_tensors.smem_B.begin())),
+                    SmemLayoutL1{});
+    auto [tDgD_mkl, tDsD] = tma_partition(*observed_tma_load_d_, get<2>(cta_coord_vmnk),
+                                          make_layout(size<2>(cta_layout_vmnk)),
+                                          group_modes<0, 3>(sD), group_modes<0, 3>(tCgD_mkl));
+    auto [tL1gL1_nkl, tL1sL1] = tma_partition(*observed_tma_load_l1_, get<1>(cta_coord_vmnk),
+                                              make_layout(size<1>(cta_layout_vmnk)),
+                                              group_modes<0, 3>(sL1), group_modes<0, 3>(tCgL1_nkl));
+    uint16_t mcast_mask_d = create_tma_multicast_mask<2>(cta_layout_vmnk, cta_coord_vmnk);
+    uint16_t mcast_mask_l1 = create_tma_multicast_mask<1>(cta_layout_vmnk, cta_coord_vmnk);
+
+    return LoadParams{
+        size<3>(gA_mkl),                         // for scheduler
+        tAgA_mkl, tBgB_nkl, tAsA, tBsB,          // for input tensor values
+        tAgSFA_mkl, tBgSFB_nkl, tAsSFA, tBsSFB,  // for input scale factor tensor
+                                                 // values
+        mcast_mask_a, mcast_mask_b, mcast_mask_sfa, mcast_mask_sfb,        // multicast masks
+        tDgD_mkl, tDsD, tL1gL1_nkl, tL1sL1, mcast_mask_d, mcast_mask_l1};  // LoRA D/L1
+  }
+
+  /// Set up the data needed by this collective for mma compute.
+  template <class TmemStorage>
+  CUTLASS_DEVICE auto mma_init(TmemStorage tmem_storage, TensorStorage& shared_tensors) const {
+    // Allocate "fragments/descriptors" for A and B matrices
+    Tensor sA = make_tensor(make_smem_ptr(shared_tensors.smem_A.begin()),
+                            SmemLayoutA{});  // (BLK_M,BLK_K,PIPE)
+    Tensor sB = make_tensor(make_smem_ptr(shared_tensors.smem_B.begin()),
+                            SmemLayoutB{});  // (BLK_N,BLK_K,PIPE)
+
+    // Allocate "fragments/descriptors" for A and B matrices
+    Tensor tCrA = TiledMma::make_fragment_A(sA);  // (MMA,MMA_M,MMA_K,PIPE)
+    Tensor tCrB = TiledMma::make_fragment_B(sB);  // (MMA,MMA_N,MMA_K,PIPE)
+
+    CUTE_STATIC_ASSERT_V(Int<DispatchPolicy::Stages>{} == size<3>(sA));  // PIPE
+    CUTE_STATIC_ASSERT_V(Int<DispatchPolicy::Stages>{} == size<3>(sB));  // PIPE
+
+    //
+    // Scale Factor
+    //
+    Tensor tCtSFA = tmem_storage.tCtSFA;
+    Tensor tCtSFB = tmem_storage.tCtSFB;
+    // Setup smem descriptors for UTCCP
+    Tensor tCsSFA = make_tensor(make_smem_ptr(shared_tensors.smem_SFA.begin()), SmemLayoutSFA{});
+    Tensor tCsSFB = make_tensor(make_smem_ptr(shared_tensors.smem_SFB.begin()), SmemLayoutSFB{});
+
+    // Make SMEM and TMEM tensors compact removing the zero strides to eliminate unnecessary copy
+    // instructions.
+    auto tCsSFA_compact = make_tensor(tCsSFA.data(), filter_zeros(tCsSFA.layout()));
+    auto tCtSFA_compact = make_tensor(tCtSFA.data(), filter_zeros(tCtSFA.layout()));
+    auto tCsSFB_compact = make_tensor(tCsSFB.data(), filter_zeros(tCsSFB.layout()));
+    auto tCtSFB_compact = make_tensor(tCtSFB.data(), filter_zeros(tCtSFB.layout()));
+
+    // Create the SMEM to TMEM copy operations based on the MMA atom used (1CTA vs 2CTA)
+    using AtomThrID = typename TiledMma::AtomThrID;
+    using UtccpOp =
+        cute::conditional_t<(decltype(cute::size(AtomThrID{}) == Int<2>{})::value),
+                            SM100_UTCCP_4x32dp128bit_2cta, SM100_UTCCP_4x32dp128bit_1cta>;
+    auto tiled_copy_s2t_SFA = make_utccp_copy(UtccpOp{}, tCtSFA_compact);
+    auto tiled_copy_s2t_SFB = make_utccp_copy(UtccpOp{}, tCtSFB_compact);
+
+    auto thr_copy_s2t_SFA = tiled_copy_s2t_SFA.get_slice(0);
+    auto thr_tCsSFA_compact_s2t_ = thr_copy_s2t_SFA.partition_S(tCsSFA_compact);
+    // SMEM to TMEM copy operation requires source SMEM operand to be an SMEM descriptor
+    auto thr_tCsSFA_compact_s2t = get_utccp_smem_desc_tensor<UtccpOp>(thr_tCsSFA_compact_s2t_);
+    auto thr_tCtSFA_compact_s2t = thr_copy_s2t_SFA.partition_D(tCtSFA_compact);
+
+    auto thr_copy_s2t_SFB = tiled_copy_s2t_SFB.get_slice(0);
+    auto thr_tCsSFB_compact_s2t_ = thr_copy_s2t_SFB.partition_S(tCsSFB_compact);
+    // SMEM to TMEM copy operation requires source SMEM operand to be an SMEM descriptor
+    auto thr_tCsSFB_compact_s2t = get_utccp_smem_desc_tensor<UtccpOp>(thr_tCsSFB_compact_s2t_);
+    auto thr_tCtSFB_compact_s2t = thr_copy_s2t_SFB.partition_D(tCtSFB_compact);
+
+    TiledMma tiled_mma;
+
+    if constexpr (IsRuntimeDataType) {
+      // Update instruction descriptor according to runtime argument.
+      // Applying bitmask (0b111) to help compiler deduce that the conversion and assignment are
+      // safe.
+      tiled_mma.idesc_.a_format_ = uint8_t(runtime_data_type_a_) & 0b111;
+      tiled_mma.idesc_.b_format_ = uint8_t(runtime_data_type_b_) & 0b111;
+    }
+
+    // LoRA fragments for the post-K-loop D@L1ᵀ MMA into the SAME f32 accumulator.
+    // D/L1 SMEM = reinterpreted residual stage buffers (multi-stage) -> tCrD/tCrL1 are
+    // stage-moded (MMA,MMA_M/N,MMA_K,Stages); apply_lora indexes the consumed stage read_stage.
+    Tensor sD =
+        make_tensor(recast_ptr<cutlass::bfloat16_t>(make_smem_ptr(shared_tensors.smem_A.begin())),
+                    SmemLayoutD{});
+    Tensor sL1 =
+        make_tensor(recast_ptr<cutlass::bfloat16_t>(make_smem_ptr(shared_tensors.smem_B.begin())),
+                    SmemLayoutL1{});
+    Tensor tCrD = LoRaMma::make_fragment_A(sD);    // (MMA,MMA_M,MMA_K,Stages)
+    Tensor tCrL1 = LoRaMma::make_fragment_B(sL1);  // (MMA,MMA_N,MMA_K,Stages)
+
+    return MmaParams{tiled_mma,
+                     tCrA,
+                     tCrB,
+                     tCtSFA,
+                     tCtSFB,
+                     tiled_copy_s2t_SFA,
+                     thr_tCsSFA_compact_s2t,
+                     thr_tCtSFA_compact_s2t,
+                     tiled_copy_s2t_SFB,
+                     thr_tCsSFB_compact_s2t,
+                     thr_tCtSFB_compact_s2t,
+                     tCrD,
+                     tCrL1};
+  }
+
+  /// Perform a collective-scoped matrix multiply-accumulate
+  /// Producer Perspective
+  template <class LoadParams, class TileCoordMNKL, class KTileIterator>
+  CUTLASS_DEVICE auto load(MainloopPipeline mainloop_pipeline,
+                           MainloopPipelineState mainloop_pipe_producer_state,
+                           LoadParams const& load_inputs, TileCoordMNKL const& cta_coord_mnkl,
+                           KTileIterator k_tile_iter, int k_tile_count) {
+    auto [unused_k_tiles, tAgA_mkl, tBgB_nkl, tAsA, tBsB, tAgSFA_mkl, tBgSFB_nkl, tAsSFA, tBsSFB,
+          mcast_mask_a, mcast_mask_b, mcast_mask_sfa, mcast_mask_sfb, tDgD_mkl, tDsD, tL1gL1_nkl,
+          tL1sL1, mcast_mask_d, mcast_mask_l1] = load_inputs;
+
+    // slice out the work coord from partitioned tensors
+    Tensor tAgA = tAgA_mkl(_, get<0>(cta_coord_mnkl) / size(typename TiledMma::AtomThrID{}), _,
+                           get<3>(cta_coord_mnkl));
+    Tensor tBgB = tBgB_nkl(_, get<1>(cta_coord_mnkl), _, get<3>(cta_coord_mnkl));
+    Tensor tAgSFA = tAgSFA_mkl(_, get<0>(cta_coord_mnkl) / size(typename TiledMma::AtomThrID{}), _,
+                               get<3>(cta_coord_mnkl));
+    Tensor tBgSFB = tBgSFB_nkl(_, get<1>(cta_coord_mnkl), _, get<3>(cta_coord_mnkl));
+    Tensor tDgD = tDgD_mkl(_, get<0>(cta_coord_mnkl) / size(typename TiledMma::AtomThrID{}), _,
+                           get<3>(cta_coord_mnkl));
+    Tensor tL1gL1 = tL1gL1_nkl(_, get<1>(cta_coord_mnkl), _, get<3>(cta_coord_mnkl));
+
+    // The kernel calls load() TWICE per work-tile: prologue (starts at k-tile 0) then mainloop
+    // (starts at k_tile_prologue>0). For a simple-GEMM scalar k-tile iterator, *k_tile_iter is
+    // that start index. We emit the post-K-loop D/L1 step ONLY in the mainloop call (start!=0)
+    // so it lands at the END of the global k-tile sequence (exactly once), matching mma()'s
+    // single post-loop consumer step. (Case k_tiles<=Stages: prologue loads all, mainloop loads
+    // 0 but still starts at k_tiles>0 -> it emits, still after all tiles. Correct either way.)
+    int lora_start_k = *k_tile_iter;
+
+    auto barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+
+    // Issue the Mainloop loads
+    CUTLASS_PRAGMA_NO_UNROLL
+    while (k_tile_count > 0) {
+      // LOCK mainloop_pipe_producer_state for _writing_
+      mainloop_pipeline.producer_acquire(mainloop_pipe_producer_state, barrier_token);
+      // Note: We don't synchronize the sf_pipeline for "Buffer_Empty". We use mainloop pipeline
+      // to do the synchronization at once.
+
+      using BarrierType = typename MainloopPipeline::ProducerBarrierType;
+      BarrierType* tma_barrier =
+          mainloop_pipeline.producer_get_barrier(mainloop_pipe_producer_state);
+
+      int write_stage = mainloop_pipe_producer_state.index();
+      ++mainloop_pipe_producer_state;
+      barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+
+      if (cute::elect_one_sync()) {
+        copy(observed_tma_load_a_->with(*tma_barrier, mcast_mask_a), tAgA(_, *k_tile_iter),
+             tAsA(_, write_stage));
+        copy(observed_tma_load_b_->with(*tma_barrier, mcast_mask_b), tBgB(_, *k_tile_iter),
+             tBsB(_, write_stage));
+        copy(observed_tma_load_sfa_->with(*tma_barrier, mcast_mask_sfa), tAgSFA(_, *k_tile_iter),
+             tAsSFA(_, write_stage));
+        copy(observed_tma_load_sfb_->with(*tma_barrier, mcast_mask_sfb), tBgSFB(_, *k_tile_iter),
+             tBsSFB(_, write_stage));
+      }
+
+      --k_tile_count;
+      ++k_tile_iter;
+    }
+
+    // === load D/L1 in ONE extra producer step AFTER the K-loop, INTO the
+    // freed residual stage buffers smem_A[ws]/smem_B[ws] (no dedicated sD/sL1, no carveout), ONLY
+    // in the mainloop call (lora_start_k != 0) so it lands at the END of the k-tile sequence (else
+    // the prologue's copy would inject mid-sequence -> consumer misreads it as a tile -> hang). The
+    // producer_acquire arms the barrier for the A+B+SF byte budget; D arrives EXACTLY the A-stage
+    // bytes (D-tile == A-stage) into smem_A[ws], L1 the B-stage bytes into smem_B[ws], and SFA/SFB
+    // are DUMMY-reloaded to arrive the SF bytes -> D+L1+SF == armed A+B+SF, so NO
+    // expect_transaction and NO A/B re-load needed. (D/L1 in pipeline-managed stage buffers also
+    // removes the earlier dedicated-single-buffer cross-tile clobber caveat.) ===
+    if (lora_start_k != 0) {
+      mainloop_pipeline.producer_acquire(mainloop_pipe_producer_state, barrier_token);
+      using BarrierTypePost = typename MainloopPipeline::ProducerBarrierType;
+      BarrierTypePost* tb = mainloop_pipeline.producer_get_barrier(mainloop_pipe_producer_state);
+      int ws = mainloop_pipe_producer_state.index();
+      ++mainloop_pipe_producer_state;
+      if (cute::elect_one_sync()) {
+        copy(observed_tma_load_sfa_->with(*tb, mcast_mask_sfa), tAgSFA(_, cute::_0{}),
+             tAsSFA(_, ws));  // dummy: arrive SFA bytes
+        copy(observed_tma_load_sfb_->with(*tb, mcast_mask_sfb), tBgSFB(_, cute::_0{}),
+             tBsSFB(_, ws));  // dummy: arrive SFB bytes
+        copy(observed_tma_load_d_->with(*tb, mcast_mask_d), tDgD(_, cute::_0{}),
+             tDsD(_, ws));  // D -> smem_A[ws] (== A-stage bytes)
+        copy(observed_tma_load_l1_->with(*tb, mcast_mask_l1), tL1gL1(_, cute::_0{}),
+             tL1sL1(_, ws));  // L1 -> smem_B[ws] (== B-stage bytes)
+      }
+    }
+
+    return cute::make_tuple(mainloop_pipe_producer_state, k_tile_iter);
+  }
+
+  /// Perform a Producer Epilogue to prevent early exit of ctas in a Cluster
+  CUTLASS_DEVICE void load_tail(MainloopPipeline mainloop_pipeline,
+                                MainloopPipelineState mainloop_pipe_producer_state) {
+    // Issue the epilogue waits
+    // This helps avoid early exit of ctas in Cluster
+    // Waits for all stages to either be released (all
+    // Consumer UNLOCKs), or if the stage was never used
+    // then would just be acquired since the phase was
+    // still inverted from make_producer_start_state
+    mainloop_pipeline.producer_tail(mainloop_pipe_producer_state);
+  }
+
+  /// Perform a collective-scoped matrix multiply-accumulate
+  /// Consumer Perspective
+  template <class AccumulatorPipeline, class FrgEngine, class FrgLayout, class MmaParams,
+            class CtaTileCoord>
+  CUTLASS_DEVICE auto mma(
+      cute::tuple<MainloopPipeline, AccumulatorPipeline> pipelines,
+      cute::tuple<MainloopPipelineState, typename AccumulatorPipeline::PipelineState>
+          pipeline_states,
+      cute::tuple<cute::Tensor<FrgEngine, FrgLayout>> const& accumulators_pair,
+      MmaParams const& mma_inputs, CtaTileCoord cta_tile_coord, int k_tile_count) {
+    static_assert(is_tmem<FrgEngine>::value, "Accumulator must be tmem resident.");
+    static_assert(rank(FrgLayout{}) == 3,
+                  "Accumulator must be MMA-partitioned: (MMA, MMA_M, MMA_N)");
+
+    auto accumulators = get<0>(accumulators_pair);
+    auto [tiled_mma, tCrA, tCrB, tCtSFA, tCtSFB, tiled_copy_s2t_SFA, thr_tCsSFA_s2t, thr_tCtSFA_s2t,
+          tiled_copy_s2t_SFB, thr_tCsSFB_s2t, thr_tCtSFB_s2t, tCrD, tCrL1] = mma_inputs;
+
+    auto [mainloop_pipeline, accumulator_pipeline] = pipelines;
+    auto [mainloop_pipe_consumer_state, accumulator_pipe_producer_state] = pipeline_states;
+
+    auto tCtSFB_mma = [tCtSFB = tCtSFB, cta_tile_coord]() {
+      if constexpr (IsCtaN192) {
+        // If this is an ODD tile, shift the TMEM start address for N=192 case by two words (ignores
+        // first 64 columns of SFB)
+        auto tCtSFB_tmp = tCtSFB;
+        if (size<1>(cta_tile_coord) % 2 == 1) {
+          tCtSFB_tmp.data() = tCtSFB_tmp.data().get() + 2;
+        }
+        return tCtSFB_tmp;
+      } else if constexpr (IsCtaN64) {
+        // Move in increments of 64 columns of SFB
+        auto tCtSFB_tmp = tCtSFB;
+        tCtSFB_tmp.data() = tCtSFB_tmp.data().get() + (size<1>(cta_tile_coord) % 2) * 2;
+        return tCtSFB_tmp;
+      } else {
+        return tCtSFB;
+      }
+    }();
+
+    uint32_t skip_wait = k_tile_count <= 0;
+    auto barrier_token =
+        mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+
+    //
+    // PIPELINED MAIN LOOP
+    //
+    tiled_mma.accumulate_ = UMMA::ScaleOut::Zero;
+
+    // LoRA-up D@L1ᵀ applied in ONE post-K-loop consumer step (see load(): D/L1 are TMA'd into the
+    // residual stage buffers smem_A[ws]/smem_B[ws] in an extra producer step after the K-loop). The
+    // residual accumulator is still held (producer_acquire'd, not yet committed), and f32 acc adds
+    // are commutative, so adding D@L1ᵀ after the full residual == folding it in. accumulate_=One
+    // adds. rstage = the consumed pipeline stage holding THIS output tile's D/L1 (tCrD/tCrL1 are
+    // stage-moded since SmemLayoutD/L1 overlay the multi-stage smem_A/smem_B).
+    auto lora_mma = LoRaMma{};
+    lora_mma.accumulate_ = UMMA::ScaleOut::One;
+    static constexpr int LoRaAtomK = cute::size<2>(typename LoRaMma::AtomShape_MNK{});
+    static_assert(LoRaK % LoRaAtomK == 0);
+    static constexpr int LoRaMmaKBlocks = LoRaK / LoRaAtomK;
+    auto apply_lora = [&](int rstage) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int kb = 0; kb < LoRaMmaKBlocks; ++kb) {
+        cute::gemm(lora_mma, tCrD(_, _, kb, rstage), tCrL1(_, _, kb, rstage), accumulators);
+      }
+    };
+
+    if constexpr (IsOverlappingAccum) {
+      // first iteration manual unroll for tmem overlap kernel
+      if (k_tile_count > 0) {
+        // WAIT on mainloop_pipe_consumer_state until its data are available
+        // (phase bit flips from mainloop_pipe_consumer_state.phase() value)
+        mainloop_pipeline.consumer_wait(mainloop_pipe_consumer_state, barrier_token);
+
+        // Compute on k_tile
+        int read_stage = mainloop_pipe_consumer_state.index();
+        // Save current mainlop pipeline read state
+        auto curr_mainloop_pipe_consumer_state = mainloop_pipe_consumer_state;
+
+        // Advance mainloop_pipe
+        ++mainloop_pipe_consumer_state;
+        --k_tile_count;
+        skip_wait = k_tile_count <= 0;
+        // Peek at next iteration
+        barrier_token =
+            mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+
+        if (cute::elect_one_sync()) {
+          copy(tiled_copy_s2t_SFA, thr_tCsSFA_s2t(_, _, _, _, read_stage), thr_tCtSFA_s2t);
+          copy(tiled_copy_s2t_SFB, thr_tCsSFB_s2t(_, _, _, _, read_stage), thr_tCtSFB_s2t);
+        }
+
+        // Wait for tmem accumulator buffer to become empty with a flipped phase
+        accumulator_pipeline.producer_acquire(accumulator_pipe_producer_state);
+
+        // Unroll the K mode manually so we can set scale C to 1
+        CUTLASS_PRAGMA_UNROLL
+        for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+          // (V,M) x (V,N) => (V,M,N)
+          cute::gemm(tiled_mma.with(tiled_mma.accumulate_, tCtSFA(_, _, k_block),
+                                    tCtSFB_mma(_, _, k_block)),
+                     tCrA(_, _, k_block, read_stage), tCrB(_, _, k_block, read_stage),
+                     accumulators);
+          tiled_mma.accumulate_ = UMMA::ScaleOut::One;
+        }
+        mainloop_pipeline.consumer_release(curr_mainloop_pipe_consumer_state);
+      }
+    } else {
+      // Wait for tmem accumulator buffer to become empty with a flipped phase
+      accumulator_pipeline.producer_acquire(accumulator_pipe_producer_state);
+    }
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    while (k_tile_count > 0) {
+      // WAIT on mainloop_pipe_consumer_state until its data are available
+      // (phase bit flips from mainloop_pipe_consumer_state.phase() value)
+      mainloop_pipeline.consumer_wait(mainloop_pipe_consumer_state, barrier_token);
+
+      // Compute on k_tile
+      int read_stage = mainloop_pipe_consumer_state.index();
+      // Save current mainlop pipeline read state
+      auto curr_mainloop_pipe_consumer_state = mainloop_pipe_consumer_state;
+
+      // Advance mainloop_pipe
+      ++mainloop_pipe_consumer_state;
+      --k_tile_count;
+      skip_wait = k_tile_count <= 0;
+      // Peek at next iteration
+      barrier_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state, skip_wait);
+
+      if (cute::elect_one_sync()) {
+        copy(tiled_copy_s2t_SFA, thr_tCsSFA_s2t(_, _, _, _, read_stage), thr_tCtSFA_s2t);
+        copy(tiled_copy_s2t_SFB, thr_tCsSFB_s2t(_, _, _, _, read_stage), thr_tCtSFB_s2t);
+      }
+
+      // Unroll the K mode manually so we can set scale C to 1
+      CUTLASS_PRAGMA_UNROLL
+      for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+        // (V,M) x (V,N) => (V,M,N)
+        cute::gemm(
+            tiled_mma.with(tiled_mma.accumulate_, tCtSFA(_, _, k_block), tCtSFB_mma(_, _, k_block)),
+            tCrA(_, _, k_block, read_stage), tCrB(_, _, k_block, read_stage), accumulators);
+        tiled_mma.accumulate_ = UMMA::ScaleOut::One;
+      }
+      mainloop_pipeline.consumer_release(curr_mainloop_pipe_consumer_state);
+    }
+
+    // === consume the SINGLE post-K-loop D/L1 producer step (load() emits it
+    // only in the mainloop call, gated by lora_start_k != 0, so exactly one occurs at the end of
+    // the k-tile sequence), then run the LoRA MMA reading D/L1 from the consumed stage buffer
+    // (read_stage = the smem_A[stage]/smem_B[stage] this step's D/L1 landed in) into the still-held
+    // residual accumulator. One consumer step balances the one producer step. ===
+    {
+      auto lora_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state);
+      mainloop_pipeline.consumer_wait(mainloop_pipe_consumer_state, lora_token);
+      int lora_read_stage = mainloop_pipe_consumer_state.index();
+      apply_lora(lora_read_stage);
+      mainloop_pipeline.consumer_release(mainloop_pipe_consumer_state);
+      ++mainloop_pipe_consumer_state;
+    }
+
+    return mainloop_pipe_consumer_state;
+  }
+
+ protected:
+  typename Params::TMA_A const* observed_tma_load_a_{nullptr};
+  typename Params::TMA_B const* observed_tma_load_b_{nullptr};
+  typename Params::TMA_SFA const* observed_tma_load_sfa_{nullptr};
+  typename Params::TMA_SFB const* observed_tma_load_sfb_{nullptr};
+  typename Params::TMA_D const* observed_tma_load_d_{nullptr};
+  typename Params::TMA_L1 const* observed_tma_load_l1_{nullptr};
+
+  LayoutSFA layout_SFA_;
+  LayoutSFB layout_SFB_;
+  RuntimeDataTypeA runtime_data_type_a_{};
+  RuntimeDataTypeB runtime_data_type_b_{};
+
+  ClusterShape cluster_shape_;
+  uint32_t block_rank_in_cluster_;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace cutlass::gemm::collective
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/flashinfer/gemm/nvfp4_svdquant_gemm_collective_sm100.h
+++ b/include/flashinfer/gemm/nvfp4_svdquant_gemm_collective_sm100.h
@@ -114,14 +114,19 @@ struct CollectiveMmaLoRA<
   // SAME f32 TMEM accumulator after the NVFP4 K-loop. Build the bf16 TiledMMA via CUTLASS's
   // own SM100 helper (matches the residual cta_group; SS = both operands SMEM-sourced, as
   // the residual mainloop requires). The MMA tile is the full CTA-group tile, while the
-  // SMEM layouts below are explicitly reduced to each CTA's partition. ===
-  static constexpr int LoRaK = 32;  // Logical SVDQuant rank r=32 = 2 bf16 16-wide K-atoms.
+  // SMEM layouts below are explicitly reduced to each CTA's partition. The runtime rank
+  // (Arguments::lora_rank) is any positive multiple of LoRaK; ranks wider than one
+  // LoRaStorageK tile are consumed as extra post-K-loop chunks over the same stage
+  // buffers (see load()/mma()). ===
+  static constexpr int LoRaK = 32;  // Rank granularity: 32 columns = 2 bf16 16-wide K-atoms.
   using ResidualElementA = remove_cvref_t<decltype(get<0>(ElementPairA_{}))>;
   static_assert((cute::size<2>(TileShape{}) * cute::sizeof_bits_v<ResidualElementA>) %
                     cute::sizeof_bits_v<cutlass::bfloat16_t> ==
                 0);
   // Match one residual A/B stage exactly: FP4 K128 -> BF16 K32, FP4 K256 -> BF16 K64.
-  // The global D/L1 tensors remain logical K32; TMA zero-fills the upper half of a K64 box.
+  // The runtime rank is chunked into ceil(rank / LoRaStorageK) such tiles; TMA zero-fills
+  // the box columns beyond the global tensors' K extent (e.g. rank 32 in a K64 box, or the
+  // upper half of the second K64 chunk of a rank-96 tensor).
   static constexpr int LoRaStorageK = cute::size<2>(TileShape{}) *
                                       cute::sizeof_bits_v<ResidualElementA> /
                                       cute::sizeof_bits_v<cutlass::bfloat16_t>;
@@ -296,11 +301,11 @@ struct CollectiveMmaLoRA<
                         cute::sizeof_bits_v<cutlass::bfloat16_t> ==
                     cute::cosize(take<0, 3>(SmemLayoutB{})) * cute::sizeof_bits_v<ElementB>,
                 "Each CTA's LoRA L1 tile must exactly overlay one residual B stage");
-  using StrideD = cute::Stride<int64_t, cute::_1, int64_t>;   // D  [M, LoRaK, L] (K-contig)
-  using StrideL1 = cute::Stride<int64_t, cute::_1, int64_t>;  // L1 [N, LoRaK, L] (K-contig)
-  // CTA-group bytes for one stage -- the post-loop TMA loads one D/L1 tile per output tile.
-  // (Unused in the post-loop, which relies on D/L1 arriving the armed A/B byte budget, but
-  // kept correct in case of an expect_transaction path.)
+  using StrideD = cute::Stride<int64_t, cute::_1, int64_t>;   // D  [M, rank, L] (K-contig)
+  using StrideL1 = cute::Stride<int64_t, cute::_1, int64_t>;  // L1 [N, rank, L] (K-contig)
+  // CTA-group bytes for one stage -- the post-loop TMA loads one D/L1 chunk per producer
+  // step. (Unused in the post-loop, which relies on D/L1 arriving the armed A/B byte
+  // budget, but kept correct in case of an expect_transaction path.)
   static constexpr uint32_t LoRaTmaBytes =
       cutlass::bits_to_bytes(cute::size(AtomThrShapeMNK{}) *
                              cute::cosize(take<0, 3>(SmemLayoutD{})) *
@@ -509,11 +514,13 @@ struct CollectiveMmaLoRA<
     LayoutSFB layout_SFB{};
     RuntimeDataTypeA runtime_data_type_a{};
     RuntimeDataTypeB runtime_data_type_b{};
-    // LoRA-up: D [M, LoRaK] (1/alpha NOT here), L1 [N, LoRaK] (1/alpha folded in). bf16.
+    // LoRA-up: D [M, lora_rank] (1/alpha NOT here), L1 [N, lora_rank] (1/alpha folded
+    // in). bf16. lora_rank must be a positive multiple of LoRaK.
     cutlass::bfloat16_t const* ptr_D{nullptr};
     StrideD dD{};
     cutlass::bfloat16_t const* ptr_L1{nullptr};
     StrideL1 dL1{};
+    int lora_rank{LoRaK};
   };
 
   // Device side kernel params
@@ -580,6 +587,7 @@ struct CollectiveMmaLoRA<
     dim3 cluster_shape_fallback;
     RuntimeDataTypeA runtime_data_type_a;
     RuntimeDataTypeB runtime_data_type_b;
+    int lora_rank;
   };
 
   CUTLASS_DEVICE
@@ -590,7 +598,8 @@ struct CollectiveMmaLoRA<
         layout_SFA_(params.layout_SFA),
         layout_SFB_(params.layout_SFB),
         runtime_data_type_a_(params.runtime_data_type_a),
-        runtime_data_type_b_(params.runtime_data_type_b) {
+        runtime_data_type_b_(params.runtime_data_type_b),
+        lora_rank_(params.lora_rank) {
     if constexpr (IsDynamicCluster) {
       bool const is_fallback_cluster =
           (cute::size<0>(cluster_shape_) == params.cluster_shape_fallback.x &&
@@ -678,11 +687,12 @@ struct CollectiveMmaLoRA<
         GmemTiledCopySFB{}, tensor_sfb, SmemLayoutSFB{}(_, _, _, cute::Int<0>{}), TileShape_SF{},
         TiledMMA_SF{}, cluster_layout_sfb_vmnk_fallback);
 
-    // LoRA D/L1 TMA atoms (bf16; [M,LoRaK,L] / [N,LoRaK,L], K-contiguous).
+    // LoRA D/L1 TMA atoms (bf16; [M,rank,L] / [N,rank,L], K-contiguous). The descriptor
+    // carries the true runtime rank so partially out-of-bounds chunk boxes zero-fill.
     Tensor tensor_d =
-        make_tensor(args.ptr_D, make_layout(make_shape(M, cute::Int<LoRaK>{}, L), args.dD));
+        make_tensor(args.ptr_D, make_layout(make_shape(M, args.lora_rank, L), args.dD));
     Tensor tensor_l1 =
-        make_tensor(args.ptr_L1, make_layout(make_shape(N, cute::Int<LoRaK>{}, L), args.dL1));
+        make_tensor(args.ptr_L1, make_layout(make_shape(N, args.lora_rank, L), args.dL1));
     typename Params::TMA_D tma_load_d = make_tma_atom_A_sm100<cutlass::bfloat16_t>(
         GmemTiledCopyA{}, tensor_d, SmemLayoutD{}(_, _, _, cute::Int<0>{}), LoRaMmaTileShape{},
         LoRaMma{}, cluster_layout_vmnk);
@@ -712,7 +722,8 @@ struct CollectiveMmaLoRA<
             args.layout_SFB,
             hw_info.cluster_shape_fallback,
             args.runtime_data_type_a,
-            args.runtime_data_type_b};
+            args.runtime_data_type_b,
+            args.lora_rank};
   }
 
   template <class ProblemShape>
@@ -750,6 +761,11 @@ struct CollectiveMmaLoRA<
     implementable = implementable && (layout_sfb_ref == take<0, 2>(args.layout_SFB));
     if (!implementable) {
       CUTLASS_TRACE_HOST("  CAN IMPLEMENT: layout_SFB mismatch, layout_SFB needs to be K-major\n");
+    }
+
+    if (args.lora_rank < LoRaK || args.lora_rank % LoRaK != 0) {
+      CUTLASS_TRACE_HOST("  CAN IMPLEMENT: lora_rank must be a positive multiple of 32\n");
+      implementable = false;
     }
 
     if (!implementable) {
@@ -936,9 +952,10 @@ struct CollectiveMmaLoRA<
     uint16_t mcast_mask_sfa = create_tma_multicast_mask<2>(cta_layout_vmnk, cta_coord_vmnk);
     uint16_t mcast_mask_sfb = create_tma_multicast_mask<1>(cta_layout_sfb_vmnk, cta_coord_sfb_vmnk);
 
-    // LoRA D[M,LoRaK]/L1[N,LoRaK]: partition like A/B (D along M, L1 along N), single k-tile.
-    Tensor mD_mkl = observed_tma_load_d_->get_tma_tensor(make_shape(M, cute::Int<LoRaK>{}, L));
-    Tensor mL1_nkl = observed_tma_load_l1_->get_tma_tensor(make_shape(N, cute::Int<LoRaK>{}, L));
+    // LoRA D[M,rank]/L1[N,rank]: partition like A/B (D along M, L1 along N); the k-tile
+    // mode holds the ceil(rank / LoRaStorageK) post-K-loop chunks.
+    Tensor mD_mkl = observed_tma_load_d_->get_tma_tensor(make_shape(M, lora_rank_, L));
+    Tensor mL1_nkl = observed_tma_load_l1_->get_tma_tensor(make_shape(N, lora_rank_, L));
     Tensor gD_mkl = local_tile(mD_mkl, LoRaMmaTileShape{}, make_coord(_, _, _), Step<_1, X, _1>{});
     Tensor gL1_nkl =
         local_tile(mL1_nkl, LoRaMmaTileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
@@ -1122,30 +1139,39 @@ struct CollectiveMmaLoRA<
       ++k_tile_iter;
     }
 
-    // === load D/L1 in ONE extra producer step AFTER the K-loop, INTO the
-    // freed residual stage buffers smem_A[ws]/smem_B[ws] (no dedicated sD/sL1, no carveout), ONLY
-    // in the mainloop call (lora_start_k != 0) so it lands at the END of the k-tile sequence (else
-    // the prologue's copy would inject mid-sequence -> consumer misreads it as a tile -> hang). The
-    // producer_acquire arms the barrier for the A+B+SF byte budget; D arrives EXACTLY the A-stage
-    // bytes (D-tile == A-stage) into smem_A[ws], L1 the B-stage bytes into smem_B[ws], and SFA/SFB
-    // are DUMMY-reloaded to arrive the SF bytes -> D+L1+SF == armed A+B+SF, so NO
-    // expect_transaction and NO A/B re-load needed. (D/L1 in pipeline-managed stage buffers also
-    // removes the earlier dedicated-single-buffer cross-tile clobber caveat.) ===
+    // === load D/L1 in ceil(rank / LoRaStorageK) extra producer steps AFTER the K-loop, INTO
+    // the freed residual stage buffers smem_A[ws]/smem_B[ws] (no dedicated sD/sL1, no carveout),
+    // ONLY in the mainloop call (lora_start_k != 0) so they land at the END of the k-tile sequence
+    // (else the prologue's copy would inject mid-sequence -> consumer misreads it as a tile ->
+    // hang). Each producer_acquire arms the barrier for the A+B+SF byte budget; a D chunk arrives
+    // EXACTLY the A-stage bytes (D-chunk box == A-stage) into smem_A[ws], an L1 chunk the B-stage
+    // bytes into smem_B[ws], and SFA/SFB are DUMMY-reloaded to arrive the SF bytes -> D+L1+SF ==
+    // armed A+B+SF, so NO expect_transaction and NO A/B re-load needed. The last chunk of a rank
+    // that does not fill its box is TMA zero-filled (the descriptor carries the true rank).
+    // (D/L1 in pipeline-managed stage buffers also removes the earlier dedicated-single-buffer
+    // cross-tile clobber caveat.) ===
     if (lora_start_k != 0) {
-      mainloop_pipeline.producer_acquire(mainloop_pipe_producer_state, barrier_token);
-      using BarrierTypePost = typename MainloopPipeline::ProducerBarrierType;
-      BarrierTypePost* tb = mainloop_pipeline.producer_get_barrier(mainloop_pipe_producer_state);
-      int ws = mainloop_pipe_producer_state.index();
-      ++mainloop_pipe_producer_state;
-      if (cute::elect_one_sync()) {
-        copy(observed_tma_load_sfa_->with(*tb, mcast_mask_sfa), tAgSFA(_, cute::_0{}),
-             tAsSFA(_, ws));  // dummy: arrive SFA bytes
-        copy(observed_tma_load_sfb_->with(*tb, mcast_mask_sfb), tBgSFB(_, cute::_0{}),
-             tBsSFB(_, ws));  // dummy: arrive SFB bytes
-        copy(observed_tma_load_d_->with(*tb, mcast_mask_d), tDgD(_, cute::_0{}),
-             tDsD(_, ws));  // D -> smem_A[ws] (== A-stage bytes)
-        copy(observed_tma_load_l1_->with(*tb, mcast_mask_l1), tL1gL1(_, cute::_0{}),
-             tL1sL1(_, ws));  // L1 -> smem_B[ws] (== B-stage bytes)
+      int const lora_k_tiles = cutlass::ceil_div(lora_rank_, LoRaStorageK);
+      CUTLASS_PRAGMA_NO_UNROLL
+      for (int lk = 0; lk < lora_k_tiles; ++lk) {
+        mainloop_pipeline.producer_acquire(mainloop_pipe_producer_state, barrier_token);
+        using BarrierTypePost = typename MainloopPipeline::ProducerBarrierType;
+        BarrierTypePost* tb = mainloop_pipeline.producer_get_barrier(mainloop_pipe_producer_state);
+        int ws = mainloop_pipe_producer_state.index();
+        ++mainloop_pipe_producer_state;
+        if (lk + 1 < lora_k_tiles) {
+          barrier_token = mainloop_pipeline.producer_try_acquire(mainloop_pipe_producer_state);
+        }
+        if (cute::elect_one_sync()) {
+          copy(observed_tma_load_sfa_->with(*tb, mcast_mask_sfa), tAgSFA(_, cute::_0{}),
+               tAsSFA(_, ws));  // dummy: arrive SFA bytes
+          copy(observed_tma_load_sfb_->with(*tb, mcast_mask_sfb), tBgSFB(_, cute::_0{}),
+               tBsSFB(_, ws));  // dummy: arrive SFB bytes
+          copy(observed_tma_load_d_->with(*tb, mcast_mask_d), tDgD(_, lk),
+               tDsD(_, ws));  // D chunk -> smem_A[ws] (== A-stage bytes)
+          copy(observed_tma_load_l1_->with(*tb, mcast_mask_l1), tL1gL1(_, lk),
+               tL1sL1(_, ws));  // L1 chunk -> smem_B[ws] (== B-stage bytes)
+        }
       }
     }
 
@@ -1213,21 +1239,27 @@ struct CollectiveMmaLoRA<
     //
     tiled_mma.accumulate_ = UMMA::ScaleOut::Zero;
 
-    // LoRA-up D@L1ᵀ applied in ONE post-K-loop consumer step (see load(): D/L1 are TMA'd into the
-    // residual stage buffers smem_A[ws]/smem_B[ws] in an extra producer step after the K-loop). The
-    // residual accumulator is still held (producer_acquire'd, not yet committed), and f32 acc adds
-    // are commutative, so adding D@L1ᵀ after the full residual == folding it in. accumulate_=One
-    // adds. rstage = the consumed pipeline stage holding THIS output tile's D/L1 (tCrD/tCrL1 are
-    // stage-moded since SmemLayoutD/L1 overlay the multi-stage smem_A/smem_B).
+    // LoRA-up D@L1ᵀ applied in ceil(rank / LoRaStorageK) post-K-loop consumer steps (see load():
+    // D/L1 chunks are TMA'd into the residual stage buffers smem_A[ws]/smem_B[ws] in matching
+    // extra producer steps after the K-loop). The residual accumulator is still held
+    // (producer_acquire'd, not yet committed), and f32 acc adds are commutative, so adding D@L1ᵀ
+    // after the full residual == folding it in. accumulate_=One adds. rstage = the consumed
+    // pipeline stage holding THIS chunk's D/L1 (tCrD/tCrL1 are stage-moded since SmemLayoutD/L1
+    // overlay the multi-stage smem_A/smem_B). k_blocks = the chunk's REAL rank columns / atom K:
+    // the tail of a partially out-of-bounds chunk is TMA zero-filled, but skipping its k-blocks
+    // keeps the rank-32 instruction stream identical to the original fixed-rank kernel.
     auto lora_mma = LoRaMma{};
     lora_mma.accumulate_ = UMMA::ScaleOut::One;
     static constexpr int LoRaAtomK = cute::size<2>(typename LoRaMma::AtomShape_MNK{});
     static_assert(LoRaK % LoRaAtomK == 0);
-    static constexpr int LoRaMmaKBlocks = LoRaK / LoRaAtomK;
-    auto apply_lora = [&](int rstage) {
+    static_assert(LoRaStorageK % LoRaAtomK == 0);
+    static constexpr int LoRaMmaKBlocksMax = LoRaStorageK / LoRaAtomK;
+    auto apply_lora = [&](int rstage, int k_blocks) {
       CUTLASS_PRAGMA_UNROLL
-      for (int kb = 0; kb < LoRaMmaKBlocks; ++kb) {
-        cute::gemm(lora_mma, tCrD(_, _, kb, rstage), tCrL1(_, _, kb, rstage), accumulators);
+      for (int kb = 0; kb < LoRaMmaKBlocksMax; ++kb) {
+        if (kb < k_blocks) {
+          cute::gemm(lora_mma, tCrD(_, _, kb, rstage), tCrL1(_, _, kb, rstage), accumulators);
+        }
       }
     };
 
@@ -1311,18 +1343,24 @@ struct CollectiveMmaLoRA<
       mainloop_pipeline.consumer_release(curr_mainloop_pipe_consumer_state);
     }
 
-    // === consume the SINGLE post-K-loop D/L1 producer step (load() emits it
-    // only in the mainloop call, gated by lora_start_k != 0, so exactly one occurs at the end of
-    // the k-tile sequence), then run the LoRA MMA reading D/L1 from the consumed stage buffer
-    // (read_stage = the smem_A[stage]/smem_B[stage] this step's D/L1 landed in) into the still-held
-    // residual accumulator. One consumer step balances the one producer step. ===
+    // === consume the post-K-loop D/L1 producer steps (load() emits them only in the mainloop
+    // call, gated by lora_start_k != 0, so they occur exactly once at the end of the k-tile
+    // sequence), running one LoRA MMA chunk per consumed stage buffer (read_stage = the
+    // smem_A[stage]/smem_B[stage] this chunk's D/L1 landed in) into the still-held residual
+    // accumulator. Consumer steps balance the producer steps one-for-one. ===
     {
-      auto lora_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state);
-      mainloop_pipeline.consumer_wait(mainloop_pipe_consumer_state, lora_token);
-      int lora_read_stage = mainloop_pipe_consumer_state.index();
-      apply_lora(lora_read_stage);
-      mainloop_pipeline.consumer_release(mainloop_pipe_consumer_state);
-      ++mainloop_pipe_consumer_state;
+      int lora_cols_left = lora_rank_;
+      CUTLASS_PRAGMA_NO_UNROLL
+      while (lora_cols_left > 0) {
+        auto lora_token = mainloop_pipeline.consumer_try_wait(mainloop_pipe_consumer_state);
+        mainloop_pipeline.consumer_wait(mainloop_pipe_consumer_state, lora_token);
+        int lora_read_stage = mainloop_pipe_consumer_state.index();
+        int const chunk_cols = lora_cols_left < LoRaStorageK ? lora_cols_left : LoRaStorageK;
+        apply_lora(lora_read_stage, chunk_cols / LoRaAtomK);
+        mainloop_pipeline.consumer_release(mainloop_pipe_consumer_state);
+        ++mainloop_pipe_consumer_state;
+        lora_cols_left -= LoRaStorageK;
+      }
     }
 
     return mainloop_pipe_consumer_state;
@@ -1340,6 +1378,7 @@ struct CollectiveMmaLoRA<
   LayoutSFB layout_SFB_;
   RuntimeDataTypeA runtime_data_type_a_{};
   RuntimeDataTypeB runtime_data_type_b_{};
+  int lora_rank_ = LoRaK;
 
   ClusterShape cluster_shape_;
   uint32_t block_rank_in_cluster_;

--- a/include/flashinfer/gemm/nvfp4_svdquant_gemm_cutlass.h
+++ b/include/flashinfer/gemm/nvfp4_svdquant_gemm_cutlass.h
@@ -33,8 +33,9 @@ namespace gemm {
 //
 //   A   [m, k]  NVFP4 (e2m1), row-major          SFA/SFB  block scale factors (ue4m3, swizzled)
 //   B   [n, k]  NVFP4 (e2m1), column-major        alpha   per-tensor dequant scale (device f32[1])
-//   D   [m, r]  bf16, row-major (r = 32)          out     [m, n] bf16
+//   D   [m, r]  bf16, row-major                   out     [m, n] bf16
 //   L1  [n, r]  bf16, row-major (= svdquant_lora_b / alpha)
+// r is the SVDQuant LoRA rank: any positive multiple of 32 (ranks 32-128 are validated).
 enum class Nvfp4SvdquantGemmTactic : int {
   // Preserve the original tactic IDs used by existing sweeps.
   k1Sm128x256x128 = 0,
@@ -76,7 +77,7 @@ size_t nvfp4_svdquant_gemm_workspace_size(int m, int n, int k, int tactic = 0);
 
 void nvfp4_svdquant_gemm_run(void* out, void const* A, void const* B, void const* sfa,
                              void const* sfb, float const* alpha, void const* D, void const* L1,
-                             void const* bias, int m, int n, int k, char* workspace,
+                             void const* bias, int m, int n, int k, int lora_rank, char* workspace,
                              size_t workspaceBytes, cudaStream_t stream, int tactic = 0,
                              bool enable_pdl = false);
 

--- a/include/flashinfer/gemm/nvfp4_svdquant_gemm_cutlass.h
+++ b/include/flashinfer/gemm/nvfp4_svdquant_gemm_cutlass.h
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace flashinfer {
+namespace gemm {
+
+// SVDQuant fused NVFP4 GEMM (SM100): the residual block-scaled NVFP4 GEMM out = alpha * (A @ Bᵀ)
+// fused with the rank-r LoRA-up correction D @ L1ᵀ, computed by a 2nd bf16 tcgen05 MMA (K = r)
+// into the SAME TMEM accumulator after the NVFP4 K-loop (a custom CUTLASS SM100 block-scaled
+// collective; the stock nvfp4 GEMM template is untouched). 1/alpha is folded into L1 host-side so
+// the fused epilogue yields alpha * residual + D @ L1ᵀ + bias.
+//
+//   A   [m, k]  NVFP4 (e2m1), row-major          SFA/SFB  block scale factors (ue4m3, swizzled)
+//   B   [n, k]  NVFP4 (e2m1), column-major        alpha   per-tensor dequant scale (device f32[1])
+//   D   [m, r]  bf16, row-major (r = 32)          out     [m, n] bf16
+//   L1  [n, r]  bf16, row-major (= svdquant_lora_b / alpha)
+enum class Nvfp4SvdquantGemmTactic : int {
+  // Preserve the original tactic IDs used by existing sweeps.
+  k1Sm128x256x128 = 0,
+  k2Sm256x256x128 = 1,
+  k1Sm128x256x128Cluster1x2 = 2,
+  k1Sm128x256x128Cluster1x4 = 3,
+  k2Sm256x256x128Cluster2x2 = 4,
+  k2Sm256x256x128Cluster2x4 = 5,
+  k2Sm256x256x128Cluster4x2 = 6,
+  k2Sm256x256x128Cluster4x4 = 7,
+  k2Sm256x256x128Cluster4x1 = 8,
+  k1Sm128x128x128 = 9,
+  k1Sm128x128x128Cluster1x2 = 10,
+  k2Sm256x192x128 = 11,
+  k2Sm256x192x128Cluster2x2 = 12,
+  k1Sm128x64x128 = 13,
+  k1Sm128x64x128Cluster1x2 = 14,
+  k1Sm128x64x128Cluster1x4 = 15,
+  k1Sm128x128x256Cluster1x2 = 16,
+  k1Sm128x128x256Cluster1x4 = 17,
+  k2Sm256x128x256 = 18,
+  k2Sm256x256x256 = 19,
+  k2Sm256x256x256Cluster2x2 = 20,
+  k2Sm256x256x256Cluster4x4 = 21,
+  k2Sm256x256x256Cluster4x1 = 22,
+  // Appended runtime-cluster variants of existing kernel shapes (no new template
+  // instantiations). These mirror the stock CUTLASS NVFP4 runner's per-shape winners
+  // (128x256x256B/4x2, /2x4; 128x128x256B/1x1; /2x2) that the original set lacked.
+  k2Sm256x256x256Cluster4x2 = 23,
+  k2Sm256x256x256Cluster2x4 = 24,
+  k1Sm128x128x256 = 25,
+  k2Sm256x128x256Cluster2x2 = 26,
+};
+
+inline constexpr int kNvfp4SvdquantGemmNumTactics = 27;
+
+// Tactic 0 preserves the original 1SM kernel and remains the source-compatible default.
+size_t nvfp4_svdquant_gemm_workspace_size(int m, int n, int k, int tactic = 0);
+
+void nvfp4_svdquant_gemm_run(void* out, void const* A, void const* B, void const* sfa,
+                             void const* sfb, float const* alpha, void const* D, void const* L1,
+                             void const* bias, int m, int n, int k, char* workspace,
+                             size_t workspaceBytes, cudaStream_t stream, int tactic = 0,
+                             bool enable_pdl = false);
+
+}  // namespace gemm
+}  // namespace flashinfer

--- a/include/flashinfer/gemm/nvfp4_svdquant_gemm_template_sm100.h
+++ b/include/flashinfer/gemm/nvfp4_svdquant_gemm_template_sm100.h
@@ -1,0 +1,327 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// SVDQuant fused NVFP4 GEMM launcher templates (SM100): build the standard block-scaled NVFP4
+// mainloop via the CUTLASS CollectiveBuilder, then re-instantiate the custom CollectiveMmaLoRA (a
+// renamed copy of the SM100 block-scaled warp-specialized collective extended with the rank-r
+// LoRA-up MMA) with the Builder's 15 template typedefs, and run it via GemmUniversal. The stock
+// nvfp4 GEMM template (fp4_gemm_template_sm100.h) is untouched.
+
+#pragma once
+
+#undef __CUDA_NO_HALF_OPERATORS__
+#undef __CUDA_NO_HALF_CONVERSIONS__
+#undef __CUDA_NO_BFLOAT16_OPERATORS__
+#undef __CUDA_NO_BFLOAT16_CONVERSIONS__
+#undef __CUDA_NO_HALF2_OPERATORS__
+#undef __CUDA_NO_BFLOAT162_OPERATORS__
+
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
+
+#include "cutlass/arch/arch.h"
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/epilogue/fusion/operations.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/gemm.h"
+#include "flashinfer/gemm/nvfp4_svdquant_gemm_collective_sm100.h"  // CollectiveMmaLoRA (must precede the Builder use)
+#include "flashinfer/gemm/nvfp4_svdquant_gemm_cutlass.h"
+
+namespace flashinfer {
+namespace gemm {
+namespace svdquant_detail {
+
+using namespace cute;
+
+using Arch = cutlass::arch::Sm100;
+using ElementType = cutlass::float_e2m1_t;  // NVFP4 operands
+using SFType = cutlass::float_ue4m3_t;
+using OutElementType = cutlass::bfloat16_t;
+using ElementAccumulator = float;
+using ElementCompute = float;
+using ElementC = void;
+using LayoutA = cutlass::layout::RowMajor;
+using LayoutB = cutlass::layout::ColumnMajor;
+using LayoutC = cutlass::layout::RowMajor;
+static constexpr int AlignA = 32;
+static constexpr int AlignB = 32;
+static constexpr int AlignC = 8;
+
+using EpilogueTileType = cutlass::epilogue::collective::EpilogueTileAuto;
+
+// The rank-r LoRA-up is fused in the mainloop. Match the stock NVFP4 epilogue so the per-column
+// bias is added without a separate bandwidth-bound kernel.
+using FusionOperation =
+    cutlass::epilogue::fusion::LinCombPerColBias<OutElementType, float, OutElementType, ElementC,
+                                                 float>;
+
+// Every kernel shape uses a dynamic cluster type so each tile can benchmark stock-compatible
+// runtime cluster shapes without multiplying the generated kernel variants.
+template <class MmaTileShape_, class EpilogueSchedule_, class MainloopSchedule_,
+          class EpilogueTile_ = EpilogueTileType>
+struct SvdquantGemmConfig {
+  using MmaTileShape = MmaTileShape_;
+  using EpilogueTile = EpilogueTile_;
+  using EpilogueSchedule = EpilogueSchedule_;
+  using MainloopSchedule = MainloopSchedule_;
+  using ClusterShape = Shape<int, int, _1>;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      Arch, cutlass::arch::OpClassTensorOp, MmaTileShape, ClusterShape, EpilogueTile,
+      ElementAccumulator, ElementCompute, ElementC, LayoutC, AlignC, OutElementType, LayoutC,
+      AlignC, EpilogueSchedule, FusionOperation>::CollectiveOp;
+
+  // Build the standard block-scaled mainloop, then re-instantiate CollectiveMmaLoRA with the
+  // builder's extracted template arguments. D/L1 overlay the residual A/B stage buffers, so no
+  // extra shared-memory carveout is needed for either the 1SM or 2SM tactic.
+  using CollectiveMainloopBase = typename cutlass::gemm::collective::CollectiveBuilder<
+      Arch, cutlass::arch::OpClassBlockScaledTensorOp, cute::tuple<ElementType, SFType>, LayoutA,
+      AlignA, cute::tuple<ElementType, SFType>, LayoutB, AlignB, ElementAccumulator, MmaTileShape,
+      ClusterShape,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(
+          sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      MainloopSchedule>::CollectiveOp;
+
+  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMmaLoRA<
+      typename CollectiveMainloopBase::DispatchPolicy, typename CollectiveMainloopBase::TileShape,
+      typename CollectiveMainloopBase::ElementPairA, typename CollectiveMainloopBase::StridePairA,
+      typename CollectiveMainloopBase::ElementPairB, typename CollectiveMainloopBase::StridePairB,
+      typename CollectiveMainloopBase::TiledMma,
+      typename CollectiveMainloopBase::GmemTiledCopyPairA,
+      typename CollectiveMainloopBase::SmemLayoutAtomPairA,
+      typename CollectiveMainloopBase::SmemCopyAtomA, typename CollectiveMainloopBase::TransformA,
+      typename CollectiveMainloopBase::GmemTiledCopyPairB,
+      typename CollectiveMainloopBase::SmemLayoutAtomPairB,
+      typename CollectiveMainloopBase::SmemCopyAtomB, typename CollectiveMainloopBase::TransformB>;
+
+  using GemmKernel =
+      cutlass::gemm::kernel::GemmUniversal<Shape<int, int, int, int>, CollectiveMainloop,
+                                           CollectiveEpilogue, cutlass::gemm::PersistentScheduler>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+using Tactic1Sm128x256x128Config =
+    SvdquantGemmConfig<Shape<_128, _256, _128>, cutlass::epilogue::TmaWarpSpecialized1Sm,
+                       cutlass::gemm::KernelTmaWarpSpecialized1SmNvf4Sm100>;
+using Tactic2Sm256x256x128Config =
+    SvdquantGemmConfig<Shape<_256, _256, _128>, cutlass::epilogue::TmaWarpSpecialized2Sm,
+                       cutlass::gemm::KernelTmaWarpSpecialized2SmNvf4Sm100>;
+using Tactic1Sm128x128x128Config =
+    SvdquantGemmConfig<Shape<_128, _128, _128>, cutlass::epilogue::TmaWarpSpecialized1Sm,
+                       cutlass::gemm::KernelTmaWarpSpecialized1SmNvf4Sm100>;
+using Tactic2Sm256x192x128Config =
+    SvdquantGemmConfig<Shape<_256, _192, _128>, cutlass::epilogue::TmaWarpSpecialized2Sm,
+                       cutlass::gemm::KernelTmaWarpSpecialized2SmNvf4Sm100>;
+using Tactic1Sm128x64x128Config =
+    SvdquantGemmConfig<Shape<_128, _64, _128>, cutlass::epilogue::TmaWarpSpecialized1Sm,
+                       cutlass::gemm::KernelTmaWarpSpecialized1SmNvf4Sm100>;
+using Tactic1Sm128x128x256Config =
+    SvdquantGemmConfig<Shape<_128, _128, _256>, cutlass::epilogue::TmaWarpSpecialized1Sm,
+                       cutlass::gemm::KernelTmaWarpSpecialized1SmNvf4Sm100>;
+using Tactic2Sm256x128x256Config =
+    SvdquantGemmConfig<Shape<_256, _128, _256>, cutlass::epilogue::TmaWarpSpecialized2Sm,
+                       cutlass::gemm::KernelTmaWarpSpecialized2SmNvf4Sm100>;
+using Tactic2Sm256x256x256Config =
+    SvdquantGemmConfig<Shape<_256, _256, _256>, cutlass::epilogue::TmaWarpSpecialized2Sm,
+                       cutlass::gemm::KernelTmaWarpSpecialized2SmNvf4Sm100, Shape<_128, _64>>;
+
+enum class KernelShape {
+  k1Sm128x256x128,
+  k2Sm256x256x128,
+  k1Sm128x128x128,
+  k2Sm256x192x128,
+  k1Sm128x64x128,
+  k1Sm128x128x256,
+  k2Sm256x128x256,
+  k2Sm256x256x256,
+};
+
+struct RuntimeTactic {
+  KernelShape kernel_shape;
+  dim3 cluster_shape;
+  dim3 cluster_shape_fallback;
+};
+
+inline RuntimeTactic resolve_tactic(int tactic) {
+  // A 1SM kernel may fall back to 1x1. A 2SM instruction always requires at least its 2x1 MMA
+  // group, so every 2SM cluster uses 2x1 as its fallback.
+  switch (static_cast<Nvfp4SvdquantGemmTactic>(tactic)) {
+    case Nvfp4SvdquantGemmTactic::k1Sm128x256x128:
+      return {KernelShape::k1Sm128x256x128, dim3(1, 1, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x128:
+      return {KernelShape::k2Sm256x256x128, dim3(2, 1, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x256x128Cluster1x2:
+      return {KernelShape::k1Sm128x256x128, dim3(1, 2, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x256x128Cluster1x4:
+      return {KernelShape::k1Sm128x256x128, dim3(1, 4, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x128Cluster2x2:
+      return {KernelShape::k2Sm256x256x128, dim3(2, 2, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x128Cluster2x4:
+      return {KernelShape::k2Sm256x256x128, dim3(2, 4, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x128Cluster4x2:
+      return {KernelShape::k2Sm256x256x128, dim3(4, 2, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x128Cluster4x4:
+      return {KernelShape::k2Sm256x256x128, dim3(4, 4, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x128Cluster4x1:
+      return {KernelShape::k2Sm256x256x128, dim3(4, 1, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x128x128:
+      return {KernelShape::k1Sm128x128x128, dim3(1, 1, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x128x128Cluster1x2:
+      return {KernelShape::k1Sm128x128x128, dim3(1, 2, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x192x128:
+      return {KernelShape::k2Sm256x192x128, dim3(2, 1, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x192x128Cluster2x2:
+      return {KernelShape::k2Sm256x192x128, dim3(2, 2, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x64x128:
+      return {KernelShape::k1Sm128x64x128, dim3(1, 1, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x64x128Cluster1x2:
+      return {KernelShape::k1Sm128x64x128, dim3(1, 2, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x64x128Cluster1x4:
+      return {KernelShape::k1Sm128x64x128, dim3(1, 4, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x128x256Cluster1x2:
+      return {KernelShape::k1Sm128x128x256, dim3(1, 2, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x128x256Cluster1x4:
+      return {KernelShape::k1Sm128x128x256, dim3(1, 4, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x128x256:
+      return {KernelShape::k2Sm256x128x256, dim3(2, 1, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x256:
+      return {KernelShape::k2Sm256x256x256, dim3(2, 1, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x256Cluster2x2:
+      return {KernelShape::k2Sm256x256x256, dim3(2, 2, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x256Cluster4x4:
+      return {KernelShape::k2Sm256x256x256, dim3(4, 4, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x256Cluster4x1:
+      return {KernelShape::k2Sm256x256x256, dim3(4, 1, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x256Cluster4x2:
+      return {KernelShape::k2Sm256x256x256, dim3(4, 2, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x256x256Cluster2x4:
+      return {KernelShape::k2Sm256x256x256, dim3(2, 4, 1), dim3(2, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k1Sm128x128x256:
+      return {KernelShape::k1Sm128x128x256, dim3(1, 1, 1), dim3(1, 1, 1)};
+    case Nvfp4SvdquantGemmTactic::k2Sm256x128x256Cluster2x2:
+      return {KernelShape::k2Sm256x128x256, dim3(2, 2, 1), dim3(2, 1, 1)};
+    default:
+      throw std::invalid_argument("nvfp4_svdquant_gemm: invalid tactic");
+  }
+}
+
+template <class Config>
+size_t workspace_size_for_tactic(int m, int n, int k, RuntimeTactic const& tactic) {
+  using Gemm = typename Config::Gemm;
+  Gemm gemm;
+  typename Gemm::Arguments args{};
+  args.mode = cutlass::gemm::GemmUniversalMode::kGemm;
+  args.problem_shape = cute::make_shape(m, n, k, 1);
+  args.hw_info.cluster_shape = tactic.cluster_shape;
+  args.hw_info.cluster_shape_fallback = tactic.cluster_shape_fallback;
+  return gemm.get_workspace_size(args);
+}
+
+template <class Config>
+void run_tactic(void* out, void const* A, void const* B, void const* sfa, void const* sfb,
+                float const* alpha, void const* D, void const* L1, void const* bias, int m, int n,
+                int k, char* ws, size_t wsBytes, cudaStream_t stream, RuntimeTactic const& tactic,
+                bool enable_pdl) {
+  using Gemm = typename Config::Gemm;
+  using Sm1xxBlkScaledConfig = typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
+  typename Gemm::Arguments args{};
+  args.mode = cutlass::gemm::GemmUniversalMode::kGemm;
+  args.problem_shape = cute::make_shape(m, n, k, 1);
+
+  args.mainloop.ptr_A = static_cast<ElementType const*>(A);
+  args.mainloop.ptr_B = static_cast<ElementType const*>(B);
+  args.mainloop.ptr_SFA = static_cast<SFType const*>(sfa);
+  args.mainloop.ptr_SFB = static_cast<SFType const*>(sfb);
+  args.mainloop.dA = cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideA>(k, 0);
+  args.mainloop.dB = cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideB>(k, 0);
+  args.mainloop.layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(args.problem_shape);
+  args.mainloop.layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(args.problem_shape);
+  // LoRA D[M,LoRaK] / L1[N,LoRaK] (bf16, row-major K-contiguous). 1/alpha is folded into L1.
+  constexpr int64_t LoRaK = 32;  // must match CollectiveMmaLoRA::LoRaK
+  args.mainloop.ptr_D = static_cast<cutlass::bfloat16_t const*>(D);
+  args.mainloop.dD = cute::make_stride(LoRaK, cute::_1{}, int64_t(m) * LoRaK);
+  args.mainloop.ptr_L1 = static_cast<cutlass::bfloat16_t const*>(L1);
+  args.mainloop.dL1 = cute::make_stride(LoRaK, cute::_1{}, int64_t(n) * LoRaK);
+
+  args.epilogue.ptr_C = nullptr;
+  args.epilogue.ptr_D = static_cast<OutElementType*>(out);
+  args.epilogue.dC = cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideC>(n, 0);
+  args.epilogue.dD = args.epilogue.dC;
+  // out = alpha * acc + bias[N] (alpha via device scalar pointer). A null bias is a no-op.
+  args.epilogue.thread.alpha = 1.0f;
+  args.epilogue.thread.beta = 0.0f;
+  args.epilogue.thread.alpha_ptr = alpha;
+  args.epilogue.thread.beta_ptr = nullptr;
+  args.epilogue.thread.bias_ptr = static_cast<OutElementType const*>(bias);
+
+  if constexpr (!std::is_const_v<decltype(args.scheduler.max_swizzle_size)>)
+    args.scheduler.max_swizzle_size = 1;
+  if constexpr (!std::is_const_v<decltype(args.scheduler.raster_order)>) {
+    using Enum_t = decltype(args.scheduler.raster_order);
+    args.scheduler.raster_order = Enum_t::Heuristic;
+  }
+  args.hw_info.cluster_shape = tactic.cluster_shape;
+  args.hw_info.cluster_shape_fallback = tactic.cluster_shape_fallback;
+
+  Gemm gemm;
+  size_t const requiredWorkspaceBytes = gemm.get_workspace_size(args);
+  if (wsBytes < requiredWorkspaceBytes)
+    throw std::invalid_argument("nvfp4_svdquant_gemm: insufficient workspace");
+  auto st = gemm.can_implement(args);
+  if (st != cutlass::Status::kSuccess)
+    throw std::runtime_error("nvfp4_svdquant_gemm: can_implement failed");
+  st = gemm.initialize(args, ws, stream);
+  if (st != cutlass::Status::kSuccess)
+    throw std::runtime_error("nvfp4_svdquant_gemm: initialize failed");
+  st = gemm.run(args, ws, stream, nullptr, enable_pdl);
+  if (st != cutlass::Status::kSuccess) throw std::runtime_error("nvfp4_svdquant_gemm: run failed");
+}
+
+#define INSTANTIATE_NVFP4_SVDQUANT_GEMM_TACTIC(Config)                                       \
+  template size_t workspace_size_for_tactic<Config>(int m, int n, int k,                     \
+                                                    RuntimeTactic const& tactic);            \
+  template void run_tactic<Config>(void* out, void const* A, void const* B, void const* sfa, \
+                                   void const* sfb, float const* alpha, void const* D,       \
+                                   void const* L1, void const* bias, int m, int n, int k,    \
+                                   char* ws, size_t wsBytes, cudaStream_t stream,            \
+                                   RuntimeTactic const& tactic, bool enable_pdl);
+
+#define EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Config)                                               \
+  extern template size_t workspace_size_for_tactic<Config>(int m, int n, int k,                 \
+                                                           RuntimeTactic const& tactic);        \
+  extern template void run_tactic<Config>(                                                      \
+      void* out, void const* A, void const* B, void const* sfa, void const* sfb,                \
+      float const* alpha, void const* D, void const* L1, void const* bias, int m, int n, int k, \
+      char* ws, size_t wsBytes, cudaStream_t stream, RuntimeTactic const& tactic,               \
+      bool enable_pdl);
+
+// The per-shape kernels are explicitly instantiated in Jinja-generated translation units (one per
+// kernel shape, see csrc/nvfp4_svdquant_gemm_cutlass_sm100.jinja) so they compile in parallel.
+EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Tactic1Sm128x256x128Config)
+EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Tactic2Sm256x256x128Config)
+EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Tactic1Sm128x128x128Config)
+EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Tactic2Sm256x192x128Config)
+EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Tactic1Sm128x64x128Config)
+EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Tactic1Sm128x128x256Config)
+EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Tactic2Sm256x128x256Config)
+EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Tactic2Sm256x256x256Config)
+
+}  // namespace svdquant_detail
+}  // namespace gemm
+}  // namespace flashinfer

--- a/include/flashinfer/gemm/nvfp4_svdquant_gemm_template_sm100.h
+++ b/include/flashinfer/gemm/nvfp4_svdquant_gemm_template_sm100.h
@@ -236,8 +236,8 @@ size_t workspace_size_for_tactic(int m, int n, int k, RuntimeTactic const& tacti
 template <class Config>
 void run_tactic(void* out, void const* A, void const* B, void const* sfa, void const* sfb,
                 float const* alpha, void const* D, void const* L1, void const* bias, int m, int n,
-                int k, char* ws, size_t wsBytes, cudaStream_t stream, RuntimeTactic const& tactic,
-                bool enable_pdl) {
+                int k, int lora_rank, char* ws, size_t wsBytes, cudaStream_t stream,
+                RuntimeTactic const& tactic, bool enable_pdl) {
   using Gemm = typename Config::Gemm;
   using Sm1xxBlkScaledConfig = typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
   typename Gemm::Arguments args{};
@@ -252,12 +252,16 @@ void run_tactic(void* out, void const* A, void const* B, void const* sfa, void c
   args.mainloop.dB = cute::make_int_tuple_from<typename Gemm::GemmKernel::StrideB>(k, 0);
   args.mainloop.layout_SFA = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFA(args.problem_shape);
   args.mainloop.layout_SFB = Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(args.problem_shape);
-  // LoRA D[M,LoRaK] / L1[N,LoRaK] (bf16, row-major K-contiguous). 1/alpha is folded into L1.
-  constexpr int64_t LoRaK = 32;  // must match CollectiveMmaLoRA::LoRaK
+  // LoRA D[M,r] / L1[N,r] (bf16, row-major K-contiguous, r a positive multiple of 32).
+  // 1/alpha is folded into L1.
+  if (lora_rank < 32 || lora_rank % 32 != 0)
+    throw std::invalid_argument("nvfp4_svdquant_gemm: lora_rank must be a positive multiple of 32");
+  int64_t const r = lora_rank;
   args.mainloop.ptr_D = static_cast<cutlass::bfloat16_t const*>(D);
-  args.mainloop.dD = cute::make_stride(LoRaK, cute::_1{}, int64_t(m) * LoRaK);
+  args.mainloop.dD = cute::make_stride(r, cute::_1{}, int64_t(m) * r);
   args.mainloop.ptr_L1 = static_cast<cutlass::bfloat16_t const*>(L1);
-  args.mainloop.dL1 = cute::make_stride(LoRaK, cute::_1{}, int64_t(n) * LoRaK);
+  args.mainloop.dL1 = cute::make_stride(r, cute::_1{}, int64_t(n) * r);
+  args.mainloop.lora_rank = lora_rank;
 
   args.epilogue.ptr_C = nullptr;
   args.epilogue.ptr_D = static_cast<OutElementType*>(out);
@@ -293,22 +297,22 @@ void run_tactic(void* out, void const* A, void const* B, void const* sfa, void c
   if (st != cutlass::Status::kSuccess) throw std::runtime_error("nvfp4_svdquant_gemm: run failed");
 }
 
-#define INSTANTIATE_NVFP4_SVDQUANT_GEMM_TACTIC(Config)                                       \
-  template size_t workspace_size_for_tactic<Config>(int m, int n, int k,                     \
-                                                    RuntimeTactic const& tactic);            \
-  template void run_tactic<Config>(void* out, void const* A, void const* B, void const* sfa, \
-                                   void const* sfb, float const* alpha, void const* D,       \
-                                   void const* L1, void const* bias, int m, int n, int k,    \
-                                   char* ws, size_t wsBytes, cudaStream_t stream,            \
+#define INSTANTIATE_NVFP4_SVDQUANT_GEMM_TACTIC(Config)                                           \
+  template size_t workspace_size_for_tactic<Config>(int m, int n, int k,                         \
+                                                    RuntimeTactic const& tactic);                \
+  template void run_tactic<Config>(void* out, void const* A, void const* B, void const* sfa,     \
+                                   void const* sfb, float const* alpha, void const* D,           \
+                                   void const* L1, void const* bias, int m, int n, int k,        \
+                                   int lora_rank, char* ws, size_t wsBytes, cudaStream_t stream, \
                                    RuntimeTactic const& tactic, bool enable_pdl);
 
-#define EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Config)                                               \
-  extern template size_t workspace_size_for_tactic<Config>(int m, int n, int k,                 \
-                                                           RuntimeTactic const& tactic);        \
-  extern template void run_tactic<Config>(                                                      \
-      void* out, void const* A, void const* B, void const* sfa, void const* sfb,                \
-      float const* alpha, void const* D, void const* L1, void const* bias, int m, int n, int k, \
-      char* ws, size_t wsBytes, cudaStream_t stream, RuntimeTactic const& tactic,               \
+#define EXTERN_NVFP4_SVDQUANT_GEMM_TACTIC(Config)                                                \
+  extern template size_t workspace_size_for_tactic<Config>(int m, int n, int k,                  \
+                                                           RuntimeTactic const& tactic);         \
+  extern template void run_tactic<Config>(                                                       \
+      void* out, void const* A, void const* B, void const* sfa, void const* sfb,                 \
+      float const* alpha, void const* D, void const* L1, void const* bias, int m, int n, int k,  \
+      int lora_rank, char* ws, size_t wsBytes, cudaStream_t stream, RuntimeTactic const& tactic, \
       bool enable_pdl);
 
 // The per-shape kernels are explicitly instantiated in Jinja-generated translation units (one per

--- a/tests/gemm/test_nvfp4_svdquant_gemm.py
+++ b/tests/gemm/test_nvfp4_svdquant_gemm.py
@@ -1,7 +1,8 @@
 """Tests for the SM100 NVFP4 SVDQuant fused GEMM ops (Blackwell):
 
 - mm_nvfp4_svdquant     : out = alpha * (a @ bT) + d @ l1T [+ bias], the block-scaled
-                          NVFP4 residual GEMM fused with the rank-32 BF16 LoRA-up.
+                          NVFP4 residual GEMM fused with the rank-r BF16 LoRA-up
+                          (r a positive multiple of 32; 32-128 covered here).
 - nvfp4_quantize_smooth : NVFP4-quantize(x * pre_quant_scale), byte-identical to the
                           stock quantizer run on the pre-smoothed input.
 - svdquant_linear       : the full quantize -> LoRA-down -> fused GEMM chain.
@@ -24,12 +25,12 @@ from flashinfer import (
 )
 from flashinfer.gemm.gemm_svdquant import (
     DEFAULT_WORKSPACE_SIZE,
-    SVDQUANT_LORA_RANK,
+    SVDQUANT_LORA_RANK_GRANULARITY,
     get_nvfp4_svdquant_module,
 )
 from flashinfer.utils import device_support_pdl, get_compute_capability
 
-_RANK = SVDQUANT_LORA_RANK  # rank fixed by the kernel's LoRA collective
+_RANK = SVDQUANT_LORA_RANK_GRANULARITY  # base rank == the collective's rank granularity
 
 
 def _skip_unless_sm100():
@@ -80,15 +81,15 @@ def _mm_fp4_residual(xq, wq, x_sf, w_sf, alpha):
     return out.float()
 
 
-def _make_gemm_problem(m, n, k, device="cuda"):
+def _make_gemm_problem(m, n, k, rank=_RANK, device="cuda"):
     """Quantized operands and fp32 references for out = alpha*(a@bT) + D@L1T [+ bias]."""
     x = torch.randn(m, k, dtype=torch.bfloat16, device=device) / (k**0.25)
     w = torch.randn(n, k, dtype=torch.bfloat16, device=device) / (k**0.25)
     xq, x_sf, gx = _nvfp4_quantize_128x4(x)
     wq, w_sf, gw = _nvfp4_quantize_128x4(w)
     alpha = (1.0 / (gx * gw)).reshape(1).float()
-    d = torch.randn(m, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
-    l1 = torch.randn(n, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    d = torch.randn(m, rank, dtype=torch.bfloat16, device=device) / (rank**0.25)
+    l1 = torch.randn(n, rank, dtype=torch.bfloat16, device=device) / (rank**0.25)
     # 1/alpha is folded into L1 so the epilogue out = alpha*acc [+ bias] yields the
     # unscaled D @ L1T correction.
     l1_scaled = (l1.float() / alpha).to(torch.bfloat16).contiguous()
@@ -148,14 +149,18 @@ def test_nvfp4_quantize_smooth(m, n):
     assert torch.equal(sf, sf_ref.view(torch.uint8).reshape(-1))
 
 
+# Rank 32 (one storage chunk, the original kernel) and rank 128 (the widest validated
+# rank: 4 chunks on K128 tiles, 2 on K256 tiles) sweep every tactic; the intermediate
+# ranks are covered by test_mm_nvfp4_svdquant_rank_chunks on representative tactics.
 @pytest.mark.parametrize("m", [129, 6912])
 @pytest.mark.parametrize("k", [3072, 12288])
-def test_mm_nvfp4_svdquant_per_tactic(m, k):
+@pytest.mark.parametrize("rank", [32, 128])
+def test_mm_nvfp4_svdquant_per_tactic(m, k, rank):
     _skip_unless_sm100()
     torch.manual_seed(0)
     n = 3072
     device = torch.device("cuda")
-    p = _make_gemm_problem(m, n, k)
+    p = _make_gemm_problem(m, n, k, rank=rank)
 
     module = get_nvfp4_svdquant_module()
     num_tactics = int(module.nvfp4_svdquant_gemm_tactic_num())
@@ -186,17 +191,79 @@ def test_mm_nvfp4_svdquant_per_tactic(m, k):
             ref = p["ref_bias"] if use_bias else p["ref"]
             sqnr = _sqnr_db(ref, out.float())
             assert sqnr > 40.0, (
-                f"tactic={tactic} use_bias={use_bias} m={m} n={n} k={k}: "
+                f"tactic={tactic} use_bias={use_bias} m={m} n={n} k={k} rank={rank}: "
                 f"SQNR={sqnr:.2f} dB <= 40 dB"
             )
 
 
+# Chunked-rank coverage on representative kernel shapes: tactics 0/1 use K128 tiles
+# (32-column chunks: rank 64 -> 2 chunks, 96 -> 3), tactics 19/25 use K256 tiles
+# (64-column chunks: rank 64 -> 1 full-width chunk, 96 -> a full chunk plus a
+# half-real TMA-zero-filled tail). Rank 128 everywhere is covered by the full
+# per-tactic sweep above.
 @pytest.mark.parametrize("m", [129, 6912])
-def test_mm_nvfp4_svdquant_autotuned(m):
+@pytest.mark.parametrize("rank", [64, 96])
+@pytest.mark.parametrize("tactic", [0, 1, 19, 25])
+def test_mm_nvfp4_svdquant_rank_chunks(m, rank, tactic):
     _skip_unless_sm100()
     torch.manual_seed(0)
     n, k = 3072, 3072
-    p = _make_gemm_problem(m, n, k)
+    device = torch.device("cuda")
+    p = _make_gemm_problem(m, n, k, rank=rank)
+
+    module = get_nvfp4_svdquant_module()
+    enable_pdl = device_support_pdl(device)
+    workspace = torch.empty(DEFAULT_WORKSPACE_SIZE, dtype=torch.uint8, device=device)
+    out = torch.full((m, n), float("nan"), dtype=torch.bfloat16, device=device)
+    module.nvfp4_svdquant_gemm(
+        p["xq"],
+        p["wq"],
+        p["x_sf_flat"],
+        p["w_sf_flat"],
+        p["alpha"],
+        p["d"],
+        p["l1_scaled"],
+        p["bias"],
+        out,
+        workspace,
+        tactic,
+        enable_pdl,
+    )
+    sqnr = _sqnr_db(p["ref_bias"], out.float())
+    assert sqnr > 40.0, (
+        f"tactic={tactic} m={m} rank={rank}: SQNR={sqnr:.2f} dB <= 40 dB"
+    )
+
+
+def test_mm_nvfp4_svdquant_rejects_bad_rank():
+    _skip_unless_sm100()
+    torch.manual_seed(0)
+    m, n, k = 128, 3072, 3072
+    p = _make_gemm_problem(m, n, k, rank=64)
+    for d, l1 in [
+        (p["d"][:, :48].contiguous(), p["l1_scaled"][:, :48].contiguous()),  # not %32
+        (p["d"], p["l1_scaled"][:, :32].contiguous()),  # rank mismatch
+    ]:
+        with pytest.raises(ValueError):
+            mm_nvfp4_svdquant(
+                p["xq"],
+                p["wq"],
+                p["x_sf_flat"],
+                p["w_sf_flat"],
+                p["alpha"],
+                d,
+                l1,
+                bias=p["bias"],
+            )
+
+
+@pytest.mark.parametrize("m", [129, 6912])
+@pytest.mark.parametrize("rank", [32, 96])
+def test_mm_nvfp4_svdquant_autotuned(m, rank):
+    _skip_unless_sm100()
+    torch.manual_seed(0)
+    n, k = 3072, 3072
+    p = _make_gemm_problem(m, n, k, rank=rank)
 
     with autotune(True):
         out = mm_nvfp4_svdquant(
@@ -227,7 +294,8 @@ def test_mm_nvfp4_svdquant_autotuned(m):
 
 
 @pytest.mark.parametrize("use_bias", [False, True])
-def test_svdquant_linear_matches_reference(use_bias):
+@pytest.mark.parametrize("rank", [_RANK, 64])
+def test_svdquant_linear_matches_reference(use_bias, rank):
     _skip_unless_sm100()
     torch.manual_seed(0)
     m, n, k = 129, 3072, 3072
@@ -250,9 +318,9 @@ def test_svdquant_linear_matches_reference(use_bias):
     wq, w_sf, gw = _nvfp4_quantize_128x4(w)
     alpha = (1.0 / (global_sf * gw)).reshape(1).float()
 
-    lora_a = torch.randn(_RANK, k, dtype=torch.bfloat16, device=device) / (k**0.25)
-    l2t_smoothed = (pqs.unsqueeze(1) * lora_a.t()).contiguous()  # [k, RANK] bf16
-    lora_b = torch.randn(n, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    lora_a = torch.randn(rank, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    l2t_smoothed = (pqs.unsqueeze(1) * lora_a.t()).contiguous()  # [k, rank] bf16
+    lora_b = torch.randn(n, rank, dtype=torch.bfloat16, device=device) / (rank**0.25)
     l1_scaled = (lora_b.float() / alpha).to(torch.bfloat16).contiguous()
     bias = (
         torch.randn(n, dtype=torch.bfloat16, device=device).contiguous()
@@ -289,7 +357,8 @@ def test_svdquant_linear_matches_reference(use_bias):
     assert _sqnr_db(ref, out.float()) > 40.0
 
 
-def test_mm_nvfp4_svdquant_cuda_graph():
+@pytest.mark.parametrize("rank", [32, 128])
+def test_mm_nvfp4_svdquant_cuda_graph(rank):
     _skip_unless_sm100()
     torch.manual_seed(0)
     m, n, k = 129, 3072, 3072
@@ -302,8 +371,8 @@ def test_mm_nvfp4_svdquant_cuda_graph():
     x_sf = x_sf2d.reshape(-1)
     w_sf_flat = w_sf.reshape(-1)
     alpha = (1.0 / (gx * gw)).reshape(1).float()
-    d = torch.randn(m, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
-    l1 = torch.randn(n, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    d = torch.randn(m, rank, dtype=torch.bfloat16, device=device) / (rank**0.25)
+    l1 = torch.randn(n, rank, dtype=torch.bfloat16, device=device) / (rank**0.25)
     l1_scaled = (l1.float() / alpha).to(torch.bfloat16).contiguous()
     bias = torch.randn(n, dtype=torch.bfloat16, device=device).contiguous()
 
@@ -349,7 +418,7 @@ def test_mm_nvfp4_svdquant_cuda_graph():
     )
     xq.copy_(xq_new.view(torch.uint8))
     x_sf.copy_(x_sf_new.view(torch.uint8).reshape(-1))
-    d.copy_(torch.randn(m, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25))
+    d.copy_(torch.randn(m, rank, dtype=torch.bfloat16, device=device) / (rank**0.25))
 
     out_graph.fill_(float("nan"))
     graph.replay()

--- a/tests/gemm/test_nvfp4_svdquant_gemm.py
+++ b/tests/gemm/test_nvfp4_svdquant_gemm.py
@@ -1,0 +1,367 @@
+"""Tests for the SM100 NVFP4 SVDQuant fused GEMM ops (Blackwell):
+
+- mm_nvfp4_svdquant     : out = alpha * (a @ bT) + d @ l1T [+ bias], the block-scaled
+                          NVFP4 residual GEMM fused with the rank-32 BF16 LoRA-up.
+- nvfp4_quantize_smooth : NVFP4-quantize(x * pre_quant_scale), byte-identical to the
+                          stock quantizer run on the pre-smoothed input.
+- svdquant_linear       : the full quantize -> LoRA-down -> fused GEMM chain.
+
+The unfused reference for the residual is flashinfer.mm_fp4 (cutlass backend) on the
+same quantized operands, plus the LoRA correction computed in fp32.
+"""
+
+import pytest
+import torch
+
+from flashinfer import (
+    SfLayout,
+    autotune,
+    mm_fp4,
+    mm_nvfp4_svdquant,
+    nvfp4_quantize,
+    nvfp4_quantize_smooth,
+    svdquant_linear,
+)
+from flashinfer.gemm.gemm_svdquant import (
+    DEFAULT_WORKSPACE_SIZE,
+    SVDQUANT_LORA_RANK,
+    get_nvfp4_svdquant_module,
+)
+from flashinfer.utils import device_support_pdl, get_compute_capability
+
+_RANK = SVDQUANT_LORA_RANK  # rank fixed by the kernel's LoRA collective
+
+
+def _skip_unless_sm100():
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] != 10:
+        pytest.skip(
+            "NVFP4 SVDQuant kernels require SM100-class GPUs, "
+            f"got compute capability {compute_capability}."
+        )
+
+
+def _sqnr_db(ref: torch.Tensor, got: torch.Tensor) -> float:
+    err = (ref - got).float()
+    noise = (err**2).mean()
+    if noise == 0:
+        return float("inf")
+    return float(10 * torch.log10((ref.float() ** 2).mean() / noise))
+
+
+def _nvfp4_quantize_128x4(t: torch.Tensor):
+    """Stock NVFP4 quantization (ue4m3 block scales, 128x4 swizzled layout).
+
+    Returns (packed e2m1 uint8 [r, c/2], swizzled sf uint8 2-D, global scale f32 [1]).
+    """
+    global_sf = ((448.0 * 6.0) / t.float().abs().nan_to_num().max()).reshape(1)
+    tq, sf = nvfp4_quantize(
+        t, global_sf, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    return tq.view(torch.uint8), sf.view(torch.uint8), global_sf
+
+
+def _mm_fp4_residual(xq, wq, x_sf, w_sf, alpha):
+    """Unfused reference residual alpha * (a @ bT) via the stock cutlass NVFP4 GEMM."""
+    out = torch.empty(xq.shape[0], wq.shape[0], dtype=torch.bfloat16, device=xq.device)
+    mm_fp4(
+        xq,
+        wq.T,
+        x_sf,
+        w_sf.T,
+        alpha,
+        torch.bfloat16,
+        out,
+        block_size=16,
+        use_8x4_sf_layout=False,
+        backend="cutlass",
+        use_nvfp4=True,
+    )
+    return out.float()
+
+
+def _make_gemm_problem(m, n, k, device="cuda"):
+    """Quantized operands and fp32 references for out = alpha*(a@bT) + D@L1T [+ bias]."""
+    x = torch.randn(m, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    w = torch.randn(n, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    xq, x_sf, gx = _nvfp4_quantize_128x4(x)
+    wq, w_sf, gw = _nvfp4_quantize_128x4(w)
+    alpha = (1.0 / (gx * gw)).reshape(1).float()
+    d = torch.randn(m, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    l1 = torch.randn(n, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    # 1/alpha is folded into L1 so the epilogue out = alpha*acc [+ bias] yields the
+    # unscaled D @ L1T correction.
+    l1_scaled = (l1.float() / alpha).to(torch.bfloat16).contiguous()
+    bias = torch.randn(n, dtype=torch.bfloat16, device=device).contiguous()
+
+    ref = _mm_fp4_residual(xq, wq, x_sf, w_sf, alpha) + d.float() @ l1.float().t()
+    return {
+        "xq": xq,
+        "wq": wq,
+        "x_sf": x_sf,  # 2-D swizzled layout (mm_fp4 convention)
+        "w_sf": w_sf,
+        "x_sf_flat": x_sf.reshape(-1),  # 1-D buffer (fused-kernel convention)
+        "w_sf_flat": w_sf.reshape(-1),
+        "alpha": alpha,
+        "d": d,
+        "l1_scaled": l1_scaled,
+        "bias": bias,
+        "ref": ref,
+        "ref_bias": ref + bias.float(),
+    }
+
+
+# n=3072 / n=12288 exercise the dedicated fast-path kernels; n=4096 the legacy
+# (generic-width) kernel. m values cover token tails and non-multiple-of-128 rows
+# (SF row padding).
+@pytest.mark.parametrize("m", [44, 129, 256, 1000])
+@pytest.mark.parametrize("n", [3072, 12288, 4096])
+def test_nvfp4_quantize_smooth(m, n):
+    _skip_unless_sm100()
+    torch.manual_seed(0)
+    device = "cuda"
+    x = torch.randn(m, n, dtype=torch.bfloat16, device=device) / (n**0.25)
+    pqs = (
+        (1.0 + 0.3 * torch.randn(n, dtype=torch.bfloat16, device=device))
+        .abs()
+        .contiguous()
+    )
+    global_sf = (
+        ((448.0 * 6.0) / (x.float() * pqs.float()).abs().nan_to_num().max())
+        .reshape(1)
+        .contiguous()
+    )
+
+    # Reference: quantize the pre-smoothed activation with the stock quantizer. The
+    # kernel multiplies x * pqs in bf16, so the reference product is bf16 as well.
+    xq_ref, sf_ref = nvfp4_quantize(
+        (x * pqs).to(torch.bfloat16),
+        global_sf,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+    )
+    xq, sf = nvfp4_quantize_smooth(x, pqs, global_sf)
+
+    assert xq.dtype == torch.uint8 and xq.shape == (m, n // 2)
+    assert sf.dtype == torch.uint8 and sf.ndim == 1
+    assert torch.equal(xq, xq_ref.view(torch.uint8))
+    assert torch.equal(sf, sf_ref.view(torch.uint8).reshape(-1))
+
+
+@pytest.mark.parametrize("m", [129, 6912])
+@pytest.mark.parametrize("k", [3072, 12288])
+def test_mm_nvfp4_svdquant_per_tactic(m, k):
+    _skip_unless_sm100()
+    torch.manual_seed(0)
+    n = 3072
+    device = torch.device("cuda")
+    p = _make_gemm_problem(m, n, k)
+
+    module = get_nvfp4_svdquant_module()
+    num_tactics = int(module.nvfp4_svdquant_gemm_tactic_num())
+    assert num_tactics > 0
+    enable_pdl = device_support_pdl(device)
+    workspace = torch.empty(DEFAULT_WORKSPACE_SIZE, dtype=torch.uint8, device=device)
+    out = torch.empty(m, n, dtype=torch.bfloat16, device=device)
+
+    for tactic in range(num_tactics):
+        # Bias is the production epilogue: exercise it for every tactic. The no-bias
+        # epilogue is orthogonal to M, so cover it on the small-M problem only.
+        for use_bias in [True, False] if m == 129 else [True]:
+            out.fill_(float("nan"))
+            module.nvfp4_svdquant_gemm(
+                p["xq"],
+                p["wq"],
+                p["x_sf_flat"],
+                p["w_sf_flat"],
+                p["alpha"],
+                p["d"],
+                p["l1_scaled"],
+                p["bias"] if use_bias else None,
+                out,
+                workspace,
+                tactic,
+                enable_pdl,
+            )
+            ref = p["ref_bias"] if use_bias else p["ref"]
+            sqnr = _sqnr_db(ref, out.float())
+            assert sqnr > 40.0, (
+                f"tactic={tactic} use_bias={use_bias} m={m} n={n} k={k}: "
+                f"SQNR={sqnr:.2f} dB <= 40 dB"
+            )
+
+
+@pytest.mark.parametrize("m", [129, 6912])
+def test_mm_nvfp4_svdquant_autotuned(m):
+    _skip_unless_sm100()
+    torch.manual_seed(0)
+    n, k = 3072, 3072
+    p = _make_gemm_problem(m, n, k)
+
+    with autotune(True):
+        out = mm_nvfp4_svdquant(
+            p["xq"],
+            p["wq"],
+            p["x_sf_flat"],
+            p["w_sf_flat"],
+            p["alpha"],
+            p["d"],
+            p["l1_scaled"],
+            bias=p["bias"],
+        )
+    assert out.shape == (m, n) and out.dtype == torch.bfloat16
+    assert _sqnr_db(p["ref_bias"], out.float()) > 40.0
+
+    # Replay outside the tuning context: the cached tactic must also be correct.
+    out_replay = mm_nvfp4_svdquant(
+        p["xq"],
+        p["wq"],
+        p["x_sf_flat"],
+        p["w_sf_flat"],
+        p["alpha"],
+        p["d"],
+        p["l1_scaled"],
+        bias=p["bias"],
+    )
+    assert _sqnr_db(p["ref_bias"], out_replay.float()) > 40.0
+
+
+@pytest.mark.parametrize("use_bias", [False, True])
+def test_svdquant_linear_matches_reference(use_bias):
+    _skip_unless_sm100()
+    torch.manual_seed(0)
+    m, n, k = 129, 3072, 3072
+    device = "cuda"
+
+    x = torch.randn(m, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    pqs = (
+        (1.0 + 0.3 * torch.randn(k, dtype=torch.bfloat16, device=device))
+        .abs()
+        .contiguous()
+    )
+    smoothed = (x * pqs).to(torch.bfloat16)
+    global_sf = (
+        ((448.0 * 6.0) / smoothed.float().abs().nan_to_num().max())
+        .reshape(1)
+        .contiguous()
+    )
+
+    w = torch.randn(n, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    wq, w_sf, gw = _nvfp4_quantize_128x4(w)
+    alpha = (1.0 / (global_sf * gw)).reshape(1).float()
+
+    lora_a = torch.randn(_RANK, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    l2t_smoothed = (pqs.unsqueeze(1) * lora_a.t()).contiguous()  # [k, RANK] bf16
+    lora_b = torch.randn(n, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    l1_scaled = (lora_b.float() / alpha).to(torch.bfloat16).contiguous()
+    bias = (
+        torch.randn(n, dtype=torch.bfloat16, device=device).contiguous()
+        if use_bias
+        else None
+    )
+
+    out = svdquant_linear(
+        x,
+        wq,
+        w_sf.reshape(-1),
+        alpha,
+        pqs,
+        l2t_smoothed,
+        l1_scaled,
+        global_sf,
+        bias=bias,
+    )
+
+    # Unfused reference on byte-identical quantized operands (nvfp4_quantize_smooth
+    # is byte-identical to the stock quantizer on the pre-smoothed input).
+    xq_ref, x_sf_ref = nvfp4_quantize(
+        smoothed, global_sf, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    residual = _mm_fp4_residual(
+        xq_ref.view(torch.uint8), wq, x_sf_ref.view(torch.uint8), w_sf, alpha
+    )
+    down = torch.mm(x, l2t_smoothed)  # same bf16 LoRA-down GEMM the chain runs
+    ref = residual + down.float() @ lora_b.float().t()
+    if bias is not None:
+        ref = ref + bias.float()
+
+    assert out.shape == (m, n) and out.dtype == torch.bfloat16
+    assert _sqnr_db(ref, out.float()) > 40.0
+
+
+def test_mm_nvfp4_svdquant_cuda_graph():
+    _skip_unless_sm100()
+    torch.manual_seed(0)
+    m, n, k = 129, 3072, 3072
+    device = torch.device("cuda")
+
+    x = torch.randn(m, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    w = torch.randn(n, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    xq, x_sf2d, gx = _nvfp4_quantize_128x4(x)
+    wq, w_sf, gw = _nvfp4_quantize_128x4(w)
+    x_sf = x_sf2d.reshape(-1)
+    w_sf_flat = w_sf.reshape(-1)
+    alpha = (1.0 / (gx * gw)).reshape(1).float()
+    d = torch.randn(m, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    l1 = torch.randn(n, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25)
+    l1_scaled = (l1.float() / alpha).to(torch.bfloat16).contiguous()
+    bias = torch.randn(n, dtype=torch.bfloat16, device=device).contiguous()
+
+    module = get_nvfp4_svdquant_module()
+    enable_pdl = device_support_pdl(device)
+    workspace = torch.empty(DEFAULT_WORKSPACE_SIZE, dtype=torch.uint8, device=device)
+    out_graph = torch.empty(m, n, dtype=torch.bfloat16, device=device)
+
+    def run(out_tensor):
+        # Fixed tactic 0 keeps eager and captured launches identical.
+        module.nvfp4_svdquant_gemm(
+            xq,
+            wq,
+            x_sf,
+            w_sf_flat,
+            alpha,
+            d,
+            l1_scaled,
+            bias,
+            out_tensor,
+            workspace,
+            0,
+            enable_pdl,
+        )
+
+    # Warm up on a side stream so JIT loading and allocations happen outside capture.
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(3):
+            run(out_graph)
+    torch.cuda.current_stream().wait_stream(stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run(out_graph)
+
+    # Refresh the captured input buffers in-place: the replay must consume the
+    # current buffer contents, not the values seen at capture time.
+    x_new = torch.randn(m, k, dtype=torch.bfloat16, device=device) / (k**0.25)
+    xq_new, x_sf_new = nvfp4_quantize(
+        x_new, gx, sfLayout=SfLayout.layout_128x4, do_shuffle=False
+    )
+    xq.copy_(xq_new.view(torch.uint8))
+    x_sf.copy_(x_sf_new.view(torch.uint8).reshape(-1))
+    d.copy_(torch.randn(m, _RANK, dtype=torch.bfloat16, device=device) / (_RANK**0.25))
+
+    out_graph.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    out_eager = torch.empty_like(out_graph)
+    run(out_eager)
+    torch.cuda.synchronize()
+
+    # Same tactic and operands: the deterministic kernel must match bit-exactly.
+    assert torch.equal(out_graph, out_eager)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -417,6 +417,34 @@ try:
 except Exception:
     pass  # Requires Blackwell (SM100)
 
+# ── SVDQuant smooth-quantize + composed linear (Blackwell SM100) ─────────────
+try:
+    M, K, N, RANK = 128, 3072, 3072, 32
+    x_sq = torch.zeros(M, K, dtype=torch.bfloat16, device=device)
+    pqs_sq = torch.ones(K, dtype=torch.bfloat16, device=device)
+    gs_sq = torch.ones(1, dtype=torch.float32, device=device)
+    flashinfer.gemm.nvfp4_quantize_smooth(x_sq, pqs_sq, gs_sq)
+except Exception:
+    pass  # Requires Blackwell (SM100)
+
+try:
+    M, K, N, RANK = 128, 3072, 3072, 32
+    x_sl = torch.zeros(M, K, dtype=torch.bfloat16, device=device)
+    w_sl = torch.zeros(N, K // 2, dtype=torch.uint8, device=device)
+    wsf_sl = torch.zeros(
+        ((N + 127) // 128 * 128) * (K // 16), dtype=torch.uint8, device=device
+    )
+    alpha_sl = torch.ones(1, dtype=torch.float32, device=device)
+    pqs_sl = torch.ones(K, dtype=torch.bfloat16, device=device)
+    l2t_sl = torch.zeros(K, RANK, dtype=torch.bfloat16, device=device)
+    l1_sl = torch.zeros(N, RANK, dtype=torch.bfloat16, device=device)
+    gs_sl = torch.ones(1, dtype=torch.float32, device=device)
+    flashinfer.gemm.svdquant_linear(
+        x_sl, w_sl, wsf_sl, alpha_sl, pqs_sl, l2t_sl, l1_sl, gs_sl
+    )
+except Exception:
+    pass  # Requires Blackwell (SM100)
+
 # ── GEMM bf16 x fp4: mm_bf16_fp4 (weight-only) ──────────────────────────────
 # Blackwell SM100+: M×7168@2048×7168, block=16. b/b_descale shapes are the
 # *prepared* layouts (prepare_bf16_fp4_weights).

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -399,6 +399,24 @@ try:
 except Exception:
     pass  # Requires Blackwell (SM100+)
 
+# ── SVDQuant fused NVFP4 GEMM (Blackwell SM100: M×3072@3072×3072, rank 32) ──
+try:
+    M, K, N, RANK = 128, 3072, 3072, 32
+    a_svdq = torch.zeros(M, K // 2, dtype=torch.uint8, device=device)
+    b_svdq = torch.zeros(N, K // 2, dtype=torch.uint8, device=device)
+    sf_len = ((M + 127) // 128 * 128) * (K // 16)
+    wsf_len = ((N + 127) // 128 * 128) * (K // 16)
+    a_sf_svdq = torch.zeros(sf_len, dtype=torch.uint8, device=device)
+    b_sf_svdq = torch.zeros(wsf_len, dtype=torch.uint8, device=device)
+    alpha_svdq = torch.ones(1, dtype=torch.float32, device=device)
+    d_svdq = torch.zeros(M, RANK, dtype=torch.bfloat16, device=device)
+    l1_svdq = torch.zeros(N, RANK, dtype=torch.bfloat16, device=device)
+    flashinfer.gemm.mm_nvfp4_svdquant(
+        a_svdq, b_svdq, a_sf_svdq, b_sf_svdq, alpha_svdq, d_svdq, l1_svdq
+    )
+except Exception:
+    pass  # Requires Blackwell (SM100)
+
 # ── GEMM bf16 x fp4: mm_bf16_fp4 (weight-only) ──────────────────────────────
 # Blackwell SM100+: M×7168@2048×7168, block=16. b/b_descale shapes are the
 # *prepared* layouts (prepare_bf16_fp4_weights).


### PR DESCRIPTION
## Summary

This PR adds a CUTLASS implementation of the NVFP4 SVDQuant linear operator for SM100-class GPUs (SM100 and SM103). The kernel was first developed in [TensorRT-LLM #15693](https://github.com/NVIDIA/TensorRT-LLM/pull/15693) and this kernel was contributed by project [KDA](https://github.com/mit-han-lab/kernel-design-agents); moving it into FlashInfer gives TensorRT-LLM and other FlashInfer users a shared implementation. The operation itself is model-independent, although the downstream validation uses Qwen-Image shapes.

## Changes

Three APIs are added:

- `nvfp4_quantize_smooth` computes NVFP4 quantization of `x * pre_quant_scale` in one pass. Its packed values and 128x4-swizzled scale factors are byte-identical to running the existing NVFP4 quantizer on the BF16-smoothed input.
- `mm_nvfp4_svdquant` computes `Y = alpha * (A @ B.T) + D @ L1.T [+ bias]`, with block-scaled NVFP4 `A`/`B` and a rank-r BF16 correction, where the LoRA rank `r` is inferred from the `D`/`L1` shapes and must be a positive multiple of 32 (ranks 32-128 are validated). The kernel argument for `L1` is stored as `L1 / alpha` because the epilogue applies `alpha` to the shared accumulator.
- `svdquant_linear` composes smooth quantization, the BF16 rank-down matrix multiplication, and the fused residual/rank-up GEMM.

The fused GEMM issues a second BF16 tcgen05 MMA for the rank-up projection into the same TMEM accumulator used by the NVFP4 GEMM. `D`/`L1` ride the residual A/B pipeline stage buffers after the NVFP4 K-loop, one `TileK/4`-column chunk per pipeline stage; ranks wider than one chunk are consumed as additional post-K-loop producer/consumer steps, and a rank that does not fill its last chunk is TMA zero-filled. Rank 32 keeps the exact single-step instruction sequence of the original fixed-rank kernel. It provides 27 tactics spanning 8 tile shapes. The FlashInfer API uses `AutoTuner`; the raw tactic count and fixed-tactic FFI are also available for frameworks such as TensorRT-LLM that own their tuning policy. The existing FP4 GEMM path is unchanged.

Current constraints are SM100/SM103, a LoRA rank that is a positive multiple of 32 (32-128 validated), BF16 correction operands and output, 128x4-swizzled UE4M3 scale factors, and `N`/`K` divisible by 32. There is no fallback for earlier architectures.

## Performance

On one GB200 with PDL enabled, both sides autotuned, CUDA-graph replay, and a 256 MiB L2 flush, fused-GEMM latency divided by tuned stock CUTLASS NVFP4 GEMM latency ranges from 0.94x to 1.06x across the 12 Qwen-Image shapes in the benchmark (rank 32).

[TensorRT-LLM #16038](https://github.com/NVIDIA/TensorRT-LLM/pull/16038) replaces the original in-tree kernel with this FlashInfer implementation while retaining TensorRT-LLM's tuner. Its operator-level FlashInfer/in-tree latency ratio is 0.97x to 1.02x across the same shapes. End-to-end Qwen-Image generation is also at parity: 0.9998x at 1024x1024 and 0.9992x at 1536x1536 after the latest FlashInfer review fixes. Operator-level and end-to-end measurements for LoRA ranks 64/96/128 are published in that PR as well. Full methodology and measurements are in the two linked TensorRT-LLM PRs.

## Tests

Validated on GB200 with:

```bash
python3 -m pytest -q tests/gemm/test_nvfp4_svdquant_gemm.py
```

The tests cover byte-exact smooth quantization, all 27 tactics at LoRA ranks 32 and 128, chunked-rank coverage of ranks 64/96 across the K128 and K256 tile shapes (including the TMA-zero-filled partial chunk), rejection of invalid ranks, bias and no-bias epilogues, greater than 40 dB SQNR against the unfused reference, FlashInfer autotuning, the composed linear operator, and CUDA graph capture/replay. This PR also adds `benchmarks/bench_nvfp4_svdquant_gemm.py` (with a `--ranks` sweep), JIT/AOT registration, API documentation, and trace definitions.

## Related PRs

- Original TensorRT-LLM implementation and SVDQuant end-to-end results: [NVIDIA/TensorRT-LLM#15693](https://github.com/NVIDIA/TensorRT-LLM/pull/15693)
- TensorRT-LLM migration to the FlashInfer kernel: [NVIDIA/TensorRT-LLM#16038](https://github.com/NVIDIA/TensorRT-LLM/pull/16038)

## Reviewer Notes

The first downstream integration is Qwen-Image, but the API is a general NVFP4 residual GEMM plus a low-rank BF16 correction. TensorRT-LLM consumes the raw per-tactic FFI and keeps its existing exact-shape autotuner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SM100 NVFP4 SVDQuant fused GEMM with smooth quantization and LoRA correction (including optional bias).
  * Exposed new GEMM and end-to-end linear APIs at the package level.
  * Added tracing support for the smooth step, fused GEMM, and full linear chain.
* **Documentation**
  * Added API documentation for the new SVDQuant NVFP4 operations.
* **Tests**
  * Added SM100-only correctness tests (SQNR), rank/tactic coverage, input validation, autotuning checks, and CUDA graph capture/replay.
* **Benchmarks**
  * Added a benchmark comparing fused vs full-chain vs baseline GEMM performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->