### PR TITLE
Raise at capture time when a default-mode wrapper's run() is captured into a CUDA graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -529,6 +529,7 @@ Used by `flashinfer.trace` / `fi_trace`.
 
 | Variable | Default | Read in | Effect |
 |----------|---------|---------|--------|
+| `FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE` | unset | `flashinfer/utils.py` | Non-zero / non-empty value disables the `RuntimeError` raised when a wrapper's `run()` is captured into a CUDA graph although the wrapper was constructed with `use_cuda_graph=False`. Escape hatch only — a graph captured in this mode replays against stale plan buffers and can silently produce wrong output. |
 | `FLASHINFER_VALIDATE_INPUTS` | `0` | `flashinfer/mla/_core.py` (MLA wrapper) | Non-zero / non-empty value enables defensive input validation inside the MLA wrapper. Adds host-side overhead; intended for debugging. |
 | `FLASHINFER_AUTOTUNER_LOAD_FROM_FILE` | `0` | `flashinfer/autotuner.py` | `1` loads previously serialized autotune results from disk instead of re-running the search. |
 | `FLASHINFER_AUTOTUNE_DIR` | unset | `flashinfer/mla/_sparse_mla_sm120.py` | Override the disk path for MLA AutoTuner cache files. Falls back to `FLASHINFER_WORKSPACE_DIR` when unset. |

--- a/flashinfer/api_logging.py
+++ b/flashinfer/api_logging.py
@@ -30,6 +30,8 @@ import contextlib
 import importlib
 import torch
 
+from .utils import is_current_stream_capturing
+
 
 # Helper function to substitute %i with process ID in file paths
 def _substitute_process_id(path: str) -> str:
@@ -645,16 +647,6 @@ def _extract_tensors_and_metadata(
     return _extract_tensors_and_metadata_common(args, kwargs, graph_capture=False)
 
 
-def _is_current_stream_capturing() -> bool:
-    """Return True iff the current CUDA stream is in graph-capture mode."""
-    if not hasattr(torch.cuda, "is_current_stream_capturing"):
-        return False
-    try:
-        return torch.cuda.is_current_stream_capturing()
-    except Exception:
-        return False
-
-
 def _extract_tensors_and_metadata_graph_refs(
     args: tuple, kwargs: dict
 ) -> Tuple[Dict[str, torch.Tensor], Dict[str, Any]]:
@@ -765,7 +757,7 @@ def _dump_function_inputs(
     # references instead; the replay hook materializes them to CPU after replay.
     # In eager mode keep the legacy ``.cpu()`` path so original CUDA strides are
     # recorded faithfully, matching pre-PR behavior.
-    is_capturing = _is_current_stream_capturing()
+    is_capturing = is_current_stream_capturing()
     if is_capturing:
         input_tensors, input_metadata = _extract_tensors_and_metadata_graph_refs(
             args, kwargs
@@ -950,7 +942,7 @@ def _dump_function_outputs(dump_dir: str, result: Any) -> None:
             _logger.error(f"Dump directory not found: {dump_dir}")
             return
 
-        is_capturing = _is_current_stream_capturing()
+        is_capturing = is_current_stream_capturing()
 
         # Extract tensors and metadata from outputs.
         # During capture, hold tensor references instead of adding D2H copies
@@ -1918,10 +1910,7 @@ def _format_value(value: Any, level: int, indent: int = 0) -> str:
             try:
                 # Skip statistics if we're in CUDA graph capture mode
                 # (operations like .min()/.max()/.mean() cause synchronization issues)
-                is_capturing = False
-                if value.is_cuda and hasattr(torch.cuda, "is_current_stream_capturing"):
-                    with contextlib.suppress(Exception):
-                        is_capturing = torch.cuda.is_current_stream_capturing()
+                is_capturing = value.is_cuda and is_current_stream_capturing()
 
                 if is_capturing:
                     # Delegate stats to a captured CUDA kernel that prints via

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -64,6 +64,8 @@ from .utils import (
     TensorLayout,
     _check_block_tables_shape,
     _check_cached_qkv_data_type,
+    _raise_cuda_graph_capture_misuse,
+    is_current_stream_capturing,
     _check_kv_layout,
     _check_pos_encoding_mode,
     _check_workspace_buffer_alignment,
@@ -1842,7 +1844,22 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
             * attention output, shape: ``[batch_size, num_qo_heads, head_dim]``
             * logsumexp of attention scores, shape: ``[batch_size, num_qo_heads]``.
+
+        Raises
+        ------
+        RuntimeError
+            If called while the current CUDA stream is being captured into a
+            CUDA graph but this wrapper was constructed with
+            ``use_cuda_graph=False``. In that mode :meth:`plan` re-allocates
+            its auxiliary buffers on every call, so a captured graph would
+            replay against stale memory and silently produce wrong output.
+            Construct the wrapper with ``use_cuda_graph=True`` and the
+            required fixed-size buffers, and call :meth:`plan` outside the
+            captured region. Setting ``FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE=1``
+            bypasses this check at your own risk.
         """
+        if not self._use_cuda_graph and is_current_stream_capturing():
+            _raise_cuda_graph_capture_misuse(type(self).__name__)
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q.device)
         k_cache, v_cache = _unpack_paged_kv_cache(paged_kv_cache, self._kv_layout)

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -32,6 +32,7 @@ from .utils import (
     TensorLayout,
     _check_kv_layout,
     check_shape_dtype_device,
+    is_current_stream_capturing,
     _unpack_paged_kv_cache,
     register_custom_op,
     register_fake_op,
@@ -731,12 +732,10 @@ def _as_float32_scalar_tensors(
 
 
 def _is_stream_capturing_on_device(device: torch.device) -> bool:
-    if not hasattr(torch.cuda, "is_current_stream_capturing"):
-        return False
     if device.type != "cuda":
         return False
     with torch.cuda.device(device):
-        return torch.cuda.is_current_stream_capturing()
+        return is_current_stream_capturing()
 
 
 @flashinfer_api(trace=nvfp4_quantize_append_paged_kv_cache_with_slot_mapping_trace)

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -57,6 +57,8 @@ from .utils import (
     TensorLayout,
     _check_block_tables_shape,
     _check_cached_qkv_data_type,
+    _raise_cuda_graph_capture_misuse,
+    is_current_stream_capturing,
     _check_kv_layout,
     _check_pos_encoding_mode,
     _check_workspace_buffer_alignment,
@@ -2670,7 +2672,22 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
             * The attention output, shape: ``[qo_indptr[-1], num_qo_heads, head_dim]``.
             * The logsumexp of attention output, shape: ``[qo_indptr[-1], num_qo_heads]``.
+
+        Raises
+        ------
+        RuntimeError
+            If called while the current CUDA stream is being captured into a
+            CUDA graph but this wrapper was constructed with
+            ``use_cuda_graph=False``. In that mode :meth:`plan` re-allocates
+            its auxiliary buffers on every call, so a captured graph would
+            replay against stale memory and silently produce wrong output.
+            Construct the wrapper with ``use_cuda_graph=True`` and the
+            required fixed-size buffers, and call :meth:`plan` outside the
+            captured region. Setting ``FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE=1``
+            bypasses this check at your own risk.
         """
+        if not self._use_cuda_graph and is_current_stream_capturing():
+            _raise_cuda_graph_capture_misuse(type(self).__name__)
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q.device)
         k_cache, v_cache = _unpack_paged_kv_cache(paged_kv_cache, self._kv_layout)
@@ -3714,7 +3731,22 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
             * The attention output, shape: ``[qo_indptr[-1], num_qo_heads, head_dim_vo]``.
             * The logsumexp of attention output, shape: ``[qo_indptr[-1], num_qo_heads]``.
+
+        Raises
+        ------
+        RuntimeError
+            If called while the current CUDA stream is being captured into a
+            CUDA graph but this wrapper was constructed with
+            ``use_cuda_graph=False``. In that mode :meth:`plan` re-allocates
+            its auxiliary buffers on every call, so a captured graph would
+            replay against stale memory and silently produce wrong output.
+            Construct the wrapper with ``use_cuda_graph=True`` and the
+            required fixed-size buffers, and call :meth:`plan` outside the
+            captured region. Setting ``FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE=1``
+            bypasses this check at your own risk.
         """
+        if not self._use_cuda_graph and is_current_stream_capturing():
+            _raise_cuda_graph_capture_misuse(type(self).__name__)
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q.device)
         _check_cached_qkv_data_type(

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import functools
 import math
+import os
 from enum import Enum
 from typing import Callable, Dict, Iterable, Optional, Sequence, Tuple, Union
 
@@ -169,6 +170,51 @@ def _check_kv_layout(kv_layout: str) -> None:
 
 def is_float8(x: torch.Tensor) -> bool:
     return x.dtype in [torch.float8_e4m3fn, torch.float8_e5m2]
+
+
+# Resolved once at import: whether this torch exposes the capture query
+# (checking per call would put a hasattr probe on wrapper hot paths).
+_torch_is_current_stream_capturing = getattr(
+    torch.cuda, "is_current_stream_capturing", None
+)
+
+
+def is_current_stream_capturing() -> bool:
+    """Return True iff the current CUDA stream is in graph-capture mode.
+
+    Returns ``False`` on torch builds without graph-capture support.
+    """
+    if _torch_is_current_stream_capturing is None:
+        return False
+    try:
+        return _torch_is_current_stream_capturing()
+    except Exception:
+        return False
+
+
+def _raise_cuda_graph_capture_misuse(wrapper_name: str) -> None:
+    """Fail a default-mode wrapper whose ``run()`` is being graph-captured.
+
+    In default mode, ``plan()`` re-allocates its auxiliary buffers on every
+    call, so a graph captured around ``run()`` would replay against stale
+    memory and silently produce wrong output (issue #3904). Callers
+    pre-check ``use_cuda_graph`` and :func:`is_current_stream_capturing`,
+    so this function (env lookup, message construction) only runs on the
+    error path.
+    """
+    if os.environ.get("FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE", "0") not in ("0", ""):
+        return
+    raise RuntimeError(
+        f"{wrapper_name}.run() is being captured into a CUDA graph, but this "
+        "wrapper was constructed with use_cuda_graph=False. In this mode, "
+        "plan() re-allocates its auxiliary buffers on every call, so the "
+        "captured graph would replay against stale memory and silently "
+        "produce wrong output (or crash with an illegal memory access as "
+        "sequences grow). Construct the wrapper with use_cuda_graph=True, "
+        "provide the required fixed-size buffers, and call plan() outside "
+        "the captured region. To bypass this check at your own risk, set "
+        "FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE=1."
+    )
 
 
 def get_indptr(x: torch.Tensor) -> torch.Tensor:

--- a/tests/attention/test_cudagraph_capture_guard.py
+++ b/tests/attention/test_cudagraph_capture_guard.py
@@ -1,0 +1,215 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+
+NUM_QO_HEADS = 8
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+PAGE_SIZE = 16
+
+
+def _make_decode_wrapper(use_cuda_graph=False, batch_size=1, max_num_pages=8):
+    """Build a decode wrapper; in graph mode, allocate the fixed-size index
+    buffers the CUDA-graph contract requires."""
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    if use_cuda_graph:
+        return flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            workspace,
+            "NHD",
+            use_cuda_graph=True,
+            paged_kv_indptr_buffer=torch.empty(
+                batch_size + 1, dtype=torch.int32, device="cuda:0"
+            ),
+            paged_kv_indices_buffer=torch.empty(
+                max_num_pages, dtype=torch.int32, device="cuda:0"
+            ),
+            paged_kv_last_page_len_buffer=torch.empty(
+                batch_size, dtype=torch.int32, device="cuda:0"
+            ),
+        )
+    return flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace, "NHD")
+
+
+def _plan_decode(wrapper, kv_len=37):
+    """Plan a single-request batch of length ``kv_len`` and return matching
+    (q, kv_cache) inputs for run()."""
+    num_pages = (kv_len + PAGE_SIZE - 1) // PAGE_SIZE
+    kv_indptr = torch.tensor([0, num_pages], dtype=torch.int32, device="cuda:0")
+    kv_indices = torch.arange(num_pages, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.tensor(
+        [(kv_len - 1) % PAGE_SIZE + 1], dtype=torch.int32, device="cuda:0"
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        q_data_type=torch.float16,
+    )
+    kv_cache = torch.randn(
+        num_pages,
+        2,
+        PAGE_SIZE,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        dtype=torch.float16,
+        device="cuda:0",
+    )
+    q = torch.randn(1, NUM_QO_HEADS, HEAD_DIM, dtype=torch.float16, device="cuda:0")
+    return q, kv_cache
+
+
+def _warmup_on_side_stream(fn, iters=3):
+    """Run ``fn`` a few times on a side stream before graph capture (the
+    torch-documented warmup idiom, as used by the existing CG decode test)."""
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(iters):
+            fn()
+    torch.cuda.current_stream().wait_stream(s)
+
+
+def test_decode_default_mode_capture_raises():
+    """Capturing run() of a default-mode decode wrapper must fail loudly,
+    with a message that names the problem, the fix, and the escape hatch —
+    and must leave the wrapper usable in eager mode afterwards."""
+    wrapper = _make_decode_wrapper(use_cuda_graph=False)
+    q, kv_cache = _plan_decode(wrapper)
+    wrapper.run(q, kv_cache)  # eager run must not raise
+
+    g = torch.cuda.CUDAGraph()
+    with pytest.raises(RuntimeError) as excinfo, torch.cuda.graph(g):
+        wrapper.run(q, kv_cache)
+    msg = str(excinfo.value)
+    assert "BatchDecodeWithPagedKVCacheWrapper" in msg
+    assert "use_cuda_graph=False" in msg  # names the problem
+    assert "use_cuda_graph=True" in msg  # names the fix
+    assert "FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE" in msg  # names the escape hatch
+
+    # the aborted capture must not poison subsequent eager use
+    wrapper.run(q, kv_cache)
+    torch.cuda.synchronize()
+
+
+def test_prefill_paged_default_mode_capture_raises():
+    """Same guard on the paged prefill wrapper (the case reported in #3904)."""
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace, "NHD")
+    qo_indptr = torch.tensor([0, 8], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, 2], dtype=torch.int32, device="cuda:0")
+    kv_indices = torch.arange(2, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.tensor([PAGE_SIZE], dtype=torch.int32, device="cuda:0")
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        causal=True,
+        q_data_type=torch.float16,
+    )
+    q = torch.randn(8, NUM_QO_HEADS, HEAD_DIM, dtype=torch.float16, device="cuda:0")
+    kv_cache = torch.randn(
+        2, 2, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.float16, device="cuda:0"
+    )
+    wrapper.run(q, kv_cache)
+
+    g = torch.cuda.CUDAGraph()
+    with (
+        pytest.raises(RuntimeError, match="BatchPrefillWithPagedKVCacheWrapper"),
+        torch.cuda.graph(g),
+    ):
+        wrapper.run(q, kv_cache)
+
+
+def test_prefill_ragged_default_mode_capture_raises():
+    """Same guard on the ragged prefill wrapper."""
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace, "NHD")
+    qo_indptr = torch.tensor([0, 8], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, 32], dtype=torch.int32, device="cuda:0")
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        causal=True,
+        q_data_type=torch.float16,
+    )
+    q = torch.randn(8, NUM_QO_HEADS, HEAD_DIM, dtype=torch.float16, device="cuda:0")
+    k = torch.randn(32, NUM_KV_HEADS, HEAD_DIM, dtype=torch.float16, device="cuda:0")
+    v = torch.randn(32, NUM_KV_HEADS, HEAD_DIM, dtype=torch.float16, device="cuda:0")
+    wrapper.run(q, k, v)
+
+    g = torch.cuda.CUDAGraph()
+    with (
+        pytest.raises(RuntimeError, match="BatchPrefillWithRaggedKVCacheWrapper"),
+        torch.cuda.graph(g),
+    ):
+        wrapper.run(q, k, v)
+
+
+@pytest.mark.parametrize("env_value,should_bypass", [("1", True), ("0", False)])
+def test_escape_hatch_env_var(monkeypatch, env_value, should_bypass):
+    """FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE=1 restores the old (unsafe)
+    behavior — this is exactly what the reporter's setup did by accident —
+    while "0" must NOT bypass the check."""
+    monkeypatch.setenv("FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE", env_value)
+    wrapper = _make_decode_wrapper(use_cuda_graph=False)
+    q, kv_cache = _plan_decode(wrapper)
+
+    g = torch.cuda.CUDAGraph()
+    if should_bypass:
+        _warmup_on_side_stream(lambda: wrapper.run(q, kv_cache))
+        with torch.cuda.graph(g):
+            wrapper.run(q, kv_cache)
+        g.replay()
+        torch.cuda.synchronize()
+    else:
+        wrapper.run(q, kv_cache)
+        with (
+            pytest.raises(RuntimeError, match="use_cuda_graph=False"),
+            torch.cuda.graph(g),
+        ):
+            wrapper.run(q, kv_cache)
+
+
+def test_graph_mode_wrapper_capture_not_blocked():
+    """The guard must not false-positive on a wrapper constructed with
+    use_cuda_graph=True. (Full graph-mode replay correctness is covered by
+    test_batch_decode_kernels.py::test_cuda_graph_batch_decode_with_paged_kv_cache.)
+    """
+    wrapper = _make_decode_wrapper(use_cuda_graph=True, batch_size=1)
+    q, kv_cache = _plan_decode(wrapper)
+    _warmup_on_side_stream(lambda: wrapper.run(q, kv_cache))
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        wrapper.run(q, kv_cache)
+    g.replay()
+    torch.cuda.synchronize()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

This PR makes the misuse fail loudly at capture time: `run()` now checks `torch.cuda.is_current_stream_capturing()` when `use_cuda_graph=False` and raises a `RuntimeError` explaining what happened, why it corrupts output, and how to fix it (construct with `use_cuda_graph=True` + fixed buffers, `plan()` outside the capture).

- `flashinfer/utils.py`: shared `is_current_stream_capturing()` helper (consolidates three pre-existing private copies in `api_logging.py` and `page.py`) and the guard's error path.
- Guard wired into `run()` of `BatchDecodeWithPagedKVCacheWrapper`, `BatchPrefillWithPagedKVCacheWrapper`, and `BatchPrefillWithRaggedKVCacheWrapper`.
- **Escape hatch**: `FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE=1` restores the old behavior for anyone who deliberately captures a default-mode wrapper and never re-plans. Documented in the env-var reference.
- Tests (`tests/attention/test_cudagraph_capture_guard.py`): real-capture raise for all three wrappers, error-message content, escape-hatch positive and negative (`=0` must still raise), no false positive on graph-mode wrappers, and wrapper usability after an aborted capture.


## 🔍 Related Issues

<!-- Link any related issues here -->
Fixes #3904

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->

The issue is phrased generically ("wrapper run()"); this PR covers the reported case (paged prefill) plus the decode and ragged-prefill wrappers. The same one-line guard extends to the `cascade`/`sparse`/`pod` wrappers — happy to follow up once the pattern is settled. Note `MultiLevelCascadeAttentionWrapper` passes `use_cuda_graph=True` through to its inner prefill wrappers, so graph-mode cascade is unaffected as of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Added runtime safeguards to prevent CUDA Graph capture/replay when wrappers are not configured for graph mode, avoiding incorrect results.
  * Improved CUDA stream/capture detection consistently across decode, prefill, paging logic, and logging behavior.

* **Documentation**
  * Updated environment-variable guidance to describe `FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE` as an unsafe escape hatch.

* **Configuration**
  * `FLASHINFER_ALLOW_UNSAFE_GRAPH_CAPTURE` can bypass the new misuse checks (advanced use only).

* **Tests**
  * Added tests covering blocked captures, bypass behavior, and correct behavior for graph-mode wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->