### PR TITLE
ci: install quack on Blackwell runners for VSA blk128 tests

### DIFF
--- a/flashinfer/cute_dsl/sparse/blk128/utils.py
+++ b/flashinfer/cute_dsl/sparse/blk128/utils.py
@@ -222,10 +222,13 @@ def fmax(
     loc=None,
     ip=None,
 ) -> Float32:
+    import cutlass as _cutlass
     from cutlass import CUDA_VERSION
 
+    _cutlass_ver = tuple(int(x) for x in _cutlass.__version__.split(".")[:2])
     # * NVVM call based on nvvm version
-    if CUDA_VERSION.major == 12 and CUDA_VERSION.minor == 9:
+    # Old API (cutlass < 4.6, cu12/CUDA 12.9): explicit result type as first positional argument
+    if CUDA_VERSION.major == 12 and CUDA_VERSION.minor == 9 and _cutlass_ver < (4, 6):
         # Old API: requires explicit result type as first positional argument
         return Float32(
             nvvm.fmax(

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -64,3 +64,20 @@ if [ -n "${CUTLASS_DSL_VERSION:-}" ]; then
   echo "nvidia-cutlass-dsl override complete."
   echo ""
 fi
+
+# Install `quack` for the VSA Blackwell (blk128) backend tests.
+# `quack` is NOT a runtime requirement of flashinfer — only users of the blk128
+# VSA backend need it, so it is intentionally kept out of requirements.txt and
+# installed here for CI only. The blk128 backend (and its tests, which are
+# gated on is_sm100a_supported) only run on Blackwell (SM 10.x), so we install
+# quack only when such a GPU is present to avoid slowing unrelated CI jobs.
+# Note: the `quack` package on PyPI is unrelated — install from source.
+SM_MAJOR=$(python -c "import torch; print(torch.cuda.get_device_capability()[0])" 2>/dev/null || echo "")
+if [ "${SM_MAJOR}" = "10" ]; then
+  echo "========================================"
+  echo "Detected Blackwell (SM 10.x); installing quack for VSA blk128 tests"
+  echo "========================================"
+  pip install "git+https://github.com/Dao-AILab/quack.git"
+  echo "quack install complete."
+  echo ""
+fi


### PR DESCRIPTION
The VSA Blackwell (blk128) backend requires the `quack` package (https://github.com/Dao-AILab/quack), which is intentionally kept out of requirements.txt since only users of the blk128 backend need it. Without it, the sm100a-gated tests in tests/attention/test_vsa_block_sparse.py fail with ImportError on Blackwell CI runners.

Install quack in scripts/setup_test_env.sh, gated to SM 10.x GPUs so unrelated CI jobs are unaffected. The tests themselves are already gated on is_sm100a_supported.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Blackwell (SM 10.x) backend test environments by automatically installing the required testing package.
  * Fixed `fmax` compatibility across CUDA 12.9 and different CUTLASS versions, improving reliability for supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->