### PR TITLE
fix (test): release CUDA cache before prefill compile subprocess

### DIFF
--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -1803,8 +1803,8 @@ def test_single_prefill_torch_compile_cuda_graph():
     env.setdefault("USER", "ci")
 
     # The parent pytest process has already run thousands of prefill cases in this
-	# file. Release its cached blocks before the subprocess initializes
-	# torch.compile/cudagraph state on memory-constrained A10G runners.
+    # file. Release its cached blocks before the subprocess initializes
+    # torch.compile/cudagraph state on memory-constrained A10G runners.
     torch.cuda.synchronize()
     gc.collect()
     torch.cuda.empty_cache()

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -1794,12 +1794,21 @@ def test_single_prefill_torch_compile_cuda_graph():
         torch.cuda.synchronize()
         print("PASS")
     """)
+    import gc
     import os
 
     # torch.compile's inductor calls getpass.getuser() for cache dir, which fails
     # in CI containers where the uid has no /etc/passwd entry. Setting USER avoids this.
     env = os.environ.copy()
     env.setdefault("USER", "ci")
+
+    # The parent pytest process has already run thousands of prefill cases in this
+	# file. Release its cached blocks before the subprocess initializes
+	# torch.compile/cudagraph state on memory-constrained A10G runners.
+    torch.cuda.synchronize()
+    gc.collect()
+    torch.cuda.empty_cache()
+
     result = subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

In recently Nightly wheel release, for example: https://github.com/flashinfer-ai/flashinfer/actions/runs/29068110170, we still got  failure in test-nightly-build with CUDA OOMs during installed-wheel validation.

=========================== short test summary info ============================
FAILED tests/attention/test_batch_prefill_kernels.py::test_single_prefill_torch_compile_cuda_graph

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3366

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Validation

- tests/attention/test_batch_prefill_kernels.py::test_single_prefill_torch_compile_cuda_graph:  **passed**
- tests/attention/test_batch_prefill_kernels.py :  8777 passed, 1320 skipped, 5760 xfailed, 2 warnings in 1078.43s (0:17:58)

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved GPU test reliability in constrained continuous integration environments by proactively releasing unused GPU memory before launching subprocesses.
  * Ensured consistent subprocess environment configuration for the affected test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->