### PR TITLE
fix(mla): allow native-width block tables for TRTLLM-GEN

### DIFF
--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -628,6 +628,7 @@ def _check_trtllm_gen_mla_shape(
     uses_shared_paged_kv_idx: bool = True,
     batch_size: Optional[int] = None,
     max_q_len: Optional[int] = None,
+    require_aligned_block_table: bool = True,
 ) -> torch.Tensor:
     is_flattened_query = False
     if query.ndim == 4:
@@ -692,7 +693,7 @@ def _check_trtllm_gen_mla_shape(
             raise ValueError(
                 f"Expected batch size {num_seqs} for query and block_table, got {num_seqs} and {B_block_table}"
             )
-        if block_num % (128 / block_size) != 0:
+        if require_aligned_block_table and block_num % (128 / block_size) != 0:
             raise ValueError(
                 f"Expected block_num % (128 / block_size) == 0, got {block_num=} and {block_size=}"
             )
@@ -2594,6 +2595,8 @@ def trtllm_batch_decode_with_kv_cache_mla(
         For SM120/SM121 sparse v32/GLM, it is the sparse index matrix and must
         have shape ``[batch_size, q_len_per_request, sparse_mla_top_k]`` with
         int32 physical token indices.
+        With ``backend="trtllm-gen"``, the final dimension may use its native
+        width and does not need padding to a multiple of ``128 / page_size``.
     seq_lens : Optional[torch.Tensor]
         Per-request KV sequence lengths for dense and TRTLLM-GEN paths. For
         SM120/SM121 sparse v32/GLM, pass ``[batch_size, q_len_per_request]`` or
@@ -2923,6 +2926,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
             uses_shared_paged_kv_idx,
             batch_size=batch_size,
             max_q_len=max_q_len,
+            require_aligned_block_table=False,
         )
 
         expected_out_shape = query.shape[:-1] + (kv_lora_rank,)
@@ -2990,6 +2994,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
         block_tables,
         block_size,
         uses_shared_paged_kv_idx,
+        require_aligned_block_table=backend != "trtllm-gen",
     )
 
     # Pre-allocate `out` so non-swept dims have a template for autotune

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -1089,6 +1089,32 @@ def test_trtllm_batch_decode_mla_sparse_cum_seq_lens_q():
     )
 
 
+@pytest.mark.parametrize("uses_shared_paged_kv_idx", [True, False])
+def test_trtllm_batch_decode_mla_native_block_table_width(
+    uses_shared_paged_kv_idx: bool,
+):
+    page_size = 32
+    max_seq_len = 1025
+    block_table_width = (max_seq_len + page_size - 1) // page_size
+    assert block_table_width == 33
+    assert block_table_width % (128 // page_size) != 0
+
+    trtllm_batch_decode_mla(
+        supported_mla_layer_dimensions[0],
+        batch_size=1,
+        scale=1.0,
+        dtype=torch.bfloat16,
+        page_size=page_size,
+        q_len_per_request=1,
+        dynamic_scale=False,
+        enable_pdl=False,
+        backend="trtllm-gen",
+        MAX_SEQ_LEN=max_seq_len,
+        skips_softmax=False,
+        uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+    )
+
+
 @pytest.mark.parametrize("q_len_per_request", [1, 2, 4])
 @pytest.mark.parametrize("batch_size", [1, 4])
 def test_trtllm_batch_decode_mla_preallocated_out(


### PR DESCRIPTION
## 📌 Description

Allow `trtllm_batch_decode_with_kv_cache_mla` to accept native, unpadded
block-table widths when the caller explicitly selects
`backend="trtllm-gen"`.

The TRTLLM-GEN launcher already consumes the actual final dimension of the
block table. The public API's `block_num % (128 / page_size)` check therefore
forced callers to add unnecessary padding and CUDA-graph fill/copy operations.

This PR:

- makes block-table width alignment optional in the internal shape validator
- disables only that alignment check for explicit TRTLLM-GEN dispatch
- covers both regular and flattened/cumulative-query TRTLLM-GEN paths
- preserves rank, shared/separate layout, dtype, device, and batch validation
- leaves `auto`, XQA, and CuTe-DSL behavior unchanged
- documents native-width support for TRTLLM-GEN

On B300, removing caller-side padding improved output throughput by 1.85% and
reduced the stable CUDA-graph makespan by 2.25%. The measured graph lost
exactly 8,192 nodes: 4,096 page-table fills and 4,096 copies.

## 🔍 Related Issues

Closes #3915.

Internal context: NVBUG 6430674.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I ran the hooks on the modified files and fixed all reported issues.

Validated hooks: standard file checks, mypy, Ruff check, and Ruff format.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All focused tests pass.

GPU validation on B300:

```text
tests/attention/test_trtllm_gen_mla.py::test_trtllm_batch_decode_mla_native_block_table_width
tests/attention/test_trtllm_gen_mla.py::test_trtllm_batch_decode_mla_preallocated_out

8 passed
```

The new test uses `page_size=32`, `max_seq_len=1025`, and native width 33,
with an active partial final page. It covers both shared 2-D and separate 3-D
block-table layouts and compares against the existing FA2 numerical reference.

## Reviewer Notes

The validator option defaults to requiring alignment. Only call sites that
unconditionally use TRTLLM-GEN disable it, keeping the behavior change narrowly
scoped. The C++ launcher already forwards `block_tables.size(-1)` without an
alignment restriction, so no launcher change is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MLA decoding compatibility with block tables whose widths are not aligned to the previously required boundary.
  * Relaxed alignment requirements where supported while preserving validation for applicable backends.
  * Added coverage for native block-table widths across shared and non-shared paged KV configurations.

* **Documentation**
  * Clarified block-table padding requirements for the supported MLA decoding backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->