### PR TITLE
[fix] fix autotuner non tensor guard

### DIFF
--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -2181,14 +2181,19 @@ class AutoTuner:
 
     def _prepare_input_tensors_with_batches(
         self,
-        inputs: list[torch.Tensor],
+        inputs: list[Any],
         tuning_config: TuningConfig,
-    ) -> list[list[torch.Tensor]]:
+    ) -> list[list[Any]]:
         """Create multiple input copies to flush the L2 cache between profiling iterations."""
         if not tuning_config.use_cold_l2_cache:
             return [inputs]
 
-        one_buffer_bytes = sum(input.numel() * input.element_size() for input in inputs)
+        one_buffer_bytes = sum(
+            input.numel() * input.element_size()
+            if isinstance(input, torch.Tensor)
+            else 0
+            for input in inputs
+        )
         if one_buffer_bytes <= 0:
             logger.debug(
                 "[Autotuner] No tensor inputs or zero-sized tensors; falling back to single-batch profiling."
@@ -2200,7 +2205,9 @@ class AutoTuner:
 
         inputs_list = [inputs]
         for _ in range(num_buffers - 1):
-            inputs_list.append(list(t.clone() for t in inputs))
+            inputs_list.append(
+                [t.clone() if isinstance(t, torch.Tensor) else t for t in inputs]
+            )
 
         logger.debug(
             f"[Autotuner] use_cold_l2_cache={tuning_config.use_cold_l2_cache}, use {num_buffers} different tensors for profiling"

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -1634,9 +1634,7 @@ class AutoTuner:
 
             return runners[runner_id], tactic
 
-    def _get_input_sizes(
-        self, inputs: list[torch.Tensor]
-    ) -> tuple[tuple[int, ...], ...]:
+    def _get_input_sizes(self, inputs: list[Any]) -> tuple[tuple[int, ...], ...]:
         """Return ``torch.Size`` for each input, using ``(0,)`` for non-Tensor values."""
         return tuple(
             tuple(tensor.size()) if isinstance(tensor, torch.Tensor) else (0,)

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -821,6 +821,31 @@ def test_prepare_input_tensors_none_input_preserved():
     assert prepared[1] is None  # None stays None
 
 
+@pytest.mark.parametrize(
+    "non_tensor",
+    [torch.bfloat16, None],
+    ids=["dtype", "none"],
+)
+def test_prepare_input_tensors_with_batches_preserves_non_tensor(
+    monkeypatch, non_tensor
+):
+    """Cold-L2 batches clone tensors while preserving scalar and optional inputs."""
+    tuner = reset_autotuner()
+    monkeypatch.setattr(tuner, "_get_l2_cache_size_in_bytes", lambda: 4)
+    inputs = [torch.ones(1), non_tensor]
+
+    batches = tuner._prepare_input_tensors_with_batches(
+        inputs, TuningConfig(use_cold_l2_cache=True)
+    )
+
+    assert batches[0] is inputs
+    assert len(batches) > 1
+    for batch in batches[1:]:
+        assert batch[0] is not inputs[0]
+        torch.testing.assert_close(batch[0], inputs[0])
+        assert batch[1] is non_tensor
+
+
 def test_choose_one_with_none_input_no_crash():
     """choose_one inference path should not crash when an input tensor is None."""
     tuner = reset_autotuner()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix AutoTuner cold-L2 profiling for operators whose input list contains non-Tensor values, such as `torch.dtype` or optional `None` arguments.

  This regression was introduced while refactoring AutoTuner in [#3687](https://github.com/flashinfer-ai/flashinfer/pull/3687). 

 During the AutoTuner refactor in [#3687](https://github.com/flashinfer-ai/flashinfer/pull/3687), guards for non-Tensor inputs were accidentally removed. 
  ```python
  input.numel() * input.element_size()
  if isinstance(input, torch.Tensor)
  else 0
```
As a result, MXFP8 and some MoE tuning paths attempted to call Tensor methods on `torch.dtype` or `None`. Profiling failures were caught internally, causing all tactics to be skipped and AutoTuner to fall back to the default tactic.

  ## Fix

Only calculate buffer sizes and clone inputs that are `torch.Tensor` instances. Preserve other inputs unchanged.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autotuning batching to correctly handle mixed inputs that include non-tensor values.
  * Updated profiling preparation to size cold-cache buffers using tensor memory only, while preserving non-tensor entries unchanged.
  * Clones are now applied only to tensor inputs when generating additional batches; non-tensors are kept as-is.
* **Tests**
  * Added regression coverage to verify non-tensor preservation and correct tensor cloning behavior during batching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->