### PR TITLE
feat(b12x): add input_global_scale arg to decouple FC1 input-quant scale from w1_alpha

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -69,6 +69,7 @@ def b12x_fused_moe(
     w1_alpha: torch.Tensor,
     w2_alpha: torch.Tensor,
     fc2_input_scale: Optional[torch.Tensor] = None,
+    input_global_scale: Optional[torch.Tensor] = None,
     num_local_experts: Optional[int] = None,
     output: Optional[torch.Tensor] = None,
     output_dtype: torch.dtype = torch.bfloat16,
@@ -117,6 +118,21 @@ def b12x_fused_moe(
         Global scale for FC2 input quantization.  Required for
         ``quant_mode="nvfp4"``; accepted but ignored for
         ``quant_mode="w4a16"``.
+    input_global_scale : Optional[torch.Tensor]
+        Global scale for FC1 input quantization, scalar or
+        ``[num_experts]`` (a scalar additionally enables the shared-input
+        micro-kernel fast path for tiny decode batches).  When given,
+        decouples the input-quant scale from ``w1_alpha`` so ``w1_alpha``
+        can carry an exact fp32 weight scale (e.g. the checkpoint's
+        ``weight_scale_2``) instead of baking it into the e4m3 weight block
+        scales.  Defaults to ``w1_alpha`` (legacy dual-use).  Ignored for
+        ``quant_mode="w4a16"``.
+
+        The global scale only positions activation scale bytes within the
+        e4m3 range: FC1 computes ``(x / input_global_scale) @ W1.T *
+        w1_alpha``, so a non-unit ``input_global_scale`` must be folded
+        into ``w1_alpha`` by the caller (the legacy dual-use cancels by
+        construction).
     num_local_experts : Optional[int]
         Local experts for expert parallelism.  Defaults to ``num_experts``.
     output : Optional[torch.Tensor]
@@ -205,6 +221,7 @@ def b12x_fused_moe(
         w1_weight_sf=w1_weight_sf,
         w1_alpha=w1_alpha,
         fc2_input_scale=fc2_input_scale,
+        input_global_scale=input_global_scale,
         w2_weight=w2_weight,
         w2_weight_sf=w2_weight_sf,
         w2_alpha=w2_alpha,
@@ -482,6 +499,7 @@ class B12xMoEWrapper:
         w1_alpha: torch.Tensor,
         w2_alpha: torch.Tensor,
         fc2_input_scale: Optional[torch.Tensor] = None,
+        input_global_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         r"""Run the b12x fused-MoE forward pass.
 
@@ -509,6 +527,11 @@ class B12xMoEWrapper:
         fc2_input_scale : Optional[torch.Tensor]
             Global scale for FC2 input quantization.  Required for
             ``quant_mode="nvfp4"``; accepted but ignored for ``"w4a16"``.
+        input_global_scale : Optional[torch.Tensor]
+            Global scale for FC1 input quantization, scalar or
+            ``[num_experts]``.  Defaults to ``w1_alpha``; see
+            :func:`b12x_fused_moe` for the decoupling rationale.  Ignored
+            for ``"w4a16"``.
 
         Returns
         -------
@@ -636,6 +659,7 @@ class B12xMoEWrapper:
             w1_weight_sf=w1_weight_sf,
             w1_alpha=w1_alpha,
             fc2_input_scale=fc2_input_scale,
+            input_global_scale=input_global_scale,
             w2_weight=w2_weight,
             w2_weight_sf=w2_weight_sf,
             w2_alpha=w2_alpha,

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -979,9 +979,13 @@ def _get_micro_kernel(
 # Launch
 # ---------------------------------------------------------------------------
 def _expand_to_experts(t: torch.Tensor, num_experts: int) -> torch.Tensor:
-    """Broadcast a scalar or [1] tensor to [num_experts]."""
+    """Broadcast a scalar or [1] tensor to [num_experts], always fp32.
+
+    Both branches must cast: the kernels are compiled against fp32 fake
+    tensors for every per-expert scale.
+    """
     if t.numel() == 1:
-        return t.expand(num_experts).contiguous()
+        return t.to(torch.float32).expand(num_experts).contiguous()
     return t.contiguous().to(torch.float32)
 
 
@@ -2536,6 +2540,7 @@ def launch_sm120_moe(
     w1_weight_sf: torch.Tensor,
     w1_alpha: torch.Tensor,
     fc2_input_scale: Optional[torch.Tensor] = None,
+    input_global_scale: Optional[torch.Tensor] = None,
     w2_weight: torch.Tensor,
     w2_weight_sf: torch.Tensor,
     w2_alpha: torch.Tensor,
@@ -2557,6 +2562,10 @@ def launch_sm120_moe(
     _prepared_weights=None,
 ) -> torch.Tensor:
     """Unified SM120 MoE dispatch — selects static or dynamic by token count.
+
+    input_global_scale (scalar or [num_experts]) overrides w1_alpha as the
+    FC1 input-quantization global scale; see :func:`b12x_fused_moe` for the
+    decoupling rationale.
 
     Optional _workspace and _weight_views can be pre-allocated and reused
     across calls to avoid per-call allocation overhead (wrapper path).
@@ -2623,6 +2632,7 @@ def launch_sm120_moe(
     if fc2_input_scale is None:
         raise ValueError("fc2_input_scale is required when quant_mode='nvfp4'.")
     down_input_scale = fc2_input_scale
+    input_gs = input_global_scale if input_global_scale is not None else w1_alpha
 
     weights = (
         _weight_views
@@ -2697,7 +2707,7 @@ def launch_sm120_moe(
             a=a,
             topk_ids=topk_ids,
             topk_weights=topk_weights,
-            input_gs=w1_alpha,
+            input_gs=input_gs,
             down_input_scale=down_input_scale,
             scatter_output=scatter_output,
             num_experts=num_experts,
@@ -2720,7 +2730,7 @@ def launch_sm120_moe(
             a=a,
             topk_ids=topk_ids,
             topk_weights=topk_weights,
-            input_gs=w1_alpha,
+            input_gs=input_gs,
             down_input_scale=down_input_scale,
             scatter_output=scatter_output,
             num_experts=num_experts,

--- a/flashinfer/trace/templates/moe.py
+++ b/flashinfer/trace/templates/moe.py
@@ -3139,6 +3139,16 @@ b12x_fused_moe_trace = TraceTemplate(
                 "activation_precision='bf16'."
             ),
         ),
+        "input_global_scale": Tensor(
+            ["num_local_experts"],
+            dtype="float32",
+            optional=True,
+            description=(
+                "Global scale for FC1 input quantization (scalar or "
+                "per-expert). Defaults to w1_alpha; ignored for "
+                "activation_precision='bf16'."
+            ),
+        ),
         "activation_precision": Scalar(
             "string",
             optional=True,

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -1135,6 +1135,163 @@ class TestB12xFunctional:
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
 
+    def test_input_global_scale_decouples_weight_alpha(self):
+        """input_global_scale lets w1_alpha carry an exact fp32 weight scale.
+
+        Encodes weights checkpoint-style (block scales hold W/scale_2, the
+        per-expert scale_2 ~ 2e-4 stays outside the e4m3 encoding, as nvfp4
+        checkpoints ship) and passes scale_2 as w1_alpha/w2_alpha with
+        input_global_scale=1.  Without the new argument a caller must bake
+        scale_2 into the e4m3 block scales (pushing them into the 3-bit
+        subnormal range) -- that path must be measurably worse against the
+        same reference.  The reference uses dequantized fp4 weights so the
+        shared weight-quantization error cancels and the comparison isolates
+        the baking error.  Also checks that omitting input_global_scale
+        reproduces the legacy dual-use bit-for-bit (modulo the bf16 atomic
+        scatter-combine noise).
+        """
+        from flashinfer import b12x_fused_moe
+        from flashinfer.fp4_quantization import fp4_quantize
+        from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+
+        torch.manual_seed(7)
+        device = "cuda"
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+        sf_vec_size = 16
+
+        # Unit-scale input keeps the intermediate activations out of the
+        # subnormal scale-byte range, so this test isolates the weight-side
+        # block-scale precision and stays orthogonal to the activation-side
+        # subnormal decode behavior.
+        x_bf16 = torch.randn(
+            num_tokens, hidden_size, dtype=torch.bfloat16, device=device
+        )
+        router = torch.randn(num_tokens, num_experts, device=device)
+        weights, ids = torch.topk(F.softmax(router, dim=1, dtype=torch.float), top_k)
+        weights = (weights / weights.sum(-1, keepdim=True)).float()
+        ids = ids.to(torch.int32)
+
+        w1_bf16 = (
+            torch.randn(
+                num_experts,
+                2 * intermediate_size,
+                hidden_size,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            / 10
+        )
+        w2_bf16 = (
+            torch.randn(
+                num_experts,
+                hidden_size,
+                intermediate_size,
+                dtype=torch.bfloat16,
+                device=device,
+            )
+            / 10
+        )
+        amax = max(w1_bf16.abs().max().item(), w2_bf16.abs().max().item())
+        scale_2 = torch.full(
+            (num_experts,), amax / (448.0 * 6.0), device=device, dtype=torch.float32
+        )
+
+        def quant_ckpt_style(w, m, k):
+            # modelopt encoding: quantize with gs=1/scale_2 so payload x
+            # block_scale ~= W/scale_2; scale_2 is applied outside as alpha.
+            q, sf = fp4_quantize(
+                w.reshape(num_experts * m, k),
+                global_scale=(1.0 / scale_2[:1]),
+                sf_vec_size=sf_vec_size,
+                is_sf_swizzled_layout=True,
+            )
+            sf_mma = convert_sf_to_mma_layout(
+                sf, m=m, k=k, num_groups=num_experts, sf_vec_size=sf_vec_size
+            )
+            return q.reshape(num_experts, m, k // 2), sf_mma
+
+        w1_q, w1_sf = quant_ckpt_style(w1_bf16, 2 * intermediate_size, hidden_size)
+        w2_q, w2_sf = quant_ckpt_style(w2_bf16, hidden_size, intermediate_size)
+        ones = torch.ones(num_experts, device=device, dtype=torch.float32)
+        fc2_scale = torch.tensor([1.0], device=device, dtype=torch.float32)
+
+        def run(w1_sf_, w2_sf_, alpha, input_gs):
+            return b12x_fused_moe(
+                x=x_bf16,
+                w1_weight=w1_q,
+                w1_weight_sf=w1_sf_,
+                w1_alpha=alpha,
+                fc2_input_scale=fc2_scale,
+                input_global_scale=input_gs,
+                w2_weight=w2_q,
+                w2_weight_sf=w2_sf_,
+                w2_alpha=alpha,
+                token_selected_experts=ids,
+                token_final_scales=weights,
+                num_experts=num_experts,
+                top_k=top_k,
+                num_local_experts=num_experts,
+            ).float()
+
+        # Reference on dequantized fp4 weights (round-tripped with the same
+        # encoding), so both kernel paths share the weight-quant error and
+        # the exact-vs-baked comparison isolates the block-scale precision.
+        w1_deq = quant_dequant_fp4_reference(
+            w1_bf16.reshape(num_experts * 2 * intermediate_size, hidden_size),
+            (1.0 / scale_2[:1]),
+        ).reshape(num_experts, 2 * intermediate_size, hidden_size)
+        w2_deq = quant_dequant_fp4_reference(
+            w2_bf16.reshape(num_experts * hidden_size, intermediate_size),
+            (1.0 / scale_2[:1]),
+        ).reshape(num_experts, hidden_size, intermediate_size)
+
+        ref = compute_reference_moe_fp4(
+            hidden_states=x_bf16.float(),
+            gemm1_weights=w1_deq,
+            gemm2_weights=w2_deq,
+            token_selected_experts=ids,
+            token_final_scales=weights,
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=fc2_scale,
+        )
+
+        # Decoupled path: exact fp32 scale_2 as alpha, unit input-quant scale.
+        out_exact = run(w1_sf, w2_sf, scale_2, ones)
+        passed, percent_within, atol = check_accuracy(out_exact, ref)
+        assert passed, (
+            f"decoupled path: only {percent_within * 100:.2f}% within "
+            f"tolerance (atol={atol:.4f})"
+        )
+
+        # Baked encoding (the workaround the new argument removes): scale_2
+        # multiplied into the e4m3 block scales, alpha = 1.
+        w1_sf_baked = (w1_sf.float() * scale_2[0]).to(torch.float8_e4m3fn)
+        w2_sf_baked = (w2_sf.float() * scale_2[0]).to(torch.float8_e4m3fn)
+        out_baked = run(w1_sf_baked, w2_sf_baked, ones, None)
+        relf_exact = ((out_exact - ref).norm() / ref.norm()).item()
+        relf_baked = ((out_baked - ref).norm() / ref.norm()).item()
+        assert relf_baked > 2.0 * relf_exact, (
+            f"baked block scales should be measurably worse: "
+            f"exact={relf_exact:.4f} baked={relf_baked:.4f}"
+        )
+
+        # Back-compat: omitting input_global_scale must reproduce the legacy
+        # dual-use within the bf16 atomic scatter-combine noise.
+        out_legacy = run(w1_sf, w2_sf, ones, None)
+        out_legacy2 = run(w1_sf, w2_sf, ones, None)
+        out_explicit = run(w1_sf, w2_sf, ones, ones)
+        noise = (out_legacy - out_legacy2).abs().max().item()
+        diff = (out_legacy - out_explicit).abs().max().item()
+        assert diff <= max(2.0 * noise, 1e-6), (
+            f"explicit input_global_scale=w1_alpha diverged from legacy "
+            f"dual-use: diff={diff:.3e} noise={noise:.3e}"
+        )
+
     @pytest.mark.parametrize(
         "activation", ["silu", "gelu_tanh", "swigluoai_uninterleave"]
     )


### PR DESCRIPTION
## 📌 Description

The b12x MoE kernels use `w1_alpha` for two different jobs: the global scale for quantizing the FC1 input activations, and the multiplier applied after the FC1 GEMM. The kernels underneath already accept separate tensors for the two; only the Python dispatch feeds `w1_alpha` into both.

This dual use is why vLLM has to bake weight scales into the checkpoint. NVFP4 checkpoints ship a tiny per-expert weight scale (`weight_scale_2`, around 2e-5). Passing it as `w1_alpha` would wreck activation quantization. So vLLM multiplies it into the e4m3 weight block scales instead and passes `w1_alpha=1.0`.

The baking has a real cost: it pushes nearly all block-scale bytes into the low-precision subnormal range, distorting the dequantized weights by about 17% on average (measured on Qwen3.6-35B-A3B-NVFP4). Both W4A4 and forced-W4A16 modes are affected.

This PR adds an optional `input_global_scale` that takes over the activation-quant job. `w1_alpha` can then carry the exact fp32 weight scale, and the block scales stay as loaded. Omitting the new argument keeps the old behavior for all current callers.

One contract worth reviewing: the input scale positions scale bytes within the e4m3 range but does not change the output magnitude on its own. A non-unit `input_global_scale` therefore has to be folded into `w1_alpha` by the caller. The docstring spells this out.

Two small things ride along: `_expand_to_experts` now casts its scalar branch to fp32 (previously hidden because callers always passed fp32 `w1_alpha`), and the b12x trace templates gain the new optional input.

## 🔍 Related Issues

Part of the SM121 support audit #3170. With vLLM updated to stop baking, replay error against the bf16 reference drops from 0.725 to 0.161, and the GPQA/SciCode excess-token inflation vs Marlin drops from +18.7%/+46% to +6.2%/+14% (combined with the quantization fixes in #3932).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New test `test_input_global_scale_decouples_weight_alpha`: passing the exact weight scale beats the baked encoding against the same reference, and omitting the new argument reproduces the legacy behavior. Run on GB10 (SM121).

## Reviewer Notes

Opened as a draft because the API shape is the main thing to settle. Two open questions: (1) the argument's name and placement (grouped with `fc2_input_scale`, keyword-only, so nothing breaks positionally); (2) whether the dispatch should fold `input_global_scale` into the alpha automatically instead of documenting the contract, at the cost of a less direct mapping to the kernel arguments. AI-assisted (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
