### PR TITLE
jit: memory-aware default for _get_num_workers() (fixes #3634)

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -366,9 +366,13 @@ def _get_available_memory_gib() -> Optional[float]:
     except (OSError, ValueError, IndexError):
         pass
     try:
-        return (os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")) / (1024**3)
+        avphys_pages = os.sysconf("SC_AVPHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if avphys_pages > 0 and page_size > 0:
+            return (avphys_pages * page_size) / (1024**3)
     except (AttributeError, OSError, ValueError):
-        return None
+        pass
+    return None
 
 
 def _get_num_workers() -> Optional[int]:

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -341,11 +341,62 @@ def generate_ninja_build_for_op(
     return "\n".join(lines)
 
 
+def _env_int(name: str, default: int, minimum: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %d.", name, value, default)
+        return default
+    if parsed < minimum:
+        logger.warning("Ignoring %s=%r (< %d); using %d.", name, value, minimum, default)
+        return default
+    return parsed
+
+
+def _get_available_memory_gib() -> Optional[float]:
+    """Best-effort available system memory in GiB; None if undetermined."""
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) / (1024**2)  # kB -> GiB
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        return (os.sysconf("SC_AVPHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")) / (1024**3)
+    except (AttributeError, OSError, ValueError):
+        return None
+
+
 def _get_num_workers() -> Optional[int]:
     max_jobs = os.environ.get("MAX_JOBS")
     if max_jobs is not None and max_jobs.isdigit():
         return int(max_jobs)
-    return None
+    # Without -j, ninja defaults to cpu_count()+2 parallel jobs. Large CUTLASS
+    # translation units peak at multiple GiB of RSS per nvcc process (the AOT
+    # build in scripts/jit_cache_build_common.sh budgets 8 GB/job for the same
+    # reason), which OOMs or hard-locks memory-constrained and unified-memory
+    # systems (e.g. DGX Spark GB10: 20 cores sharing 121 GiB with the GPU,
+    # where the model may already be resident when JIT compilation starts).
+    # Mirror the AOT logic: budget per-job memory against MemAvailable, keep
+    # headroom for concurrent allocations, and never exceed the CPU count.
+    mem_per_job_gib = _env_int("FLASHINFER_JIT_JOB_MEMORY_GB", 8, 1)
+    headroom_gib = _env_int("FLASHINFER_JIT_MEMORY_HEADROOM_GB", 16, 0)
+    available_gib = _get_available_memory_gib()
+    if available_gib is None:
+        return None  # cannot determine memory: keep previous behavior
+    budget_jobs = int(max(0.0, available_gib - headroom_gib) // mem_per_job_gib)
+    num_workers = max(1, min(os.cpu_count() or 1, budget_jobs))
+    if budget_jobs < 1:
+        logger.warning(
+            "Low available memory (%.1f GiB); limiting JIT compilation to a "
+            "single job. Set MAX_JOBS to override.",
+            available_gib,
+        )
+    return num_workers
 
 
 def run_ninja(workdir: Path, ninja_file: Path, verbose: bool) -> None:


### PR DESCRIPTION
## Summary

`_get_num_workers()` currently returns `None` when `MAX_JOBS` is unset, which lets ninja fall back to `cpu_count() + 2` parallel jobs. Large CUTLASS translation units (e.g. the SM120 NVFP4 GEMM kernels this repo builds by default) peak at ~8 GiB RSS per nvcc, so a 22-way parallel JIT compile tries to allocate ~176 GiB of anonymous memory. On memory-constrained hosts and especially on unified-memory systems (DGX Spark GB10: 121 GiB shared between CPU and GPU, 20 cores, plus a possibly-resident model), this either OOM-kills nvcc mid-build or — with `kernel.hardlockup_panic=0`, which is the default on many ARM64 distros — sends the kernel into a hard lockup that only a hardware watchdog can recover from.

This PR ports the exact same guard that already lives in `scripts/jit_cache_build_common.sh::compute_jit_cache_parallelism()` (added in #3205) from the AOT path to the runtime JIT path. Same formula, same 8 GB/job baseline, same idea — just applied where end-users hit it.

Closes #3634.

## Formula

```
budget = max(0, (MemAvailable_GiB - headroom_GiB) // mem_per_job_GiB)
num_workers = max(1, min(cpu_count, budget))
```

Defaults (overridable via env):

- `FLASHINFER_JIT_JOB_MEMORY_GB=8` — matches the AOT baseline in `jit_cache_build_common.sh`
- `FLASHINFER_JIT_MEMORY_HEADROOM_GB=16` — for OS + a possibly-resident model when the JIT runs mid-serving

Explicit `MAX_JOBS=N` still wins, preserving the existing behaviour for callers that already tuned it. When memory cannot be determined (`/proc/meminfo` unreadable and no `SC_AVPHYS_PAGES`), `_get_num_workers()` returns `None` as before, so ninja's `cpu_count + 2` default kicks in on those platforms.

## Impact examples

| Host | `MemAvailable` | Jobs before | Jobs after |
|------|---------------:|------------:|-----------:|
| DGX Spark GB10 (20 cores, 121 GiB UMA) | 105 GiB | 22 (ninja default) | **11** |
| DGX Spark GB10, model resident | 40 GiB  | 22                 | **3**  |
| Workstation (16 cores, 64 GiB) | 60 GiB  | 18                 | **5**  |
| Small VM (8 cores, 16 GiB)     | 12 GiB  | 10                 | **1**  |

Values are computed against `_get_available_memory_gib()` at ninja-start time. `NVCC_THREADS` (`--threads=N` per nvcc) stays untouched; it is orthogonal.

## Test plan

- [x] `python -c "import ast; ast.parse(open('flashinfer/jit/cpp_ext.py').read())"` — syntax OK
- [x] Manual unit-check with monkey-patched `/proc/meminfo` for 105 / 40 / 12 GiB → 11 / 3 / 1 jobs
- [ ] Live rebuild on GB10 after the fix — I will follow up in the thread once I have a controlled repro slot

## Reproduction of the pre-patch failure

Today I purged one CUTLASS FP4 kernel directory (`~/.cache/flashinfer/0.6.12/121a/cached_ops/fp4_gemm_cutlass_sm120/`) on my DGX Spark to force a targeted recompile — nothing dramatic, just the ~85 kernels in that one module. With the current default MAX_JOBS behaviour, ninja fanned out enough concurrent nvcc processes that the box went into a hard lockup within ~10 minutes and was recovered by the ARM SBSA hardware watchdog (`ACPI GTDT: found 1 SBSA generic Watchdog(s)` in the boot log). No panic message, no OOM in `journalctl -b -1` — the classic `hardlockup_panic=0` failure mode. `MAX_JOBS=4` avoids it manually, but that is exactly the knowledge users should not need to have for a first-run JIT.

## Notes for review

- I kept the environment variable naming under the `FLASHINFER_JIT_*` prefix that already exists for JIT-related knobs (`FLASHINFER_JIT_VERBOSE`, `FLASHINFER_JIT_DEBUG`, etc.).
- No `psutil` dependency added — `/proc/meminfo` + `os.sysconf("SC_AVPHYS_PAGES")` cover Linux and most other POSIX systems without pulling in a new requirement.
- Deliberately did not add a hard cap. The AOT script uses `nproc` as its ceiling and I mirrored that — a hard cap here would also slow down the maintainers' AOT builds if they later share this helper.
- Non-Linux fallback: `os.sysconf("SC_AVPHYS_PAGES")` returns free-not-available, so it under-schedules slightly on macOS / BSD. That is on the safe side for a JIT default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced JIT build parallelism so it scales more accurately with available system memory and CPU capacity.
  - Added smarter handling for concurrency limits, including configurable memory-based budgeting and headroom to reduce the risk of unstable builds.
- **Bug Fixes**
  - Improved fallback behavior when environment settings are missing or invalid, ensuring the build can still proceed safely (including limiting to a single job when necessary).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->