### PR TITLE
perf(norm): vectorize fp32 gamma/beta + cap threads_per_row in CuTe LayerNorm (~2.4x)

### DIFF
--- a/flashinfer/norm/kernels/layernorm.py
+++ b/flashinfer/norm/kernels/layernorm.py
@@ -229,16 +229,34 @@ class LayerNormKernel:
         beta_reg = cute.make_rmem_tensor(x.shape, Float32)
         gamma_reg.store(cute.zeros_like(gamma_reg, dtype=Float32))
         beta_reg.store(cute.zeros_like(beta_reg, dtype=Float32))
-
-        col_offset = tidx * vec_size
-        for v in cutlass.range_constexpr(num_vec_blocks):
-            for e in cutlass.range_constexpr(vec_size):
-                idx = col_offset + v * threads_per_row * vec_size + e
-                reg_idx = v * vec_size + e
-                if idx < H:
-                    gamma_reg[reg_idx] = mGamma[idx]
-                    beta_reg[reg_idx] = mBeta[idx]
-
+        num_elems = vec_size * num_vec_blocks
+        # Vectorized fp32 gamma/beta: recast [H] fp32 -> [H//4] Int128 (128b). Each group of 4
+        # consecutive columns = one LDG.E.128. Uses the verified col formula (input block stride),
+        # so the loaded values land in the correct x-aligned register slots. Guarded to
+        # vec_size % 4 == 0 (col base 4-aligned); scalar fallback for odd/small H.
+        if cutlass.const_expr(vec_size % 4 == 0):
+            # recast the fp32 gamma [H] and the fp32 register fragment BOTH to Int128, so a single
+            # 128-bit assignment moves 4 fp32 at once (LDG.E.128). Column via verified formula.
+            gI = cute.recast_tensor(mGamma, cutlass.Int128)
+            bI = cute.recast_tensor(mBeta, cutlass.Int128)
+            gR = cute.recast_tensor(gamma_reg, cutlass.Int128)
+            bR = cute.recast_tensor(beta_reg, cutlass.Int128)
+            for g in cutlass.range_constexpr(num_elems // 4):
+                i0 = g * 4
+                vec_idx = i0 % vec_size
+                block_idx = i0 // vec_size
+                col = tidx * vec_size + vec_idx + block_idx * vec_size * threads_per_row
+                if col < H:
+                    gR[g] = gI[col // 4]  # 128-bit reg <- 128-bit gmem (4 fp32)
+                    bR[g] = bI[col // 4]
+        else:
+            for i in cutlass.range_constexpr(num_elems):
+                vec_idx = i % vec_size
+                block_idx = i // vec_size
+                col = tidx * vec_size + vec_idx + block_idx * vec_size * threads_per_row
+                if col < H:
+                    gamma_reg[i] = mGamma[col]
+                    beta_reg[i] = mBeta[col]
         gamma = gamma_reg.load()
         beta = beta_reg.load()
 

--- a/flashinfer/norm/utils.py
+++ b/flashinfer/norm/utils.py
@@ -672,9 +672,11 @@ def compute_threads_per_row(H: int, vec_size: int) -> int:
     threads_needed = (H + vec_size - 1) // vec_size
     # Round up to power of 2, capped at 1024
     threads = 32
-    while threads < threads_needed and threads < 1024:
+    while (
+        threads < threads_needed and threads < 128
+    ):  # PORT: cap 1024->128 (regblock register-blocking)
         threads *= 2
-    return min(threads, 1024)
+    return min(threads, 128)
 
 
 def make_tv_layout(threads_per_row: int, vec_size: int, num_vec_blocks: int) -> tuple:


### PR DESCRIPTION
## 📌 Description

Default CuTe-DSL `layernorm_cute` is up to 2.7x slower than necessary at large hidden sizes.
Two changes bring it to parity with a register-blocked kernel, on the default dispatch path
(no env flag, torch.compile / CUDA-graph capturable). Each is backed by before/after SASS
at hidden=8192 (one row per block).

> The core optimization techniques in this kernel (128-bit vectorized gamma/beta loads,
> register blocking via reduced threads-per-row) were discovered by IFCO, an autonomous CUDA
> optimization agent built by AWS, then ported to the production CuTe-DSL `layernorm_cute` path

### SASS: before vs after, hidden=8192
| instruction        | before | after | meaning                          |
|--------------------|:------:|:-----:|----------------------------------|
| LDG.E.128 (128-bit)|   1    |  40   | wide gamma/beta + input loads    |
| LDG.E (32-bit)     |  16    |   0   | scalar gamma/beta loads removed  |
| SHFL.BFLY          |  20    |  20   | reduction unchanged              |
| STS / LDS          |  2 / 2 | 2 / 2 | reduction-buffer traffic same    |
| BAR.SYNC           |   3    |   3   | barriers unchanged               |

### Change 1 — vectorize fp32 gamma/beta
Stock loads gamma/beta per-element (scalar). Recast gamma/beta and the register fragment to
Int128 so 4 consecutive columns load as one 128-bit access, reusing the kernel's column formula
(order preserved). Guarded on `vec_size % 4 == 0`; odd hidden (e.g. 129) keeps the scalar path.
Evidence: `LDG.E` (scalar) 16 -> 0, `LDG.E.128` 1 -> 40.

### Change 2 — cap compute_threads_per_row at 128 (was 1024)
Fewer warps/row -> cheaper cross-warp reduction, higher occupancy. layernorm-only (rmsnorm uses
its own helper).

### Compute is unchanged (both changes)
SHFL.BFLY 20 -> 20, BAR.SYNC 3 -> 3, STS/LDS 2/2 -> 2/2: the speedup is entirely wider loads +
fewer warps, not altered arithmetic.

### Results (H200, 20 trials, clock-locked)
| hidden | speedup |
|--------|---------|
| 512    | 2.02x |
| 1024   | 2.06x |
| 3584   | 2.67x |
| 4096   | 2.64x |
| 8192   | 2.66x |
| 12288  | 2.67x |

Geomean 2.43x (large hidden), CV <=1.1%. Small hidden (256) / small batch: ~1.0-1.25x.


## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/pull/3607

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

- `tests/utils/test_norm.py -k layernorm`: 33/33 pass (H=128..16384, bf16/fp16, incl. 129).
- compute-sanitizer racecheck/synccheck/initcheck clean; memcheck no kernel faults.
- ruff / pyflakes clean.

## Reviewer Notes

- The `LDG.E.128` fast path for gamma/beta is guarded on `vec_size % 4 == 0`; odd/small hidden
  (e.g. 129) falls back to the original scalar loop, so all shapes stay correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layer normalization data handling to reduce overhead on supported input sizes, improving runtime efficiency.
  * Updated internal layer normalization execution sizing to cap thread usage, improving stability and consistency across different workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->