### PR TITLE
fix(mla): enable cute-dsl/auto on SM103 + cluster-aware cutlass split_kv

### DIFF
--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -411,7 +411,7 @@ routine_cc_to_supported_backends = {
         "8.9": ["fa2"],
         "9.0": ["fa2", "fa3"],
         "10.0": ["fa2", "cutlass", "trtllm-native", "cute-dsl", "auto"],
-        "10.3": ["fa2", "cutlass", "trtllm-native"],
+        "10.3": ["fa2", "cutlass", "trtllm-native", "cute-dsl", "auto"],
         "12.0": ["fa2"],
         "12.1": ["fa2"],
     },

--- a/include/flashinfer/attention/blackwell/device/sm100_mla.hpp
+++ b/include/flashinfer/attention/blackwell/device/sm100_mla.hpp
@@ -123,7 +123,7 @@ class MLA {
     // reduction width, costing up to ~2x MLA decode latency at DeepSeek
     // shapes (measured on B200/B300).
     int ctas_per_split = cute::size<0>(typename Kernel::ClusterShape{});
-    int sms_per_batch = max(1, sm_count / (B * ctas_per_split));
+    int sms_per_batch = max(1, sm_count / max(1, B * ctas_per_split));
     int split_heur = min(max_splits, sms_per_batch);
     int k_waves = ceil_div(max_splits, split_heur);
     int split_wave_aware = ceil_div(max_splits, k_waves);

--- a/include/flashinfer/attention/blackwell/device/sm100_mla.hpp
+++ b/include/flashinfer/attention/blackwell/device/sm100_mla.hpp
@@ -116,9 +116,15 @@ class MLA {
     auto [H, K, D, B] = args.problem_shape;
     int sm_count = args.hw_info.sm_count;
     int max_splits = ceil_div(K, 128);
-    int sms_per_batch = max(1, sm_count / B);
+    // Each split is executed by a full CTA cluster (ClusterShape[0] CTAs — 2
+    // for this 2-SM kernel), so the per-batch split budget must count cluster
+    // slots, not raw SMs. Budgeting raw SMs over-splits ~2x: the extra splits
+    // do not fit in one wave of cluster slots and also double the LSE
+    // reduction width, costing up to ~2x MLA decode latency at DeepSeek
+    // shapes (measured on B200/B300).
+    int ctas_per_split = cute::size<0>(typename Kernel::ClusterShape{});
+    int sms_per_batch = max(1, sm_count / (B * ctas_per_split));
     int split_heur = min(max_splits, sms_per_batch);
-    int waves = ceil_div(B * split_heur, sm_count);
     int k_waves = ceil_div(max_splits, split_heur);
     int split_wave_aware = ceil_div(max_splits, k_waves);
     args.split_kv = split_wave_aware;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Two fixes for MLA decode (`BatchMLAPagedAttentionWrapper`) on Blackwell, found while benchmarking DeepSeek-V3 decode shapes on B300 (CC 10.3):

1. **`benchmarks/routines/flashinfer_benchmark_utils.py`**: the `"10.3"` row of `routine_cc_to_supported_backends` omitted `cute-dsl` and `auto` (the `"10.0"` row has both). The library's own compatibility gate for the cute-dsl MLA path (`_cute_dsl_incompatibility_reason` in `flashinfer/mla/_core.py`) only requires SM100+, and cute-dsl runs fine on SM103 — it is in fact the **fastest** backend at these shapes. Before this change the benchmark printed `cute-dsl for routine BatchMLAPagedAttentionWrapper is not supported on compute capability 10.3. Skipping.`, so any backend comparison on B300 silently excluded the winner.

2. **`include/flashinfer/attention/blackwell/device/sm100_mla.hpp`**: `set_split_kv` budgets splits per batch as `sm_count / B`, but each split is executed by a full CTA **cluster** (`ClusterShape[0] = 2` CTAs for this 2-SM kernel). The heuristic therefore over-splits ~2x: the extra splits don't fit in one wave of cluster slots and double the LSE-reduction width. Budgeting cluster slots (`sm_count / (B * ClusterShape[0])`) fixes it, and addresses the `TODO(kaixih@nvidia)` about auto split_kv balance in `include/flashinfer/attention/cutlass_mla.cuh`. (Also removes the unused `waves` local.)

**Measurements** — `benchmarks/flashinfer_benchmark.py --routine BatchMLAPagedAttentionWrapper --backends cutlass --num_qo_heads 128 --num_kv_heads 1 --head_dim_ckv 512 --head_dim_kpe 64 --page_size 64 --s_qo 1 --refcheck --num_iters 30` on B300 (CC 10.3, CUDA 13), median times:

| batch | s_kv | cutlass before | cutlass after | speedup |
|---|---|---|---|---|
| 4 | 4096 | 75 us | **54 us** | 1.39x |
| 1 | 16384 | 77 us | **54 us** | 1.43x |
| 4 | 16384 | 180 us | **145 us** | 1.24x |
| 8 | 4096 | 102 us | **96 us** | 1.06x |

`--refcheck` passes on every cell before and after (the split count changes the reduction tree, not the math).

With fix 1, `--backends cute-dsl` on the same b4/kv4096 cell runs at **20 us** (226 TFLOP/s) on CC 10.3 — consistent with the row's own NOTE that `auto` autotunes across trtllm-gen/cute-dsl; the stale table was excluding it from every SM103 comparison.

## 🔍 Related Issues

- #3355 added `auto` to the `"10.0"` row only; this PR brings `"10.3"` to parity.
- Addresses the `TODO(kaixih@nvidia)` in `include/flashinfer/attention/cutlass_mla.cuh` about balancing auto `split_kv` across SMs.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Details:
- `tests/attention/test_cutlass_mla_fp8_output.py` + the cutlass cells of `test_deepseek_mla.py::test_batch_mla_page_attention`: **16/16 pass** with the new heuristic (B300).
- `tests/attention/test_cute_dsl_mla_decode.py`: 647 passed / 48 skipped; the single failure (`test_cute_dsl_mla_decode_attention_sink[128-256-4]`) **fails identically on pristine main `715a9157`** in this environment — pre-existing, unrelated (this PR does not touch the cute-dsl path).
- No new test added: the heuristic is host-side C++ with no direct unit-test surface; behavior is covered by the existing MLA correctness tests plus benchmark `--refcheck`.

## Reviewer Notes

- The heuristic fix is in the vendored copy under `include/flashinfer/attention/blackwell/device/sm100_mla.hpp`; the same cluster-blind heuristic exists in CUTLASS example 77 (`device/sm100_mla.hpp`, still present in v4.4.2) — happy to file the mirror fix there too.
- The numerically identical fix was validated independently on the CuTeDSL Blackwell MLA example kernel (its `get_split_kv` had the same 2x wave-budget issue).
- AI-assisted (Claude Code); all numbers measured on live hardware as described.

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split selection for MLA attention on supported hardware to better balance work across available capacity, improving runtime consistency.
* **Benchmarks**
  * Expanded compute capability 10.3 backend support in benchmarking utilities, adding additional valid execution paths for attention benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->