### PR TITLE
fix(comm): make TRT-LLM reductions partial-warp safe

### DIFF
--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -390,7 +390,8 @@ inline __device__ float reciprocal_approximate_ftz(float a) {
 
 namespace utils {
 
-#define FINAL_MASK 0xffffffff
+static constexpr int kWarpSize = 32;
+static constexpr unsigned int kFullWarpMask = 0xffffffffU;
 
 template <typename T, int NUM>
 __inline__ __device__ T warpReduceSumV2(T* val) {
@@ -398,7 +399,24 @@ __inline__ __device__ T warpReduceSumV2(T* val) {
   for (int i = 0; i < NUM; i++) {
 #pragma unroll
     for (int mask = 16; mask > 0; mask >>= 1)
-      val[i] += __shfl_xor_sync(FINAL_MASK, val[i], mask, 32);
+      val[i] += __shfl_xor_sync(kFullWarpMask, val[i], mask, kWarpSize);
+  }
+  return (T)(0.0f);
+}
+
+template <typename T, int NUM>
+__inline__ __device__ T warpReduceSumPartialV2(T* val, int active_lanes) {
+  int lane = threadIdx.x & (kWarpSize - 1);
+  unsigned int active_mask = active_lanes == kWarpSize ? kFullWarpMask : (1U << active_lanes) - 1;
+#pragma unroll
+  for (int i = 0; i < NUM; i++) {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1) {
+      T other = __shfl_xor_sync(active_mask, val[i], mask, kWarpSize);
+      if ((lane ^ mask) < active_lanes) {
+        val[i] += other;
+      }
+    }
   }
   return (T)(0.0f);
 }
@@ -408,8 +426,15 @@ __inline__ __device__ T blockReduceSumV2(T* val) {
   static __shared__ T shared[NUM][33];
   int lane = threadIdx.x & 0x1f;
   int wid = threadIdx.x >> 5;
+  int warp_count = ceil_div(blockDim.x, kWarpSize);
+  int tail_lanes = blockDim.x & (kWarpSize - 1);
+  bool is_partial_warp = tail_lanes != 0 && wid == warp_count - 1;
 
-  warpReduceSumV2<T, NUM>(val);
+  if (is_partial_warp) {
+    warpReduceSumPartialV2<T, NUM>(val, tail_lanes);
+  } else {
+    warpReduceSumV2<T, NUM>(val);
+  }
 
   if (lane == 0) {
 #pragma unroll
@@ -420,12 +445,16 @@ __inline__ __device__ T blockReduceSumV2(T* val) {
 
   __syncthreads();
 
-  bool is_mask = threadIdx.x < (blockDim.x >> 5);
+  bool is_mask = threadIdx.x < warp_count;
 #pragma unroll
   for (int i = 0; i < NUM; i++) {
     val[i] = is_mask ? shared[i][lane] : (T)(0.0f);
   }
-  warpReduceSumV2<T, NUM>(val);
+  if (is_partial_warp) {
+    warpReduceSumPartialV2<T, NUM>(val, tail_lanes);
+  } else {
+    warpReduceSumV2<T, NUM>(val);
+  }
   return (T)0.0f;
 }
 
@@ -435,7 +464,24 @@ __inline__ __device__ T warpReduceMaxV2(T* val) {
   for (int i = 0; i < NUM; i++) {
 #pragma unroll
     for (int mask = 16; mask > 0; mask >>= 1) {
-      val[i] = fmaxf(val[i], __shfl_xor_sync(FINAL_MASK, val[i], mask, 32));
+      val[i] = fmaxf(val[i], __shfl_xor_sync(kFullWarpMask, val[i], mask, kWarpSize));
+    }
+  }
+  return (T)(0.0f);
+}
+
+template <typename T, int NUM>
+__inline__ __device__ T warpReduceMaxPartialV2(T* val, int active_lanes) {
+  int lane = threadIdx.x & (kWarpSize - 1);
+  unsigned int active_mask = active_lanes == kWarpSize ? kFullWarpMask : (1U << active_lanes) - 1;
+#pragma unroll
+  for (int i = 0; i < NUM; i++) {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1) {
+      T other = __shfl_xor_sync(active_mask, val[i], mask, kWarpSize);
+      if ((lane ^ mask) < active_lanes) {
+        val[i] = fmaxf(val[i], other);
+      }
     }
   }
   return (T)(0.0f);
@@ -446,8 +492,15 @@ __inline__ __device__ T blockReduceMaxV2(T* val) {
   static __shared__ T shared[NUM][33];
   int lane = threadIdx.x & 0x1f;
   int wid = threadIdx.x >> 5;
+  int warp_count = ceil_div(blockDim.x, kWarpSize);
+  int tail_lanes = blockDim.x & (kWarpSize - 1);
+  bool is_partial_warp = tail_lanes != 0 && wid == warp_count - 1;
 
-  warpReduceMaxV2<T, NUM>(val);
+  if (is_partial_warp) {
+    warpReduceMaxPartialV2<T, NUM>(val, tail_lanes);
+  } else {
+    warpReduceMaxV2<T, NUM>(val);
+  }
 
   if (lane == 0) {
 #pragma unroll
@@ -458,13 +511,17 @@ __inline__ __device__ T blockReduceMaxV2(T* val) {
 
   __syncthreads();
 
-  bool is_mask = threadIdx.x < (blockDim.x >> 5);
+  bool is_mask = threadIdx.x < warp_count;
 #pragma unroll
   for (int i = 0; i < NUM; i++) {
     val[i] = is_mask ? shared[i][lane]
                      : maths::cuda_cast<T>(-cuda::std::numeric_limits<float>::infinity());
   }
-  warpReduceMaxV2<T, NUM>(val);
+  if (is_partial_warp) {
+    warpReduceMaxPartialV2<T, NUM>(val, tail_lanes);
+  } else {
+    warpReduceMaxV2<T, NUM>(val);
+  }
   return (T)0.0f;
 }
 

--- a/tests/comm/test_trtllm_allreduce_reduction.py
+++ b/tests/comm/test_trtllm_allreduce_reduction.py
@@ -1,0 +1,76 @@
+import pathlib
+
+import pytest
+import torch
+from torch.utils.cpp_extension import load_inline
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_FLASHINFER_INCLUDE = str(_REPO_ROOT / "include")
+_SPDLOG_INCLUDE = str(_REPO_ROOT / "3rdparty" / "spdlog" / "include")
+_CUDA_FLAGS = [
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_HALF2_OPERATORS__",
+    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+]
+
+_CPP_SOURCE = r"""
+torch::Tensor test_block_reductions(int64_t num_threads);
+"""
+
+_CUDA_SOURCE = r"""
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/extension.h>
+
+#include <flashinfer/comm/trtllm_allreduce_fusion.cuh>
+
+__global__ void block_reduction_kernel(float* output) {
+  float sum = 1.0f;
+  float max = static_cast<float>(threadIdx.x + 1);
+
+  flashinfer::trtllm_allreduce_fusion::utils::blockReduceSumV2<float, 1>(&sum);
+  flashinfer::trtllm_allreduce_fusion::utils::blockReduceMaxV2<float, 1>(&max);
+
+  if (threadIdx.x == 0) {
+    output[0] = sum;
+    output[1] = max;
+  }
+}
+
+torch::Tensor test_block_reductions(int64_t num_threads) {
+  TORCH_CHECK(num_threads > 0 && num_threads <= 1024, "invalid block size");
+  auto output = torch::empty({2}, torch::dtype(torch::kFloat32).device(torch::kCUDA));
+  block_reduction_kernel<<<1, num_threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+      output.data_ptr<float>());
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return output;
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def reduction_module():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    gencode = f"-gencode=arch=compute_{major}{minor},code=sm_{major}{minor}"
+    return load_inline(
+        name="test_trtllm_allreduce_reduction",
+        cpp_sources=[_CPP_SOURCE],
+        cuda_sources=[_CUDA_SOURCE],
+        extra_include_paths=[_FLASHINFER_INCLUDE, _SPDLOG_INCLUDE],
+        extra_cuda_cflags=[*_CUDA_FLAGS, gencode],
+        functions=["test_block_reductions"],
+        verbose=False,
+    )
+
+
+@pytest.mark.parametrize("num_threads", [129, 159, 180, 192])
+def test_block_reductions(reduction_module, num_threads):
+    output = reduction_module.test_block_reductions(num_threads)
+    expected = torch.tensor(
+        [float(num_threads), float(num_threads)], device="cuda", dtype=torch.float32
+    )
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)


### PR DESCRIPTION
## 📌 Description

Fix the TRT-LLM block sum and max reductions for block sizes that are not a
multiple of 32.

The original code had two problems for a trailing partial warp:

1. `blockDim.x >> 5` omitted that warp from the second-stage reduction.
2. The warp reduction used `__shfl_xor_sync(0xffffffff, ...)`, although not all
   lanes named in the mask exist in a partial warp. Reads from inactive source
   lanes are undefined by the [CUDA shuffle contract](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#warp-shuffle-functions).

On GB200, the ceiling warp-count fix alone makes a 180-thread sum return 192
instead of 180. This change incorporates that fix and makes both reduction
stages partial-warp safe:

- preserve the existing full-warp fast path;
- use the active-lane mask for the trailing warp;
- ignore XOR partners outside the active-lane range; and
- apply the same handling to sum and max reductions.

The focused CUDA test covers a one-lane tail (129 threads), a 31-lane tail
(159), the observed failure (180), and an aligned control (192).

## 🔍 Related Issues

Builds on and supersedes #3879.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Local:

- `pre-commit run --all-files`: passed.

4x GB200

- public AR+RMSNorm and AR+RMSNorm+dynamic-FP8 validation passed for one-shot
  and two-shot at the partial-warp shape `16x2880`;
- 52 public benchmark validation instances passed across all ranks, including
  CUDA graph replay; and
- same-node exact-base/candidate A/B showed no material performance regression
  (median-of-three deltas from `-2.5%` to `+3.4%`).

Focused reduction test: 4 passed for 129, 159, 180, and 192 threads.

## Reviewer Notes

Official A10G, T4, and H100 jobs are still skipped because this contributor is
not in `@flashinfer-ai/ci-users`. An authorized maintainer must comment
`@flashinfer-bot run` before merge.
