### PR TITLE
fix(moe): allocate trtllm-gen expert_weights as bf16 in all launchers

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -259,7 +259,6 @@ class FusedMoeLauncher {
   btg::Dtype mRoutingLogitsDtype{btg::Dtype::Bfloat16};
   bool norm_topk_prob{true};
   ActivationType activation_type{ActivationType::Swiglu};
-  btg::Dtype mDtypeScore{btg::Dtype::Bfloat16};
 
   // Optional routing replay output: [num_tokens, top_k] int16 tensor
   Optional<TensorView> routing_replay_out;
@@ -488,15 +487,6 @@ class FusedMoeLauncher {
     workspace.cta_idx_xy_to_batch_idx = static_cast<int*>(cta_idx_xy_to_batch_idx.data_ptr());
     workspace.cta_idx_xy_to_mn_limit = static_cast<int*>(cta_idx_xy_to_mn_limit.data_ptr());
     workspace.num_non_exiting_ctas = static_cast<int*>(num_non_exiting_ctas.data_ptr());
-
-    // Set dtype of score based on actual routing_logits dtype
-    if (routing_logits.has_value()) {
-      if (routing_logits.value().dtype() == dl_float32) {
-        mDtypeScore = btg::Dtype::Fp32;
-      } else {
-        mDtypeScore = btg::Dtype::Bfloat16;
-      }
-    }
   }
 
   void check_moe_common() const {
@@ -784,9 +774,12 @@ class Bf16MoeLauncher : public FusedMoeLauncher {
     if (has_precomputed_weights) {
       workspace.expert_weights = const_cast<void*>(expert_weights.data_ptr());
     } else {
-      auto ew_dtype = mDtypeScore == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
+      // Allocate the routing-output buffer as bf16 to match the kernel's output
+      // (mDtypeOutput is always Bfloat16 in trtllm_fused_moe_runner.cu, never the
+      // logits dtype); a fp32 alloc would mislabel bf16 data when this buffer is
+      // surfaced to the caller verbatim on do_finalize=false. See #3595.
       FusedMoeLauncher::expert_weights =
-          alloc_tensor({args->num_tokens, args->top_k}, ew_dtype, hidden_states.device());
+          alloc_tensor({args->num_tokens, args->top_k}, dl_bfloat16, hidden_states.device());
       workspace.expert_weights = FusedMoeLauncher::expert_weights.data_ptr();
     }
   }
@@ -951,9 +944,12 @@ class Fp8PerTensorLauncher : public FusedMoeLauncher {
     mRoutingLogitsDtype =
         routing_logits_dtype == dl_float32 ? btg::Dtype::Fp32 : btg::Dtype::Bfloat16;
 
-    auto expert_weights_dtype = mRoutingLogitsDtype == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
+    // Allocate the routing-output buffer as bf16 to match the kernel's output
+    // (always Bfloat16, never the logits dtype); a fp32 alloc would mislabel bf16
+    // data when this buffer is surfaced to the caller verbatim on
+    // do_finalize=false. See #3595.
     expert_weights =
-        alloc_tensor({args->num_tokens, args->top_k}, expert_weights_dtype, hidden_states.device());
+        alloc_tensor({args->num_tokens, args->top_k}, dl_bfloat16, hidden_states.device());
 
     workspace.expert_weights = expert_weights.data_ptr();
     if (static_cast<RoutingMethodType>(routing_method_type) == RoutingMethodType::Llama4) {
@@ -1252,9 +1248,12 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
     // Check ndim==2 and size>0 because empty placeholder tensors may have non-null data_ptr
     bool has_precomputed_weights = expert_weights.ndim() == 2 && expert_weights.size(0) > 0;
     if (!has_precomputed_weights) {
-      auto ew_dtype = mDtypeScore == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
-      FusedMoeLauncher::expert_weights =
-          alloc_tensor({args->num_tokens, totalExpertsPerToken}, ew_dtype, hidden_states.device());
+      // Allocate the routing-output buffer as bf16 to match the kernel's output
+      // (always Bfloat16, never the logits dtype); a fp32 alloc would mislabel
+      // bf16 data when this buffer is surfaced to the caller verbatim on
+      // do_finalize=false. See #3595.
+      FusedMoeLauncher::expert_weights = alloc_tensor({args->num_tokens, totalExpertsPerToken},
+                                                      dl_bfloat16, hidden_states.device());
       workspace.expert_weights = FusedMoeLauncher::expert_weights.data_ptr();
     } else {
       workspace.expert_weights = const_cast<void*>(expert_weights.data_ptr());
@@ -1624,9 +1623,12 @@ class MxInt4BlockScaleLauncher : public FusedMoeLauncher {
     if (has_precomputed_weights) {
       workspace.expert_weights = const_cast<void*>(expert_weights.data_ptr());
     } else {
-      auto ew_dtype = mRoutingLogitsDtype == btg::Dtype::Fp32 ? dl_float32 : dl_bfloat16;
+      // Allocate the routing-output buffer as bf16 to match the kernel's output
+      // (always Bfloat16, never the logits dtype); a fp32 alloc would mislabel
+      // bf16 data when this buffer is surfaced to the caller verbatim on
+      // do_finalize=false. See #3595.
       FusedMoeLauncher::expert_weights =
-          alloc_tensor({args->num_tokens, args->top_k}, ew_dtype, hidden_states.device());
+          alloc_tensor({args->num_tokens, args->top_k}, dl_bfloat16, hidden_states.device());
       workspace.expert_weights = FusedMoeLauncher::expert_weights.data_ptr();
     }
   }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Follow-up to #3595 / #3644 (which fixed the FP4 op). The trtllm-gen routing kernel **always** writes expert weights in bfloat16 — `routingData.mDtypeOutput` is hard-set to `Bfloat16` in every branch of `Routing::Runner::run` (`csrc/trtllm_fused_moe_runner.cu`), independent of the `routing_logits` dtype.

But four launchers in `csrc/trtllm_fused_moe_kernel_launcher.cu` allocated the `expert_weights` output buffer from the **routing-logits** dtype (`dl_float32` when logits are fp32):

- `Bf16MoeLauncher`
- `Fp8PerTensorLauncher`
- `Fp8BlockScaleLauncher`
- `MxInt4BlockScaleLauncher`

The base `run()` returns that buffer verbatim on `do_finalize=false`, and the Python wrappers hand it straight back via `torch.from_dlpack`. So with fp32 routing logits (the conventional DeepSeekV3 case) + `do_finalize=false`, the caller receives **bf16 data mislabeled as fp32** and reads garbage — the same corruption #3644 fixed for FP4.

**Fix:** allocate `expert_weights` as `bfloat16` unconditionally to match the kernel's actual output. No-op for the common bf16-logits path and for `do_finalize=true` (internal workspace read back as bf16, just avoids a 2× over-allocation). Also removes the now-dead `mDtypeScore` member (write-only after this change).

**Why the fp32 branch existed:** a latent mismatch since #2534, which added a configurable score dtype (`mDtypeScore`) to support fp32 routing *logits*. But the expert-weights *output* (`mDtypeExpW`, later renamed `mDtypeOutput`) was always bf16 in that same PR — the launcher mistakenly sized/labeled the *output* buffer from `mDtypeScore` (an input/score knob). **fp32 logits remain fully supported** — they still flow to the kernel via `mRoutingLogitsDtype`/`mDtypeInput`; only the output-buffer dtype is corrected.

## 🔍 Related Issues

- Follow-up to #3595 / #3644 (same bug class, FP4 op)
- Latent mismatch originated in #2534

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation via GitHub CI (SM100-class trtllm-gen kernels). Suggested follow-up: a regression test that runs each of the four ops with fp32 DeepSeekV3 routing logits + `do_finalize=False` and asserts the returned `expert_weights.dtype == torch.bfloat16` (mirrors the FP4 test added in #3644).

## Reviewer Notes

Focus areas: confirm the Llama4 `token_scales` aliasing of this buffer is also fine as bf16, and that no caller depended on the (incorrect) fp32 labeling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed routing output and expert weight buffers to consistently use the correct bfloat16 format.
  * Prevented potential data mislabeling when routing results are returned before finalization.
  * Improved consistency across supported Mixture-of-Experts execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->