### PR TITLE
feat(attention): accept token-unit batch offsets on the cudnn prefill path

### DIFF
--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -1,3 +1,4 @@
+import functools
 from enum import Enum
 from typing import Optional
 
@@ -14,6 +15,34 @@ try:
 except Exception:
     cudnn = None
     CUDNN_AVAILABLE = False
+
+
+@functools.cache
+def _cudnn_supports_direct_seqlens(dtype: torch.dtype) -> bool:
+    """True if cuDNN can consume token-unit indptr buffers directly for `dtype`.
+
+    Requires cu_seq_len_q/kv SDPA inputs and per-tensor ragged-offset
+    multipliers on the unified SDPA engine (forward only):
+    - fp16/bf16: cuDNN backend 9.24+ with cudnn-frontend 1.25+
+    - fp8 (e4m3/e5m2): cuDNN backend 9.25+ with cudnn-frontend 1.27+ (the first
+      release whose sdpa_fp8 python binding exposes cu_seq_len_q/kv)
+    """
+    if not CUDNN_AVAILABLE:
+        return False
+    if dtype in (torch.float16, torch.bfloat16):
+        min_backend, min_frontend = 92400, (1, 25)
+    elif dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        min_backend, min_frontend = 92500, (1, 27)
+    else:
+        return False
+    try:
+        if cudnn.backend_version() < min_backend:
+            return False
+        major, minor = map(int, cudnn.__version__.split(".")[:2])
+        return (major, minor) >= min_frontend
+    except Exception:
+        return False
+
 
 # Global cudnn handle. need to make it per device in future
 _cudnn_handle = None
@@ -82,7 +111,9 @@ def _sdpa_prefill_key_fn(
     max_token_seq_q: Optional[int] = None,
     max_sequence_kv: Optional[int] = None,
     actual_seq_lens_q: Optional[torch.Tensor] = None,
-    actual_seq_lens_kv: torch.Tensor,
+    actual_seq_lens_kv: Optional[torch.Tensor] = None,
+    cu_seq_lens_q: Optional[torch.Tensor] = None,
+    cu_seq_lens_kv: Optional[torch.Tensor] = None,
     block_tables: Optional[torch.Tensor] = None,
     page_size: Optional[int] = None,
     bottom_right_causal_mask: Optional[bool] = None,
@@ -96,7 +127,12 @@ def _sdpa_prefill_key_fn(
     lse: Optional[torch.Tensor] = None,
     o_data_type: Optional[torch.dtype] = None,
 ):
-    graph_b = actual_seq_lens_q.shape[0]
+    if actual_seq_lens_q is not None:
+        graph_b = actual_seq_lens_q.shape[0]
+    elif cu_seq_lens_q is not None:
+        graph_b = cu_seq_lens_q.shape[0] - 1
+    else:
+        raise ValueError("Either actual_seq_lens_q or cu_seq_lens_q must be provided")
 
     if q.dim() == 3:
         h_qo, d_qk = q.shape[1], q.shape[2]
@@ -126,6 +162,7 @@ def _sdpa_prefill_key_fn(
         return_lse,
         bottom_right_causal_mask,
         page_size,
+        cu_seq_lens_q is not None,
     )
     return key
 
@@ -144,6 +181,8 @@ if CUDNN_AVAILABLE:
         max_sequence_kv: Optional[int] = None,
         actual_seq_lens_q: Optional[torch.Tensor] = None,
         actual_seq_lens_kv: Optional[torch.Tensor] = None,
+        cu_seq_lens_q: Optional[torch.Tensor] = None,
+        cu_seq_lens_kv: Optional[torch.Tensor] = None,
         block_tables: Optional[torch.Tensor] = None,
         bottom_right_causal_mask: Optional[bool] = True,
         return_lse: Optional[bool] = False,
@@ -158,7 +197,39 @@ if CUDNN_AVAILABLE:
     ):
         handle = _create_cudnn_handle(torch.cuda.current_stream(q.device))
 
-        graph_b = actual_seq_lens_q.shape[0]
+        # cu_seq_lens_q/kv select the direct path: cuDNN consumes (b+1)-shaped
+        # token-unit prefix sums for the padding mask, and the batch_offsets_*
+        # ragged offsets are token-unit indptrs scaled by per-tensor
+        # multipliers. Mutually exclusive with actual_seq_lens_q/kv for the
+        # mask role; dtype/version support is the caller's responsibility
+        # (_cudnn_supports_direct_seqlens).
+        assert (cu_seq_lens_q is None) == (cu_seq_lens_kv is None), (
+            "cu_seq_lens_q and cu_seq_lens_kv must both be set or both unset"
+        )
+        use_cu_seq_lens = cu_seq_lens_q is not None
+        if use_cu_seq_lens:
+            # Non-paged only for now: this is a FlashInfer plumbing limitation,
+            # not a cuDNN one (the unified engine supports paged attention with
+            # cu_seq_lens). The direct path reuses the token-unit indptrs as
+            # both cu_seq_lens and ragged offsets, and no paged caller passes a
+            # token-unit KV prefix sum today.
+            assert (
+                batch_offsets_q is not None
+                and batch_offsets_k is not None
+                and block_tables is None
+            ), (
+                "the cu_seq_lens path currently requires non-paged KV with "
+                "token-unit q/k batch offsets"
+            )
+
+        if actual_seq_lens_q is not None:
+            graph_b = actual_seq_lens_q.shape[0]
+        elif cu_seq_lens_q is not None:
+            graph_b = cu_seq_lens_q.shape[0] - 1
+        else:
+            raise ValueError(
+                "Either actual_seq_lens_q or cu_seq_lens_q must be provided"
+            )
         graph_s_qo = max_token_seq_q
         graph_s_kv = max_sequence_kv
 
@@ -257,6 +328,10 @@ if CUDNN_AVAILABLE:
                 ragged_q = g.tensor_like(batch_offsets_q)
                 ragged_q.set_uid(UIDs.RAGGED_Q_UID.value)
                 cudnn_q.set_ragged_offset(ragged_q)
+                if use_cu_seq_lens:
+                    # Offsets are token-unit indptrs; the engine scales them
+                    # back to elements.
+                    cudnn_q.set_ragged_offset_multiplier(h_qo * d_qk)
 
             if v_cache.dim() == 3:
                 assert block_tables is None, (
@@ -284,6 +359,8 @@ if CUDNN_AVAILABLE:
                     ragged_k = g.tensor_like(batch_offsets_k)
                     ragged_k.set_uid(UIDs.RAGGED_K_UID.value)
                     cudnn_k_cache.set_ragged_offset(ragged_k)
+                    if use_cu_seq_lens:
+                        cudnn_k_cache.set_ragged_offset_multiplier(h_kv * d_qk)
 
                 assert v_cache.dim() == 3, (
                     "v_cache must have 3 dimensions since k_cache has 3 dimensions"
@@ -300,6 +377,8 @@ if CUDNN_AVAILABLE:
                     ragged_v = g.tensor_like(batch_offsets_v)
                     ragged_v.set_uid(UIDs.RAGGED_V_UID.value)
                     cudnn_v_cache.set_ragged_offset(ragged_v)
+                    if use_cu_seq_lens:
+                        cudnn_v_cache.set_ragged_offset_multiplier(h_kv * d_vo)
 
             elif k_cache.dim() == 4:
                 cudnn_k_cache = g.tensor(
@@ -330,19 +409,52 @@ if CUDNN_AVAILABLE:
                 cudnn_v_block_tables = g.tensor_like(nd_block_tables)
                 cudnn_v_block_tables.set_uid(UIDs.BLOCK_TABLES_V_UID.value)
 
-            if actual_seq_lens_q is not None:
-                cudnn_actual_seq_lens_q = g.tensor_like(actual_seq_lens_q)
-                cudnn_actual_seq_lens_q.set_name("actual_seq_lens_q")
-                cudnn_actual_seq_lens_q.set_uid(UIDs.ACTUAL_SEQ_LENS_Q_UID.value)
+            if use_cu_seq_lens:
+                # The cumulative seq lens occupy the ACTUAL_SEQ_LENS UID slots
+                # -- mutually exclusive with per-batch seq lens, same role. On
+                # the ragged path the caller passes the token-unit indptrs
+                # here, i.e. the same buffers as the ragged offsets.
+                cudnn_cu_seq_lens_q = g.tensor_like(cu_seq_lens_q)
+                cudnn_cu_seq_lens_q.set_name("cu_seq_lens_q")
+                cudnn_cu_seq_lens_q.set_uid(UIDs.ACTUAL_SEQ_LENS_Q_UID.value)
 
-            if actual_seq_lens_kv is not None:
-                cudnn_actual_seq_lens_kv = g.tensor_like(actual_seq_lens_kv)
-                cudnn_actual_seq_lens_kv.set_name("actual_seq_lens_kv")
-                cudnn_actual_seq_lens_kv.set_uid(UIDs.ACTUAL_SEQ_LENS_KV_UID.value)
+                cudnn_cu_seq_lens_kv = g.tensor_like(cu_seq_lens_kv)
+                cudnn_cu_seq_lens_kv.set_name("cu_seq_lens_kv")
+                cudnn_cu_seq_lens_kv.set_uid(UIDs.ACTUAL_SEQ_LENS_KV_UID.value)
 
-            padding_mask = (
-                actual_seq_lens_q is not None and actual_seq_lens_kv is not None
-            )
+                padding_mask = True
+                # cu_seq_len kwargs are gated behind cudnn-frontend 1.25+, so
+                # only mention them when the direct path is taken.
+                seq_len_kwargs = {
+                    "cu_seq_len_q": cudnn_cu_seq_lens_q,
+                    "cu_seq_len_kv": cudnn_cu_seq_lens_kv,
+                }
+            else:
+                if actual_seq_lens_q is not None:
+                    cudnn_actual_seq_lens_q = g.tensor_like(actual_seq_lens_q)
+                    cudnn_actual_seq_lens_q.set_name("actual_seq_lens_q")
+                    cudnn_actual_seq_lens_q.set_uid(UIDs.ACTUAL_SEQ_LENS_Q_UID.value)
+
+                if actual_seq_lens_kv is not None:
+                    cudnn_actual_seq_lens_kv = g.tensor_like(actual_seq_lens_kv)
+                    cudnn_actual_seq_lens_kv.set_name("actual_seq_lens_kv")
+                    cudnn_actual_seq_lens_kv.set_uid(UIDs.ACTUAL_SEQ_LENS_KV_UID.value)
+
+                padding_mask = (
+                    actual_seq_lens_q is not None and actual_seq_lens_kv is not None
+                )
+                seq_len_kwargs = {
+                    "seq_len_q": (
+                        cudnn_actual_seq_lens_q
+                        if actual_seq_lens_q is not None
+                        else None
+                    ),
+                    "seq_len_kv": (
+                        cudnn_actual_seq_lens_kv
+                        if actual_seq_lens_kv is not None
+                        else None
+                    ),
+                }
 
             if (
                 cudnn_q_data_type == cudnn.data_type.BFLOAT16
@@ -353,16 +465,7 @@ if CUDNN_AVAILABLE:
                     q=cudnn_q,
                     k=cudnn_k_cache,
                     v=cudnn_v_cache,
-                    seq_len_q=(
-                        cudnn_actual_seq_lens_q
-                        if actual_seq_lens_q is not None
-                        else None
-                    ),
-                    seq_len_kv=(
-                        cudnn_actual_seq_lens_kv
-                        if actual_seq_lens_kv is not None
-                        else None
-                    ),
+                    **seq_len_kwargs,
                     use_padding_mask=padding_mask,
                     attn_scale=scale,
                     generate_stats=return_lse,
@@ -397,16 +500,9 @@ if CUDNN_AVAILABLE:
                     attn_scale=scale,
                     use_causal_mask_bottom_right=bottom_right_causal_mask,
                     use_padding_mask=padding_mask,
-                    seq_len_q=(
-                        cudnn_actual_seq_lens_q
-                        if actual_seq_lens_q is not None
-                        else None
-                    ),
-                    seq_len_kv=(
-                        cudnn_actual_seq_lens_kv
-                        if actual_seq_lens_kv is not None
-                        else None
-                    ),
+                    # cu_seq_len kwargs (direct path) exist on sdpa_fp8 only in
+                    # cudnn-frontend 1.27+; the version gate guarantees that.
+                    **seq_len_kwargs,
                     paged_attention_k_table=(
                         cudnn_k_block_tables if block_tables is not None else None
                     ),
@@ -429,11 +525,15 @@ if CUDNN_AVAILABLE:
                 ragged_o = g.tensor_like(batch_offsets_o)
                 ragged_o.set_uid(UIDs.RAGGED_O_UID.value)
                 O.set_ragged_offset(ragged_o)
+                if use_cu_seq_lens:
+                    O.set_ragged_offset_multiplier(h_qo * d_vo)
 
             if batch_offsets_stats is not None:
                 ragged_stats = g.tensor_like(batch_offsets_stats)
                 ragged_stats.set_uid(UIDs.RAGGED_STATS_UID.value)
                 Stats.set_ragged_offset(ragged_stats)
+                if use_cu_seq_lens:
+                    Stats.set_ragged_offset_multiplier(h_qo)
 
             O.set_uid(UIDs.O_UID.value).set_output(True).set_dim(
                 [graph_b, h_qo, graph_s_qo, d_vo]
@@ -452,10 +552,14 @@ if CUDNN_AVAILABLE:
             if return_lse:
                 tensors_to_return.append(Stats)
 
-            if actual_seq_lens_q is not None:
-                tensors_to_return.append(cudnn_actual_seq_lens_q)
-            if actual_seq_lens_kv is not None:
-                tensors_to_return.append(cudnn_actual_seq_lens_kv)
+            if use_cu_seq_lens:
+                tensors_to_return.append(cudnn_cu_seq_lens_q)
+                tensors_to_return.append(cudnn_cu_seq_lens_kv)
+            else:
+                if actual_seq_lens_q is not None:
+                    tensors_to_return.append(cudnn_actual_seq_lens_q)
+                if actual_seq_lens_kv is not None:
+                    tensors_to_return.append(cudnn_actual_seq_lens_kv)
 
             return g, tensors_to_return
 
@@ -469,8 +573,10 @@ def _batch_prefill_with_kv_cache(
     *,
     max_token_per_sequence: int,
     max_sequence_kv: int,
-    actual_seq_lens_q: torch.Tensor,
-    actual_seq_lens_kv: torch.Tensor,
+    actual_seq_lens_q: Optional[torch.Tensor] = None,
+    actual_seq_lens_kv: Optional[torch.Tensor] = None,
+    cu_seq_lens_q: Optional[torch.Tensor] = None,
+    cu_seq_lens_kv: Optional[torch.Tensor] = None,
     block_tables: Optional[torch.Tensor] = None,
     causal: bool,
     return_lse: bool,
@@ -495,6 +601,8 @@ def _batch_prefill_with_kv_cache(
         max_sequence_kv=max_sequence_kv,
         actual_seq_lens_q=actual_seq_lens_q,
         actual_seq_lens_kv=actual_seq_lens_kv,
+        cu_seq_lens_q=cu_seq_lens_q,
+        cu_seq_lens_kv=cu_seq_lens_kv,
         block_tables=block_tables,
         bottom_right_causal_mask=causal,
         return_lse=return_lse,
@@ -515,9 +623,16 @@ def _batch_prefill_with_kv_cache(
         UIDs.O_UID.value: out,
     }
 
-    if actual_seq_lens_q is not None:
+    # The cumulative seq lens feed the padding mask via the seq-lens UID
+    # slots (on the ragged path these are the same buffers as the
+    # token-unit ragged offsets below).
+    if cu_seq_lens_q is not None:
+        var_map[UIDs.ACTUAL_SEQ_LENS_Q_UID.value] = cu_seq_lens_q
+    elif actual_seq_lens_q is not None:
         var_map[UIDs.ACTUAL_SEQ_LENS_Q_UID.value] = actual_seq_lens_q
-    if actual_seq_lens_kv is not None:
+    if cu_seq_lens_kv is not None:
+        var_map[UIDs.ACTUAL_SEQ_LENS_KV_UID.value] = cu_seq_lens_kv
+    elif actual_seq_lens_kv is not None:
         var_map[UIDs.ACTUAL_SEQ_LENS_KV_UID.value] = actual_seq_lens_kv
 
     if batch_offsets_q is not None:
@@ -569,8 +684,8 @@ def cudnn_batch_prefill_with_kv_cache(
     *,
     max_token_per_sequence: int,
     max_sequence_kv: int,
-    actual_seq_lens_q: torch.Tensor,
-    actual_seq_lens_kv: torch.Tensor,
+    actual_seq_lens_q: Optional[torch.Tensor] = None,
+    actual_seq_lens_kv: Optional[torch.Tensor] = None,
     block_tables: Optional[torch.Tensor] = None,
     causal: bool,
     return_lse: bool,
@@ -582,6 +697,7 @@ def cudnn_batch_prefill_with_kv_cache(
     batch_offsets_k: Optional[torch.Tensor] = None,
     batch_offsets_v: Optional[torch.Tensor] = None,
     batch_offsets_stats: Optional[torch.Tensor] = None,
+    batch_offsets_units: str = "elements",
     out: Optional[torch.Tensor] = None,
     lse: Optional[torch.Tensor] = None,
     is_cuda_graph_compatible: bool = False,
@@ -611,16 +727,20 @@ def cudnn_batch_prefill_with_kv_cache(
         Maximum number of tokens per query sequence (``s_qo_max``).
     max_sequence_kv : int
         Maximum number of tokens per KV sequence (``s_kv_max``).
-    actual_seq_lens_q : torch.Tensor
+    actual_seq_lens_q : Optional[torch.Tensor]
         Per-request query lengths, shape ``(batch_size, 1, 1, 1)``.  When cuDNN is
         available (the default backend) this tensor must reside on the same
         CUDA device as ``q``.  Only the fallback non-cuDNN path accepts (and
         internally copies) a CPU tensor; that fallback is also the only path
         that requires a CPU tensor when ``is_cuda_graph_compatible`` is
-        ``False``.
-    actual_seq_lens_kv : torch.Tensor
+        ``False``.  May be omitted with ``batch_offsets_units="tokens"`` and
+        ``batch_offsets_q`` set (the lengths are then implied by the indptr);
+        the cubin backend always requires it.
+    actual_seq_lens_kv : Optional[torch.Tensor]
         Per-request KV lengths, shape ``(batch_size, 1, 1, 1)``.  Same device
-        rules as ``actual_seq_lens_q``.
+        rules as ``actual_seq_lens_q``.  May be omitted with
+        ``batch_offsets_units="tokens"`` and ``batch_offsets_k`` set (non-paged
+        KV); the cubin backend always requires it.
     block_tables : Optional[torch.Tensor]
         Paged KV block table, shape ``(batch_size, num_pages_per_seq)`` on GPU.
         Pass ``None`` for non-paged KV layouts.
@@ -636,25 +756,42 @@ def cudnn_batch_prefill_with_kv_cache(
     v_scale : Optional[torch.Tensor]
         FP8 dequantization scale for the value, shape ``(1, 1, 1, 1)`` on GPU.
     batch_offsets_q : Optional[torch.Tensor]
-        Cumulative per-request start offsets into the packed query tensor, in
-        **elements** (``token_offset * num_heads_qo * head_dim_qk``), shape
-        ``(batch_size + 1,)``, int32, on GPU.  Required when ``batch_size > 1``
-        on the cuDNN graph path; may be omitted only for ``batch_size == 1``.
+        Cumulative per-request start offsets into the packed query tensor,
+        shape ``(batch_size + 1,)``, int32, on GPU, in the units given by
+        ``batch_offsets_units`` (element offsets are
+        ``token_offset * num_heads_qo * head_dim_qk``).  Required when
+        ``batch_size > 1`` on the cuDNN graph path; may be omitted only for
+        ``batch_size == 1``.
     batch_offsets_o : Optional[torch.Tensor]
-        Cumulative per-request start offsets into the packed output tensor, in
-        elements (``token_offset * num_heads_qo * head_dim_vo``), shape
-        ``(batch_size + 1,)``, int32, on GPU.  Required when ``batch_size > 1``
-        on the cuDNN graph path.
+        Cumulative per-request start offsets into the packed output tensor,
+        shape ``(batch_size + 1,)``, int32, on GPU, in the units given by
+        ``batch_offsets_units`` (element offsets are
+        ``token_offset * num_heads_qo * head_dim_vo``).  Required when
+        ``batch_size > 1`` on the cuDNN graph path; with
+        ``batch_offsets_units="tokens"`` it defaults to ``batch_offsets_q``.
     batch_offsets_k : Optional[torch.Tensor]
-        Cumulative per-request start offsets into the key tensor, in elements,
-        shape ``(batch_size + 1,)`` on GPU.  Only used for non-paged (3-D) KV.
+        Cumulative per-request start offsets into the key tensor, shape
+        ``(batch_size + 1,)`` on GPU, in the units given by
+        ``batch_offsets_units``.  Only used for non-paged (3-D) KV.
     batch_offsets_v : Optional[torch.Tensor]
-        Cumulative per-request start offsets into the value tensor, in
-        elements, shape ``(batch_size + 1,)`` on GPU.  Only used for non-paged
-        (3-D) KV.
+        Cumulative per-request start offsets into the value tensor, shape
+        ``(batch_size + 1,)`` on GPU, in the units given by
+        ``batch_offsets_units``.  Only used for non-paged (3-D) KV; with
+        ``batch_offsets_units="tokens"`` it defaults to ``batch_offsets_k``.
     batch_offsets_stats : Optional[torch.Tensor]
-        Cumulative per-request start offsets into the LSE / stats tensor, in
-        elements, shape ``(batch_size + 1,)``.
+        Cumulative per-request start offsets into the LSE / stats tensor,
+        shape ``(batch_size + 1,)``, in the units given by
+        ``batch_offsets_units``.
+    batch_offsets_units : str
+        Units of the ``batch_offsets_*`` tensors. ``"elements"`` (default, the
+        historical behavior): offsets are pre-scaled tensor-element offsets,
+        e.g. ``cumsum(seq_lens) * num_heads * head_dim`` for the query.
+        ``"tokens"``: offsets are plain token-unit prefix sums
+        (``qo_indptr``/``kv_indptr`` style, the FlashInfer convention). For
+        non-paged KV, token-unit indptrs are consumed directly by the kernel
+        with no conversion pre-pass on cuDNN backend 9.24+ with cudnn-frontend
+        1.25+ (fp16/bf16) or backend 9.25+ with cudnn-frontend 1.27+ (fp8);
+        otherwise FlashInfer scales them to element units internally.
     out : Optional[torch.Tensor]
         Pre-allocated output tensor, shape
         ``(total_qo_tokens, num_heads_qo, head_dim_vo)``.  Allocated internally
@@ -689,7 +826,30 @@ def cudnn_batch_prefill_with_kv_cache(
 
     num_tokens = q.shape[0]
 
-    num_sequences = actual_seq_lens_q.shape[0]
+    if batch_offsets_units not in ("elements", "tokens"):
+        raise ValueError(
+            f"batch_offsets_units must be 'elements' or 'tokens', got {batch_offsets_units!r}"
+        )
+
+    # actual_seq_lens_q/kv may be omitted only when they are derivable from
+    # token-unit indptrs (the direct path consumes the indptrs as-is; the
+    # conversion path derives per-request lengths from them below).
+    if actual_seq_lens_q is not None:
+        num_sequences = actual_seq_lens_q.shape[0]
+    elif batch_offsets_units == "tokens" and batch_offsets_q is not None:
+        num_sequences = batch_offsets_q.shape[0] - 1
+    else:
+        raise ValueError(
+            "actual_seq_lens_q may be omitted only with "
+            'batch_offsets_units="tokens" and batch_offsets_q set'
+        )
+    if actual_seq_lens_kv is None and not (
+        batch_offsets_units == "tokens" and batch_offsets_k is not None
+    ):
+        raise ValueError(
+            "actual_seq_lens_kv may be omitted only with "
+            'batch_offsets_units="tokens" and batch_offsets_k set (non-paged KV)'
+        )
 
     if q.dim() == 3:
         h_qo, d_qk = q.shape[1], q.shape[2]
@@ -723,6 +883,13 @@ def cudnn_batch_prefill_with_kv_cache(
         out_shape = (num_tokens, h_qo, d_vo)
         out = torch.empty(out_shape, device=q.device, dtype=o_data_type)
 
+    if batch_offsets_units == "tokens":
+        # Convenience feature to allow user to set just batch_offsets_{q,k} if desired.
+        if batch_offsets_o is None:
+            batch_offsets_o = batch_offsets_q
+        if batch_offsets_v is None:
+            batch_offsets_v = batch_offsets_k
+
     if CUDNN_AVAILABLE and backend != "cubin":
         # The cuDNN graph declares packed q/out with THD nominal strides
         # (batch stride == one token), which is only addressable through ragged
@@ -735,9 +902,10 @@ def cudnn_batch_prefill_with_kv_cache(
                 "batch_offsets_q and batch_offsets_o are required when batch_size > 1: "
                 "packed q/out cannot be addressed without ragged offsets. Pass "
                 "cumulative element offsets of shape (batch_size + 1,), e.g. "
-                "cumsum([0, *actual_seq_lens_q]) * num_qo_heads * head_dim."
+                "cumsum([0, *actual_seq_lens_q]) * num_qo_heads * head_dim, or "
+                'token-unit indptrs with batch_offsets_units="tokens".'
             )
-        return _batch_prefill_with_kv_cache(
+        run_kwargs = dict(
             q=q,
             k_cache=k_cache,
             v_cache=v_cache,
@@ -753,16 +921,66 @@ def cudnn_batch_prefill_with_kv_cache(
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            out=out,
+            lse=lse,
+            o_data_type=o_data_type,
+        )
+
+        if batch_offsets_units == "tokens":
+            h_kv = k_cache.shape[1]
+            use_direct = (
+                _cudnn_supports_direct_seqlens(q.dtype)
+                and block_tables is None
+                # The direct path consumes the q/k indptrs as cu_seq_lens.
+                and batch_offsets_q is not None
+                and batch_offsets_k is not None
+            )
+            if use_direct:
+                # On the ragged path the token-unit indptrs are also the
+                # cumulative seq lens; cuDNN consumes them and the offsets
+                # directly (scaling offsets by per-tensor multipliers).
+                run_kwargs["cu_seq_lens_q"] = batch_offsets_q
+                run_kwargs["cu_seq_lens_kv"] = batch_offsets_k
+            else:
+                # Old cuDNN/frontend or paged: convert the token-unit indptrs
+                # to the element units the legacy graph expects. Names are
+                # rebound, not mutated, so the aliasing defaults above (o from
+                # q, v from k) still read the original token-unit buffers.
+
+                # The legacy graph's padding mask needs per-request lengths;
+                # derive them from the token-unit indptrs when omitted.
+                if actual_seq_lens_q is None:
+                    run_kwargs["actual_seq_lens_q"] = (
+                        batch_offsets_q[1:] - batch_offsets_q[:-1]
+                    ).view(-1, 1, 1, 1)
+                if actual_seq_lens_kv is None:
+                    run_kwargs["actual_seq_lens_kv"] = (
+                        batch_offsets_k[1:] - batch_offsets_k[:-1]
+                    ).view(-1, 1, 1, 1)
+
+                def apply_multiplier(offsets, multiplier):
+                    return offsets * multiplier if offsets is not None else None
+
+                batch_offsets_q = apply_multiplier(batch_offsets_q, h_qo * d_qk)
+                batch_offsets_o = apply_multiplier(batch_offsets_o, h_qo * d_vo)
+                batch_offsets_k = apply_multiplier(batch_offsets_k, h_kv * d_qk)
+                batch_offsets_v = apply_multiplier(batch_offsets_v, h_kv * d_vo)
+                batch_offsets_stats = apply_multiplier(batch_offsets_stats, h_qo)
+
+        return _batch_prefill_with_kv_cache(
+            **run_kwargs,
             batch_offsets_q=batch_offsets_q,
             batch_offsets_o=batch_offsets_o,
             batch_offsets_k=batch_offsets_k,
             batch_offsets_v=batch_offsets_v,
             batch_offsets_stats=batch_offsets_stats,
-            out=out,
-            lse=lse,
-            o_data_type=o_data_type,
         )
     else:
+        if actual_seq_lens_q is None or actual_seq_lens_kv is None:
+            raise ValueError(
+                "the cubin backend requires actual_seq_lens_q and actual_seq_lens_kv"
+            )
+
         assert return_lse, "Currently only supports return_lse = True"
 
         assert (d_qk == 192 and block_tables is None) or (

--- a/flashinfer/cudnn/prefill.py
+++ b/flashinfer/cudnn/prefill.py
@@ -423,11 +423,18 @@ if CUDNN_AVAILABLE:
                 cudnn_cu_seq_lens_kv.set_uid(UIDs.ACTUAL_SEQ_LENS_KV_UID.value)
 
                 padding_mask = True
-                # cu_seq_len kwargs are gated behind cudnn-frontend 1.25+, so
-                # only mention them when the direct path is taken.
+                # These kwargs need a newer cudnn-frontend than the declared
+                # >=1.13 floor (cu_seq_len_*: 1.25+; implementation /
+                # attention_implementation: 1.14+), so they are only mentioned
+                # on this path, which _cudnn_supports_direct_seqlens guards.
                 seq_len_kwargs = {
                     "cu_seq_len_q": cudnn_cu_seq_lens_q,
                     "cu_seq_len_kv": cudnn_cu_seq_lens_kv,
+                    # cu_seq_lens are unified-engine-only; pin the
+                    # implementation so an unsupported config fails with the
+                    # unified engine's specific error instead of
+                    # auto-selection's generic failure.
+                    "implementation": cudnn.attention_implementation.UNIFIED,
                 }
             else:
                 if actual_seq_lens_q is not None:

--- a/tests/attention/test_cudnn_prefill_token_indptr.py
+++ b/tests/attention/test_cudnn_prefill_token_indptr.py
@@ -1,0 +1,214 @@
+"""Tests for batch_offsets_units="tokens" on the cuDNN prefill path.
+
+Token-unit indptrs must produce the same results as the historical
+element-unit offsets, both on the direct path (cuDNN consumes the indptrs
+via cu_seq_len + ragged-offset multipliers, no conversion pre-pass) and on
+the conversion path (FlashInfer scales them to element units internally).
+"""
+
+import pytest
+import torch
+
+from flashinfer.cudnn import cudnn_batch_prefill_with_kv_cache
+from flashinfer.cudnn import prefill as cudnn_prefill
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("s_qo", [32, 87])
+@pytest.mark.parametrize("s_kv", [87, 512])
+@pytest.mark.parametrize("num_kv_heads", [1, 4])
+@pytest.mark.parametrize("num_qo_heads", [8])
+@pytest.mark.parametrize("head_dim_qk,head_dim_vo", [(128, 128), (192, 128)])
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.parametrize("direct", [True, False])
+def test_cudnn_prefill_token_indptr(
+    monkeypatch,
+    batch_size,
+    s_qo,
+    s_kv,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim_qk,
+    head_dim_vo,
+    causal,
+    direct,
+):
+    if not cudnn_prefill.CUDNN_AVAILABLE:
+        pytest.skip("cudnn-frontend python package not available")
+    if direct and not cudnn_prefill._cudnn_supports_direct_seqlens(torch.bfloat16):
+        pytest.skip("cuDNN backend/frontend too old for direct token-unit seqlens")
+    if s_qo > s_kv:
+        pytest.skip("s_qo > s_kv, skipping test as causal")
+
+    if not direct:
+        # Force the conversion path even where the direct path is supported.
+        monkeypatch.setattr(
+            cudnn_prefill, "_cudnn_supports_direct_seqlens", lambda dtype: False
+        )
+
+    torch.manual_seed(0)
+    device = "cuda:0"
+
+    actual_seq_lens_q = torch.randint(
+        1, s_qo + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    actual_seq_lens_kv = torch.randint(
+        s_qo, s_kv + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+
+    zero = torch.zeros(1, dtype=torch.int32, device=device)
+    qo_indptr = torch.cat([zero, torch.cumsum(actual_seq_lens_q, 0)]).int()
+    kv_indptr = torch.cat([zero, torch.cumsum(actual_seq_lens_kv, 0)]).int()
+
+    q = torch.randn(
+        int(actual_seq_lens_q.sum()),
+        num_qo_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k_cache = torch.randn(
+        int(actual_seq_lens_kv.sum()),
+        num_kv_heads,
+        head_dim_qk,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v_cache = torch.randn(
+        int(actual_seq_lens_kv.sum()),
+        num_kv_heads,
+        head_dim_vo,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    workspace_buffer = torch.empty(512 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    common = dict(
+        scale=float(1.0 / (head_dim_qk**0.5)),
+        workspace_buffer=workspace_buffer,
+        max_token_per_sequence=s_qo,
+        max_sequence_kv=s_kv,
+        actual_seq_lens_q=actual_seq_lens_q.view(batch_size, 1, 1, 1),
+        actual_seq_lens_kv=actual_seq_lens_kv.view(batch_size, 1, 1, 1),
+        causal=causal,
+        return_lse=True,
+    )
+
+    out_ref, lse_ref = cudnn_batch_prefill_with_kv_cache(
+        q,
+        k_cache,
+        v_cache,
+        **common,
+        batch_offsets_q=qo_indptr * (num_qo_heads * head_dim_qk),
+        batch_offsets_o=qo_indptr * (num_qo_heads * head_dim_vo),
+        batch_offsets_k=kv_indptr * (num_kv_heads * head_dim_qk),
+        batch_offsets_v=kv_indptr * (num_kv_heads * head_dim_vo),
+    )
+
+    out, lse = cudnn_batch_prefill_with_kv_cache(
+        q,
+        k_cache,
+        v_cache,
+        **common,
+        batch_offsets_q=qo_indptr,
+        batch_offsets_k=kv_indptr,
+        batch_offsets_units="tokens",
+    )
+
+    if direct:
+        # There is no fallback: reaching here proves the direct
+        # (unified-engine) path ran. Engines differ from the reference run,
+        # so compare with tolerances.
+        torch.testing.assert_close(out, out_ref, atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(lse, lse_ref, atol=1e-2, rtol=1e-2)
+    else:
+        # The conversion path scales the indptrs and builds the identical
+        # legacy graph, so results are bitwise equal.
+        assert torch.equal(out, out_ref)
+        assert torch.equal(lse, lse_ref)
+
+
+@pytest.mark.parametrize("direct", [True, False])
+def test_cudnn_prefill_token_indptr_omit_actual_seq_lens(monkeypatch, direct):
+    """actual_seq_lens_q/kv are optional with token-unit indptrs.
+
+    The direct path never reads them, and the conversion path derives them
+    from the indptrs, so omitting them must be bitwise-identical to passing
+    them within either path.
+    """
+    if not cudnn_prefill.CUDNN_AVAILABLE:
+        pytest.skip("cudnn-frontend python package not available")
+    if direct and not cudnn_prefill._cudnn_supports_direct_seqlens(torch.bfloat16):
+        pytest.skip("cuDNN backend/frontend too old for direct token-unit seqlens")
+
+    if not direct:
+        monkeypatch.setattr(
+            cudnn_prefill, "_cudnn_supports_direct_seqlens", lambda dtype: False
+        )
+
+    torch.manual_seed(0)
+    device = "cuda:0"
+    batch_size, s_qo, s_kv = 4, 87, 512
+    num_qo_heads, num_kv_heads, head_dim = 8, 4, 128
+
+    actual_seq_lens_q = torch.randint(
+        1, s_qo + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    actual_seq_lens_kv = torch.randint(
+        s_qo, s_kv + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    zero = torch.zeros(1, dtype=torch.int32, device=device)
+    qo_indptr = torch.cat([zero, torch.cumsum(actual_seq_lens_q, 0)]).int()
+    kv_indptr = torch.cat([zero, torch.cumsum(actual_seq_lens_kv, 0)]).int()
+
+    q = torch.randn(
+        int(actual_seq_lens_q.sum()),
+        num_qo_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    k_cache = torch.randn(
+        int(actual_seq_lens_kv.sum()),
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    v_cache = torch.randn(
+        int(actual_seq_lens_kv.sum()),
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    common = dict(
+        scale=float(1.0 / (head_dim**0.5)),
+        workspace_buffer=torch.empty(
+            512 * 1024 * 1024, dtype=torch.int8, device=device
+        ),
+        max_token_per_sequence=s_qo,
+        max_sequence_kv=s_kv,
+        causal=True,
+        return_lse=True,
+        batch_offsets_q=qo_indptr,
+        batch_offsets_k=kv_indptr,
+        batch_offsets_units="tokens",
+    )
+
+    out_with, lse_with = cudnn_batch_prefill_with_kv_cache(
+        q,
+        k_cache,
+        v_cache,
+        **common,
+        actual_seq_lens_q=actual_seq_lens_q.view(batch_size, 1, 1, 1),
+        actual_seq_lens_kv=actual_seq_lens_kv.view(batch_size, 1, 1, 1),
+    )
+    out_without, lse_without = cudnn_batch_prefill_with_kv_cache(
+        q, k_cache, v_cache, **common
+    )
+
+    assert torch.equal(out_without, out_with)
+    assert torch.equal(lse_without, lse_with)


### PR DESCRIPTION
## 📌 Description

The cudnn backend is the only FlashInfer backend whose `batch_offsets_*` are element-unit (`tokens * heads * head_dim`); every other backend takes token-unit indptrs — a wart that leaks into the generic wrapper, where `qo_indptr`'s meaning changes when `backend="cudnn"`. This PR adds `batch_offsets_units={"elements","tokens"}` to `cudnn_batch_prefill_with_kv_cache` so callers can pass ordinary token-unit indptrs:

- **Direct path** (non-paged; cuDNN backend 9.24+ / cudnn-frontend 1.25+ for fp16/bf16, 9.25+ / 1.27+ declared for fp8): the indptrs are handed to cuDNN as-is — they double as `cu_seq_len_q/kv` for the padding mask, and as ragged offsets scaled to elements *inside the engine* via per-tensor ragged offset multipliers. This removes the host-side offset conversion, and one Q-side + one KV-side indptr serve q/o and k/v respectively, like every other backend.
- **Conversion path** (older cuDNN/frontend, or paged KV): FlashInfer scales the token-unit indptrs to element units and builds the unchanged legacy graph.

Notes:
- `"tokens"` is purely a units declaration: like `"elements"`, it does not require any `batch_offsets_*` to be present, so callers can set it unconditionally regardless of layout.
- No silent fallback: if cuDNN rejects a direct-path graph, the error propagates.
- The paged restriction on the direct path is a FlashInfer plumbing scope choice, not a cuDNN limitation (the unified engine supports paged attention with cu_seq_lens).
- Default `"elements"` keeps the existing API contract bit-for-bit; a follow-up can migrate the generic wrapper's `backend="cudnn"` calls to `"tokens"` and retire its cudnn-only `o_indptr`/`v_indptr` plan parameters.

## 🧪 Tests

- New `tests/attention/test_cudnn_prefill_token_indptr.py`: 128 configs comparing token-unit against historical element-unit calls — direct path vs reference with tolerances (different engines), conversion path bitwise-identical. Run on H100 with cuDNN 9.25 + cudnn-frontend 1.27: 128/128 passed.
- Existing element-unit suite `test_cudnn_prefill.py`: 288 passed, unaffected.
- [x] Tests have been added/updated as needed
- [x] All tests are passing locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `batch_offsets_units` to `cudnn_batch_prefill_with_kv_cache` (default: `elements`) to support token-unit ragged offsets via `batch_offsets_units="tokens"`.
  - When supported and applicable, cuDNN can consume token-unit offsets directly; otherwise offsets are converted internally to element units.
  - If output/value offsets are omitted, they are inferred from the Q/K offsets.

- **Tests**
  - Added coverage for token-unit offsets across batch sizes, head counts/dimensions, sequence lengths, causal settings, and direct-mode behavior (with appropriate result checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->