### PR TITLE
[fix] Clear cuda cache and gc to avoid OOM

### DIFF
--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -1794,7 +1794,14 @@ def test_single_prefill_torch_compile_cuda_graph():
         torch.cuda.synchronize()
         print("PASS")
     """)
+    import gc
     import os
+
+    # The subprocess needs its own CUDA context and cudagraph pool, but the parent
+    # pytest process's caching allocator may still hold nearly all GPU memory from
+    # earlier tests, OOM-ing the child on 24GB CI GPUs. Release it first.
+    gc.collect()
+    torch.cuda.empty_cache()
 
     # torch.compile's inductor calls getpass.getuser() for cache dir, which fails
     # in CI containers where the uid has no /etc/passwd entry. Setting USER avoids this.


### PR DESCRIPTION
Fix nightly CI OOM in test_single_prefill_torch_compile_cuda_graph: release the parent pytest process's cached GPU memory before spawning the torch.compile subprocess, which needs its own CUDA context and cudagraph pool on 24GB CI GPUs.

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved GPU test reliability by clearing retained memory before running isolated CUDA checks.
  * Reduced the likelihood of out-of-memory failures during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->