### PR TITLE
feat: add plan_mm_bf16 — plan/run API for repeated BF16 GEMMs

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -109,6 +109,8 @@ from .gemm import bmm_bf16 as bmm_bf16
 from .gemm import bmm_fp8 as bmm_fp8
 from .gemm import bmm_mxfp8 as bmm_mxfp8
 from .gemm import mm_bf16 as mm_bf16
+from .gemm import MmBf16Plan as MmBf16Plan
+from .gemm import plan_mm_bf16 as plan_mm_bf16
 from .gemm import mm_fp4 as mm_fp4
 from .gemm import mm_bf16_fp4 as mm_bf16_fp4
 from .gemm import prepare_bf16_fp4_weights as prepare_bf16_fp4_weights

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -3,6 +3,8 @@ from .gemm_base import bmm_bf16 as bmm_bf16
 from .gemm_base import bmm_fp8 as bmm_fp8
 from .gemm_base import bmm_mxfp8 as bmm_mxfp8
 from .gemm_base import mm_bf16 as mm_bf16
+from .gemm_base import MmBf16Plan as MmBf16Plan
+from .gemm_base import plan_mm_bf16 as plan_mm_bf16
 from .gemm_base import mm_fp4 as mm_fp4
 from .gemm_base import mm_fp8 as mm_fp8
 from .gemm_base import mm_mxfp8 as mm_mxfp8

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1172,6 +1172,16 @@ def get_mm_bf16_cublaslt_module():
                 self._algo_cache: dict = {}
 
             def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+                # Must be synthesis-invariant: including a.shape (dynamic M)
+                # makes the runtime key miss the bucketed profile key, so the
+                # tuned tactic is dropped for tactic=-1. Shapes are already in
+                # the autotuner's input_shapes; add only dtypes.
+                a, b, _, _, out, _ = inputs
+                return (a.dtype, b.dtype, self._compute_dtype(out.dtype))
+
+            def _algo_cache_key(self, inputs: List[torch.Tensor]) -> tuple:
+                # Internal cuBLASLt algo-enumeration cache: this one is
+                # shape-specific, so key on full shapes (incl. M).
                 a, b, _, _, out, _ = inputs
                 return (
                     a.shape[0],
@@ -1192,7 +1202,7 @@ def get_mm_bf16_cublaslt_module():
             def _get_algos(self, inputs):
                 a, b, _, _, out, workspace_buffer = inputs
                 compute_dt = self._compute_dtype(out.dtype)
-                key = self.get_cache_key_extras(inputs)
+                key = self._algo_cache_key(inputs)
                 cached = self._algo_cache.get(key)
                 if cached is not None:
                     return cached
@@ -1255,13 +1265,11 @@ def get_mm_bf16_cublaslt_module():
                         f"dtype={compute_out.dtype}. "
                         "This shape/dtype combination may not be supported."
                     )
-                if tactic >= count:
-                    raise ValueError(
-                        f"Requested tactic {tactic} but only {count} algorithms "
-                        f"available for M={a.shape[0]}, N={b.shape[1]}, K={a.shape[1]}, "
-                        f"dtype={compute_out.dtype}."
-                    )
-                if tactic < 0:
+                # The cuBLASLt algo list is enumerated per-shape, so a tactic
+                # tuned at a different (bucketed) M may be out of range here.
+                # Fall back to the heuristic-best algo (index 0) rather than
+                # raising.
+                if tactic < 0 or tactic >= count:
                     tactic = 0
                 module.mm_bf16_cublaslt_run_with_algo(
                     a,
@@ -1298,6 +1306,11 @@ _BF16_GEMM_SM100_TUNING_CONFIG = TuningConfig(
             -2,
             lambda shapes: shapes[0][-2],
         ),
+        ConstraintSpec(
+            5,  # workspace_buffer index: scratch buffer that a backend may
+            0,  # resize during profiling. Wildcard its size out of the cache
+            lambda shapes: shapes[5][0],  # key so a mid-tune resize never
+        ),  # changes the key (would otherwise cause a silent cache miss).
     ),
 )
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import bisect
 import functools
 from enum import Enum
 from types import SimpleNamespace
-from typing import List, Literal, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 from flashinfer.trtllm_low_latency_gemm import trtllm_low_latency_gemm
 import torch
@@ -39,6 +40,7 @@ from ..trace.templates.attention import segment_gemm_run_trace
 from ..trace.templates.page import tgv_gemm_sm100_trace
 from ..autotuner import (
     AutoTuner,
+    autotune,
     ConstraintSpec,
     DynamicTensorSpec,
     OptimizationProfile,
@@ -1159,6 +1161,7 @@ def get_gemm_sm100_module_cutlass_bf16():
 
     return SimpleNamespace(
         cutlass_bf16_gemm_runner=cutlass_bf16_gemm_runner,
+        module=module,
     )
 
 
@@ -1288,6 +1291,7 @@ def get_mm_bf16_cublaslt_module():
 
     return SimpleNamespace(
         cublaslt_bf16_gemm_runner=cublaslt_bf16_gemm_runner,
+        module=module,
     )
 
 
@@ -1462,6 +1466,223 @@ def bf16_gemm_sm100(
     )
 
     runner(inputs=inputs, tactic=tactic)
+
+
+# Shared tuned tables for MmBf16Plan: weights with the same problem signature
+# reuse one (buckets, [(runner, tactic)]) table, so tuning runs once per
+# unique shape rather than once per layer.
+_MM_BF16_PLAN_TABLES: Dict[tuple, tuple] = {}
+
+
+def _mm_bf16_plan_runners(dtype, device, has_bias: bool):
+    runners = []
+    builders = [
+        lambda: _cudnn_gemm_bf16_runner(is_a_k_major=True, is_b_k_major=True),
+    ]
+    if not has_bias:
+        # The cuBLASLt / CUTLASS BF16 runners do not apply bias.
+        builders += [
+            lambda: get_mm_bf16_cublaslt_module().cublaslt_bf16_gemm_runner(),
+            lambda: get_gemm_sm100_module_cutlass_bf16().cutlass_bf16_gemm_runner(),
+        ]
+    builders.append(lambda: _tgv_gemm_runner(dtype, is_sm100f_supported(device)))
+    for build in builders:
+        try:
+            runners.append(build())
+        except Exception:  # pragma: no cover - backend unavailable on this arch
+            continue
+    return runners
+
+
+def _mm_bf16_plan_table(n, k, dtype, device, has_bias, pdl, out_dtype, max_m):
+    key = (n, k, dtype, device.index, has_bias, pdl, out_dtype, max_m)
+    cached = _MM_BF16_PLAN_TABLES.get(key)
+    if cached is not None:
+        return cached
+    buckets = tuple(get_hybrid_num_tokens_buckets(max_m))
+    b_proxy = torch.empty(n, k, dtype=dtype, device=device).transpose(-2, -1)
+    bias_proxy = torch.zeros(n, dtype=dtype, device=device) if has_bias else None
+    ws = _get_cache_buf("mm_bf16_workspace", DEFAULT_WORKSPACE_SIZE, device)
+    runners = _mm_bf16_plan_runners(dtype, device, has_bias)
+    tuner = AutoTuner.get()
+    cfg = _BF16_GEMM_SM100_TUNING_CONFIG
+    # Tuning the largest bucket profiles every smaller bucket in the same
+    # pass; the per-bucket queries below read the winners back.
+    with autotune(True):
+        a = torch.empty(buckets[-1], k, dtype=dtype, device=device)
+        out = torch.empty(buckets[-1], n, dtype=out_dtype, device=device)
+        tuner.choose_one(
+            "bf16_gemm", runners, cfg, [a, b_proxy, bias_proxy, pdl, out, ws]
+        )
+    table = []
+    for bucket in buckets:
+        a = torch.empty(bucket, k, dtype=dtype, device=device)
+        out = torch.empty(bucket, n, dtype=out_dtype, device=device)
+        table.append(
+            tuner.choose_one(
+                "bf16_gemm", runners, cfg, [a, b_proxy, bias_proxy, pdl, out, ws]
+            )
+        )
+    result = (buckets, table)
+    _MM_BF16_PLAN_TABLES[key] = result
+    return result
+
+
+class MmBf16Plan:
+    r"""Tuned execution plan for repeated BF16 GEMMs against a fixed weight.
+
+    Create via :func:`plan_mm_bf16` (tunes every M bucket up to ``max_m``
+    once, outside of any CUDA graph capture); afterwards :meth:`run` is a
+    bucket lookup plus a prebound kernel launch -- no per-call backend
+    selection, autotuner lookup, or wrapper overhead. Mirrors the
+    ``plan()``/``run()`` contract of the attention wrappers.
+    """
+
+    def __init__(
+        self,
+        b: torch.Tensor,
+        bias: Optional[torch.Tensor],
+        pdl: bool,
+        out_dtype: torch.dtype,
+        max_m: int,
+    ) -> None:
+        if b.dim() != 2:
+            raise ValueError(f"expected 2-D weight, got {b.dim()}-D")
+        k, n = b.shape
+        self._b = b
+        self._b_t = b.transpose(-2, -1)
+        self._bias = bias
+        self._pdl = pdl
+        self._out_dtype = out_dtype
+        self._n = n
+        self._max_m = max_m
+        self._workspace = _get_cache_buf(
+            "mm_bf16_workspace", DEFAULT_WORKSPACE_SIZE, b.device
+        )
+        buckets, table = _mm_bf16_plan_table(
+            n, k, b.dtype, b.device, bias is not None, pdl, out_dtype, max_m
+        )
+        self._buckets = buckets
+        self._lanes = [self._make_lane(runner, tactic) for runner, tactic in table]
+
+    def _make_lane(self, runner: TunableRunner, tactic: int):
+        name = type(runner).__name__
+        b, b_t, ws = self._b, self._b_t, self._workspace
+        if name == "CutlassBf16GemmRunner":
+            module = get_gemm_sm100_module_cutlass_bf16().module
+
+            def lane(a, out):
+                module.bf16_gemm(a, b_t, out, ws, tactic)
+
+            return lane
+        if name == "CublasltBf16GemmRunner":
+            module = get_mm_bf16_cublaslt_module().module
+            clamped = max(tactic, 0)
+            get_algos = runner._get_algos
+            algo_cache: dict = {}
+
+            def lane(a, out):
+                m = a.shape[0]
+                entry = algo_cache.get(m)
+                if entry is None:
+                    algo_buf, count = get_algos([a, b, None, False, out, ws])
+                    entry = algo_cache[m] = (
+                        algo_buf,
+                        clamped if clamped < count else 0,
+                    )
+                with torch.cuda.device(a.device):
+                    handle = torch.cuda.current_blas_handle()
+                module.mm_bf16_cublaslt_run_with_algo(
+                    a, b_t, out, ws, handle, entry[0], entry[1]
+                )
+
+            return lane
+        if name == "CudnnBf16GemmRunner" and runner._use_override_shape:
+            clamped = max(tactic, 0)
+            get_graph = runner._get_override_graph
+            bias = self._bias
+            graph_cache: dict = {}
+
+            def lane(a, out):
+                m = a.shape[0]
+                graph = graph_cache.get(m)
+                if graph is None:
+                    graph = graph_cache[m] = get_graph(a, b, bias, out)
+                execute_cudnn_gemm_bf16_graph_override_shape(
+                    graph, a, b, bias, out, ws, tactic=clamped
+                )
+
+            return lane
+
+        bias, pdl = self._bias, self._pdl
+
+        def lane(a, out):
+            runner(inputs=[a, b, bias, pdl, out, ws], tactic=tactic)
+
+        return lane
+
+    def run(self, a: torch.Tensor, out: Optional[torch.Tensor] = None) -> torch.Tensor:
+        r"""Run the planned GEMM: ``a @ b (+ bias)``.
+
+        Parameters
+        ----------
+        a: torch.Tensor
+            Input tensor, shape ``(m, k)``, same dtype as the planned weight.
+        out: Optional[torch.Tensor]
+            Preallocated output, shape ``(m, n)``; allocated when ``None``.
+        """
+        m = a.shape[0]
+        if out is None:
+            out = torch.empty((m, self._n), dtype=self._out_dtype, device=a.device)
+        if m == 0:
+            return out
+        if m > self._max_m:
+            # Outside the tuned bucket range: use the auto-dispatch path
+            # rather than a tactic tuned for a much smaller shape.
+            return mm_bf16(
+                a,
+                self._b,
+                bias=self._bias,
+                pdl=self._pdl,
+                out=out,
+                out_dtype=self._out_dtype,
+                backend="auto",
+            )
+        lane = self._lanes[bisect.bisect_left(self._buckets, m)]
+        lane(a, out)
+        return out
+
+
+def plan_mm_bf16(
+    b: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    pdl: bool = False,
+    out_dtype: torch.dtype = torch.bfloat16,
+    max_m: int = 4096,
+) -> MmBf16Plan:
+    r"""Build a tuned :class:`MmBf16Plan` for repeated ``mm_bf16`` calls.
+
+    Tunes every M bucket up to ``max_m`` for the weight's problem shape (the
+    tuned table is shared across weights with the same shape/dtype), then
+    :meth:`MmBf16Plan.run` dispatches with a prebound launch per bucket.
+    Must not be called during CUDA graph capture.
+
+    Parameters
+    ----------
+    b: torch.Tensor
+        Weight tensor, shape ``(k, n)``, bf16 in column-major layout (same
+        layout as :func:`mm_bf16`).
+    bias: Optional[torch.Tensor]
+        Optional bias, shape ``(n,)``, bound into the plan.
+    pdl: bool
+        Whether to use Programmatic Dependent Launch (backend permitting).
+    out_dtype: torch.dtype
+        Output dtype. Defaults to ``torch.bfloat16``.
+    max_m: int
+        Largest expected number of rows; larger calls fall back to
+        :func:`mm_bf16` auto dispatch.
+    """
+    return MmBf16Plan(b, bias, pdl, out_dtype, max_m)
 
 
 def fp8_gemm_sm100(

--- a/tests/autotuner/test_autotuner_mm_bf16.py
+++ b/tests/autotuner/test_autotuner_mm_bf16.py
@@ -1,0 +1,159 @@
+import pytest
+import torch
+
+from flashinfer import autotune, mm_bf16
+from flashinfer.autotuner import AutoTuner
+from flashinfer.gemm.gemm_base import (
+    _BF16_GEMM_SM100_TUNING_CONFIG,
+    _cudnn_gemm_bf16_runner,
+    _get_cache_buf,
+    get_mm_bf16_cublaslt_module,
+    DEFAULT_WORKSPACE_SIZE,
+)
+from flashinfer.utils import get_compute_capability
+
+
+def _skip_unless_supported(backend: str):
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    cc = compute_capability[0] * 10 + compute_capability[1]
+    if not mm_bf16.is_compute_capability_supported(cc):
+        pytest.skip(f"mm_bf16 not supported on sm{cc}.")
+    if not mm_bf16.is_backend_supported(backend, cc):
+        pytest.skip(f"{backend} backend not supported on sm{cc}.")
+
+
+def _make_inputs(m: int, n: int, k: int):
+    # a is row-major (k-major); b is (k, n) column-major, matching the
+    # layouts mm_bf16 expects and the stride flags bf16_gemm_sm100 captures.
+    a = torch.randn([m, k], device="cuda", dtype=torch.bfloat16)
+    b = torch.randn([n, k], device="cuda", dtype=torch.bfloat16).transpose(-2, -1)
+    return a, b
+
+
+def _search_bf16_gemm_cache(runner, a, b, out):
+    workspace_buffer = _get_cache_buf(
+        "mm_bf16_workspace", DEFAULT_WORKSPACE_SIZE, a.device
+    )
+    # bf16_gemm_sm100's inputs layout: [a, b, bias, pdl, out, workspace];
+    # bias=None and pdl=False are represented as torch.Size([0]) in the
+    # autotuner's input_shapes.
+    return AutoTuner.get().search_cache(
+        "bf16_gemm",
+        [runner],
+        (
+            a.shape,
+            b.shape,
+            torch.Size([0]),
+            torch.Size([0]),
+            out.shape,
+            workspace_buffer.shape,
+        ),
+        _BF16_GEMM_SM100_TUNING_CONFIG,
+        inputs=[a, b, None, False, out, workspace_buffer],
+    )
+
+
+@pytest.mark.parametrize(
+    "pre_tune,tune_mode,expected_cache_hit",
+    [
+        (False, False, False),  # Cold inference: no cache hit
+        (False, True, True),  # Tune in this call: cache hit
+        (True, False, True),  # Warm cache then inference: cache hit
+    ],
+    ids=["cold_infer", "tune_now", "warm_then_infer"],
+)
+@pytest.mark.parametrize(
+    "m,n,k",
+    [
+        # Test power-of-2 dimensions
+        (128, 64, 256),
+        (2048, 256, 512),
+        # Test non power-of-2 dimensions
+        (48, 80, 64),
+        (200, 2048, 200),
+    ],
+)
+def test_autotuner_gemm(pre_tune, tune_mode, expected_cache_hit, m, n, k):
+    _skip_unless_supported("cudnn")
+
+    autotuner = AutoTuner.get()
+    # Keep each test independent from other parametrized runs.
+    autotuner.clear_cache()
+
+    a, b = _make_inputs(m, n, k)
+
+    if pre_tune:
+        with autotune(tune_mode=True):
+            mm_bf16(a, b, backend="cudnn")
+
+    with autotune(tune_mode=tune_mode):
+        out = mm_bf16(a, b, backend="cudnn")
+
+    assert out.isfinite().all()
+
+    is_a_k_major = a.stride(-1) == 1
+    is_b_k_major = b.stride(-2) == 1
+    is_cache_hit, runner_id, tactic, stored_profile = _search_bf16_gemm_cache(
+        _cudnn_gemm_bf16_runner(is_a_k_major=is_a_k_major, is_b_k_major=is_b_k_major),
+        a,
+        b,
+        out,
+    )
+
+    assert is_cache_hit == expected_cache_hit
+    if is_cache_hit:
+        assert runner_id == 0
+        # Tactic == -1 would mean the fallback path was chosen (no hit),
+        # which contradicts the hit.
+        assert tactic >= 0
+        assert stored_profile is not None
+
+
+@pytest.mark.parametrize("backend", ["cudnn", "cublaslt"])
+def test_autotuner_gemm_cross_bucket_m(backend):
+    """Tune at one M bucket, then run inference at a non-bucket M.
+
+    The cuBLASLt algo list is enumerated at the *real* shape, so a tactic
+    tuned against a different (bucketed) M may be out of range for the
+    runtime algo list. This must NOT raise (the runner clamps an
+    out-of-range index back to the heuristic default), and the autotuner
+    must still reuse the tuned bucket entry for the non-bucket M — the
+    runner's cache-key extras must not contain the raw M, and the
+    workspace scratch size (which a backend may grow mid-tuning) must not
+    leak into the cache key.
+    """
+    _skip_unless_supported(backend)
+
+    autotuner = AutoTuner.get()
+    autotuner.clear_cache()
+
+    n, k = 64, 256
+    # Tuning at M=256 profiles all buckets up to 256 (incl. 128). A runtime
+    # M=100 rounds up to bucket 128, so real-M (100) != bucket-M (128).
+    tune_m, run_m = 256, 100
+
+    # 1) Tune over the bucket range.
+    a, b = _make_inputs(tune_m, n, k)
+    with autotune(tune_mode=True):
+        mm_bf16(a, b, backend=backend)
+
+    # 2) Run at a non-bucket M. Must not raise (out-of-range tactic is
+    #    clamped) and must produce finite output.
+    a, b = _make_inputs(run_m, n, k)
+    out = mm_bf16(a, b, backend=backend)
+    assert out.isfinite().all()
+
+    # 3) The tuned bucket entry must be reused for the non-bucket M.
+    if backend == "cudnn":
+        runner = _cudnn_gemm_bf16_runner(
+            is_a_k_major=a.stride(-1) == 1,
+            is_b_k_major=b.stride(-2) == 1,
+        )
+    else:
+        runner = get_mm_bf16_cublaslt_module().cublaslt_bf16_gemm_runner()
+    is_cache_hit, runner_id, tactic, stored_profile = _search_bf16_gemm_cache(
+        runner, a, b, out
+    )
+    assert is_cache_hit
+    assert tactic >= 0
+    assert stored_profile is not None

--- a/tests/gemm/test_mm_bf16_plan.py
+++ b/tests/gemm/test_mm_bf16_plan.py
@@ -1,0 +1,79 @@
+import pytest
+import torch
+
+from flashinfer import mm_bf16, plan_mm_bf16
+from flashinfer.gemm.gemm_base import _MM_BF16_PLAN_TABLES
+from flashinfer.utils import get_compute_capability
+
+
+def _skip_unless_supported():
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    cc = compute_capability[0] * 10 + compute_capability[1]
+    if not mm_bf16.is_compute_capability_supported(cc):
+        pytest.skip(f"mm_bf16 not supported on sm{cc}.")
+
+
+def _make_weight(n: int, k: int):
+    # (k, n) column-major, the layout mm_bf16 / plan_mm_bf16 expect.
+    return torch.randn(n, k, device="cuda", dtype=torch.bfloat16).transpose(-2, -1)
+
+
+@pytest.mark.parametrize("has_bias", [False, True])
+@pytest.mark.parametrize("n,k", [(128, 256), (2048, 512)])
+def test_plan_numerics_across_m(has_bias, n, k):
+    """run() must match F.linear for bucket and non-bucket M values."""
+    _skip_unless_supported()
+    torch.manual_seed(0)
+    b = _make_weight(n, k)
+    bias = torch.randn(n, device="cuda", dtype=torch.bfloat16) if has_bias else None
+    plan = plan_mm_bf16(b, bias=bias, max_m=256)
+    with torch.inference_mode():
+        for m in [1, 3, 24, 40, 100, 233, 256]:
+            a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+            got = plan.run(a)
+            ref = torch.nn.functional.linear(a, b.transpose(-2, -1), bias)
+            torch.testing.assert_close(got, ref, rtol=2e-2, atol=2e-2)
+
+
+def test_plan_out_param_and_zero_m():
+    _skip_unless_supported()
+    torch.manual_seed(0)
+    n, k = 128, 256
+    b = _make_weight(n, k)
+    plan = plan_mm_bf16(b, max_m=64)
+    with torch.inference_mode():
+        a = torch.randn(16, k, device="cuda", dtype=torch.bfloat16)
+        out = torch.empty(16, n, device="cuda", dtype=torch.bfloat16)
+        got = plan.run(a, out=out)
+        assert got is out
+        ref = torch.nn.functional.linear(a, b.transpose(-2, -1))
+        torch.testing.assert_close(got, ref, rtol=2e-2, atol=2e-2)
+
+        empty = plan.run(torch.empty(0, k, device="cuda", dtype=torch.bfloat16))
+        assert empty.shape == (0, n)
+
+
+def test_plan_m_above_max_falls_back():
+    """M beyond the tuned range must still be correct (auto-dispatch path)."""
+    _skip_unless_supported()
+    torch.manual_seed(0)
+    n, k = 128, 256
+    b = _make_weight(n, k)
+    plan = plan_mm_bf16(b, max_m=64)
+    with torch.inference_mode():
+        a = torch.randn(100, k, device="cuda", dtype=torch.bfloat16)
+        got = plan.run(a)
+        ref = torch.nn.functional.linear(a, b.transpose(-2, -1))
+        torch.testing.assert_close(got, ref, rtol=2e-2, atol=2e-2)
+
+
+def test_plan_table_shared_across_same_shape_weights():
+    """Weights with identical problem signature share one tuned table."""
+    _skip_unless_supported()
+    n, k = 128, 256
+    before = len(_MM_BF16_PLAN_TABLES)
+    plan_a = plan_mm_bf16(_make_weight(n, k), max_m=64)
+    after_first = len(_MM_BF16_PLAN_TABLES)
+    plan_b = plan_mm_bf16(_make_weight(n, k), max_m=64)
+    assert len(_MM_BF16_PLAN_TABLES) == after_first >= before
+    assert plan_a._buckets == plan_b._buckets


### PR DESCRIPTION
## 📌 Description

Adds `plan_mm_bf16()` / `MmBf16Plan` — a plan/run API for repeated BF16 GEMMs against a fixed weight, mirroring the attention wrappers' contract.

**Why:** with per-call auto dispatch (`mm_bf16(backend="auto")`), each call pays ~250 µs of host time (`sig.bind` + backend heuristic + runner construction + autotuner lookup), which makes eager LLM-serving prefill host-bound — nsys shows GPU-busy identical to a plain cuBLAS path but 1.5–2.4× wall time. Caching inside the existing call structure (#3873) recovers about half; the rest is the per-call decision structure itself.

**What:** `plan_mm_bf16(b, bias=..., pdl=..., max_m=...)` tunes every M bucket up to `max_m` in one autotune pass (tuned tables are shared across weights with the same problem signature, so tuning runs once per unique shape, not per layer). `plan.run(a, out=None)` is then a bisect bucket lookup plus a prebound launch lane: CUTLASS lanes call the kernel module directly, cuBLASLt lanes prebind the algo buffer (per-M cache, since the algo list is enumerated per shape, with out-of-range tactic clamping), cuDNN lanes prebind the execution graph. `m > max_m` falls back to `mm_bf16` auto dispatch; `plan()` must not run during CUDA graph capture (`run()` is capture-safe — launches only).

Measured on B300 via vLLM BF16 serving (Qwen3.5-9B, prefill microbench ISL=10/OSL=1 bs=4; torch backend reference 29.0 ms/iter): **75.0 → 36.1 ms/iter**, per-call host overhead ~250 µs → **13.7 µs** (torch `F.linear`: 9.6 µs). GPU-side kernel time unchanged or better — exhaustive per-bucket tuning picks e.g. non-splitK cuBLASLt algos that heuristics miss (−6% decode GPU time on Qwen3.5). E2E serving TTFT at concurrency 4 went from +110% vs the torch backend (untuned) to ≈ parity with this API.

## 🔍 Related Issues

Stacked on #3868 (first commit here; without the workspace cache-key fix the per-bucket winner readback misses). Independent of but complementary to #3873. Consumed by vLLM's BF16 linear backend in vllm-project/vllm#40638 (consumption patch: raayandhar/vllm#5).

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.) — the equivalent implementation was validated end-to-end on B300 (numerics vs `F.linear` across bucket/non-bucket M, CUDA-graph serving, nsys); a pytest run of the new file on this exact branch is pending GPU access and will be posted in a comment.

`tests/gemm/test_mm_bf16_plan.py`: numerics across bucket and non-bucket M (with and without bias), `out=` and zero-M handling, `m > max_m` fallback correctness, and tuned-table sharing across same-shape weights.

## Reviewer Notes

- The cuBLASLt/CUTLASS pybind modules are now exposed on their cached namespaces (`module=module`) so lanes bind them directly instead of reaching into runner closures.
- A follow-up could move the registry + lanes behind a single C++ op (measured headroom: the remaining ~4 µs/call gap to `F.linear` plus the cuDNN Python-frontend execute).
- The table machinery (`_mm_bf16_plan_table`) is intentionally op-agnostic; the natural follow-up is `plan_bmm_fp8` / `plan_mm_fp4` reusing it — `CublasFp8GemmRunner` and `_cudnn_gemm_fp8_runner` are structural twins of the BF16 runners, so the lanes copy-adapt. GEMMs would then match the plan()/run() contract that all 15 attention-side wrappers already follow.
