### PR TITLE
fix: preserve DeepSeek no-group sigmoid routing weights

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom.cu
@@ -1479,6 +1479,9 @@ void run(Data const& data, void* stream) {
   TVM_FFI_ICHECK(data.mPtrTopKPacked != nullptr || data.mPtrScores != nullptr ||
                  data.mPtrTopKIds != nullptr)
       << "Routing kernel requires at least one input parameter";
+  TVM_FFI_ICHECK_LE(data.mTopK, data.mNumExperts)
+      << "Routing kernel expects topK (" << data.mTopK << ") to be <= numExperts ("
+      << data.mNumExperts << ").";
 
   // When topK is already computed (mPtrTopKIds or mPtrTopKPacked without scores),
   // delegate to the shared post-topK pipeline which handles all path selection

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -78,11 +78,10 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mDtypeBias = dtypeBias;
     routingData.mRouteScale = routedScalingFactor;
     // Floor the renorm denominator. ScaledSumNormalizePostprocess computes
-    // sigmoid * routeScale / (sum + mSumEpsilon). If a token's top-K selected experts all have
-    // strongly negative pre-bias logits, their sigmoids underflow to exactly 0.0 (bf16) so sum ==
-    // 0, and mSumEpsilon's 0.0f default makes this 0/0 = NaN across the token's whole output row.
-    // 1e-20f matches DeepSeek-V3's reference gate (modeling_deepseek.py: sum + 1e-20) and the
-    // MiniMax2 branch.
+    // sigmoid(raw) * routeScale / (sum + mSumEpsilon). If every selected
+    // expert contributes a zero sigmoid after underflow, the 0.0f default
+    // makes this 0/0 = NaN across the token's output row. 1e-20f matches the
+    // adjacent MiniMax2 path and prevents that zero-denominator case.
     routingData.mSumEpsilon = 1e-20f;
 
     routingData.mPtrScores = expertIds == nullptr ? routingLogits : nullptr;

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -3306,8 +3306,8 @@ def trtllm_bf16_moe(
         ``[seq_len, num_experts]`` tensor of routing logits.  ``float32`` or
         ``bfloat16``.
     routing_bias : Optional[torch.Tensor]
-        Optional ``[num_experts]`` tensor of routing bias.  Must be
-        ``bfloat16`` if provided.
+        Optional ``[num_experts]`` tensor of routing bias.  ``float32`` or
+        ``bfloat16``.
     hidden_states : torch.Tensor
         ``[seq_len, hidden_size]`` tensor of input hidden states.  Must be
         ``bfloat16``.

--- a/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
+++ b/include/flashinfer/trtllm/fused_moe/RoutingCustomPolicy.cuh
@@ -386,14 +386,19 @@ struct SumNormalizePostprocess {
   }
 };
 
-/// ScaledSumNormalize: recovers un-biased sigmoid scores by subtracting per-expert bias from the
-/// selection scores (sigmoid + bias), then normalizes by sum and applies routeScale.
+/// ScaledSumNormalize: normalizes un-biased sigmoid scores by sum and applies
+/// routeScale. SigmoidBias selection uses sigmoid(raw) + bias as the top-K key,
+/// but final weights must use sigmoid(raw). Warp-per-token routing recomputes
+/// selected sigmoid(raw) from raw logits to avoid cancellation when a tiny
+/// sigmoid is rounded away by a large bias; block-per-token routing reads the
+/// same un-biased sigmoid from smemAux.
 /// Used by DeepSeek-style routing: final_weight = sigmoid(raw) * routeScale / (sum + epsilon).
-/// DeepSeek uses epsilon=0 (no guard); MiniMax2 uses epsilon=1e-20 to prevent division by zero.
+/// The DeepSeek and MiniMax2 runners use epsilon=1e-20 to prevent division by zero.
 struct ScaledSumNormalizePostprocess {
   /// Opts into the block-per-token kernel (provides applyWithAux below).
   static constexpr bool kSupportsBlockPerToken = true;
   static constexpr bool kSupportsLaneOwnedTopK = true;
+  static constexpr bool kNeedsRawScores = true;
 
   /// Needs per-expert aux data (un-biased sigmoid) in the block-per-token
   /// kernel — paired with SigmoidBiasPreprocess, which writes the un-biased
@@ -403,32 +408,30 @@ struct ScaledSumNormalizePostprocess {
 
   template <typename OutputT>
   struct Params {
-    // Store as void const* to support any bias dtype (float, bfloat16, etc.) without conversion.
-    void const* ptrRoutingBias = nullptr;
-    batchedGemm::trtllm::gen::Dtype dtypeBias = batchedGemm::trtllm::gen::Dtype::Bfloat16;
     float routeScale = 1.0f;
     float sumEpsilon = 0.0f;
 
     void set(routingCustom::Data const& data) {
-      ptrRoutingBias = data.mPtrRoutingBias;
-      dtypeBias = data.mDtypeBias;
       routeScale = data.mRouteScale;
       sumEpsilon = data.mSumEpsilon;
     }
   };
 
-  template <typename DataType, int K, typename ParamsT>
-  __forceinline__ __device__ static void apply(cg::thread_block_tile<WarpSize> const& warp,
-                                               DataType (&warpTopKScore)[K],
-                                               int32_t const (&warpTopKExpertIdx)[K],
-                                               int32_t laneIdx, int32_t topK,
-                                               ParamsT const& params) {
-    // Recover sigmoid score: selection_score = sigmoid(raw) + bias, so sigmoid = score - bias
-    float biasVal = laneIdx < topK ? loadScalar(params.ptrRoutingBias, warpTopKExpertIdx[laneIdx],
-                                                params.dtypeBias)
-                                   : 0.f;
-    float sigmoidScore =
-        laneIdx < topK ? (static_cast<float>(warpTopKScore[laneIdx]) - biasVal) : 0.f;
+  /// Warp-per-token variant with access to the original raw scores. SigmoidBias
+  /// selection uses sigmoid(raw) + bias as the topK key, but final weights must
+  /// be normalized from the un-biased sigmoid(raw). Recomputing sigmoid(raw)
+  /// avoids lossy recovery when a tiny sigmoid is rounded away by a large bias.
+  template <typename DataType, typename InputType, int K, typename ParamsT>
+  __forceinline__ __device__ static void applyWithScores(
+      cg::thread_block_tile<WarpSize> const& warp, DataType (&warpTopKScore)[K],
+      int32_t const (&warpTopKExpertIdx)[K], int32_t laneIdx, int32_t topK,
+      InputType const* ptrScores, ParamsT const& params) {
+    float sigmoidScore = 0.f;
+    if (laneIdx < topK) {
+      int32_t const expertIdx = warpTopKExpertIdx[laneIdx];
+      sigmoidScore = sigmoid_accurate(static_cast<float>(ptrScores[expertIdx]));
+    }
+
     float sum = cg::reduce(warp, sigmoidScore, cg::plus<float>());
     if (laneIdx < topK) {
       warpTopKScore[laneIdx] =
@@ -436,18 +439,15 @@ struct ScaledSumNormalizePostprocess {
     }
   }
 
-  /// Lane-owned TopK postprocess for warp-per-token kernels. The selected
-  /// score/expert are scalar values owned by laneIdx, so no K-element output
-  /// arrays need to be materialized in local memory.
-  template <typename DataType, typename ParamsT>
-  __forceinline__ __device__ static void applyForLane(cg::thread_block_tile<WarpSize> const& warp,
-                                                      DataType& laneTopKScore,
-                                                      int32_t laneTopKExpertIdx, int32_t laneIdx,
-                                                      int32_t topK, ParamsT const& params) {
-    float const biasVal =
-        laneIdx < topK ? loadScalar(params.ptrRoutingBias, laneTopKExpertIdx, params.dtypeBias)
-                       : 0.f;
-    float const sigmoidScore = laneIdx < topK ? static_cast<float>(laneTopKScore) - biasVal : 0.f;
+  /// Lane-owned warp-per-token variant with access to the original raw scores.
+  /// This is the scalar counterpart to applyWithScores.
+  template <typename DataType, typename InputType, typename ParamsT>
+  __forceinline__ __device__ static void applyForLaneWithScores(
+      cg::thread_block_tile<WarpSize> const& warp, DataType& laneTopKScore,
+      int32_t laneTopKExpertIdx, int32_t laneIdx, int32_t topK, InputType const* ptrScores,
+      ParamsT const& params) {
+    float const sigmoidScore =
+        laneIdx < topK ? sigmoid_accurate(static_cast<float>(ptrScores[laneTopKExpertIdx])) : 0.f;
     float const sum = cg::reduce(warp, sigmoidScore, cg::plus<float>());
     if (laneIdx < topK) {
       laneTopKScore =
@@ -515,8 +515,8 @@ struct ScaledSumNormalizePostprocess {
 /// differs from the topK selection key (via its `kNeedsAux` member).  Today
 /// only `ScaledSumNormalize` sets `kNeedsAux = true`.  For every other
 /// postprocess, `smemAux` aliases `smemBiased` and no extra smem is
-/// allocated.  Postprocess policies that don't declare `kNeedsAux` are
-/// treated as not needing it (safe default).
+/// allocated. Postprocess policies that don't declare `kNeedsAux` are treated
+/// as not needing it (safe default).
 template <typename PostprocessPolicy_, typename = void>
 struct PostprocessNeedsAux : std::false_type {};
 
@@ -526,6 +526,17 @@ struct PostprocessNeedsAux<PostprocessPolicy_, std::void_t<decltype(PostprocessP
 
 template <typename PreprocessPolicy_, typename PostprocessPolicy_>
 struct PolicyPairNeedsAux : PostprocessNeedsAux<PostprocessPolicy_> {};
+
+/// Does a postprocess policy need the original raw scores after TopK?
+/// This is intentionally opt-in so generic routing policies do not acquire a
+/// raw-score dependency unless they implement the corresponding overloads.
+template <typename PostprocessPolicy_, typename = void>
+struct PostprocessNeedsRawScores : std::false_type {};
+
+template <typename PostprocessPolicy_>
+struct PostprocessNeedsRawScores<PostprocessPolicy_,
+                                 std::void_t<decltype(PostprocessPolicy_::kNeedsRawScores)>>
+    : std::bool_constant<PostprocessPolicy_::kNeedsRawScores> {};
 
 /// Does a postprocess policy implement the scalar lane-owned TopK interface?
 /// This is intentionally opt-in: adding a new policy cannot silently select a
@@ -613,8 +624,14 @@ struct TopKExpertSelect {
     topk::reduceTopK(warp, warpTopKScore, warpTopKExpertIdx, score, idx, minScore, topK);
 
     // Apply postprocess (e.g. renormalize, softmax over top-K, scaled renormalize, ...)
-    PostprocessPolicy_::apply(warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK,
-                              params.mExpertSelectParams.mPostprocessParams);
+    if constexpr (PostprocessNeedsRawScores<PostprocessPolicy_>::value) {
+      PostprocessPolicy_::template applyWithScores<DataType, InputType, K>(
+          warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK, ptrScores,
+          params.mExpertSelectParams.mPostprocessParams);
+    } else {
+      PostprocessPolicy_::apply(warp, warpTopKScore, warpTopKExpertIdx, laneIdx, topK,
+                                params.mExpertSelectParams.mPostprocessParams);
+    }
   }
 
   /// Lane-owned TopK variant. It shares the generic preprocess and exact
@@ -642,8 +659,14 @@ struct TopKExpertSelect {
                              params.mExpertSelectParams.mPreprocessParams);
     topk::reduceTopKForLane<K>(warp, laneTopKScore, laneTopKExpertIdx, score, idx, minScore,
                                laneIdx);
-    PostprocessPolicy_::applyForLane(warp, laneTopKScore, laneTopKExpertIdx, laneIdx, topK,
-                                     params.mExpertSelectParams.mPostprocessParams);
+    if constexpr (PostprocessNeedsRawScores<PostprocessPolicy_>::value) {
+      PostprocessPolicy_::template applyForLaneWithScores<DataType, InputType>(
+          warp, laneTopKScore, laneTopKExpertIdx, laneIdx, topK, ptrScores,
+          params.mExpertSelectParams.mPostprocessParams);
+    } else {
+      PostprocessPolicy_::applyForLane(warp, laneTopKScore, laneTopKExpertIdx, laneIdx, topK,
+                                       params.mExpertSelectParams.mPostprocessParams);
+    }
   }
 };
 

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -344,7 +344,7 @@ struct Data : public DataBase {
   // Optional: scaling factor applied to final scores (used by ScaledSumNormalize postprocess).
   float mRouteScale{1.0f};
   // Optional: epsilon added to the sum before division to prevent division by zero.
-  // MiniMax2 uses 1e-20f; DeepSeek uses 0.0f (no epsilon).
+  // DeepSeek and MiniMax2 runners use 1e-20f.
   float mSumEpsilon{0.0f};
 };
 

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -17,7 +17,7 @@ limitations under the License.
 import pytest
 import torch
 
-from flashinfer.utils import get_compute_capability
+from flashinfer.utils import get_compute_capability, is_sm100a_supported
 
 from flashinfer.fused_moe import fill_w_ptr
 from tests.moe.trtllm_gen_fused_moe_utils import (
@@ -1304,6 +1304,149 @@ def test_deepseek_ngroup1_block_per_token_routing(
         weight_processing,
         activation_type,
         cache_permute_indices=cache_permute_indices,
+    )
+
+
+@pytest.mark.parametrize("enable_pdl", [False, True])
+@pytest.mark.parametrize(
+    "num_tokens, num_experts, top_k, hidden_size, intermediate_size",
+    [
+        pytest.param(8, 384, 6, 512, 512, id="array-topk"),
+        pytest.param(1025, 896, 16, 128, 128, id="lane-owned-topk"),
+    ],
+)
+def test_deepseek_ngroup1_sigmoid_bias_output_uses_unbiased_sigmoid(
+    num_tokens,
+    num_experts,
+    top_k,
+    hidden_size,
+    intermediate_size,
+    enable_pdl,
+    cache_permute_indices,
+):
+    """DeepSeek no-group warp routes use sigmoid(raw), not biased top-k keys."""
+    if not torch.cuda.is_available():
+        pytest.skip("TRT-LLM Gen BF16 MoE test requires CUDA.")
+
+    device = torch.device("cuda:0")
+    if not is_sm100a_supported(device):
+        pytest.skip("TRT-LLM Gen BF16 MoE requires SM100a and CUDA 12.8+.")
+
+    # The two shapes cover the array TopK route and the high-expert lane-owned
+    # HistogramScores route. Block-per-token paths already carry sigmoid(raw).
+    padding = 8
+    routed_scaling = 2.5
+    activation_type = ActivationType.Relu2
+    weight_processing = {
+        "use_shuffled_weight": True,
+        "layout": WeightLayout.BlockMajorK,
+    }
+
+    # This is below fp32 ULP at bias=12, so sigmoid(raw)+bias rounds back to
+    # the bias. A key-minus-bias recovery path therefore loses the nonzero
+    # selected weights, while recomputing sigmoid(raw) remains stable.
+    tiny_sigmoid = torch.tensor(2e-7, device=device, dtype=torch.float32)
+    routing_logits = (
+        torch.logit(tiny_sigmoid).expand(num_tokens, num_experts).contiguous()
+    )
+    routing_bias = torch.full((num_experts,), 12.0, device=device, dtype=torch.float32)
+    hidden_states = torch.zeros(
+        (num_tokens, hidden_size), device=device, dtype=torch.bfloat16
+    )
+    hidden_states[:, 0] = 1
+    gemm1_weights = torch.zeros(
+        (num_experts, intermediate_size, hidden_size),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    gemm2_weights = torch.zeros(
+        (num_experts, hidden_size, intermediate_size),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    gemm1_weights[:, 0, 0] = 1
+    gemm2_weights[:, 0, 0] = 1
+
+    moe_impl = BF16Moe()
+    moe_impl._cache_permute_indices = cache_permute_indices
+    weights_data = moe_impl.quantize_weights(
+        gemm1_weights, gemm2_weights, hidden_states
+    )
+    inputs_data = moe_impl.quantize_inputs(
+        hidden_states, weights_data["hidden_states_scale_global"]
+    )
+    quant_data = {**weights_data, **inputs_data}
+    args = moe_args(
+        num_tokens,
+        num_experts,
+        hidden_size,
+        intermediate_size,
+        top_k,
+        padding,
+        quant_data["hidden_states"],
+        quant_data["hidden_states_scale"],
+        quant_data["hidden_states_scale_global"],
+        routing_logits,
+        quant_data["gemm1_weights"],
+        quant_data["gemm1_scales"],
+        quant_data["gemm1_scales_global"],
+        quant_data["gemm2_weights"],
+        quant_data["gemm2_scales"],
+        quant_data["gemm2_scales_global"],
+        {},
+        False,
+        activation_type,
+    )
+    static_data = moe_impl.prepare_static_weights_for_kernel(
+        None,
+        args,
+        gemm1_weights,
+        gemm2_weights,
+        hidden_size,
+        intermediate_size,
+        num_experts,
+        weight_processing,
+    )
+
+    routing_replay_out = torch.full(
+        (num_tokens, top_k), -1, device=device, dtype=torch.int16
+    )
+    output = trtllm_bf16_moe(
+        routing_logits=routing_logits,
+        routing_bias=routing_bias,
+        hidden_states=quant_data["hidden_states"],
+        gemm1_weights=static_data["gemm1_weights"],
+        gemm2_weights=static_data["gemm2_weights"],
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=1,
+        topk_group=1,
+        intermediate_size=intermediate_size,
+        local_expert_offset=0,
+        local_num_experts=num_experts,
+        routed_scaling_factor=routed_scaling,
+        routing_method_type=RoutingMethodType.DeepSeekV3.value,
+        use_shuffled_weight=static_data["use_shuffled_weight"],
+        weight_layout=static_data["weight_layout"],
+        do_finalize=True,
+        enable_pdl=enable_pdl,
+        activation_type=activation_type.value,
+        norm_topk_prob=True,
+        routing_replay_out=routing_replay_out,
+    )
+
+    assert torch.all((routing_replay_out >= 0) & (routing_replay_out < num_experts))
+    assert torch.isfinite(output).all()
+
+    expected = torch.full((num_tokens,), routed_scaling, device=device)
+    # The finalized output is BF16. The topK=6 case cannot represent each
+    # normalized route weight exactly, so allow one BF16-scale rounding step.
+    torch.testing.assert_close(
+        output[:, 0].to(torch.float32), expected, rtol=1e-2, atol=1e-2
+    )
+    torch.testing.assert_close(
+        output[:, 1:].to(torch.float32),
+        torch.zeros_like(output[:, 1:].to(torch.float32)),
     )
 
 


### PR DESCRIPTION
## Summary

DeepSeek no-group routing selects experts with `sigmoid(logit) + bias`, but its
final `ScaledSumNormalize` weights must be normalized from the unbiased
`sigmoid(logit)`.

The warp-per-token TopK paths previously recovered that value as
`selected_score - bias`. For GLM-5.2, selected sigmoid values can be around
`1e-8` to `1e-7` while routing biases are around `12`. In FP32, adding the tiny
sigmoid to the bias can round back to the bias, so subtracting the bias yields
zero for every selected expert.

This PR:

- recomputes `sigmoid(raw)` from the selected experts' original logits in both
  the array and lane-owned warp-per-token paths;
- declares that raw-score dependency through a postprocess capability trait;
- keeps the block-per-token path unchanged, where the unbiased sigmoid is
  already retained in `smemAux`;
- enforces `topK <= numExperts` before both raw and precomputed routing branches;
- adds SM100 regression coverage for the array TopK and high-expert lane-owned
  HistogramScores paths, with PDL disabled and enabled; and
- corrects the adjacent epsilon and routing-bias dtype documentation.

## Relationship to #3803 and #3946

#3803 and #3946 add a `1e-20` denominator guard to the no-group and grouped
DeepSeek paths. Those changes prevent division by zero, but they cannot recover
nonzero numerator values already lost through `(sigmoid + bias) - bias`
cancellation.

This PR restores the unbiased-score dataflow used by the legacy DeepSeek kernel
and the current block-per-token path. The existing denominator guard complements
this fix.

## Validation

- Repository pre-commit hooks pass for all modified files.
- Python byte-compilation passes for the modified Python files.
- The original array-path B200 regression passed with the fix and failed on the
  baseline because `output[:, 0]` was `0` instead of `routeScale=2.5`.
- The rebased regression now also includes an `E=896`, `K=16` lane-owned
  HistogramScores case.
- e2e validated with glm5.2 on gb200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter runtime validation for fused MoE routing to reject invalid expert configurations when `top_k` exceeds `num_experts`, preventing unstable or erroneous results.
  * Improved DeepSeekV3-style fused MoE normalization for the `n_group=1` case by using an unbiased sigmoid computation for more numerically correct BF16 routing outputs.
* **Documentation**
  * Updated `routing_bias` parameter docs to allow `float32` or `bfloat16`.
  * Clarified the epsilon behavior used during routing normalization.
* **Tests**
  * Added a CUDA-only regression test (SM100a-gated) covering the DeepSeekV3 `n_group=1` sigmoid-bias scenario with expected output shape and finiteness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->