### PR TITLE
Add back the GDN perf improvements due to compatibility with public Cutlass DSL

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -1271,6 +1271,7 @@ class GatedDeltaNetChunkedKernel:
                         shared_inp_ready_producer,
                         o_store_producer,
                         checkpoint_idx,
+                        carried_kv_handle,
                     ) = self.compute_group_1(
                         tidx,
                         tmem_ptr,
@@ -1295,36 +1296,12 @@ class GatedDeltaNetChunkedKernel:
                             state_inp_ready_producer,
                             shared_inp_ready_producer,
                             o_store_producer,
+                            None,
                         ),
-                        (True, 0, head_idx),
+                        (True, num_chunks_b == 1, 0, head_idx),
                     )
-                for chunk_idx in cutlass.range(1, num_chunks_b):
-                    chunk_offset = batch_start + chunk_idx * self.b_t
-                    (
-                        load_v_consumer,
-                        load_gate_consumer,
-                        shared_acc_consumer,
-                        kv_acc_consumer,
-                        q_state_acc_consumer,
-                        group_order_consumer,
-                        kv_acc_producer,
-                        state_inp_ready_producer,
-                        shared_inp_ready_producer,
-                        o_store_producer,
-                        checkpoint_offset,
-                    ) = self.compute_group_1(
-                        tidx,
-                        tmem_ptr,
-                        scale,
-                        (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
-                        (
-                            sV_pisl,
-                            sCumsumlog,
-                            sCumprod,
-                            sBeta,
-                            sO_pisl,
-                        ),
-                        (mS_checkpoints, checkpoint_offset, checkpoint_every_n_tokens),
+                    for chunk_idx in cutlass.range(1, num_chunks_b):
+                        chunk_offset = batch_start + chunk_idx * self.b_t
                         (
                             load_v_consumer,
                             load_gate_consumer,
@@ -1336,14 +1313,44 @@ class GatedDeltaNetChunkedKernel:
                             state_inp_ready_producer,
                             shared_inp_ready_producer,
                             o_store_producer,
-                        ),
-                        (False, chunk_idx, head_idx),
-                    )
-                if num_chunks_b > 0:
+                            checkpoint_offset,
+                            carried_kv_handle,
+                        ) = self.compute_group_1(
+                            tidx,
+                            tmem_ptr,
+                            scale,
+                            (tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv),
+                            (
+                                sV_pisl,
+                                sCumsumlog,
+                                sCumprod,
+                                sBeta,
+                                sO_pisl,
+                            ),
+                            (
+                                mS_checkpoints,
+                                checkpoint_offset,
+                                checkpoint_every_n_tokens,
+                            ),
+                            (
+                                load_v_consumer,
+                                load_gate_consumer,
+                                shared_acc_consumer,
+                                kv_acc_consumer,
+                                q_state_acc_consumer,
+                                group_order_consumer,
+                                kv_acc_producer,
+                                state_inp_ready_producer,
+                                shared_inp_ready_producer,
+                                o_store_producer,
+                                carried_kv_handle,
+                            ),
+                            (False, chunk_idx == num_chunks_b - 1, chunk_idx, head_idx),
+                        )
                     if cutlass.const_expr(
                         self.store_final_state or self.enable_checkpoints
                     ):
-                        kv_acc_consumer = self._store_final_state(
+                        self._store_final_state(
                             tidx,
                             mS_out,
                             mS_indices,
@@ -1351,15 +1358,14 @@ class GatedDeltaNetChunkedKernel:
                             batch_idx,
                             tmem_ptr,
                             tiled_mma_kv,
-                            kv_acc_consumer,
+                            carried_kv_handle,
                             seqlen_b,
                             mS_checkpoints,
                             checkpoint_offset,
                             checkpoint_every_n_tokens,
                         )
                     else:
-                        kv_acc_handle = kv_acc_consumer.wait_and_advance()
-                        kv_acc_handle.release()
+                        carried_kv_handle.release()
 
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
@@ -1424,31 +1430,11 @@ class GatedDeltaNetChunkedKernel:
                             state_inp_ready_consumer,
                             shared_inp_ready_consumer,
                         ),
-                        (True,),
+                        # is_first_chunk=True; has_next iff >1 chunk; no prefetch in.
+                        (True, num_chunks_b > 1),
                     )
-                # Main loop: chunks 1..num_chunks_b-1 with previous state.
-                for chunk_idx in cutlass.range(1, num_chunks_b):  # noqa: B007
-                    (
-                        shared_acc_producer,
-                        q_state_acc_producer,
-                        kv_acc_producer,
-                        load_k_consumer,
-                        load_q_consumer,
-                        load_v_consumer,
-                        a_inv_ready_consumer,
-                        qk_ready_consumer,
-                        state_inp_ready_consumer,
-                        shared_inp_ready_consumer,
-                    ) = self.mma_warp(
-                        tmem_ptr,
-                        (
-                            tiled_mma_qk,
-                            tiled_mma_qs,
-                            tiled_mma_qkv,
-                            tiled_mma_qkv_ss,
-                            tiled_mma_kv,
-                        ),
-                        (sQ, sK, sK_trans, sV, sAinv, sQk),
+                    # Main loop: chunks 1..num_chunks_b-1 with previous state.
+                    for chunk_idx in cutlass.range(1, num_chunks_b):  # noqa: B007
                         (
                             shared_acc_producer,
                             q_state_acc_producer,
@@ -1460,9 +1446,32 @@ class GatedDeltaNetChunkedKernel:
                             qk_ready_consumer,
                             state_inp_ready_consumer,
                             shared_inp_ready_consumer,
-                        ),
-                        (False,),
-                    )
+                        ) = self.mma_warp(
+                            tmem_ptr,
+                            (
+                                tiled_mma_qk,
+                                tiled_mma_qs,
+                                tiled_mma_qkv,
+                                tiled_mma_qkv_ss,
+                                tiled_mma_kv,
+                            ),
+                            (sQ, sK, sK_trans, sV, sAinv, sQk),
+                            (
+                                shared_acc_producer,
+                                q_state_acc_producer,
+                                kv_acc_producer,
+                                load_k_consumer,
+                                load_q_consumer,
+                                load_v_consumer,
+                                a_inv_ready_consumer,
+                                qk_ready_consumer,
+                                state_inp_ready_consumer,
+                                shared_inp_ready_consumer,
+                            ),
+                            # is_first_chunk=False; has_next iff not the last chunk;
+                            # consume the GEMM 1 the previous chunk prefetched.
+                            (False, chunk_idx < num_chunks_b - 1),
+                        )
 
                 scheduler.advance_to_next_work()
                 work = scheduler.get_current_work()
@@ -1974,8 +1983,6 @@ class GatedDeltaNetChunkedKernel:
         pipeline.PipelineConsumer,
         pipeline.PipelineConsumer,
         pipeline.PipelineConsumer,
-        pipeline.PipelineConsumer,
-        pipeline.PipelineConsumer,
     ]:
         """Warp 8: issue all 7 GEMMs in dependency order."""
         tiled_mma_qk, tiled_mma_qs, tiled_mma_qkv, tiled_mma_qkv_ss, tiled_mma_kv = (
@@ -1994,7 +2001,7 @@ class GatedDeltaNetChunkedKernel:
             state_inp_ready_consumer,
             shared_inp_ready_consumer,
         ) = pipeline_args
-        (is_first_chunk,) = work_args
+        (is_first_chunk, has_next) = work_args
 
         valid_state = not is_first_chunk or self.use_initial_state
 
@@ -2093,24 +2100,37 @@ class GatedDeltaNetChunkedKernel:
         # K^T as B for GEMM 7
         tCrKt_B = tiled_mma_kv.make_fragment_B(sK_trans)
 
+        num_kphases = cute.size(tCrK_A, mode=[2])
+
         # ---- GEMM 1: kk  (K @ K^T -> shared acc) ----------------------------
         # Both A and B are K; valid because tiled_mma_qk has K-major for both operands.
-        k_handle = load_k_consumer.wait_and_advance()
-        kk_handle = shared_acc_producer.acquire_and_advance()
+        if cutlass.const_expr(is_first_chunk):
+            k_handle = load_k_consumer.wait_and_advance()
+            kk_handle = shared_acc_producer.acquire_and_advance()
 
-        num_kphases = cute.size(tCrK_A, mode=[2])
-        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
-            tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
-            cute.gemm(
-                tiled_mma_qk,
-                tCtShared[None, None, None, kk_handle.index],
-                tCrK_A[None, None, kphase_idx, k_handle.index],
-                tCrK_B[None, None, kphase_idx, k_handle.index],
-                tCtShared[None, None, None, kk_handle.index],
-            )
+            for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qk,
+                    tCtShared[None, None, None, kk_handle.index],
+                    tCrK_A[None, None, kphase_idx, k_handle.index],
+                    tCrK_B[None, None, kphase_idx, k_handle.index],
+                    tCtShared[None, None, None, kk_handle.index],
+                )
 
-        # Signal W_kk ready -> CG0 kk_epi
-        kk_handle.commit()
+            # Signal W_kk ready -> CG0 kk_epi
+            kk_handle.commit()
+        else:
+            # GEMM 1 already issued + committed by the previous chunk's
+            # prefetch, which waits/acquires WITHOUT advancing: snapshot the
+            # prefetched K slot locally, then step both pipelines past it.
+            # Do NOT loop-carry handle objects across chunks instead - ptxas
+            # (CUDA 13.3, as shipped in nvidia-cutlass-dsl) cannot prove them
+            # warp-uniform and the whole MMA warp falls off the uniform
+            # datapath (elect/BSSY explosion + spills, ~30% kernel slowdown).
+            k_handle = load_k_consumer.clone().current_handle()
+            load_k_consumer.advance()
+            shared_acc_producer.advance()
 
         # ---- GEMM 2: qk  (Q @ K^T -> shared acc) ----------------------------
         # K is still held (k_handle not yet released).
@@ -2189,10 +2209,54 @@ class GatedDeltaNetChunkedKernel:
         ainv_handle.release()
         vks_handle.release()
 
-        # ---- GEMM 6: qkv  (W_qkv @ NV -> q * state acc) ------------------------
-        # W_qkv from CG0 (qk_ready, stored in sQk); NV from CG1 (new_v_ready, stored in sNv).
-        qkv_qk_handle = qk_ready_consumer.wait_and_advance()
+        # ---- prefetch next chunk's GEMM 1 (KK^T) -----------------------------
+        # wait()/acquire() do NOT advance the pipeline states; the next
+        # chunk's body snapshots the slot and advances (see the else branch
+        # above), so no handle crosses the chunk boundary.
+        if has_next:
+            pf_k_handle = load_k_consumer.wait()
+            pf_kk_handle = shared_acc_producer.acquire()
+            for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                tiled_mma_qk.set(tcgen05.Field.ACCUMULATE, kphase_idx != 0)
+                cute.gemm(
+                    tiled_mma_qk,
+                    tCtShared[None, None, None, pf_kk_handle.index],
+                    tCrK_A[None, None, kphase_idx, pf_k_handle.index],
+                    tCrK_B[None, None, kphase_idx, pf_k_handle.index],
+                    tCtShared[None, None, None, pf_kk_handle.index],
+                )
+            # Signal W_kk ready -> CG0 kk_epi (for the next chunk).
+            pf_kk_handle.commit()
+
+        # ---- GEMMs 6 + 7 (GEMM 7 issued first) --------------------------------
+        # shared_inp_ready is FIFO: consume nv (GEMM 6) before decay_v (GEMM 7).
         qkv_nv_handle = shared_inp_ready_consumer.wait_and_advance()
+        # delta from CG1 (decay_v_ready, stored in sDecayV); K^T reuses k_handle slot.
+        dv_handle = shared_inp_ready_consumer.wait_and_advance()
+
+        # ---- GEMM 7: kv_update  (K^T @ delta -> state TMEM) ---------------------
+        # First chunk: zero-init on kphase 0. Subsequent chunks: always accumulate.
+        if cutlass.const_expr(self.use_initial_state and is_first_chunk):
+            kv_acc_producer.advance()
+        kv_acc_handle = kv_acc_producer.acquire_and_advance()
+
+        num_kphases_kv = cute.size(tCrKt_B, mode=[2])
+        for kphase_idx in cutlass.range(num_kphases_kv, unroll_full=True):
+            tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0))
+            cute.gemm(
+                tiled_mma_kv,
+                tCtState[None, None, None, kv_acc_handle.index],
+                tCrDecayV_A[None, None, kphase_idx, dv_handle.index],
+                tCrKt_B[None, None, kphase_idx, k_handle.index],
+                tCtState[None, None, None, kv_acc_handle.index],
+            )
+        kv_acc_handle.commit()
+        dv_handle.release()
+        # K SMEM slot now free for next chunk
+        k_handle.release()
+
+        # ---- GEMM 6: qkv  (W_qkv @ NV -> q * state acc) ------------------------
+        qkv_qk_handle = qk_ready_consumer.wait_and_advance()
         q_state_acc_handle = q_state_acc_producer.acquire_and_advance()
 
         num_kphases_qkv = cute.size(tCrQkv_A, mode=[2])
@@ -2211,29 +2275,6 @@ class GatedDeltaNetChunkedKernel:
         qkv_qk_handle.release()
         qkv_nv_handle.release()
         q_state_acc_handle.commit()
-
-        # ---- GEMM 7: kv_update  (K^T @ delta -> state TMEM) ---------------------
-        # delta from CG1 (decay_v_ready, stored in sDecayV); K^T reuses k_handle slot.
-        # First chunk: zero-init on kphase 0. Subsequent chunks: always accumulate.
-        if cutlass.const_expr(self.use_initial_state and is_first_chunk):
-            kv_acc_producer.advance()
-        kv_acc_handle = kv_acc_producer.acquire_and_advance()
-        dv_handle = shared_inp_ready_consumer.wait_and_advance()
-
-        num_kphases_kv = cute.size(tCrKt_B, mode=[2])
-        for kphase_idx in cutlass.range(num_kphases_kv, unroll_full=True):
-            tiled_mma_kv.set(tcgen05.Field.ACCUMULATE, valid_state or (kphase_idx != 0))
-            cute.gemm(
-                tiled_mma_kv,
-                tCtState[None, None, None, kv_acc_handle.index],
-                tCrDecayV_A[None, None, kphase_idx, dv_handle.index],
-                tCrKt_B[None, None, kphase_idx, k_handle.index],
-                tCtState[None, None, None, kv_acc_handle.index],
-            )
-        kv_acc_handle.commit()
-        dv_handle.release()
-        # K SMEM slot now free for next chunk
-        k_handle.release()
 
         return (  # type: ignore[return-value]
             shared_acc_producer,
@@ -2391,34 +2432,22 @@ class GatedDeltaNetChunkedKernel:
             coord = tTR_tScS[k]
             tGrBeta[k] = sBeta[coord[0], 0, beta_handle.index]
 
-        # ------------------------------------------------------------------
         # Step 2: kk_epi - load W_kk (GEMM 1 result from TMEM), scale -> M_kk
-        #   Depends on: shared_acc stage 0 (MMA warp GEMM 1 kk done)
-        #   W_kk[i,j] *= T[i,j] * beta[i]  where T[i,j] = exp2(cumsumlog[i]-cumsumlog[j])
-        #   TMEM load is split into num_kk_subs subtiles (each covering kk_sub_size cols).
-        # ------------------------------------------------------------------
-        # Acquire sAinvNv slot, fence, signal
         ainv_handle = a_inv_ready_producer.acquire_and_advance()
-        # Acquire sQkOstore slot, write W_qkv (fp16), fence, signal
-        qk_ready_handle = qk_ready_producer.acquire_and_advance()
-        group_order_handle = group_order_producer.acquire_and_advance()
         kk_handle = shared_acc_consumer.wait_and_advance()
-
-        # tStS_for_t2r = tStS_staged[(None, None), 0, 0, kk_handle.index]
-        # tTR_tStS = thr_shared_t2r.partition_S(tStS_for_t2r)
-        # tKKrKK: full-size register buffer for M_kk (inverse step), filled subtile by subtile.
-        # tKKrKK[j] = M_kk[cg0_tidx, j] after the loop (thread owns its full row).
-        # SMEM write is deferred to the inverse step (row-major layout, below).
         tKKrKK = cute.make_rmem_tensor_like(tTR_tScS, self.acc_dtype)
-
-        tKKrKK_out = cute.make_rmem_tensor_like(tKKrKK, self.io_dtype)
-        tCrAI = tiled_ainv_r2s.retile(tKKrKK_out)
         for sub in cutlass.range(tKKrKK.shape[2]):
             cute.copy(
                 tiled_shared_t2r,
                 tTR_tStS[None, 0, sub, kk_handle.index],
                 tKKrKK[None, 0, sub],
             )
+        cute.arch.fence_view_async_tmem_load()
+        kk_handle.release()
+
+        tKKrKK_out = cute.make_rmem_tensor_like(tKKrKK, self.io_dtype)
+        tCrAI = tiled_ainv_r2s.retile(tKKrKK_out)
+        for sub in cutlass.range(tKKrKK.shape[2]):
             for k in cutlass.range(sub_tile_size):
                 tKKrKK[k, 0, sub] = (
                     tKKrKK[k, 0, sub] * tGrCumsumlog[k, 0, sub] * tGrBeta[k, 0, sub]
@@ -2431,8 +2460,36 @@ class GatedDeltaNetChunkedKernel:
                 tCrAI[None, 0, sub],
                 tCsAI[None, 0, sub, ainv_handle.index],
             )
-        # Release shared_acc stage 0 (CG1 also releases its side - collective barrier)
-        kk_handle.release()
+
+        # -- Hierarchical blockwise inverse: A_inv = (I + M_kk)^{-1} ----------
+        # Thread cg0_tidx owns row cg0_tidx of the BTxBT matrix.
+        # sAinv is reinterpreted as row-major (BTxBT) fp16 for the algorithm;
+        # the MMA-ready A-operand layout is written back via tiled_store_ainv after.
+        # NOTE: assumes io_dtype == Float16 (algorithm uses fp16 SMEM + fp32 accumulators).
+        # ------------------------------------------------------------------
+        warp_id = cg0_tidx // 32
+        lane_id = cg0_tidx % 32
+
+        sA = sAinv_mn_view[None, None, ainv_handle.index]
+        # Stage 1: Gauss-Jordan inversion of BT//8 = 16 diagonal 8x8 blocks.
+        sM_8x8 = cute.flat_divide(sA, (8, 8))
+        self.inverse_barrier.arrive_and_wait()
+        if warp_id < 2:
+            self._invert_diagonal_NxN(
+                sM_8x8[None, None, cg0_tidx // 8, cg0_tidx // 8], cg0_tidx, 8
+            )
+        self.inverse_barrier.arrive_and_wait()
+
+        # Stage 2: off-diagonal correction 8x8 -> 16x16.
+        # 8 diagonal 16x16 tiles; each warp handles 2 tiles sequentially.
+        sM_16x16 = cute.flat_divide(sA, (16, 16))
+        self._blockwise_diagonal_8x8_to_16x16(
+            sM_16x16[None, None, warp_id, warp_id], lane_id
+        )
+        self.inverse_barrier.arrive_and_wait()
+
+        qk_ready_handle = qk_ready_producer.acquire_and_advance()
+        group_order_handle = group_order_producer.acquire_and_advance()
 
         # ------------------------------------------------------------------
         # Step 3: qk_epi - load W_qk (GEMM 2 result from TMEM), scale -> W_qkv
@@ -2483,38 +2540,6 @@ class GatedDeltaNetChunkedKernel:
         valid_state = not is_first_chunk or self.use_initial_state
         if valid_state:
             shared_acc_consumer.advance()
-
-        # ------------------------------------------------------------------
-        # Step 4: inverse - compute A_inv = (I + M_kk)^{-1}, write to sAinvNv
-        #   Done after qk_epi so the inverse computation overlaps with GEMM 6
-        #   (qkv) running in the MMA warp.
-        # ------------------------------------------------------------------
-
-        # -- Hierarchical blockwise inverse: A_inv = (I + M_kk)^{-1} ----------
-        # Thread cg0_tidx owns row cg0_tidx of the BTxBT matrix.
-        # sAinv is reinterpreted as row-major (BTxBT) fp16 for the algorithm;
-        # the MMA-ready A-operand layout is written back via tiled_store_ainv after.
-        # NOTE: assumes io_dtype == Float16 (algorithm uses fp16 SMEM + fp32 accumulators).
-        warp_id = cg0_tidx // 32
-        lane_id = cg0_tidx % 32
-
-        sA = sAinv_mn_view[None, None, ainv_handle.index]
-        # Stage 1: Gauss-Jordan inversion of BT//8 = 16 diagonal 8x8 blocks.
-        sM_8x8 = cute.flat_divide(sA, (8, 8))
-        self.inverse_barrier.arrive_and_wait()
-        if warp_id < 2:
-            self._invert_diagonal_NxN(
-                sM_8x8[None, None, cg0_tidx // 8, cg0_tidx // 8], cg0_tidx, 8
-            )
-        self.inverse_barrier.arrive_and_wait()
-
-        # Stage 2: off-diagonal correction 8x8 -> 16x16.
-        # 8 diagonal 16x16 tiles; each warp handles 2 tiles sequentially.
-        sM_16x16 = cute.flat_divide(sA, (16, 16))
-        self._blockwise_diagonal_8x8_to_16x16(
-            sM_16x16[None, None, warp_id, warp_id], lane_id
-        )
-        self.inverse_barrier.arrive_and_wait()
 
         # Stage 3: off-diagonal correction 16x16 -> 32x32.
         # 4 diagonal 32x32 tiles; one tile per warp.
@@ -3037,8 +3062,7 @@ class GatedDeltaNetChunkedKernel:
         batch_idx,
         tmem_ptr,
         tiled_mma_kv,
-        # MMA -> CG1 consumer; waited+released inside this method
-        kv_acc_consumer,
+        carried_kv_handle,
         seqlen_b,
         mS_checkpoints,
         checkpoint_offset,
@@ -3046,8 +3070,9 @@ class GatedDeltaNetChunkedKernel:
     ):
         """Store final recurrent state from TMEM (fp32) to GMEM mS_out.
 
-        Waits for the last GEMM-7 (kv_acc) to complete, reads state TMEM -> registers,
-        writes registers -> GMEM fp32, then releases the consumer handle.
+        The last GEMM-7 (kv_acc) was already awaited in compute_group_1's
+        kv_update_epi; here we read state TMEM -> registers, write -> GMEM fp32,
+        then release the carried kv_acc handle.
         """
         num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
         cg1_tidx = tidx % num_threads_cg1
@@ -3079,8 +3104,7 @@ class GatedDeltaNetChunkedKernel:
         tTR_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.acc_dtype)
         tRG_rState = cute.make_rmem_tensor_like(tTR_tCcState, self.state_dtype)
 
-        # Wait for last GEMM-7 to finish
-        kv_acc_handle = kv_acc_consumer.wait_and_advance()
+        kv_acc_handle = carried_kv_handle
 
         # Optional indexed (pool) access: write the recurrent-state row by an
         # indirection index instead of the sequence-order batch_idx. Loaded
@@ -3090,7 +3114,6 @@ class GatedDeltaNetChunkedKernel:
             state_row = mS_indices[batch_idx]
         else:
             state_row = batch_idx
-
         for sub in cutlass.range(tTR_rState.shape[2]):
             # Read state TMEM -> fp32 registers
             cute.copy(
@@ -3131,8 +3154,7 @@ class GatedDeltaNetChunkedKernel:
                     tRG_tCgState,
                     l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
                 )
-        kv_acc_handle.release()
-        return kv_acc_consumer
+        carried_kv_handle.release()
 
     @cute.jit
     def compute_group_1(
@@ -3173,9 +3195,10 @@ class GatedDeltaNetChunkedKernel:
             state_inp_ready_producer,
             shared_inp_ready_producer,
             o_store_producer,
+            carried_kv_handle,
         ) = pipeline_args
         tiled_mma_kv, tiled_mma_qs, tiled_mma_qkv = mma_args
-        (is_first_chunk, chunk_idx, head_idx) = work_args
+        (is_first_chunk, is_last_chunk, chunk_idx, head_idx) = work_args
 
         num_threads_cg1 = self.threads_per_warp * len(self.compute_group_1_warp_ids)
         cg1_tidx = tidx % num_threads_cg1
@@ -3359,20 +3382,21 @@ class GatedDeltaNetChunkedKernel:
 
         sub_tile_size = 32
 
-        gate_handle = load_gate_consumer.wait_and_advance()
-
-        cumprod_total = sCumprod[sCumprod.shape[0] - 1, 0, gate_handle.index]
+        shared_acc_consumer.advance()
+        shared_acc_consumer.advance()
 
         valid_state = not is_first_chunk or self.use_initial_state
         if cutlass.const_expr(valid_state):
             if cutlass.const_expr(self.use_initial_state):
                 kv_acc_producer.advance()
-            # Wait for previous chunk's GEMM 7 to finish writing dS.
-            # This also serialises the TMEM read-modify-write vs GEMM 7.
-            kv_handle = kv_acc_consumer.wait_and_advance()
+            if cutlass.const_expr(is_first_chunk):
+                # First chunk has no carried handle; wait for the initial-state
+                # kv_acc loaded by _load_initial_state.
+                kv_handle = kv_acc_consumer.wait_and_advance()
+            else:
+                kv_handle = carried_kv_handle
 
-            state_inp_ready_handle = state_inp_ready_producer.acquire_and_advance()
-            for sub in cutlass.range(tRT_rState_inp.shape[2]):
+            for sub in cutlass.range(tTR_rState.shape[2]):
                 cute.copy(
                     tiled_state_t2r,
                     tTR_tCtState[None, 0, sub, kv_handle.index],
@@ -3402,16 +3426,25 @@ class GatedDeltaNetChunkedKernel:
                             l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
                         )
 
-                tRT_rState_inp[None, 0, sub].store(
-                    tTR_rState[None, 0, sub].load().to(self.io_dtype)
-                )
-                cute.copy(
-                    tiled_state_inp_r2t,
-                    tRT_rState_inp[None, 0, sub],
-                    tRT_tCtState_inp[None, 0, sub, state_inp_ready_handle.index],
-                )
-            cute.arch.fence_view_async_tmem_store()
-            state_inp_ready_handle.commit()
+            if cutlass.const_expr(is_first_chunk):
+                # First chunk with an initial state: stage the (raw) initial S into
+                # state_inp for this chunk's GEMM 3/4. Later chunks receive this
+                # from the previous chunk's kv_update_epi.
+                si_init_handle = state_inp_ready_producer.acquire_and_advance()
+                for sub in cutlass.range(tRT_rState_inp.shape[2]):
+                    tRT_rState_inp[None, 0, sub].store(
+                        tTR_rState[None, 0, sub].load().to(self.io_dtype)
+                    )
+                    cute.copy(
+                        tiled_state_inp_r2t,
+                        tRT_rState_inp[None, 0, sub],
+                        tRT_tCtState_inp[None, 0, sub, si_init_handle.index],
+                    )
+                cute.arch.fence_view_async_tmem_store()
+                si_init_handle.commit()
+
+            gate_handle = load_gate_consumer.wait_and_advance()
+            cumprod_total = sCumprod[sCumprod.shape[0] - 1, 0, gate_handle.index]
 
             # Load S_prev -> scale by Phi -> write Phi*S_prev back to same TMEM slot.
             for sub in cutlass.range(tTR_rState.shape[2]):
@@ -3430,10 +3463,8 @@ class GatedDeltaNetChunkedKernel:
             # Release slot - MMA can now acquire it for this chunk's GEMM 7
             # (which accumulates dS on top of Phi*S_prev).
             kv_handle.release()
-
-        # wait for kk and qk epilogue to finish
-        shared_acc_consumer.advance()
-        shared_acc_consumer.advance()
+        else:
+            gate_handle = load_gate_consumer.wait_and_advance()
 
         rCumprod = cute.make_rmem_tensor((1, cute.size(tTR_tCcShared)), self.acc_dtype)
         tGrCumprod = thr_shared_t2r.partition_D(rCumprod)
@@ -3565,6 +3596,27 @@ class GatedDeltaNetChunkedKernel:
         cute.arch.fence_view_async_tmem_store()
         decay_v_handle.commit()
 
+        # ---- kv_update_epi: stage this chunk's updated state to state_inp -------
+        new_kv_handle = kv_acc_consumer.wait_and_advance()
+        if not is_last_chunk:
+            si_handle = state_inp_ready_producer.acquire_and_advance()
+            for sub in cutlass.range(tRT_rState_inp.shape[2]):
+                cute.copy(
+                    tiled_state_t2r,
+                    tTR_tCtState[None, 0, sub, new_kv_handle.index],
+                    tTR_rState[None, 0, sub],
+                )
+                tRT_rState_inp[None, 0, sub].store(
+                    tTR_rState[None, 0, sub].load().to(self.io_dtype)
+                )
+                cute.copy(
+                    tiled_state_inp_r2t,
+                    tRT_rState_inp[None, 0, sub],
+                    tRT_tCtState_inp[None, 0, sub, si_handle.index],
+                )
+            cute.arch.fence_view_async_tmem_store()
+            si_handle.commit()
+
         # ---- qkv_epilogue -----------------------------------------------------
         # GEMM 6 accumulated W_qkv@NV into q_state TMEM on top of the scaled Q*S.
         # q_state_acc second wait (same 1-stage pipeline, wraps back to stage 0).
@@ -3580,16 +3632,15 @@ class GatedDeltaNetChunkedKernel:
             tTR_tOrO,
         )
         group_order_handle.release()
+        cute.arch.fence_view_async_tmem_load()
+        qs_handle2.release()
         tTR_rO_out.store(tTR_tOrO.load().to(self.io_dtype))
+
         cute.copy(tiled_o_r2s, tRS_tOrO, tCsO[None, None, None, o_handle.index])
         cute.arch.fence_view_async_shared()
-        qs_handle2.release()
 
         # O in sQkOstore ready for epilogue warp TMA store
         o_handle.commit()
-
-        # ---- kv_update_epi ----------------------------------------------------
-        # None, do state update at the beginning of the next chunk.
         return (  # type: ignore[return-value]
             load_v_consumer,
             load_gate_consumer,
@@ -3602,6 +3653,7 @@ class GatedDeltaNetChunkedKernel:
             shared_inp_ready_producer,
             o_store_producer,
             checkpoint_offset,
+            new_kv_handle,
         )
 
     @cute.jit


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description
Add back GDN prefill optimizations (~20-25% mainloop -> up to 15% total kernel time). Benchmarks are collected at h_q = h_v = 1, d_k = d_v = 128 at locked 900 MHz.

  | config    | pre us  | MR us   | MR vs pre |
  |-----------|--------:|--------:|----------:|
  | 1x8192    | 672.679 | 585.815 |    -12.9% |
  | 1x4096    | 351.188 | 308.325 |    -12.2% |
  | 1x2048    | 190.556 | 169.249 |    -11.2% |
  | 6144+2048 | 511.785 | 447.305 |    -12.6% |
  | 4096+4096 | 351.431 | 308.618 |    -12.2% |
  | 2048+6144 | 504.766 | 446.014 |    -11.6% |
  | 1024+7168 | 583.742 | 515.259 |    -11.7% |
  | 2048x4    | 190.582 | 169.815 |    -10.9% |
  | 1024x8    | 110.743 | 100.595 |     -9.2% |


# GDN Prefill Benchmark: FI Pre-MR vs Post-MR (GB200)

- **GPU**: NVIDIA GB200 [Blackwell (SM100)], free clocks
- **Models**: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128
- **FI Pre-MR**: main @ `a6c62681` (without change)
- **FI Post-MR**: `jopark/gdn_prefill_opt_dsl_fix`
- **Command**: `python -u benchmarks/bench_gdn_prefill.py --use-cuda-graph --cooling-time 0.3 --warmup 2 --iters 8`
- **Delta** = (Post - Pre) / Pre; **Speedup** = FLA / FI Post-MR

| Heads | Seqlens | h_qk | h_v | FI Pre-MR | FI Post-MR | Delta | FLA/Triton | Speedup |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| 397B/122B TP8 | 1x65536 | 2 | 8 | 2.311ms | 2.177ms | -5.8% | 1.862ms | 0.86x |
| 397B/122B TP8 | 1x32768 | 2 | 8 | 1.165ms | 1.099ms | -5.7% | 0.948ms | 0.86x |
| 397B/122B TP8 | 1x16384 | 2 | 8 | 0.591ms | 0.558ms | -5.6% | 0.483ms | 0.87x |
| 397B/122B TP8 | 1x8192 | 2 | 8 | 0.305ms | 0.281ms | -7.9% | 0.250ms | 0.89x |
| 397B/122B TP8 | 1x4096 | 2 | 8 | 0.162ms | 0.150ms | -7.4% | 0.141ms | 0.94x |
| 397B/122B TP8 | 1x2048 | 2 | 8 | 0.089ms | 0.082ms | -7.9% | 0.086ms | 1.05x |
| 397B/122B TP8 | 6144+2048 | 2 | 8 | 0.233ms | 0.215ms | -7.7% | 0.209ms | 0.97x |
| 397B/122B TP8 | 4096+4096 | 2 | 8 | 0.161ms | 0.150ms | -6.8% | 0.167ms | 1.11x |
| 397B/122B TP8 | 2048+6144 | 2 | 8 | 0.233ms | 0.215ms | -7.7% | 0.208ms | 0.97x |
| 397B/122B TP8 | 1024+7168 | 2 | 8 | 0.269ms | 0.248ms | -7.8% | 0.229ms | 0.92x |
| 397B/122B TP8 | 2048x4 | 2 | 8 | 0.091ms | 0.086ms | -5.5% | 0.125ms | 1.45x |
| 397B/122B TP8 | 1024x8 | 2 | 8 | 0.056ms | 0.053ms | -5.4% | 0.130ms | 2.45x |
| 397B/122B TP8 | 8192x8 | 2 | 8 | 0.307ms | 0.294ms | -4.2% | 0.866ms | 2.95x |
| 397B/122B TP8 | 8192x16 | 2 | 8 | 0.309ms | 0.306ms | -1.0% | 1.710ms | 5.59x |
| 397B/122B TP8 | 8192x32 | 2 | 8 | 0.611ms | 0.600ms | -1.8% | 3.214ms | 5.36x |
| 397B/122B TP4 | 1x65536 | 4 | 16 | 2.306ms | 2.180ms | -5.5% | 2.385ms | 1.09x |
| 397B/122B TP4 | 1x32768 | 4 | 16 | 1.162ms | 1.098ms | -5.5% | 1.200ms | 1.09x |
| 397B/122B TP4 | 1x16384 | 4 | 16 | 0.591ms | 0.560ms | -5.2% | 0.619ms | 1.11x |
| 397B/122B TP4 | 1x8192 | 4 | 16 | 0.305ms | 0.288ms | -5.6% | 0.318ms | 1.10x |
| 397B/122B TP4 | 1x4096 | 4 | 16 | 0.161ms | 0.149ms | -7.5% | 0.168ms | 1.13x |
| 397B/122B TP4 | 1x2048 | 4 | 16 | 0.090ms | 0.084ms | -6.7% | 0.100ms | 1.19x |
| 397B/122B TP4 | 6144+2048 | 4 | 16 | 0.233ms | 0.220ms | -5.6% | 0.277ms | 1.26x |
| 397B/122B TP4 | 4096+4096 | 4 | 16 | 0.163ms | 0.155ms | -4.9% | 0.235ms | 1.52x |
| 397B/122B TP4 | 2048+6144 | 4 | 16 | 0.235ms | 0.222ms | -5.5% | 0.277ms | 1.25x |
| 397B/122B TP4 | 1024+7168 | 4 | 16 | 0.271ms | 0.256ms | -5.5% | 0.298ms | 1.16x |
| 397B/122B TP4 | 2048x4 | 4 | 16 | 0.092ms | 0.090ms | -2.2% | 0.240ms | 2.67x |
| 397B/122B TP4 | 1024x8 | 4 | 16 | 0.058ms | 0.058ms | +0.0% | 0.248ms | 4.28x |
| 397B/122B TP4 | 8192x8 | 4 | 16 | 0.308ms | 0.307ms | -0.3% | 1.718ms | 5.60x |
| 397B/122B TP4 | 8192x16 | 4 | 16 | 0.611ms | 0.613ms | +0.3% | 3.244ms | 5.29x |
| 397B/122B TP4 | 8192x32 | 4 | 16 | 1.208ms | 1.203ms | -0.4% | 6.471ms | 5.38x |
| 397B/122B TP2 | 1x65536 | 8 | 32 | 2.325ms | 2.275ms | -2.2% | 3.431ms | 1.51x |
| 397B/122B TP2 | 1x32768 | 8 | 32 | 1.172ms | 1.148ms | -2.0% | 1.726ms | 1.50x |
| 397B/122B TP2 | 1x16384 | 8 | 32 | 0.596ms | 0.585ms | -1.8% | 0.875ms | 1.50x |
| 397B/122B TP2 | 1x8192 | 8 | 32 | 0.308ms | 0.302ms | -1.9% | 0.456ms | 1.51x |
| 397B/122B TP2 | 1x4096 | 8 | 32 | 0.164ms | 0.158ms | -3.7% | 0.238ms | 1.51x |
| 397B/122B TP2 | 1x2048 | 8 | 32 | 0.091ms | 0.085ms | -6.6% | 0.128ms | 1.51x |
| 397B/122B TP2 | 6144+2048 | 8 | 32 | 0.235ms | 0.233ms | -0.9% | 0.456ms | 1.96x |
| 397B/122B TP2 | 4096+4096 | 8 | 32 | 0.164ms | 0.164ms | +0.0% | 0.458ms | 2.79x |
| 397B/122B TP2 | 2048+6144 | 8 | 32 | 0.237ms | 0.231ms | -2.5% | 0.460ms | 1.99x |
| 397B/122B TP2 | 1024+7168 | 8 | 32 | 0.273ms | 0.266ms | -2.6% | 0.460ms | 1.73x |
| 397B/122B TP2 | 2048x4 | 8 | 32 | 0.094ms | 0.096ms | +2.1% | 0.465ms | 4.84x |
| 397B/122B TP2 | 1024x8 | 8 | 32 | 0.111ms | 0.111ms | +0.0% | 0.460ms | 4.14x |
| 397B/122B TP2 | 8192x8 | 8 | 32 | 0.614ms | 0.629ms | +2.4% | 3.265ms | 5.19x |
| 397B/122B TP2 | 8192x16 | 8 | 32 | 1.216ms | 1.246ms | +2.5% | 6.532ms | 5.24x |
| 397B/122B TP2 | 8192x32 | 8 | 32 | 2.137ms | 2.197ms | +2.8% | 12.916ms | 5.88x |
| 397B/122B TP1 | 1x65536 | 16 | 64 | 2.327ms | 2.318ms | -0.4% | 5.985ms | 2.58x |
| 397B/122B TP1 | 1x32768 | 16 | 64 | 1.175ms | 1.169ms | -0.5% | 2.958ms | 2.53x |
| 397B/122B TP1 | 1x16384 | 16 | 64 | 0.597ms | 0.595ms | -0.3% | 1.494ms | 2.51x |
| 397B/122B TP1 | 1x8192 | 16 | 64 | 0.308ms | 0.308ms | +0.0% | 0.761ms | 2.47x |
| 397B/122B TP1 | 1x4096 | 16 | 64 | 0.164ms | 0.164ms | +0.0% | 0.401ms | 2.45x |
| 397B/122B TP1 | 1x2048 | 16 | 64 | 0.092ms | 0.092ms | +0.0% | 0.213ms | 2.32x |
| 397B/122B TP1 | 6144+2048 | 16 | 64 | 0.237ms | 0.240ms | +1.3% | 0.761ms | 3.17x |
| 397B/122B TP1 | 4096+4096 | 16 | 64 | 0.167ms | 0.171ms | +2.4% | 0.765ms | 4.47x |
| 397B/122B TP1 | 2048+6144 | 16 | 64 | 0.238ms | 0.240ms | +0.8% | 0.768ms | 3.20x |
| 397B/122B TP1 | 1024+7168 | 16 | 64 | 0.274ms | 0.275ms | +0.4% | 0.769ms | 2.80x |
| 397B/122B TP1 | 2048x4 | 16 | 64 | 0.182ms | 0.186ms | +2.2% | 0.777ms | 4.18x |
| 397B/122B TP1 | 1024x8 | 16 | 64 | 0.214ms | 0.215ms | +0.5% | 0.768ms | 3.57x |
| 397B/122B TP1 | 8192x8 | 16 | 64 | 1.219ms | 1.253ms | +2.8% | 5.755ms | 4.59x |
| 397B/122B TP1 | 8192x16 | 16 | 64 | 2.142ms | 2.212ms | +3.3% | 11.550ms | 5.22x |
| 397B/122B TP1 | 8192x32 | 16 | 64 | 4.248ms | 4.416ms | +4.0% | 22.977ms | 5.20x |
| 35B/9B/4B TP1 | 1x65536 | 16 | 32 | 2.327ms | 2.271ms | -2.4% | 3.430ms | 1.51x |
| 35B/9B/4B TP1 | 1x32768 | 16 | 32 | 1.173ms | 1.146ms | -2.3% | 1.724ms | 1.50x |
| 35B/9B/4B TP1 | 1x16384 | 16 | 32 | 0.596ms | 0.584ms | -2.0% | 0.874ms | 1.50x |
| 35B/9B/4B TP1 | 1x8192 | 16 | 32 | 0.307ms | 0.301ms | -2.0% | 0.455ms | 1.51x |
| 35B/9B/4B TP1 | 1x4096 | 16 | 32 | 0.163ms | 0.160ms | -1.8% | 0.237ms | 1.48x |
| 35B/9B/4B TP1 | 1x2048 | 16 | 32 | 0.091ms | 0.085ms | -6.6% | 0.128ms | 1.51x |
| 35B/9B/4B TP1 | 6144+2048 | 16 | 32 | 0.235ms | 0.233ms | -0.9% | 0.456ms | 1.96x |
| 35B/9B/4B TP1 | 4096+4096 | 16 | 32 | 0.163ms | 0.164ms | +0.6% | 0.458ms | 2.79x |
| 35B/9B/4B TP1 | 2048+6144 | 16 | 32 | 0.235ms | 0.231ms | -1.7% | 0.459ms | 1.99x |
| 35B/9B/4B TP1 | 1024+7168 | 16 | 32 | 0.272ms | 0.265ms | -2.6% | 0.460ms | 1.74x |
| 35B/9B/4B TP1 | 2048x4 | 16 | 32 | 0.094ms | 0.097ms | +3.2% | 0.465ms | 4.79x |
| 35B/9B/4B TP1 | 1024x8 | 16 | 32 | 0.110ms | 0.111ms | +0.9% | 0.459ms | 4.14x |
| 35B/9B/4B TP1 | 8192x8 | 16 | 32 | 0.615ms | 0.631ms | +2.6% | 3.272ms | 5.19x |
| 35B/9B/4B TP1 | 8192x16 | 16 | 32 | 1.217ms | 1.250ms | +2.7% | 6.540ms | 5.23x |
| 35B/9B/4B TP1 | 8192x32 | 16 | 32 | 2.143ms | 2.204ms | +2.8% | 12.915ms | 5.86x |
| 27B TP1 | 1x65536 | 16 | 48 | 2.284ms | 2.292ms | +0.4% | 5.074ms | 2.21x |
| 27B TP1 | 1x32768 | 16 | 48 | 1.152ms | 1.157ms | +0.4% | 2.496ms | 2.16x |
| 27B TP1 | 1x16384 | 16 | 48 | 0.586ms | 0.588ms | +0.3% | 1.261ms | 2.14x |
| 27B TP1 | 1x8192 | 16 | 48 | 0.304ms | 0.305ms | +0.3% | 0.653ms | 2.14x |
| 27B TP1 | 1x4096 | 16 | 48 | 0.162ms | 0.163ms | +0.6% | 0.341ms | 2.09x |
| 27B TP1 | 1x2048 | 16 | 48 | 0.091ms | 0.087ms | -4.4% | 0.192ms | 2.21x |
| 27B TP1 | 6144+2048 | 16 | 48 | 0.234ms | 0.236ms | +0.9% | 0.598ms | 2.53x |
| 27B TP1 | 4096+4096 | 16 | 48 | 0.164ms | 0.167ms | +1.8% | 0.652ms | 3.90x |
| 27B TP1 | 2048+6144 | 16 | 48 | 0.236ms | 0.235ms | -0.4% | 0.654ms | 2.78x |
| 27B TP1 | 1024+7168 | 16 | 48 | 0.271ms | 0.269ms | -0.7% | 0.655ms | 2.43x |
| 27B TP1 | 2048x4 | 16 | 48 | 0.181ms | 0.182ms | +0.6% | 0.607ms | 3.34x |
| 27B TP1 | 1024x8 | 16 | 48 | 0.162ms | 0.162ms | +0.0% | 0.615ms | 3.80x |
| 27B TP1 | 8192x8 | 16 | 48 | 0.913ms | 0.940ms | +3.0% | 4.505ms | 4.79x |
| 27B TP1 | 8192x16 | 16 | 48 | 1.822ms | 1.877ms | +3.0% | 8.861ms | 4.72x |
| 27B TP1 | 8192x32 | 16 | 48 | 3.329ms | 3.449ms | +3.6% | 17.570ms | 5.09x |
| 2B/0.8B TP1 | 1x65536 | 16 | 16 | 2.318ms | 2.185ms | -5.7% | 2.389ms | 1.09x |
| 2B/0.8B TP1 | 1x32768 | 16 | 16 | 1.169ms | 1.099ms | -6.0% | 1.200ms | 1.09x |
| 2B/0.8B TP1 | 1x16384 | 16 | 16 | 0.594ms | 0.562ms | -5.4% | 0.619ms | 1.10x |
| 2B/0.8B TP1 | 1x8192 | 16 | 16 | 0.307ms | 0.293ms | -4.6% | 0.318ms | 1.09x |
| 2B/0.8B TP1 | 1x4096 | 16 | 16 | 0.163ms | 0.151ms | -7.4% | 0.168ms | 1.11x |
| 2B/0.8B TP1 | 1x2048 | 16 | 16 | 0.091ms | 0.085ms | -6.6% | 0.100ms | 1.18x |
| 2B/0.8B TP1 | 6144+2048 | 16 | 16 | 0.234ms | 0.225ms | -3.8% | 0.277ms | 1.23x |
| 2B/0.8B TP1 | 4096+4096 | 16 | 16 | 0.164ms | 0.159ms | -3.0% | 0.235ms | 1.48x |
| 2B/0.8B TP1 | 2048+6144 | 16 | 16 | 0.237ms | 0.226ms | -4.6% | 0.277ms | 1.23x |
| 2B/0.8B TP1 | 1024+7168 | 16 | 16 | 0.273ms | 0.260ms | -4.8% | 0.298ms | 1.15x |
| 2B/0.8B TP1 | 2048x4 | 16 | 16 | 0.093ms | 0.092ms | -1.1% | 0.240ms | 2.61x |
| 2B/0.8B TP1 | 1024x8 | 16 | 16 | 0.059ms | 0.059ms | +0.0% | 0.248ms | 4.20x |
| 2B/0.8B TP1 | 8192x8 | 16 | 16 | 0.310ms | 0.314ms | +1.3% | 1.718ms | 5.47x |
| 2B/0.8B TP1 | 8192x16 | 16 | 16 | 0.618ms | 0.620ms | +0.3% | 3.246ms | 5.24x |
| 2B/0.8B TP1 | 8192x32 | 16 | 16 | 1.223ms | 1.218ms | -0.4% | 6.481ms | 5.32x |
| Sym h32 | 1x65536 | 32 | 32 | 2.345ms | 2.281ms | -2.7% | 3.426ms | 1.50x |
| Sym h32 | 1x32768 | 32 | 32 | 1.183ms | 1.150ms | -2.8% | 1.724ms | 1.50x |
| Sym h32 | 1x16384 | 32 | 32 | 0.601ms | 0.585ms | -2.7% | 0.874ms | 1.49x |
| Sym h32 | 1x8192 | 32 | 32 | 0.310ms | 0.302ms | -2.6% | 0.456ms | 1.51x |
| Sym h32 | 1x4096 | 32 | 32 | 0.165ms | 0.161ms | -2.4% | 0.238ms | 1.48x |
| Sym h32 | 1x2048 | 32 | 32 | 0.092ms | 0.086ms | -6.5% | 0.128ms | 1.49x |
| Sym h32 | 6144+2048 | 32 | 32 | 0.237ms | 0.234ms | -1.3% | 0.456ms | 1.95x |
| Sym h32 | 4096+4096 | 32 | 32 | 0.165ms | 0.165ms | +0.0% | 0.458ms | 2.78x |
| Sym h32 | 2048+6144 | 32 | 32 | 0.237ms | 0.232ms | -2.1% | 0.459ms | 1.98x |
| Sym h32 | 1024+7168 | 32 | 32 | 0.274ms | 0.266ms | -2.9% | 0.460ms | 1.73x |
| Sym h32 | 2048x4 | 32 | 32 | 0.095ms | 0.097ms | +2.1% | 0.465ms | 4.79x |
| Sym h32 | 1024x8 | 32 | 32 | 0.111ms | 0.112ms | +0.9% | 0.459ms | 4.10x |
| Sym h32 | 8192x8 | 32 | 32 | 0.620ms | 0.639ms | +3.1% | 3.263ms | 5.11x |
| Sym h32 | 8192x16 | 32 | 32 | 1.231ms | 1.265ms | +2.8% | 6.532ms | 5.16x |
| Sym h32 | 8192x32 | 32 | 32 | 2.164ms | 2.235ms | +3.3% | 12.929ms | 5.78x |

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced chunked Gated Delta Net prefill efficiency on Blackwell GPUs.
  * Added next-chunk lookahead to better overlap compute and memory work.
  * Improved scheduling of GEMM stages for smoother pipeline utilization.

* **Bug Fixes**
  * Fixed multi-chunk final-state handling to ensure correct state materialization.
  * Improved synchronization and intermediate computation ordering for more reliable chunk transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->