### PR TITLE
docs(mla): fix kv_len docstrings in BatchMLAPagedAttentionWrapper

### DIFF
--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1586,7 +1586,7 @@ class BatchMLAPagedAttentionWrapper:
         kv_indices : torch.IntTensor
             The page indices of the paged kv-cache, shape: ``[kv_indptr[-1]]`` or larger.
         kv_len_arr : torch.IntTensor
-            The query length of each request, shape: ``[batch_size]``.
+            The KV length of each request, shape: ``[batch_size]``.
         num_heads : int
             The number of heads in query/output tensor.
         head_dim_ckv : int
@@ -1773,7 +1773,7 @@ class BatchMLAPagedAttentionWrapper:
         profiler_buffer : Optional[torch.Tensor]
             The buffer to store the profiler data.
         kv_len : Optional[torch.Tensor]
-            The query length of each request, shape: ``[batch_size]``. Required when ``backend`` is ``cutlass``.
+            The KV length of each request, shape: ``[batch_size]``. Required when ``backend`` is ``cutlass``.
         page_table : Optional[torch.Tensor]
             The page table of the paged kv-cache, shape: ``[batch_size, num_pages]``. Required when ``backend`` is ``cutlass``.
         return_lse_base_on_e : bool, optional


### PR DESCRIPTION
## Summary

This PR fixes two incorrect docstrings in `BatchMLAPagedAttentionWrapper`.

Both `kv_len_arr` in `plan()` and `kv_len` in `run()` were documented as query length, but they actually represent the KV length of each request.

This is a documentation-only change and does not affect runtime behavior.

## Changes

- Update `kv_len_arr` docstring in `BatchMLAPagedAttentionWrapper.plan()`
- Update `kv_len` docstring in `BatchMLAPagedAttentionWrapper.run()`

## Test Plan

- Verified the change with `git diff`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `kv_len` argument in attention wrapper docs so it now correctly refers to the KV length for each request when using the relevant backend.
  * Improved API wording to reduce confusion around input sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->