### PR TITLE
DeepSeek 4 NVFP4 KV cache model type for sparse_mla on SM_120

### DIFF
--- a/csrc/sparse_mla_sm120.cu
+++ b/csrc/sparse_mla_sm120.cu
@@ -273,7 +273,8 @@ void SparseMlaSm120PagedAttention(
   TVM_FFI_ICHECK(ok) << "Unsupported sparse-MLA prefill configuration: "
                      << "model="
                      << (mt == ModelType::DSV3_2 ? "DSV3_2"
-                                                 : (mt == ModelType::GLM_NSA ? "GLM_NSA" : "DSV4"))
+                         : mt == ModelType::GLM_NSA ? "GLM_NSA"
+                         : mt == ModelType::DSV4_NVFP4 ? "DSV4_NVFP4" : "DSV4")
                      << " num_heads=" << num_heads << " topk=" << topk
                      << " page_block_size=" << page_block_size << " topk_extra=" << extra_topk
                      << " extra_page_block_size=" << extra_page_block_size;

--- a/csrc/sparse_mla_sm120.cu
+++ b/csrc/sparse_mla_sm120.cu
@@ -68,8 +68,8 @@ inline ModelType resolve_model_type(int d_qk, int64_t model_type) {
   if (d_qk == 512) {
     const auto mt = static_cast<ModelType>(
         model_type == kAuto ? static_cast<int64_t>(ModelType::DSV4) : model_type);
-    TVM_FFI_ICHECK(mt == ModelType::DSV4)
-        << "d_qk=512 supports only model_type auto or DSV4; got " << model_type;
+    TVM_FFI_ICHECK(mt == ModelType::DSV4 || mt == ModelType::DSV4_NVFP4)
+        << "d_qk=512 supports model_type auto, DSV4, or DSV4_NVFP4; got " << model_type;
     return mt;
   }
   TVM_FFI_ICHECK(false) << "Unsupported d_qk=" << d_qk
@@ -84,6 +84,8 @@ inline int bytes_per_token(ModelType mt) {
       return 656;
     case ModelType::DSV4:
       return 584;
+    case ModelType::DSV4_NVFP4:
+      return 360;
   }
   TVM_FFI_ICHECK(false) << "Unsupported sparse MLA model type";
   return 0;

--- a/csrc/sparse_mla_sm120_decode_dsv4.cu
+++ b/csrc/sparse_mla_sm120_decode_dsv4.cu
@@ -143,29 +143,38 @@ bool launch_sparse_mla_decode_dsv4(ModelType mt, int num_heads, int topk, int pa
                                    const int* extra_topk_length, int extra_topk, int pbs_extra,
                                    size_t stride_extra_kv_block, int chunks_per_block_override,
                                    float sm_scale, size_t stride_kv_block, cudaStream_t stream) {
-  if (mt != ModelType::DSV4 || page_block_size != 64) return false;
+  if ((mt != ModelType::DSV4 && mt != ModelType::DSV4_NVFP4) || page_block_size != 64)
+    return false;
   if (num_splits <= 0) return false;
-#define DSV4_DISPATCH(H, K)                                                                 \
-  if (num_heads == (H) && topk == (K)) {                                                    \
-    return launch_decode_dsv4_impl<ModelType::DSV4, (H), (K), 64>(                          \
+#define DSV4_DISPATCH_MT(MT_, H, K)                                                         \
+  if (mt == (MT_) && num_heads == (H) && topk == (K)) {                                     \
+    return launch_decode_dsv4_impl<(MT_), (H), (K), 64>(                                    \
         Q, KV_cache, indices, mid_out, mid_lse, topk_length, output, out_lse, attn_sink,    \
         extra_KV_cache, extra_indices, extra_topk_length, extra_topk, pbs_extra,            \
         stride_extra_kv_block, num_tokens, num_splits, chunks_per_block_override, sm_scale, \
         stride_kv_block, stream);                                                           \
   }
+#define DSV4_DISPATCH(H, K)                    \
+  DSV4_DISPATCH_MT(ModelType::DSV4, H, K)      \
+  DSV4_DISPATCH_MT(ModelType::DSV4_NVFP4, H, K)
   DSV4_DISPATCH(8, 128)
+  DSV4_DISPATCH(8, 256)
   DSV4_DISPATCH(8, 512)
   DSV4_DISPATCH(8, 1024)
   DSV4_DISPATCH(16, 128)
+  DSV4_DISPATCH(16, 256)
   DSV4_DISPATCH(16, 512)
   DSV4_DISPATCH(16, 1024)
   DSV4_DISPATCH(32, 128)
+  DSV4_DISPATCH(32, 256)
   DSV4_DISPATCH(32, 512)
   DSV4_DISPATCH(32, 1024)
   DSV4_DISPATCH(64, 128)
+  DSV4_DISPATCH(64, 256)
   DSV4_DISPATCH(64, 512)
   DSV4_DISPATCH(64, 1024)
   DSV4_DISPATCH(128, 128)
+  DSV4_DISPATCH(128, 256)
   DSV4_DISPATCH(128, 512)
   DSV4_DISPATCH(128, 1024)
 #undef DSV4_DISPATCH

--- a/csrc/sparse_mla_sm120_decode_dsv4.cu
+++ b/csrc/sparse_mla_sm120_decode_dsv4.cu
@@ -132,8 +132,8 @@ static bool launch_decode_dsv4_impl(const bf16* Q, const uint8_t* KV_cache, cons
 }
 
 // Public surface — explicit instantiation switch over the PR-body bench grid.
-// DSV4 only, page_block_size=64 only. NUM_HEADS ∈ {8, 16, 32, 64, 128},
-// TOPK ∈ {128, 512, 1024}.
+// DSV4 and DSV4_NVFP4, page_block_size=64 only. NUM_HEADS ∈ {8, 16, 32, 64, 128},
+// TOPK ∈ {128, 256, 512, 1024}.
 bool launch_sparse_mla_decode_dsv4(ModelType mt, int num_heads, int topk, int page_block_size,
                                    int num_tokens, int num_splits, const bf16* Q,
                                    const uint8_t* KV_cache, const int32_t* indices, bf16* mid_out,
@@ -148,7 +148,7 @@ bool launch_sparse_mla_decode_dsv4(ModelType mt, int num_heads, int topk, int pa
   if (num_splits <= 0) return false;
 #define DSV4_DISPATCH_MT(MT_, H, K)                                                         \
   if (mt == (MT_) && num_heads == (H) && topk == (K)) {                                     \
-    return launch_decode_dsv4_impl<(MT_), (H), (K), 64>(                                    \
+    return launch_decode_dsv4_impl<MT_, H, K, 64>(                                          \
         Q, KV_cache, indices, mid_out, mid_lse, topk_length, output, out_lse, attn_sink,    \
         extra_KV_cache, extra_indices, extra_topk_length, extra_topk, pbs_extra,            \
         stride_extra_kv_block, num_tokens, num_splits, chunks_per_block_override, sm_scale, \

--- a/csrc/sparse_mla_sm120_decode_dsv4.cu
+++ b/csrc/sparse_mla_sm120_decode_dsv4.cu
@@ -132,7 +132,7 @@ static bool launch_decode_dsv4_impl(const bf16* Q, const uint8_t* KV_cache, cons
 }
 
 // Public surface — explicit instantiation switch over the PR-body bench grid.
-// DSV4 only, page_block_size=64 only. NUM_HEADS ∈ {8, 16, 32, 64, 128},
+// DSV4 and DSV4_NVFP4, page_block_size=64 only. NUM_HEADS ∈ {8, 16, 32, 64, 128},
 // TOPK ∈ {128, 192, 256, 512, 1024}. TOPK=192 covers the padded
 // DeepSeek-V4-Flash-0731 DSpark K=5 shape (128 SWA + 5 active draft entries),
 // while TOPK=256 covers wider DSpark configurations.
@@ -145,16 +145,20 @@ bool launch_sparse_mla_decode_dsv4(ModelType mt, int num_heads, int topk, int pa
                                    const int* extra_topk_length, int extra_topk, int pbs_extra,
                                    size_t stride_extra_kv_block, int chunks_per_block_override,
                                    float sm_scale, size_t stride_kv_block, cudaStream_t stream) {
-  if (mt != ModelType::DSV4 || page_block_size != 64) return false;
+  if ((mt != ModelType::DSV4 && mt != ModelType::DSV4_NVFP4) || page_block_size != 64)
+    return false;
   if (num_splits <= 0) return false;
-#define DSV4_DISPATCH(H, K)                                                                 \
-  if (num_heads == (H) && topk == (K)) {                                                    \
-    return launch_decode_dsv4_impl<ModelType::DSV4, (H), (K), 64>(                          \
+#define DSV4_DISPATCH_MT(MT_, H, K)                                                         \
+  if (mt == (MT_) && num_heads == (H) && topk == (K)) {                                     \
+    return launch_decode_dsv4_impl<(MT_), (H), (K), 64>(                                    \
         Q, KV_cache, indices, mid_out, mid_lse, topk_length, output, out_lse, attn_sink,    \
         extra_KV_cache, extra_indices, extra_topk_length, extra_topk, pbs_extra,            \
         stride_extra_kv_block, num_tokens, num_splits, chunks_per_block_override, sm_scale, \
         stride_kv_block, stream);                                                           \
   }
+#define DSV4_DISPATCH(H, K)                    \
+  DSV4_DISPATCH_MT(ModelType::DSV4, H, K)      \
+  DSV4_DISPATCH_MT(ModelType::DSV4_NVFP4, H, K)
   DSV4_DISPATCH(8, 128)
   DSV4_DISPATCH(8, 192)
   DSV4_DISPATCH(8, 256)

--- a/csrc/sparse_mla_sm120_decode_dsv4.cu
+++ b/csrc/sparse_mla_sm120_decode_dsv4.cu
@@ -150,7 +150,7 @@ bool launch_sparse_mla_decode_dsv4(ModelType mt, int num_heads, int topk, int pa
   if (num_splits <= 0) return false;
 #define DSV4_DISPATCH_MT(MT_, H, K)                                                         \
   if (mt == (MT_) && num_heads == (H) && topk == (K)) {                                     \
-    return launch_decode_dsv4_impl<(MT_), (H), (K), 64>(                                    \
+    return launch_decode_dsv4_impl<MT_, H, K, 64>(                                          \
         Q, KV_cache, indices, mid_out, mid_lse, topk_length, output, out_lse, attn_sink,    \
         extra_KV_cache, extra_indices, extra_topk_length, extra_topk, pbs_extra,            \
         stride_extra_kv_block, num_tokens, num_splits, chunks_per_block_override, sm_scale, \

--- a/csrc/sparse_mla_sm120_jit_binding.cu
+++ b/csrc/sparse_mla_sm120_jit_binding.cu
@@ -90,7 +90,7 @@ void SparseMlaSm120DecodeDsv4(TensorView q, TensorView kv_cache, TensorView indi
                               Optional<TensorView> extra_kv_cache,
                               Optional<TensorView> extra_indices,
                               Optional<TensorView> extra_topk_length,
-                              int64_t chunks_per_block_override) {
+                              int64_t chunks_per_block_override, int64_t model_type) {
   TVM_FFI_ICHECK_EQ(q.ndim(), 3) << "q must be [T, H, D_QK]";
   TVM_FFI_ICHECK_GE(kv_cache.ndim(), 2);
   // indices may be 2D [T, topk] or 3D [T, s_q=1, topk] (some callers keep
@@ -108,12 +108,14 @@ void SparseMlaSm120DecodeDsv4(TensorView q, TensorView kv_cache, TensorView indi
   const int num_heads = static_cast<int>(q.size(1));
   const int topk = static_cast<int>(indices.size(-1));
   const int d_qk = static_cast<int>(q.size(2));
-  ModelType mt = (d_qk == 512) ? ModelType::DSV4 : ModelType::DSV3_2;
-  // Currently the kernel only supports DSV4.
-  TVM_FFI_ICHECK_EQ(static_cast<int>(mt), static_cast<int>(ModelType::DSV4))
-      << "decode-dsv4 currently DSV4-only";
+  // model_type is the ModelType enum int from Python (DSV4=1, DSV4_NVFP4=3).
+  ModelType mt = static_cast<ModelType>(model_type);
+  TVM_FFI_ICHECK(mt == ModelType::DSV4 || mt == ModelType::DSV4_NVFP4)
+      << "decode-dsv4 handles DSV4 / DSV4_NVFP4; got model_type=" << model_type;
+  TVM_FFI_ICHECK_EQ(d_qk, 512) << "decode-dsv4 expects d_qk=512; got " << d_qk;
 
-  constexpr int BPT_DSV4 = 584;
+  // fp8 page = 584 B/token, NVFP4 page = 360 B/token (224 E2M1 + 128 bf16 rope + 8 UE8M0).
+  const int BPT_DSV4 = (mt == ModelType::DSV4_NVFP4) ? 360 : 584;
   const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, BPT_DSV4, "kv_cache");
   const int page_block_size = kv_layout.page_block_size;
 

--- a/csrc/sparse_mla_sm120_jit_binding.cu
+++ b/csrc/sparse_mla_sm120_jit_binding.cu
@@ -91,7 +91,7 @@ void SparseMlaSm120DecodeDsv4(TensorView q, TensorView kv_cache, TensorView indi
                               Optional<TensorView> extra_kv_cache,
                               Optional<TensorView> extra_indices,
                               Optional<TensorView> extra_topk_length,
-                              int64_t chunks_per_block_override) {
+                              int64_t chunks_per_block_override, int64_t model_type) {
   TVM_FFI_ICHECK_EQ(q.ndim(), 3) << "q must be [T, H, D_QK]";
   TVM_FFI_ICHECK_GE(kv_cache.ndim(), 2);
   // indices may be 2D [T, topk] or 3D [T, s_q=1, topk] (some callers keep
@@ -109,12 +109,14 @@ void SparseMlaSm120DecodeDsv4(TensorView q, TensorView kv_cache, TensorView indi
   const int num_heads = static_cast<int>(q.size(1));
   const int topk = static_cast<int>(indices.size(-1));
   const int d_qk = static_cast<int>(q.size(2));
-  ModelType mt = (d_qk == 512) ? ModelType::DSV4 : ModelType::DSV3_2;
-  // Currently the kernel only supports DSV4.
-  TVM_FFI_ICHECK_EQ(static_cast<int>(mt), static_cast<int>(ModelType::DSV4))
-      << "decode-dsv4 currently DSV4-only";
+  // model_type is the ModelType enum int from Python (DSV4=1, DSV4_NVFP4=3).
+  ModelType mt = static_cast<ModelType>(model_type);
+  TVM_FFI_ICHECK(mt == ModelType::DSV4 || mt == ModelType::DSV4_NVFP4)
+      << "decode-dsv4 handles DSV4 / DSV4_NVFP4; got model_type=" << model_type;
+  TVM_FFI_ICHECK_EQ(d_qk, 512) << "decode-dsv4 expects d_qk=512; got " << d_qk;
 
-  constexpr int BPT_DSV4 = 584;
+  // fp8 page = 584 B/token, NVFP4 page = 360 B/token (224 E2M1 + 128 bf16 rope + 8 UE8M0).
+  const int BPT_DSV4 = (mt == ModelType::DSV4_NVFP4) ? 360 : 584;
   const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, BPT_DSV4, "kv_cache");
   const int page_block_size = kv_layout.page_block_size;
 

--- a/csrc/sparse_mla_sm120_prefill.cu
+++ b/csrc/sparse_mla_sm120_prefill.cu
@@ -257,13 +257,14 @@ inline bool dispatch_v32(int num_heads, int topk, const bf16* Q, const uint8_t* 
 #undef DISPATCH_DSV3_2_MG
 }
 
+template <ModelType MT>
 inline bool dispatch_dsv4_single(int num_heads, int topk, const bf16* Q, const uint8_t* KV,
                                  const int32_t* indices, const float* attn_sink, bf16* output,
                                  float* out_lse, float sm_scale, int num_tokens,
                                  size_t stride_kv_block, const int* topk_length_ptr,
                                  cudaStream_t stream) {
 #define DISPATCH_MG_CM(CM, NH, TK, NHG)                                                  \
-  launch_prefill_mg<ModelType::DSV4, ComputeMode::CM, NH, TK, 64, NHG>(                  \
+  launch_prefill_mg<MT, ComputeMode::CM, NH, TK, 64, NHG>(                               \
       Q, KV, indices, attn_sink, output, out_lse, sm_scale, num_tokens, stride_kv_block, \
       topk_length_ptr, stream)
 
@@ -293,6 +294,8 @@ inline bool dispatch_dsv4_single(int num_heads, int topk, const bf16* Q, const u
   // amortises FP8's higher Tensor-Core throughput.
   if (topk == 128)
     DISPATCH_BY_NH_CM(BF16, 128);
+  else if (topk == 256)
+    DISPATCH_BY_NH_CM(BF16, 256);
   else if (topk == 512)
     DISPATCH_BY_NH_CM(FP8, 512);
   else if (topk == 1024)
@@ -307,6 +310,7 @@ inline bool dispatch_dsv4_single(int num_heads, int topk, const bf16* Q, const u
   return false;  // unreachable
 }
 
+template <ModelType MT>
 inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extra_page_block_size,
                                const bf16* Q, const uint8_t* KV, const int32_t* indices,
                                const uint8_t* KV_extra, const int32_t* idx_extra,
@@ -317,7 +321,7 @@ inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extr
   if (topk == 128 && topk_length_ptr == nullptr && topk_length_extra_ptr == nullptr &&
       topk_extra % BI == 0 && (extra_page_block_size == 64 || extra_page_block_size == 2)) {
 #define DISPATCH_DUAL_MG_FULLTILE(NH, TK, PBSX, NHG)                                         \
-  launch_prefill_mg_dual_fulltile<ModelType::DSV4, NH, TK, 64, PBSX, NHG>(                   \
+  launch_prefill_mg_dual_fulltile<MT, NH, TK, 64, PBSX, NHG>(                                \
       Q, KV, indices, KV_extra, idx_extra, attn_sink, output, out_lse, sm_scale, num_tokens, \
       topk_extra, stride_kv_block, stride_kv_block_extra, stream)
 
@@ -353,7 +357,7 @@ inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extr
 // topk_extra is runtime; extra_page_block_size stays template because it
 // changes the KV stride. NH=16 uses MG_N_HG_T=1.
 #define DISPATCH_DUAL_MG_CM(CM, NH, TK, PBSX, NHG)                                                \
-  launch_prefill_mg_dual<ModelType::DSV4, ComputeMode::CM, NH, TK, 64, PBSX, NHG>(                \
+  launch_prefill_mg_dual<MT, ComputeMode::CM, NH, TK, 64, PBSX, NHG>(                             \
       Q, KV, indices, KV_extra, idx_extra, attn_sink, output, out_lse, sm_scale, num_tokens,      \
       topk_extra, stride_kv_block, stride_kv_block_extra, topk_length_ptr, topk_length_extra_ptr, \
       stream)
@@ -403,11 +407,17 @@ bool sparse_mla_prefill_dispatch(ModelType mt, int num_heads, int topk, int page
                                  const float* attn_sink, const int* topk_length,
                                  const int* extra_topk_length, cudaStream_t stream) {
   if (extra_KV_cache != nullptr) {
-    if (mt != ModelType::DSV4) return false;
-    return dispatch_dsv4_dual(num_heads, topk, topk_extra, extra_page_block_size, Q, KV_cache,
-                              indices, extra_KV_cache, extra_indices, attn_sink, output, out_lse,
-                              sm_scale, num_tokens, stride_kv_block, stride_kv_block_extra,
-                              topk_length, extra_topk_length, stream);
+    if (mt == ModelType::DSV4)
+      return dispatch_dsv4_dual<ModelType::DSV4>(
+          num_heads, topk, topk_extra, extra_page_block_size, Q, KV_cache, indices, extra_KV_cache,
+          extra_indices, attn_sink, output, out_lse, sm_scale, num_tokens, stride_kv_block,
+          stride_kv_block_extra, topk_length, extra_topk_length, stream);
+    if (mt == ModelType::DSV4_NVFP4)
+      return dispatch_dsv4_dual<ModelType::DSV4_NVFP4>(
+          num_heads, topk, topk_extra, extra_page_block_size, Q, KV_cache, indices, extra_KV_cache,
+          extra_indices, attn_sink, output, out_lse, sm_scale, num_tokens, stride_kv_block,
+          stride_kv_block_extra, topk_length, extra_topk_length, stream);
+    return false;
   }
 
   switch (mt) {
@@ -420,8 +430,13 @@ bool sparse_mla_prefill_dispatch(ModelType mt, int num_heads, int topk, int page
                                               output, out_lse, sm_scale, num_tokens,
                                               stride_kv_block, topk_length, stream);
     case ModelType::DSV4:
-      return dispatch_dsv4_single(num_heads, topk, Q, KV_cache, indices, attn_sink, output, out_lse,
-                                  sm_scale, num_tokens, stride_kv_block, topk_length, stream);
+      return dispatch_dsv4_single<ModelType::DSV4>(num_heads, topk, Q, KV_cache, indices, attn_sink,
+                                                   output, out_lse, sm_scale, num_tokens,
+                                                   stride_kv_block, topk_length, stream);
+    case ModelType::DSV4_NVFP4:
+      return dispatch_dsv4_single<ModelType::DSV4_NVFP4>(
+          num_heads, topk, Q, KV_cache, indices, attn_sink, output, out_lse, sm_scale, num_tokens,
+          stride_kv_block, topk_length, stream);
   }
   return false;
 }

--- a/csrc/sparse_mla_sm120_prefill.cu
+++ b/csrc/sparse_mla_sm120_prefill.cu
@@ -257,13 +257,14 @@ inline bool dispatch_v32(int num_heads, int topk, const bf16* Q, const uint8_t* 
 #undef DISPATCH_DSV3_2_MG
 }
 
+template <ModelType MT>
 inline bool dispatch_dsv4_single(int num_heads, int topk, const bf16* Q, const uint8_t* KV,
                                  const int32_t* indices, const float* attn_sink, bf16* output,
                                  float* out_lse, float sm_scale, int num_tokens,
                                  size_t stride_kv_block, const int* topk_length_ptr,
                                  cudaStream_t stream) {
 #define DISPATCH_MG_CM(CM, NH, TK, NHG)                                                  \
-  launch_prefill_mg<ModelType::DSV4, ComputeMode::CM, NH, TK, 64, NHG>(                  \
+  launch_prefill_mg<MT, ComputeMode::CM, NH, TK, 64, NHG>(                               \
       Q, KV, indices, attn_sink, output, out_lse, sm_scale, num_tokens, stride_kv_block, \
       topk_length_ptr, stream)
 
@@ -314,6 +315,7 @@ inline bool dispatch_dsv4_single(int num_heads, int topk, const bf16* Q, const u
   return false;  // unreachable
 }
 
+template <ModelType MT>
 inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extra_page_block_size,
                                const bf16* Q, const uint8_t* KV, const int32_t* indices,
                                const uint8_t* KV_extra, const int32_t* idx_extra,
@@ -324,7 +326,7 @@ inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extr
   if (topk == 128 && topk_length_ptr == nullptr && topk_length_extra_ptr == nullptr &&
       topk_extra % BI == 0 && (extra_page_block_size == 64 || extra_page_block_size == 2)) {
 #define DISPATCH_DUAL_MG_FULLTILE(NH, TK, PBSX, NHG)                                         \
-  launch_prefill_mg_dual_fulltile<ModelType::DSV4, NH, TK, 64, PBSX, NHG>(                   \
+  launch_prefill_mg_dual_fulltile<MT, NH, TK, 64, PBSX, NHG>(                                \
       Q, KV, indices, KV_extra, idx_extra, attn_sink, output, out_lse, sm_scale, num_tokens, \
       topk_extra, stride_kv_block, stride_kv_block_extra, stream)
 
@@ -363,7 +365,7 @@ inline bool dispatch_dsv4_dual(int num_heads, int topk, int topk_extra, int extr
 // topk_extra is runtime; extra_page_block_size stays template because it
 // changes the KV stride. NH=8/16 use MG_N_HG_T=1; NH=8 is padded internally.
 #define DISPATCH_DUAL_MG_CM(CM, NH, TK, PBSX, NHG)                                                \
-  launch_prefill_mg_dual<ModelType::DSV4, ComputeMode::CM, NH, TK, 64, PBSX, NHG>(                \
+  launch_prefill_mg_dual<MT, ComputeMode::CM, NH, TK, 64, PBSX, NHG>(                             \
       Q, KV, indices, KV_extra, idx_extra, attn_sink, output, out_lse, sm_scale, num_tokens,      \
       topk_extra, stride_kv_block, stride_kv_block_extra, topk_length_ptr, topk_length_extra_ptr, \
       stream)
@@ -416,11 +418,17 @@ bool sparse_mla_prefill_dispatch(ModelType mt, int num_heads, int topk, int page
                                  const float* attn_sink, const int* topk_length,
                                  const int* extra_topk_length, cudaStream_t stream) {
   if (extra_KV_cache != nullptr) {
-    if (mt != ModelType::DSV4) return false;
-    return dispatch_dsv4_dual(num_heads, topk, topk_extra, extra_page_block_size, Q, KV_cache,
-                              indices, extra_KV_cache, extra_indices, attn_sink, output, out_lse,
-                              sm_scale, num_tokens, stride_kv_block, stride_kv_block_extra,
-                              topk_length, extra_topk_length, stream);
+    if (mt == ModelType::DSV4)
+      return dispatch_dsv4_dual<ModelType::DSV4>(
+          num_heads, topk, topk_extra, extra_page_block_size, Q, KV_cache, indices, extra_KV_cache,
+          extra_indices, attn_sink, output, out_lse, sm_scale, num_tokens, stride_kv_block,
+          stride_kv_block_extra, topk_length, extra_topk_length, stream);
+    if (mt == ModelType::DSV4_NVFP4)
+      return dispatch_dsv4_dual<ModelType::DSV4_NVFP4>(
+          num_heads, topk, topk_extra, extra_page_block_size, Q, KV_cache, indices, extra_KV_cache,
+          extra_indices, attn_sink, output, out_lse, sm_scale, num_tokens, stride_kv_block,
+          stride_kv_block_extra, topk_length, extra_topk_length, stream);
+    return false;
   }
 
   switch (mt) {
@@ -433,8 +441,13 @@ bool sparse_mla_prefill_dispatch(ModelType mt, int num_heads, int topk, int page
                                               output, out_lse, sm_scale, num_tokens,
                                               stride_kv_block, topk_length, stream);
     case ModelType::DSV4:
-      return dispatch_dsv4_single(num_heads, topk, Q, KV_cache, indices, attn_sink, output, out_lse,
-                                  sm_scale, num_tokens, stride_kv_block, topk_length, stream);
+      return dispatch_dsv4_single<ModelType::DSV4>(num_heads, topk, Q, KV_cache, indices, attn_sink,
+                                                   output, out_lse, sm_scale, num_tokens,
+                                                   stride_kv_block, topk_length, stream);
+    case ModelType::DSV4_NVFP4:
+      return dispatch_dsv4_single<ModelType::DSV4_NVFP4>(
+          num_heads, topk, Q, KV_cache, indices, attn_sink, output, out_lse, sm_scale, num_tokens,
+          stride_kv_block, topk_length, stream);
   }
   return false;
 }

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -933,10 +933,10 @@ def _check_dsv4_sparse_mla_inputs(
             swa_kv_cache, kv_layout, "swa_kv_cache"
         )
     if allow_sm120_packed_kv and swa_kv_cache.dtype == torch.uint8:
-        if swa_kv_cache.size(-1) != 584:
+        if swa_kv_cache.size(-1) not in (584, 360):
             raise ValueError(
-                "Expected packed SM120 DSV4 swa_kv_cache head dim 584, got "
-                f"{swa_kv_cache.size(-1)}"
+                "Expected packed SM120 DSV4 swa_kv_cache head dim 584 (fp8) or "
+                f"360 (nvfp4), got {swa_kv_cache.size(-1)}"
             )
     elif swa_kv_cache.dtype != query.dtype:
         raise ValueError(
@@ -957,10 +957,10 @@ def _check_dsv4_sparse_mla_inputs(
             compressed_kv_cache, kv_layout, "compressed_kv_cache"
         )
     if allow_sm120_packed_kv and compressed_kv_cache.dtype == torch.uint8:
-        if compressed_kv_cache.size(-1) != 584:
+        if compressed_kv_cache.size(-1) not in (584, 360):
             raise ValueError(
-                "Expected packed SM120 DSV4 compressed_kv_cache head dim 584, got "
-                f"{compressed_kv_cache.size(-1)}"
+                "Expected packed SM120 DSV4 compressed_kv_cache head dim 584 (fp8) "
+                f"or 360 (nvfp4), got {compressed_kv_cache.size(-1)}"
             )
     elif compressed_kv_cache.dtype != query.dtype:
         raise ValueError(
@@ -1045,6 +1045,7 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
     bmm2_scale: float,
     sinks: Optional[torch.Tensor],
     kv_layout: Literal["HND", "NHD"],
+    kv_scale_format: str = "auto",
 ) -> torch.Tensor:
     if bmm2_scale != 1.0:
         raise ValueError("SM120 DSv4 sparse MLA does not support bmm2_scale")
@@ -1070,10 +1071,10 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
         swa_kv_cache, kv_layout, "swa_kv_cache"
     )
     if swa_kv_cache.dtype == torch.uint8:
-        if swa_kv_cache.size(-1) != 584:
+        if swa_kv_cache.size(-1) not in (584, 360):
             raise ValueError(
-                "Expected packed SM120 DSV4 swa_kv_cache head dim 584, got "
-                f"{swa_kv_cache.size(-1)}"
+                "Expected packed SM120 DSV4 swa_kv_cache head dim 584 (fp8) or "
+                f"360 (nvfp4), got {swa_kv_cache.size(-1)}"
             )
     elif swa_kv_cache.dtype != query.dtype:
         raise ValueError(
@@ -1105,10 +1106,10 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
             compressed_kv_cache, kv_layout, "compressed_kv_cache"
         )
         if compressed_kv_cache.dtype == torch.uint8:
-            if compressed_kv_cache.size(-1) != 584:
+            if compressed_kv_cache.size(-1) not in (584, 360):
                 raise ValueError(
-                    "Expected packed SM120 DSV4 compressed_kv_cache head dim 584, "
-                    f"got {compressed_kv_cache.size(-1)}"
+                    "Expected packed SM120 DSV4 compressed_kv_cache head dim 584 "
+                    f"(fp8) or 360 (nvfp4), got {compressed_kv_cache.size(-1)}"
                 )
         elif compressed_kv_cache.dtype != query.dtype:
             raise ValueError(
@@ -1140,7 +1141,7 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
             sinks=sinks,
             lse=None,
             return_lse=False,
-            kv_scale_format="auto",
+            kv_scale_format=kv_scale_format,
         ),
     )
     if query.ndim == 3:
@@ -1167,6 +1168,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     swa_topk_lens: Optional[torch.Tensor] = None,
     extra_sparse_indices: Optional[torch.Tensor] = None,
     extra_sparse_topk_lens: Optional[torch.Tensor] = None,
+    kv_scale_format: str = "auto",
 ) -> torch.Tensor:
     r"""Decode DeepSeek V4 sparse MLA.
 
@@ -1276,6 +1278,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
             bmm2_scale=float(bmm2_scale),
             sinks=sinks,
             kv_layout=kv_layout,
+            kv_scale_format=kv_scale_format,
         )
 
     if (

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1184,11 +1184,13 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     length for the SWA validity window.
 
     On SM120/SM121, this calls the packed sparse backend. ``swa_kv_cache`` is
-    the required packed uint8 SWA pool with 584 bytes per token. ``sparse_indices``
-    and ``swa_topk_lens`` describe the active SWA segment. To add a compressed
-    segment, pass ``compressed_kv_cache`` as another packed uint8 pool and pass
-    ``extra_sparse_indices`` with ``extra_sparse_topk_lens``. The SM120/SM121
-    path accepts BF16 query tensors and produces BF16 output.
+    the required packed uint8 SWA pool with 584 bytes per token for the FP8
+    layout, or 360 bytes per token when ``kv_scale_format="nvfp4"``.
+    ``sparse_indices`` and ``swa_topk_lens`` describe the active SWA segment.
+    To add a compressed segment, pass ``compressed_kv_cache`` as another packed
+    uint8 pool and pass ``extra_sparse_indices`` with
+    ``extra_sparse_topk_lens``. The SM120/SM121 path accepts BF16 query tensors
+    and produces BF16 output.
 
     Parameters
     ----------
@@ -1243,6 +1245,11 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     extra_sparse_topk_lens : Optional[torch.Tensor]
         Active compressed segment lengths for SM120/SM121, shape ``[sum_q]``
         INT32.
+    kv_scale_format : str
+        Packed KV cache layout for SM120/SM121. ``"auto"`` selects the FP8
+        layout (584 bytes per token); ``"nvfp4"`` selects the NVFP4 layout with
+        E2M1 nope and a per-64 UE8M0 scale footer (360 bytes per token).
+        Ignored by the ``trtllm-gen`` path.
     """
     backend = _resolve_dsv4_sparse_mla_backend(query.device)
     if enable_pdl is None:

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -923,10 +923,10 @@ def _check_dsv4_sparse_mla_inputs(
             swa_kv_cache, kv_layout, "swa_kv_cache"
         )
     if allow_sm120_packed_kv and swa_kv_cache.dtype == torch.uint8:
-        if swa_kv_cache.size(-1) != 584:
+        if swa_kv_cache.size(-1) not in (584, 360):
             raise ValueError(
-                "Expected packed SM120 DSV4 swa_kv_cache head dim 584, got "
-                f"{swa_kv_cache.size(-1)}"
+                "Expected packed SM120 DSV4 swa_kv_cache head dim 584 (fp8) or "
+                f"360 (nvfp4), got {swa_kv_cache.size(-1)}"
             )
     elif swa_kv_cache.dtype != query.dtype:
         raise ValueError(
@@ -947,10 +947,10 @@ def _check_dsv4_sparse_mla_inputs(
             compressed_kv_cache, kv_layout, "compressed_kv_cache"
         )
     if allow_sm120_packed_kv and compressed_kv_cache.dtype == torch.uint8:
-        if compressed_kv_cache.size(-1) != 584:
+        if compressed_kv_cache.size(-1) not in (584, 360):
             raise ValueError(
-                "Expected packed SM120 DSV4 compressed_kv_cache head dim 584, got "
-                f"{compressed_kv_cache.size(-1)}"
+                "Expected packed SM120 DSV4 compressed_kv_cache head dim 584 (fp8) "
+                f"or 360 (nvfp4), got {compressed_kv_cache.size(-1)}"
             )
     elif compressed_kv_cache.dtype != query.dtype:
         raise ValueError(
@@ -1053,6 +1053,7 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
     bmm2_scale: float,
     sinks: Optional[torch.Tensor],
     kv_layout: Literal["HND", "NHD"],
+    kv_scale_format: str = "auto",
 ) -> torch.Tensor:
     if bmm2_scale != 1.0:
         raise ValueError("SM120 DSv4 sparse MLA does not support bmm2_scale")
@@ -1078,10 +1079,10 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
         swa_kv_cache, kv_layout, "swa_kv_cache"
     )
     if swa_kv_cache.dtype == torch.uint8:
-        if swa_kv_cache.size(-1) != 584:
+        if swa_kv_cache.size(-1) not in (584, 360):
             raise ValueError(
-                "Expected packed SM120 DSV4 swa_kv_cache head dim 584, got "
-                f"{swa_kv_cache.size(-1)}"
+                "Expected packed SM120 DSV4 swa_kv_cache head dim 584 (fp8) or "
+                f"360 (nvfp4), got {swa_kv_cache.size(-1)}"
             )
     elif swa_kv_cache.dtype != query.dtype:
         raise ValueError(
@@ -1113,10 +1114,10 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
             compressed_kv_cache, kv_layout, "compressed_kv_cache"
         )
         if compressed_kv_cache.dtype == torch.uint8:
-            if compressed_kv_cache.size(-1) != 584:
+            if compressed_kv_cache.size(-1) not in (584, 360):
                 raise ValueError(
-                    "Expected packed SM120 DSV4 compressed_kv_cache head dim 584, "
-                    f"got {compressed_kv_cache.size(-1)}"
+                    "Expected packed SM120 DSV4 compressed_kv_cache head dim 584 "
+                    f"(fp8) or 360 (nvfp4), got {compressed_kv_cache.size(-1)}"
                 )
         elif compressed_kv_cache.dtype != query.dtype:
             raise ValueError(
@@ -1148,7 +1149,7 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
             sinks=sinks,
             lse=None,
             return_lse=False,
-            kv_scale_format="auto",
+            kv_scale_format=kv_scale_format,
         ),
     )
     if query.ndim == 3:
@@ -1485,6 +1486,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     hca_sparse_indices_format: Optional[Literal["compressed-page-aligned"]] = None,
     remapped_sparse_indices_buffer: Optional[torch.Tensor] = None,
     sparse_indices_are_storage_offsets: Optional[bool] = None,
+    kv_scale_format: str = "auto",
 ) -> torch.Tensor:
     r"""Decode DeepSeek V4 sparse MLA.
 
@@ -1831,6 +1833,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
             bmm2_scale=float(bmm2_scale),
             sinks=sinks,
             kv_layout=kv_layout,
+            kv_scale_format=kv_scale_format,
         )
 
     if (

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1502,11 +1502,13 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     length for the SWA validity window.
 
     On SM120/SM121, this calls the packed sparse backend. ``swa_kv_cache`` is
-    the required packed uint8 SWA pool with 584 bytes per token. ``sparse_indices``
-    and ``swa_topk_lens`` describe the active SWA segment. To add a compressed
-    segment, pass ``compressed_kv_cache`` as another packed uint8 pool and pass
-    ``extra_sparse_indices`` with ``extra_sparse_topk_lens``. The SM120/SM121
-    path accepts BF16 query tensors and produces BF16 output.
+    the required packed uint8 SWA pool with 584 bytes per token for the FP8
+    layout, or 360 bytes per token when ``kv_scale_format="nvfp4"``.
+    ``sparse_indices`` and ``swa_topk_lens`` describe the active SWA segment.
+    To add a compressed segment, pass ``compressed_kv_cache`` as another packed
+    uint8 pool and pass ``extra_sparse_indices`` with
+    ``extra_sparse_topk_lens``. The SM120/SM121 path accepts BF16 query tensors
+    and produces BF16 output.
 
     With ``backend="cute-dsl"`` on SM100/SM103, this calls the DeepSeek V4
     HCA kernel. Its SWA stream consumes arbitrary physical token-row indices,
@@ -1628,6 +1630,11 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         ``False`` for logical flattened token indices or ``True`` for indices
         already adjusted to storage-row offsets. Strided pools require an
         explicit value to prevent accidental double remapping.
+    kv_scale_format : str
+        Packed KV cache layout for SM120/SM121. ``"auto"`` selects the FP8
+        layout (584 bytes per token); ``"nvfp4"`` selects the NVFP4 layout with
+        E2M1 nope and a per-64 UE8M0 scale footer (360 bytes per token).
+        Ignored by the ``trtllm-gen`` path.
     """
     backend = _resolve_dsv4_sparse_mla_backend(query.device, backend)
 

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -79,18 +79,23 @@ _DECODE_MAX_TOKENS = 64
 _DECODE_DSV4_DISPATCH = frozenset(
     {
         (8, 128),
+        (8, 256),
         (8, 512),
         (8, 1024),
         (16, 128),
+        (16, 256),
         (16, 512),
         (16, 1024),
         (32, 128),
+        (32, 256),
         (32, 512),
         (32, 1024),
         (64, 128),
+        (64, 256),
         (64, 512),
         (64, 1024),
         (128, 128),
+        (128, 256),
         (128, 512),
         (128, 1024),
     }
@@ -127,9 +132,11 @@ _DECODE_DSV3_2_PAGE_BLOCK_SIZE = 64
 _MODEL_TYPE_DSV3_2 = 0
 _MODEL_TYPE_DSV4 = 1
 _MODEL_TYPE_GLM_NSA = 2
-_KV_SCALE_FORMATS = frozenset({"auto", "pow2_fp32", "arbitrary_fp32"})
+_MODEL_TYPE_DSV4_NVFP4 = 3
+_KV_SCALE_FORMATS = frozenset({"auto", "pow2_fp32", "arbitrary_fp32", "nvfp4"})
 _BPT_DSV3_2 = 656
 _BPT_DSV4 = 584
+_BPT_DSV4_NVFP4 = 360
 
 
 def _require_d_v_512(d_v: int) -> None:
@@ -161,6 +168,8 @@ def _resolve_model_type(d_qk: int, kv_scale_format: str) -> int:
             return _MODEL_TYPE_GLM_NSA
         return _MODEL_TYPE_DSV3_2
     if d_qk == 512:
+        if fmt == "nvfp4":
+            return _MODEL_TYPE_DSV4_NVFP4
         if fmt != "auto":
             raise ValueError(
                 "kv_scale_format is only configurable for d_qk=576; "
@@ -175,6 +184,8 @@ def _bytes_per_token_for_model_type(model_type: int) -> int:
         return _BPT_DSV3_2
     if model_type == _MODEL_TYPE_DSV4:
         return _BPT_DSV4
+    if model_type == _MODEL_TYPE_DSV4_NVFP4:
+        return _BPT_DSV4_NVFP4
     raise ValueError(f"Unsupported SM120 sparse-MLA model_type={model_type}")
 
 
@@ -322,7 +333,7 @@ def get_sparse_mla_sm120_module():
         )
         extra_topk = int(extra_indices.size(-1)) if extra_indices is not None else 0
         if (
-            model_type == _MODEL_TYPE_DSV4
+            model_type in (_MODEL_TYPE_DSV4, _MODEL_TYPE_DSV4_NVFP4)
             and kv_pbs == _DECODE_DSV4_PAGE_BLOCK_SIZE
             and _decode_dsv4_dispatchable(
                 num_tokens, num_heads, topk, d_qk, kv_pbs, extra_topk
@@ -351,6 +362,7 @@ def get_sparse_mla_sm120_module():
                 extra_kv_cache=extra_kv_cache,
                 extra_indices=extra_indices,
                 extra_topk_length=extra_topk_length,
+                model_type=model_type,
             )
             return
 
@@ -849,6 +861,7 @@ def _get_sparse_mla_decode_dsv4_module():
             sm_scale = kwargs["sm_scale"]
             kv_cache = kwargs["kv_cache"]
             extra_kv_cache = kwargs.get("extra_kv_cache")
+            model_type = kwargs.get("model_type", _MODEL_TYPE_DSV4)
             if len(inputs) > 6:
                 (
                     topk_length,
@@ -881,6 +894,7 @@ def _get_sparse_mla_decode_dsv4_module():
                 extra_indices,
                 extra_topk_length,
                 cpb_override,
+                int(model_type),
             )
             return output
 
@@ -1204,6 +1218,7 @@ def sparse_mla_sm120_decode_dsv4(
     extra_indices: Optional[torch.Tensor] = None,
     extra_topk_length: Optional[torch.Tensor] = None,
     chunks_per_block: Optional[int] = None,
+    model_type: int = _MODEL_TYPE_DSV4,
 ) -> torch.Tensor:
     r"""Sparse-MLA paged decode (DSv4 standalone kernel) on SM120.
 
@@ -1272,6 +1287,7 @@ def sparse_mla_sm120_decode_dsv4(
         "sm_scale": sm_scale,
         "kv_cache": kv_cache,
         "extra_kv_cache": extra_kv_cache,
+        "model_type": int(model_type),
     }
 
     if chunks_per_block is not None:

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -818,11 +818,17 @@ def _get_sparse_mla_decode_dsv3_module(model_type: int):
 
 
 @functools.cache
-def _get_sparse_mla_decode_dsv4_module():
+def _get_sparse_mla_decode_dsv4_module(model_type: int):
     module = gen_sparse_mla_sm120_module().build_and_load()
 
     class SparseMlaDecodeV3Runner(TunableRunner):
         """Tactic = chunks_per_block ∈ [1, num_splits]; ≤0 → C++ heuristic."""
+
+        def __init__(self, model_type: int) -> None:
+            self.model_type = int(model_type)
+
+        def __hash__(self) -> int:
+            return hash((self.__class__.__name__, self.model_type))
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
             topk_length = inputs[6] if len(inputs) > 6 else None
@@ -830,7 +836,11 @@ def _get_sparse_mla_decode_dsv4_module():
             extra_indices = inputs[8] if len(inputs) > 8 else None
             extra_topk_length = inputs[9] if len(inputs) > 9 else None
             extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
+            # model_type selects the KV layout (FP8 584 B/token vs NVFP4
+            # 360 B/token), which changes the optimal chunks_per_block at an
+            # otherwise identical shape, so it must key the profiling cache.
             return (
+                self.model_type,
                 topk_length is not None,
                 attn_sink is not None,
                 int(extra_topk),
@@ -861,7 +871,6 @@ def _get_sparse_mla_decode_dsv4_module():
             sm_scale = kwargs["sm_scale"]
             kv_cache = kwargs["kv_cache"]
             extra_kv_cache = kwargs.get("extra_kv_cache")
-            model_type = kwargs.get("model_type", _MODEL_TYPE_DSV4)
             if len(inputs) > 6:
                 (
                     topk_length,
@@ -894,11 +903,14 @@ def _get_sparse_mla_decode_dsv4_module():
                 extra_indices,
                 extra_topk_length,
                 cpb_override,
-                int(model_type),
+                self.model_type,
             )
             return output
 
-    return SimpleNamespace(module=module, runner_cls=SparseMlaDecodeV3Runner)
+    return SimpleNamespace(
+        module=module,
+        runner_cls=lambda: SparseMlaDecodeV3Runner(model_type),
+    )
 
 
 def _decode_dsv4_num_token_buckets(*_args, **_kwargs):
@@ -1021,8 +1033,8 @@ def _decode_dsv3_2_runner_singleton(model_type: int):
 
 
 @functools.cache
-def _decode_dsv4_runner_singleton():
-    return _get_sparse_mla_decode_dsv4_module().runner_cls()
+def _decode_dsv4_runner_singleton(model_type: int):
+    return _get_sparse_mla_decode_dsv4_module(model_type).runner_cls()
 
 
 def _decode_dsv3_2_default_cache_path():
@@ -1274,7 +1286,7 @@ def sparse_mla_sm120_decode_dsv4(
     _check_last_dim_512(output, "output")
     _check_last_dim_512(mid_out, "mid_out")
 
-    runner = _decode_dsv4_runner_singleton()
+    runner = _decode_dsv4_runner_singleton(int(model_type))
     inputs = [
         q,
         indices,
@@ -1288,11 +1300,12 @@ def sparse_mla_sm120_decode_dsv4(
         extra_topk_length,
     ]
 
+    # model_type is bound on the runner (and keys its autotune cache entries),
+    # so it is not passed per-call.
     forward_kwargs = {
         "sm_scale": sm_scale,
         "kv_cache": kv_cache,
         "extra_kv_cache": extra_kv_cache,
-        "model_type": int(model_type),
     }
 
     if chunks_per_block is not None:

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -172,8 +172,8 @@ def _resolve_model_type(d_qk: int, kv_scale_format: str) -> int:
             return _MODEL_TYPE_DSV4_NVFP4
         if fmt != "auto":
             raise ValueError(
-                "kv_scale_format is only configurable for d_qk=576; "
-                f"got d_qk=512 with kv_scale_format={kv_scale_format!r}"
+                "kv_scale_format for d_qk=512 must be 'auto' (fp8) or 'nvfp4'; "
+                f"got kv_scale_format={kv_scale_format!r}"
             )
         return _MODEL_TYPE_DSV4
     raise ValueError(f"SM120 sparse-MLA supports d_qk=576 or d_qk=512, got d_qk={d_qk}")
@@ -1239,12 +1239,14 @@ def sparse_mla_sm120_decode_dsv4(
     Parameters
     ----------
     q : torch.Tensor
-        ``[T, num_heads, d_qk]`` bf16. ``d_qk == 512`` (DSV4 only).
+        ``[T, num_heads, d_qk]`` bf16. ``d_qk == 512`` (DSV4 or DSV4_NVFP4).
     kv_cache : torch.Tensor
-        Paged FP8 cache, shape ``[num_blocks, page_bytes]`` uint8.
+        Paged packed cache, shape ``[num_blocks, page_bytes]`` uint8. DSV4
+        stores 584 bytes/token (FP8 nope); DSV4_NVFP4 stores 360 bytes/token
+        (E2M1 nope with a per-64 UE8M0 scale footer).
     indices : torch.Tensor
-        ``[T, topk]`` int32. ``topk`` must be one of {128, 512, 1024}; ``-1``
-        marks invalid slots.
+        ``[T, topk]`` int32. ``topk`` must be one of {128, 256, 512, 1024};
+        ``-1`` marks invalid slots.
     mid_out : torch.Tensor
         Scratch, ``[T, num_heads, num_splits, d_v]`` bf16. ``num_splits =
         ceil(topk / 64) + ceil(extra_topk / 64)``.
@@ -1260,6 +1262,9 @@ def sparse_mla_sm120_decode_dsv4(
         Per-token effective top-k length, ``[T]`` int32.
     chunks_per_block : Optional[int]
         Explicit override. If ``None`` and no AutoTuner active, uses heuristic.
+    model_type : int
+        KV cache layout selector: ``_MODEL_TYPE_DSV4`` (FP8, 584 bytes/token)
+        or ``_MODEL_TYPE_DSV4_NVFP4`` (NVFP4, 360 bytes/token).
 
     Returns
     -------
@@ -1315,6 +1320,7 @@ def sparse_mla_sm120_decode_dsv4(
             extra_topk,
             num_splits,
             runner.get_cache_key_extras(inputs),
+            int(model_type),
         )
         cached_tactic = _decode_dsv4_hot_cache.get(hot_key)
         if cached_tactic is not None:
@@ -1349,6 +1355,7 @@ def sparse_mla_sm120_decode_dsv4(
             extra_topk,
             num_splits,
             runner.get_cache_key_extras(inputs),
+            int(model_type),
         )
         _decode_dsv4_hot_cache[hot_key] = int(tactic)
     chosen(inputs=inputs, tactic=tactic, **forward_kwargs)

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -136,9 +136,11 @@ _DECODE_DSV3_2_PAGE_BLOCK_SIZE = 64
 _MODEL_TYPE_DSV3_2 = 0
 _MODEL_TYPE_DSV4 = 1
 _MODEL_TYPE_GLM_NSA = 2
-_KV_SCALE_FORMATS = frozenset({"auto", "pow2_fp32", "arbitrary_fp32"})
+_MODEL_TYPE_DSV4_NVFP4 = 3
+_KV_SCALE_FORMATS = frozenset({"auto", "pow2_fp32", "arbitrary_fp32", "nvfp4"})
 _BPT_DSV3_2 = 656
 _BPT_DSV4 = 584
+_BPT_DSV4_NVFP4 = 360
 
 
 def _require_d_v_512(d_v: int) -> None:
@@ -170,6 +172,8 @@ def _resolve_model_type(d_qk: int, kv_scale_format: str) -> int:
             return _MODEL_TYPE_GLM_NSA
         return _MODEL_TYPE_DSV3_2
     if d_qk == 512:
+        if fmt == "nvfp4":
+            return _MODEL_TYPE_DSV4_NVFP4
         if fmt != "auto":
             raise ValueError(
                 "kv_scale_format is only configurable for d_qk=576; "
@@ -184,6 +188,8 @@ def _bytes_per_token_for_model_type(model_type: int) -> int:
         return _BPT_DSV3_2
     if model_type == _MODEL_TYPE_DSV4:
         return _BPT_DSV4
+    if model_type == _MODEL_TYPE_DSV4_NVFP4:
+        return _BPT_DSV4_NVFP4
     raise ValueError(f"Unsupported SM120 sparse-MLA model_type={model_type}")
 
 
@@ -331,7 +337,7 @@ def get_sparse_mla_sm120_module():
         )
         extra_topk = int(extra_indices.size(-1)) if extra_indices is not None else 0
         if (
-            model_type == _MODEL_TYPE_DSV4
+            model_type in (_MODEL_TYPE_DSV4, _MODEL_TYPE_DSV4_NVFP4)
             and kv_pbs == _DECODE_DSV4_PAGE_BLOCK_SIZE
             and _decode_dsv4_dispatchable(
                 num_tokens, num_heads, topk, d_qk, kv_pbs, extra_topk
@@ -360,6 +366,7 @@ def get_sparse_mla_sm120_module():
                 extra_kv_cache=extra_kv_cache,
                 extra_indices=extra_indices,
                 extra_topk_length=extra_topk_length,
+                model_type=model_type,
             )
             return
 
@@ -871,6 +878,7 @@ def _get_sparse_mla_decode_dsv4_module():
             sm_scale = kwargs["sm_scale"]
             kv_cache = kwargs["kv_cache"]
             extra_kv_cache = kwargs.get("extra_kv_cache")
+            model_type = kwargs.get("model_type", _MODEL_TYPE_DSV4)
             if len(inputs) > 6:
                 (
                     topk_length,
@@ -903,6 +911,7 @@ def _get_sparse_mla_decode_dsv4_module():
                 extra_indices,
                 extra_topk_length,
                 cpb_override,
+                int(model_type),
             )
             return output
 
@@ -1226,6 +1235,7 @@ def sparse_mla_sm120_decode_dsv4(
     extra_indices: Optional[torch.Tensor] = None,
     extra_topk_length: Optional[torch.Tensor] = None,
     chunks_per_block: Optional[int] = None,
+    model_type: int = _MODEL_TYPE_DSV4,
 ) -> torch.Tensor:
     r"""Sparse-MLA paged decode (DSv4 standalone kernel) on SM120.
 
@@ -1294,6 +1304,7 @@ def sparse_mla_sm120_decode_dsv4(
         "sm_scale": sm_scale,
         "kv_cache": kv_cache,
         "extra_kv_cache": extra_kv_cache,
+        "model_type": int(model_type),
     }
 
     if chunks_per_block is not None:

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -835,11 +835,17 @@ def _get_sparse_mla_decode_dsv3_module(model_type: int):
 
 
 @functools.cache
-def _get_sparse_mla_decode_dsv4_module():
+def _get_sparse_mla_decode_dsv4_module(model_type: int):
     module = gen_sparse_mla_sm120_module().build_and_load()
 
     class SparseMlaDecodeV3Runner(TunableRunner):
         """Tactic = chunks_per_block ∈ [1, num_splits]; ≤0 → C++ heuristic."""
+
+        def __init__(self, model_type: int) -> None:
+            self.model_type = int(model_type)
+
+        def __hash__(self) -> int:
+            return hash((self.__class__.__name__, self.model_type))
 
         def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
             topk_length = inputs[6] if len(inputs) > 6 else None
@@ -847,7 +853,11 @@ def _get_sparse_mla_decode_dsv4_module():
             extra_indices = inputs[8] if len(inputs) > 8 else None
             extra_topk_length = inputs[9] if len(inputs) > 9 else None
             extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
+            # model_type selects the KV layout (FP8 584 B/token vs NVFP4
+            # 360 B/token), which changes the optimal chunks_per_block at an
+            # otherwise identical shape, so it must key the profiling cache.
             return (
+                self.model_type,
                 topk_length is not None,
                 attn_sink is not None,
                 int(extra_topk),
@@ -878,7 +888,6 @@ def _get_sparse_mla_decode_dsv4_module():
             sm_scale = kwargs["sm_scale"]
             kv_cache = kwargs["kv_cache"]
             extra_kv_cache = kwargs.get("extra_kv_cache")
-            model_type = kwargs.get("model_type", _MODEL_TYPE_DSV4)
             if len(inputs) > 6:
                 (
                     topk_length,
@@ -911,11 +920,14 @@ def _get_sparse_mla_decode_dsv4_module():
                 extra_indices,
                 extra_topk_length,
                 cpb_override,
-                int(model_type),
+                self.model_type,
             )
             return output
 
-    return SimpleNamespace(module=module, runner_cls=SparseMlaDecodeV3Runner)
+    return SimpleNamespace(
+        module=module,
+        runner_cls=lambda: SparseMlaDecodeV3Runner(model_type),
+    )
 
 
 def _decode_dsv4_num_token_buckets(*_args, **_kwargs):
@@ -1038,8 +1050,8 @@ def _decode_dsv3_2_runner_singleton(model_type: int):
 
 
 @functools.cache
-def _decode_dsv4_runner_singleton():
-    return _get_sparse_mla_decode_dsv4_module().runner_cls()
+def _decode_dsv4_runner_singleton(model_type: int):
+    return _get_sparse_mla_decode_dsv4_module(model_type).runner_cls()
 
 
 def _decode_dsv3_2_default_cache_path():
@@ -1291,7 +1303,7 @@ def sparse_mla_sm120_decode_dsv4(
     _check_last_dim_512(output, "output")
     _check_last_dim_512(mid_out, "mid_out")
 
-    runner = _decode_dsv4_runner_singleton()
+    runner = _decode_dsv4_runner_singleton(int(model_type))
     inputs = [
         q,
         indices,
@@ -1305,11 +1317,12 @@ def sparse_mla_sm120_decode_dsv4(
         extra_topk_length,
     ]
 
+    # model_type is bound on the runner (and keys its autotune cache entries),
+    # so it is not passed per-call.
     forward_kwargs = {
         "sm_scale": sm_scale,
         "kv_cache": kv_cache,
         "extra_kv_cache": extra_kv_cache,
-        "model_type": int(model_type),
     }
 
     if chunks_per_block is not None:

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -176,8 +176,8 @@ def _resolve_model_type(d_qk: int, kv_scale_format: str) -> int:
             return _MODEL_TYPE_DSV4_NVFP4
         if fmt != "auto":
             raise ValueError(
-                "kv_scale_format is only configurable for d_qk=576; "
-                f"got d_qk=512 with kv_scale_format={kv_scale_format!r}"
+                "kv_scale_format for d_qk=512 must be 'auto' (fp8) or 'nvfp4'; "
+                f"got kv_scale_format={kv_scale_format!r}"
             )
         return _MODEL_TYPE_DSV4
     raise ValueError(f"SM120 sparse-MLA supports d_qk=576 or d_qk=512, got d_qk={d_qk}")
@@ -1256,9 +1256,11 @@ def sparse_mla_sm120_decode_dsv4(
     Parameters
     ----------
     q : torch.Tensor
-        ``[T, num_heads, d_qk]`` bf16. ``d_qk == 512`` (DSV4 only).
+        ``[T, num_heads, d_qk]`` bf16. ``d_qk == 512`` (DSV4 or DSV4_NVFP4).
     kv_cache : torch.Tensor
-        Paged FP8 cache, shape ``[num_blocks, page_bytes]`` uint8.
+        Paged packed cache, shape ``[num_blocks, page_bytes]`` uint8. DSV4
+        stores 584 bytes/token (FP8 nope); DSV4_NVFP4 stores 360 bytes/token
+        (E2M1 nope with a per-64 UE8M0 scale footer).
     indices : torch.Tensor
         ``[T, topk]`` int32. ``topk`` must be one of
         {128, 192, 256, 512, 1024}; ``-1`` marks invalid slots.
@@ -1277,6 +1279,9 @@ def sparse_mla_sm120_decode_dsv4(
         Per-token effective top-k length, ``[T]`` int32.
     chunks_per_block : Optional[int]
         Explicit override. If ``None`` and no AutoTuner active, uses heuristic.
+    model_type : int
+        KV cache layout selector: ``_MODEL_TYPE_DSV4`` (FP8, 584 bytes/token)
+        or ``_MODEL_TYPE_DSV4_NVFP4`` (NVFP4, 360 bytes/token).
 
     Returns
     -------
@@ -1332,6 +1337,7 @@ def sparse_mla_sm120_decode_dsv4(
             extra_topk,
             num_splits,
             runner.get_cache_key_extras(inputs),
+            int(model_type),
         )
         cached_tactic = _decode_dsv4_hot_cache.get(hot_key)
         if cached_tactic is not None:
@@ -1366,6 +1372,7 @@ def sparse_mla_sm120_decode_dsv4(
             extra_topk,
             num_splits,
             runner.get_cache_key_extras(inputs),
+            int(model_type),
         )
         _decode_dsv4_hot_cache[hot_key] = int(tactic)
     chosen(inputs=inputs, tactic=tactic, **forward_kwargs)

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -38,7 +38,7 @@ __device__ __forceinline__ uint8_t e2m1_nibble_to_fp8_io(uint8_t nib) {
   const uint8_t sign = static_cast<uint8_t>((nib & 0x8) << 4);
   const uint8_t code = static_cast<uint8_t>(nib & 0x7);
   const uint8_t mag =
-      (code == 0) ? 0x00 : (code == 1) ? 0x30 : static_cast<uint8_t>(0x38 + (code - 2) * 4);
+      (code == 0) ? 0x00 : (code == 1) ? 0x30 : static_cast<uint8_t>(0x30 + code * 4);
   return static_cast<uint8_t>(sign | mag);
 }
 

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -32,6 +32,54 @@
 #include "../arch/cp_async.cuh"
 #include "../model/kv_cache_traits.cuh"
 
+// E2M1 (NVFP4) nibble -> fp8 e4m3 byte (magnitudes {0,.5,1,1.5,2,3,4,6}, bit3=sign).
+// Branchless expand of the packed NVFP4 NoPE into the fp8 smem the MMA consumes.
+__device__ __forceinline__ uint8_t e2m1_nibble_to_fp8_io(uint8_t nib) {
+  const uint8_t sign = static_cast<uint8_t>((nib & 0x8) << 4);
+  const uint8_t code = static_cast<uint8_t>(nib & 0x7);
+  const uint8_t mag =
+      (code == 0) ? 0x00 : (code == 1) ? 0x30 : static_cast<uint8_t>(0x38 + (code - 2) * 4);
+  return static_cast<uint8_t>(sign | mag);
+}
+
+// Consumer-side in-place expand for the NVFP4 KV tile (math warps, after the mbar
+// wake). TMA landed 224 packed E2M1 bytes at row[224:448); expand to 448 fp8 bytes
+// at row[0:448). Call with one WARP per 8 rows: row = first_row + (lane>>2), 4 lanes
+// per row each handling 56 packed bytes. Register-stages the packed bytes, then
+// __syncwarp()s before writing (lane q=2/3 writes over lane q=0/1's source region).
+// Caller must CTA/math-barrier afterwards if other warps read these rows.
+template <int SMEM_STRIDE>
+__device__ __forceinline__ void nvfp4_expand_rows_warp(uint8_t* tile, int first_row, int lane) {
+  static_assert(SMEM_STRIDE % 4 == 0);
+  uint8_t* row = tile + (size_t)(first_row + (lane >> 2)) * SMEM_STRIDE;
+  const int q = lane & 3;
+  const uint32_t* src = reinterpret_cast<const uint32_t*>(row + 224 + 56 * q);
+  uint32_t stage[14];
+#pragma unroll
+  for (int i = 0; i < 14; ++i) stage[i] = src[i];
+  __syncwarp();
+  uint32_t* dst = reinterpret_cast<uint32_t*>(row + 112 * q);
+#pragma unroll
+  for (int i = 0; i < 14; ++i) {
+    const uint32_t p = stage[i];
+    uint32_t lo = 0, hi = 0;
+#pragma unroll
+    for (int b = 0; b < 4; ++b) {
+      const uint8_t byte = static_cast<uint8_t>((p >> (8 * b)) & 0xFF);
+      const uint32_t e0 = e2m1_nibble_to_fp8_io(byte & 0xF);
+      const uint32_t e1 = e2m1_nibble_to_fp8_io(byte >> 4);
+      const uint32_t pair = e0 | (e1 << 8);
+      if (b < 2)
+        lo |= pair << (16 * b);
+      else
+        hi |= pair << (16 * (b - 2));
+    }
+    dst[2 * i] = lo;
+    dst[2 * i + 1] = hi;
+  }
+  __syncwarp();
+}
+
 // KV cache IO: gather BI entries from global KV pool to smem.
 //
 // FlashMLA ABI: stride_kv_row = bytes_per_token (DSV3_2: 656, DSV4: 584).
@@ -52,8 +100,10 @@ struct KVIOTraits {
   using KV = KVCacheTraits<MT>;
   // DSV3_2: IO_STRIDE = KV_GMEM_STRIDE = 656 (inline, bulk copy includes scale)
   // DSV4: IO_STRIDE = D_NOPE + D_ROPE*2 = 576 (footer, data portion only)
+  // DSV4_NVFP4: NOPE_STORAGE_BYTES(=D_NOPE/2=224) + D_ROPE*2 = 352 (E2M1-packed nope).
   static constexpr int IO_STRIDE =
-      KV::SCALE_IN_KV_SMEM ? KV::KV_GMEM_STRIDE : (KV::D_NOPE + D_ROPE * sizeof(bf16));
+      KV::SCALE_IN_KV_SMEM ? KV::KV_GMEM_STRIDE
+                           : (KV::NOPE_STORAGE_BYTES + D_ROPE * sizeof(bf16));
   static_assert(IO_STRIDE % 16 == 0, "IO stride must be 16B aligned for cp.async.bulk");
 };
 
@@ -69,6 +119,12 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, const int32_t*
   using IO = KVIOTraits<MT>;
   constexpr int COPY_BYTES = KV::KV_SMEM_COPY_BYTES;
   constexpr int SMEM_STRIDE = KV::KV_SMEM_STRIDE;
+  // NVFP4: gmem nope is packed E2M1 (D_NOPE/2 bytes). TMA-copy the packed bytes
+  // into the top of the smem row (offset D_NOPE - COPY_BYTES); the consumer expands
+  // them in place to the full D_NOPE fp8 layout after the mbar wake
+  // (nvfp4_expand_rows_warp below). fp8: DST_OFF = 0.
+  constexpr int DST_OFF = KV::D_NOPE - COPY_BYTES;  // 0 fp8 / 224 nvfp4
+  static_assert(DST_OFF % 16 == 0 && COPY_BYTES % 16 == 0, "cp.async.bulk needs 16B alignment");
 
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, BI * COPY_BYTES);
 
@@ -87,9 +143,10 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, const int32_t*
       src = kv_ptr + (size_t)block_idx * stride_kv_block + (size_t)local_idx * IO::IO_STRIDE;
     }
     if constexpr (USE_L2_HINT)
-      cp_async_bulk_g2s_l2hint(dst + bi * SMEM_STRIDE, src, COPY_BYTES, mbar, cache_policy);
+      cp_async_bulk_g2s_l2hint(dst + bi * SMEM_STRIDE + DST_OFF, src, COPY_BYTES, mbar,
+                               cache_policy);
     else
-      cp_async_bulk_g2s(dst + bi * SMEM_STRIDE, src, COPY_BYTES, mbar);
+      cp_async_bulk_g2s(dst + bi * SMEM_STRIDE + DST_OFF, src, COPY_BYTES, mbar);
   }
 }
 

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -122,9 +122,14 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, const int32_t*
   // NVFP4: gmem nope is packed E2M1 (D_NOPE/2 bytes). TMA-copy the packed bytes
   // into the top of the smem row (offset D_NOPE - COPY_BYTES); the consumer expands
   // them in place to the full D_NOPE fp8 layout after the mbar wake
-  // (nvfp4_expand_rows_warp below). fp8: DST_OFF = 0.
-  constexpr int DST_OFF = KV::D_NOPE - COPY_BYTES;  // 0 fp8 / 224 nvfp4
-  static_assert(DST_OFF % 16 == 0 && COPY_BYTES % 16 == 0, "cp.async.bulk needs 16B alignment");
+  // (nvfp4_expand_rows_warp below). Every other model type bulk-copies a whole
+  // smem row -- the full-width nope for DSV4, nope plus the inline scales for
+  // DSV3_2/GLM_NSA -- so the copy starts at the base of the row.
+  constexpr int DST_OFF = KV::KV_IS_NVFP4 ? (KV::D_NOPE - COPY_BYTES) : 0;  // 224 nvfp4 / 0 else
+  static_assert(DST_OFF >= 0 && DST_OFF % 16 == 0 && COPY_BYTES % 16 == 0,
+                "cp.async.bulk needs a non-negative, 16B-aligned destination offset and size");
+  static_assert(DST_OFF + COPY_BYTES <= SMEM_STRIDE,
+                "bulk copy must land inside the smem row it is addressed to");
 
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, BI * COPY_BYTES);
 

--- a/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_kernel.cuh
@@ -11,6 +11,7 @@
 #include "arch/mma_sm120.cuh"
 #include "common/d2_load_b.cuh"
 #include "common/fp8_quant.cuh"
+#include "common/kv_cache_io.cuh"
 #include "common/online_softmax.cuh"
 #include "model/kv_cache_traits.cuh"
 #include "model/scale_convert.cuh"
@@ -43,10 +44,13 @@ constexpr int DSV4_KV_BUF_COUNT = 2;
 constexpr int DSV4_ENTRIES_PER_WARP = DSV4_BI / DSV4_N_WARPS;  // 8
 constexpr int DSV4_QK_N_TILES = DSV4_ENTRIES_PER_WARP / 8;     // 1
 
+// E2M1 (NVFP4) 4-bit code -> fp8 e4m3 byte with the same numeric magnitude.
+// E2M1 magnitudes {0,0.5,1,1.5,2,3,4,6}; bit3 = sign.
+//   0.5=0x30 1=0x38 1.5=0x3C 2=0x40 3=0x44 4=0x48 6=0x4C ; sign bit sets 0x80.
 template <ModelType MT>
 struct DecodeDsv4Smem {
   using KV = KVCacheTraits<MT>;
-  static_assert(MT == ModelType::DSV4);
+  static_assert(MT == ModelType::DSV4 || MT == ModelType::DSV4_NVFP4);
 
   static constexpr int N_V_CHUNKS = KV::D_NOPE / KV::QUANT_TILE;
   static constexpr size_t SMEM_Q_ROPE = HPB * KV::D_ROPE * sizeof(bf16);
@@ -135,7 +139,9 @@ __global__ void __launch_bounds__(DSV4_BLOCK_THREADS) sparse_mla_decode_dsv4_ker
     size_t stride_extra_kv_block, int num_tokens, int num_splits, int chunks_per_block,
     float sm_scale, size_t stride_kv_block) {
   using KV = KVCacheTraits<MT>;
-  static_assert(MT == ModelType::DSV4, "decode-dsv4 currently DSV4-only");
+  static_assert(MT == ModelType::DSV4 || MT == ModelType::DSV4_NVFP4,
+                "decode-dsv4 handles DSV4 (fp8) and DSV4_NVFP4 (E2M1 nope)");
+  constexpr bool KV_IS_NVFP4 = KV::KV_IS_NVFP4;
   constexpr int D_NOPE = KV::D_NOPE;                                // 448
   constexpr int D_ROPE_C = KV::D_ROPE;                              // 64
   constexpr int D_QK = KV::D_QK;                                    // 512
@@ -145,7 +151,9 @@ __global__ void __launch_bounds__(DSV4_BLOCK_THREADS) sparse_mla_decode_dsv4_ker
   constexpr int Q_NOPE_STRIDE = KV::Q_NOPE_STRIDE;                  // 464
   constexpr int KV_SMEM_STRIDE = KV::KV_SMEM_STRIDE;                // 464
   constexpr int SCALE_BYTES_PER_TOKEN = KV::SCALE_BYTES_PER_TOKEN;  // 8
-  constexpr int IO_STRIDE = D_NOPE + D_ROPE_C * 2;                  // 576
+  // Data-slot bytes/token in gmem: fp8 = 448+128=576; nvfp4 = 224+128=352.
+  constexpr int NOPE_STORAGE_BYTES = KV::NOPE_STORAGE_BYTES;        // 448 fp8 / 224 nvfp4
+  constexpr int IO_STRIDE = NOPE_STORAGE_BYTES + D_ROPE_C * 2;      // 576 / 352
   constexpr int pbs = PAGE_BLOCK_SIZE;
   // Kernel always computes a full HPB×CAND tile (zero-Q-padded for unused
   // head slots); NUM_HEADS=8 small-TP shards write back only VALID_HPB rows.
@@ -233,8 +241,11 @@ __global__ void __launch_bounds__(DSV4_BLOCK_THREADS) sparse_mla_decode_dsv4_ker
   __syncthreads();
 
   // ── TMA bulk constants ──
-  constexpr uint32_t DSV4_BULK_NOPE_BYTES = (uint32_t)D_NOPE;                   // 448
+  // fp8: nope = 448B at row offset 0. nvfp4: nope = 224 packed E2M1 bytes landed
+  // at row offset +224 (top half), expanded in place by the consumer.
+  constexpr uint32_t DSV4_BULK_NOPE_BYTES = (uint32_t)NOPE_STORAGE_BYTES;       // 448 / 224
   constexpr uint32_t DSV4_BULK_ROPE_BYTES = (uint32_t)D_ROPE_C * sizeof(bf16);  // 128
+  constexpr int DSV4_BULK_DST_OFF = D_NOPE - NOPE_STORAGE_BYTES;                // 0 / 224
   constexpr uint32_t DSV4_BULK_TX_BYTES =
       (uint32_t)DSV4_BI * (DSV4_BULK_NOPE_BYTES + DSV4_BULK_ROPE_BYTES);
 
@@ -287,9 +298,11 @@ __global__ void __launch_bounds__(DSV4_BLOCK_THREADS) sparse_mla_decode_dsv4_ker
       mbarrier_arrive_expect_tx(sm.mbar_full(buf), DSV4_BULK_TX_BYTES);
     }
 
-    // Issue cp.async.bulk for NoPE (448 B/entry) + RoPE (128 B/entry).
-    // Bulk completion decrements mbar tx; phase flips when arrival count
-    // (1, by leader above) AND tx=0 both met.
+    // Issue cp.async.bulk for NoPE (fp8: 448 B/entry; nvfp4: 224 packed B/entry,
+    // landed at row offset +224 for the consumer's in-place expand) + RoPE (128
+    // B/entry, directly after the stored nope region in gmem). Bulk completion
+    // decrements mbar tx; phase flips when arrival count (1, by leader above)
+    // and tx=0 are both met.
 #pragma unroll
     for (int eo = 0; eo < DSV4_BI; eo += DSV4_IO_THREADS) {
       const int entry_idx = eo + lane;
@@ -301,10 +314,10 @@ __global__ void __launch_bounds__(DSV4_BLOCK_THREADS) sparse_mla_decode_dsv4_ker
       const int local_idx_g = idx - block_idx_g * section_pbs;
       const uint8_t* data_base =
           section_kv + (size_t)block_idx_g * section_stride + (size_t)local_idx_g * IO_STRIDE;
-      cp_async_bulk_g2s(kv_fp8_dst + (size_t)entry_idx * KV_SMEM_STRIDE, data_base,
-                        DSV4_BULK_NOPE_BYTES, sm.mbar_full(buf));
-      cp_async_bulk_g2s(kv_rope_dst + (size_t)entry_idx * D_ROPE_C, data_base + D_NOPE,
-                        DSV4_BULK_ROPE_BYTES, sm.mbar_full(buf));
+      cp_async_bulk_g2s(kv_fp8_dst + (size_t)entry_idx * KV_SMEM_STRIDE + DSV4_BULK_DST_OFF,
+                        data_base, DSV4_BULK_NOPE_BYTES, sm.mbar_full(buf));
+      cp_async_bulk_g2s(kv_rope_dst + (size_t)entry_idx * D_ROPE_C,
+                        data_base + NOPE_STORAGE_BYTES, DSV4_BULK_ROPE_BYTES, sm.mbar_full(buf));
     }
   };
 
@@ -371,6 +384,14 @@ __global__ void __launch_bounds__(DSV4_BLOCK_THREADS) sparse_mla_decode_dsv4_ker
     uint8_t* sm_kv_fp8 = sm.kv_fp8(buf);
     uint8_t* sm_kv_sc = sm.kv_sc(buf);
     bf16* sm_kv_rope = sm.kv_rope(buf);
+
+    if constexpr (KV_IS_NVFP4) {
+      // Expand this tile's packed E2M1 nope (at row[224:448)) in place to the full
+      // 448B fp8 layout. Each warp expands its own 8 candidate rows; the math-wide
+      // barrier that separates P from XV orders the cross-warp XV reads.
+      nvfp4_expand_rows_warp<KV_SMEM_STRIDE>(sm_kv_fp8, warp_id * DSV4_ENTRIES_PER_WARP, lane);
+      bar_sync_t<3, DSV4_MATH_THREADS>();
+    }
 
     // ── Stage 2 QK ────────────────────────────────────────────
     float qk[DSV4_QK_N_TILES][4] = {0};

--- a/include/flashinfer/attention/sparse_mla_sm120/model/kv_cache_traits.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/model/kv_cache_traits.cuh
@@ -80,6 +80,10 @@ struct KVCacheTraits<ModelType::DSV3_2> {
   // V = pure nope (no rope component)
   static constexpr bool V_HAS_ROPE = false;
 
+  // true => nope stored as packed NVFP4; false => full-width fp8.
+  static constexpr bool KV_IS_NVFP4 = false;
+  static constexpr int NOPE_STORAGE_BYTES = D_NOPE;  // gmem bytes for the nope region
+
   // FP32→UE8M0 scale conversion for block-scaled MMA
   // FlashMLA stores power-of-2 FP32 scales → bit-shift gives exact UE8M0
   __device__ static __forceinline__ uint8_t scale_to_ue8m0(float scale) {
@@ -137,8 +141,32 @@ struct KVCacheTraits<ModelType::DSV4> {
   // XV rope: CUDA core scalar FMA from global (zero smem, M5b verified)
   static constexpr bool V_HAS_ROPE = true;
 
+  // true => nope stored as packed NVFP4; false => full-width fp8.
+  static constexpr bool KV_IS_NVFP4 = false;
+  static constexpr int NOPE_STORAGE_BYTES = D_NOPE;  // 448
+
   // UE8M0 scales are native — no conversion needed
   __device__ static __forceinline__ uint8_t scale_to_ue8m0(uint8_t scale) { return scale; }
+};
+
+// DSV4 with the NoPE region packed as NVFP4. Inherits DSV4's dims, smem layout,
+// per-64 UE8M0 scale format, Q strides, and compute traits; only the gmem NoPE
+// storage differs (448 E2M1 nibbles packed 2/byte = 224B vs 448B fp8), expanded
+// to the 448B fp8 smem row on IO load. Logical page = 224 + 128 + 8 = 360 B/token.
+template <>
+struct KVCacheTraits<ModelType::DSV4_NVFP4> : KVCacheTraits<ModelType::DSV4> {
+  static constexpr bool KV_IS_NVFP4 = true;
+  static constexpr int NOPE_STORAGE_BYTES = D_NOPE / 2;  // 224 (E2M1, 2 nibbles/byte)
+  // TMA copies only the packed nope bytes; the consumer expands them to the full
+  // 448B fp8 row in smem.
+  static constexpr int KV_SMEM_COPY_BYTES = NOPE_STORAGE_BYTES;  // 224
+  // FOOTER layout, 360 logical bytes/token:
+  //   data slot (IO stride): [0:224) E2M1 nope, [224:352) bf16 rope  = 352B (16B aligned)
+  //   footer: 8B/token (7 UE8M0 per-64 + 1 pad)
+  static constexpr int KV_GMEM_STRIDE =
+      NOPE_STORAGE_BYTES + D_ROPE * sizeof(bf16) + SCALE_BYTES_PER_TOKEN;  // 360
+  static constexpr int KV_ROPE_GMEM_OFFSET = NOPE_STORAGE_BYTES;                 // 224
+  static constexpr int KV_SCALE_GMEM_OFFSET = NOPE_STORAGE_BYTES + D_ROPE * sizeof(bf16);  // 352
 };
 
 // ============================================================================
@@ -156,6 +184,10 @@ static_assert(KVCacheTraits<ModelType::DSV3_2>::D_ROPE == D_ROPE);
 static_assert(KVCacheTraits<ModelType::DSV3_2>::D_V == D_V);
 static_assert(KVCacheTraits<ModelType::DSV4>::D_ROPE == D_ROPE);
 static_assert(KVCacheTraits<ModelType::DSV4>::D_V == D_V);
+static_assert(KVCacheTraits<ModelType::DSV4_NVFP4>::D_ROPE == D_ROPE);
+static_assert(KVCacheTraits<ModelType::DSV4_NVFP4>::D_V == D_V);
+static_assert(KVCacheTraits<ModelType::DSV4_NVFP4>::NOPE_STORAGE_BYTES == 224);
+static_assert(KVCacheTraits<ModelType::DSV4_NVFP4>::KV_GMEM_STRIDE == 360);
 static_assert(KVCacheTraits<ModelType::GLM_NSA>::D_ROPE == D_ROPE);
 static_assert(KVCacheTraits<ModelType::GLM_NSA>::D_V == D_V);
 

--- a/include/flashinfer/attention/sparse_mla_sm120/model/model_type.h
+++ b/include/flashinfer/attention/sparse_mla_sm120/model/model_type.h
@@ -29,10 +29,11 @@
 #pragma once
 
 // ModelType determines KV cache layout, dimensions, and scale format.
-//   DSV3_2:  d_nope=512, power-of-2 FP32 scale inline, 656B/token
-//   DSV4:    d_nope=448, UE8M0 scale footer, 584B/token
-//   GLM_NSA: d_nope=512, arbitrary FP32 scale inline, 656B/token
-enum class ModelType { DSV3_2, DSV4, GLM_NSA };
+//   DSV3_2:     d_nope=512, power-of-2 FP32 scale inline, 656B/token
+//   DSV4:       d_nope=448, UE8M0 scale footer, 584B/token
+//   DSV4_NVFP4: d_nope=448 stored E2M1 (4-bit), per-64 UE8M0 scale footer, 360B/token
+//   GLM_NSA:    d_nope=512, arbitrary FP32 scale inline, 656B/token
+enum class ModelType { DSV3_2, DSV4, GLM_NSA, DSV4_NVFP4 };
 
 enum class ScaleFormat { POW2_FP32, UE8M0_BYTE, ARBITRARY_FP32 };
 

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
@@ -193,6 +193,14 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1)
 #pragma unroll 1
     for (int ti = 0; ti < actual_ni; ti++) {
       uint8_t* kv_smem = sm.kv_bufs[ti & 1];
+      if constexpr (KV::KV_IS_NVFP4) {
+        // Expand each row's packed E2M1 nope (at [224:448)) in place to the 448B
+        // fp8 layout the math below expects; the buffer's mbar wait is satisfied by
+        // loop-top. Each warp expands its own 8 rows; the math barrier orders the
+        // cross-warp XV reads.
+        nvfp4_expand_rows_warp<KV::KV_SMEM_STRIDE>(kv_smem, mwarp * ENTRIES_PER_WARP, lane);
+        bar_sync_t<2, MATH_THREADS>();
+      }
       const int32_t* ib = idx_base + ti * BI;
       const int qk_nb = mwarp * ENTRIES_PER_WARP;
       uint8_t* kv_warp_base = kv_smem + qk_nb * KV::KV_SMEM_STRIDE;
@@ -890,6 +898,11 @@ __device__ __forceinline__ void prefill_mg_impl(
 #pragma unroll 1
     for (int ti = 0; ti < loop_bound; ti++) {
       uint8_t* kv_smem = sm.kv_buf(ti & 1);
+      if constexpr (KV::KV_IS_NVFP4) {
+        // In-place E2M1->fp8 expand of this tile; mbar wait satisfied by loop-top.
+        nvfp4_expand_rows_warp<KV::KV_SMEM_STRIDE>(kv_smem, mwarp * ENTRIES_PER_WARP, lane);
+        bar_sync_t<2, MATH_THREADS>();
+      }
       const int qk_nb = mwarp * ENTRIES_PER_WARP;
       uint8_t* kv_warp_base = kv_smem + qk_nb * KV::KV_SMEM_STRIDE;
 

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
@@ -193,6 +193,14 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1)
 #pragma unroll 1
     for (int ti = 0; ti < actual_ni; ti++) {
       uint8_t* kv_smem = sm.kv_bufs[ti & 1];
+      if constexpr (KV::KV_IS_NVFP4) {
+        // Expand each row's packed E2M1 nope (at [224:448)) in place to the 448B
+        // fp8 layout the math below expects; the buffer's mbar wait is satisfied by
+        // loop-top. Each warp expands its own 8 rows; the math barrier orders the
+        // cross-warp XV reads.
+        nvfp4_expand_rows_warp<KV::KV_SMEM_STRIDE>(kv_smem, mwarp * ENTRIES_PER_WARP, lane);
+        bar_sync_t<2, MATH_THREADS>();
+      }
       const int32_t* ib = idx_base + ti * BI;
       const int qk_nb = mwarp * ENTRIES_PER_WARP;
       uint8_t* kv_warp_base = kv_smem + qk_nb * KV::KV_SMEM_STRIDE;
@@ -891,6 +899,11 @@ __device__ __forceinline__ void prefill_mg_impl(
 #pragma unroll 1
     for (int ti = 0; ti < loop_bound; ti++) {
       uint8_t* kv_smem = sm.kv_buf(ti & 1);
+      if constexpr (KV::KV_IS_NVFP4) {
+        // In-place E2M1->fp8 expand of this tile; mbar wait satisfied by loop-top.
+        nvfp4_expand_rows_warp<KV::KV_SMEM_STRIDE>(kv_smem, mwarp * ENTRIES_PER_WARP, lane);
+        bar_sync_t<2, MATH_THREADS>();
+      }
       const int qk_nb = mwarp * ENTRIES_PER_WARP;
       uint8_t* kv_warp_base = kv_smem + qk_nb * KV::KV_SMEM_STRIDE;
 

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -38,6 +38,12 @@ from flashinfer.mla._sparse_mla_sm120 import (
     _sparse_mla_sm120_paged_attention as sparse_mla_sm120_paged_attention,
 )
 from flashinfer.utils import is_sm12x_supported
+from tests.utils_fp4 import (
+    nvfp4_dequantize_blocks,
+    nvfp4_quantize_blocks,
+    ue8m0_block_scales,
+    ue8m0_to_scale,
+)
 
 pytestmark = pytest.mark.skipif(
     not is_sm12x_supported(torch.device("cuda")),
@@ -122,6 +128,110 @@ def dequantize_kv_dsv4(packed: torch.Tensor) -> torch.Tensor:
         result[:, tok, d_nope:] = rope_bytes.view(torch.bfloat16).reshape(nb, d_rope)
 
     return result.view(nb, bs, 1, 512)
+
+
+# DSv4 NVFP4 FOOTER pack.
+#
+# 360 bytes per token. Per page block of ``bs`` tokens the data slots come
+# first, then the scale footers:
+#   [0 : bs*352)          data slot, 352 B per token
+#       [0:224)           NoPE as E2M1, 448 elements packed 2 per byte,
+#                         the even element in the low nibble
+#       [224:352)         RoPE, 64 bf16 elements
+#   [bs*352 : bs*360)     footer, 8 B per token: 7 UE8M0 scale bytes, one per
+#                         64-element NoPE tile, plus one pad byte
+#
+# Note this is not the microscaling NVFP4 of ``nvfp4_attention_sm120`` (per-16
+# E4M3 block scales); it reuses the DSv4 FP8 per-64 UE8M0 scale footer and only
+# narrows the NoPE elements to 4 bits.
+
+_NVFP4_D_NOPE = 448
+_NVFP4_D_ROPE = 64
+_NVFP4_TILE = 64
+_NVFP4_NUM_TILES = _NVFP4_D_NOPE // _NVFP4_TILE  # 7
+_NVFP4_NOPE_BYTES = _NVFP4_D_NOPE // 2  # 224
+_NVFP4_DATA_STRIDE = _NVFP4_NOPE_BYTES + _NVFP4_D_ROPE * 2  # 352
+_NVFP4_SCALE_BYTES = _NVFP4_NUM_TILES + 1  # 8
+_NVFP4_BPT = _NVFP4_DATA_STRIDE + _NVFP4_SCALE_BYTES  # 360
+
+
+def quantize_kv_dsv4_nvfp4(kv_bf16: torch.Tensor) -> torch.Tensor:
+    """Pack bf16 KV into the DSv4 NVFP4 FOOTER format."""
+    nb, bs, hk, d = kv_bf16.shape
+    assert d == _NVFP4_D_NOPE + _NVFP4_D_ROPE and hk == 1
+    kv = kv_bf16.squeeze(2).float()
+
+    nope = kv[..., :_NVFP4_D_NOPE]
+    scale, ue8m0 = ue8m0_block_scales(nope, _NVFP4_TILE)
+    nope_packed = nvfp4_quantize_blocks(nope, scale)
+    rope = (
+        kv[..., _NVFP4_D_NOPE:]
+        .to(torch.bfloat16)
+        .contiguous()
+        .view(torch.uint8)
+        .reshape(nb, bs, _NVFP4_D_ROPE * 2)
+    )
+
+    footer = torch.zeros(
+        nb, bs, _NVFP4_SCALE_BYTES, dtype=torch.uint8, device=kv.device
+    )
+    footer[..., :_NVFP4_NUM_TILES] = ue8m0
+
+    data = torch.cat((nope_packed, rope), dim=-1)
+    result = torch.cat(
+        (data.reshape(nb, bs * _NVFP4_DATA_STRIDE), footer.reshape(nb, -1)), dim=1
+    )
+    return result.view(nb, bs, 1, _NVFP4_BPT)
+
+
+def dequantize_kv_dsv4_nvfp4(packed: torch.Tensor) -> torch.Tensor:
+    """Unpack DSv4 NVFP4 FOOTER → bf16. Inverse of :func:`quantize_kv_dsv4_nvfp4`."""
+    nb, bs, _, _ = packed.shape
+    p = packed.reshape(nb, bs * _NVFP4_BPT)
+    data = p[:, : bs * _NVFP4_DATA_STRIDE].reshape(nb, bs, _NVFP4_DATA_STRIDE)
+    footer = p[:, bs * _NVFP4_DATA_STRIDE :].reshape(nb, bs, _NVFP4_SCALE_BYTES)
+
+    scale = ue8m0_to_scale(footer[..., :_NVFP4_NUM_TILES])
+    nope = nvfp4_dequantize_blocks(data[..., :_NVFP4_NOPE_BYTES], scale)
+    rope = (
+        data[..., _NVFP4_NOPE_BYTES:]
+        .contiguous()
+        .view(torch.bfloat16)
+        .reshape(nb, bs, _NVFP4_D_ROPE)
+    )
+
+    result = torch.cat((nope.to(torch.bfloat16), rope), dim=-1)
+    return result.view(nb, bs, 1, _NVFP4_D_NOPE + _NVFP4_D_ROPE)
+
+
+def vary_nvfp4_tile_magnitudes(kv_bf16: torch.Tensor) -> torch.Tensor:
+    """Give each 64-element NoPE tile its own magnitude.
+
+    KV drawn from one distribution produces the same block amax everywhere, so
+    all seven UE8M0 footer bytes of every token hold the same value and a footer
+    read at the wrong offset would still land on the right number. Spreading the
+    per-tile magnitudes makes the scale bytes distinguishable from each other.
+    """
+    gains = torch.pow(
+        2.0,
+        torch.randint(
+            -1,
+            2,
+            kv_bf16.shape[:-1] + (_NVFP4_NUM_TILES,),
+            device=kv_bf16.device,
+        ).float(),
+    ).to(kv_bf16.dtype)
+    out = kv_bf16.clone()
+    out[..., :_NVFP4_D_NOPE] *= gains.repeat_interleave(_NVFP4_TILE, dim=-1)
+    return out
+
+
+# ``kv_format`` parametrisation for the DSv4 tests: the packer, its matching
+# dequantizer, and the ``kv_scale_format`` the kernel is told to expect.
+_DSV4_KV_FORMATS = {
+    "fp8": (quantize_kv_dsv4, dequantize_kv_dsv4, "auto"),
+    "nvfp4": (quantize_kv_dsv4_nvfp4, dequantize_kv_dsv4_nvfp4, "nvfp4"),
+}
 
 
 # DSv3.2 INLINE pack.
@@ -304,16 +414,18 @@ _DSV4_DECODE_CONFIGS = [
 @pytest.mark.parametrize("num_heads,topk", _DSV4_DECODE_CONFIGS)
 @pytest.mark.parametrize("num_tokens", [1, 16, 64])
 @pytest.mark.parametrize("with_sink", [False, True])
+@pytest.mark.parametrize("kv_format", list(_DSV4_KV_FORMATS))
 def test_sparse_mla_sm120_decode_dsv4(
-    num_heads: int, topk: int, num_tokens: int, with_sink: bool
+    num_heads: int, topk: int, num_tokens: int, with_sink: bool, kv_format: str
 ) -> None:
-    """DSv4 decode."""
+    """DSv4 decode, FP8 and NVFP4 KV cache."""
     torch.manual_seed(0)
     device = torch.device("cuda")
     d_qk, d_v = 512, 512
     page_block_size = 64
     num_blocks = 64
     s_kv = num_blocks * page_block_size  # 4096
+    quantize, dequantize, kv_scale_format = _DSV4_KV_FORMATS[kv_format]
 
     kv_bf16 = (
         torch.randn(
@@ -321,8 +433,8 @@ def test_sparse_mla_sm120_decode_dsv4(
         )
         / 10.0
     ).clamp(-1, 1)
-    kv_packed = quantize_kv_dsv4(kv_bf16)
-    kv_dequant = dequantize_kv_dsv4(kv_packed)
+    kv_packed = quantize(kv_bf16)
+    kv_dequant = dequantize(kv_packed)
 
     q = (
         torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
@@ -360,6 +472,7 @@ def test_sparse_mla_sm120_decode_dsv4(
         sm_scale,
         d_v=d_v,
         attn_sink=attn_sink,
+        kv_scale_format=kv_scale_format,
         mid_out=mid_out,
         mid_lse=mid_lse,
     )
@@ -899,16 +1012,18 @@ _DSV4_PREFILL_CONFIGS = [
 @pytest.mark.parametrize("num_heads,topk", _DSV4_PREFILL_CONFIGS)
 @pytest.mark.parametrize("num_tokens", [128, 256])
 @pytest.mark.parametrize("with_sink", [False, True])
+@pytest.mark.parametrize("kv_format", list(_DSV4_KV_FORMATS))
 def test_sparse_mla_sm120_prefill_dsv4(
-    num_heads: int, topk: int, num_tokens: int, with_sink: bool
+    num_heads: int, topk: int, num_tokens: int, with_sink: bool, kv_format: str
 ) -> None:
-    """DSv4 prefill."""
+    """DSv4 prefill, FP8 and NVFP4 KV cache."""
     torch.manual_seed(0)
     device = torch.device("cuda")
     d_qk, d_v = 512, 512
     page_block_size = 64
     num_blocks = 64
     s_kv = num_blocks * page_block_size
+    quantize, dequantize, kv_scale_format = _DSV4_KV_FORMATS[kv_format]
 
     kv_bf16 = (
         torch.randn(
@@ -916,8 +1031,8 @@ def test_sparse_mla_sm120_prefill_dsv4(
         )
         / 10.0
     ).clamp(-1, 1)
-    kv_packed = quantize_kv_dsv4(kv_bf16)
-    kv_dequant = dequantize_kv_dsv4(kv_packed)
+    kv_packed = quantize(kv_bf16)
+    kv_dequant = dequantize(kv_packed)
 
     q = (
         torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
@@ -954,6 +1069,160 @@ def test_sparse_mla_sm120_prefill_dsv4(
         sm_scale,
         d_v=d_v,
         attn_sink=attn_sink,
+        kv_scale_format=kv_scale_format,
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+# The two tests below exist because the shared DSv4 configuration above is a
+# weak probe of the KV layout: it keeps |q| and |kv| around 0.1 and averages
+# over ~256 candidates, so its outputs sit near 6e-3 RMS — an order of magnitude
+# inside the 5e-2 tolerance. That is enough to catch a broken kernel, but not a
+# subtly misdecoded KV cache. These two drive the output up to where the
+# tolerance actually binds on the decoded NVFP4 values.
+
+
+@pytest.mark.parametrize("num_heads", [16, 128])
+@pytest.mark.parametrize("num_tokens", [16, 128])
+@pytest.mark.parametrize("target_token", [0, 4095])
+def test_sparse_mla_sm120_dsv4_nvfp4_single_token_gather(
+    num_heads: int, num_tokens: int, target_token: int
+) -> None:
+    """Pin the NVFP4 page layout element by element.
+
+    Every candidate slot points at the same KV token, so the attention output is
+    that token's value vector verbatim whatever the scores are. Each of the 448
+    E2M1 NoPE elements, all 7 UE8M0 block scales and the 64 bf16 RoPE elements
+    have to decode correctly for the comparison to hold. ``num_tokens`` selects
+    the decode (16) or the prefill (128) kernel.
+    """
+    torch.manual_seed(3)
+    device = torch.device("cuda")
+    d_qk, d_v = 512, 512
+    topk = 512
+    page_block_size = 64
+    num_blocks = 64
+
+    kv_bf16 = vary_nvfp4_tile_magnitudes(
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        ).clamp(-1, 1)
+    )
+    kv_packed = quantize_kv_dsv4_nvfp4(kv_bf16)
+    kv_dequant = dequantize_kv_dsv4_nvfp4(kv_packed)
+
+    q = torch.randn(
+        num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16
+    ).clamp(-1, 1)
+    indices = torch.full(
+        (num_tokens, topk), target_token, device=device, dtype=torch.int32
+    )
+    sm_scale = d_qk**-0.5
+
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, indices, sm_scale, d_v)
+
+    # Guard the premise: with one distinct candidate the reference must reduce
+    # to the dequantized KV row, otherwise this test is not probing what its
+    # name says.
+    expected = kv_dequant.reshape(-1, d_qk)[target_token, :d_v]
+    torch.testing.assert_close(
+        ref_out, expected.expand_as(ref_out).contiguous(), atol=1e-2, rtol=1e-2
+    )
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    mid_out, mid_lse = _make_decode_scratch(num_tokens, num_heads, topk, d_v, device)
+
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        kv_scale_format="nvfp4",
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+@pytest.mark.parametrize("num_heads", [32, 128])
+@pytest.mark.parametrize("num_tokens", [16, 128])
+@pytest.mark.parametrize("with_sink", [False, True])
+def test_sparse_mla_sm120_dsv4_nvfp4_full_scale(
+    num_heads: int, num_tokens: int, with_sink: bool
+) -> None:
+    """DSv4 NVFP4 over many candidates with Q and KV at full scale.
+
+    Dropping the ``/10`` peaks the softmax enough that the output lands around
+    1e-1 RMS rather than 6e-3, so the 5e-2 tolerance constrains the decoded KV
+    instead of being satisfied by near-zero outputs on both sides.
+    ``num_tokens`` selects the decode (16) or the prefill (128) kernel.
+    """
+    torch.manual_seed(4)
+    device = torch.device("cuda")
+    d_qk, d_v = 512, 512
+    topk = 128
+    page_block_size = 64
+    num_blocks = 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = vary_nvfp4_tile_magnitudes(
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        ).clamp(-1, 1)
+    )
+    kv_packed = quantize_kv_dsv4_nvfp4(kv_bf16)
+    kv_dequant = dequantize_kv_dsv4_nvfp4(kv_packed)
+
+    q = torch.randn(
+        num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk // 2 :] = -1
+
+    attn_sink = (
+        torch.randn(num_heads, device=device, dtype=torch.float32) * 2.0
+        if with_sink
+        else None
+    )
+    sm_scale = d_qk**-0.5
+
+    ref_out, ref_lse = _ref_sparse_attn(
+        q, kv_dequant, indices, sm_scale, d_v, attn_sink=attn_sink
+    )
+    # Guard the premise: the comparison is only meaningful while the output is
+    # comfortably above the absolute tolerance.
+    assert ref_out.float().pow(2).mean().sqrt() > 5e-2
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    mid_out, mid_lse = _make_decode_scratch(num_tokens, num_heads, topk, d_v, device)
+
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        attn_sink=attn_sink,
+        kv_scale_format="nvfp4",
+        mid_out=mid_out,
+        mid_lse=mid_lse,
     )
 
     torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -38,6 +38,12 @@ from flashinfer.mla._sparse_mla_sm120 import (
     _sparse_mla_sm120_paged_attention as sparse_mla_sm120_paged_attention,
 )
 from flashinfer.utils import is_sm12x_supported
+from tests.utils_fp4 import (
+    nvfp4_dequantize_blocks,
+    nvfp4_quantize_blocks,
+    ue8m0_block_scales,
+    ue8m0_to_scale,
+)
 
 pytestmark = pytest.mark.skipif(
     not is_sm12x_supported(torch.device("cuda")),
@@ -122,6 +128,110 @@ def dequantize_kv_dsv4(packed: torch.Tensor) -> torch.Tensor:
         result[:, tok, d_nope:] = rope_bytes.view(torch.bfloat16).reshape(nb, d_rope)
 
     return result.view(nb, bs, 1, 512)
+
+
+# DSv4 NVFP4 FOOTER pack.
+#
+# 360 bytes per token. Per page block of ``bs`` tokens the data slots come
+# first, then the scale footers:
+#   [0 : bs*352)          data slot, 352 B per token
+#       [0:224)           NoPE as E2M1, 448 elements packed 2 per byte,
+#                         the even element in the low nibble
+#       [224:352)         RoPE, 64 bf16 elements
+#   [bs*352 : bs*360)     footer, 8 B per token: 7 UE8M0 scale bytes, one per
+#                         64-element NoPE tile, plus one pad byte
+#
+# Note this is not the microscaling NVFP4 of ``nvfp4_attention_sm120`` (per-16
+# E4M3 block scales); it reuses the DSv4 FP8 per-64 UE8M0 scale footer and only
+# narrows the NoPE elements to 4 bits.
+
+_NVFP4_D_NOPE = 448
+_NVFP4_D_ROPE = 64
+_NVFP4_TILE = 64
+_NVFP4_NUM_TILES = _NVFP4_D_NOPE // _NVFP4_TILE  # 7
+_NVFP4_NOPE_BYTES = _NVFP4_D_NOPE // 2  # 224
+_NVFP4_DATA_STRIDE = _NVFP4_NOPE_BYTES + _NVFP4_D_ROPE * 2  # 352
+_NVFP4_SCALE_BYTES = _NVFP4_NUM_TILES + 1  # 8
+_NVFP4_BPT = _NVFP4_DATA_STRIDE + _NVFP4_SCALE_BYTES  # 360
+
+
+def quantize_kv_dsv4_nvfp4(kv_bf16: torch.Tensor) -> torch.Tensor:
+    """Pack bf16 KV into the DSv4 NVFP4 FOOTER format."""
+    nb, bs, hk, d = kv_bf16.shape
+    assert d == _NVFP4_D_NOPE + _NVFP4_D_ROPE and hk == 1
+    kv = kv_bf16.squeeze(2).float()
+
+    nope = kv[..., :_NVFP4_D_NOPE]
+    scale, ue8m0 = ue8m0_block_scales(nope, _NVFP4_TILE)
+    nope_packed = nvfp4_quantize_blocks(nope, scale)
+    rope = (
+        kv[..., _NVFP4_D_NOPE:]
+        .to(torch.bfloat16)
+        .contiguous()
+        .view(torch.uint8)
+        .reshape(nb, bs, _NVFP4_D_ROPE * 2)
+    )
+
+    footer = torch.zeros(
+        nb, bs, _NVFP4_SCALE_BYTES, dtype=torch.uint8, device=kv.device
+    )
+    footer[..., :_NVFP4_NUM_TILES] = ue8m0
+
+    data = torch.cat((nope_packed, rope), dim=-1)
+    result = torch.cat(
+        (data.reshape(nb, bs * _NVFP4_DATA_STRIDE), footer.reshape(nb, -1)), dim=1
+    )
+    return result.view(nb, bs, 1, _NVFP4_BPT)
+
+
+def dequantize_kv_dsv4_nvfp4(packed: torch.Tensor) -> torch.Tensor:
+    """Unpack DSv4 NVFP4 FOOTER → bf16. Inverse of :func:`quantize_kv_dsv4_nvfp4`."""
+    nb, bs, _, _ = packed.shape
+    p = packed.reshape(nb, bs * _NVFP4_BPT)
+    data = p[:, : bs * _NVFP4_DATA_STRIDE].reshape(nb, bs, _NVFP4_DATA_STRIDE)
+    footer = p[:, bs * _NVFP4_DATA_STRIDE :].reshape(nb, bs, _NVFP4_SCALE_BYTES)
+
+    scale = ue8m0_to_scale(footer[..., :_NVFP4_NUM_TILES])
+    nope = nvfp4_dequantize_blocks(data[..., :_NVFP4_NOPE_BYTES], scale)
+    rope = (
+        data[..., _NVFP4_NOPE_BYTES:]
+        .contiguous()
+        .view(torch.bfloat16)
+        .reshape(nb, bs, _NVFP4_D_ROPE)
+    )
+
+    result = torch.cat((nope.to(torch.bfloat16), rope), dim=-1)
+    return result.view(nb, bs, 1, _NVFP4_D_NOPE + _NVFP4_D_ROPE)
+
+
+def vary_nvfp4_tile_magnitudes(kv_bf16: torch.Tensor) -> torch.Tensor:
+    """Give each 64-element NoPE tile its own magnitude.
+
+    KV drawn from one distribution produces the same block amax everywhere, so
+    all seven UE8M0 footer bytes of every token hold the same value and a footer
+    read at the wrong offset would still land on the right number. Spreading the
+    per-tile magnitudes makes the scale bytes distinguishable from each other.
+    """
+    gains = torch.pow(
+        2.0,
+        torch.randint(
+            -1,
+            2,
+            kv_bf16.shape[:-1] + (_NVFP4_NUM_TILES,),
+            device=kv_bf16.device,
+        ).float(),
+    ).to(kv_bf16.dtype)
+    out = kv_bf16.clone()
+    out[..., :_NVFP4_D_NOPE] *= gains.repeat_interleave(_NVFP4_TILE, dim=-1)
+    return out
+
+
+# ``kv_format`` parametrisation for the DSv4 tests: the packer, its matching
+# dequantizer, and the ``kv_scale_format`` the kernel is told to expect.
+_DSV4_KV_FORMATS = {
+    "fp8": (quantize_kv_dsv4, dequantize_kv_dsv4, "auto"),
+    "nvfp4": (quantize_kv_dsv4_nvfp4, dequantize_kv_dsv4_nvfp4, "nvfp4"),
+}
 
 
 # DSv3.2 INLINE pack.
@@ -314,16 +424,18 @@ _DSV4_DECODE_CONFIGS = [
 @pytest.mark.parametrize("num_heads,topk", _DSV4_DECODE_CONFIGS)
 @pytest.mark.parametrize("num_tokens", [1, 16, 64])
 @pytest.mark.parametrize("with_sink", [False, True])
+@pytest.mark.parametrize("kv_format", list(_DSV4_KV_FORMATS))
 def test_sparse_mla_sm120_decode_dsv4(
-    num_heads: int, topk: int, num_tokens: int, with_sink: bool
+    num_heads: int, topk: int, num_tokens: int, with_sink: bool, kv_format: str
 ) -> None:
-    """DSv4 decode."""
+    """DSv4 decode, FP8 and NVFP4 KV cache."""
     torch.manual_seed(0)
     device = torch.device("cuda")
     d_qk, d_v = 512, 512
     page_block_size = 64
     num_blocks = 64
     s_kv = num_blocks * page_block_size  # 4096
+    quantize, dequantize, kv_scale_format = _DSV4_KV_FORMATS[kv_format]
 
     kv_bf16 = (
         torch.randn(
@@ -331,8 +443,8 @@ def test_sparse_mla_sm120_decode_dsv4(
         )
         / 10.0
     ).clamp(-1, 1)
-    kv_packed = quantize_kv_dsv4(kv_bf16)
-    kv_dequant = dequantize_kv_dsv4(kv_packed)
+    kv_packed = quantize(kv_bf16)
+    kv_dequant = dequantize(kv_packed)
 
     q = (
         torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
@@ -370,6 +482,7 @@ def test_sparse_mla_sm120_decode_dsv4(
         sm_scale,
         d_v=d_v,
         attn_sink=attn_sink,
+        kv_scale_format=kv_scale_format,
         mid_out=mid_out,
         mid_lse=mid_lse,
     )
@@ -987,16 +1100,18 @@ _DSV4_PREFILL_CONFIGS = [
 @pytest.mark.parametrize("num_heads,topk", _DSV4_PREFILL_CONFIGS)
 @pytest.mark.parametrize("num_tokens", [65, 128, 256])
 @pytest.mark.parametrize("with_sink", [False, True])
+@pytest.mark.parametrize("kv_format", list(_DSV4_KV_FORMATS))
 def test_sparse_mla_sm120_prefill_dsv4(
-    num_heads: int, topk: int, num_tokens: int, with_sink: bool
+    num_heads: int, topk: int, num_tokens: int, with_sink: bool, kv_format: str
 ) -> None:
-    """DSv4 prefill."""
+    """DSv4 prefill, FP8 and NVFP4 KV cache."""
     torch.manual_seed(0)
     device = torch.device("cuda")
     d_qk, d_v = 512, 512
     page_block_size = 64
     num_blocks = 64
     s_kv = num_blocks * page_block_size
+    quantize, dequantize, kv_scale_format = _DSV4_KV_FORMATS[kv_format]
 
     kv_bf16 = (
         torch.randn(
@@ -1004,8 +1119,8 @@ def test_sparse_mla_sm120_prefill_dsv4(
         )
         / 10.0
     ).clamp(-1, 1)
-    kv_packed = quantize_kv_dsv4(kv_bf16)
-    kv_dequant = dequantize_kv_dsv4(kv_packed)
+    kv_packed = quantize(kv_bf16)
+    kv_dequant = dequantize(kv_packed)
 
     q = (
         torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
@@ -1042,6 +1157,160 @@ def test_sparse_mla_sm120_prefill_dsv4(
         sm_scale,
         d_v=d_v,
         attn_sink=attn_sink,
+        kv_scale_format=kv_scale_format,
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+# The two tests below exist because the shared DSv4 configuration above is a
+# weak probe of the KV layout: it keeps |q| and |kv| around 0.1 and averages
+# over ~256 candidates, so its outputs sit near 6e-3 RMS — an order of magnitude
+# inside the 5e-2 tolerance. That is enough to catch a broken kernel, but not a
+# subtly misdecoded KV cache. These two drive the output up to where the
+# tolerance actually binds on the decoded NVFP4 values.
+
+
+@pytest.mark.parametrize("num_heads", [16, 128])
+@pytest.mark.parametrize("num_tokens", [16, 128])
+@pytest.mark.parametrize("target_token", [0, 4095])
+def test_sparse_mla_sm120_dsv4_nvfp4_single_token_gather(
+    num_heads: int, num_tokens: int, target_token: int
+) -> None:
+    """Pin the NVFP4 page layout element by element.
+
+    Every candidate slot points at the same KV token, so the attention output is
+    that token's value vector verbatim whatever the scores are. Each of the 448
+    E2M1 NoPE elements, all 7 UE8M0 block scales and the 64 bf16 RoPE elements
+    have to decode correctly for the comparison to hold. ``num_tokens`` selects
+    the decode (16) or the prefill (128) kernel.
+    """
+    torch.manual_seed(3)
+    device = torch.device("cuda")
+    d_qk, d_v = 512, 512
+    topk = 512
+    page_block_size = 64
+    num_blocks = 64
+
+    kv_bf16 = vary_nvfp4_tile_magnitudes(
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        ).clamp(-1, 1)
+    )
+    kv_packed = quantize_kv_dsv4_nvfp4(kv_bf16)
+    kv_dequant = dequantize_kv_dsv4_nvfp4(kv_packed)
+
+    q = torch.randn(
+        num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16
+    ).clamp(-1, 1)
+    indices = torch.full(
+        (num_tokens, topk), target_token, device=device, dtype=torch.int32
+    )
+    sm_scale = d_qk**-0.5
+
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, indices, sm_scale, d_v)
+
+    # Guard the premise: with one distinct candidate the reference must reduce
+    # to the dequantized KV row, otherwise this test is not probing what its
+    # name says.
+    expected = kv_dequant.reshape(-1, d_qk)[target_token, :d_v]
+    torch.testing.assert_close(
+        ref_out, expected.expand_as(ref_out).contiguous(), atol=1e-2, rtol=1e-2
+    )
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    mid_out, mid_lse = _make_decode_scratch(num_tokens, num_heads, topk, d_v, device)
+
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        kv_scale_format="nvfp4",
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+@pytest.mark.parametrize("num_heads", [32, 128])
+@pytest.mark.parametrize("num_tokens", [16, 128])
+@pytest.mark.parametrize("with_sink", [False, True])
+def test_sparse_mla_sm120_dsv4_nvfp4_full_scale(
+    num_heads: int, num_tokens: int, with_sink: bool
+) -> None:
+    """DSv4 NVFP4 over many candidates with Q and KV at full scale.
+
+    Dropping the ``/10`` peaks the softmax enough that the output lands around
+    1e-1 RMS rather than 6e-3, so the 5e-2 tolerance constrains the decoded KV
+    instead of being satisfied by near-zero outputs on both sides.
+    ``num_tokens`` selects the decode (16) or the prefill (128) kernel.
+    """
+    torch.manual_seed(4)
+    device = torch.device("cuda")
+    d_qk, d_v = 512, 512
+    topk = 128
+    page_block_size = 64
+    num_blocks = 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = vary_nvfp4_tile_magnitudes(
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        ).clamp(-1, 1)
+    )
+    kv_packed = quantize_kv_dsv4_nvfp4(kv_bf16)
+    kv_dequant = dequantize_kv_dsv4_nvfp4(kv_packed)
+
+    q = torch.randn(
+        num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk // 2 :] = -1
+
+    attn_sink = (
+        torch.randn(num_heads, device=device, dtype=torch.float32) * 2.0
+        if with_sink
+        else None
+    )
+    sm_scale = d_qk**-0.5
+
+    ref_out, ref_lse = _ref_sparse_attn(
+        q, kv_dequant, indices, sm_scale, d_v, attn_sink=attn_sink
+    )
+    # Guard the premise: the comparison is only meaningful while the output is
+    # comfortably above the absolute tolerance.
+    assert ref_out.float().pow(2).mean().sqrt() > 5e-2
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    mid_out, mid_lse = _make_decode_scratch(num_tokens, num_heads, topk, d_v, device)
+
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        attn_sink=attn_sink,
+        kv_scale_format="nvfp4",
+        mid_out=mid_out,
+        mid_lse=mid_lse,
     )
 
     torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)

--- a/tests/utils_fp4.py
+++ b/tests/utils_fp4.py
@@ -1,0 +1,113 @@
+"""Reference NVFP4 (E2M1) quantization helpers for tests.
+
+Written against the OCP FP4 ``E2M1`` definition rather than against any kernel,
+so kernel tests that quantize with these helpers exercise the kernel's own
+understanding of the packed layout.
+
+``E2M1`` encodes a 4-bit value as ``sign(1) | exponent(2) | mantissa(1)``, which
+gives the eight magnitudes ``{0, 0.5, 1, 1.5, 2, 3, 4, 6}`` in code order, with
+bit 3 as the sign bit. Two elements share one byte, the even element in the low
+nibble.
+
+Block scaling is applied on top: element ``i`` decodes to
+``E2M1_VALUES[code] * scale[i // block_size]``. Callers supply the block scales,
+because the on-the-wire scale encoding is format specific (``UE8M0`` exponent
+bytes, ``E4M3`` bytes, or plain FP32).
+"""
+
+from __future__ import annotations
+
+import torch
+
+FLOAT4_E2M1_MAX = 6.0
+
+# Magnitudes for codes 0..7; bit 3 of the nibble carries the sign.
+E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+# Midpoints between adjacent magnitudes, and the code that a value landing
+# exactly on a midpoint rounds to under round-half-to-even.
+_E2M1_MIDPOINTS = (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+_E2M1_TIE_CODES = (0, 2, 2, 4, 4, 6, 6)
+
+
+def e2m1_magnitude_codes(x: torch.Tensor) -> torch.Tensor:
+    """Round ``|x|`` to the nearest E2M1 magnitude code (0..7), ties to even."""
+    a = x.abs().float()
+    code = torch.zeros_like(a, dtype=torch.uint8)
+    for midpoint in _E2M1_MIDPOINTS:
+        code = code + (a > midpoint).to(torch.uint8)
+    for i, midpoint in enumerate(_E2M1_MIDPOINTS):
+        code = torch.where(
+            a == midpoint, torch.full_like(code, _E2M1_TIE_CODES[i]), code
+        )
+    return code
+
+
+def e2m1_encode(x: torch.Tensor) -> torch.Tensor:
+    """Round ``x`` to E2M1 and return the 4-bit codes (0..15) as uint8."""
+    sign = (torch.signbit(x.float())).to(torch.uint8) << 3
+    return sign | e2m1_magnitude_codes(x)
+
+
+def e2m1_decode(codes: torch.Tensor) -> torch.Tensor:
+    """Decode E2M1 codes (0..15) to FP32 values."""
+    lut = torch.tensor(E2M1_VALUES, dtype=torch.float32, device=codes.device)
+    magnitude = lut[(codes & 0x7).long()]
+    return torch.where(codes & 0x8 != 0, -magnitude, magnitude)
+
+
+def e2m1_pack(codes: torch.Tensor) -> torch.Tensor:
+    """Pack an even-length trailing dim of E2M1 codes 2-per-byte, low nibble first."""
+    assert codes.shape[-1] % 2 == 0, "packed dimension must be even"
+    low = codes[..., 0::2]
+    high = codes[..., 1::2]
+    return (low & 0xF) | ((high & 0xF) << 4)
+
+
+def e2m1_unpack(packed: torch.Tensor) -> torch.Tensor:
+    """Inverse of :func:`e2m1_pack`."""
+    low = packed & 0xF
+    high = (packed >> 4) & 0xF
+    return torch.stack((low, high), dim=-1).flatten(start_dim=-2)
+
+
+def ue8m0_block_scales(
+    x: torch.Tensor, block_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-block power-of-2 scales sized so ``x / scale`` fits the E2M1 range.
+
+    Returns ``(scale_fp32, ue8m0_bytes)`` with a trailing block dimension. The
+    byte is the IEEE-754 exponent field of the FP32 power-of-2 scale, i.e.
+    ``scale == 2 ** (byte - 127)``.
+    """
+    assert x.shape[-1] % block_size == 0
+    blocks = x.float().unflatten(-1, (-1, block_size))
+    amax = blocks.abs().amax(dim=-1).clamp(min=1e-30)
+    scale = torch.pow(2.0, torch.ceil(torch.log2(amax / FLOAT4_E2M1_MAX)))
+    ue8m0 = ((scale.view(torch.int32) >> 23) & 0xFF).to(torch.uint8)
+    return scale, ue8m0
+
+
+def ue8m0_to_scale(ue8m0: torch.Tensor) -> torch.Tensor:
+    """Decode UE8M0 exponent bytes to FP32 scales."""
+    return torch.pow(2.0, ue8m0.float() - 127.0)
+
+
+def nvfp4_quantize_blocks(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Quantize ``x`` to packed E2M1 bytes given per-block ``scale``.
+
+    ``scale`` has the same shape as ``x`` with the last dim divided by the block
+    size. The returned tensor has the last dim of ``x`` halved.
+    """
+    block_size = x.shape[-1] // scale.shape[-1]
+    blocks = x.float().unflatten(-1, (-1, block_size))
+    codes = e2m1_encode(blocks / scale.unsqueeze(-1)).flatten(start_dim=-2)
+    return e2m1_pack(codes)
+
+
+def nvfp4_dequantize_blocks(packed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Inverse of :func:`nvfp4_quantize_blocks`; returns FP32 values."""
+    codes = e2m1_unpack(packed)
+    block_size = codes.shape[-1] // scale.shape[-1]
+    values = e2m1_decode(codes).unflatten(-1, (-1, block_size))
+    return (values * scale.unsqueeze(-1)).flatten(start_dim=-2)


### PR DESCRIPTION
## 📌 Description

This adds Deepseek version 4 NVFP4 KV Cache for sparse_mla.

This takes tokens from 584B/token (FP8) -> 360 B/token (NVFP4).

Quality was slightly higher in the 10 benchmarks I ran by 1 or 2% but I'm sure this is just noise. This doesn't leak CJK, still has perfect 1M / needle. Still is similarly bad at thinking level: max

## 🔍 Related Issues

I didn't open one.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [Y✅] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [Y✅] I have installed the hooks with `pre-commit install`.
- [Y✅ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ✅ ] All tests are passing (`unittest`, etc.).
- [ ✅] I tested both performance and quality remained high even at 1M context window. Was tested on 2 x RTX 6000 pros.

## Reviewer Notes

I think this would work fine more generically than SM_120 (eg at least SM_121) what is the norm for gating / enabling these features?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 (DSV4_NVFP4) sparse-MLA KV-cache support for both prefill and decode, including packed NoPE/scale handling and shared-memory expansion.
  * Extended dispatch to recognize the NVFP4 model variant and added support for additional `(num_heads, topk)` combinations, including `topk = 256`.
  * Updated sparse MLA decode/prefill APIs to accept an explicit `model_type` selector and added `kv_scale_format` support on the SM120 DSV4 decode entry path.
* **Bug Fixes / Improvements**
  * Improved input validation and corrected bytes-per-token/layout selection and model-name reporting for NVFP4 vs DSV4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->