### PR TITLE
fix(sparse-mla-sm120): add topk=256 prefill-dsv4 dispatch (fixes #3828)

### DIFF
--- a/csrc/sparse_mla_sm120_prefill.cu
+++ b/csrc/sparse_mla_sm120_prefill.cu
@@ -293,6 +293,8 @@ inline bool dispatch_dsv4_single(int num_heads, int topk, const bf16* Q, const u
   // amortises FP8's higher Tensor-Core throughput.
   if (topk == 128)
     DISPATCH_BY_NH_CM(BF16, 128);
+  else if (topk == 256)
+    DISPATCH_BY_NH_CM(FP8, 256);
   else if (topk == 512)
     DISPATCH_BY_NH_CM(FP8, 512);
   else if (topk == 1024)

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -890,6 +890,8 @@ def test_sparse_mla_sm120_prefill_glm_nsa_arbitrary_fp32(num_heads: int) -> None
 
 _DSV4_PREFILL_CONFIGS = [
     (16, 128),
+    (16, 256),
+    (32, 256),
     (32, 512),
     (64, 1024),
     (128, 1024),


### PR DESCRIPTION
## 📌 Description

Implements the prefill half of #3828, exactly as proposed there by @eous: the
SM120 sparse-MLA DSV4 **prefill** path (`dispatch_dsv4_single` in
`csrc/sparse_mla_sm120_prefill.cu`) has no `topk == 256` branch — the dispatch
chain covers {128, 512, 1024, 2048} — so a prefill-shaped call
(`num_tokens > 64`) with `topk=256` returns false and fails:

```
Check failed: (ok) is false: Unsupported sparse-MLA prefill configuration:
model=DSV4 num_heads=32 topk=256 page_block_size=64 topk_extra=0 extra_page_block_size=0
```

As #3828 notes, `topk=256` is a valid shape (4 × BI(64), between the
instantiated 128 and 512); it's simply missing from the grid. The shape occurs
in practice via DeepSeek-V4-Flash-DSpark under tensor-parallel=2 — the decode
half of the same gap is addressed by #3817.

### Change

- `csrc/sparse_mla_sm120_prefill.cu`: `else if (topk == 256) DISPATCH_BY_NH_CM(FP8, 256);`
  in `dispatch_dsv4_single` — FP8 compute mode per the existing comment (the
  BF16 QK fast path is reserved for the small K-loop at 128; FP8-512 already
  builds, so the smaller 256 tile is smem-safe).
- `tests/attention/test_sparse_mla_sm120.py`: add `(16, 256)` and `(32, 256)`
  to `_DSV4_PREFILL_CONFIGS` (16 exercises the MG_N_HG_T=1 routing, 32 is the
  motivating TP=2 shape).

## 🧪 Testing

Isolation A/B on GB10 (sm_121a), CUDA 13 — identical container and environment,
module JIT-built from source in both legs, only the two dispatch lines varied.
This complements the RTX PRO 6000 (SM120) serving validation reported in #3828 —
two architectures, same result:

- **A (unmodified main + the new test configs):** exactly the 8 `topk=256`
  prefill combos fail (`num_tokens ∈ {128, 256}` × `with_sink ∈ {False, True}` ×
  NH ∈ {16, 32}) with the error above; all 36 pre-existing prefill combos pass.
- **B (this branch):** all prefill combos pass, new shapes verified against the
  bf16 reference implementation.

## 🔗 Related

- Fixes #3828 (prefill half; analysis and fix design are @eous's — this PR
  implements it with test coverage and additional hardware validation)
- #3817 — the decode half of the same missing-topk=256 gap (independently
  confirmed on my hardware in that thread)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional prefill configurations, including `topk=256`, for certain sparse attention workloads.
* **Tests**
  * Added test coverage for two more head-count and `topk=256` combinations to improve validation of the new supported settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->