### PR TITLE
fix: error in blockReduceSumV2 when blockDim.x not a multiple of 32

### DIFF
--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -420,7 +420,9 @@ __inline__ __device__ T blockReduceSumV2(T* val) {
 
   __syncthreads();
 
-  bool is_mask = threadIdx.x < (blockDim.x >> 5);
+  // ceil(blockDim.x / 32): a trailing partial warp still contributes a value
+  // to shared[] and must be included in the final reduction.
+  bool is_mask = threadIdx.x < ((blockDim.x + 31) >> 5);
 #pragma unroll
   for (int i = 0; i < NUM; i++) {
     val[i] = is_mask ? shared[i][lane] : (T)(0.0f);
@@ -458,7 +460,9 @@ __inline__ __device__ T blockReduceMaxV2(T* val) {
 
   __syncthreads();
 
-  bool is_mask = threadIdx.x < (blockDim.x >> 5);
+  // ceil(blockDim.x / 32): a trailing partial warp still contributes a value
+  // to shared[] and must be included in the final reduction.
+  bool is_mask = threadIdx.x < ((blockDim.x + 31) >> 5);
 #pragma unroll
   for (int i = 0; i < NUM; i++) {
     val[i] = is_mask ? shared[i][lane]

--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -420,9 +420,9 @@ __inline__ __device__ T blockReduceSumV2(T* val) {
 
   __syncthreads();
 
-  // ceil(blockDim.x / 32): a trailing partial warp still contributes a value
-  // to shared[] and must be included in the final reduction.
-  bool is_mask = threadIdx.x < ((blockDim.x + 31) >> 5);
+  // A trailing partial warp still contributes a value to shared[]; round the
+  // warp count up so its slot is included in the final reduction.
+  bool is_mask = threadIdx.x < ceil_div(blockDim.x, 32);
 #pragma unroll
   for (int i = 0; i < NUM; i++) {
     val[i] = is_mask ? shared[i][lane] : (T)(0.0f);
@@ -460,9 +460,9 @@ __inline__ __device__ T blockReduceMaxV2(T* val) {
 
   __syncthreads();
 
-  // ceil(blockDim.x / 32): a trailing partial warp still contributes a value
-  // to shared[] and must be included in the final reduction.
-  bool is_mask = threadIdx.x < ((blockDim.x + 31) >> 5);
+  // A trailing partial warp still contributes a value to shared[]; round the
+  // warp count up so its slot is included in the final reduction.
+  bool is_mask = threadIdx.x < ceil_div(blockDim.x, 32);
 #pragma unroll
   for (int i = 0; i < NUM; i++) {
     val[i] = is_mask ? shared[i][lane]


### PR DESCRIPTION
## 📌 Description

### Symptom

tests/comm/test_allreduce_unified_api.py::test_allreduce_unified on 4× B300, trtllm backend, hidden_size=2880, fusion=True, for seq_lens [15] (bf16) and [27,11,24,256] (fp16 + bf16). The fused RMS-norm output (output[0]) comes out wrong while the allreduce+residual output (output[1]) is fine. In the log, every printed element of the failing norm output is a uniform ~1.061× of the reference — that ratio is √(9/8) = 1.0607, i.e. the RMS denominator is computed over exactly 8/9 of the row.

### Root cause

Commit dc5d2bc3 changed the block reduction mask in `trtllm_allreduce_fusion.cuh`. When blockDim.x is not a multiple of 32, the last (partial) warp still writes its sum, but the floored mask means nobody reads it. For hidden=2880, fp16/bf16 (VEC_SIZE=8): threads_per_token = 360. The launcher picks cluster_size=8 → 45 threads/block, then doubles to reach ≥128: blockDim=180 (5 full warps + one 20-thread partial warp), cluster=2. The sum-of-squares then covers 2×160×8 = 2560 of 2880 elements → norm output scaled by √(2880/2560) ≈ 1.0607. That matches the observed error to three decimals.

### Proposed fix

Ceiling integer arithmetic, keeping the intent of the optimization: threadIdx.x < ((blockDim.x + 31) >> 5) — in both blockReduceSumV2 and blockReduceMaxV2

## 🔍 Related Issues

No logged issue, fixes CI pipeline failure on B300.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [NA] Tests have been added or updated as needed.
- [NA] All tests are passing (`unittest`, etc.).

### Perf A/B: `blockReduceSumV2`/`MaxV2` partial-warp fix (4× B300, TP=4, bf16)

| tokens | hidden | reduction changed | fused old (µs) | fused fixed (µs) | Δ fused | unfused old (µs) | unfused fixed (µs) |
|-------:|-------:|:-----------------:|---------------:|-----------------:|--------:|-----------------:|-------------------:|
|      4 |   2880 | yes               |           6.06 |             6.06 |    0.0% |            23.25 |              23.26 |
|     27 |   2880 | yes               |           6.88 |             6.88 |    0.0% |            26.32 |              26.74 |
|    128 |   2880 | yes               |           9.34 |             9.34 |    0.0% |            27.66 |              27.58 |
|   1024 |   2880 | yes               |          42.11 |            42.10 |    0.0% |            55.11 |              55.00 |
|      4 |   7168 | no                |           6.27 |             6.27 |    0.0% |            23.98 |              24.08 |
|     27 |   7168 | no                |           7.71 |             7.90 |   +2.5% |            26.73 |              26.34 |
|    128 |   7168 | no                |          14.46 |            14.47 |   +0.1% |            32.87 |              32.74 |
|   1024 |   7168 | no                |          71.50 |            71.59 |   +0.1% |           112.45 |             112.15 |

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reduction logic so sum and max operations properly include trailing partial warps.
  * Improves accuracy for block sizes that aren’t an exact multiple of a warp, preventing missed contributions in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->