### PR TITLE
fix(quantization): prefer arch-specific fp4_quantization module on SM12x

### DIFF
--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -234,24 +234,19 @@ def get_fp4_quantization_module(backend: str = "100"):
         "90": gen_fp4_quantization_sm90_module,
     }
 
-    # On SM12x, prefer the arch-specific module (sm_120a / sm_121a), matching
-    # GEMM/MoE dispatch and what aot.py builds. Fall back to the sm_120f family
-    # variant only when it is the one prebuilt (release wheels build 12.0f only),
-    # so wheel users load it instead of JIT-compiling.
-    if backend in ("120", "121"):
-        from ..utils import version_at_least
-
-        if (
-            version_at_least(torch.version.cuda, "12.9")
-            and not backend_modules[backend]().is_aot
-            and gen_fp4_quantization_sm120f_module().is_aot
-        ):
-            backend = "120f"
-
     if backend not in backend_modules:
         raise ValueError(f"Invalid backend: {backend}")
 
-    module = backend_modules[backend]().build_and_load()
+    spec = backend_modules[backend]()
+    # SM12x uses the arch-specific module (sm_120a / sm_121a). When only the
+    # sm_120f family module is prebuilt (SM121 release wheels), load it
+    # instead of JIT-compiling.
+    if backend in ("120", "121") and not spec.is_aot:
+        family_spec = backend_modules["120f"]()
+        if family_spec.is_aot:
+            spec = family_spec
+
+    module = spec.build_and_load()
 
     @register_custom_op(
         "flashinfer::fp4_quantize_sm100",

--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -234,14 +234,18 @@ def get_fp4_quantization_module(backend: str = "100"):
         "90": gen_fp4_quantization_sm90_module,
     }
 
-    # Prefer 'f' (family / feature-set) variant for SM12x when CUDA >= 12.9,
-    # as it enables native FP4 conversion instructions (cvt.rn.satfinite.e2m1x2.f32).
-    # sm_120f covers the entire SM12x family (both SM120 and SM121).
-    # See: https://developer.nvidia.com/blog/nvidia-blackwell-and-nvidia-cuda-12-9-introduce-family-specific-architecture-features/
+    # On SM12x, prefer the arch-specific module (sm_120a / sm_121a), matching
+    # GEMM/MoE dispatch and what aot.py builds. Fall back to the sm_120f family
+    # variant only when it is the one prebuilt (release wheels build 12.0f only),
+    # so wheel users load it instead of JIT-compiling.
     if backend in ("120", "121"):
         from ..utils import version_at_least
 
-        if version_at_least(torch.version.cuda, "12.9"):
+        if (
+            version_at_least(torch.version.cuda, "12.9")
+            and not backend_modules[backend]().is_aot
+            and gen_fp4_quantization_sm120f_module().is_aot
+        ):
             backend = "120f"
 
     if backend not in backend_modules:

--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -245,24 +245,19 @@ def get_fp4_quantization_module(backend: str = "100"):
         "90": gen_fp4_quantization_sm90_module,
     }
 
-    # On SM12x, prefer the arch-specific module (sm_120a / sm_121a), matching
-    # GEMM/MoE dispatch and what aot.py builds. Fall back to the sm_120f family
-    # variant only when it is the one prebuilt (release wheels build 12.0f only),
-    # so wheel users load it instead of JIT-compiling.
-    if backend in ("120", "121"):
-        from ..utils import version_at_least
-
-        if (
-            version_at_least(torch.version.cuda, "12.9")
-            and not backend_modules[backend]().is_aot
-            and gen_fp4_quantization_sm120f_module().is_aot
-        ):
-            backend = "120f"
-
     if backend not in backend_modules:
         raise ValueError(f"Invalid backend: {backend}")
 
-    module = backend_modules[backend]().build_and_load()
+    spec = backend_modules[backend]()
+    # SM12x uses the arch-specific module (sm_120a / sm_121a). When only the
+    # sm_120f family module is prebuilt (SM121 release wheels), load it
+    # instead of JIT-compiling.
+    if backend in ("120", "121") and not spec.is_aot:
+        family_spec = backend_modules["120f"]()
+        if family_spec.is_aot:
+            spec = family_spec
+
+    module = spec.build_and_load()
 
     @register_custom_op(
         "flashinfer::fp4_quantize_sm100",

--- a/flashinfer/quantization/fp4_quantization.py
+++ b/flashinfer/quantization/fp4_quantization.py
@@ -245,14 +245,18 @@ def get_fp4_quantization_module(backend: str = "100"):
         "90": gen_fp4_quantization_sm90_module,
     }
 
-    # Prefer 'f' (family / feature-set) variant for SM12x when CUDA >= 12.9,
-    # as it enables native FP4 conversion instructions (cvt.rn.satfinite.e2m1x2.f32).
-    # sm_120f covers the entire SM12x family (both SM120 and SM121).
-    # See: https://developer.nvidia.com/blog/nvidia-blackwell-and-nvidia-cuda-12-9-introduce-family-specific-architecture-features/
+    # On SM12x, prefer the arch-specific module (sm_120a / sm_121a), matching
+    # GEMM/MoE dispatch and what aot.py builds. Fall back to the sm_120f family
+    # variant only when it is the one prebuilt (release wheels build 12.0f only),
+    # so wheel users load it instead of JIT-compiling.
     if backend in ("120", "121"):
         from ..utils import version_at_least
 
-        if version_at_least(torch.version.cuda, "12.9"):
+        if (
+            version_at_least(torch.version.cuda, "12.9")
+            and not backend_modules[backend]().is_aot
+            and gen_fp4_quantization_sm120f_module().is_aot
+        ):
             backend = "120f"
 
     if backend not in backend_modules:

--- a/tests/utils/test_fp4_quantize.py
+++ b/tests/utils/test_fp4_quantize.py
@@ -1522,5 +1522,54 @@ def test_nvfp4_quantize_global_scale_dtype_regression(m: int, scale_dtype: torch
     )
 
 
+class _StopAfterSelection(Exception):
+    """Raised by the stubbed build_and_load to halt before op registration."""
+
+
+@pytest.mark.parametrize(
+    "backend,aot_names,expected",
+    [
+        # No AOT modules (source install): use the arch-specific module.
+        ("120", frozenset(), "fp4_quantization_120"),
+        ("121", frozenset(), "fp4_quantization_121"),
+        # Only the family module is prebuilt (SM121 release wheels): use it.
+        ("120", frozenset({"fp4_quantization_120f"}), "fp4_quantization_120f"),
+        ("121", frozenset({"fp4_quantization_120f"}), "fp4_quantization_120f"),
+        # Arch module prebuilt: prefer it over the family module.
+        (
+            "121",
+            frozenset({"fp4_quantization_121", "fp4_quantization_120f"}),
+            "fp4_quantization_121",
+        ),
+        # Non-SM12x backends never redirect.
+        ("100", frozenset({"fp4_quantization_120f"}), "fp4_quantization_100"),
+    ],
+)
+def test_fp4_quantization_module_selection(monkeypatch, backend, aot_names, expected):
+    """CPU-only check of the SM12x arch-vs-family module selection."""
+    from flashinfer.jit.core import JitSpec
+    from flashinfer.quantization import fp4_quantization as fp4q
+
+    selected = []
+
+    def fake_build_and_load(self):
+        selected.append(self.name)
+        raise _StopAfterSelection
+
+    monkeypatch.setattr(
+        JitSpec, "is_aot", property(lambda self: self.name in aot_names)
+    )
+    monkeypatch.setattr(JitSpec, "build_and_load", fake_build_and_load)
+
+    fp4q.get_fp4_quantization_module.cache_clear()
+    try:
+        with pytest.raises(_StopAfterSelection):
+            fp4q.get_fp4_quantization_module(backend)
+    finally:
+        fp4q.get_fp4_quantization_module.cache_clear()
+
+    assert selected == [expected]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/utils/test_fp4_quantize.py
+++ b/tests/utils/test_fp4_quantize.py
@@ -1856,5 +1856,54 @@ def test_nvfp4_quantize_global_scale_dtype_regression(m: int, scale_dtype: torch
     )
 
 
+class _StopAfterSelection(Exception):
+    """Raised by the stubbed build_and_load to halt before op registration."""
+
+
+@pytest.mark.parametrize(
+    "backend,aot_names,expected",
+    [
+        # No AOT modules (source install): use the arch-specific module.
+        ("120", frozenset(), "fp4_quantization_120"),
+        ("121", frozenset(), "fp4_quantization_121"),
+        # Only the family module is prebuilt (SM121 release wheels): use it.
+        ("120", frozenset({"fp4_quantization_120f"}), "fp4_quantization_120f"),
+        ("121", frozenset({"fp4_quantization_120f"}), "fp4_quantization_120f"),
+        # Arch module prebuilt: prefer it over the family module.
+        (
+            "121",
+            frozenset({"fp4_quantization_121", "fp4_quantization_120f"}),
+            "fp4_quantization_121",
+        ),
+        # Non-SM12x backends never redirect.
+        ("100", frozenset({"fp4_quantization_120f"}), "fp4_quantization_100"),
+    ],
+)
+def test_fp4_quantization_module_selection(monkeypatch, backend, aot_names, expected):
+    """CPU-only check of the SM12x arch-vs-family module selection."""
+    from flashinfer.jit.core import JitSpec
+    from flashinfer.quantization import fp4_quantization as fp4q
+
+    selected = []
+
+    def fake_build_and_load(self):
+        selected.append(self.name)
+        raise _StopAfterSelection
+
+    monkeypatch.setattr(
+        JitSpec, "is_aot", property(lambda self: self.name in aot_names)
+    )
+    monkeypatch.setattr(JitSpec, "build_and_load", fake_build_and_load)
+
+    fp4q.get_fp4_quantization_module.cache_clear()
+    try:
+        with pytest.raises(_StopAfterSelection):
+            fp4q.get_fp4_quantization_module(backend)
+    finally:
+        fp4q.get_fp4_quantization_module.cache_clear()
+
+    assert selected == [expected]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/utils/test_fp4_quantize.py
+++ b/tests/utils/test_fp4_quantize.py
@@ -1879,10 +1879,18 @@ class _StopAfterSelection(Exception):
         ("100", frozenset({"fp4_quantization_120f"}), "fp4_quantization_100"),
     ],
 )
-def test_fp4_quantization_module_selection(monkeypatch, backend, aot_names, expected):
+def test_fp4_quantization_module_selection(
+    monkeypatch, tmp_path, backend, aot_names, expected
+):
     """CPU-only check of the SM12x arch-vs-family module selection."""
+    from flashinfer.jit import env as jit_env
     from flashinfer.jit.core import JitSpec
     from flashinfer.quantization import fp4_quantization as fp4q
+
+    for name in aot_names:
+        (tmp_path / name).mkdir()
+        (tmp_path / name / f"{name}.so").touch()
+    monkeypatch.setattr(jit_env, "FLASHINFER_AOT_DIR", tmp_path)
 
     selected = []
 
@@ -1890,9 +1898,6 @@ def test_fp4_quantization_module_selection(monkeypatch, backend, aot_names, expe
         selected.append(self.name)
         raise _StopAfterSelection
 
-    monkeypatch.setattr(
-        JitSpec, "is_aot", property(lambda self: self.name in aot_names)
-    )
     monkeypatch.setattr(JitSpec, "build_and_load", fake_build_and_load)
 
     fp4q.get_fp4_quantization_module.cache_clear()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Resolves item 15 of the SM121 support audit (#3170): the FP4 quantization runtime and AOT disagree about which module to use on SM12x.

`get_fp4_quantization_module()` unconditionally redirected backends `"120"`/`"121"` to `"120f"` on CUDA >= 12.9 (introduced in #2650), while `aot.py` builds the arch-specific `fp4_quantization_120`/`_121` modules. The AOT artifacts for `12.0a`/`12.1a` were dead weight, and a JIT-cache build without `12.0f` in the arch list broke `FLASHINFER_DISABLE_JIT`.

Fixes:

- Use the arch-specific module (`sm_120a`/`sm_121a`) directly.
- Redirect to `120f` only when it is the module available ahead-of-time, so release wheels keep loading their prebuilt module with no new JIT compile.

## 🔍 Related Issues

#3170 (item 15), #2650 (introduced the redirect).

## 🧪 Tests

On DGX Spark (GB10, SM121, CUDA 13, source install):

- New CPU-only `test_fp4_quantization_module_selection` covering the arch-vs-family selection.
- `tests/utils/test_fp4_quantize.py` (10300 passed) and `test_fp4_quantize_padding.py` (16 passed); the JIT cache now builds `fp4_quantization_121` with `compute_121a`.
- Wheel-fallback simulation: with a real `sm_120f` module staged in `FLASHINFER_AOT_DIR`, a fresh process loads it and round-trips correctly.

## Reviewer Notes

- Source installs on SM12x recompile once (the warm `120f` JIT cache no longer matches).
- Wheel installs on SM121 load `sm_120f` while source installs compile `sm_121a`, matching the existing SM12x GEMM/MoE behavior.
- The CUDA >= 12.9 gate is dropped: the redirect only loads a prebuilt `.so`, so the toolkit version is irrelevant.
- Verified on SM121 only; SM120 takes the identical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FP4 quantization backend selection for greater compatibility across supported architectures.
  - Preserved requested backend selection while applying the appropriate available AOT module when needed.
  - Removed outdated CUDA-version-based backend remapping.

- **Tests**
  - Added coverage for backend and AOT module selection scenarios, including architecture-specific and family-level modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->