### PR TITLE
fix: autotuner memory leak follow up

### DIFF
--- a/benchmarks/bench_cutlass_fused_moe.py
+++ b/benchmarks/bench_cutlass_fused_moe.py
@@ -219,9 +219,10 @@ if __name__ == "__main__":
 
     configs = AutoTuner.get().profiling_cache
     if args.update_config and configs:
-        # The original key contains a runner's hash in k[2] which might be different across machines.
-        # So, we remove it for now. v[0] and v[1] are the runner id and the tactic.
-        converted = {str((k[0], k[1], k[3])): (v[0], v[1]) for k, v in configs.items()}
+        # ProfilingCacheKey.file_key excludes the runner's hash, which might be
+        # different across machines, and matches the lookup format used by
+        # load_from_file. v[0] and v[1] are the runner id and the tactic.
+        converted = {k.file_key: (v[0], v[1]) for k, v in configs.items()}
         config_path = get_config_path(is_module=False)
         with open(config_path, "w") as f:
             f.write("best_configs = ")

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -86,6 +86,31 @@ from .utils import (
 )
 
 
+@functools.lru_cache(maxsize=32)
+def _moe_topk_ids_init(num_experts: int):
+    """Return a packed-topk-ids initializer for a given expert count. Cached for
+    object identity preservation.
+    """
+
+    def _init(
+        shapes: tuple[int, ...],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor:
+        expert_ids = make_random_topk_ids(
+            num_experts=num_experts,
+            num_tokens=math.prod(shapes[:-1]),
+            top_k=shapes[-1],
+            device=device,
+        ).view(shapes)
+        expert_weights = torch.ones(shapes, dtype=torch.bfloat16, device=device).view(
+            torch.int16
+        )
+        return (expert_ids << 16) | expert_weights
+
+    return _init
+
+
 # Routing input modes for FusedMoE launcher
 # Please keep this in sync with the counterpart defined in csrc/trtllm_fused_moe_kernel_launcher.cu
 class RoutingInputMode(IntEnum):
@@ -1250,22 +1275,6 @@ def get_trtllm_moe_sm100_module():
                 **kwargs: Extra TuningConfig kwargs (e.g. use_cold_l2_cache).
             """
 
-            def _init_packed_topk_ids(
-                shapes: tuple[int, ...],
-                dtype: torch.dtype,
-                device: torch.device,
-            ) -> torch.Tensor:
-                expert_ids = make_random_topk_ids(
-                    num_experts=self.num_experts,
-                    num_tokens=math.prod(shapes[:-1]),
-                    top_k=shapes[-1],
-                    device=device,
-                ).view(shapes)
-                expert_weights = torch.ones(
-                    shapes, dtype=torch.bfloat16, device=device
-                ).view(torch.int16)
-                return (expert_ids << 16) | expert_weights
-
             spec = {
                 "output": autotuner_initializer_empty,
                 "hidden_states": autotuner_initializer_randn,
@@ -1273,7 +1282,7 @@ def get_trtllm_moe_sm100_module():
             if moe_inputs.routing_logits is not None:
                 spec["routing_logits"] = autotuner_initializer_rand
             if moe_inputs.topk_ids is not None:
-                spec["topk_ids"] = _init_packed_topk_ids
+                spec["topk_ids"] = _moe_topk_ids_init(self.num_experts)
             if moe_inputs.expert_weights is not None:
                 spec["expert_weights"] = autotuner_initializer_ones
             if moe_inputs.hidden_states_scale is not None:

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -86,7 +86,7 @@ from .utils import (
 )
 
 
-@functools.lru_cache(maxsize=32)
+@functools.cache
 def _moe_topk_ids_init(num_experts: int):
     """Return a packed-topk-ids initializer for a given expert count. Cached for
     object identity preservation.

--- a/tests/attention/test_vsa_block_sparse.py
+++ b/tests/attention/test_vsa_block_sparse.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
 import math
 import os
 import statistics
@@ -27,13 +28,22 @@ from flashinfer.testing import bench_gpu_time
 from flashinfer.utils import is_sm100a_supported
 
 # ---------------------------------------------------------------------------
-# Hardware gate
+# Hardware / dependency gates
 # ---------------------------------------------------------------------------
 
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda")),
-    reason="VSA Blackwell backend requires sm100a (Blackwell GPU)",
-)
+_HAS_QUACK = importlib.util.find_spec("quack") is not None
+
+pytestmark = [
+    pytest.mark.skipif(
+        not torch.cuda.is_available() or not is_sm100a_supported(torch.device("cuda")),
+        reason="VSA Blackwell backend requires sm100a (Blackwell GPU)",
+    ),
+    pytest.mark.skipif(
+        not _HAS_QUACK,
+        reason="VSA Blackwell backend requires the quack package "
+        "(pip install git+https://github.com/Dao-AILab/quack.git)",
+    ),
+]
 
 # BSA blk128 kernel block granularity: 128-token Q/KV blocks
 R = C = 128

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -1156,3 +1156,94 @@ def test_find_nearest_profile_cache_grows_with_fresh_callable():
         f"Python allocations grew by {allocated_bytes / 1024:.1f} KB "
         f"({allocated_bytes / N:.0f} B/call)."
     )
+
+
+def _build_moe_style_tuning_config(topk_ids_initializer):
+    """Build a config with tensor_initializers present, MoE-style.
+    Mimics ``_make_tuning_config`` in fused_moe/core.py.
+    """
+    from flashinfer.autotuner.initializers import autotuner_initializer_randn
+    from flashinfer.fused_moe.utils import (
+        get_hybrid_num_tokens_buckets,
+        make_hybrid_bucket_mapper,
+    )
+
+    return TuningConfig(
+        dynamic_tensor_specs=(
+            DynamicTensorSpec(
+                input_idx=(0, 1),
+                dim_idx=(0, 0),
+                gen_tuning_buckets=get_hybrid_num_tokens_buckets(8192, 1),
+                map_to_tuning_buckets=make_hybrid_bucket_mapper(8192),
+                tensor_initializers=[
+                    autotuner_initializer_randn,
+                    topk_ids_initializer,
+                ],
+            ),
+        ),
+    )
+
+
+def test_find_nearest_profile_cache_dedups_moe_config_with_initializers():
+    """Regression test: rebuilt MoE-style configs with tensor_initializers
+    must collapse to a single cache entry.
+    """
+    from flashinfer.fused_moe.core import _moe_topk_ids_init
+
+    # The factory must return the identical object for the same expert count.
+    assert _moe_topk_ids_init(128) is _moe_topk_ids_init(128)
+
+    AutoTuner._find_nearest_profile.cache_clear()
+    shapes = ((1024, 4096), (1024, 8))
+
+    AutoTuner._find_nearest_profile(
+        shapes, _build_moe_style_tuning_config(_moe_topk_ids_init(128))
+    )
+    cache_before = AutoTuner._find_nearest_profile.cache_info().currsize
+
+    N = 1_000
+    for _ in range(N):
+        config = _build_moe_style_tuning_config(_moe_topk_ids_init(128))
+        AutoTuner._find_nearest_profile(shapes, config)
+
+    cache_growth = AutoTuner._find_nearest_profile.cache_info().currsize - cache_before
+    AutoTuner._find_nearest_profile.cache_clear()
+
+    assert cache_growth == 0, (
+        f"Cache grew by {cache_growth} entries across {N} rebuilds of an "
+        "equivalent MoE-style config with a fixed shape."
+    )
+
+
+def test_find_nearest_profile_cache_grows_with_fresh_closure_initializer():
+    """Negative control: a fresh initializer closure per call leaks one
+    entry per call DESPITE equal hashes.
+    """
+    AutoTuner._find_nearest_profile.cache_clear()
+    shapes = ((1024, 4096), (1024, 8))
+
+    def make_fresh_closure():
+        def _init(s, dt, dev):
+            return None
+
+        return _init
+
+    ref_config = _build_moe_style_tuning_config(make_fresh_closure())
+    other_config = _build_moe_style_tuning_config(make_fresh_closure())
+    assert hash(ref_config) == hash(other_config), "hashes should match"
+    assert ref_config != other_config, "equality should fail on fresh closures"
+
+    AutoTuner._find_nearest_profile(shapes, ref_config)
+    cache_before = AutoTuner._find_nearest_profile.cache_info().currsize
+
+    N = 1_000
+    for _ in range(N):
+        config = _build_moe_style_tuning_config(make_fresh_closure())
+        AutoTuner._find_nearest_profile(shapes, config)
+
+    cache_growth = AutoTuner._find_nearest_profile.cache_info().currsize - cache_before
+    AutoTuner._find_nearest_profile.cache_clear()
+
+    assert cache_growth == N, (
+        f"Expected {N} new cache entries (one per fresh closure), got {cache_growth}."
+    )

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -1215,6 +1215,71 @@ def test_find_nearest_profile_cache_dedups_moe_config_with_initializers():
     )
 
 
+def test_make_tuning_config_reuses_topk_ids_initializer():
+    """_make_tuning_config must return configs whose topk_ids initializer is the
+    same object across calls for the same num_experts.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import flashinfer.fused_moe.core as core_mod
+    from flashinfer.fused_moe.core import MoeRunnerInputs
+    from flashinfer.tllm_enums import DtypeTrtllmGen, Fp8QuantizationType
+
+    fn = core_mod.get_trtllm_moe_sm100_module
+    fn.cache_clear()
+    try:
+        mock_module = MagicMock()
+        mock_module.get_library_path.return_value = "/tmp/fake.so"
+        with (
+            patch.object(
+                core_mod,
+                "gen_trtllm_gen_fused_moe_sm100_module",
+                return_value=mock_module,
+            ),
+            patch.object(core_mod, "setup_cubin_loader"),
+        ):
+            MoERunner = core_mod.get_trtllm_moe_sm100_module().MoERunner
+
+        runner = MoERunner(
+            top_k=8,
+            num_local_experts=128,
+            dtype_act=DtypeTrtllmGen.Bfloat16,
+            dtype_weights=DtypeTrtllmGen.Bfloat16,
+            fp8_quantization_type=Fp8QuantizationType.NoneFp8,
+            hidden_size=4096,
+            intermediate_size=14336,
+            num_experts=128,
+        )
+        moe_inputs = MoeRunnerInputs(
+            output=torch.empty((8, 4096)),
+            routing_logits=None,
+            topk_ids=torch.zeros((8, 8), dtype=torch.int32),
+            expert_weights=None,
+            hidden_states=torch.empty((8, 4096)),
+            hidden_states_scale=None,
+            gemm1_lora_delta=None,
+            per_token_scale=None,
+        )
+
+        config_a = runner._make_tuning_config(moe_inputs)
+        config_b = runner._make_tuning_config(moe_inputs)
+
+        spec_a = config_a.dynamic_tensor_specs[0]
+        spec_b = config_b.dynamic_tensor_specs[0]
+        topk_idx = MoeRunnerInputs.idx("topk_ids")
+        init_a = spec_a.tensor_initializers[spec_a.input_idx.index(topk_idx)]
+        init_b = spec_b.tensor_initializers[spec_b.input_idx.index(topk_idx)]
+
+        assert init_a is init_b, (
+            "_make_tuning_config returned a different topk_ids initializer object "
+            "on each call. It must reuse _moe_topk_ids_init(num_experts) so that "
+            "rebuilt TuningConfigs collapse to the same _find_nearest_profile "
+            "lru_cache key — a per-call closure reintroduces the memory leak."
+        )
+    finally:
+        fn.cache_clear()
+
+
 def test_find_nearest_profile_cache_grows_with_fresh_closure_initializer():
     """Negative control: a fresh initializer closure per call leaks one
     entry per call DESPITE equal hashes.

--- a/tests/autotuner/test_trtllm_fused_moe_autotuner_integration.py
+++ b/tests/autotuner/test_trtllm_fused_moe_autotuner_integration.py
@@ -57,7 +57,7 @@ def _overwrite_cached_tactic_for_op(custom_op: str, new_tactic):
     tuner = AutoTuner.get()
     updated = 0
     for key, (runner_id, _tactic, profile) in list(tuner.profiling_cache.items()):
-        if key[0] == custom_op:
+        if key.custom_op == custom_op:
             tuner.profiling_cache[key] = (runner_id, new_tactic, profile)
             updated += 1
     assert updated > 0, f"No autotuner cache entries found for {custom_op}"

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1665,10 +1665,10 @@ class TestCuteDslMoEWrapper:
             torch.cuda.synchronize()
             assert not torch.isnan(result).any()
             # Confirm profiling actually ran for this custom op. Cache keys
-            # are (custom_op, runner_class, hash(runner), profile, extras)
-            # tuples; see AutoTuner._get_cache_key in flashinfer/autotuner.py.
+            # are ProfilingCacheKey instances; see AutoTuner._get_cache_key
+            # in flashinfer/autotuner/autotuner.py.
             assert any(
-                isinstance(k, tuple) and k[:1] == ("CuteDslMoEWrapper::run::Swiglu",)
+                k.custom_op == "CuteDslMoEWrapper::run::Swiglu"
                 for k in autotuner.profiling_cache
             ), "autotune(True) did not populate a CuteDslMoEWrapper::run cache entry"
             return ref, finalized


### PR DESCRIPTION
## 📌 Description

In #3687, we partially fixed the identity of objects used to identify cache entries in the cache of `_find_nearest_profile`. However, as correctly pointed out in #3810, we did not handle the initializer for the MoE TopK IDs.

This PR fixes this gap and adds a test to preserve the correct behaviour.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [X] Tests have been added or updated as needed.
- [X] All tests are passing (`unittest`, etc.).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Mixture-of-Experts autotuning efficiency by reusing the expert-routing initialization used to build tuning configurations.

* **Reliability / Bug Fixes**
  * Improved autotuner profile-cache stability by ensuring equivalent tuning configurations deduplicate correctly.
  * Updated integration-test cache injection to target the correct operator entry.

* **Tests**
  * Added regression coverage for profile-cache deduplication and verifying cache growth when new initializers are recreated.
  * Made VSA BlockSparseAttention tests conditional on the presence of `quack`.

* **Chores**
  * Updated benchmark cache-update keying to match loader expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->