### PR TITLE
fix(comm): make find_loaded_library skip look-alike libs like libcudart_stub.so

### DIFF
--- a/flashinfer/comm/cuda_ipc.py
+++ b/flashinfer/comm/cuda_ipc.py
@@ -47,24 +47,25 @@ def find_loaded_library(lib_name) -> Optional[str]:
     shared libraries loaded by the process. We can use this file to find the path of the
     a loaded library.
     """  # noqa
-    found = False
+    # A plain `lib_name in line` substring match on the first hit is not enough:
+    # another loaded library can have a filename that merely contains lib_name but
+    # is not the library we want (e.g. tilelang's libcudart_stub.so vs the real
+    # libcudart.so.13). Because /proc/self/maps is address-sorted, the first hit is
+    # whichever mapping has the lowest base address, so the stub can win and later
+    # raise "undefined symbol" on load. Scan every mapping and keep only names that
+    # are really lib_name, i.e. `lib_name.so[.ver]` or `lib_name-<hash>.so[.ver]`.
+    # See https://github.com/flashinfer-ai/flashinfer/issues/3676.
     with open("/proc/self/maps") as f:
         for line in f:
-            if lib_name in line:
-                found = True
-                break
-    if not found:
-        # the library is not loaded in the current process
-        return None
-    # if lib_name is libcudart, we need to match a line with:
-    # address /path/to/libcudart-hash.so.11.0
-    start = line.index("/")
-    path = line[start:].strip()
-    filename = path.split("/")[-1]
-    assert filename.rpartition(".so")[0].startswith(lib_name), (
-        f"Unexpected filename: {filename} for library {lib_name}"
-    )
-    return path
+            if lib_name not in line or "/" not in line:
+                continue
+            path = line[line.index("/"):].strip()
+            filename = path.split("/")[-1]
+            stem = filename.rpartition(".so")[0]
+            if stem == lib_name or stem.startswith(lib_name + ".") or stem.startswith(lib_name + "-"):
+                return path
+    # the library is not loaded in the current process
+    return None
 
 
 class CudaRTLibrary:


### PR DESCRIPTION
Fixes #3676.

## Problem
`import flashinfer.comm` can fail at import time with `AttributeError: undefined symbol: cudaDeviceReset` when another package in the same process ships a shared object whose filename merely *contains* `libcudart` but is not the real CUDA runtime.

`find_loaded_library("libcudart")` scanned `/proc/self/maps` and returned the **first** line containing the substring `libcudart`. Because `/proc/self/maps` is address-sorted, that is whichever `libcudart`-named mapping has the lowest base address. When [`tilelang`](https://github.com/tile-ai/tilelang) is co-loaded (e.g. both it and flashinfer are pulled in by vLLM), its `libcudart_stub.so` can map below the real `libcudart.so.13` and get selected. The stub does not export `cudaDeviceReset`, so `CudaRTLibrary.__init__` raises at import.

The existing `assert filename.rpartition(".so")[0].startswith(lib_name)` did not catch this: the stub stem `libcudart_stub` still `startswith("libcudart")`.

## Fix
Scan every mapping instead of breaking on the first hit, and accept only filenames that are really `lib_name`: `lib_name.so[.ver]` or `lib_name-<hash>.so[.ver]` (the hash form the original comment already documented). This rejects `libcudart_stub.so` while still matching the real runtime regardless of load order.

## Verification
Arch-independent, no GPU needed (the bug is in path selection). Ran the edited function against a mocked `/proc/self/maps`:
- stub mapped *below* the real runtime -> returns `libcudart.so.13` (previously returned the stub)
- hashed name `libcudart-<hash>.so.11` -> matched
- only the stub present -> `None` (so `__init__`'s existing assert reports "not loaded" instead of a confusing undefined-symbol crash)
- library not loaded -> `None`

AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of loaded CUDA runtime libraries.
  * Prevented incorrect matches for stub libraries and dotted look-alike filenames.
  * Preserved support for exact library names, version or hash suffixes, and hyphenated variants.
  * Returns no result when a valid matching library cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->