### PR TITLE
feat(comm): make mixed-comm VMM workspaces checkpointable

### DIFF
--- a/flashinfer/comm/mixed_comm.py
+++ b/flashinfer/comm/mixed_comm.py
@@ -48,6 +48,7 @@ from ..cuda_utils import checkCudaErrors
 from ..jit.comm import gen_mixed_comm_module
 from ..testing.utils import bench_gpu_time
 from ..utils import backend_requirement, supported_compute_capability
+from .mnnvl import CommBackend, TorchDistBackend
 
 
 @functools.cache
@@ -578,6 +579,7 @@ class MixedCommHandler:
         self.vm_handle_type = (
             cuda.CUmemAllocationHandleType.CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
         )
+        self._vm_mapped = False
         self.vm_workspace_bytes = None
         self.uc_handle_list = None
         self.uc_ptr_list = None
@@ -639,7 +641,7 @@ class MixedCommHandler:
             valid_mode_list.append(MixedCommMode.AUTOTUNE)
         return valid_mode_list
 
-    def init_virtual_memory(self):
+    def _create_and_map_vmm_handles(self, comm_backend):
         """Initialize CUDA virtual memory for intra-node communication.
 
         Allocates unicast and multicast memory handles, exchanges them between
@@ -693,7 +695,7 @@ class MixedCommHandler:
                     cuda.cuMemImportFromShareableHandle(uc_fd_recv, self.vm_handle_type)
                 )
                 os.close(uc_fd_recv)
-                torch.distributed.barrier(group=self.local_comm_group)
+                comm_backend.barrier()
             os.close(uc_fd_send)
             return uc_handle_list
 
@@ -719,11 +721,14 @@ class MixedCommHandler:
             checkCudaErrors(cuda.cuMulticastAddDevice(mc_handle, self.device.index))
             return mc_handle
 
-        def map_handle(handle, access_desc, vm_granularity):
+        def map_handle(handle, access_desc, vm_granularity, ptr=None):
             """Reserve virtual address space and map a memory handle into it."""
-            ptr = checkCudaErrors(
-                cuda.cuMemAddressReserve(self.vm_workspace_bytes, vm_granularity, 0, 0)
-            )
+            if ptr is None:
+                ptr = checkCudaErrors(
+                    cuda.cuMemAddressReserve(
+                        self.vm_workspace_bytes, vm_granularity, 0, 0
+                    )
+                )
             checkCudaErrors(cuda.cuMemMap(ptr, self.vm_workspace_bytes, 0, handle, 0))
             checkCudaErrors(
                 cuda.cuMemSetAccess(ptr, self.vm_workspace_bytes, [access_desc], 1)
@@ -748,16 +753,12 @@ class MixedCommHandler:
             os.chmod(socket_folder_list[0], 0o700)
         else:
             socket_folder_list = [None]
-        torch.distributed.broadcast_object_list(
-            socket_folder_list,
-            src=self.para_info.inter_rank * self.para_info.local_size,
-            group=self.local_comm_group,
-        )
+        socket_folder_list[0] = comm_backend.bcast(socket_folder_list[0], root=0)
         socket_folder = socket_folder_list[0]
         socket_path = get_socket_path(self.para_info.local_rank)
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
         sock.bind(socket_path)
-        torch.distributed.barrier(group=self.local_comm_group)
+        comm_backend.barrier()
 
         # Create multicast and unicast handles
         uc_prop = cuda.CUmemAllocationProp()
@@ -782,11 +783,14 @@ class MixedCommHandler:
             )
         )
         vm_granularity = math.lcm(mc_granularity, uc_granularity)
-        self.vm_workspace_bytes = _round_up(
-            self.vm_buffer_bytes_all + self.buffer_info_bytes, vm_granularity
-        )
-        self.uc_handle_list = create_and_allgather_uc_handle(sock, uc_prop)
-        mc_prop.size = self.vm_workspace_bytes
+        if self.vm_workspace_bytes is None:
+            self.vm_workspace_bytes = _round_up(
+                self.vm_buffer_bytes_all + self.buffer_info_bytes, vm_granularity
+            )
+        vm_workspace_bytes = self.vm_workspace_bytes
+        uc_handle_list = create_and_allgather_uc_handle(sock, uc_prop)
+        self.uc_handle_list = uc_handle_list
+        mc_prop.size = vm_workspace_bytes
         if self.para_info.local_rank == 0:
             mc_prop.numDevices = self.para_info.local_size
             self.mc_handle_dict["full"] = create_and_send_mc_handle(
@@ -794,7 +798,7 @@ class MixedCommHandler:
             )
         else:
             self.mc_handle_dict["full"] = recv_and_create_mc_handle(sock)
-        torch.distributed.barrier(group=self.local_comm_group)
+        comm_backend.barrier()
         if self.para_info.use_local_tp:
             if self.para_info.local_tp_rank == 0:
                 mc_prop.numDevices = self.para_info.local_tp_size
@@ -803,11 +807,11 @@ class MixedCommHandler:
                 )
             else:
                 self.mc_handle_dict["tp"] = recv_and_create_mc_handle(sock)
-            torch.distributed.barrier(group=self.local_comm_group)
-        torch.distributed.barrier(group=self.local_comm_group)
+            comm_backend.barrier()
+        comm_backend.barrier()
         sock.close()
         os.unlink(socket_path)
-        torch.distributed.barrier(group=self.local_comm_group)
+        comm_backend.barrier()
         if self.para_info.local_rank == 0:
             os.rmdir(socket_folder)
 
@@ -817,42 +821,144 @@ class MixedCommHandler:
         access_desc.location.id = self.device.index
         access_desc.location.type = cuda.CUmemLocationType.CU_MEM_LOCATION_TYPE_DEVICE
         access_desc.flags = cuda.CUmemAccess_flags.CU_MEM_ACCESS_FLAGS_PROT_READWRITE
-        self.uc_ptr_list = [
-            map_handle(val, access_desc, vm_granularity) for val in self.uc_handle_list
-        ]
-        ptr_list = [int(val) for val in self.uc_ptr_list]
-        uc_buffer_list = []
-        local_tp_rank = self.para_info.local_tp_rank
-        local_dp_rank = self.para_info.local_dp_rank
-        local_tp_size = self.para_info.local_tp_size
-        local_dp_size = self.para_info.local_dp_size
-        for i in range(local_dp_size):
-            peer_local_dp_rank = (local_dp_rank + i + 1) % local_dp_size
-            for j in range(local_tp_size):
-                peer_local_tp_rank = (local_tp_rank + j + 1) % local_tp_size
-                uc_buffer_list.append(
-                    ptr_list[peer_local_tp_rank + peer_local_dp_rank * local_tp_size]
-                )
-        self.uc_buffer_dict = create_gpu_array(uc_buffer_list)
+        if self.uc_ptr_list is None:
+            uc_ptr_list = [
+                map_handle(val, access_desc, vm_granularity) for val in uc_handle_list
+            ]
+            self.uc_ptr_list = uc_ptr_list
+        else:
+            uc_ptr_list = self.uc_ptr_list
+            for handle, ptr in zip(uc_handle_list, uc_ptr_list, strict=True):
+                map_handle(handle, access_desc, vm_granularity, ptr)
+        ptr_list = [int(val) for val in uc_ptr_list]
+        if not self.uc_buffer_dict["raw"]:
+            uc_buffer_list = []
+            local_tp_rank = self.para_info.local_tp_rank
+            local_dp_rank = self.para_info.local_dp_rank
+            local_tp_size = self.para_info.local_tp_size
+            local_dp_size = self.para_info.local_dp_size
+            for i in range(local_dp_size):
+                peer_local_dp_rank = (local_dp_rank + i + 1) % local_dp_size
+                for j in range(local_tp_size):
+                    peer_local_tp_rank = (local_tp_rank + j + 1) % local_tp_size
+                    uc_buffer_list.append(
+                        ptr_list[
+                            peer_local_tp_rank + peer_local_dp_rank * local_tp_size
+                        ]
+                    )
+            self.uc_buffer_dict = create_gpu_array(uc_buffer_list)
         ptr = ptr_list[self.para_info.local_rank]
         self.mem_buffer = ctypes.c_void_p(ptr)
+        self._initialize_vmm_protocol()
+        uc_handle_self = uc_handle_list[self.para_info.local_rank]
+        for key, val in self.mc_handle_dict.items():
+            if val is None:
+                continue
+            checkCudaErrors(
+                cuda.cuMulticastBindMem(
+                    val, 0, uc_handle_self, 0, vm_workspace_bytes, 0
+                )
+            )
+            self.mc_ptr_dict[key] = map_handle(
+                val, access_desc, vm_granularity, self.mc_ptr_dict[key]
+            )
+            self.mc_buffer_dict[key] = ctypes.c_void_p(int(self.mc_ptr_dict[key]))
+
+    def _initialize_vmm_protocol(self):
+        """Reset the virtual-memory communication protocol."""
+        ptr = int(self.uc_ptr_list[self.para_info.local_rank])
         checkCudaErrors(
             cuda.cuMemsetD16(ptr, self.neg_zero_uint16, self.vm_buffer_bytes_all // 2)
         )
         checkCudaErrors(
             cuda.cuMemsetD8(ptr + self.vm_buffer_bytes_all, 0, self.buffer_info_bytes)
         )
-        uc_handle_self = self.uc_handle_list[self.para_info.local_rank]
+
+    def _unmap_and_release_vmm_handles(self):
+        """Unmap and release physical VMM backing while retaining addresses."""
         for key, val in self.mc_handle_dict.items():
             if val is None:
                 continue
             checkCudaErrors(
-                cuda.cuMulticastBindMem(
-                    val, 0, uc_handle_self, 0, self.vm_workspace_bytes, 0
+                cuda.cuMulticastUnbind(
+                    val, self.device.index, 0, self.vm_workspace_bytes
                 )
             )
-            self.mc_ptr_dict[key] = map_handle(val, access_desc, vm_granularity)
-            self.mc_buffer_dict[key] = ctypes.c_void_p(int(self.mc_ptr_dict[key]))
+            checkCudaErrors(
+                cuda.cuMemUnmap(self.mc_ptr_dict[key], self.vm_workspace_bytes)
+            )
+            checkCudaErrors(cuda.cuMemRelease(val))
+            self.mc_handle_dict[key] = None
+        for handle, ptr in zip(self.uc_handle_list, self.uc_ptr_list, strict=True):
+            checkCudaErrors(cuda.cuMemUnmap(ptr, self.vm_workspace_bytes))
+            checkCudaErrors(cuda.cuMemRelease(handle))
+        self.uc_handle_list = None
+        self._vm_mapped = False
+
+    def _free_vmm_addresses(self):
+        """Free permanent VMM addresses and the GPU peer-pointer table."""
+        for ptr in self.mc_ptr_dict.values():
+            if ptr is not None:
+                checkCudaErrors(cuda.cuMemAddressFree(ptr, self.vm_workspace_bytes))
+        for ptr in self.uc_ptr_list:
+            checkCudaErrors(cuda.cuMemAddressFree(ptr, self.vm_workspace_bytes))
+        checkCudaErrors(cuda.cuMemFree(self.uc_buffer_dict["raw"]))
+
+    def init_virtual_memory(self):
+        """Initialize CUDA virtual memory for intra-node communication.
+
+        Allocates unicast and multicast memory handles, exchanges them between
+        local ranks via Unix domain sockets, and maps them into the GPU virtual
+        address space so that all ranks on a node can directly read/write each
+        other's buffers.
+        """
+        comm_backend = TorchDistBackend(self.local_comm_group)
+        self._create_and_map_vmm_handles(comm_backend)
+        self._vmm_comm_backend = comm_backend
+        self._vm_mapped = True
+
+    def _validate_vmm_comm_backend(self, comm_backend: CommBackend):
+        """Validate the local checkpoint rendezvous backend."""
+        if comm_backend.Get_rank() != self.para_info.local_rank:
+            raise ValueError(
+                "MixedComm checkpoint backend rank does not match local rank"
+            )
+        if comm_backend.Get_size() != self.para_info.local_size:
+            raise ValueError(
+                "MixedComm checkpoint backend size does not match local size"
+            )
+
+    @flashinfer_api
+    def checkpoint_prepare(self):
+        """Release physical VMM backing while retaining graph-visible addresses."""
+        if self.para_info.use_inter:
+            raise NotImplementedError(
+                "MixedComm checkpointing does not yet support multi-node handlers"
+            )
+        if not self._vm_mapped:
+            return
+        torch.cuda.synchronize()
+        assert self._vmm_comm_backend is not None
+        self._vmm_comm_backend.barrier()
+        self._unmap_and_release_vmm_handles()
+        self._vmm_comm_backend.barrier()
+        self._vmm_comm_backend = None
+
+    @flashinfer_api
+    def checkpoint_restore(self, comm_backend: CommBackend):
+        """Restore physical VMM backing at retained graph-visible addresses."""
+        if self.para_info.use_inter:
+            raise NotImplementedError(
+                "MixedComm checkpointing does not yet support multi-node handlers"
+            )
+        if self._vm_mapped:
+            return
+        self._validate_vmm_comm_backend(comm_backend)
+        self._create_and_map_vmm_handles(comm_backend)
+        torch.cuda.synchronize()
+        comm_backend.barrier()
+        self._vmm_comm_backend = comm_backend
+        self._vm_mapped = True
 
     def init_nvshmem(self):
         """Initialize nvshmem for inter-node communication.
@@ -919,28 +1025,19 @@ class MixedCommHandler:
         and destroys process groups. Must be called at most once.
         """
 
-        def unmap_handle(ptr, handle):
-            """Unmap, release, and free a virtual memory handle and its address range."""
-            checkCudaErrors(cuda.cuMemUnmap(ptr, self.vm_workspace_bytes))
-            checkCudaErrors(cuda.cuMemRelease(handle))
-            checkCudaErrors(cuda.cuMemAddressFree(ptr, self.vm_workspace_bytes))
-
         assert self.is_running, "Should not call shutdown() more than once."
         self.is_running = False
         torch.cuda.synchronize()
-        torch.distributed.barrier()
+        if self.para_info.use_inter:
+            torch.distributed.barrier()
+        elif self._vm_mapped:
+            assert self._vmm_comm_backend is not None
+            self._vmm_comm_backend.barrier()
 
-        for key, val in self.mc_handle_dict.items():
-            if val is not None:
-                checkCudaErrors(
-                    cuda.cuMulticastUnbind(
-                        val, self.device.index, 0, self.vm_workspace_bytes
-                    )
-                )
-                unmap_handle(self.mc_ptr_dict[key], val)
-        for handle, ptr in zip(self.uc_handle_list, self.uc_ptr_list, strict=True):
-            unmap_handle(ptr, handle)
-        checkCudaErrors(cuda.cuMemFree(self.uc_buffer_dict["raw"]))
+        if self._vm_mapped:
+            self._unmap_and_release_vmm_handles()
+            self._vmm_comm_backend = None
+        self._free_vmm_addresses()
 
         if self.para_info.use_inter:
             del self.ns_workspace

--- a/flashinfer/comm/mixed_comm.py
+++ b/flashinfer/comm/mixed_comm.py
@@ -900,9 +900,11 @@ class MixedCommHandler:
         for ptr in self.mc_ptr_dict.values():
             if ptr is not None:
                 checkCudaErrors(cuda.cuMemAddressFree(ptr, self.vm_workspace_bytes))
-        for ptr in self.uc_ptr_list:
-            checkCudaErrors(cuda.cuMemAddressFree(ptr, self.vm_workspace_bytes))
-        checkCudaErrors(cuda.cuMemFree(self.uc_buffer_dict["raw"]))
+        if self.uc_ptr_list is not None:
+            for ptr in self.uc_ptr_list:
+                checkCudaErrors(cuda.cuMemAddressFree(ptr, self.vm_workspace_bytes))
+        if self.uc_buffer_dict["raw"]:
+            checkCudaErrors(cuda.cuMemFree(self.uc_buffer_dict["raw"]))
 
     def init_virtual_memory(self):
         """Initialize CUDA virtual memory for intra-node communication.

--- a/tests/comm/test_mixed_comm_checkpoint.py
+++ b/tests/comm/test_mixed_comm_checkpoint.py
@@ -1,0 +1,215 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+import flashinfer.comm.mixed_comm as mixed_comm
+from flashinfer.comm.mixed_comm import (
+    MixedCommHandler,
+    MixedCommMode,
+    MixedCommOp,
+    run_mixed_comm,
+)
+from flashinfer.comm.mnnvl import TorchDistBackend
+from flashinfer.utils import get_compute_capability
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _addresses(handler: MixedCommHandler) -> tuple:
+    return (
+        tuple(int(ptr) for ptr in handler.uc_ptr_list),
+        tuple(int(ptr) for ptr in handler.mc_ptr_dict.values() if ptr is not None),
+        int(handler.uc_buffer_dict["raw"]),
+    )
+
+
+def _set_input(
+    op: MixedCommOp,
+    input_: torch.Tensor,
+    rank: int,
+    world_size: int,
+    offset: int,
+) -> torch.Tensor:
+    if op == MixedCommOp.ALLGATHER:
+        input_.fill_(rank + offset)
+        return torch.cat(
+            [
+                torch.full_like(input_, peer_rank + offset)
+                for peer_rank in range(world_size)
+            ]
+        )
+
+    rows_per_rank = input_.shape[0] // world_size
+    row_values = torch.arange(
+        input_.shape[0], dtype=input_.dtype, device=input_.device
+    ).view(-1, 1)
+    input_.copy_(row_values + rank + offset)
+    expected = row_values * world_size + sum(range(world_size)) + offset * world_size
+    return expected[rank * rows_per_rank : (rank + 1) * rows_per_rank].expand(
+        -1, input_.shape[1]
+    )
+
+
+def _run_checkpoint_worker(rank: int, world_size: int, port: int) -> None:
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        "gloo",
+        init_method=f"tcp://127.0.0.1:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    def _make_handler() -> MixedCommHandler:
+        return MixedCommHandler(
+            world_rank=rank,
+            world_size=world_size,
+            local_rank=rank,
+            local_size=world_size,
+            inter_rank=0,
+            inter_size=1,
+            local_tp_size=1,
+            local_dp_size=world_size,
+            inter_tp_size=1,
+            inter_dp_size=1,
+            dtype=torch.float16,
+            device=torch.device("cuda", rank),
+            use_autotune=False,
+        )
+
+    handler = _make_handler()
+    initial_addresses = _addresses(handler)
+    op_modes = tuple(
+        (op, mode)
+        for op in (MixedCommOp.ALLGATHER, MixedCommOp.REDUCESCATTER)
+        for mode in (
+            MixedCommMode.FUSED_OPT_WAITS_UC,
+            MixedCommMode.FUSED_OPT_WAITS_MC,
+        )
+    )
+    graphs = {}
+    inputs = {}
+    outputs = {}
+
+    for op, mode in op_modes:
+        input_rows = 4 if op == MixedCommOp.ALLGATHER else 4 * world_size
+        input_ = torch.empty((input_rows, 64), dtype=torch.float16, device="cuda")
+        output_rows = (
+            input_rows * world_size
+            if op == MixedCommOp.ALLGATHER
+            else input_rows // world_size
+        )
+        output = torch.empty((output_rows, 64), dtype=torch.float16, device="cuda")
+        expected = _set_input(op, input_, rank, world_size, offset=1)
+        run_mixed_comm(op, handler, input_, output, mode)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+        graph = torch.cuda.CUDAGraph()
+        dist.barrier()
+        with torch.cuda.graph(graph):
+            run_mixed_comm(op, handler, input_, output, mode)
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(output, expected, rtol=0, atol=0)
+        key = (op, mode)
+        graphs[key] = graph
+        inputs[key] = input_
+        outputs[key] = output
+
+    handler.checkpoint_prepare()
+    handler.checkpoint_prepare()
+    assert not handler._vm_mapped
+    assert _addresses(handler) == initial_addresses
+
+    fresh_group = dist.new_group()
+    fresh_backend = TorchDistBackend(fresh_group)
+    handler.checkpoint_restore(fresh_backend)
+    handler.checkpoint_restore(fresh_backend)
+    assert handler._vm_mapped
+    assert handler._vmm_comm_backend is fresh_backend
+    assert _addresses(handler) == initial_addresses
+
+    for key in op_modes:
+        op, _mode = key
+        expected = _set_input(op, inputs[key], rank, world_size, offset=4)
+        graphs[key].replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(outputs[key], expected, rtol=0, atol=0)
+
+    handler.checkpoint_prepare()
+    handler.checkpoint_restore(fresh_backend)
+    handler.shutdown()
+    assert not handler.is_running
+    assert not handler._vm_mapped
+
+    detached_handler = _make_handler()
+    detached_handler.checkpoint_prepare()
+    detached_handler.checkpoint_prepare()
+    detached_handler.shutdown()
+    assert not detached_handler.is_running
+    assert not detached_handler._vm_mapped
+
+    dist.destroy_process_group(fresh_group)
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+    reason="checkpointable MixedComm requires two CUDA devices",
+)
+def test_graph_replay_after_mixed_comm_checkpoint_restore() -> None:
+    try:
+        multicast_attribute = (
+            mixed_comm.cuda.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED
+        )
+        multicast_supported = all(
+            mixed_comm.checkCudaErrors(
+                mixed_comm.cuda.cuDeviceGetAttribute(multicast_attribute, device)
+            )
+            for device in range(2)
+        )
+        peer_access_supported = all(
+            src == dst or torch.cuda.can_device_access_peer(src, dst)
+            for src in range(2)
+            for dst in range(2)
+        )
+    except (AttributeError, RuntimeError):
+        multicast_supported = False
+        peer_access_supported = False
+    if not multicast_supported or not peer_access_supported:
+        pytest.skip("CUDA multicast and peer-access topology are required")
+
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    compute_capability_number = compute_capability[0] * 10 + compute_capability[1]
+    if not run_mixed_comm.is_compute_capability_supported(compute_capability_number):
+        pytest.skip(f"run_mixed_comm is not supported on sm{compute_capability_number}")
+
+    mp.spawn(
+        _run_checkpoint_worker,
+        args=(2, _free_port()),
+        nprocs=2,
+        join=True,
+    )


### PR DESCRIPTION
## Summary

Make the existing intranode `MixedCommHandler` all-gather and reduce-scatter paths checkpointable without adding a new collective kernel.

- Add one `_vm_mapped` boolean and idempotent `checkpoint_prepare()` / `checkpoint_restore(comm_backend)` methods.
- Reuse the existing VMM startup structure for initial mapping and restore.
- During prepare, synchronize through the retained VMM `CommBackend` and release UC/MC physical, imported, mapped, and bound resources while retaining all CUDA VA reservations and the GPU peer-pointer table captured by CUDA graphs.
- During restore, validate a fresh local `CommBackend`, recreate backing resources at the exact retained addresses, reset mixed-comm protocol memory, collectively fence, and retain that backend for the next prepare or attached shutdown.
- Clear the retained backend after prepare so its caller-owned process group may be destroyed while the workspace is detached.
- Use the same unmap/release and permanent-address-free helpers in explicit shutdown, including shutdown from an already detached state.

This PR deliberately does **not** add a standalone symmetric all-gather kernel. It makes the existing mixed-comm all-gather and reduce-scatter kernels checkpointable.

## Lifecycle contract

The public API matches #3727/#3745:

```python
handler.checkpoint_prepare()
handler.checkpoint_restore(fresh_comm_backend)
```

The current backend must remain valid through `checkpoint_prepare()`. After prepare returns, MixedComm no longer retains it and the caller may destroy its underlying process group. The fresh backend passed to restore is retained until the next prepare or attached shutdown. MixedComm does not own or destroy externally supplied process groups.

No Python launch or CUDA graph replay guard is added. The caller/checkpoint orchestrator is responsible for not executing mixed-comm operations while the workspace is detached.

## Scope

Checkpoint prepare/restore currently supports intranode mixed-comm workspaces only. Multi-node checkpoint calls fail during preflight without mutating the handler. Existing multi-node/NVSHMEM execution and normal shutdown remain unchanged. `CommBackend` is control-plane rendezvous only; it does not add multi-node NVSHMEM/RDMA checkpoint support.

The implementation follows the earlier checkpoint lifecycle pattern:

- no additional workspace wrapper;
- no attachment-state enum;
- no terminal/partial-recovery state machine;
- fail-fast resource transitions;
- successful prepare/restore idempotence derived from `_vm_mapped`;
- upstream-style unannotated dynamic CUDA resource fields.

The branch is one commit directly on the PR base. Final diff:

```text
flashinfer/comm/mixed_comm.py            | 221 lines changed
 tests/comm/test_mixed_comm_checkpoint.py | 215 lines added
2 files changed, 374 insertions(+), 62 deletions(-)
```

## Validation

### Static and local

- Full pre-commit: pass, including `mypy --all-files`, Ruff lint, and Ruff format.
- Python compilation and `git diff --check`: pass.
- Focused checkpoint test: exactly 1 test collected; expected hardware skip on SM89 because CUDA multicast is unavailable.
- Existing mixed-comm suite: exactly 6 tests collected; expected SM89 capability skips.
- Independent implementation review: approved.

### B200 CUDA process checkpoint/restore

Validated exact commit `1c2ead3272289c2688be8d810cc019734dcc5149` on two NVIDIA B200 GPUs in `nscale-dev` using NVIDIA's official `cuda-checkpoint` utility.

Before checkpoint, both ranks passed eager execution and CUDA graph capture/replay for all four combinations:

```text
ALLGATHER     x FUSED_OPT_WAITS_UC
ALLGATHER     x FUSED_OPT_WAITS_MC
REDUCESCATTER x FUSED_OPT_WAITS_UC
REDUCESCATTER x FUSED_OPT_WAITS_MC
```

Each rank called `checkpoint_prepare()` twice, verified it was detached, verified the backend reference was cleared, and verified exact UC/MC/pointer-table address equality. No operation was launched or replayed while detached.

An external controller drove both rank PIDs through:

```text
running -> locked -> checkpointed -> locked -> running
```

While both were `checkpointed`, `nvidia-smi --query-compute-apps` returned no compute processes.

After CUDA restore/unlock, each rank:

1. created a fresh Gloo process group and `TorchDistBackend`;
2. called `checkpoint_restore()` twice;
3. verified the fresh backend was retained and all addresses matched exactly;
4. replayed the original four captured graphs with changed inputs and exact AG/RS results;
5. ran a second prepare/restore lifecycle using the retained fresh backend;
6. replayed all four original graphs again with another set of changed inputs;
7. completed attached shutdown while the fresh group remained valid;
8. let the caller destroy the fresh process group afterward.

Both worker return codes were zero. The successful E2E runtime was approximately 41 seconds; the clean optimized SM100a JIT build took approximately 361 seconds. The temporary test pod was deleted after evidence collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checkpoint restore for mixed communication with reusable GPU virtual-memory mappings.
  * Extended checkpoint restore to accept a communication backend.
  * Switched setup/restore/shutdown synchronization to backend-mediated coordination.

* **Bug Fixes**
  * Improved checkpoint prepare/restore correctness, including repeated checkpoint cycles.
  * Preserved GPU address reservations across prepare and restore, ensuring stable teardown.

* **Tests**
  * Added distributed CUDA tests covering checkpoint/restore, CUDA graph capture and replay, and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->