### PR TITLE
perf: cut per-call host overhead on the autotuned GEMM dispatch path

### DIFF
--- a/flashinfer/autotuner.py
+++ b/flashinfer/autotuner.py
@@ -796,6 +796,12 @@ def load_from_file(key):
     return False, 0, -1, None
 
 
+# Inference-mode replay table: (custom_op, profile_sig) -> (runner, tactic).
+# choose_one()'s slow path builds per-runner cache keys under a lock even on
+# a hit; repeat lookups go through this flat dict instead.
+_REPLAY_CACHE: dict = {}
+
+
 class AutoTuner:
     """AutoTuner for optimizing TensorRT-LLM operations.
 
@@ -1141,6 +1147,24 @@ class AutoTuner:
                 raise ValueError(f"No runners provided for op '{custom_op}'")
             return runners[0], -1
 
+        # Replay fast path: one signature computation, no lock, no per-runner
+        # key construction on repeat inference lookups.
+        _sig = None
+        if (
+            not self.is_tuning_mode
+            and self._override_tuning_buckets is None
+            and not self._override_round_up
+        ):
+            _sig = (
+                custom_op,
+                AutoTuner._find_nearest_profile(
+                    tuple(self._get_input_sizes(inputs)), tuning_config
+                ),
+            )
+            _hit = _REPLAY_CACHE.get(_sig)
+            if _hit is not None:
+                return _hit
+
         with self._lock:
             # Apply tuning bucket / rounding overrides from autotune() context.
             if self._override_tuning_buckets is not None or self._override_round_up:
@@ -1217,6 +1241,8 @@ class AutoTuner:
                                 f"max_num_tokens during the next tuning "
                                 f"pass to avoid this perf cliff."
                             )
+                if is_cache_hit and _sig is not None:
+                    _REPLAY_CACHE[_sig] = (runner, tactic)
                 return runner, tactic
 
             assert len(runners) > 0, "At least one runner is required"
@@ -1936,6 +1962,7 @@ class AutoTuner:
 
     def clear_cache(self) -> None:
         """Clear the profiling cache and user-loaded file configs."""
+        _REPLAY_CACHE.clear()
         with self._lock:
             self.profiling_cache.clear()
             self._file_configs.clear()

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -269,7 +269,7 @@ def get_gemm_module():
 
     # Register the module
     _gemm_module = SimpleNamespace(
-        cublas_fp8_gemm_runner=cublas_fp8_gemm_runner,
+        cublas_fp8_gemm_runner=functools.cache(cublas_fp8_gemm_runner),
         cutlass_segment_gemm=cutlass_segment_gemm,
     )
 
@@ -1158,7 +1158,7 @@ def get_gemm_sm100_module_cutlass_bf16():
         return CutlassBf16GemmRunner()
 
     return SimpleNamespace(
-        cutlass_bf16_gemm_runner=cutlass_bf16_gemm_runner,
+        cutlass_bf16_gemm_runner=functools.cache(cutlass_bf16_gemm_runner),
     )
 
 
@@ -1279,7 +1279,7 @@ def get_mm_bf16_cublaslt_module():
         return CublasltBf16GemmRunner()
 
     return SimpleNamespace(
-        cublaslt_bf16_gemm_runner=cublaslt_bf16_gemm_runner,
+        cublaslt_bf16_gemm_runner=functools.cache(cublaslt_bf16_gemm_runner),
     )
 
 
@@ -3428,6 +3428,7 @@ def _cudnn_gemm_fp8(
     return out
 
 
+@functools.cache
 def _cudnn_gemm_fp8_runner():
     m_bucket_mapper = AutoTuner.get().get_effective_map_to_tuning_buckets(
         _FP8_GEMM_SM100_TUNING_CONFIG, spec_idx=0
@@ -3867,6 +3868,7 @@ def _cudnn_gemm_bf16(
     return out
 
 
+@functools.cache
 def _cudnn_gemm_bf16_runner(
     is_a_k_major: Optional[bool] = None,
     is_b_k_major: Optional[bool] = None,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -1227,11 +1227,38 @@ def backend_requirement(
 
         # @brief: Wrapper function that calls the orignal, decorated function, after applying a number of checks.
         # @note that here we manually apply defaults to the arguments in the wrapper function when doing validation.
+        _auto_memo: dict = {}
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             # skip_check is an optional argument that the decorator adds to any API function.
             # It prevents the performance overhead of checking.
             skip_check = kwargs.pop("skip_check", False)
+
+            # Memoize backend="auto" resolution per call signature
+            # (shapes/dtypes/scalars): validation + heuristic run once per
+            # distinct signature instead of on every call.
+            _mkey = None
+            if kwargs.get("backend") == "auto" and heuristic_func is not None:
+                _parts = []
+                _hashable = True
+                for _v in args + tuple(kwargs.values()):
+                    if isinstance(_v, torch.Tensor):
+                        _parts.append((tuple(_v.shape), _v.dtype, _v.device.index))
+                    elif (
+                        isinstance(_v, (str, bool, int, float, torch.dtype))
+                        or _v is None
+                    ):
+                        _parts.append(_v)
+                    else:
+                        _hashable = False
+                        break
+                if _hashable:
+                    _mkey = tuple(_parts)
+                    _hit = _auto_memo.get(_mkey)
+                    if _hit is not None:
+                        wrapper.suitable_auto_backends = _hit
+                        return func(*args, **kwargs)
 
             if not skip_check:
                 # Apply defaults from the function signature for validation
@@ -1284,6 +1311,10 @@ def backend_requirement(
                     capability = _get_capability(*args, **kwargs)
                     suitable_auto_backends(capability, *args, **kwargs)
 
+            if _mkey is not None:
+                _resolved = getattr(wrapper, "suitable_auto_backends", None)
+                if _resolved:
+                    _auto_memo[_mkey] = _resolved
             return func(*args, **kwargs)
 
         wrapper.is_backend_supported = is_backend_supported


### PR DESCRIPTION
## 📌 Description

Follow-up to #3868. With the cache keys fixed, `bf16_gemm` lookups *hit* — but each eager call still paid ~250 µs of Python dispatch, which made vLLM BF16 prefill host-bound (GPU busy identical to the torch backend, wall time 1.5–2.4×). Three independent reductions:

1. **Cache the runner factories** (`gemm_base.py`). `_cudnn_gemm_bf16_runner` / `_cudnn_gemm_fp8_runner` re-created the runner *class* on every call, and the cuBLASLt/CUTLASS/cuBLAS-FP8 factories returned a fresh instance per call — which also reset `CublasltBf16GemmRunner._algo_cache`, re-running `cublasLtMatmulAlgoGetHeuristic` on every GEMM. Runner identity is already assumed stable by the autotuner cache keys.
2. **Inference-mode replay table in `AutoTuner.choose_one`** (`autotuner.py`). Even on a hit, the slow path builds per-runner cache keys under a lock; repeat lookups now resolve through a flat `(custom_op, profile_sig)` dict (~2.5 µs/call). Populated on cache hits only; cleared by `clear_cache()`; bypassed while tuning or when bucket/rounding overrides are active.
3. **Memoize `backend="auto"` resolution in `backend_requirement`** (`utils.py`). The wrapper re-ran `sig.bind` + all backend requirement checks + the heuristic on every call; now resolved once per distinct shapes/dtypes/scalars signature.

Measured on B300 via vLLM BF16 serving (qwen3.5-9B, prefill-dominated microbench, ms/iter; torch backend reference 29.0):

| baseline | +1 | +1,2 | +1,2,3 |
|---|---|---|---|
| 75.0 | 53.7 | 51.3 | 48.4 |

E2E (`vllm bench serve`, concurrency 4): TTFT regression vs torch backend −93% → −45%; output throughput −9% → −2%.

## 🔍 Related Issues

Builds on the cache-key fixes in #3868 (without them, lookups miss and this path falls back untuned). The residual gap vs the torch backend is structural (per-call wrapper/glue layering) — a plan/run-style API proposal with measurements will follow separately.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed — behavior is unchanged by design; existing autotuner tests (including `test_autotuner_gemm_cross_bucket_m` from #3868) cover the replay path since every repeat lookup now goes through it.
- [ ] All tests are passing (`unittest`, etc.) — validated on B300 via serving E2E + microbench; CI run pending.

## Reviewer Notes

The three changes are independent; happy to split if preferred. The replay table intentionally does not cache fallback (miss) results, so late tuning still upgrades those shapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced repeated setup work during inference and backend selection, improving responsiveness for repeated calls.
  * Added additional caching for common matrix operation runners to speed up reuse and lower overhead.
  * Optimized automatic backend selection so repeated inputs can reuse prior suitability results more efficiently.
* **Bug Fixes**
  * Cache resets now clear all related stored results to keep behavior consistent after clearing caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->