### PR TITLE
Migrate deprecated cutlass.utils spellings to canonical namespaces

### DIFF
--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -1690,7 +1690,9 @@ def _infer_single_instance_kv_stages(
         cfg.qk_mma_tiler[1] * cfg.head_dim_per_stage_kv * kv_dtype_width // 8
     )
     kv_stage_footprint_bytes = kv_stage_bytes + _PIPELINE_BARRIER_BYTES_PER_STAGE
-    kv_budget_bytes = utils.get_smem_capacity_in_bytes("sm_100") - fixed_smem_bytes
+    kv_budget_bytes = (
+        cutlass.memory.get_smem_capacity_in_bytes("sm_100") - fixed_smem_bytes
+    )
     memory_fit_stages = kv_budget_bytes // kv_stage_footprint_bytes
     cadence_stages = cfg.num_head_dim_stages_k + cfg.num_head_dim_stages_v
     if require_cadence and memory_fit_stages < cadence_stages:

--- a/flashinfer/attn_scores/kernels/fp4_paged_mqa_logits.py
+++ b/flashinfer/attn_scores/kernels/fp4_paged_mqa_logits.py
@@ -66,7 +66,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass import BFloat16, Float4E2M1FN, Float8E8M0FNU, Float16, Int32
@@ -538,7 +537,7 @@ class FP4MQALogitsKernel:
         # acc TMEM (per math WG, per UMMA stage)
         acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(acc_shape)
-        self.num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(
+        self.num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(
             tCtAcc_fake, rounding=False
         )
 
@@ -615,7 +614,7 @@ class FP4MQALogitsKernel:
         )
         # TMEM allocator requires num_columns to be a power of two AND a
         # multiple of 32, between 32 and 512. Round up to next valid value.
-        # Equivalent to utils.get_num_tmem_alloc_cols(..., rounding=True) but
+        # Equivalent to cutlass.memory.get_num_tmem_alloc_cols(..., rounding=True) but
         # without needing a tmem tensor handle (we already have raw_total).
         self.num_tmem_alloc_cols_total = max(1 << math.ceil(math.log2(raw_total)), 32)
         assert self.num_tmem_alloc_cols_total <= 512, (
@@ -711,8 +710,8 @@ class FP4MQALogitsKernel:
 
         a_dtype = a.element_type
         b_dtype = b.element_type
-        a_major = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        b_major = utils.LayoutEnum.ROW_MAJOR.mma_major_mode()
+        a_major = cutlass.tensor_utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        b_major = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR.mma_major_mode()
 
         tiled_mma = self._setup_mma(a_dtype, b_dtype, a_major, b_major)
         atom_thr_size = cute.size(tiled_mma.thr_id.shape)
@@ -978,7 +977,7 @@ class FP4MQALogitsKernel:
             cpasync.prefetch_descriptor(tma_atom_sf_kv)
             cpasync.prefetch_descriptor(tma_atom_sf_q)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         block_kv_val = self.block_kv
@@ -1117,7 +1116,7 @@ class FP4MQALogitsKernel:
         # 64 threads = 32 (umma_warp_0) + 32 (umma_warp_1). DeepGEMM avoids this
         # entirely by issuing both groups' UMMAs from a single UMMA warp.
         sfb_sync_barrier = pipeline.NamedBarrier(barrier_id=2, num_threads=64)
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=0,  # math warp 0 does alloc+free (last TMEM consumer)
@@ -1300,7 +1299,7 @@ class FP4MQALogitsKernel:
         num_tmem_alloc_cols_total = self.num_tmem_alloc_cols_total
 
         # Epilogue setup
-        c_layout = utils.LayoutEnum.ROW_MAJOR
+        c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
         epi_sub_mn = (epi_tile[0], num_heads // num_epi_subtiles)
         copy_atom_t2r = sm100_utils.get_tmem_load_op(
             self.cta_tile_shape_mnk,

--- a/flashinfer/attn_scores/kernels/fp8_paged_mqa_logits.py
+++ b/flashinfer/attn_scores/kernels/fp8_paged_mqa_logits.py
@@ -76,7 +76,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass import Float16, Int32
 from cutlass._mlir import ir
@@ -287,7 +286,7 @@ class FP8MQALogitsKernel:
             self.num_umma_stages = 1
 
         if max_kv_pipeline:
-            smem_capacity = utils.get_smem_capacity_in_bytes()
+            smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
             # Reserve ~1 KB for barriers and misc
             SMEM_BUDGET = smem_capacity - 1024
             # KV+Scale per stage (×2 groups):
@@ -377,7 +376,7 @@ class FP8MQALogitsKernel:
 
         acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(acc_shape)
-        self.num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake)
+        self.num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(tCtAcc_fake)
         self.num_tmem_alloc_cols_total = (
             self.num_tmem_alloc_cols * self.num_groups * self.num_umma_stages
         )
@@ -440,8 +439,8 @@ class FP8MQALogitsKernel:
 
         a_dtype = a.element_type
         b_dtype = b.element_type
-        a_major = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        b_major = utils.LayoutEnum.ROW_MAJOR.mma_major_mode()
+        a_major = cutlass.tensor_utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        b_major = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR.mma_major_mode()
 
         tiled_mma = self._setup_mma(a_dtype, b_dtype, a_major, b_major)
         atom_thr_size = cute.size(tiled_mma.thr_id.shape)
@@ -640,7 +639,7 @@ class FP8MQALogitsKernel:
             cpasync.prefetch_descriptor(tma_atom_w)
             cpasync.prefetch_descriptor(tma_atom_s)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         block_kv_val = self.block_kv
@@ -776,7 +775,7 @@ class FP8MQALogitsKernel:
         tmem_alloc_barrier = pipeline.NamedBarrier(
             barrier_id=1, num_threads=tmem_alloc_num_threads
         )
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=0,  # math warp 0 does alloc+free (last TMEM consumer)
@@ -933,7 +932,7 @@ class FP8MQALogitsKernel:
         num_tmem_alloc_cols_total = self.num_tmem_alloc_cols_total
 
         # Epilogue setup
-        c_layout = utils.LayoutEnum.ROW_MAJOR
+        c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
         epi_sub_mn = (epi_tile[0], num_heads // num_epi_subtiles)
         copy_atom_t2r = sm100_utils.get_tmem_load_op(
             self.cta_tile_shape_mnk,

--- a/flashinfer/attn_scores/kernels/schedule_kernel.py
+++ b/flashinfer/attn_scores/kernels/schedule_kernel.py
@@ -33,7 +33,7 @@ from typing import Tuple
 import cutlass
 import cutlass.cute as cute
 import cuda.bindings.driver as cuda
-from cutlass.utils.smem_allocator import SmemAllocator
+from cutlass.memory import SmemAllocator
 
 
 class PagedMQALogitsScheduleKernel:

--- a/flashinfer/comm/mnnvl_cutedsl/kernel_bt/device_kernels.py
+++ b/flashinfer/comm/mnnvl_cutedsl/kernel_bt/device_kernels.py
@@ -156,7 +156,7 @@ class _ScalarFinalizeUnicastDeviceKernel:
         token = block // self.ctas_per_token
         hidden_index = (block % self.ctas_per_token) * self.threads + tidx
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         staged_indices = smem.allocate_array(Int32, self.top_k)
         staged_weights = smem.allocate_array(Float32, self.top_k)
         metadata_index = Int32(tidx)
@@ -365,7 +365,7 @@ class _NarrowVectorFinalizeUnicastDeviceKernel:
         token = block // self.ctas_per_token
         fragment = (block % self.ctas_per_token) * self.threads + tidx
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         staged_indices = smem.allocate_array(Int32, self.top_k)
         staged_weights = smem.allocate_array(Float32, self.top_k)
         metadata_index = Int32(tidx)
@@ -664,7 +664,7 @@ class _VectorFinalizeUnicastDeviceKernel:
         token = block // self.ctas_per_token
         fragment = (block % self.ctas_per_token) * self.threads + tidx
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         staged_indices = smem.allocate_array(Int32, self.top_k)
         staged_weights = smem.allocate_array(Float32, self.top_k)
         metadata_index = Int32(tidx)
@@ -1244,7 +1244,7 @@ class _MaterializeRMSNormDeviceKernel:
                     reduction_profile=0,
                 )
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         warp_sums = smem.allocate_array(Float32, self.warps)
         full_sum = _block_sum(thread_sum, warp_sums, self.warps)
         inverse_rms = cute.math.rsqrt(

--- a/flashinfer/comm/mnnvl_cutedsl/kernel_ht/device_kernel.py
+++ b/flashinfer/comm/mnnvl_cutedsl/kernel_ht/device_kernel.py
@@ -20,7 +20,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 from cutlass import BFloat16, Float32, Int32, Int64, Uint32
 
 from ..cute_dsl_primitives import (
@@ -308,7 +307,7 @@ class _MoeFinalizeAllReduceRMSNormHTDeviceKernel:
         cta_slot = block % self.tp
         wave = Int64(cta_group)
         token = wave * self.tp + cta_slot
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
         rows = storage.rows.get_tensor(smem_layout)
         barrier_storage = storage.barriers.data_ptr()

--- a/flashinfer/comm/mnnvl_cutedsl/kernel_ll/device_kernels.py
+++ b/flashinfer/comm/mnnvl_cutedsl/kernel_ll/device_kernels.py
@@ -170,7 +170,7 @@ class _ScalarFinalizePublishDeviceKernel:
         cta_in_token = block % self.ctas_per_token
         hidden_index = cta_in_token * self.threads + tidx
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         staged_indices = smem.allocate_array(Int32, self.top_k)
         staged_weights = smem.allocate_array(Float32, self.top_k)
         metadata_index = Int32(tidx)
@@ -381,7 +381,7 @@ class _QuadFinalizePublishDeviceKernel:
         cta_in_token = block % self.ctas_per_token
         fragment = cta_in_token * self.threads + tidx
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         staged_indices = smem.allocate_array(Int32, self.top_k)
         staged_weights = smem.allocate_array(Float32, self.top_k)
         metadata_index = Int32(tidx)
@@ -959,7 +959,7 @@ class _LamportResidualRMSNormDeviceKernel:
                     reduction_profile=0,
                 )
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         warp_sums = smem.allocate_array(Float32, self.warps)
         cluster_sums = smem.allocate_array(Float32, self.cluster_size)
         cta_sum = _group_leader_block_sum(

--- a/flashinfer/cute_dsl/add_rmsnorm_fp4quant.py
+++ b/flashinfer/cute_dsl/add_rmsnorm_fp4quant.py
@@ -390,7 +390,7 @@ class AddRMSNormFP4QuantKernel:
         fp4_max_rcp = rcp_approx_ftz(Float32(FLOAT4_E2M1_MAX))
 
         # Allocate shared memory
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         sX = smem.allocate_tensor(
             mX.element_type,

--- a/flashinfer/cute_dsl/add_rmsnorm_fp4quant.py
+++ b/flashinfer/cute_dsl/add_rmsnorm_fp4quant.py
@@ -542,7 +542,7 @@ class AddRMSNormFP4QuantKernel:
         fp4_max_rcp = rcp_approx_ftz(Float32(FLOAT4_E2M1_MAX))
 
         # Allocate shared memory
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         sX = smem.allocate_tensor(
             mX.element_type,

--- a/flashinfer/cute_dsl/attention/dsa/hca_fp8.py
+++ b/flashinfer/cute_dsl/attention/dsa/hca_fp8.py
@@ -36,7 +36,6 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import tcgen05, OperandMajorMode
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -1041,11 +1040,11 @@ class BlackwellHeavilyCompressedAttentionForwardFP8:
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose_cmp)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.mma_pv_warp_id,
@@ -1667,7 +1666,7 @@ class BlackwellHeavilyCompressedAttentionForwardFP8:
         local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
         # Alloc shared memory
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(MAX_SPLITS * self.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.acc_dtype)
         smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))

--- a/flashinfer/cute_dsl/attention/fmha/fmha.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha.py
@@ -38,7 +38,6 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import tcgen05
 from cutlass.cute.nvgpu.common import OperandMajorMode
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -487,10 +486,10 @@ class BlackwellFusedMultiHeadAttentionForward:
             self.cta_tiler,
             self.is_persistent,
         )
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.o_layout = utils.LayoutEnum.from_tensor(o)
+        self.q_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(o)
 
         if cutlass.const_expr(self.q_major_mode != OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
@@ -806,7 +805,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
@@ -927,7 +926,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             barrier_storage=storage.s1_p0_inplace_barrier_ptr.data_ptr(),
             defer_sync=True,
         ).make_participants()
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             # Correction warp is the last one that accesses tmem

--- a/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
@@ -39,7 +39,6 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import tcgen05
 from cutlass.cute.nvgpu.common import OperandMajorMode
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.torch as cutlass_torch
@@ -627,10 +626,10 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
             self.cta_tiler,
             self.is_persistent,
         )
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.o_layout = utils.LayoutEnum.from_tensor(o)
+        self.q_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(o)
 
         if cutlass.const_expr(self.q_major_mode != OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
@@ -1030,7 +1029,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
                 cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         load_q_producer, load_q_consumer = pipeline.PipelineTmaUmma.create(
@@ -1172,7 +1171,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
             barrier_storage=storage.qk_sf_inplace_1_barrier_ptr.data_ptr(),
             defer_sync=True,
         ).make_participants()
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             # Correction warp is the last one that accesses tmem

--- a/flashinfer/cute_dsl/attention/gqa_decode.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode.py
@@ -10,7 +10,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import tcgen05, OperandMajorMode
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import (
     Agent,
@@ -335,7 +334,7 @@ class GroupedQueryAttentionDecode:
         smem_alloc_bits += o_stages * pipe_stage_bits  # o in tmem
         alignment_bits = 1024 - (smem_alloc_bits % 1024)
         # K, V
-        smem_capacity_bits = utils.get_smem_capacity_in_bytes("sm_100") * 8
+        smem_capacity_bits = cutlass.memory.get_smem_capacity_in_bytes("sm_100") * 8
         remaining_bits = smem_capacity_bits - smem_alloc_bits - alignment_bits
         kv_stages = remaining_bits // mk_stage_bits
         kv_stages -= 1 if kv_stages * pipe_stage_bits > alignment_bits else 0
@@ -556,7 +555,7 @@ class GroupedQueryAttentionDecode:
         # Smem alloc helper
         svector_align = 16
         stensor_align = 128
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         # No multicast
         mcast_coord = 0

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -10,7 +10,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.nvgpu import tcgen05, OperandMajorMode
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import (
     Agent,
@@ -310,7 +309,7 @@ class GroupedQueryAttentionDecodePaged:
         smem_alloc_bits += o_stages * pipe_stage_bits  # o in tmem
         alignment_bits = 1024 - (smem_alloc_bits % 1024)
         # K, V
-        smem_capacity_bits = utils.get_smem_capacity_in_bytes("sm_100") * 8
+        smem_capacity_bits = cutlass.memory.get_smem_capacity_in_bytes("sm_100") * 8
         remaining_bits = smem_capacity_bits - smem_alloc_bits - alignment_bits
         kv_stages = remaining_bits // mk_stage_bits
         kv_stages -= 1 if kv_stages * pipe_stage_bits > alignment_bits else 0
@@ -569,7 +568,7 @@ class GroupedQueryAttentionDecodePaged:
         # Smem alloc helper
         svector_align = 16
         stensor_align = 128
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         # No multicast
         mcast_coord = 0

--- a/flashinfer/cute_dsl/attention/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/mla_decode.py
@@ -15,7 +15,6 @@ from types import SimpleNamespace
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 
@@ -365,10 +364,10 @@ class BlackwellMultiLatentAttentionForward:
             cpasync.prefetch_descriptor(tma_atom_c_rope)
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.schedule.mma_warp_id,
@@ -635,7 +634,7 @@ class BlackwellMultiLatentAttentionForward:
         k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
         local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(MAX_SPLITS * self.config.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.config.acc_dtype)
         smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))

--- a/flashinfer/cute_dsl/attention/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/mla_decode.py
@@ -15,7 +15,6 @@ from types import SimpleNamespace
 import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 
@@ -367,10 +366,10 @@ class BlackwellMultiLatentAttentionForward:
             cpasync.prefetch_descriptor(tma_atom_c_rope)
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.schedule.mma_warp_id,
@@ -638,7 +637,7 @@ class BlackwellMultiLatentAttentionForward:
         k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
         local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(MAX_SPLITS * self.config.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.config.acc_dtype)
         smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))

--- a/flashinfer/cute_dsl/attention/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/mla_decode_fp8.py
@@ -24,7 +24,6 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
@@ -369,10 +368,10 @@ class BlackwellMultiLatentAttentionForwardFP8:
             cpasync.prefetch_descriptor(tma_atom_c_rope)
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.schedule.mma_warp_id,
@@ -654,7 +653,7 @@ class BlackwellMultiLatentAttentionForwardFP8:
         k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
         local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(MAX_SPLITS * self.config.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.config.acc_dtype)
         smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))

--- a/flashinfer/cute_dsl/attention/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/mla_decode_fp8.py
@@ -24,7 +24,6 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
@@ -371,10 +370,10 @@ class BlackwellMultiLatentAttentionForwardFP8:
             cpasync.prefetch_descriptor(tma_atom_c_rope)
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.schedule.mma_warp_id,
@@ -657,7 +656,7 @@ class BlackwellMultiLatentAttentionForwardFP8:
         k_tile_per_cta = cute.ceil_div(k_tile_total, local_split_kv)
         local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(MAX_SPLITS * self.config.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.config.acc_dtype)
         smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
@@ -67,7 +67,6 @@ def _get_max_tmem_alloc_cols(compute_capability: str) -> int:
 
 from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -940,11 +939,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.mma_warp_id,
@@ -1411,7 +1410,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
         # Alloc shared memory
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(MAX_SPLITS * self.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.acc_dtype)
         smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
@@ -67,7 +67,6 @@ def _get_max_tmem_alloc_cols(compute_capability: str) -> int:
 
 from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -1102,11 +1101,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.mma_warp_id,
@@ -1710,7 +1709,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
 
         # In the variable-Q specialization, inactive CTAs still execute the
         # balanced PDL protocol but do not touch workspace or outputs.
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.reducer_max_splits * self.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.acc_dtype)
         smem_lse_scale = cute.make_tensor(

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
@@ -65,7 +65,6 @@ def _get_max_tmem_alloc_cols(compute_capability: str) -> int:
 
 
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -1051,7 +1050,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Tensor memory dealloc barrier init.
@@ -1060,7 +1059,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # keeps reading P / writing O until its mma_o.producer_tail. Putting
         # allocate + free on W11 avoids the race where W8 frees TMEM while
         # W11 still has in-flight mma_pv. See OPT#14.
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.mma_pv_warp_id,
@@ -1641,7 +1640,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         local_split_kv = cute.ceil_div(k_tile_total, k_tile_per_cta)
 
         # Alloc shared memory
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(MAX_SPLITS * self.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.acc_dtype)
         smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
@@ -65,7 +65,6 @@ def _get_max_tmem_alloc_cols(compute_capability: str) -> int:
 
 
 import cutlass.cute.nvgpu.cpasync as cpasync
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -1209,7 +1208,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             cpasync.prefetch_descriptor(tma_atom_c_latent_transpose)
 
         # Alloc
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Tensor memory dealloc barrier init.
@@ -1218,7 +1217,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # keeps reading P / writing O until its mma_o.producer_tail. Putting
         # allocate + free on W11 avoids the race where W8 frees TMEM while
         # W11 still has in-flight mma_pv. See OPT#14.
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_bar,
             allocator_warp_id=self.mma_pv_warp_id,
@@ -1961,7 +1960,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
 
         # Inactive compact rows still complete the PDL protocol, but do not
         # touch workspace or enter the active-row shared-memory barrier.
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.reducer_max_splits * self.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.acc_dtype)
         smem_lse_scale = cute.make_tensor(

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -5,7 +5,6 @@ from typing import Tuple
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.utils as utils
 from cutlass.cute.typing import Int32, Float32
 
 from .config import AttentionConfig, AttentionFusion
@@ -161,10 +160,10 @@ class BlackwellFusedMultiHeadAttentionForward:
             self.config.is_persistent,
         )
 
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.o_layout = utils.LayoutEnum.from_tensor(o)
+        self.q_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(q).mma_major_mode()
+        self.k_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(k).mma_major_mode()
+        self.v_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(v).mma_major_mode()
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(o)
 
         if cutlass.const_expr(self.q_major_mode != cute.nvgpu.OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
@@ -232,7 +231,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.shared_storage = lp.SharedStorage
 
         smem_bytes = lp.SharedStorage.size_in_bytes()
-        smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         if cutlass.const_expr(smem_bytes > smem_capacity):
             head_dim = self.config.mma_tiler[2]
             raise ValueError(
@@ -389,7 +388,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         pipes = self._create_pipelines(storage)

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -5,7 +5,6 @@ from typing import Tuple
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.utils as utils
 from cutlass.cute.typing import Int32, Float32
 
 from .config import AttentionConfig, AttentionFusion
@@ -238,10 +237,16 @@ class BlackwellFusedMultiHeadAttentionForward:
             self.config.is_persistent,
         )
 
-        self.q_major_mode = utils.LayoutEnum.from_tensor(q).mma_major_mode()
-        self.k_major_mode = utils.LayoutEnum.from_tensor(k).mma_major_mode()
-        self.v_major_mode = utils.LayoutEnum.from_tensor(v).mma_major_mode()
-        self.o_layout = utils.LayoutEnum.from_tensor(o)
+        self.q_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            q
+        ).mma_major_mode()
+        self.k_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            k
+        ).mma_major_mode()
+        self.v_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            v
+        ).mma_major_mode()
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(o)
 
         if cutlass.const_expr(self.q_major_mode != cute.nvgpu.OperandMajorMode.K):
             raise RuntimeError("The layout of q is not supported")
@@ -319,7 +324,7 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         smem_bytes = lp.SharedStorage.size_in_bytes()
         arch = _get_current_arch()
-        smem_capacity = utils.get_smem_capacity_in_bytes(arch)
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(arch)
         if cutlass.const_expr(smem_bytes > smem_capacity):
             head_dim = self.config.mma_tiler[2]
             raise ValueError(
@@ -496,7 +501,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_v)
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_o)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         pipes = self._create_pipelines(storage)

--- a/flashinfer/cute_dsl/gemm_allreduce_two_shot.py
+++ b/flashinfer/cute_dsl/gemm_allreduce_two_shot.py
@@ -349,7 +349,7 @@ class PersistentDenseGemmKernel:
         self.epilog_sync_bar_id = 1
         self.tmem_ptr_sync_bar_id = 2
         self.all_reduce_sync_bar_id = 3
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(sm_version)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(sm_version)
 
         self.num_ranks = 1
         self.rank_id = 0
@@ -512,9 +512,9 @@ class PersistentDenseGemmKernel:
         self.a_dtype: Type[cutlass.Numeric] = a.element_type
         self.b_dtype: Type[cutlass.Numeric] = b.element_type
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -713,7 +713,7 @@ class PersistentDenseGemmKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.ptr
@@ -1682,7 +1682,7 @@ class PersistentDenseGemmKernel:
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         smem_capacity: int,
         occupancy: int,
         use_tma_store: bool,
@@ -1702,7 +1702,7 @@ class PersistentDenseGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param smem_capacity: Total available shared memory capacity in bytes.
         :type smem_capacity: int
         :param occupancy: Target number of CTAs per SM (occupancy).
@@ -1831,7 +1831,7 @@ class PersistentDenseGemmKernel:
         """
         acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
-        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake)
+        num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(tCtAcc_fake)
 
         return num_tmem_alloc_cols
 

--- a/flashinfer/cute_dsl/gemm_allreduce_two_shot.py
+++ b/flashinfer/cute_dsl/gemm_allreduce_two_shot.py
@@ -349,7 +349,7 @@ class PersistentDenseGemmKernel:
         self.epilog_sync_bar_id = 1
         self.tmem_ptr_sync_bar_id = 2
         self.all_reduce_sync_bar_id = 3
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(sm_version)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(sm_version)
 
         self.num_ranks = 1
         self.rank_id = 0
@@ -512,9 +512,13 @@ class PersistentDenseGemmKernel:
         self.a_dtype: Type[cutlass.Numeric] = a.element_type
         self.b_dtype: Type[cutlass.Numeric] = b.element_type
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -713,7 +717,7 @@ class PersistentDenseGemmKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.ptr
@@ -1681,7 +1685,7 @@ class PersistentDenseGemmKernel:
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         smem_capacity: int,
         occupancy: int,
         use_tma_store: bool,
@@ -1701,7 +1705,7 @@ class PersistentDenseGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param smem_capacity: Total available shared memory capacity in bytes.
         :type smem_capacity: int
         :param occupancy: Target number of CTAs per SM (occupancy).
@@ -1830,7 +1834,7 @@ class PersistentDenseGemmKernel:
         """
         acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
-        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake)
+        num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(tCtAcc_fake)
 
         return num_tmem_alloc_cols
 

--- a/flashinfer/cute_dsl/rmsnorm_fp4quant.py
+++ b/flashinfer/cute_dsl/rmsnorm_fp4quant.py
@@ -356,7 +356,7 @@ class RMSNormFP4QuantKernel:
         # ==================================================================
         # Allocate shared memory
         # ==================================================================
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         # Shared memory tile for input (for sum-of-squares)
         sX = smem.allocate_tensor(

--- a/flashinfer/cute_dsl/rmsnorm_fp4quant.py
+++ b/flashinfer/cute_dsl/rmsnorm_fp4quant.py
@@ -357,7 +357,7 @@ class RMSNormFP4QuantKernel:
         # ==================================================================
         # Allocate shared memory
         # ==================================================================
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         # Shared memory tile for input (for sum-of-squares)
         sX = smem.allocate_tensor(

--- a/flashinfer/cute_dsl/sparse/blk128/flash_fwd_sm100.py
+++ b/flashinfer/cute_dsl/sparse/blk128/flash_fwd_sm100.py
@@ -386,7 +386,7 @@ class FlashAttentionForwardSm100:
         q_major_mode = tcgen05.OperandMajorMode.K
         k_major_mode = tcgen05.OperandMajorMode.K
         v_major_mode = tcgen05.OperandMajorMode.MN
-        self.o_layout = cutlass.utils.LayoutEnum.from_tensor(mO)
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mO)
         # the intermediate tensor p is from tmem & mK-major
         p_source = tcgen05.OperandSource.TMEM
         p_major_mode = tcgen05.OperandMajorMode.K
@@ -724,7 +724,7 @@ class FlashAttentionForwardSm100:
         is_leader_cta = mma_tile_coord_v == 0
 
         # Alloc
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_alloc_barrier = pipeline.NamedBarrier(
@@ -740,7 +740,7 @@ class FlashAttentionForwardSm100:
             ),
         )
         # Tensor memory dealloc barrier init
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,

--- a/flashinfer/cute_dsl/sparse/sm100_blk128/flash_fwd_sm100.py
+++ b/flashinfer/cute_dsl/sparse/sm100_blk128/flash_fwd_sm100.py
@@ -387,7 +387,7 @@ class FlashAttentionForwardSm100:
         q_major_mode = tcgen05.OperandMajorMode.K
         k_major_mode = tcgen05.OperandMajorMode.K
         v_major_mode = tcgen05.OperandMajorMode.MN
-        self.o_layout = cutlass.utils.LayoutEnum.from_tensor(mO)
+        self.o_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mO)
         # the intermediate tensor p is from tmem & mK-major
         p_source = tcgen05.OperandSource.TMEM
         p_major_mode = tcgen05.OperandMajorMode.K
@@ -725,7 +725,7 @@ class FlashAttentionForwardSm100:
         is_leader_cta = mma_tile_coord_v == 0
 
         # Alloc
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_alloc_barrier = pipeline.NamedBarrier(
@@ -741,7 +741,7 @@ class FlashAttentionForwardSm100:
             ),
         )
         # Tensor memory dealloc barrier init
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.mma_warp_id,

--- a/flashinfer/cute_dsl/sparse/sm120_blk64/flash_fwd_sm120.py
+++ b/flashinfer/cute_dsl/sparse/sm120_blk64/flash_fwd_sm120.py
@@ -17,7 +17,6 @@ import operator
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.hopper_helpers as sm90_utils
 import cuda.bindings.driver as cuda
 from . import layout_utils
@@ -113,7 +112,7 @@ class BlockSparseAttnForwardSm120Blk64(BatchedStaticSchedulerMixin):
         seqlen = mK.shape[0]
         num_compute_tiles = cute.ceil_div(seqlen, self.tile_size)
 
-        shared_storage = cutlass.utils.SmemAllocator().allocate(self.shared_storage_t)
+        shared_storage = cutlass.memory.SmemAllocator().allocate(self.shared_storage_t)
 
         if warp_idx == 0 and lane_idx == 0:
             cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_Q)
@@ -557,10 +556,10 @@ class BlockSparseAttnForwardSm120Blk64(BatchedStaticSchedulerMixin):
         self.check_dim([mQ, mK, mO], 1)
         self.check_dim(mV, 0)
 
-        Q_layout = utils.LayoutEnum.from_tensor(mQ)
-        K_layout = utils.LayoutEnum.from_tensor(mK)
-        V_layout = utils.LayoutEnum.from_tensor(mV)
-        O_layout = utils.LayoutEnum.from_tensor(mO)
+        Q_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mQ)
+        K_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mK)
+        V_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mV)
+        O_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mO)
 
         self.Q_dtype = mQ.element_type
         self.K_dtype = mK.element_type

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -548,7 +548,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             num_threads=self.threads_per_warp,
         )
 
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
@@ -846,9 +846,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         self.b_dtype: Type[cutlass.Numeric] = b.element_type
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -1244,7 +1244,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Pipeline Init: Initialize A pipeline for LDGSTS operations
@@ -1334,7 +1334,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -3174,7 +3174,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         num_smem_capacity: int,
@@ -3195,7 +3195,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Vector size of scale factor.

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -569,7 +569,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             num_threads=self.threads_per_warp,
         )
 
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
@@ -892,9 +892,13 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         self.smem_alloc_b_dtype = (
             cutlass.Int8 if self.unpack_tma and self.b_dtype.width < 8 else self.b_dtype
         )
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         self.is_mxfp8_output = (
             self.c_dtype is cutlass.Float8E4M3FN
@@ -1311,7 +1315,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Pipeline Init: Initialize A pipeline for LDGSTS operations
@@ -1401,7 +1405,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -3443,7 +3447,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         num_smem_capacity: int,
@@ -3464,7 +3468,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Vector size of scale factor.

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -435,7 +435,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             barrier_id=4,
             num_threads=self.threads_per_warp,
         )
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         # TMEM offset for final accumulator
         self.tmem_final_offset = 384
 
@@ -680,9 +680,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.out_dtype: Type[cutlass.Numeric] = out.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
         self.final_scale_dtype: Type[cutlass.Numeric] = token_final_scales.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.gemm_output_layout = utils.LayoutEnum.ROW_MAJOR
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.gemm_output_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         self.topK = token_final_scales.shape[1]
         # Check if input data types are compatible with MMA instruction
@@ -1080,7 +1080,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -1149,7 +1149,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -443,7 +443,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             barrier_id=4,
             num_threads=self.threads_per_warp,
         )
-        self.num_smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         # TMEM offset for final accumulator
         self.tmem_final_offset = 384
 
@@ -693,9 +693,13 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.out_dtype: Type[cutlass.Numeric] = out.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
         self.final_scale_dtype: Type[cutlass.Numeric] = token_final_scales.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.gemm_output_layout = utils.LayoutEnum.ROW_MAJOR
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b
+        ).mma_major_mode()
+        self.gemm_output_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         self.topK = token_final_scales.shape[1]
         self.needs_unpack = self.needs_unpack_tma(self.a_dtype, self.b_dtype)
@@ -1116,7 +1120,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -1185,7 +1189,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],

--- a/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/moe_w4a16_kernel.py
@@ -664,12 +664,16 @@ class Sm100W4A16GroupedGemmKernel:
         self.c_dtype: type[cutlass.Numeric] = c.element_type
         self.mma_dtype = self.b_dtype
 
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         if cutlass.const_expr(
-            utils.LayoutEnum.from_tensor(a_scale).mma_major_mode()
+            cutlass.tensor_utils.LayoutEnum.from_tensor(a_scale).mma_major_mode()
             != cute.nvgpu.OperandMajorMode.K
         ):
             raise ValueError("scale_major_mode must be K-major")
@@ -884,7 +888,7 @@ class Sm100W4A16GroupedGemmKernel:
         block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
             cta_rank_in_cluster
         )
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
         clc_response_ptr = storage.clc_response.data_ptr()
 
@@ -978,7 +982,7 @@ class Sm100W4A16GroupedGemmKernel:
             )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -2323,7 +2327,7 @@ class Sm100W4A16GroupedGemmKernel:
         a_dtype: type[cutlass.Numeric],
         b_dtype: type[cutlass.Numeric],
         c_dtype: type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         transform_a_source: tcgen05.OperandSource,
         smem_buffer_align_bytes: int,
         use_fused_finalize: bool,
@@ -2333,7 +2337,9 @@ class Sm100W4A16GroupedGemmKernel:
         # Compute tmem columns required for accumulator
         acc_shape = tiled_mma.partition_shape_C(mma_tiler_mnk[:2])
         tCtAcc_stage1 = tiled_mma.make_fragment_C(cute.append(acc_shape, 1))
-        num_tmem_acc_col_per_stage = utils.get_num_tmem_alloc_cols(tCtAcc_stage1, True)
+        num_tmem_acc_col_per_stage = cutlass.memory.get_num_tmem_alloc_cols(
+            tCtAcc_stage1, True
+        )
         # Heuristic to decide the number of stages for accumulator
         sm100_tmem_columns = cute.arch.get_max_tmem_alloc_cols("sm_100")
         accumulator_stage_count = sm100_tmem_columns // num_tmem_acc_col_per_stage
@@ -2379,7 +2385,7 @@ class Sm100W4A16GroupedGemmKernel:
             else 0
         )
 
-        smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         a_scale_k_mode = max(cta_tile_shape_mnk[2] // _NVFP4_SCALE_GRANULARITY_K, 1)
         a_scale_m_mode = max(cta_tile_shape_mnk[0] // _NVFP4_SCALE_GRANULARITY_M, 1)
         a_scale_bytes_per_stage = cute.round_up(

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/_moe_dynamic/gated.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/_moe_dynamic/gated.py
@@ -8,7 +8,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 
 from cutlass.cutlass_dsl import (
@@ -792,7 +791,7 @@ class MoEGatedDynamicKernel:
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
         self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         self.buffer_align_bytes = 1024
 
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -3701,11 +3700,11 @@ class MoEGatedDynamicKernel:
         self.a_dtype = packed_a.element_type
         self.b_dtype = b_w13.element_type
         self.sf_dtype = sfa_ptr.dtype
-        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b_w13)
         # Dynamic never materializes the intermediate C tensor. Preserve the
         # original row-major epilogue layout without carrying a dead memref.
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         hidden_size = a_input.shape[1]
         if cutlass.const_expr(
@@ -3947,7 +3946,7 @@ class MoEGatedDynamicKernel:
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class StorageGated:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/_moe_dynamic/generic.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/_moe_dynamic/generic.py
@@ -54,7 +54,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 
 from cutlass.cutlass_dsl import (
@@ -322,7 +321,7 @@ class MoEDynamicKernel:
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
         self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         self.buffer_align_bytes = 1024
 
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -613,11 +612,11 @@ class MoEDynamicKernel:
         self.a_dtype = packed_a.element_type
         self.b_dtype = b_w13.element_type
         self.sf_dtype = sfa_ptr.dtype
-        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b_w13)
         # Dynamic never materializes the intermediate C tensor. Preserve the
         # original row-major epilogue layout without carrying a dead memref.
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         hidden_size = a_input.shape[1]
         self._setup_attributes(hidden_size=hidden_size)
@@ -820,7 +819,7 @@ class MoEDynamicKernel:
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class StorageGated:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dynamic_kernel.py
@@ -54,7 +54,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 
 from cutlass.cutlass_dsl import (
@@ -305,7 +304,7 @@ class MoEDynamicKernel:
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
         self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         self.buffer_align_bytes = 1024
 
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -558,11 +557,11 @@ class MoEDynamicKernel:
         self.a_dtype = packed_a.element_type
         self.b_dtype = b_w13.element_type
         self.sf_dtype = sfa_ptr.dtype
-        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b_w13)
         # Dynamic never materializes the intermediate C tensor. Preserve the
         # original row-major epilogue layout without carrying a dead memref.
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         hidden_size = a_input.shape[1]
         self._setup_attributes(hidden_size=hidden_size)
@@ -776,7 +775,7 @@ class MoEDynamicKernel:
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class StorageGated:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -88,7 +88,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 
 from cutlass.cutlass_dsl import (
@@ -410,7 +409,7 @@ class MoEMicroKernel:
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
         self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         self.buffer_align_bytes = 1024
 
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -659,10 +658,10 @@ class MoEMicroKernel:
         self.a_dtype = packed_a.element_type
         self.b_dtype = b_w13.element_type
         self.sf_dtype = sfa_ptr.dtype
-        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b_w13)
         # Micro decode always scatters into token-major row-major output.
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         hidden_size = a_input.shape[1]
         self._setup_attributes(hidden_size=hidden_size)
@@ -851,7 +850,7 @@ class MoEMicroKernel:
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class StorageGated:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_micro_kernel.py
@@ -88,7 +88,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 
 from cutlass.cutlass_dsl import (
@@ -412,7 +411,7 @@ class MoEMicroKernel:
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
         self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         self.buffer_align_bytes = 1024
 
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -669,10 +668,10 @@ class MoEMicroKernel:
         self.a_dtype = packed_a.element_type
         self.b_dtype = b_w13.element_type
         self.sf_dtype = sfa_ptr.dtype
-        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b_w13)
         # Micro decode always scatters into token-major row-major output.
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         hidden_size = a_input.shape[1]
         self._setup_attributes(hidden_size=hidden_size)
@@ -864,7 +863,7 @@ class MoEMicroKernel:
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class StorageGated:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -86,7 +86,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 
 from cutlass.cutlass_dsl import (
@@ -380,7 +379,7 @@ class MoEStaticKernel:
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
         self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         self.buffer_align_bytes = 1024
 
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -629,10 +628,10 @@ class MoEStaticKernel:
         self.a_dtype = packed_a.element_type
         self.b_dtype = b_w13.element_type
         self.sf_dtype = sfa_ptr.dtype
-        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b_w13)
         # Compact static always scatters into token-major row-major output.
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         hidden_size = a_input.shape[1]
         self._setup_attributes(hidden_size=hidden_size)
@@ -821,7 +820,7 @@ class MoEStaticKernel:
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class StorageGated:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -86,7 +86,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 
 from cutlass.cutlass_dsl import (
@@ -386,7 +385,7 @@ class MoEStaticKernel:
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
         self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
         self.buffer_align_bytes = 1024
 
         self.epilog_sync_barrier = pipeline.NamedBarrier(
@@ -643,10 +642,10 @@ class MoEStaticKernel:
         self.a_dtype = packed_a.element_type
         self.b_dtype = b_w13.element_type
         self.sf_dtype = sfa_ptr.dtype
-        self.a_layout = utils.LayoutEnum.from_tensor(packed_a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b_w13)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(packed_a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b_w13)
         # Compact static always scatters into token-major row-major output.
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         hidden_size = a_input.shape[1]
         self._setup_attributes(hidden_size=hidden_size)
@@ -838,7 +837,7 @@ class MoEStaticKernel:
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class StorageGated:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_kernel.py
@@ -606,7 +606,7 @@ class W4A16GemmKernel:
         tid = Int32(tidx)
         cta = Int32(bidx)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class Storage:
@@ -2797,7 +2797,7 @@ class W4A16FusedMoeKernel:
         cta = Int32(bidx)
         grid_x = Int32(grid_x_raw)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class Storage:

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_kernel.py
@@ -996,7 +996,7 @@ class W4A16GemmKernel:
         tid = Int32(tidx)
         cta = Int32(bidx)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class Storage:
@@ -4393,7 +4393,7 @@ class W4A16FusedMoeKernel:
         cta = Int32(bidx)
         grid_x = Int32(grid_x_raw)
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class Storage:

--- a/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
@@ -217,7 +217,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel:
         self.use_2cta_instrs = mma_inst_shape[0] == 256
         self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
         self.arch = "sm_107"
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(self.arch)
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
         self.occupancy = 1
@@ -779,9 +779,9 @@ class Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel:
         self.b_dtype: Type[cutlass.Numeric] = b.element_type
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         # Note: Rubin supports mixed A/B dtypes (e.g., Float8E4M3FN x Float8E5M2)
 
@@ -1290,7 +1290,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # (a_pipeline created below alongside b_pipeline.)
@@ -1446,7 +1446,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel:
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -3435,7 +3435,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel:
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         num_smem_capacity: int,
@@ -3457,7 +3457,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Vector size of scale factor.

--- a/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -176,7 +176,7 @@ class Sm107BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.use_2cta_instrs = mma_inst_shape[0] == 256
         self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
         self.arch = "sm_107"
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(self.arch)
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
         self.occupancy = 1
@@ -605,9 +605,9 @@ class Sm107BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa.element_type
         self.final_scale_dtype = cutlass.Float32
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.ROW_MAJOR  # Always N-major for GEMM output
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR  # Always N-major for GEMM output
 
         # Check data types
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -932,7 +932,7 @@ class Sm107BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         tidx, _, _ = cute.arch.thread_idx()
 
         # Allocate shared memory
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize pipelines
@@ -982,7 +982,7 @@ class Sm107BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         )
 
         # Initialize tensor memory allocator
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -91,8 +91,7 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.utils as utils
-from cutlass.utils import TensorMapManager, TensorMapUpdateMode
+from cutlass.tensor_utils import TensorMapManager, TensorMapUpdateMode
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 from cutlass.cute.nvgpu import cpasync, tcgen05, OperandMajorMode
@@ -615,7 +614,7 @@ class GatedDeltaNetChunkedKernel:
 
         o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
             self.io_dtype,
-            utils.LayoutEnum.from_tensor(o),
+            cutlass.tensor_utils.LayoutEnum.from_tensor(o),
             self.mma_tiler_qkv[:2],
             self.smem_o_stages,
         )
@@ -947,7 +946,7 @@ class GatedDeltaNetChunkedKernel:
         # ------------------------------------------------------------------
         # 1. Allocate SMEM / TMEM, prefetch TMA descriptors
         # ------------------------------------------------------------------
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         sQ = storage.sQ.get_tensor(
@@ -985,7 +984,7 @@ class GatedDeltaNetChunkedKernel:
             cpasync.prefetch_descriptor(tma_o.atom)
 
         # TMEM allocator object - CG1 will issue the actual allocation
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             # Correction warp is the last one that accesses tmem

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_chunked.py
@@ -92,7 +92,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.utils as utils
-from cutlass.utils import TensorMapManager, TensorMapUpdateMode
+from cutlass.tensor_utils import TensorMapManager, TensorMapUpdateMode
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 from cutlass.cute.nvgpu import cpasync, tcgen05, OperandMajorMode
@@ -665,7 +665,7 @@ class GatedDeltaNetChunkedKernel:
 
         o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
             self.io_dtype,
-            cutlass.utils.LayoutEnum.from_tensor(o),
+            cutlass.tensor_utils.LayoutEnum.from_tensor(o),
             self.mma_tiler_qkv[:2],
             self.smem_o_stages,
         )
@@ -1005,7 +1005,7 @@ class GatedDeltaNetChunkedKernel:
         # ------------------------------------------------------------------
         # 1. Allocate SMEM / TMEM, prefetch TMA descriptors
         # ------------------------------------------------------------------
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         sQ = storage.sQ.get_tensor(
@@ -1050,7 +1050,7 @@ class GatedDeltaNetChunkedKernel:
             cpasync.prefetch_descriptor(tma_o.atom)
 
         # TMEM allocator object - CG1 will issue the actual allocation
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             # CG1 owns allocation and is the last group to release TMEM state.

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp.py
@@ -1164,7 +1164,7 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
             seq_idx, seq_start, chunk_idx_in_seq * t_blocks_per_cp_chunk, self.BLK
         )
 
-        allocator = utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sK = storage.sK.get_tensor(k_layout.outer, swizzle=k_layout.inner)
         sK_trans = storage.sK.get_tensor(
@@ -1332,7 +1332,7 @@ class CPDeltaRuleMNPrecomputeUtcmma1Sm100(KeyedCompileMixin):
             cluster_shape_mn=cluster_layout_vmnk, is_relaxed=True
         )
         pipeline.pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.compute_group_1_warp_ids[0],
@@ -2031,7 +2031,7 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         )
         num_iters = num_chunks - start
 
-        allocator = utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sM = storage.sM.get_tensor(m_layout.outer, swizzle=m_layout.inner)
         sN = storage.sN.get_tensor(n_layout.outer, swizzle=n_layout.inner)
@@ -2158,7 +2158,7 @@ class CPDeltaRuleFixupUtcmmaSm100(KeyedCompileMixin):
         else:
             gOutputState = gFixedStateCta[None, None, chunk_start]
 
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=0,

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -52,7 +52,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.utils as utils
-from cutlass.utils import TensorMapManager, TensorMapUpdateMode
+from cutlass.tensor_utils import TensorMapManager, TensorMapUpdateMode
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 from cutlass.cute.nvgpu import cpasync, tcgen05, OperandMajorMode
@@ -677,7 +677,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
 
         o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
             self.io_dtype,
-            cutlass.utils.LayoutEnum.from_tensor(o),
+            cutlass.tensor_utils.LayoutEnum.from_tensor(o),
             self.mma_tiler_qkv[:2],
             self.smem_o_stages,
         )
@@ -1049,7 +1049,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         # ------------------------------------------------------------------
         # 1. Allocate SMEM / TMEM, prefetch TMA descriptors
         # ------------------------------------------------------------------
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         sQ = storage.sQ.get_tensor(
@@ -1090,7 +1090,7 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
             cpasync.prefetch_descriptor(tma_o.atom)
 
         # TMEM allocator object - CG1 will issue the actual allocation
-        tmem = cutlass.utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             # CG1 owns allocation and is the last group to release TMEM state.

--- a/flashinfer/gdn_kernels/delta_rule_dsl/collective_store_tma.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/collective_store_tma.py
@@ -3,7 +3,7 @@ import cutlass.cute as cute
 import cutlass.pipeline as pipeline
 import cutlass._mlir.dialects.cute as _cute_ir
 from cutlass.cute.nvgpu import cpasync
-from cutlass.utils.tensormap_manager import TensorMapManager, TensorMapUpdateMode
+from cutlass.tensor_utils import TensorMapManager, TensorMapUpdateMode
 from .helpers import smid, tensormap_replace_global_dim_1
 
 

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -330,7 +330,7 @@ class CPDeltaRuleTPrecomputeSm120(KeyedCompileMixin):
             )
             beta_layout = cute.make_layout(self.BLK)
 
-            allocator = cutlass.utils.SmemAllocator()
+            allocator = cutlass.memory.SmemAllocator()
             storage = allocator.allocate(self.shared_storage)
             sK_DS = storage.smem_k.get_tensor(
                 k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner
@@ -1367,7 +1367,7 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
             (self.BLK, AlphaProcessor.NUM_CHANNELS, self.alpha_stage)
         )
 
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sV_DS = storage.smem_v.get_tensor(
             v_storage_layout_ds.outer, swizzle=v_storage_layout_ds.inner
@@ -2049,7 +2049,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
         workspace_layout = out_layout
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sM = storage.smem_m.get_tensor(
             transfer_layout.outer, swizzle=transfer_layout.inner
@@ -2486,7 +2486,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
         workspace_layout = out_layout
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         gTransfer = cute.make_tensor(g_transfer_t.iterator.align(128), workspace_layout)
         gLocalState = cute.make_tensor(
@@ -4292,7 +4292,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         math_tidx = tidx - THREADS_PER_WARP_GROUP
         wg_idx = math_tidx // THREADS_PER_WARP_GROUP
 
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -359,7 +359,7 @@ class CPDeltaRuleTPrecomputeSm120(KeyedCompileMixin):
             )
             beta_layout = cute.make_layout(self.BLK)
 
-            allocator = cutlass.utils.SmemAllocator()
+            allocator = cutlass.memory.SmemAllocator()
             storage = allocator.allocate(self.shared_storage)
             sK_DS = storage.smem_k.get_tensor(
                 k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner
@@ -1423,7 +1423,7 @@ class CPDeltaRuleMNPrecomputeSm120(KeyedCompileMixin):
             (self.BLK, AlphaProcessor.NUM_CHANNELS, self.alpha_stage)
         )
 
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sV_DS = storage.smem_v.get_tensor(
             v_storage_layout_ds.outer, swizzle=v_storage_layout_ds.inner
@@ -2207,7 +2207,7 @@ class CPDeltaRuleFixupHmmaSm120(KeyedCompileMixin):
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
         workspace_layout = out_layout
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sM = storage.smem_m.get_tensor(
             transfer_layout.outer, swizzle=transfer_layout.inner
@@ -2738,7 +2738,7 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
         workspace_layout = out_layout
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         gTransfer = cute.make_tensor(g_transfer_t.iterator.align(128), workspace_layout)
         gLocalState = cute.make_tensor(
@@ -4838,7 +4838,7 @@ class CPDeltaRulePrefillSm120(KeyedCompileMixin):
         math_tidx = tidx - THREADS_PER_WARP_GROUP
         wg_idx = math_tidx // THREADS_PER_WARP_GROUP
 
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -321,7 +321,7 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
             )
             beta_layout = cute.make_layout(self.BLK)
 
-            allocator = cutlass.utils.SmemAllocator()
+            allocator = cutlass.memory.SmemAllocator()
             storage = allocator.allocate(self.shared_storage)
             sK_DS = storage.smem_k.get_tensor(
                 k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner
@@ -1375,7 +1375,7 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
             (self.BLK, AlphaProcessor.NUM_CHANNELS, self.alpha_stage)
         )
 
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sV_DS = storage.smem_v.get_tensor(
             v_storage_layout_ds.outer, swizzle=v_storage_layout_ds.inner
@@ -2120,7 +2120,7 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
             (self.D, self.D, num_heads, total_cp_chunks),
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sM = storage.smem_m.get_tensor(
             transfer_layout.outer, swizzle=transfer_layout.inner
@@ -2484,7 +2484,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
         workspace_layout = out_layout
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         gTransfer = cute.make_tensor(g_transfer_t.iterator.align(128), workspace_layout)
         gLocalState = cute.make_tensor(
@@ -3611,7 +3611,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         math_tidx = tidx - THREADS_PER_WARP_GROUP
         wg_idx = math_tidx // THREADS_PER_WARP_GROUP
 
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm90.py
@@ -341,7 +341,7 @@ class CPDeltaRuleTPrecomputeSm90(KeyedCompileMixin):
             )
             beta_layout = cute.make_layout(self.BLK)
 
-            allocator = cutlass.utils.SmemAllocator()
+            allocator = cutlass.memory.SmemAllocator()
             storage = allocator.allocate(self.shared_storage)
             sK_DS = storage.smem_k.get_tensor(
                 k_storage_layout_ds.outer, swizzle=k_storage_layout_ds.inner
@@ -1418,7 +1418,7 @@ class CPDeltaRuleMNPrecomputeSm90(KeyedCompileMixin):
             (self.BLK, AlphaProcessor.NUM_CHANNELS, self.alpha_stage)
         )
 
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sV_DS = storage.smem_v.get_tensor(
             v_storage_layout_ds.outer, swizzle=v_storage_layout_ds.inner
@@ -2211,7 +2211,7 @@ class CPDeltaRuleFixupHmmaSm90(KeyedCompileMixin):
             (self.D, self.D, num_heads, total_cp_chunks),
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         sM = storage.smem_m.get_tensor(
             transfer_layout.outer, swizzle=transfer_layout.inner
@@ -2612,7 +2612,7 @@ class CPDeltaRuleFixupSimtSm90(KeyedCompileMixin):
             stride=(self.D, 1, self.D * self.D, self.D * self.D * num_heads),
         )
         workspace_layout = out_layout
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
         gTransfer = cute.make_tensor(g_transfer_t.iterator.align(128), workspace_layout)
         gLocalState = cute.make_tensor(
@@ -3969,7 +3969,7 @@ class CPDeltaRulePrefillSm90(_FullyFusedDeltaRuleSm90):
         math_tidx = tidx - THREADS_PER_WARP_GROUP
         wg_idx = math_tidx // THREADS_PER_WARP_GROUP
 
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -1710,7 +1710,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         wg_idx = math_tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
 
         # ── Smem allocation ───────────────────────────────────────────────────
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm120.py
@@ -1772,7 +1772,7 @@ class _FullyFusedDeltaRuleSm120(KeyedCompileMixin):
         wg_idx = math_tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
 
         # ── Smem allocation ───────────────────────────────────────────────────
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -1998,7 +1998,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         wg_idx = math_tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
 
         # ── Smem allocation ───────────────────────────────────────────────────
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_sm90.py
@@ -2057,7 +2057,7 @@ class _FullyFusedDeltaRuleSm90(KeyedCompileMixin):
         wg_idx = math_tidx // cutlass.Int32(THREADS_PER_WARP_GROUP)
 
         # ── Smem allocation ───────────────────────────────────────────────────
-        allocator = cutlass.utils.SmemAllocator()
+        allocator = cutlass.memory.SmemAllocator()
         storage = allocator.allocate(self.shared_storage)
 
         qkv_smem_layout_atom = warpgroup.make_smem_layout_atom(

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -222,7 +222,7 @@ def gdn_decode_bf16state_mtp_ilp4_kernel(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
 
     if cutlass.const_expr(T > 1):
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sQ = smem.allocate_tensor(
             cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
         )
@@ -954,7 +954,7 @@ def gdn_wide_vec_kernel(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
 
     # ----- SMEM -----
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sQ = smem.allocate_tensor(
         cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
     )
@@ -1996,7 +1996,7 @@ def gdn_wide_vec_kernel_t1(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
 
     # ----- SMEM -----
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sQ = smem.allocate_tensor(
         cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
     )

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -224,7 +224,7 @@ def gdn_decode_bf16state_mtp_ilp4_kernel(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
 
     if cutlass.const_expr(T > 1):
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sQ = smem.allocate_tensor(
             cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
         )
@@ -956,7 +956,7 @@ def gdn_wide_vec_kernel(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
 
     # ----- SMEM -----
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sQ = smem.allocate_tensor(
         cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
     )
@@ -1998,7 +1998,7 @@ def gdn_wide_vec_kernel_t1(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
 
     # ----- SMEM -----
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sQ = smem.allocate_tensor(
         cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
     )

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
@@ -39,7 +39,6 @@ import cutlass
 from cutlass import const_expr
 import cutlass.cute as cute
 import cutlass.cute.experimental  # noqa: F401  # side effect: registers cute.experimental.jit
-import cutlass.utils as utils
 from cutlass.cute.arch import sync_threads
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp import MmaF16BF16Op
@@ -841,7 +840,7 @@ class GdnDecodeKernel:
             _v7e_alog_bf16 = gAlog.iterator[pid_hv].to(f32)
             _v7e_dt_bf16 = gDtbias.iterator[pid_hv].to(f32)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class SS:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_output_only.py
@@ -38,7 +38,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 from cutlass import const_expr
 import cutlass.cute as cute
-import cutlass.utils as utils
 from cutlass.cute.arch import sync_threads
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp import MmaF16BF16Op
@@ -863,7 +862,7 @@ class GdnDecodeKernel:
             _v7e_alog_bf16 = gAlog.iterator[pid_hv].to(f32)
             _v7e_dt_bf16 = gDtbias.iterator[pid_hv].to(f32)
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class SS:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache.py
@@ -76,7 +76,6 @@ import cutlass
 from cutlass import const_expr
 import cutlass.cute as cute
 import cutlass.cute.experimental  # noqa: F401  # side effect: registers cute.experimental.jit
-import cutlass.utils as utils
 from cutlass.cute.arch import sync_threads
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp import MmaF16BF16Op
@@ -957,7 +956,7 @@ class GdnDecodeUCacheKernel:
                     _pf_row * V_DIM + _pf_half,
                 )
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class SS:

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_wy_ucache_flush.py
@@ -116,7 +116,6 @@ import cutlass
 from cutlass import const_expr
 import cutlass.cute as cute
 import cutlass.cute.experimental  # noqa: F401  # side effect: registers cute.experimental.jit
-import cutlass.utils as utils
 from cutlass.cute.arch import sync_threads
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.nvgpu.warp import MmaF16BF16Op
@@ -1479,7 +1478,7 @@ class GdnDecodeUCacheFlushKernel:
                     _pf_ring * V_DIM + _pf_half,
                 )
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         @cute.struct
         class SS:

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -280,7 +280,7 @@ def gdn_verify_kernel_mtp(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
 
     # Allocate shared memory for pre-computed values (broadcast to all warps)
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sQ = smem.allocate_tensor(
         cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
     )
@@ -1704,7 +1704,7 @@ def gdn_verify_kernel_mtp_inline(
 
     # v10: No sQ/sK/sG/sBeta — q/k/g/β are inlined into T-loop (deferred L2 norm)
     # Only allocate sVdata (for use_smem_v) and sOutput (for coalesced writeback)
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sVdata = smem.allocate_tensor(
         cutlass.Float32, cute.make_layout((T, tile_v), stride=(tile_v, 1)), 16
     )

--- a/flashinfer/gdn_kernels/gdn_decode_mtp.py
+++ b/flashinfer/gdn_kernels/gdn_decode_mtp.py
@@ -283,7 +283,7 @@ def gdn_verify_kernel_mtp(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
 
     # Allocate shared memory for pre-computed values (broadcast to all warps)
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sQ = smem.allocate_tensor(
         cutlass.Float32, cute.make_layout((T, K), stride=(K + 8, 1)), 16
     )
@@ -1708,7 +1708,7 @@ def gdn_verify_kernel_mtp_inline(
 
     # v10: No sQ/sK/sG/sBeta — q/k/g/β are inlined into T-loop (deferred L2 norm)
     # Only allocate sVdata (for use_smem_v) and sOutput (for coalesced writeback)
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sVdata = smem.allocate_tensor(
         cutlass.Float32, cute.make_layout((T, tile_v), stride=(tile_v, 1)), 16
     )

--- a/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_nontranspose.py
@@ -99,7 +99,7 @@ def gdn_decode_kernel_small_batch_nontranspose(
         v_base = warp_idx * V_PER_WARP_SMALL
         v_idx = v_base + v_local
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sData = smem.allocate_tensor(cutlass.Float32, smem_layout_staged, 128)
         smem_o_layout = cute.make_layout((TILE_V_SMALL_NT,), stride=(1,))
         smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)
@@ -330,7 +330,7 @@ def gdn_decode_kernel_big_batch_nontranspose(
         v_base = warp_idx * V_PER_WARP_NT
         v_idx = v_base + v_local
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sData = smem.allocate_tensor(cutlass.Float32, smem_layout_staged, 128)
         smem_o_layout = cute.make_layout((TILE_V_NT,), stride=(1,))
         smem_o = smem.allocate_tensor(cutlass.Float32, smem_o_layout, 128)

--- a/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
+++ b/flashinfer/gdn_kernels/gdn_decode_pretranspose.py
@@ -86,7 +86,7 @@ def gdn_decode_kernel_small_batch_pretranspose(
     i_h = i_hv // (HV // H)
     i_t = 0
 
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
 
     # ===================================================================
     # Allocate shared memory (using passed-in layout)
@@ -408,7 +408,7 @@ def gdn_decode_kernel_big_batch_pretranspose(
     r_dt_bias = cutlass.Float32(dt_bias[i_hv])
     r_b = cutlass.Float32(b[i_n, i_t, i_hv])
 
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
 
     # ===================================================================
     # Allocate shared memory (using passed-in layout)

--- a/flashinfer/gemm/kernels/bmm_fp8_blackwell.py
+++ b/flashinfer/gemm/kernels/bmm_fp8_blackwell.py
@@ -248,7 +248,7 @@ class PersistentDenseGemmKernel:
                 self.c_dtype, self.c_layout, self.epi_tile, 1
             )
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
         self.num_acc_stage, self.num_ab_stage, self.num_c_stage = _compute_stages(
@@ -303,9 +303,13 @@ class PersistentDenseGemmKernel:
         self.a_dtype: Type[cutlass.Numeric] = a.element_type
         self.b_dtype: Type[cutlass.Numeric] = b.element_type
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -457,7 +461,7 @@ class PersistentDenseGemmKernel:
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -504,7 +508,7 @@ class PersistentDenseGemmKernel:
                 num_threads=32 * len(self.epilogue_warp_id),
             )
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],
@@ -793,7 +797,9 @@ class PersistentDenseGemmKernel:
         """Compute the number of tensor memory allocation columns."""
         acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
-        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake, arch=arch)
+        num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(
+            tCtAcc_fake, arch=arch
+        )
 
         return num_tmem_alloc_cols
 

--- a/flashinfer/gemm/kernels/bmm_fp8_rubin.py
+++ b/flashinfer/gemm/kernels/bmm_fp8_rubin.py
@@ -112,7 +112,7 @@ class SM107PersistentDenseGemmKernel(BlackwellPersistentDenseGemmKernel):
             raster_along,
         )
         self.arch = "sm_107"
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(self.arch)
         self.mma_tiler = mma_tiler
         self.mma_inst_shape = mma_inst_shape
         # Bkeep-Breuse pattern is controlled by mma_inst_shape and mma_tiler
@@ -315,7 +315,7 @@ class SM107PersistentDenseGemmKernel(BlackwellPersistentDenseGemmKernel):
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -362,7 +362,7 @@ class SM107PersistentDenseGemmKernel(BlackwellPersistentDenseGemmKernel):
                 num_threads=32 * len(self.epilogue_warp_id),
             )
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],
@@ -731,9 +731,13 @@ class SM107PersistentDenseGemmKernel(BlackwellPersistentDenseGemmKernel):
         self.a_dtype: Type[cutlass.Numeric] = a.element_type
         self.b_dtype: Type[cutlass.Numeric] = b.element_type
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         tiled_mma = self._create_tiled_mma()
         # Create Bkeep-Breuse tiled_mma variants if enabled

--- a/flashinfer/gemm/kernels/cute_dsl/dense_gemm_bf16_fp4_blackwell.py
+++ b/flashinfer/gemm/kernels/cute_dsl/dense_gemm_bf16_fp4_blackwell.py
@@ -227,7 +227,7 @@ class BlackwellDenseGemmBf16Fp4Kernel:
             self.num_mma_warps + self.num_dma_warps
         ) * self.num_threads_per_warp
         # SM100/103 expose >= SM120 SMEM/CTA
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
 
         self.ab_stage = None
         self.epi_stage = None
@@ -343,9 +343,9 @@ class BlackwellDenseGemmBf16Fp4Kernel:
             self.b_compute_dtype = a.element_type
         self.c_dtype = c.element_type
 
-        self.a_layout = utils.LayoutEnum.from_tensor(a)
-        self.b_layout_compute = utils.LayoutEnum.ROW_MAJOR
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(a)
+        self.b_layout_compute = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         if cutlass.const_expr(self.a_dtype.width != 16):
             raise TypeError(f"a_dtype must be 16-bit (bf16/fp16), got {self.a_dtype}")
@@ -517,7 +517,7 @@ class BlackwellDenseGemmBf16Fp4Kernel:
             + cute.size_in_bytes(cutlass.Uint8, b_sf_smem_layout)
         )
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()

--- a/flashinfer/gemm/kernels/cute_dsl/dense_gemm_bf16_fp4_sm100.py
+++ b/flashinfer/gemm/kernels/cute_dsl/dense_gemm_bf16_fp4_sm100.py
@@ -565,12 +565,16 @@ class Sm100DenseGemmBf16Fp4Kernel:
         self.c_dtype: type[cutlass.Numeric] = c.element_type
         self.mma_dtype = self.b_dtype
 
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         if cutlass.const_expr(
-            utils.LayoutEnum.from_tensor(a_scale).mma_major_mode()
+            cutlass.tensor_utils.LayoutEnum.from_tensor(a_scale).mma_major_mode()
             != cute.nvgpu.OperandMajorMode.K
         ):
             raise ValueError("scale_major_mode must be K-major")
@@ -779,7 +783,7 @@ class Sm100DenseGemmBf16Fp4Kernel:
         block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
             cta_rank_in_cluster
         )
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
         clc_response_ptr = storage.clc_response.data_ptr()
 
@@ -871,7 +875,7 @@ class Sm100DenseGemmBf16Fp4Kernel:
             )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_ptr_sync_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -2158,7 +2162,7 @@ class Sm100DenseGemmBf16Fp4Kernel:
         a_dtype: type[cutlass.Numeric],
         b_dtype: type[cutlass.Numeric],
         c_dtype: type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         transform_a_source: tcgen05.OperandSource,
         smem_buffer_align_bytes: int,
         use_fused_finalize: bool,
@@ -2168,7 +2172,9 @@ class Sm100DenseGemmBf16Fp4Kernel:
         # Compute tmem columns required for accumulator
         acc_shape = tiled_mma.partition_shape_C(mma_tiler_mnk[:2])
         tCtAcc_stage1 = tiled_mma.make_fragment_C(cute.append(acc_shape, 1))
-        num_tmem_acc_col_per_stage = utils.get_num_tmem_alloc_cols(tCtAcc_stage1, True)
+        num_tmem_acc_col_per_stage = cutlass.memory.get_num_tmem_alloc_cols(
+            tCtAcc_stage1, True
+        )
         # Heuristic to decide the number of stages for accumulator
         sm100_tmem_columns = cute.arch.get_max_tmem_alloc_cols("sm_100")
         accumulator_stage_count = sm100_tmem_columns // num_tmem_acc_col_per_stage
@@ -2214,7 +2220,7 @@ class Sm100DenseGemmBf16Fp4Kernel:
             else 0
         )
 
-        smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         a_scale_k_mode = max(cta_tile_shape_mnk[2] // _NVFP4_SCALE_GRANULARITY_K, 1)
         a_scale_m_mode = max(cta_tile_shape_mnk[0] // _NVFP4_SCALE_GRANULARITY_M, 1)
         a_scale_bytes_per_stage = cute.round_up(

--- a/flashinfer/gemm/kernels/cute_dsl/dense_gemm_bf16_fp4_sm12x.py
+++ b/flashinfer/gemm/kernels/cute_dsl/dense_gemm_bf16_fp4_sm12x.py
@@ -237,7 +237,7 @@ class Sm12xDenseGemmBf16Fp4Kernel:
         self.threads_per_cta = (
             self.num_mma_warps + self.num_dma_warps
         ) * self.num_threads_per_warp
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
 
         self.ab_stage = None
         self.epi_stage = None
@@ -354,9 +354,9 @@ class Sm12xDenseGemmBf16Fp4Kernel:
             self.b_compute_dtype = a.element_type
         self.c_dtype = c.element_type
 
-        self.a_layout = utils.LayoutEnum.from_tensor(a)
-        self.b_layout_compute = utils.LayoutEnum.ROW_MAJOR
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(a)
+        self.b_layout_compute = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         if cutlass.const_expr(self.a_dtype.width != 16):
             raise TypeError(f"a_dtype must be 16-bit (bf16/fp16), got {self.a_dtype}")
@@ -584,7 +584,7 @@ class Sm12xDenseGemmBf16Fp4Kernel:
             + cute.size_in_bytes(cutlass.Uint8, b_sf_smem_layout)
         )
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         mainloop_pipeline_array_ptr = storage.mainloop_pipeline_array_ptr.data_ptr()

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_direct.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_direct.py
@@ -262,7 +262,7 @@ class DirectDenseGemmKernel:
             (num_rows, outputs_per_block, num_warps),
             stride=(outputs_per_block * num_warps, num_warps, 1),
         )
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         partials = smem.allocate_tensor(cutlass.Float32, smem_layout, byte_alignment=16)
         with cute.arch.elect_one():
             for mi in cutlass.range_constexpr(num_rows):

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_sm100_splitk.py
@@ -15,7 +15,6 @@ import functools
 import cuda.bindings.driver as _cuda
 import cutlass
 import cutlass.cute as cute
-import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass import Int32
 from cutlass._mlir.dialects import llvm
@@ -26,7 +25,7 @@ from cutlass.cutlass_dsl import T, dsl_user_op
 
 
 #: Per-CTA SMEM capacity reported by CuTeDSL on SM100/SM103.
-_SMEM_CAPACITY_BYTES = utils.get_smem_capacity_in_bytes("sm_100")
+_SMEM_CAPACITY_BYTES = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
 
 #: K extent of one CTA tile.
 _CTA_K = 128
@@ -372,7 +371,7 @@ class SplitKDenseGemmKernel:
             ),
             block=(self.threads_per_cta, 1, 1),
             cluster=self.cluster_shape,
-            smem=cute.Int64(utils.get_smem_capacity_in_bytes("sm_100")),
+            smem=cute.Int64(cutlass.memory.get_smem_capacity_in_bytes("sm_100")),
             stream=stream,
             use_pdl=self.use_pdl,
         )
@@ -392,8 +391,8 @@ class SplitKDenseGemmKernel:
         tiled_mma = sm100_utils.make_trivial_tiled_mma(
             ab_dtype,
             ab_dtype,
-            utils.LayoutEnum.from_tensor(mA).mma_major_mode(),
-            utils.LayoutEnum.from_tensor(mB).mma_major_mode(),
+            cutlass.tensor_utils.LayoutEnum.from_tensor(mA).mma_major_mode(),
+            cutlass.tensor_utils.LayoutEnum.from_tensor(mB).mma_major_mode(),
             self.acc_dtype,
             self.cta_group,
             self.mma_tiler_mn,
@@ -557,7 +556,7 @@ class SplitKDenseGemmKernel:
                 cute.local_tile(mBias, c_tiler_mn, (bidx, n_idx, l_idx)),
                 cute.arch.thread_idx()[0] - 128,
                 mC.element_type,
-                utils.LayoutEnum.from_tensor(mC),
+                cutlass.tensor_utils.LayoutEnum.from_tensor(mC),
                 mailbox,
                 bar_reduce,
                 split_rank,

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100.py
@@ -135,7 +135,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel(_Sm100BlockScaledGemmCommon):
         self.cta_sync_bar_id = 0
         self.epilog_sync_bar_id = 1
         self.tmem_ptr_sync_bar_id = 2
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
@@ -535,7 +535,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel(_Sm100BlockScaledGemmCommon):
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.ptr

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100_common.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100_common.py
@@ -31,7 +31,6 @@ from typing import Any, Tuple, Type, Union
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
@@ -95,9 +94,9 @@ class _Sm100BlockScaledGemmCommon:
         self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
         self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c_tensor)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -266,7 +265,7 @@ class _Sm100BlockScaledGemmCommon:
         b_major_mode: cute.nvgpu.OperandMajorMode,
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -289,7 +288,7 @@ class _Sm100BlockScaledGemmCommon:
             b_major_mode (cute.nvgpu.OperandMajorMode): Layout of operand B.
             epi_tile (cute.Tile): The epilogue tile shape.
             c_dtype (Type[cutlass.Numeric]): Data type of operand C.
-            c_layout (utils.LayoutEnum): Layout of operand C.
+            c_layout (cutlass.tensor_utils.LayoutEnum): Layout of operand C.
             sf_dtype (Type[cutlass.Numeric]): Data type of the scale factors.
             sf_vec_size (int): Vector size of the scale factors.
             smem_capacity (int): Total available shared memory in bytes.

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100_common.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100_common.py
@@ -31,7 +31,6 @@ from typing import Any, Tuple, Type, Union
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
@@ -95,9 +94,13 @@ class _Sm100BlockScaledGemmCommon:
         self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
         self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a_tensor
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b_tensor
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c_tensor)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -266,7 +269,7 @@ class _Sm100BlockScaledGemmCommon:
         b_major_mode: cute.nvgpu.OperandMajorMode,
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -289,7 +292,7 @@ class _Sm100BlockScaledGemmCommon:
             b_major_mode (cute.nvgpu.OperandMajorMode): Layout of operand B.
             epi_tile (cute.Tile): The epilogue tile shape.
             c_dtype (Type[cutlass.Numeric]): Data type of operand C.
-            c_layout (utils.LayoutEnum): Layout of operand C.
+            c_layout (cutlass.tensor_utils.LayoutEnum): Layout of operand C.
             sf_dtype (Type[cutlass.Numeric]): Data type of the scale factors.
             sf_vec_size (int): Vector size of the scale factors.
             smem_capacity (int): Total available shared memory in bytes.

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100_splitk.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm100_splitk.py
@@ -279,7 +279,7 @@ class Sm100BlockScaledSplitKGemmKernel(_Sm100BlockScaledGemmCommon):
         self.cta_sync_bar_id = 0
         self.epilog_sync_bar_id = 1
         self.tmem_ptr_sync_bar_id = 2
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
@@ -691,7 +691,7 @@ class Sm100BlockScaledSplitKGemmKernel(_Sm100BlockScaledGemmCommon):
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_holding_buf = storage.tmem_holding_buf.ptr

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm103.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm103.py
@@ -154,7 +154,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         self.epilog_sync_bar_id = 1
         self.tmem_alloc_sync_bar_id = 2
         self.tmem_dealloc_sync_bar_id = 3
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_103")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_103")
         # SM103 TMEM capacity is 512 columns (same as SM100).
         # This replaces cute.arch.get_max_tmem_alloc_cols("sm_103") which
         # may not be available in older cutlass-dsl versions.
@@ -353,9 +353,9 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
         self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c_tensor)
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
             raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
@@ -647,7 +647,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         #
         # Alloc and init: a+b full/empty, sfa+sfb full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize mainloop ab_producer and ab_consumer
@@ -710,7 +710,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
                 num_threads=32 * len(self.epilogue_warp_id),
             )
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],
@@ -2013,7 +2013,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         mma_tiler: Tuple[int, int, int],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -2033,7 +2033,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm103.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm103.py
@@ -158,7 +158,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         self.epilog_sync_bar_id = 1
         self.tmem_alloc_sync_bar_id = 2
         self.tmem_dealloc_sync_bar_id = 3
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_103")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_103")
         # SM103 TMEM capacity is 512 columns (same as SM100).
         # This replaces cute.arch.get_max_tmem_alloc_cols("sm_103") which
         # may not be available in older cutlass-dsl versions.
@@ -357,9 +357,13 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
         self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a_tensor
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b_tensor
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c_tensor)
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
             raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
@@ -651,7 +655,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         #
         # Alloc and init: a+b full/empty, sfa+sfb full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize mainloop ab_producer and ab_consumer
@@ -714,7 +718,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
                 num_threads=32 * len(self.epilogue_warp_id),
             )
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],
@@ -2017,7 +2021,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         mma_tiler: Tuple[int, int, int],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -2037,7 +2041,7 @@ class Sm103BlockScaledPersistentDenseGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py
@@ -211,7 +211,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(Sm100BlockScaledPersistentDenseG
         self.use_2cta_instrs = mma_inst_shape[0] == 256
         self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
         self.arch = "sm_107"
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(self.arch)
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
         self.swizzle_size = swizzle_size
         self.raster_order = raster_order
@@ -374,9 +374,9 @@ class Sm107BlockScaledPersistentDenseGemmKernel(Sm100BlockScaledPersistentDenseG
         a_major_mode = OperandMajorMode.K
         b_major_mode = OperandMajorMode.K
         if cutlass.const_expr(swap_ab):
-            c_layout = utils.LayoutEnum.COL_MAJOR
+            c_layout = cutlass.tensor_utils.LayoutEnum.COL_MAJOR
         else:
-            c_layout = utils.LayoutEnum.ROW_MAJOR
+            c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         layouts = (a_major_mode, b_major_mode, c_layout)
         problem_mnkl = (cutlass.Int32(m), cutlass.Int32(n), cutlass.Int32(k), l)
@@ -418,7 +418,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(Sm100BlockScaledPersistentDenseG
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -440,7 +440,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(Sm100BlockScaledPersistentDenseG
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.
@@ -869,7 +869,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(Sm100BlockScaledPersistentDenseG
         sfb_ptr: cute.Pointer,
         c_ptr: cute.Pointer,
         alpha: cute.Tensor,
-        layouts: cutlass.Constexpr[Tuple[OperandMajorMode, OperandMajorMode, utils.LayoutEnum]],
+        layouts: cutlass.Constexpr[Tuple[OperandMajorMode, OperandMajorMode, cutlass.tensor_utils.LayoutEnum]],
         problem_mnkl: Tuple[int, int, int, int],
         max_active_clusters: cutlass.Constexpr,
         stream: cuda.CUstream,
@@ -922,7 +922,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(Sm100BlockScaledPersistentDenseG
             b_layout = cute.make_ordered_layout((cute.assume(n, 32), k, l), order=(1, 0, 2))
         # c supports strided output for uGPU shared buffers.
         # c_ld: leading dimension (0 = use default contiguous layout).
-        if cutlass.const_expr(self.c_layout == utils.LayoutEnum.ROW_MAJOR):
+        if cutlass.const_expr(self.c_layout == cutlass.tensor_utils.LayoutEnum.ROW_MAJOR):
             actual_c_ld = c_ld + (n - c_ld) * (c_ld == 0)
             c_out_layout = cute.make_layout(
                 (m, cute.assume(n, 32), l), stride=(actual_c_ld, 1, m * actual_c_ld)
@@ -1277,7 +1277,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(Sm100BlockScaledPersistentDenseG
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -1311,7 +1311,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(Sm100BlockScaledPersistentDenseG
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -2760,7 +2760,7 @@ class Sm107BlockScaledPersistentDenseGemmMixedClustersKernel(
         sfa_ptr: cute.Pointer,
         sfb_ptr: cute.Pointer,
         c_ptr: cute.Pointer,
-        layouts: cutlass.Constexpr[Tuple[OperandMajorMode, OperandMajorMode, utils.LayoutEnum]],
+        layouts: cutlass.Constexpr[Tuple[OperandMajorMode, OperandMajorMode, cutlass.tensor_utils.LayoutEnum]],
         problem_mnkl: Tuple[int, int, int, int],
         preferred_max_active_clusters: cutlass.Constexpr,
         fallback_max_active_clusters: cutlass.Constexpr,
@@ -2817,7 +2817,7 @@ class Sm107BlockScaledPersistentDenseGemmMixedClustersKernel(
             b_layout = cute.make_ordered_layout((cute.assume(n, 32), k, l), order=(1, 0, 2))
         # c supports strided output for uGPU shared buffers.
         # c_ld: leading dimension (0 = use default contiguous layout).
-        if cutlass.const_expr(self.c_layout == utils.LayoutEnum.ROW_MAJOR):
+        if cutlass.const_expr(self.c_layout == cutlass.tensor_utils.LayoutEnum.ROW_MAJOR):
             actual_c_ld = c_ld + (n - c_ld) * (c_ld == 0)
             c_layout = cute.make_layout(
                 (m, cute.assume(n, 32), l), stride=(actual_c_ld, 1, m * actual_c_ld)
@@ -3230,7 +3230,7 @@ class Sm107BlockScaledPersistentDenseGemmMixedClustersKernel(
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -3264,7 +3264,7 @@ class Sm107BlockScaledPersistentDenseGemmMixedClustersKernel(
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -4073,9 +4073,9 @@ class Sm107BlockScaledPersistentDenseGemmMixedClustersKernel(
         a_major_mode = OperandMajorMode.K
         b_major_mode = OperandMajorMode.K
         if cutlass.const_expr(swap_ab):
-            c_layout = utils.LayoutEnum.COL_MAJOR
+            c_layout = cutlass.tensor_utils.LayoutEnum.COL_MAJOR
         else:
-            c_layout = utils.LayoutEnum.ROW_MAJOR
+            c_layout = cutlass.tensor_utils.LayoutEnum.ROW_MAJOR
 
         self(
             a_ptr,

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -259,7 +259,7 @@ class DenseGemmKernel:
             self.num_mma_warps + 1  # 1 warp for DMA
         ) * self.num_threads_per_warp
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
 
         self.ab_stage = None
         self.epi_stage = None
@@ -397,9 +397,9 @@ class DenseGemmKernel:
         self.c_dtype = c.element_type
         self.sf_dtype = sfa.element_type
 
-        self.a_layout = utils.LayoutEnum.from_tensor(a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b)
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b)
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
             raise TypeError(f"Type mismatch: {self.a_dtype} != {self.b_dtype}")
@@ -886,7 +886,7 @@ class DenseGemmKernel:
             )
 
         # Allocate shared memory
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Pipeline setup

--- a/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
+++ b/flashinfer/gemm/kernels/dense_blockscaled_gemm_sm120_b12x.py
@@ -311,7 +311,7 @@ class DenseGemmKernel:
             self.num_mma_warps + 1  # 1 warp for DMA
         ) * self.num_threads_per_warp
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_120")
 
         self.ab_stage = None
         self.epi_stage = None
@@ -432,7 +432,7 @@ class DenseGemmKernel:
                 ),
             )
             self.svdquant_a_smem_layout = sm90_utils.make_smem_layout_a(
-                utils.LayoutEnum.ROW_MAJOR,
+                cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
                 (
                     self.mma_tile_shape_mnk[0],
                     self.mma_tile_shape_mnk[1],
@@ -442,7 +442,7 @@ class DenseGemmKernel:
                 self.ab_stage,
             )
             self.svdquant_b_smem_layout = sm90_utils.make_smem_layout_b(
-                utils.LayoutEnum.ROW_MAJOR,
+                cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
                 (
                     self.mma_tile_shape_mnk[0],
                     self.mma_tile_shape_mnk[1],
@@ -515,9 +515,9 @@ class DenseGemmKernel:
         self.sf_dtype = sfa.element_type
         self.is_mxfp8 = self.a_dtype == cutlass.Float8E4M3FN
 
-        self.a_layout = utils.LayoutEnum.from_tensor(a)
-        self.b_layout = utils.LayoutEnum.from_tensor(b)
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(a)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(b)
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
         self.svdquant_enabled = svdquant_d is not None
         if cutlass.const_expr(self.svdquant_enabled):
             self.svdquant_dtype = svdquant_d.element_type
@@ -1112,7 +1112,7 @@ class DenseGemmKernel:
             )
 
         # Allocate shared memory
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Pipeline setup

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -421,7 +421,7 @@ class MaskedScheduler:
 @dsl_user_op
 def make_fused_smem_layout_epi(
     epi_dtype: Type[cutlass.Numeric],
-    epi_layout: utils.LayoutEnum,
+    epi_layout: cutlass.tensor_utils.LayoutEnum,
     epi_tile: cute.Tile,
     epi_stage: int,
     *,
@@ -690,7 +690,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         self.cta_sync_bar_id = 0
         self.epilog_sync_bar_id = 1
         self.tmem_ptr_sync_bar_id = 2
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(sm_version)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(sm_version)
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
@@ -897,9 +897,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
         self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c_tensor)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -1215,7 +1215,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.ptr
@@ -2385,7 +2385,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         b_major_mode: cute.nvgpu.OperandMajorMode,
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -2411,7 +2411,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -424,7 +424,7 @@ class MaskedScheduler:
 @dsl_user_op
 def make_fused_smem_layout_epi(
     epi_dtype: Type[cutlass.Numeric],
-    epi_layout: utils.LayoutEnum,
+    epi_layout: cutlass.tensor_utils.LayoutEnum,
     epi_tile: cute.Tile,
     epi_stage: int,
     *,
@@ -693,7 +693,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         self.cta_sync_bar_id = 0
         self.epilog_sync_bar_id = 1
         self.tmem_ptr_sync_bar_id = 2
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(sm_version)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(sm_version)
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
@@ -900,9 +900,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
         self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a_tensor
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b_tensor
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c_tensor)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -1218,7 +1222,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.ptr
@@ -2388,7 +2392,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         b_major_mode: cute.nvgpu.OperandMajorMode,
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -2414,7 +2418,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.

--- a/flashinfer/gemm/kernels/grouped_gemm_masked_rubin.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_rubin.py
@@ -16,7 +16,6 @@ import cutlass.cute.testing as testing
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.nvgpu.tcgen05.mma import CollectorOp
 import cutlass.torch as cutlass_torch
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.rubin_helpers as sm107_utils
@@ -183,7 +182,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(
             tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
         )
         self.arch = "sm_107"
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(self.arch)
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
         # Alias needed by utils.gemm.sm107 helpers
@@ -212,7 +211,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -234,7 +233,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.
@@ -684,9 +683,13 @@ class Sm107BlockScaledPersistentDenseGemmKernel(
         self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
         self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
         self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            a_tensor
+        ).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
+            b_tensor
+        ).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c_tensor)
 
         # Check if input data types are compatible with MMA instruction
         # (Rubin allows different A/B dtypes for MXF8, but we check anyway)
@@ -1053,7 +1056,7 @@ class Sm107BlockScaledPersistentDenseGemmKernel(
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.ptr

--- a/flashinfer/gemm/kernels/tgv_gemm_cute_ext.py
+++ b/flashinfer/gemm/kernels/tgv_gemm_cute_ext.py
@@ -109,7 +109,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute import experimental as cute_ext
-import cutlass.utils as utils
 from cutlass.cute.runtime import from_dlpack, make_fake_stream
 from cutlass.cute.nvgpu import tcgen05
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -258,7 +257,7 @@ class TgvGemmCuteExtKernel:
             grid=grid,
             block=(self.threads_per_cta, 1, 1),
             cluster=self.cluster_shape,
-            smem=cute.Int64(utils.get_smem_capacity_in_bytes("sm_100")),
+            smem=cute.Int64(cutlass.memory.get_smem_capacity_in_bytes("sm_100")),
             stream=stream,
             use_pdl=self.pdl_launch,
         )
@@ -281,11 +280,11 @@ class TgvGemmCuteExtKernel:
         # make_trivial_tiled_mma picks the largest tcgen05.mma atom that fits
         # mma_tiler_mn. 1-CTA bf16 (64,8): Mma_M=(16,4)=64, Mma_N=8, Mma_K=16.
         # 2-CTA bf16 K-major (128,N): Mma_M=128 split across cluster, Mma_K=16.
-        a_major = utils.LayoutEnum.from_tensor(mA).mma_major_mode()
-        b_major = utils.LayoutEnum.from_tensor(mB).mma_major_mode()
+        a_major = cutlass.tensor_utils.LayoutEnum.from_tensor(mA).mma_major_mode()
+        b_major = cutlass.tensor_utils.LayoutEnum.from_tensor(mB).mma_major_mode()
         ab_dtype = mA.element_type  # bf16
         c_dtype = mC.element_type  # bf16
-        d_layout = utils.LayoutEnum.from_tensor(mC)
+        d_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(mC)
 
         tiled_mma = sm100_utils.make_trivial_tiled_mma(
             ab_dtype,

--- a/flashinfer/kda_kernels/fused_kda_decode.py
+++ b/flashinfer/kda_kernels/fused_kda_decode.py
@@ -28,7 +28,7 @@ import cutlass
 import cutlass.cute as cute
 import cuda.bindings.driver as cuda
 import torch
-from cutlass.utils import SmemAllocator
+from cutlass.memory import SmemAllocator
 import tvm_ffi  # noqa: F401 -- TVM FFI is required for kernel dispatch
 
 from ..jit.cute_dsl_core import build_and_load_cute_dsl_kernel

--- a/flashinfer/kda_kernels/packed_kda_decode_cute.py
+++ b/flashinfer/kda_kernels/packed_kda_decode_cute.py
@@ -834,7 +834,7 @@ def _kda_packed_t1_smem_kernel(
     warp_idx = tidx // 32
     WARP_ROWS: cutlass.Constexpr[int] = 2 * ilp_rows
 
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sH = smem.allocate_tensor(
         cutlass.BFloat16,
         cute.make_layout((n_stages, CHUNK_ROWS, K), stride=(CHUNK_ROWS * K, K, 1)),
@@ -1402,7 +1402,7 @@ def _kda_packed_t1_persist_kernel(
     VALSI = tuple(range(vals))
     ITERI = tuple(range(ITERS))
 
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     sH = smem.allocate_tensor(
         cutlass.BFloat16,
         cute.make_layout((n_stages, CHUNK_ROWS, K), stride=(CHUNK_ROWS * K, K, 1)),

--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -40,7 +40,6 @@ import cutlass
 import cutlass.cute as cute
 import cuda.bindings.driver as cuda
 import torch
-from cutlass import utils
 from cutlass._mlir.dialects import arith as mlir_arith
 from cutlass._mlir.dialects import math as mlir_math
 from cutlass._mlir.dialects import nvvm
@@ -694,7 +693,7 @@ def recurrent_kda_decode_kernel(
         A_log_val = cute.exp(gALog[query_head_idx].to(cutlass.Float32), fastmath=True)
         h_K_offset = query_head_idx * HEAD_DIM
 
-    smem = utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
 
     # Allocate SMEM -- 2 ping-pong H buffers (D=128 reuses for chunks 2,3)
     h_sh_a = smem.allocate_tensor(
@@ -1170,7 +1169,7 @@ def recurrent_kda_decode_chunk_major_kernel(
         A_log_val = cute.exp(gALog[query_head_idx].to(cutlass.Float32), fastmath=True)
         h_K_offset = query_head_idx * HEAD_DIM
 
-    smem = utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     h_sh_a = smem.allocate_tensor(
         cutlass.BFloat16,
         cute.make_layout((32, HEAD_DIM), stride=(HEAD_DIM + H_SMEM_PADDING, 1)),
@@ -1417,7 +1416,7 @@ def recurrent_kda_decode_vtile_kernel(
         A_log_val = cute.exp(gALog[query_head_idx].to(cutlass.Float32), fastmath=True)
         h_K_offset = query_head_idx * HEAD_DIM
 
-    smem = utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
 
     # Single SMEM h buffer -- no ping-pong, only one chunk per CTA.
     # Physical row count is always 32 (=LANES_PER_WARP), even at V_TILE_ROWS=16.

--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -46,7 +46,7 @@ import torch
 from cutlass._mlir.dialects import arith as mlir_arith
 from cutlass._mlir.dialects import math as mlir_math
 from cutlass.cute.runtime import from_dlpack, make_fake_stream
-from cutlass.utils import SmemAllocator
+from cutlass.memory import SmemAllocator
 import tvm_ffi  # noqa: F401 -- TVM FFI required for zero-overhead kernel dispatch
 
 from ..jit.flash_kda_decode import (

--- a/flashinfer/kda_kernels/sm120_prefill/decomp.py
+++ b/flashinfer/kda_kernels/sm120_prefill/decomp.py
@@ -3272,7 +3272,7 @@ def prepare_kernel(
     lane = tidx % 32
     head = bidy
 
-    alloc = cutlass.utils.SmemAllocator()
+    alloc = cutlass.memory.SmemAllocator()
     p_kd = alloc.allocate_array(cutlass.BFloat16, BT * DK)
     # Four resident CTAs are reachable and were measured: at CPC == 1 the raw
     # Q and K stages are dead after the Kd/Ki/Qd loop, so Qd can overwrite Q
@@ -4211,7 +4211,7 @@ def recurrence_kernel(
     # --- fixed arena ------------------------------------
     # One allocation of exactly SMEM_DYNAMIC_BYTES, so the launch parameter is
     # the plan's number and every address is a compile-time constant offset.
-    alloc = cutlass.utils.SmemAllocator()
+    alloc = cutlass.memory.SmemAllocator()
     p_base = alloc.allocate(SMEM_DYNAMIC_BYTES, 1024)
     p16 = cute.recast_ptr(p_base, dtype=cutlass.BFloat16)
     p32 = cute.recast_ptr(p_base, dtype=cutlass.Float32)

--- a/flashinfer/kda_kernels/sm120_prefill/fused.py
+++ b/flashinfer/kda_kernels/sm120_prefill/fused.py
@@ -3547,7 +3547,7 @@ def fused_kda_kernel(
     # --- fixed arena ------------------------------------
     # One allocation of exactly DYNAMIC_SMEM_BYTES, so the launch parameter is
     # the plan's number and every region base is a compile-time constant.
-    alloc = cutlass.utils.SmemAllocator()
+    alloc = cutlass.memory.SmemAllocator()
     p_base = alloc.allocate(DYNAMIC_SMEM_BYTES, 1024)
     p16 = cute.recast_ptr(p_base, dtype=cutlass.BFloat16)
     p32 = cute.recast_ptr(p_base, dtype=cutlass.Float32)

--- a/flashinfer/mamba/ssd_kernel.py
+++ b/flashinfer/mamba/ssd_kernel.py
@@ -33,7 +33,6 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
-import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
@@ -127,7 +126,7 @@ class SSDKernel:
                 *self.epilog_warp_id,
             )
         )
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes("sm_100")
 
         # Named barriers
         self.pre_inter_sync_bar_id = 1
@@ -201,7 +200,7 @@ class SSDKernel:
         # the transposed view (L, D) needs ROW_MAJOR to keep D contiguous in mode 1.
         self.xt_smem_layout = sm100_utils.make_smem_layout_epi(
             self.io_dtype,
-            utils.LayoutEnum.ROW_MAJOR,
+            cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
             self.tile_shape_mnk_intra2[:2],
             self.input_stages,
         )
@@ -231,7 +230,7 @@ class SSDKernel:
         self.bt_smem_layout = cute.coalesce(
             sm100_utils.make_smem_layout_epi(
                 self.io_dtype,
-                utils.LayoutEnum.COL_MAJOR,
+                cutlass.tensor_utils.LayoutEnum.COL_MAJOR,
                 (self.tile_shape_mnk_inter1[0], self.tile_shape_mnk_inter1[2]),
                 self.input_stages,
             ),
@@ -244,7 +243,7 @@ class SSDKernel:
         self.bt_store_smem_layout = cute.coalesce(
             sm100_utils.make_smem_layout_epi(
                 self.io_dtype,
-                utils.LayoutEnum.ROW_MAJOR,
+                cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
                 (self.tile_shape_mnk_inter1[0], self.tile_shape_mnk_inter1[2]),
                 self.internal_stages,
             ),
@@ -273,7 +272,7 @@ class SSDKernel:
         # PT is ACC operand (from tmem) of INTER1_MMA, after postprocessed by PRE_INTER
         self.pt_smem_layout = sm100_utils.make_smem_layout_epi(
             self.io_dtype,
-            utils.LayoutEnum.COL_MAJOR,
+            cutlass.tensor_utils.LayoutEnum.COL_MAJOR,
             self.tile_shape_mnk_inter1[:2],
             self.internal_stages,
         )
@@ -289,7 +288,7 @@ class SSDKernel:
         # P is ACC operand (from tmem) of INTER1_MMA, to be TMA stored by PRE_INTER
         self.p_smem_layout_store = sm100_utils.make_smem_layout_epi(
             self.state_dtype,
-            utils.LayoutEnum.COL_MAJOR,
+            cutlass.tensor_utils.LayoutEnum.COL_MAJOR,
             (self.tile_shape_mnk_inter2[2], self.tile_shape_mnk_inter2[1]),
             self.internal_stages,
         )
@@ -303,7 +302,7 @@ class SSDKernel:
         self.p_smem_layout_load = (
             sm100_utils.make_smem_layout_epi(
                 self.state_dtype,
-                utils.LayoutEnum.COL_MAJOR,
+                cutlass.tensor_utils.LayoutEnum.COL_MAJOR,
                 (
                     self.tile_shape_mnk_inter2[2],
                     self.tile_shape_mnk_inter2[1],
@@ -325,7 +324,7 @@ class SSDKernel:
         # Y is ACC operand (from smem) of INTER2_MMA and INTRA2_MMA, after postprocessed and TMA stored by EPILOG
         self.y_smem_layout = sm100_utils.make_smem_layout_epi(
             self.io_dtype,
-            utils.LayoutEnum.COL_MAJOR,
+            cutlass.tensor_utils.LayoutEnum.COL_MAJOR,
             self.epi_tile,
             self.output_stages,
         )
@@ -840,7 +839,7 @@ class SSDKernel:
         local_warp_idx = cute.arch.make_warp_uniform(local_tidx // 32)
 
         # Alloc and init smem tensors and pipelines
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         smem_storage = smem.allocate(self.shared_storage)
 
         # Setup smem tensors

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_bf16_glu/epilogue_bf16.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_bf16_glu/epilogue_bf16.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple, Type
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.utils as utils
 
 from common.megamoe_constants import Log2E
 from cutlass.cute.typing import Float32
@@ -101,7 +100,7 @@ class GluBf16Epilogue(GluMxfp8Epilogue):
         cluster_shape_mn: Tuple[int, int],
         use_2cta_instrs: bool,
         fc1_output_dtype: Type[cutlass.Numeric],
-        fc1_output_layout: utils.LayoutEnum,
+        fc1_output_layout: cutlass.tensor_utils.LayoutEnum,
         acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
         c_dtype: Type[cutlass.Numeric] = cutlass.BFloat16,
         glu_clamp: Optional[float] = None,

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_bf16_glu/kernel_bf16_glu_fc12.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_bf16_glu/kernel_bf16_glu_fc12.py
@@ -16,7 +16,6 @@ try:
 except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -213,7 +212,7 @@ class Sm100SwigluBf16Fc12Kernel:
         self.token_back_warp_id: Optional[Tuple[int, int, int, int]] = None
         self.token_back_standalone: bool = False
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
     def _validate_mma_tiler_and_cluster_shape(self) -> None:
@@ -820,13 +819,13 @@ class Sm100SwigluBf16Fc12Kernel:
         self.a_dtype: Type[cutlass.Numeric] = activation_gemm.element_type
         self.b_dtype: Type[cutlass.Numeric] = fc1_weight_gemm.element_type
         self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
             activation_gemm
         ).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
             fc1_weight_gemm
         ).mma_major_mode()
-        self.fc1_output_layout = utils.LayoutEnum.from_tensor(fc1_output_gemm)
+        self.fc1_output_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(fc1_output_gemm)
 
         self._setup_attributes()
         tiled_mma = self._create_tiled_mma()
@@ -1125,7 +1124,7 @@ class Sm100SwigluBf16Fc12Kernel:
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # MegaMoE-only dispatch-warp SMEM (pull_buffer, mbarriers, etc.).
@@ -1186,7 +1185,7 @@ class Sm100SwigluBf16Fc12Kernel:
             barrier_id=self.tmem_alloc_sync_bar_id,
             num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
         )
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_bf16_glu/mega_reference_bf16.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_bf16_glu/mega_reference_bf16.py
@@ -484,7 +484,7 @@ class PersistentDenseGemmKernel:
                 self.c_dtype, self.c_layout, self.epi_tile, 1
             )
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
         self.num_acc_stage, self.num_ab_stage, self.num_c_stage = _compute_stages(
@@ -554,9 +554,9 @@ class PersistentDenseGemmKernel:
         self.a_dtype: Type[cutlass.Numeric] = a.element_type
         self.b_dtype: Type[cutlass.Numeric] = b.element_type
         self.c_dtype: Type[cutlass.Numeric] = c.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(a).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(b).mma_major_mode()
-        self.c_layout = utils.LayoutEnum.from_tensor(c)
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(a).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(b).mma_major_mode()
+        self.c_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(c)
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -710,7 +710,7 @@ class PersistentDenseGemmKernel:
             tmem_dealloc_mbar: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -757,7 +757,7 @@ class PersistentDenseGemmKernel:
                 num_threads=32 * len(self.epilogue_warp_id),
             )
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],
@@ -1219,7 +1219,7 @@ class PersistentDenseGemmKernel:
         """
         acc_shape = tiled_mma.partition_shape_C(mma_tiler[:2])
         tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, num_acc_stage))
-        num_tmem_alloc_cols = utils.get_num_tmem_alloc_cols(tCtAcc_fake, arch=arch)
+        num_tmem_alloc_cols = cutlass.memory.get_num_tmem_alloc_cols(tCtAcc_fake, arch=arch)
 
         return num_tmem_alloc_cols
 

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_mxfp8_glu/epilogue_mxfp8.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_mxfp8_glu/epilogue_mxfp8.py
@@ -18,7 +18,6 @@ except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.typing import AddressSpace
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 
@@ -159,7 +158,7 @@ class GluMxfp8Epilogue:
         use_2cta_instrs: bool,
         sf_vec_size: int,
         fc1_output_dtype: Type[cutlass.Numeric],
-        fc1_output_layout: utils.LayoutEnum,
+        fc1_output_layout: cutlass.tensor_utils.LayoutEnum,
         acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
         sf_dtype: Type[cutlass.Numeric] = cutlass.Float8E8M0FNU,
         c_dtype: Type[cutlass.Numeric] = cutlass.BFloat16,

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_mxfp8_glu/kernel_mxfp8_glu_fc12.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_mxfp8_glu/kernel_mxfp8_glu_fc12.py
@@ -16,7 +16,6 @@ try:
 except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -212,7 +211,7 @@ class Sm100SwigluMxfp8Fc12Kernel:
         self.token_back_warp_id: Optional[Tuple[int, int, int, int]] = None
         self.token_back_standalone: bool = False
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
     def _validate_mma_tiler_and_cluster_shape(self) -> None:
@@ -990,13 +989,13 @@ class Sm100SwigluMxfp8Fc12Kernel:
         self.b_dtype: Type[cutlass.Numeric] = fc1_weight_gemm.element_type
         self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
         self.sf_dtype: Type[cutlass.Numeric] = activation_sf_gemm.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
             activation_gemm
         ).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
             fc1_weight_gemm
         ).mma_major_mode()
-        self.fc1_output_layout = utils.LayoutEnum.from_tensor(fc1_output_gemm)
+        self.fc1_output_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(fc1_output_gemm)
 
         self._setup_attributes()
         tiled_mma, tiled_mma_sfb = self._create_tiled_mmas()
@@ -1406,7 +1405,7 @@ class Sm100SwigluMxfp8Fc12Kernel:
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # MegaMoE-only dispatch-warp SMEM (pull_buffer, mbarriers, etc.).
@@ -1467,7 +1466,7 @@ class Sm100SwigluMxfp8Fc12Kernel:
             barrier_id=self.tmem_alloc_sync_bar_id,
             num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
         )
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/benchmark_p2p.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/benchmark_p2p.py
@@ -134,7 +134,7 @@ def ublkcp_bench_kernel(
     warp_idx = cute.arch.make_warp_uniform(tidx // Int32(32))
     lane_idx = cute.arch.lane_idx()
 
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     pull_mbar = smem.allocate_array(Int64, NUM_WARPS)
     payload = smem.allocate_array(Uint8, NUM_WARPS * y_copy_per_iter * z_bytes_per_inst)
 
@@ -370,7 +370,7 @@ def smem_capacity_bytes() -> int:
     major, minor = torch.cuda.get_device_capability(0)
     arch = f"sm_{major}{minor}"
     try:
-        return int(cutlass.utils.get_smem_capacity_in_bytes(arch))
+        return int(cutlass.memory.get_smem_capacity_in_bytes(arch))
     except Exception:
         if major >= 10:
             return 227 * 1024

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/epilogue.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/epilogue.py
@@ -19,7 +19,6 @@ except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.typing import AddressSpace
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 
@@ -1988,7 +1987,7 @@ class SwapABSwigluFp4Epilogue:
         use_2cta_instrs: bool,
         sf_vec_size: int,
         fc1_output_dtype: Type[cutlass.Numeric],
-        fc1_output_layout: utils.LayoutEnum,
+        fc1_output_layout: cutlass.tensor_utils.LayoutEnum,
         fc2_output_dtype: Type[cutlass.Numeric],
         non_ubulk_fc2_store: bool,
         in_kernel_fc2_reduce: bool,

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/epilogue_refactor.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/epilogue_refactor.py
@@ -20,7 +20,6 @@ from cutlass.cutlass_dsl import Int64, T
 from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.typing import AddressSpace
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 
@@ -1121,7 +1120,7 @@ class SwapABSwigluFp4Epilogue:
     ) -> Union[cute.Layout, cute.ComposedLayout]:
         layout = sm100_utils.make_smem_layout_epi(
             self.fc1_output_dtype,
-            utils.LayoutEnum.ROW_MAJOR,
+            cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
             (self._EpilogueTokenTileSize, self._EpilogueFc1IntermediateDownTileSize),
             n_stages,
         )

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/kernel_fc12.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/kernel_fc12.py
@@ -17,7 +17,6 @@ try:
 except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -184,7 +183,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         self.epi_reg_cnt = 256
         self.task_reg_cnt = 72
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
     def name(self) -> str:
@@ -1029,10 +1028,10 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         self.b_dtype: Type[cutlass.Numeric] = activation_gemm.element_type
         self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
         self.sf_dtype: Type[cutlass.Numeric] = fc1_weight_sf_gemm.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
             fc1_weight_gemm
         ).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(
             activation_gemm
         ).mma_major_mode()
 
@@ -1454,7 +1453,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # MegaMoE-only ``token_comm_storage``: standalone SMEM region whose
@@ -1511,7 +1510,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             barrier_id=self.tmem_alloc_sync_bar_id,
             num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
         )
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/mega_reference.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/moe_nvfp4_swapab/mega_reference.py
@@ -464,7 +464,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
         # Resolve SMEM from the active cuTeDSL target (e.g. SM100 vs SM107).
         self.arch = get_cutedsl_target_arch()
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
     def _setup_attributes(self):
@@ -644,7 +644,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         sfb_tensor: cute.Tensor,
         c_tensor: cute.Tensor,
         layouts: cutlass.Constexpr[
-            Tuple[OperandMajorMode, OperandMajorMode, utils.LayoutEnum]
+            Tuple[OperandMajorMode, OperandMajorMode, cutlass.tensor_utils.LayoutEnum]
         ],
         problem_mnkl: Tuple[int, int, int, int],
         max_active_clusters: cutlass.Constexpr,
@@ -710,7 +710,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 (cute.assume(n, 32), k, l), order=(1, 0, 2)
             )
         c_layout = cute.make_ordered_layout((cute.assume(m, 32), n, l), order=(0, 1, 2))
-        if cutlass.const_expr(self.c_layout == utils.LayoutEnum.ROW_MAJOR):
+        if cutlass.const_expr(self.c_layout == cutlass.tensor_utils.LayoutEnum.ROW_MAJOR):
             c_layout = cute.make_ordered_layout(
                 (m, cute.assume(n, 32), l), order=(1, 0, 2)
             )
@@ -1022,7 +1022,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -1061,7 +1061,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -1965,7 +1965,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -1986,7 +1986,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.
@@ -2510,7 +2510,7 @@ class _BlockScaledGemmReferenceLauncher:
         self.layouts = (
             OperandMajorMode.K,
             OperandMajorMode.K,
-            utils.LayoutEnum.ROW_MAJOR,
+            cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
         )
         cluster_size = cluster_shape_mn[0] * cluster_shape_mn[1]
         self.max_active_clusters = utils.HardwareInfo().get_max_active_clusters(

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/src/dispatch_kernel.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/src/dispatch_kernel.py
@@ -77,7 +77,7 @@ def dispatch_kernel(
         flag_batch=flag_batch,
         is_swap_ab=True,
     )
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     storage = smem.allocate(token_comm.extra_smem_storage_class())
 
     sm_idx = cute.arch.block_idx()[0]

--- a/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/src/inputs_process.py
+++ b/flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src/src/inputs_process.py
@@ -257,7 +257,7 @@ class DataPreprocess:
         tid = cute.arch.thread_idx()[0]
         hidden = activation_bf16.shape[1]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         warp_partials = smem.allocate_array(Float32, num_warps)
 
         is_padding = False
@@ -345,7 +345,7 @@ class DataPreprocess:
         # Stage the whole bf16 row into swizzled smem via cp.async (LDGSTS):
         # coalesced 16 B loads (8 bf16/lane), all issued up front, no mbarrier.
         # The swizzle makes the later per-block LDS.128 bank-conflict free.
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         smem_row = smem.allocate_tensor(
             cutlass.BFloat16, cute.make_layout(hidden), 1024, swizzle=cute.make_swizzle(1, 4, 3)
         )
@@ -447,7 +447,7 @@ class DataPreprocess:
         data_rcp_limit = Float32(self._mxfp8_data_rcp_limit)
         fp32_max = Fp32Max
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         smem_row = smem.allocate_tensor(
             cutlass.BFloat16, cute.make_layout(hidden), 1024, swizzle=cute.make_swizzle(1, 4, 3)
         )

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_hopper_fp8/epilogue_fp8.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_hopper_fp8/epilogue_fp8.py
@@ -10,7 +10,6 @@ try:
     from cutlass.cute import iket  # type: ignore
 except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.hopper_helpers as sm90_utils
 
@@ -70,7 +69,7 @@ class Fp8GluEpilogue:
         use_2cta_instrs: bool,
         sf_vec_size: int,
         fc1_output_dtype: Type[cutlass.Numeric],
-        fc1_output_layout: utils.LayoutEnum,
+        fc1_output_layout: cutlass.tensor_utils.LayoutEnum,
         acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
         sf_dtype: Type[cutlass.Numeric] = cutlass.Float8E8M0FNU,
         fp8_scale_mode: str = "per_tensor",

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_hopper_fp8/epilogue_fp8_swapab.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_hopper_fp8/epilogue_fp8_swapab.py
@@ -11,7 +11,6 @@ try:
     from cutlass.cute import iket  # type: ignore
 except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.hopper_helpers as sm90_utils
 
@@ -63,7 +62,7 @@ class SwapABFp8GluEpilogue:
         use_2cta_instrs: bool,
         sf_vec_size: int,
         fc1_output_dtype: Type[cutlass.Numeric],
-        fc1_output_layout: utils.LayoutEnum,
+        fc1_output_layout: cutlass.tensor_utils.LayoutEnum,
         acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
         sf_dtype: Type[cutlass.Numeric] = cutlass.Float8E8M0FNU,
         fp8_scale_mode: str = "per_tensor",

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_hopper_fp8/kernel_fp8_glu_fc12.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_hopper_fp8/kernel_fp8_glu_fc12.py
@@ -14,7 +14,6 @@ except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.typing import Float32
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.hopper_helpers as sm90_utils
@@ -313,7 +312,7 @@ class Sm90SwigluFp8Fc12Kernel:
         self.token_back_reg_cnt = 32
         self.task_reg_cnt = 32
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(self.arch)
 
     def _validate_mma_tiler_and_cluster_shape(self) -> None:
         """Validate user-provided geometry against v1 fused-fc12 constraints.
@@ -1866,11 +1865,11 @@ class Sm90SwigluFp8Fc12Kernel:
         self.b_dtype: Type[cutlass.Numeric] = fc1_weight_gemm.element_type
         self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
         self.sf_dtype: Type[cutlass.Numeric] = activation_sf.element_type
-        self.a_layout = utils.LayoutEnum.from_tensor(activation_gemm)
-        self.b_layout = utils.LayoutEnum.from_tensor(fc1_weight_gemm)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(activation_gemm)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(fc1_weight_gemm)
         self.a_major_mode = self.a_layout.sm90_mma_major_mode()
         self.b_major_mode = self.b_layout.sm90_mma_major_mode()
-        self.fc1_output_layout = utils.LayoutEnum.from_tensor(fc1_output_gemm)
+        self.fc1_output_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(fc1_output_gemm)
 
         self._setup_attributes()
         tiled_mma = self._create_tiled_mma()
@@ -2249,7 +2248,7 @@ class Sm90SwigluFp8Fc12Kernel:
             ]
             sched_storage: SchedStorage
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # MegaMoE-only dispatch-warp SMEM (pull_buffer, mbarriers, etc.).

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_hopper_fp8/kernel_fp8_glu_fc12_swapab.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_hopper_fp8/kernel_fp8_glu_fc12_swapab.py
@@ -14,7 +14,6 @@ except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync
 from cutlass.cute.typing import Float32
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.hopper_helpers as sm90_utils
@@ -290,7 +289,7 @@ class Sm90SwapABSwigluFp8Fc12Kernel(_Sm90Fp8Fc12KernelBase):
         self.token_back_reg_cnt = 32
         self.task_reg_cnt = 32
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes(self.arch)
 
     def _validate_mma_tiler_and_cluster_shape(self) -> None:
         """Validate user-provided geometry against v1 fused-fc12 constraints.
@@ -795,11 +794,11 @@ class Sm90SwapABSwigluFp8Fc12Kernel(_Sm90Fp8Fc12KernelBase):
         self.b_dtype: Type[cutlass.Numeric] = activation_gemm.element_type
         self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
         self.sf_dtype: Type[cutlass.Numeric] = activation_sf.element_type
-        self.a_layout = utils.LayoutEnum.from_tensor(fc1_weight_gemm)
-        self.b_layout = utils.LayoutEnum.from_tensor(activation_gemm)
+        self.a_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(fc1_weight_gemm)
+        self.b_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(activation_gemm)
         self.a_major_mode = self.a_layout.sm90_mma_major_mode()
         self.b_major_mode = self.b_layout.sm90_mma_major_mode()
-        self.fc1_output_layout = utils.LayoutEnum.from_tensor(fc1_output_gemm)
+        self.fc1_output_layout = cutlass.tensor_utils.LayoutEnum.from_tensor(fc1_output_gemm)
 
         self._setup_attributes()
         tiled_mma = self._create_tiled_mma()
@@ -1177,7 +1176,7 @@ class Sm90SwapABSwigluFp8Fc12Kernel(_Sm90Fp8Fc12KernelBase):
             ]
             sched_storage: SchedStorage
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # MegaMoE-only dispatch-warp SMEM (pull_buffer, mbarriers, etc.).

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/benchmark_p2p.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/benchmark_p2p.py
@@ -130,7 +130,7 @@ def ublkcp_bench_kernel(
     warp_idx = cute.arch.make_warp_uniform(tidx // Int32(32))
     lane_idx = cute.arch.lane_idx()
 
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     pull_mbar = smem.allocate_array(Int64, NUM_WARPS)
     payload = smem.allocate_array(Uint8, NUM_WARPS * y_copy_per_iter * z_bytes_per_inst)
 
@@ -373,7 +373,7 @@ def smem_capacity_bytes() -> int:
     major, minor = torch.cuda.get_device_capability(0)
     arch = f"sm_{major}{minor}"
     try:
-        return int(cutlass.utils.get_smem_capacity_in_bytes(arch))
+        return int(cutlass.memory.get_smem_capacity_in_bytes(arch))
     except Exception:
         if major >= 10:
             return 227 * 1024

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/epilogue.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/epilogue.py
@@ -18,7 +18,6 @@ except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.typing import AddressSpace
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 
@@ -1954,7 +1953,7 @@ class SwapABSwigluFp4Epilogue:
         use_2cta_instrs: bool,
         sf_vec_size: int,
         fc1_output_dtype: Type[cutlass.Numeric],
-        fc1_output_layout: utils.LayoutEnum,
+        fc1_output_layout: cutlass.tensor_utils.LayoutEnum,
         fc2_output_dtype: Type[cutlass.Numeric],
         non_ubulk_fc2_store: bool,
         in_kernel_fc2_reduce: bool,

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/epilogue_refactor.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/epilogue_refactor.py
@@ -20,7 +20,6 @@ from cutlass.cutlass_dsl import Int64, T
 from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.typing import AddressSpace
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 
@@ -1045,7 +1044,7 @@ class SwapABSwigluFp4Epilogue:
     ) -> Union[cute.Layout, cute.ComposedLayout]:
         layout = sm100_utils.make_smem_layout_epi(
             self.fc1_output_dtype,
-            utils.LayoutEnum.ROW_MAJOR,
+            cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
             (self._EpilogueTokenTileSize, self._EpilogueFc1IntermediateDownTileSize),
             n_stages,
         )

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/kernel_fc12.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/kernel_fc12.py
@@ -13,7 +13,6 @@ try:
 except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
     from src.iket_compat import iket
 from cutlass.cute.nvgpu import cpasync, tcgen05
-import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import cutlass.utils.blackwell_helpers as sm100_utils
@@ -180,7 +179,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         self.epi_reg_cnt = 256
         self.task_reg_cnt = 72
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(
             self.arch
         )
@@ -954,8 +953,8 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         self.b_dtype: Type[cutlass.Numeric] = activation_gemm.element_type
         self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
         self.sf_dtype: Type[cutlass.Numeric] = fc1_weight_sf_gemm.element_type
-        self.a_major_mode = utils.LayoutEnum.from_tensor(fc1_weight_gemm).mma_major_mode()
-        self.b_major_mode = utils.LayoutEnum.from_tensor(activation_gemm).mma_major_mode()
+        self.a_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(fc1_weight_gemm).mma_major_mode()
+        self.b_major_mode = cutlass.tensor_utils.LayoutEnum.from_tensor(activation_gemm).mma_major_mode()
 
         self._setup_attributes()
         tiled_mma, tiled_mma_sfb = self._create_tiled_mmas()
@@ -1365,7 +1364,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
 
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
 
         # MegaMoE-only ``token_comm_storage``: standalone SMEM region whose
@@ -1424,7 +1423,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             barrier_id=self.tmem_alloc_sync_bar_id,
             num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
         )
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/mega_reference.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/moe_nvfp4_swapab/mega_reference.py
@@ -452,7 +452,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
         # Resolve SMEM from the active cuTeDSL target (e.g. SM100 vs SM107).
         self.arch = get_cutedsl_target_arch()
-        self.smem_capacity = utils.get_smem_capacity_in_bytes()
+        self.smem_capacity = cutlass.memory.get_smem_capacity_in_bytes()
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
 
     def _setup_attributes(self):
@@ -632,7 +632,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         sfb_tensor: cute.Tensor,
         c_tensor: cute.Tensor,
         layouts: cutlass.Constexpr[
-            Tuple[OperandMajorMode, OperandMajorMode, utils.LayoutEnum]
+            Tuple[OperandMajorMode, OperandMajorMode, cutlass.tensor_utils.LayoutEnum]
         ],
         problem_mnkl: Tuple[int, int, int, int],
         max_active_clusters: cutlass.Constexpr,
@@ -698,7 +698,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 (cute.assume(n, 32), k, l), order=(1, 0, 2)
             )
         c_layout = cute.make_ordered_layout((cute.assume(m, 32), n, l), order=(0, 1, 2))
-        if cutlass.const_expr(self.c_layout == utils.LayoutEnum.ROW_MAJOR):
+        if cutlass.const_expr(self.c_layout == cutlass.tensor_utils.LayoutEnum.ROW_MAJOR):
             c_layout = cute.make_ordered_layout(
                 (m, cute.assume(n, 32), l), order=(1, 0, 2)
             )
@@ -1010,7 +1010,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         #
         # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
         #
-        smem = utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         # Initialize mainloop ab_pipeline (barrier) and states
@@ -1049,7 +1049,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
 
         # Tensor memory dealloc barrier init
-        tmem = utils.TmemAllocator(
+        tmem = cutlass.memory.TmemAllocator(
             storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
@@ -1953,7 +1953,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         b_dtype: Type[cutlass.Numeric],
         epi_tile: cute.Tile,
         c_dtype: Type[cutlass.Numeric],
-        c_layout: utils.LayoutEnum,
+        c_layout: cutlass.tensor_utils.LayoutEnum,
         sf_dtype: Type[cutlass.Numeric],
         sf_vec_size: int,
         smem_capacity: int,
@@ -1974,7 +1974,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :param c_dtype: Data type of operand C (output).
         :type c_dtype: type[cutlass.Numeric]
         :param c_layout: Layout enum of operand C.
-        :type c_layout: utils.LayoutEnum
+        :type c_layout: cutlass.tensor_utils.LayoutEnum
         :param sf_dtype: Data type of Scale factor.
         :type sf_dtype: type[cutlass.Numeric]
         :param sf_vec_size: Scale factor vector size.
@@ -2498,7 +2498,7 @@ class _BlockScaledGemmReferenceLauncher:
         self.layouts = (
             OperandMajorMode.K,
             OperandMajorMode.K,
-            utils.LayoutEnum.ROW_MAJOR,
+            cutlass.tensor_utils.LayoutEnum.ROW_MAJOR,
         )
         cluster_size = cluster_shape_mn[0] * cluster_shape_mn[1]
         self.max_active_clusters = utils.HardwareInfo().get_max_active_clusters(

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/src/dispatch_kernel.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/src/dispatch_kernel.py
@@ -77,7 +77,7 @@ def dispatch_kernel(
         flag_batch=flag_batch,
         is_swap_ab=True,
     )
-    smem = cutlass.utils.SmemAllocator()
+    smem = cutlass.memory.SmemAllocator()
     storage = smem.allocate(token_comm.extra_smem_storage_class())
 
     sm_idx = cute.arch.block_idx()[0]

--- a/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/src/inputs_process.py
+++ b/flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/src/inputs_process.py
@@ -272,7 +272,7 @@ class DataPreprocess:
         tid = cute.arch.thread_idx()[0]
         hidden = activation_bf16.shape[1]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         warp_partials = smem.allocate_array(Float32, num_warps)
 
         is_padding = False
@@ -366,7 +366,7 @@ class DataPreprocess:
         # Stage the whole bf16 row into swizzled smem via cp.async (LDGSTS):
         # coalesced 16 B loads (8 bf16/lane), all issued up front, no mbarrier.
         # The swizzle makes the later per-block LDS.128 bank-conflict free.
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         smem_row = smem.allocate_tensor(
             cutlass.BFloat16,
             cute.make_layout(hidden),
@@ -488,7 +488,7 @@ class DataPreprocess:
         data_rcp_limit = Float32(self._mxfp8_data_rcp_limit)
         fp32_max = Fp32Max
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         smem_row = smem.allocate_tensor(
             cutlass.BFloat16,
             cute.make_layout(hidden),

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
@@ -217,7 +217,7 @@ class MsaProxyScoreFp4MmaSm12x:
                     cute.struct.MemRange[cutlass.Float32, self._M * 2], 1024
                 ]
 
-            smem = cutlass.utils.SmemAllocator()
+            smem = cutlass.memory.SmemAllocator()
             storage = smem.allocate(SharedStorage)
             sA = storage.sA.get_tensor(sA_layout)
             sB = storage.sB.get_tensor(sB_layout)
@@ -774,7 +774,7 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
                 cute.struct.MemRange[cutlass.Float32, self._M * 2], 1024
             ]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sA = storage.sA.get_tensor(sA_layout)
         sB = storage.sB.get_tensor(sB_layout)

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -246,7 +246,7 @@ class MsaProxyScoreSm12x:
                     1024,
                 ]
 
-            smem = cutlass.utils.SmemAllocator()
+            smem = cutlass.memory.SmemAllocator()
             storage = smem.allocate(SharedStorage)
             sQ = storage.sQ.get_tensor(sQ_layout)
             sK = storage.sK.get_tensor(sK_layout)
@@ -652,7 +652,7 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
                 1024,
             ]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sQ = storage.sQ.get_tensor(sQ_layout)
         sK = storage.sK.get_tensor(sK_layout)
@@ -928,7 +928,7 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                 16,
             ]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sQ = storage.sQ.get_tensor(sQ_layout)
         sK0 = storage.sK0.get_tensor(sK_layout)
@@ -1548,7 +1548,7 @@ class MsaProxyScoreDecodeKeyMajorSm12x:
         kw = hd // 2 if self._kv_fp8 else hd
         qw = hd // 2 if self._q_fp8 else hd
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         sK_full = smem.allocate_tensor(
             dtype,
             k_tma.smem_layout.outer,
@@ -2106,7 +2106,7 @@ class MsaProxyScoreDecodeStreamSm12x:
         class SharedStorage:
             s_max: cute.struct.MemRange[cutlass.Float32, self._NUM_WARPS * G]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         s_max = storage.s_max.get_tensor(
             cute.make_layout((self._NUM_WARPS, G), stride=(G, 1))

--- a/flashinfer/msa_ops/cute_dsl/sparse_decode_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/sparse_decode_sm12x.py
@@ -349,7 +349,7 @@ class SparseDecodeForwardSm12x:
                     1024,
                 ]
 
-            smem = cutlass.utils.SmemAllocator()
+            smem = cutlass.memory.SmemAllocator()
             storage = smem.allocate(SharedStorage)
             sK_all = storage.sK.get_tensor(sKV_all_layout)
             sV_all = storage.sV.get_tensor(sKV_all_layout)
@@ -908,7 +908,7 @@ class SparseDecodeForwardSm12x:
                 1024,
             ]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         sK = storage.sK.get_tensor(sKV_layout)
         sV = storage.sV.get_tensor(sKV_layout)
@@ -1335,7 +1335,7 @@ class SparseCombineSm12x:
             s_lse: cute.struct.MemRange[cutlass.Float32, self._topk]
             s_lse_t: cute.struct.MemRange[cutlass.Float32, lse_t_slots]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(SharedStorage)
         s_lse = storage.s_lse.get_tensor(cute.make_layout(self._topk))
         s_lse_t = storage.s_lse_t.get_tensor(cute.make_layout(lse_t_slots))

--- a/flashinfer/msa_ops/cute_dsl/sparse_prefill_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/sparse_prefill_sm12x.py
@@ -410,7 +410,7 @@ class SparsePrefillSm12x:
             tile_first = q_tile * tpt
             q_off = mQOffset[batch_idx]
 
-            smem = cutlass.utils.SmemAllocator()
+            smem = cutlass.memory.SmemAllocator()
             storage = smem.allocate(SharedStorage)
             sK = storage.sK.get_tensor(self._make_skv_layout())
             sV = storage.sV.get_tensor(self._make_skv_layout())

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -139,7 +139,7 @@ class TopKSelectChunkedSm12x:
         class SharedStorage:
             score: cute.struct.MemRange[cutlass.Uint32, _MAX_CHUNK_BLOCKS]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         st = smem.allocate(SharedStorage)
         score = st.score.get_tensor(cute.make_layout(_MAX_CHUNK_BLOCKS))
 
@@ -221,7 +221,7 @@ class TopKSelectChunkedSm12x:
         class SharedStorage:
             score: cute.struct.MemRange[cutlass.Uint32, _MAX_CHUNK_BLOCKS * _QTILE]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         st = smem.allocate(SharedStorage)
         score = st.score.get_tensor(cute.make_layout(_MAX_CHUNK_BLOCKS * _QTILE))
 
@@ -308,7 +308,7 @@ class TopKSelectChunkedSm12x:
             idx: cute.struct.MemRange[cutlass.Int32, _MAX_CHUNKS * 16]
             sel: cute.struct.MemRange[cutlass.Int32, 16]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         st = smem.allocate(SharedStorage)
         key = st.key.get_tensor(cute.make_layout(_MAX_CHUNKS * 16))
         idx = st.idx.get_tensor(cute.make_layout(_MAX_CHUNKS * 16))

--- a/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
@@ -85,7 +85,7 @@ class TopKSelectCountRankSm12x:
             sel: cute.struct.MemRange[cutlass.Int32, 16]
             cnt: cute.struct.MemRange[cutlass.Int32, 1]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         st = smem.allocate(SharedStorage)
         score = st.score.get_tensor(cute.make_layout(_MAX_BLOCKS))
         sel = st.sel.get_tensor(cute.make_layout(16))

--- a/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
@@ -118,7 +118,7 @@ class TopKSelectRadixSm12x:
             scal: cute.struct.MemRange[cutlass.Int32, 8]
             pat: cute.struct.MemRange[cutlass.Uint32, 1]
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         st = smem.allocate(SharedStorage)
         hist = st.hist.get_tensor(cute.make_layout(_NUM_BINS))
         grpsum = st.grpsum.get_tensor(cute.make_layout(_NUM_BINS // _GROUP))

--- a/flashinfer/norm/kernels/fused_add_rmsnorm.py
+++ b/flashinfer/norm/kernels/fused_add_rmsnorm.py
@@ -248,7 +248,7 @@ class FusedAddRMSNormKernel:
             cluster_y = cutlass.const_expr(0)
 
         # ===== Allocate shared memory =====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         if cutlass.const_expr(self.use_async_copy):
             sX = smem.allocate_tensor(
@@ -570,7 +570,7 @@ class FusedAddRMSNormQuantKernel:
         inv_scale = rcp_approx_ftz(mS[0])
 
         # ===== Allocate shared memory =====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         if cutlass.const_expr(self.use_async_copy):
             sX = smem.allocate_tensor(

--- a/flashinfer/norm/kernels/fused_add_rmsnorm.py
+++ b/flashinfer/norm/kernels/fused_add_rmsnorm.py
@@ -248,7 +248,7 @@ class FusedAddRMSNormKernel:
             cluster_y = cutlass.const_expr(0)
 
         # ===== Allocate shared memory =====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         if cutlass.const_expr(self.use_async_copy):
             sX = smem.allocate_tensor(
@@ -571,7 +571,7 @@ class FusedAddRMSNormQuantKernel:
         inv_scale = rcp_approx_ftz(mS[0])
 
         # ===== Allocate shared memory =====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         if cutlass.const_expr(self.use_async_copy):
             sX = smem.allocate_tensor(

--- a/flashinfer/norm/kernels/layernorm.py
+++ b/flashinfer/norm/kernels/layernorm.py
@@ -143,7 +143,7 @@ class LayerNormKernel:
         num_vec_blocks = self.num_vec_blocks
         copy_bits = self.copy_bits
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         # Two reduction buffers: one for sum, one for variance
         reduction_buffer_sum = smem.allocate_tensor(

--- a/flashinfer/norm/kernels/rmsnorm.py
+++ b/flashinfer/norm/kernels/rmsnorm.py
@@ -264,7 +264,7 @@ class RMSNormKernel:
             cluster_y = cutlass.const_expr(0)
 
         # ===== Allocate shared memory =====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         if cutlass.const_expr(self.use_async_copy):
             sX = smem.allocate_tensor(
@@ -543,7 +543,7 @@ class QKRMSNormKernel:
         row_in_bounds = actual_row < M
 
         # ===== Allocate shared memory =====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         if cutlass.const_expr(self.use_async_copy):
             sX = smem.allocate_tensor(
@@ -823,7 +823,7 @@ class RMSNormQuantKernel:
         inv_scale = rcp_approx_ftz(mS[0])
 
         # ===== Allocate shared memory =====
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
 
         if cutlass.const_expr(self.use_async_copy):
             sX = smem.allocate_tensor(

--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -714,7 +714,7 @@ class NVFP4QuantizePerTokenKernel:
         if cutlass.const_expr(self.enable_pdl):
             cute.arch.griddepcontrol_wait()
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         reduction_buffer = smem.allocate_tensor(
             Float32,
             cute.make_layout((1, _PER_TOKEN_WARPS)),
@@ -1097,7 +1097,7 @@ class NVFP4QuantizeTMAKernel:
         elems_per_stage = self.elems_per_stage
 
         # ---- SMEM allocation ----
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         load_mbar_ptr = storage.load_full_mbar.data_ptr()

--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -817,7 +817,7 @@ class NVFP4QuantizePerTokenKernel:
         if cutlass.const_expr(self.enable_pdl):
             cute.arch.griddepcontrol_wait()
 
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         reduction_buffer = smem.allocate_tensor(
             Float32,
             cute.make_layout((1, _PER_TOKEN_WARPS)),
@@ -1231,7 +1231,7 @@ class NVFP4QuantizeTMAKernel:
         elems_per_stage = self.elems_per_stage
 
         # ---- SMEM allocation ----
-        smem = cutlass.utils.SmemAllocator()
+        smem = cutlass.memory.SmemAllocator()
         storage = smem.allocate(self.shared_storage)
 
         load_mbar_ptr = storage.load_full_mbar.data_ptr()

--- a/flashinfer/topk_varlen/kernels/block_scan.py
+++ b/flashinfer/topk_varlen/kernels/block_scan.py
@@ -18,7 +18,7 @@ import cutlass
 import cutlass.cute as cute
 from cutlass._mlir.dialects import llvm
 from cutlass.cute.runtime import from_dlpack
-from cutlass.utils.smem_allocator import SmemAllocator
+from cutlass.memory import SmemAllocator
 
 """
 block prefix sum kernel (input is loading from shared memory) in CuTe DSL.

--- a/flashinfer/topk_varlen/kernels/gvr_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr_topk_decode.py
@@ -34,7 +34,7 @@ import cutlass.cute as cute
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import T, dsl_user_op
 from cutlass.utils.distributed import atomicAdd
-from cutlass.utils.smem_allocator import SmemAllocator
+from cutlass.memory import SmemAllocator
 
 from cutlass.cute.arch import griddepcontrol_launch_dependents, griddepcontrol_wait
 from .block_scan import warp_scan

--- a/flashinfer/topk_varlen/kernels/gvr_topk_decode_lb.py
+++ b/flashinfer/topk_varlen/kernels/gvr_topk_decode_lb.py
@@ -33,7 +33,7 @@ from typing import Optional
 
 import cutlass
 import cutlass.cute as cute
-from cutlass.utils.smem_allocator import SmemAllocator
+from cutlass.memory import SmemAllocator
 
 from .block_scan import block_prefix_sum_kernel
 from .gvr_topk_decode import GvrTopKKernel

--- a/flashinfer/topk_varlen/kernels/radix_topk.py
+++ b/flashinfer/topk_varlen/kernels/radix_topk.py
@@ -25,7 +25,7 @@ from cutlass.cute.typing import Int32 as CuteInt32
 from cutlass.cute.typing import Pointer as CutePointer
 from cutlass.cutlass_dsl import dsl_user_op
 from cutlass.utils.distributed import atomicAdd
-from cutlass.utils.smem_allocator import SmemAllocator
+from cutlass.memory import SmemAllocator
 
 from .block_scan import block_prefix_sum_kernel
 from cutlass.cute.arch import griddepcontrol_launch_dependents, griddepcontrol_wait

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -35,7 +35,6 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import BFloat16, Float16, Float8E4M3FN, Int32
 from cutlass.cute.runtime import make_ptr
-from cutlass import utils as cutlass_utils
 from cutlass.experimental.task_scheduling.memory import SmemAllocation
 
 from flashinfer.attention.prims_ts import (
@@ -2022,7 +2021,7 @@ def _assert_decode_smem_within_capacity(cfg, smem_allocator) -> None:
         + smem_allocator.barrier_smem_bytes
     )
     launch_smem_bytes = _align_up(unified_smem_bytes, cfg.stensor_align)
-    assert launch_smem_bytes <= cutlass_utils.get_smem_capacity_in_bytes("sm_100")
+    assert launch_smem_bytes <= cutlass.memory.get_smem_capacity_in_bytes("sm_100")
 
 
 @pytest.mark.parametrize("page_size", (16, 32, 64, 128))


### PR DESCRIPTION
Memory allocators and capacity queries:

- cutlass.utils.SmemAllocator -> cutlass.memory.SmemAllocator
- cutlass.utils.SmemPartition -> cutlass.memory.SmemPartition
- cutlass.utils.TmemAllocator -> cutlass.memory.TmemAllocator
- cutlass.utils.TmemBufferPool -> cutlass.memory.TmemBufferPool
- cutlass.utils.VirtualMemoryManager -> cutlass.memory.VirtualMemoryManager
- cutlass.utils.get_smem_capacity_in_bytes -> cutlass.memory.get_smem_capacity_in_bytes
- cutlass.utils.get_kernel_smem_size -> cutlass.memory.get_kernel_smem_size
- cutlass.utils.get_num_tmem_alloc_cols -> cutlass.memory.get_num_tmem_alloc_cols
- cutlass.utils.compute_tmem_cols_from_layout -> cutlass.memory.compute_tmem_cols_from_layout

Tensor description utilities:

- cutlass.utils.LayoutEnum -> cutlass.tensor_utils.LayoutEnum
- cutlass.utils.TensorMapManager -> cutlass.tensor_utils.TensorMapManager
- cutlass.utils.TensorMapUpdateMode -> cutlass.tensor_utils.TensorMapUpdateMode

Block copy:

- cutlass.utils.block_copy -> cutlass.block.block_copy

Layout visualization:

- cutlass.utils.print_latex -> cutlass.cute.viz.print_latex
- cutlass.utils.print_latex_tv -> cutlass.cute.viz.print_latex_tv
- cutlass.utils.PALETTES / Band / tikz_* -> cutlass.cute.viz.*

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->
