### PR TITLE
perf(gdn): optimize delta rule cp prefill for ultra low parallelism case

### DIFF
--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -1734,7 +1734,7 @@ def cp_delta_rule_mn_precompute_dsl_sm120(
     return transfer_t, state_t
 
 
-class CPDeltaRuleFixupSm120(KeyedCompileMixin):
+class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
     class WarpGroupRole(IntEnum):
         LOAD = 0
         MATH = 1
@@ -2663,7 +2663,14 @@ def cp_delta_rule_fixup_dsl_sm120(
         if needs_initial_state
         else None
     )
-    kernel = CPDeltaRuleFixupSm120(needs_initial_state)
+    # NCU on SM120 shows row4 is best for H <= 8 and row8 wins for H = 16.
+    # HMMA remains the fallback above that.
+    if num_heads <= 8:
+        kernel = CPDeltaRuleFixupSimtSm120(needs_initial_state, 4)
+    elif num_heads <= 16:
+        kernel = CPDeltaRuleFixupSimtSm120(needs_initial_state, 8)
+    else:
+        kernel = CPDeltaRuleFixupHmmaSm120(needs_initial_state)
     kernel_args = (
         from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(
             leading_dim=1

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -4863,6 +4863,9 @@ def cp_delta_rule_dsl_sm120(
             num_heads,
             num_sms,
             chunk_len_granularity=cp_chunk_len_granularity,
+            device_capability=torch.cuda.get_device_capability(q.device),
+            total_seqlen=total_seqlen,
+            device_name=torch.cuda.get_device_properties(q.device).name,
         )
     if q.ndim != 3:
         raise RuntimeError(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -2561,6 +2561,7 @@ def cp_delta_rule_fixup_dsl_sm120(
     initial_state: torch.Tensor | None = None,
     *,
     _skip_check: bool = False,
+    _kernel_kind: str | None = None,
 ):
     """Fix CP precompute chunk artifacts into global chunk-boundary states.
 
@@ -2663,14 +2664,23 @@ def cp_delta_rule_fixup_dsl_sm120(
         if needs_initial_state
         else None
     )
-    # NCU on SM120 shows row4 is best for H <= 8 and row8 wins for H = 16.
-    # HMMA remains the fallback above that.
-    if num_heads <= 8:
+    if _kernel_kind is None:
+        # NCU on SM120 shows row4 is best for H <= 8 and row8 wins for H = 16.
+        # HMMA remains the fallback above that.
+        if num_heads <= 8:
+            _kernel_kind = "simt_row4"
+        elif num_heads <= 16:
+            _kernel_kind = "simt_row8"
+        else:
+            _kernel_kind = "hmma"
+    if _kernel_kind == "simt_row4":
         kernel = CPDeltaRuleFixupSimtSm120(needs_initial_state, 4)
-    elif num_heads <= 16:
+    elif _kernel_kind == "simt_row8":
         kernel = CPDeltaRuleFixupSimtSm120(needs_initial_state, 8)
-    else:
+    elif _kernel_kind == "hmma":
         kernel = CPDeltaRuleFixupHmmaSm120(needs_initial_state)
+    else:
+        raise ValueError(f"Unsupported fixup kernel kind: {_kernel_kind}")
     kernel_args = (
         from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(
             leading_dim=1

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -2674,11 +2674,11 @@ def cp_delta_rule_fixup_dsl_sm120(
         else:
             _kernel_kind = "hmma"
     if _kernel_kind == "simt_row4":
-        kernel = CPDeltaRuleFixupSimtSm120(needs_initial_state, 4)
+        kernel = CPDeltaRuleFixupSimtSm120(needs_initial_state, 4)  # type: ignore
     elif _kernel_kind == "simt_row8":
-        kernel = CPDeltaRuleFixupSimtSm120(needs_initial_state, 8)
+        kernel = CPDeltaRuleFixupSimtSm120(needs_initial_state, 8)  # type: ignore
     elif _kernel_kind == "hmma":
-        kernel = CPDeltaRuleFixupHmmaSm120(needs_initial_state)
+        kernel = CPDeltaRuleFixupHmmaSm120(needs_initial_state)  # type: ignore
     else:
         raise ValueError(f"Unsupported fixup kernel kind: {_kernel_kind}")
     kernel_args = (

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -2248,6 +2248,310 @@ class CPDeltaRuleFixupSm120(KeyedCompileMixin):
                 )
 
 
+class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
+    def __init__(
+        self,
+        needs_initial_state: bool = False,
+        rows_per_cta: int = 4,
+    ):
+        self.needs_initial_state = needs_initial_state
+        self.D = 128
+        self.rows_per_cta = rows_per_cta
+        self.row_ctas = self.D // self.rows_per_cta
+        self.threads_per_cta = 128
+        self.num_warps = 4
+        self.min_blocks_per_mp = 2
+        self.registers_per_thread = 256
+        self.manual_cache_key(
+            "needs_initial_state",
+            "D",
+            "rows_per_cta",
+            "row_ctas",
+            "threads_per_cta",
+            "num_warps",
+            "min_blocks_per_mp",
+            "registers_per_thread",
+        )
+
+    @cute.jit
+    def init_state_tile(
+        self,
+        sState: cute.Tensor,
+        gFixedState: cute.Tensor,
+        gLocalState: cute.Tensor,
+        gInitialState: cute.Tensor,
+        col: cutlass.Int32,
+    ) -> cutlass.Int32:
+        start = cutlass.Int32(0)
+        if cutlass.const_expr(self.needs_initial_state):
+            for i in cutlass.range_constexpr(self.rows_per_cta):
+                sState[i, col] = gInitialState[i, col]
+        else:
+            start = cutlass.Int32(1)
+            for i in cutlass.range_constexpr(self.rows_per_cta):
+                value = gLocalState[i, col, 0]
+                sState[i, col] = value
+                gFixedState[i, col, 0] = value
+        return start
+
+    @cute.jit
+    def load_transfer_fragment(
+        self,
+        rM: cute.Tensor,
+        gTransferTile: cute.Tensor,
+        chunk_idx: cutlass.Int32,
+        k_tile: cutlass.Int32,
+    ):
+        for j in cutlass.range_constexpr(16):
+            rM[j] = gTransferTile[(j, chunk_idx), (k_tile, 0)]
+
+    @cute.jit
+    def load_local_state_fragment(
+        self,
+        rAcc: cute.Tensor,
+        gLocalState: cute.Tensor,
+        chunk_idx: cutlass.Int32,
+        col: cutlass.Int32,
+    ):
+        for i in cutlass.range_constexpr(self.rows_per_cta):
+            rAcc[i] = gLocalState[i, col, chunk_idx]
+
+    @cute.jit
+    def accumulate_state_fragment(
+        self,
+        rAcc: cute.Tensor,
+        sState: cute.Tensor,
+        rM: cute.Tensor,
+        k: cutlass.Int32,
+    ):
+        for i in cutlass.range_constexpr(self.rows_per_cta):
+            for j in cutlass.range_constexpr(16):
+                rAcc[i] = rAcc[i] + sState[i, k + cutlass.Int32(j)] * rM[j]
+
+    @cute.jit
+    def run_simt_fixup_loop(
+        self,
+        sState: cute.Tensor,
+        gTransfer: cute.Tensor,
+        gLocalState: cute.Tensor,
+        gFixedState: cute.Tensor,
+        num_chunks: cutlass.Int32,
+        col: cutlass.Int32,
+        start: cutlass.Int32,
+    ):
+        rAcc = cute.make_rmem_tensor(self.rows_per_cta, cutlass.Float32)
+        rM = cute.make_rmem_tensor(16, cutlass.Float32)
+        rM_next = cute.make_rmem_tensor(16, cutlass.Float32)
+        # ((k_in_tile, chunk_idx), (k_tile, _)); column is fixed by this thread.
+        gTransferTile = cute.zipped_divide(gTransfer[None, col, None], (16, num_chunks))
+        k_tiles = cute.size(gTransferTile, mode=[1, 0])
+        last_k_tile = k_tiles - 1
+        rAccNext = cute.make_rmem_tensor(self.rows_per_cta, cutlass.Float32)
+        if start < num_chunks:
+            self.load_local_state_fragment(rAcc, gLocalState, start, col)
+            self.load_transfer_fragment(rM, gTransferTile, start, cutlass.Int32(0))
+
+        for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
+            next_chunk_idx = chunk_idx + cutlass.Int32(1)
+            for iter_k in cutlass.range_constexpr(last_k_tile):
+                self.load_transfer_fragment(
+                    rM_next,
+                    gTransferTile,
+                    chunk_idx,
+                    cutlass.Int32(iter_k + 1),
+                )
+                self.accumulate_state_fragment(
+                    rAcc, sState, rM, cutlass.Int32(iter_k * 16)
+                )
+                for j in cutlass.range_constexpr(16):
+                    rM[j] = rM_next[j]
+
+            # Last K tile owns the inter-chunk handoff: preload next chunk
+            # before the final accumulation, then publish the new state.
+            if next_chunk_idx < num_chunks:
+                self.load_local_state_fragment(
+                    rAccNext,
+                    gLocalState,
+                    next_chunk_idx,
+                    col,
+                )
+                self.load_transfer_fragment(
+                    rM_next,
+                    gTransferTile,
+                    next_chunk_idx,
+                    cutlass.Int32(0),
+                )
+            self.accumulate_state_fragment(
+                rAcc, sState, rM, cutlass.Int32(last_k_tile * 16)
+            )
+            cute.arch.sync_threads()
+            for i in cutlass.range_constexpr(self.rows_per_cta):
+                value = rAcc[i]
+                sState[i, col] = value
+                gFixedState[i, col, chunk_idx] = value
+            cute.arch.sync_threads()
+            if next_chunk_idx < num_chunks:
+                for i in cutlass.range_constexpr(self.rows_per_cta):
+                    rAcc[i] = rAccNext[i]
+                for j in cutlass.range_constexpr(16):
+                    rM[j] = rM_next[j]
+
+    @cute.jit
+    def zero_invalid_slots(
+        self,
+        gFixedState: cute.Tensor,
+        gap_len: cutlass.Int32,
+        col: cutlass.Int32,
+    ):
+        for slot in cutlass.range(0, gap_len, unroll=1):
+            for i in cutlass.range_constexpr(self.rows_per_cta):
+                gFixedState[i, col, slot] = cutlass.Float32(0.0)
+
+    @cute.jit
+    def __call__(
+        self,
+        g_transfer_t: cute.Tensor,
+        g_local_state_t: cute.Tensor,
+        g_initial_state_t: cute.Tensor,
+        g_fixed_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        stream,
+    ):
+        state_layout = cute.make_layout((self.rows_per_cta, self.D), stride=(self.D, 1))
+
+        @cute.struct
+        class SharedStorage:
+            smem_state: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(state_layout)], 128
+            ]
+
+        self.shared_storage = SharedStorage
+        self.kernel(
+            g_transfer_t,
+            g_local_state_t,
+            g_initial_state_t,
+            g_fixed_state_t,
+            g_cu_seqlens,
+            chunk_len,
+            total_cp_chunks,
+            num_seqs,
+            num_heads,
+        ).launch(
+            grid=(num_seqs * num_heads * self.row_ctas, 1, 1),
+            block=(self.threads_per_cta, 1, 1),
+            max_number_threads=(self.threads_per_cta, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=self.min_blocks_per_mp,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        g_transfer_t: cute.Tensor,
+        g_local_state_t: cute.Tensor,
+        g_initial_state_t: cute.Tensor,
+        g_fixed_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        num_heads: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bx, _, _ = cute.arch.block_idx()
+        row_cta_idx = bx % self.row_ctas
+        head_seq_idx = bx // self.row_ctas
+        head_idx = head_seq_idx % num_heads
+        seq_idx = head_seq_idx // num_heads
+        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
+        seq_len = seq_end - seq_start
+        num_chunks = chunks_for_len(seq_len, chunk_len)
+        chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
+        gap_start = chunk_start + num_chunks
+        gap_end = total_cp_chunks
+        if seq_idx + cutlass.Int32(1) < num_seqs:
+            gap_end = varlen_chunk_idx(
+                seq_idx + cutlass.Int32(1), seq_end, 0, chunk_len
+            )
+
+        cute.arch.setmaxregister_increase(self.registers_per_thread)
+        state_layout = cute.make_layout((self.rows_per_cta, self.D), stride=(self.D, 1))
+        out_layout = cute.make_layout(
+            (self.D, self.D, num_heads, total_cp_chunks),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        workspace_layout = out_layout
+        allocator = cutlass.utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+        gTransfer = cute.make_tensor(g_transfer_t.iterator.align(128), workspace_layout)
+        gLocalState = cute.make_tensor(
+            g_local_state_t.iterator.align(128), workspace_layout
+        )
+        gFixedState = cute.make_tensor(g_fixed_state_t.iterator.align(128), out_layout)
+        fixed_state_layout = cute.make_layout(
+            (self.D, self.D, num_heads, num_seqs),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        if cutlass.const_expr(self.needs_initial_state):
+            gInitialState = cute.make_tensor(
+                g_initial_state_t.iterator, fixed_state_layout
+            )
+        else:
+            gInitialState = gFixedState
+
+        sState = storage.smem_state.get_tensor(state_layout)
+        gTransfer_head = gTransfer[None, None, head_idx, None]
+        gLocalState_cta = cute.local_tile(
+            gLocalState[None, None, head_idx, None],
+            (self.rows_per_cta, self.D, total_cp_chunks),
+            (row_cta_idx, 0, 0),
+        )
+        gFixedState_cta = cute.local_tile(
+            gFixedState[None, None, head_idx, None],
+            (self.rows_per_cta, self.D, total_cp_chunks),
+            (row_cta_idx, 0, 0),
+        )
+        gTransfer_seq = cute.domain_offset((0, 0, chunk_start), gTransfer_head)
+        gLocalState_seq = cute.domain_offset((0, 0, chunk_start), gLocalState_cta)
+        gFixedState_seq = cute.domain_offset((0, 0, chunk_start), gFixedState_cta)
+        if cutlass.const_expr(self.needs_initial_state):
+            gInitialState_cta = cute.local_tile(
+                gInitialState[None, None, head_idx, seq_idx],
+                (self.rows_per_cta, self.D),
+                (row_cta_idx, 0),
+            )
+        else:
+            gInitialState_cta = gFixedState_seq
+        col = tidx
+
+        cute.arch.sync_threads()
+        if num_chunks > 0:
+            start = self.init_state_tile(
+                sState,
+                gFixedState_seq,
+                gLocalState_seq,
+                gInitialState_cta,
+                col,
+            )
+            cute.arch.sync_threads()
+            self.run_simt_fixup_loop(
+                sState,
+                gTransfer_seq,
+                gLocalState_seq,
+                gFixedState_seq,
+                num_chunks,
+                col,
+                start,
+            )
+        gFixedState_gap = cute.domain_offset((0, 0, gap_start), gFixedState_cta)
+        self.zero_invalid_slots(gFixedState_gap, gap_end - gap_start, col)
+
+
 def cp_delta_rule_fixup_dsl_sm120(
     local_transfer: torch.Tensor,
     local_state: torch.Tensor,

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -1744,7 +1744,7 @@ def cp_delta_rule_mn_precompute_dsl_sm90(
     return transfer_t, state_t
 
 
-class CPDeltaRuleFixupSm90(KeyedCompileMixin):
+class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
     class WarpGroupRole(IntEnum):
         LOAD = 0
         MATH = 1
@@ -2246,6 +2246,310 @@ class CPDeltaRuleFixupSm90(KeyedCompileMixin):
                 )
 
 
+class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
+    def __init__(
+        self,
+        needs_initial_state: bool = False,
+        rows_per_cta: int = 4,
+    ):
+        self.needs_initial_state = needs_initial_state
+        self.D = 128
+        self.rows_per_cta = rows_per_cta
+        self.row_ctas = self.D // self.rows_per_cta
+        self.threads_per_cta = 128
+        self.num_warps = 4
+        self.min_blocks_per_mp = 2
+        self.registers_per_thread = 256
+        self.manual_cache_key(
+            "needs_initial_state",
+            "D",
+            "rows_per_cta",
+            "row_ctas",
+            "threads_per_cta",
+            "num_warps",
+            "min_blocks_per_mp",
+            "registers_per_thread",
+        )
+
+    @cute.jit
+    def init_state_tile(
+        self,
+        sState: cute.Tensor,
+        gFixedState: cute.Tensor,
+        gLocalState: cute.Tensor,
+        gInitialState: cute.Tensor,
+        col: cutlass.Int32,
+    ) -> cutlass.Int32:
+        start = cutlass.Int32(0)
+        if cutlass.const_expr(self.needs_initial_state):
+            for i in cutlass.range_constexpr(self.rows_per_cta):
+                sState[i, col] = gInitialState[i, col]
+        else:
+            start = cutlass.Int32(1)
+            for i in cutlass.range_constexpr(self.rows_per_cta):
+                value = gLocalState[i, col, 0]
+                sState[i, col] = value
+                gFixedState[i, col, 0] = value
+        return start
+
+    @cute.jit
+    def load_transfer_fragment(
+        self,
+        rM: cute.Tensor,
+        gTransferTile: cute.Tensor,
+        chunk_idx: cutlass.Int32,
+        k_tile: cutlass.Int32,
+    ):
+        for j in cutlass.range_constexpr(16):
+            rM[j] = gTransferTile[(j, chunk_idx), (k_tile, 0)]
+
+    @cute.jit
+    def load_local_state_fragment(
+        self,
+        rAcc: cute.Tensor,
+        gLocalState: cute.Tensor,
+        chunk_idx: cutlass.Int32,
+        col: cutlass.Int32,
+    ):
+        for i in cutlass.range_constexpr(self.rows_per_cta):
+            rAcc[i] = gLocalState[i, col, chunk_idx]
+
+    @cute.jit
+    def accumulate_state_fragment(
+        self,
+        rAcc: cute.Tensor,
+        sState: cute.Tensor,
+        rM: cute.Tensor,
+        k: cutlass.Int32,
+    ):
+        for i in cutlass.range_constexpr(self.rows_per_cta):
+            for j in cutlass.range_constexpr(16):
+                rAcc[i] = rAcc[i] + sState[i, k + cutlass.Int32(j)] * rM[j]
+
+    @cute.jit
+    def run_simt_fixup_loop(
+        self,
+        sState: cute.Tensor,
+        gTransfer: cute.Tensor,
+        gLocalState: cute.Tensor,
+        gFixedState: cute.Tensor,
+        num_chunks: cutlass.Int32,
+        col: cutlass.Int32,
+        start: cutlass.Int32,
+    ):
+        rAcc = cute.make_rmem_tensor(self.rows_per_cta, cutlass.Float32)
+        rM = cute.make_rmem_tensor(16, cutlass.Float32)
+        rM_next = cute.make_rmem_tensor(16, cutlass.Float32)
+        # ((k_in_tile, chunk_idx), (k_tile, _)); column is fixed by this thread.
+        gTransferTile = cute.zipped_divide(gTransfer[None, col, None], (16, num_chunks))
+        k_tiles = cute.size(gTransferTile, mode=[1, 0])
+        last_k_tile = k_tiles - 1
+        rAccNext = cute.make_rmem_tensor(self.rows_per_cta, cutlass.Float32)
+        if start < num_chunks:
+            self.load_local_state_fragment(rAcc, gLocalState, start, col)
+            self.load_transfer_fragment(rM, gTransferTile, start, cutlass.Int32(0))
+
+        for chunk_idx in cutlass.range(start, num_chunks, unroll=1):
+            next_chunk_idx = chunk_idx + cutlass.Int32(1)
+            for iter_k in cutlass.range_constexpr(last_k_tile):
+                self.load_transfer_fragment(
+                    rM_next,
+                    gTransferTile,
+                    chunk_idx,
+                    cutlass.Int32(iter_k + 1),
+                )
+                self.accumulate_state_fragment(
+                    rAcc, sState, rM, cutlass.Int32(iter_k * 16)
+                )
+                for j in cutlass.range_constexpr(16):
+                    rM[j] = rM_next[j]
+
+            # Last K tile owns the inter-chunk handoff: preload next chunk
+            # before the final accumulation, then publish the new state.
+            if next_chunk_idx < num_chunks:
+                self.load_local_state_fragment(
+                    rAccNext,
+                    gLocalState,
+                    next_chunk_idx,
+                    col,
+                )
+                self.load_transfer_fragment(
+                    rM_next,
+                    gTransferTile,
+                    next_chunk_idx,
+                    cutlass.Int32(0),
+                )
+            self.accumulate_state_fragment(
+                rAcc, sState, rM, cutlass.Int32(last_k_tile * 16)
+            )
+            cute.arch.sync_threads()
+            for i in cutlass.range_constexpr(self.rows_per_cta):
+                value = rAcc[i]
+                sState[i, col] = value
+                gFixedState[i, col, chunk_idx] = value
+            cute.arch.sync_threads()
+            if next_chunk_idx < num_chunks:
+                for i in cutlass.range_constexpr(self.rows_per_cta):
+                    rAcc[i] = rAccNext[i]
+                for j in cutlass.range_constexpr(16):
+                    rM[j] = rM_next[j]
+
+    @cute.jit
+    def zero_invalid_slots(
+        self,
+        gFixedState: cute.Tensor,
+        gap_len: cutlass.Int32,
+        col: cutlass.Int32,
+    ):
+        for slot in cutlass.range(0, gap_len, unroll=1):
+            for i in cutlass.range_constexpr(self.rows_per_cta):
+                gFixedState[i, col, slot] = cutlass.Float32(0.0)
+
+    @cute.jit
+    def __call__(
+        self,
+        g_transfer_t: cute.Tensor,
+        g_local_state_t: cute.Tensor,
+        g_initial_state_t: cute.Tensor,
+        g_fixed_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        num_heads: cutlass.Int32,
+        stream,
+    ):
+        state_layout = cute.make_layout((self.rows_per_cta, self.D), stride=(self.D, 1))
+
+        @cute.struct
+        class SharedStorage:
+            smem_state: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Float32, cute.cosize(state_layout)], 128
+            ]
+
+        self.shared_storage = SharedStorage
+        self.kernel(
+            g_transfer_t,
+            g_local_state_t,
+            g_initial_state_t,
+            g_fixed_state_t,
+            g_cu_seqlens,
+            chunk_len,
+            total_cp_chunks,
+            num_seqs,
+            num_heads,
+        ).launch(
+            grid=(num_seqs * num_heads * self.row_ctas, 1, 1),
+            block=(self.threads_per_cta, 1, 1),
+            max_number_threads=(self.threads_per_cta, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=self.min_blocks_per_mp,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        g_transfer_t: cute.Tensor,
+        g_local_state_t: cute.Tensor,
+        g_initial_state_t: cute.Tensor,
+        g_fixed_state_t: cute.Tensor,
+        g_cu_seqlens: cute.Tensor,
+        chunk_len: cutlass.Int32,
+        total_cp_chunks: cutlass.Int32,
+        num_seqs: cutlass.Int32,
+        num_heads: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bx, _, _ = cute.arch.block_idx()
+        row_cta_idx = bx % self.row_ctas
+        head_seq_idx = bx // self.row_ctas
+        head_idx = head_seq_idx % num_heads
+        seq_idx = head_seq_idx // num_heads
+        seq_start = cutlass.Int32(g_cu_seqlens[seq_idx])
+        seq_end = cutlass.Int32(g_cu_seqlens[seq_idx + 1])
+        seq_len = seq_end - seq_start
+        num_chunks = chunks_for_len(seq_len, chunk_len)
+        chunk_start = varlen_chunk_idx(seq_idx, seq_start, 0, chunk_len)
+        gap_start = chunk_start + num_chunks
+        gap_end = total_cp_chunks
+        if seq_idx + cutlass.Int32(1) < num_seqs:
+            gap_end = varlen_chunk_idx(
+                seq_idx + cutlass.Int32(1), seq_end, 0, chunk_len
+            )
+
+        cute.arch.setmaxregister_increase(self.registers_per_thread)
+        state_layout = cute.make_layout((self.rows_per_cta, self.D), stride=(self.D, 1))
+        out_layout = cute.make_layout(
+            (self.D, self.D, num_heads, total_cp_chunks),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        workspace_layout = out_layout
+        allocator = cutlass.utils.SmemAllocator()
+        storage = allocator.allocate(self.shared_storage)
+        gTransfer = cute.make_tensor(g_transfer_t.iterator.align(128), workspace_layout)
+        gLocalState = cute.make_tensor(
+            g_local_state_t.iterator.align(128), workspace_layout
+        )
+        gFixedState = cute.make_tensor(g_fixed_state_t.iterator.align(128), out_layout)
+        fixed_state_layout = cute.make_layout(
+            (self.D, self.D, num_heads, num_seqs),
+            stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
+        )
+        if cutlass.const_expr(self.needs_initial_state):
+            gInitialState = cute.make_tensor(
+                g_initial_state_t.iterator, fixed_state_layout
+            )
+        else:
+            gInitialState = gFixedState
+
+        sState = storage.smem_state.get_tensor(state_layout)
+        gTransfer_head = gTransfer[None, None, head_idx, None]
+        gLocalState_cta = cute.local_tile(
+            gLocalState[None, None, head_idx, None],
+            (self.rows_per_cta, self.D, total_cp_chunks),
+            (row_cta_idx, 0, 0),
+        )
+        gFixedState_cta = cute.local_tile(
+            gFixedState[None, None, head_idx, None],
+            (self.rows_per_cta, self.D, total_cp_chunks),
+            (row_cta_idx, 0, 0),
+        )
+        gTransfer_seq = cute.domain_offset((0, 0, chunk_start), gTransfer_head)
+        gLocalState_seq = cute.domain_offset((0, 0, chunk_start), gLocalState_cta)
+        gFixedState_seq = cute.domain_offset((0, 0, chunk_start), gFixedState_cta)
+        if cutlass.const_expr(self.needs_initial_state):
+            gInitialState_cta = cute.local_tile(
+                gInitialState[None, None, head_idx, seq_idx],
+                (self.rows_per_cta, self.D),
+                (row_cta_idx, 0),
+            )
+        else:
+            gInitialState_cta = gFixedState_seq
+        col = tidx
+
+        cute.arch.sync_threads()
+        if num_chunks > 0:
+            start = self.init_state_tile(
+                sState,
+                gFixedState_seq,
+                gLocalState_seq,
+                gInitialState_cta,
+                col,
+            )
+            cute.arch.sync_threads()
+            self.run_simt_fixup_loop(
+                sState,
+                gTransfer_seq,
+                gLocalState_seq,
+                gFixedState_seq,
+                num_chunks,
+                col,
+                start,
+            )
+        gFixedState_gap = cute.domain_offset((0, 0, gap_start), gFixedState_cta)
+        self.zero_invalid_slots(gFixedState_gap, gap_end - gap_start, col)
+
+
 def cp_delta_rule_fixup_dsl_sm90(
     local_transfer: torch.Tensor,
     local_state: torch.Tensor,
@@ -2357,7 +2661,12 @@ def cp_delta_rule_fixup_dsl_sm90(
         if needs_initial_state
         else None
     )
-    kernel = CPDeltaRuleFixupSm90(needs_initial_state)
+    if num_heads <= 8:
+        kernel = CPDeltaRuleFixupSimtSm90(needs_initial_state, 4)
+    elif num_heads <= 16:
+        kernel = CPDeltaRuleFixupSimtSm90(needs_initial_state, 8)
+    else:
+        kernel = CPDeltaRuleFixupHmmaSm90(needs_initial_state)
     kernel_args = (
         from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(
             leading_dim=1

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -2559,6 +2559,7 @@ def cp_delta_rule_fixup_dsl_sm90(
     initial_state: torch.Tensor | None = None,
     *,
     _skip_check: bool = False,
+    _kernel_kind: str | None = None,
 ):
     """Fix CP precompute chunk artifacts into global chunk-boundary states.
 
@@ -2661,12 +2662,21 @@ def cp_delta_rule_fixup_dsl_sm90(
         if needs_initial_state
         else None
     )
-    if num_heads <= 8:
+    if _kernel_kind is None:
+        if num_heads <= 8:
+            _kernel_kind = "simt_row4"
+        elif num_heads <= 16:
+            _kernel_kind = "simt_row8"
+        else:
+            _kernel_kind = "hmma"
+    if _kernel_kind == "simt_row4":
         kernel = CPDeltaRuleFixupSimtSm90(needs_initial_state, 4)
-    elif num_heads <= 16:
+    elif _kernel_kind == "simt_row8":
         kernel = CPDeltaRuleFixupSimtSm90(needs_initial_state, 8)
-    else:
+    elif _kernel_kind == "hmma":
         kernel = CPDeltaRuleFixupHmmaSm90(needs_initial_state)
+    else:
+        raise ValueError(f"Unsupported fixup kernel kind: {_kernel_kind}")
     kernel_args = (
         from_dlpack(local_transfer_tma, assumed_align=128).mark_layout_dynamic(
             leading_dim=1

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -3855,6 +3855,9 @@ def cp_delta_rule_dsl_sm90(
             num_heads,
             num_sms,
             chunk_len_granularity=cp_chunk_len_granularity,
+            device_capability=torch.cuda.get_device_capability(q.device),
+            total_seqlen=total_seqlen,
+            device_name=torch.cuda.get_device_properties(q.device).name,
         )
     if q.ndim != 3:
         raise RuntimeError(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -2670,11 +2670,11 @@ def cp_delta_rule_fixup_dsl_sm90(
         else:
             _kernel_kind = "hmma"
     if _kernel_kind == "simt_row4":
-        kernel = CPDeltaRuleFixupSimtSm90(needs_initial_state, 4)
+        kernel = CPDeltaRuleFixupSimtSm90(needs_initial_state, 4)  # type: ignore
     elif _kernel_kind == "simt_row8":
-        kernel = CPDeltaRuleFixupSimtSm90(needs_initial_state, 8)
+        kernel = CPDeltaRuleFixupSimtSm90(needs_initial_state, 8)  # type: ignore
     elif _kernel_kind == "hmma":
-        kernel = CPDeltaRuleFixupHmmaSm90(needs_initial_state)
+        kernel = CPDeltaRuleFixupHmmaSm90(needs_initial_state)  # type: ignore
     else:
         raise ValueError(f"Unsupported fixup kernel kind: {_kernel_kind}")
     kernel_args = (

--- a/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/varlen_helper.py
@@ -1,13 +1,29 @@
+import math
+
 import torch
 import cutlass
 import cutlass.cute as cute
 
 
+BLK = 64
 CP_CHUNK_LEN_GRANULARITY = 512
+CP_DEFAULT_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_NUMERATOR = 1
+CP_DEFAULT_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_DENOMINATOR = 1
+CP_SM120_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_NUMERATOR = 1
+CP_SM120_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_DENOMINATOR = 2
+CP_SM120_SHORT_HEURISTIC_MAX_HEADS = 16
 CP_HBM_PARALLELISM_THRESHOLD_NUMERATOR = 1
 CP_HBM_PARALLELISM_THRESHOLD_DENOMINATOR = 2
 CP_GDDR_PARALLELISM_THRESHOLD_NUMERATOR = 1
 CP_GDDR_PARALLELISM_THRESHOLD_DENOMINATOR = 3
+
+
+def _ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def _round_up(a, b):
+    return _ceil_div(a, b) * b
 
 
 def chunk_bound_host(num_items: int, total: int, chunk_size: int) -> int:
@@ -53,6 +69,23 @@ def cp_parallelism_threshold_host(device_name: str) -> tuple[int, int]:
     )
 
 
+def cp_short_workload_ratio_host(
+    device_capability: tuple[int, int] | None = None,
+    num_heads: int | None = None,
+) -> tuple[int, int] | None:
+    if device_capability is not None and device_capability[0] == 12:
+        if num_heads is None or num_heads > CP_SM120_SHORT_HEURISTIC_MAX_HEADS:
+            return None
+        return (
+            CP_SM120_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_NUMERATOR,
+            CP_SM120_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_DENOMINATOR,
+        )
+    return (
+        CP_DEFAULT_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_NUMERATOR,
+        CP_DEFAULT_SHORT_FIXUP_TO_PREFILL_WORKLOAD_RATIO_DENOMINATOR,
+    )
+
+
 def should_use_cp_host(num_parallel_work: int, num_sms: int, device_name: str) -> bool:
     """Return whether a public wrapper should dispatch to the CP path.
 
@@ -69,6 +102,9 @@ def choose_cp_chunk_len_host(
     num_heads: int,
     num_sms: int,
     chunk_len_granularity: int = CP_CHUNK_LEN_GRANULARITY,
+    device_capability: tuple[int, int] | None = None,
+    total_seqlen: int | None = None,
+    device_name: str = "",
 ) -> int:
     """Choose a CP chunk length for the CP workspace kernels.
 
@@ -76,26 +112,35 @@ def choose_cp_chunk_len_host(
     launches `ceil_div(max_seqlen, chunk_len) * num_heads` CTAs. Pick the
     smallest granularity-aligned chunk length whose CTA count is at most one wave.
     """
-    if max_seqlen <= 0:
-        raise RuntimeError(f"max_seqlen must be positive, got {max_seqlen}")
-    if num_heads <= 0:
-        raise RuntimeError(f"num_heads must be positive, got {num_heads}")
-    if num_sms <= 0:
-        raise RuntimeError(f"num_sms must be positive, got {num_sms}")
-    if chunk_len_granularity <= 0:
-        raise RuntimeError(
-            f"chunk_len_granularity must be positive, got {chunk_len_granularity}"
-        )
-    if chunk_len_granularity % 64 != 0:
-        raise RuntimeError(
-            f"chunk_len_granularity must be a multiple of 64, got {chunk_len_granularity}"
-        )
+    assert chunk_len_granularity % 64 == 0
+    if total_seqlen is None:
+        total_seqlen = max_seqlen
 
+    # Short sequences are dominated by the fixup recurrence and
+    # prefill recurrence. Balance S / C * F against C / BLK * P, with tunable
+    # F/P measured from fixed-iteration profiles.
+    # S / C: Number of chunks per sequence
+    # C / BLK: Number of prefill iterations per chunk
+    # F: Fixup recurrence cost per iteration
+    # P: Prefill recurrence cost per iteration
+    # Then S / C * F = C / BLK * P => C = sqrt(S * BLK * F / P)
+    ratio = cp_short_workload_ratio_host(device_capability, num_heads)
+    if ratio is not None:
+        ratio_num, ratio_den = ratio
+        threshold_num, threshold_den = cp_parallelism_threshold_host(device_name)
+
+        approx_ctas = _ceil_div(total_seqlen, chunk_len_granularity) * num_heads
+        if approx_ctas * threshold_den < num_sms * threshold_num:
+            square = _ceil_div(max_seqlen * BLK * ratio_num, ratio_den)
+            balanced_chunk_len = math.isqrt(square)
+            if balanced_chunk_len * balanced_chunk_len < square:
+                balanced_chunk_len += 1
+            return max(BLK, _round_up(balanced_chunk_len, BLK))
+
+    # target for one wave of CTAs
     target_chunks = max(1, num_sms // num_heads)
-    min_chunk_len = (max_seqlen + target_chunks - 1) // target_chunks
-    return (
-        (min_chunk_len + chunk_len_granularity - 1) // chunk_len_granularity
-    ) * chunk_len_granularity
+    min_chunk_len = _ceil_div(max_seqlen, target_chunks)
+    return _round_up(min_chunk_len, chunk_len_granularity)
 
 
 @cute.jit

--- a/tests/gdn/test_prefill_cp_delta_rule.py
+++ b/tests/gdn/test_prefill_cp_delta_rule.py
@@ -59,6 +59,7 @@ from flashinfer.gdn_prefill import chunk_gated_delta_rule
 
 FIXUP_TF32_ATOL = 2e-3
 FIXUP_TF32_RTOL = 2e-3
+FIXUP_KERNEL_KINDS = ["simt_row4", "simt_row8", "hmma"]
 
 
 def _skip_if_cp_unsupported():
@@ -375,6 +376,7 @@ def test_cp_delta_rule_mn_precompute(
 
 
 @torch.inference_mode()
+@pytest.mark.parametrize("kernel_kind", FIXUP_KERNEL_KINDS)
 @pytest.mark.parametrize("use_initial_state", [False, True])
 @pytest.mark.parametrize("num_heads", [1, 3])
 @pytest.mark.parametrize(
@@ -385,6 +387,7 @@ def test_cp_delta_rule_fixup(
     cp_chunk_len,
     num_heads,
     use_initial_state,
+    kernel_kind,
     seed=int(os.environ.get("SEED", "0")),
 ):
     _skip_if_cp_unsupported()
@@ -442,6 +445,7 @@ def test_cp_delta_rule_fixup(
         total_seqlen,
         cp_chunk_len=cp_chunk_len,
         initial_state=initial_state,
+        _kernel_kind=kernel_kind,
     )
     torch.cuda.synchronize()
 


### PR DESCRIPTION
## 📌 Description

This PR updated CP chunking heuristics and implemented a SIMT kernel for CP Fixup, target for ultralow parallelism performance.

## 🔍 Related Issues

#3491 

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

```
GPU: NVIDIA H100 80GB HBM3 [Hopper (SM90)]
Models: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128

Heads            Seqlens           h_qk  h_v        FI Hopper (SM90)   TFLOPS  FLA/Triton   Speedup
---------------------------------------------------------------------------------------------------
397B/122B TP8    1x65536              2    8                  0.399ms    86.1      1.954ms     4.90x +
397B/122B TP8    1x32768              2    8                  0.239ms    72.0      0.997ms     4.18x +
397B/122B TP8    1x16384              2    8                  0.156ms    55.2      0.508ms     3.26x +
397B/122B TP8    1x8192               2    8                  0.114ms    37.6      0.259ms     2.27x +
397B/122B TP8    1x4096               2    8                  0.079ms    27.1      0.144ms     1.81x +
397B/122B TP8    1x2048               2    8                  0.061ms    17.5      0.086ms     1.40x +
397B/122B TP8    6144+2048            2    8                  0.114ms    37.6      0.221ms     1.94x +
397B/122B TP8    4096+4096            2    8                  0.115ms    37.2      0.184ms     1.59x +
397B/122B TP8    2048+6144            2    8                  0.116ms    37.0      0.222ms     1.91x +
397B/122B TP8    1024+7168            2    8                  0.117ms    36.7      0.241ms     2.06x +
397B/122B TP8    2048x4               2    8                  0.128ms    33.5      0.149ms     1.17x +
397B/122B TP8    1024x8               2    8                  0.155ms    27.7      0.155ms     1.00x +
397B/122B TP8    8192x8               2    8                  0.471ms    72.9      1.084ms     2.30x +
397B/122B TP8    8192x16              2    8                  0.365ms   188.5      2.145ms     5.88x +
397B/122B TP8    8192x32              2    8                  0.799ms   172.0      4.231ms     5.30x +

397B/122B TP4    1x65536              4   16                  0.732ms    93.9      2.742ms     3.75x +
397B/122B TP4    1x32768              4   16                  0.401ms    85.7      1.385ms     3.45x +
397B/122B TP4    1x16384              4   16                  0.234ms    73.5      0.703ms     3.01x +
397B/122B TP4    1x8192               4   16                  0.149ms    57.6      0.361ms     2.42x +
397B/122B TP4    1x4096               4   16                  0.106ms    40.4      0.187ms     1.76x +
397B/122B TP4    1x2048               4   16                  0.079ms    27.1      0.107ms     1.35x +
397B/122B TP4    6144+2048            4   16                  0.152ms    56.5      0.324ms     2.13x +
397B/122B TP4    4096+4096            4   16                  0.154ms    55.9      0.287ms     1.87x +
397B/122B TP4    2048+6144            4   16                  0.154ms    55.9      0.324ms     2.11x +
397B/122B TP4    1024+7168            4   16                  0.154ms    55.9      0.344ms     2.24x +
397B/122B TP4    2048x4               4   16                  0.165ms    52.2      0.294ms     1.78x +
397B/122B TP4    1024x8               4   16                  0.058ms   149.2      0.304ms     5.29x +
397B/122B TP4    8192x8               4   16                  0.366ms   187.7      2.188ms     5.98x +
397B/122B TP4    8192x16              4   16                  0.791ms   173.7      4.347ms     5.49x +
397B/122B TP4    8192x32              4   16                  1.559ms   176.3      8.694ms     5.58x +
```
------
NOTE:  this sm120 device is a **Server Edition**, previous PR is **Workstation Edition**
```
GPU: NVIDIA RTX PRO 6000 Blackwell Server Edition [SM120]
Models: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128

Heads            Seqlens           h_qk  h_v                FI SM120   TFLOPS  FLA/Triton   Speedup
---------------------------------------------------------------------------------------------------
397B/122B TP8    1x65536              2    8                  0.698ms    49.2      2.707ms     3.88x +
397B/122B TP8    1x32768              2    8                  0.398ms    43.1      1.341ms     3.37x +
397B/122B TP8    1x16384              2    8                  0.259ms    33.1      0.635ms     2.45x +
397B/122B TP8    1x8192               2    8                  0.161ms    26.6      0.267ms     1.65x +
397B/122B TP8    1x4096               2    8                  0.128ms    16.7      0.137ms     1.06x +
397B/122B TP8    1x2048               2    8                  0.086ms    12.5      0.080ms     0.93x -
397B/122B TP8    6144+2048            2    8                  0.163ms    26.3      0.228ms     1.40x +
397B/122B TP8    4096+4096            2    8                  0.168ms    25.6      0.188ms     1.12x +
397B/122B TP8    2048+6144            2    8                  0.166ms    25.8      0.227ms     1.36x +
397B/122B TP8    1024+7168            2    8                  0.170ms    25.3      0.248ms     1.46x +
397B/122B TP8    2048x4               2    8                  0.162ms    26.4      0.155ms     0.95x -
397B/122B TP8    1024x8               2    8                  0.098ms    43.8      0.150ms     1.53x +
397B/122B TP8    8192x8               2    8                  0.716ms    48.0      1.736ms     2.42x +
397B/122B TP8    8192x16              2    8                  0.684ms   100.5      3.519ms     5.15x +
397B/122B TP8    8192x32              2    8                  1.405ms    97.8      7.127ms     5.07x +

397B/122B TP4    1x65536              4   16                  1.221ms    56.3      4.141ms     3.39x +
397B/122B TP4    1x32768              4   16                  0.641ms    53.6      2.053ms     3.20x +
397B/122B TP4    1x16384              4   16                  0.374ms    45.9      1.025ms     2.74x +
397B/122B TP4    1x8192               4   16                  0.244ms    35.2      0.470ms     1.92x +
397B/122B TP4    1x4096               4   16                  0.143ms    30.0      0.199ms     1.39x +
397B/122B TP4    1x2048               4   16                  0.120ms    18.0      0.094ms     0.79x -
397B/122B TP4    6144+2048            4   16                  0.244ms    35.2      0.439ms     1.80x +
397B/122B TP4    4096+4096            4   16                  0.250ms    34.4      0.398ms     1.60x +
397B/122B TP4    2048+6144            4   16                  0.249ms    34.4      0.436ms     1.75x +
397B/122B TP4    1024+7168            4   16                  0.247ms    34.8      0.454ms     1.84x +
397B/122B TP4    2048x4               4   16                  0.186ms    46.1      0.382ms     2.05x +
397B/122B TP4    1024x8               4   16                  0.101ms    85.3      0.401ms     3.98x +
397B/122B TP4    8192x8               4   16                  0.679ms   101.2      3.619ms     5.33x +
397B/122B TP4    8192x16              4   16                  1.394ms    98.6      7.379ms     5.29x +
397B/122B TP4    8192x32              4   16                  2.182ms   126.0     14.616ms     6.70x +
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device- and workload-aware runtime selection for CP delta-rule fixup kernels, including new SIMT and HMMA variants.
  * Enhanced chunk-length selection using device capability and sequence length for more balanced performance.

* **Bug Fixes**
  * Improved fixup correctness by ensuring unused output slots are cleared beyond the last valid chunk.

* **Tests**
  * Expanded CP delta-rule fixup tests to run across multiple kernel kinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->