### PR TITLE
feat(moe): expose pre-reduce buffer from SM90 CUTLASS runner for fused allreduce

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -3292,7 +3292,7 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, IsMX
     int64_t const k, float const** alpha_scale_ptr_array, bool use_lora, void* fc2_lora,
     cudaStream_t stream, MOEParallelismConfig parallelism_config, bool const enable_alltoall,
     cutlass_extensions::CutlassGemmConfig config, bool min_latency_mode,
-    int* num_active_experts_per, int* active_expert_global_ids, bool enable_pdl) {
+    int* num_active_experts_per, int* active_expert_global_ids, bool enable_pdl, bool do_finalize) {
   int64_t const* total_tokens_including_expert = expert_first_token_offset + 1;
 
   bool const using_tma_ws_gemm2 = gemm_runner.isTmaWarpSpecialized(config);
@@ -3378,6 +3378,9 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, IsMX
                       stream);
     sync_check_cuda_error(stream);
   }
+
+  // When do_finalize is false, skip finalize — leave GEMM2 output in gemm_output (permuted layout).
+  if (!do_finalize) return;
 
   bool has_different_output_type_ampere = (use_w4afp8 || use_fp8) && !using_tma_ws_gemm2;
   bool using_fused_finalize =
@@ -3635,7 +3638,8 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, IsMX
            int* unpermuted_row_to_permuted_row, MOEParallelismConfig parallelism_config,
            bool const enable_alltoall, bool use_lora, LoraParams& lora_params,
            bool use_deepseek_fp8_block_scale, bool use_mxfp8_act_scaling, bool min_latency_mode,
-           MoeMinLatencyParams& min_latency_params, bool enable_pdl, cudaStream_t stream) {
+           MoeMinLatencyParams& min_latency_params, bool enable_pdl, cudaStream_t stream,
+           bool do_finalize) {
   static constexpr bool int_scales_required = std::is_same<WeightType, uint8_t>::value ||
                                               std::is_same<WeightType, cutlass::uint4b_t>::value ||
                                               use_wfp4a16;
@@ -3907,6 +3911,16 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, IsMX
 
     sync_check_cuda_error(stream);
 
+    // When do_finalize is false, the runner must have been created with
+    // use_fused_finalize=false so that GEMM2 writes to fc2_result_ (workspace)
+    // rather than directly to final_output via atomics.
+    TLLM_CHECK_WITH_INFO(
+        do_finalize || !use_fused_finalize_,
+        "do_finalize=false requires the runner to be created with use_fused_finalize=false");
+    TLLM_CHECK_WITH_INFO(
+        do_finalize || !use_deepseek_fp8_block_scale,
+        "do_finalize=false is not yet supported with the DeepSeek FP8 block-scale path");
+
     auto [gemm1_tma_ws_input, gemm2_tma_ws_input] = setupTmaWarpSpecializedInputs(
         num_rows, expanded_num_rows, fc1_activation_type, hidden_size, unpadded_hidden_size,
         inter_size, num_experts_per_node, input_activations_void, input_sf, final_output,
@@ -3956,15 +3970,16 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, IsMX
         applyPrequantScale(smoothed_act_, fc1_result_, quant_params.groupwise.fc2.act_scales,
                            num_valid_tokens_ptr, expanded_num_rows, inter_size, use_awq, stream);
     sync_check_cuda_error(stream);
-    Self::gemm2(
-        moe_gemm_runner_, blockscale_gemm_runner, gemm2_input, fc2_result_, final_output,
-        expert_first_token_offset_, gemm2_tma_ws_input, fc2_expert_weights, fc2_expert_biases,
-        fc2_int_scales, fc2_fp8_dequant, fc2_fp4_act_scale_, quant_params,
-        token_topk_unpermuted_scales, permuted_token_final_scales_, unpermuted_row_to_permuted_row,
-        permuted_row_to_unpermuted_row_, token_selected_experts, num_valid_tokens_ptr, num_rows,
-        expanded_num_rows, hidden_size, unpadded_hidden_size, inter_size, num_experts_per_node,
-        experts_per_token, alpha_scale_ptr_array_fc2_, use_lora, lora_fc2_result_, stream,
-        parallelism_config, enable_alltoall, *gemm2_config_, false, nullptr, nullptr, enable_pdl);
+    Self::gemm2(moe_gemm_runner_, blockscale_gemm_runner, gemm2_input, fc2_result_, final_output,
+                expert_first_token_offset_, gemm2_tma_ws_input, fc2_expert_weights,
+                fc2_expert_biases, fc2_int_scales, fc2_fp8_dequant, fc2_fp4_act_scale_,
+                quant_params, token_topk_unpermuted_scales, permuted_token_final_scales_,
+                unpermuted_row_to_permuted_row, permuted_row_to_unpermuted_row_,
+                token_selected_experts, num_valid_tokens_ptr, num_rows, expanded_num_rows,
+                hidden_size, unpadded_hidden_size, inter_size, num_experts_per_node,
+                experts_per_token, alpha_scale_ptr_array_fc2_, use_lora, lora_fc2_result_, stream,
+                parallelism_config, enable_alltoall, *gemm2_config_, false, nullptr, nullptr,
+                enable_pdl, do_finalize);
     sync_check_cuda_error(stream);
   }
 }

--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -247,16 +247,18 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
         << ", Output: " << DLDataTypeToString(mOutputDtype);
   }
 
-  void runMoe(TensorView output, TensorView input, TensorView token_selected_experts,
-              Optional<TensorView> token_final_scales, TensorView fc1_expert_weights,
-              Optional<TensorView> fc1_expert_biases, TensorView fc2_expert_weights,
-              Optional<TensorView> fc2_expert_biases, Optional<Array<Tensor>> quant_scales,
-              Optional<TensorView> input_sf, Optional<TensorView> swiglu_alpha,
-              Optional<TensorView> swiglu_beta, Optional<TensorView> swiglu_limit,
-              bool swizzled_input_sf, int64_t tp_size, int64_t tp_rank, int64_t ep_size,
-              int64_t ep_rank, int64_t cluster_size, int64_t cluster_rank, bool enable_alltoall,
-              bool min_latency_mode, Optional<Array<int64_t>> profile_ids, bool enable_pdl,
-              ActivationType base_activation_type = ActivationType::Swiglu) {
+  Array<Tensor> runMoe(TensorView output, TensorView input, TensorView token_selected_experts,
+                       Optional<TensorView> token_final_scales, TensorView fc1_expert_weights,
+                       Optional<TensorView> fc1_expert_biases, TensorView fc2_expert_weights,
+                       Optional<TensorView> fc2_expert_biases, Optional<Array<Tensor>> quant_scales,
+                       Optional<TensorView> input_sf, Optional<TensorView> swiglu_alpha,
+                       Optional<TensorView> swiglu_beta, Optional<TensorView> swiglu_limit,
+                       bool swizzled_input_sf, int64_t tp_size, int64_t tp_rank, int64_t ep_size,
+                       int64_t ep_rank, int64_t cluster_size, int64_t cluster_rank,
+                       bool enable_alltoall, bool min_latency_mode,
+                       Optional<Array<int64_t>> profile_ids, bool enable_pdl,
+                       ActivationType base_activation_type = ActivationType::Swiglu,
+                       bool do_finalize = true) {
     std::lock_guard<std::mutex> lock(mMutex);
 
     TVM_FFI_ICHECK(cluster_size == 1 && cluster_rank == 0)
@@ -428,6 +430,30 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
         mUseDeepSeekFP8BlockScaling, mUseMxfp8ActScaling, min_latency_mode, min_latency_params,
         enable_pdl, stream);
 #endif
+    // When do_finalize=false, copy fc2_result_ and src_to_dest_map while workspace is alive
+    if (!do_finalize) {
+      int64_t expanded_num_rows = num_rows * experts_per_token;
+      int device_id;
+      check_cuda_error(cudaGetDevice(&device_id));
+
+      void* fc2_result_ptr = mKernelRunner->getGemm2ResultPtr();
+      size_t gemm2_bytes = expanded_num_rows * hidden_size * ((mOutputDtype.bits + 7) / 8);
+      auto gemm2_output = alloc_tensor({expanded_num_rows, hidden_size}, mOutputDtype,
+                                       DLDevice{kDLCUDA, device_id});
+      check_cuda_error(cudaMemcpyAsync(gemm2_output.data_ptr(), fc2_result_ptr, gemm2_bytes,
+                                       cudaMemcpyDeviceToDevice, stream));
+
+      auto expanded_idx = alloc_tensor({expanded_num_rows}, dl_int32, DLDevice{kDLCUDA, device_id});
+      check_cuda_error(cudaMemcpyAsync(expanded_idx.data_ptr(), workspace_info.src_to_dest_map,
+                                       expanded_num_rows * sizeof(int32_t),
+                                       cudaMemcpyDeviceToDevice, stream));
+
+      Array<Tensor> result;
+      result.push_back(gemm2_output);
+      result.push_back(expanded_idx);
+      return result;
+    }
+    return Array<Tensor>{};
   }
 
   void runMoeMinLantency(TensorView output, TensorView input, TensorView token_selected_experts,
@@ -755,12 +781,14 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
                  bool swizzled_input_sf, int64_t tp_size, int64_t tp_rank, int64_t ep_size,
                  int64_t ep_rank, int64_t cluster_size, int64_t cluster_rank, bool enable_alltoall,
                  bool min_latency_mode, Optional<Array<int64_t>> profile_ids, bool enable_pdl,
-                 int64_t base_activation_type) {
-            runMoe(output, input, token_selected_experts, token_final_scales, fc1_expert_weights,
-                   fc1_expert_biases, fc2_expert_weights, fc2_expert_biases, quant_scales, input_sf,
-                   swiglu_alpha, swiglu_beta, swiglu_limit, swizzled_input_sf, tp_size, tp_rank,
-                   ep_size, ep_rank, cluster_size, cluster_rank, enable_alltoall, min_latency_mode,
-                   profile_ids, enable_pdl, static_cast<ActivationType>(base_activation_type));
+                 int64_t base_activation_type, bool do_finalize) -> Array<Tensor> {
+            return runMoe(output, input, token_selected_experts, token_final_scales,
+                          fc1_expert_weights, fc1_expert_biases, fc2_expert_weights,
+                          fc2_expert_biases, quant_scales, input_sf, swiglu_alpha, swiglu_beta,
+                          swiglu_limit, swizzled_input_sf, tp_size, tp_rank, ep_size, ep_rank,
+                          cluster_size, cluster_rank, enable_alltoall, min_latency_mode,
+                          profile_ids, enable_pdl,
+                          static_cast<ActivationType>(base_activation_type), do_finalize);
           });
     } else if (name == "run_moe_min_latency") {
       return Function::FromTyped(

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -460,6 +460,10 @@ class CutlassMoeFCRunnerInterface {
   // Returns 0 if the config is incompatible with the current device.
   virtual int queryOccupancyForConfig(cutlass_extensions::CutlassGemmConfig const& config) = 0;
 
+  // Returns the internal fc2_result_ pointer (GEMM2 output in permuted layout).
+  // Valid only after runMoe(..., do_finalize=false) and before the next runMoe call.
+  virtual void* getGemm2ResultPtr() const = 0;
+
   virtual void runMoe(void const* input_activations, void const* input_sf,
                       bool const swizzled_input_sf, int const* token_selected_experts,
                       float const* token_final_scales, void const* fc1_expert_weights,
@@ -472,8 +476,8 @@ class CutlassMoeFCRunnerInterface {
                       MOEParallelismConfig parallelism_config, bool const enable_alltoall,
                       bool use_lora, LoraParams& lora_params, bool use_deepseek_fp8_block_scale,
                       bool use_mxfp8_act_scaling, bool min_latency_mode,
-                      MoeMinLatencyParams& min_latency_params, bool enable_pdl,
-                      cudaStream_t stream) = 0;
+                      MoeMinLatencyParams& min_latency_params, bool enable_pdl, cudaStream_t stream,
+                      bool do_finalize = true) = 0;
 
   // Aliases for profiling the gemms
   virtual void gemm1(void const* const input, void* const output, void* const intermediate_result,
@@ -619,6 +623,8 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
 
   ~CutlassMoeFCRunner() override = default;
 
+  void* getGemm2ResultPtr() const override { return fc2_result_; }
+
   static_assert(std::is_same_v<T, WeightType> || !std::is_same_v<T, float>,
                 "Does not support float with quantized weights");
 
@@ -678,8 +684,8 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
               MOEParallelismConfig parallelism_config, bool const enable_alltoall, bool use_lora,
               LoraParams& lora_params, bool use_deepseek_fp8_block_scale,
               bool use_mxfp8_act_scaling, bool min_latency_mode,
-              MoeMinLatencyParams& min_latency_params, bool enable_pdl,
-              cudaStream_t stream) override;
+              MoeMinLatencyParams& min_latency_params, bool enable_pdl, cudaStream_t stream,
+              bool do_finalize = true) override;
 
   // We make these GEMM1 & GEMM2 static because they need to be stateless for the profiler to work
   static void gemm1(MoeGemmRunner<T, WeightType, OutputType, ScaleBiasType, IsMXFPX>& gemm_runner,
@@ -726,7 +732,7 @@ class CutlassMoeFCRunner : public CutlassMoeFCRunnerInterface {
       void* fc2_lora, cudaStream_t stream, MOEParallelismConfig parallelism_config,
       bool const enable_alltoall, cutlass_extensions::CutlassGemmConfig config,
       bool min_latency_mode, int* num_active_experts_per, int* active_expert_global_ids,
-      bool enable_pdl);
+      bool enable_pdl, bool do_finalize = true);
 
   // Overrides to allow us to forward on to the internal functions with the pointers using the
   // correct type

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -528,6 +528,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         activation_type: ActivationType = ActivationType.Swiglu,
         use_packed_weights: bool = False,
         use_fused_finalize: bool = True,
+        do_finalize: bool = True,
     ) -> List[torch.Tensor]:
         if enable_pdl is None:
             enable_pdl = device_support_pdl(input.device)
@@ -616,7 +617,7 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             if min_latency_mode
             else []
         )
-        run_moe(
+        unreduced_result = run_moe(
             output,
             input,
             token_selected_experts,
@@ -643,7 +644,18 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             [gemm_tactic_1, gemm_tactic_2],
             enable_pdl,
             activation_type,
+            do_finalize,
         )
+
+        if not do_finalize:
+            gemm2_output = torch.from_dlpack(unreduced_result[0])
+            expanded_idx = torch.from_dlpack(unreduced_result[1])
+            # C++ returns idx in slot-major layout [K, N] (slot * N + token).
+            # Reshape to token-major [N, K] (token * K + slot) for downstream use.
+            num_tokens = input.shape[0]
+            top_k = token_selected_experts.shape[1]
+            expanded_idx = expanded_idx.view(top_k, num_tokens).T.contiguous().view(-1)
+            return [gemm2_output, token_final_scales, expanded_idx]
 
         return (
             output
@@ -689,11 +701,20 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
         activation_type: ActivationType = ActivationType.Swiglu,
         use_packed_weights: bool = False,
         use_fused_finalize: bool = True,
+        do_finalize: bool = True,
     ) -> List[torch.Tensor]:
         seq_len = input.shape[0]
         hidden_size = fc2_expert_weights.shape[1]
+        top_k = token_selected_experts.shape[1]
 
-        if min_latency_mode:
+        if not do_finalize:
+            expanded_num_rows = seq_len * top_k
+            return [
+                input.new_empty([expanded_num_rows, hidden_size], dtype=output_dtype),
+                token_final_scales,
+                input.new_empty([expanded_num_rows], dtype=torch.int32),
+            ]
+        elif min_latency_mode:
             num_experts_on_rank = fc2_expert_weights.shape[0]
             output_shape = [seq_len * num_experts_on_rank, hidden_size]
             experts_to_token_score_shape = [num_experts_on_rank, seq_len]
@@ -860,7 +881,8 @@ def cutlass_fused_moe(
     activation_type: ActivationType = ActivationType.Swiglu,
     swizzled_input_sf: bool = True,
     use_fused_finalize: bool = True,
-) -> torch.Tensor:
+    do_finalize: bool = True,
+) -> Union[torch.Tensor, List[torch.Tensor]]:
     """Compute a Mixture of Experts (MoE) layer using CUTLASS backend.
 
     This function implements a fused MoE layer that combines expert selection, expert computation,
@@ -1032,6 +1054,17 @@ def cutlass_fused_moe(
     hidden_size = fc2_expert_weights.shape[1]
     output_shape = (num_rows, hidden_size)
 
+    if not do_finalize:
+        if min_latency_mode:
+            raise ValueError("do_finalize=False is not supported with min_latency_mode")
+        if use_deepseek_fp8_block_scale:
+            raise ValueError(
+                "do_finalize=False is not yet supported with "
+                "use_deepseek_fp8_block_scale=True"
+            )
+        # use_fused_finalize must be False when do_finalize=False (C++ assertion)
+        use_fused_finalize = False
+
     if output is None:
         output = torch.empty(output_shape, dtype=output_dtype, device=input.device)
     else:
@@ -1071,6 +1104,7 @@ def cutlass_fused_moe(
         enable_pdl=enable_pdl,
         activation_type=activation_type,
         use_fused_finalize=use_fused_finalize,
+        do_finalize=do_finalize,
     )
 
 

--- a/tests/moe/test_cutlass_fused_moe_do_finalize.py
+++ b/tests/moe/test_cutlass_fused_moe_do_finalize.py
@@ -1,0 +1,154 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+from torch.nn import functional as F
+
+import flashinfer.fused_moe as fused_moe
+from flashinfer.utils import is_sm90a_supported
+
+pytestmark = pytest.mark.solo
+
+BATCH_SIZES = [1, 4, 16]
+HIDDEN_SIZES = [128, 2048]
+NUM_EXPERTS = [2, 8]
+TOP_K_VALUES = [2, 6]
+INTERMEDIATE_SIZES = [128, 1024]
+
+
+def compute_routing(router_logits, top_k):
+    routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+    routing_weights, selected_experts = torch.topk(routing_weights, top_k, dim=-1)
+    routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+    return routing_weights.float(), selected_experts
+
+
+def reference_finalize(gemm2_output, token_final_scales, expanded_idx):
+    """Vectorized manual finalize: gather, scale, sum."""
+    num_tokens, top_k = token_final_scales.shape
+    hidden_size = gemm2_output.shape[1]
+    gathered = gemm2_output[expanded_idx.long()].view(num_tokens, top_k, hidden_size)
+    weights = token_final_scales.unsqueeze(-1)
+    return (gathered.float() * weights.float()).sum(dim=1).to(gemm2_output.dtype)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_sm90a_supported(torch.device("cuda:0")),
+    reason="Requires SM90a (H100/H200)",
+)
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+@pytest.mark.parametrize("num_experts", NUM_EXPERTS)
+@pytest.mark.parametrize("top_k", TOP_K_VALUES)
+@pytest.mark.parametrize("intermediate_size", INTERMEDIATE_SIZES)
+def test_do_finalize_false(
+    batch_size, hidden_size, num_experts, top_k, intermediate_size
+):
+    """``do_finalize=False`` skips the finalize kernel and returns raw GEMM2 output.
+
+    Verifies that manual finalize of the returned data matches the pure-Python
+    reference implementation, and that results are deterministic across calls.
+    """
+    if top_k > num_experts:
+        pytest.skip(f"top_k ({top_k}) > num_experts ({num_experts})")
+
+    torch.manual_seed(42)
+    dtype = torch.bfloat16
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda") / 5
+    router_logits = torch.randn(
+        batch_size, num_experts, dtype=torch.float32, device="cuda"
+    )
+    w31_weight = (
+        torch.randn(
+            num_experts, 2 * intermediate_size, hidden_size, dtype=dtype, device="cuda"
+        )
+        / 5
+    )
+    w2_weight = (
+        torch.randn(
+            num_experts, hidden_size, intermediate_size, dtype=dtype, device="cuda"
+        )
+        / 5
+    )
+
+    routing_weights, selected_experts = compute_routing(router_logits, top_k)
+
+    # Reference: do_finalize=True with use_fused_finalize=False (same autotuned runner)
+    ref_raw = fused_moe.cutlass_fused_moe(
+        x,
+        selected_experts.to(torch.int32),
+        routing_weights,
+        w31_weight,
+        w2_weight,
+        dtype,
+        quant_scales=None,
+        use_fused_finalize=False,
+        do_finalize=True,
+    )
+    ref_output = ref_raw[0] if isinstance(ref_raw, list) else ref_raw
+
+    # do_finalize=False: get raw GEMM2 output + mapping
+    result = fused_moe.cutlass_fused_moe(
+        x,
+        selected_experts.to(torch.int32),
+        routing_weights,
+        w31_weight,
+        w2_weight,
+        dtype,
+        quant_scales=None,
+        use_fused_finalize=False,
+        do_finalize=False,
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 3
+    gemm2_output, scales_out, expanded_idx = result
+
+    # Shape checks
+    assert gemm2_output.shape == (batch_size * top_k, hidden_size)
+    assert scales_out.shape == (batch_size, top_k)
+    assert expanded_idx.shape == (batch_size * top_k,)
+    assert expanded_idx.dtype == torch.int32
+
+    # Scales passed through unchanged
+    assert torch.equal(scales_out, routing_weights)
+
+    # Permutation indices in valid range
+    assert expanded_idx.min() >= 0
+    assert expanded_idx.max() < batch_size * top_k
+
+    # Manual finalize matches the kernel's own finalize (same runner, same tactics)
+    manual_output = reference_finalize(gemm2_output, scales_out, expanded_idx)
+    torch.testing.assert_close(ref_output, manual_output, rtol=1e-2, atol=1e-2)
+
+    # Determinism: run again, must be bit-exact
+    result2 = fused_moe.cutlass_fused_moe(
+        x,
+        selected_experts.to(torch.int32),
+        routing_weights,
+        w31_weight,
+        w2_weight,
+        dtype,
+        quant_scales=None,
+        use_fused_finalize=False,
+        do_finalize=False,
+    )
+    gemm2_output2, _, expanded_idx2 = result2
+    assert torch.equal(gemm2_output, gemm2_output2), "GEMM2 output not deterministic"
+    assert torch.equal(expanded_idx, expanded_idx2), (
+        "Permutation mapping not deterministic"
+    )


### PR DESCRIPTION
## 📌 Description

Add `do_finalize=False` support to the SM90 CUTLASS MoE runner, allowing callers to skip `finalizeMoeRoutingKernel` and receive the raw permuted GEMM2 output buffer + permutation mapping.

This enables downstream fusion of MoE finalize + allreduce + residual + RMSNorm into a single Lamport kernel via `trtllm_moe_finalize_allreduce_fusion` (pattern 7). The SM100 TRT-LLM gen runner already has this capability — this change brings parity to SM90 (H100/H200).

**What changes:**
- `cutlass_fused_moe_kernels.cuh`: `do_finalize` param on `runMoe()` and `gemm2()`. When false, GEMM2 runs normally but `finalizeMoeRoutingKernel` is skipped.
- `flashinfer_cutlass_fused_moe_binding.cu`: After GEMM2, copies `fc2_result_` and `src_to_dest_map` to returned tensors via D2D memcpy (while workspace is still in scope).
- `moe_kernels.h`: `getGemm2ResultPtr()` virtual + `do_finalize=true` default on interface.
- `flashinfer/fused_moe/core.py`: `do_finalize` param on `cutlass_fused_moe()`. Reshapes returned idx from slot-major `[K, N]` to token-major `[N, K]` (matching `expanded_idx_to_permuted_idx` layout expected by pattern 7).

**Constraints:**
- Requires `use_fused_finalize=False` (asserted in C++) so GEMM2 writes to `fc2_result_` workspace rather than directly to `final_output` via fused epilogue atomics.
- SM90 only — SM100+ already has this via the TRT-LLM gen runner path.

## 🔍 Related Issues

- vllm-project/vllm#40544 — Integrate `trtllm_moe_finalize_allreduce_fusion` into vLLM (requires this upstream change for SM90)
- flashinfer-ai/flashinfer#2982 — Pattern 7 kernel (merged, provides the fusion kernel this PR feeds into)

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Test file: `tests/moe/test_cutlass_fused_moe_do_finalize.py`

48 parametrized configs (36 pass, 12 skip for `top_k > num_experts`):
- `batch_size`: 1, 4, 16
- `hidden_size`: 128, 2048
- `num_experts`: 2, 8
- `top_k`: 2, 6
- `intermediate_size`: 128, 1024

Tested on H200 (SM90a), CUDA 13.0, FlashInfer 0.6.15 editable install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `do_finalize` option to defer Mixture-of-Experts output finalization.
  - When `do_finalize=False`, the API returns intermediate GEMM2 output along with routing `token_final_scales` and expert index data (`expanded_idx`) for custom post-processing.
  - Added guards to reject unsupported `do_finalize=False` configurations (including specific latency and FP8 block-scale modes).
- **Tests**
  - Added CUDA test coverage validating shapes, routing outputs, manual finalize equivalence to the default path, and deterministic repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->