### PR TITLE
Add BF16 weight preparation and unified fuzzer coverage

### DIFF
--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -527,10 +527,12 @@ class MoEConfig:
 
 @dataclass
 class MoEActivationPack:
-    """Per-call transient data — pre-quantized NVFP4 activations + pre-routed indices."""
+    """Per-call transient data — activations (backend-native encoding) + pre-routed indices."""
 
-    hidden_states_q: Tensor  # [M, H//2] uint8 (packed NVFP4)
-    hidden_states_scale: Tensor  # [M, H//16] float8_e4m3fn
+    hidden_states_q: Tensor  # [M, H//2] uint8 (packed NVFP4) or [M, H] bf16 (BF16 path)
+    hidden_states_scale: Optional[
+        Tensor
+    ]  # [M, H//16] float8_e4m3fn block scales; None for BF16
     selected_experts: Tensor  # [M, top_k] int32
     final_scales: Tensor  # [M, top_k] float32
 

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -298,6 +298,34 @@ class TrtllmBf16Config:
     def supported(cls, arch: int) -> bool:
         return arch >= 100
 
+    @staticmethod
+    def prepare_weights(
+        w1_bf16,
+        w2_bf16,
+        *,
+        num_local_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        device=None,
+        permute_cache=None,
+    ):
+        """Build the ``trtllm_bf16_routed`` weight view from canonical bf16 weights.
+
+        Register the result with ``MoEWeightPack.prepare_for("trtllm_bf16_routed", ...)``.
+        See :func:`flashinfer.fused_moe.prepare.prepare_trtllm_bf16_weights`.
+        """
+        from .prepare import prepare_trtllm_bf16_weights
+
+        return prepare_trtllm_bf16_weights(
+            w1_bf16,
+            w2_bf16,
+            num_local_experts=num_local_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            device=device,
+            permute_cache=permute_cache,
+        )
+
     def __repr__(self) -> str:
         return "TrtllmBf16Config()"
 

--- a/flashinfer/fused_moe/prepare.py
+++ b/flashinfer/fused_moe/prepare.py
@@ -223,14 +223,25 @@ def prepare_trtllm_bf16_weights(
 
     if device is None:
         device = w1_bf16.device
-    # Honor the documented device target (no-op if already resident).
-    w1_bf16 = w1_bf16.to(device)
-    w2_bf16 = w2_bf16.to(device)
+    if w1_bf16.dtype != torch.bfloat16 or w2_bf16.dtype != torch.bfloat16:
+        raise ValueError(
+            f"prepare_trtllm_bf16_weights expects bf16 weights, got "
+            f"w1={w1_bf16.dtype}, w2={w2_bf16.dtype} (the uint8 byte-view below "
+            f"would silently reinterpret other dtypes)"
+        )
+    expect_w1 = (num_local_experts, 2 * intermediate_size, hidden_size)
+    expect_w2 = (num_local_experts, hidden_size, intermediate_size)
+    if tuple(w1_bf16.shape) != expect_w1 or tuple(w2_bf16.shape) != expect_w2:
+        raise ValueError(
+            f"weight shapes {tuple(w1_bf16.shape)}/{tuple(w2_bf16.shape)} != "
+            f"expected {expect_w1}/{expect_w2}"
+        )
+    # Honor the documented device target (no-op if already resident); contiguity
+    # is required for the uint8 view below.
+    w1_bf16 = w1_bf16.to(device).contiguous()
+    w2_bf16 = w2_bf16.to(device).contiguous()
     if permute_cache is None:
         permute_cache = _TRTLLM_PERMUTE_CACHE
-
-    assert w1_bf16.shape == (num_local_experts, 2 * intermediate_size, hidden_size)
-    assert w2_bf16.shape == (num_local_experts, hidden_size, intermediate_size)
 
     epilogue_tile_m = 128  # TRTLLM kernel-internal constant
     block_k = 128

--- a/flashinfer/fused_moe/prepare.py
+++ b/flashinfer/fused_moe/prepare.py
@@ -1,4 +1,4 @@
-"""First-class NVFP4 weight-preparation helpers for the unified MoE API.
+"""First-class weight-preparation helpers for the unified MoE API.
 
 Copyright (c) 2026 by FlashInfer team.
 
@@ -21,7 +21,8 @@ implementation surface rather than being copy-pasted into tests and benchmarks
 (design doc CR2/CR7; reviewer comments C6, C7, C31, C32).
 
 They are exposed as ``TrtllmFp4Config.prepare_weights(...)`` /
-``CuteDslConfig.prepare_weights(...)`` static helpers (see ``api.py``).
+``CuteDslConfig.prepare_weights(...)`` / ``TrtllmBf16Config.prepare_weights(...)``
+static helpers (see ``api.py``).
 """
 
 from __future__ import annotations
@@ -171,6 +172,88 @@ def prepare_trtllm_fp4_weights(
         "output1_scale_scalar": ones,
         "output1_scale_gate_scalar": ones,
         "output2_scale_scalar": ones,
+    }
+
+
+def prepare_trtllm_bf16_weights(
+    w1_bf16: torch.Tensor,
+    w2_bf16: torch.Tensor,
+    *,
+    num_local_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    device: Optional[torch.device] = None,
+    permute_cache: Optional[dict] = None,
+) -> Dict[str, torch.Tensor]:
+    """Build the TRTLLM BF16 ``trtllm_bf16_routed`` weight view.
+
+    Layout is ``BlockMajorK`` — the only layout the bf16 trtllm-gen entry points
+    accept: per-expert fused-gated-activation row reorder chained with the
+    ``epilogue_tile_m=128`` MMA shuffle for gemm1 (the w3_w1 permute), plain
+    shuffle for gemm2, then ``block_k=128`` K-blocking on the uint8 view.  No
+    quantization — weights stay bf16.  The gated-act reorder on gemm1 is
+    required for SwiGLU: the kernel pairs gate/linear rows interleaved, and a
+    shuffle-only layout mis-pairs them (systematically wrong output that still
+    passes kernel-vs-same-kernel parity checks).
+
+    Parameters
+    ----------
+    w1_bf16 : Tensor
+        Gate+up expert weights ``[num_local_experts, 2*intermediate_size, hidden_size]``.
+    w2_bf16 : Tensor
+        Down-projection expert weights ``[num_local_experts, hidden_size, intermediate_size]``.
+    num_local_experts, hidden_size, intermediate_size : int
+        Expert geometry.
+    device : torch.device, optional
+        Target device; defaults to ``w1_bf16.device``.
+    permute_cache : dict, optional
+        Shape-keyed permute-index cache; defaults to a module-level cache.
+
+    Returns
+    -------
+    dict
+        Keys expected by ``TrtllmBf16RoutedRunner.pack_inputs``:
+        ``gemm1_weights``, ``gemm2_weights`` (both bf16, BlockMajorK).
+    """
+    from .core import (
+        _maybe_get_cached_w3_w1_permute_indices,
+        convert_to_block_layout,
+        get_w2_permute_indices_with_cache,
+    )
+
+    if device is None:
+        device = w1_bf16.device
+    # Honor the documented device target (no-op if already resident).
+    w1_bf16 = w1_bf16.to(device)
+    w2_bf16 = w2_bf16.to(device)
+    if permute_cache is None:
+        permute_cache = _TRTLLM_PERMUTE_CACHE
+
+    assert w1_bf16.shape == (num_local_experts, 2 * intermediate_size, hidden_size)
+    assert w2_bf16.shape == (num_local_experts, hidden_size, intermediate_size)
+
+    epilogue_tile_m = 128  # TRTLLM kernel-internal constant
+    block_k = 128
+
+    w1_views, w2_views = [], []
+    for i in range(num_local_experts):
+        w1_u8 = w1_bf16[i].view(torch.uint8)
+        p1 = _maybe_get_cached_w3_w1_permute_indices(
+            permute_cache, w1_u8, epilogue_tile_m, is_gated_act_gemm=True
+        )
+        w1_views.append(
+            convert_to_block_layout(w1_u8[p1.to(device)].contiguous(), block_k)
+        )
+
+        w2_u8 = w2_bf16[i].view(torch.uint8)
+        p2 = get_w2_permute_indices_with_cache(permute_cache, w2_u8, epilogue_tile_m)
+        w2_views.append(
+            convert_to_block_layout(w2_u8[p2.to(device)].contiguous(), block_k)
+        )
+
+    return {
+        "gemm1_weights": torch.stack(w1_views).view(torch.bfloat16),
+        "gemm2_weights": torch.stack(w2_views).view(torch.bfloat16),
     }
 
 

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -1296,3 +1296,60 @@ class TestTrtllmEPOffset:
             f"offset={local_expert_offset}: EP-shard output diverges from the "
             f"offset-0 baseline ({pct * 100:.2f}% within tolerance, atol={atol:.4f})"
         )
+
+
+# ---------------------------------------------------------------------------
+# 6. prepare_trtllm_bf16_weights input contract
+# ---------------------------------------------------------------------------
+# Validation fires before any CUDA work, so the negative tests are CPU-only.
+
+
+class TestPrepareTrtllmBf16Weights:
+    _E, _I, _H = 2, 64, 128
+
+    def _weights(self, dtype=torch.bfloat16):
+        E, I, H = self._E, self._I, self._H
+        return (
+            torch.randn(E, 2 * I, H).to(dtype),
+            torch.randn(E, H, I).to(dtype),
+        )
+
+    def _prepare(self, w1, w2, **overrides):
+        kwargs = dict(
+            num_local_experts=self._E,
+            hidden_size=self._H,
+            intermediate_size=self._I,
+        )
+        kwargs.update(overrides)
+        return TrtllmBf16Config.prepare_weights(w1, w2, **kwargs)
+
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+    def test_rejects_non_bf16_dtype(self, dtype):
+        w1, w2 = self._weights(dtype)
+        with pytest.raises(ValueError, match="bf16"):
+            self._prepare(w1, w2)
+
+    def test_rejects_wrong_shape(self):
+        w1, w2 = self._weights()
+        with pytest.raises(ValueError, match="shape"):
+            self._prepare(w1[:, : self._I], w2)  # missing the gate half of gemm1
+
+    @sm100_required
+    def test_normalizes_noncontiguous_and_cpu_inputs(self):
+        """Non-contiguous and CPU-resident inputs yield the same views as the
+        contiguous on-device call (the .to(device).contiguous() normalization)."""
+        w1, w2 = self._weights()
+        w1, w2 = w1.cuda(), w2.cuda()
+        base = self._prepare(w1, w2)
+
+        # Same values, non-contiguous layout.
+        w1_nc = w1.transpose(1, 2).contiguous().transpose(1, 2)
+        assert not w1_nc.is_contiguous()
+        nc = self._prepare(w1_nc, w2)
+
+        # CPU-resident inputs with an explicit device target.
+        cpu = self._prepare(w1.cpu(), w2.cpu(), device=torch.device("cuda"))
+
+        for view in (nc, cpu):
+            for key in ("gemm1_weights", "gemm2_weights"):
+                assert torch.equal(view[key], base[key])

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -803,6 +803,7 @@ def _bf16_dense_reference(
         tok, nth = torch.where(mask)
         a = x32[tok] @ w1[local_e].float().t()
         inter = F.silu(a[:, intermediate_size:]) * a[:, :intermediate_size]
+        inter = inter.to(torch.bfloat16).float()  # gemm1 output is stored bf16
         out[tok] += final_scales[tok, nth, None].float() * (
             inter @ w2[local_e].float().t()
         )

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -782,47 +782,6 @@ BF16_RTOL = 3e-2
 BF16_ATOL = 3e-2
 
 
-def _bf16_kernel_weight_views(w1: torch.Tensor, w2: torch.Tensor):
-    """BlockMajorK weight views for the trtllm bf16 routed runner (per-expert).
-
-    The authoritative recipe is ``BF16Moe.prepare_static_weights_for_kernel``
-    (tests/moe/trtllm_gen_fused_moe_utils.py) — the only bf16 prep validated
-    against independent dense math: gemm1 rows get the fused-gated-activation
-    reorder chained with the ``epilogue_tile_m=128`` shuffle (the w3_w1
-    permute), gemm2 gets the plain shuffle, then both convert to BlockMajorK
-    (``block_k=128`` on the uint8 view).  Pure layout transform: the dense
-    reference uses the unshuffled weights.  (Do NOT copy the moe_ep /
-    routed-parity recipe of shuffle(64) without the gated reorder — those
-    tests compare kernel-vs-same-kernel, so their layout was never validated
-    against dense math and disagrees with the kernel's gate/linear pairing.)
-    """
-    from flashinfer.fused_moe.core import (
-        _maybe_get_cached_w3_w1_permute_indices,
-        convert_to_block_layout,
-        get_w2_permute_indices_with_cache,
-    )
-
-    epilogue_tile_m = 128
-    block_k = 128
-    cache: dict = {}
-    w1_views, w2_views = [], []
-    for i in range(w1.shape[0]):
-        p1 = _maybe_get_cached_w3_w1_permute_indices(
-            cache, w1[i].view(torch.uint8), epilogue_tile_m
-        )
-        s1 = w1[i].view(torch.uint8)[p1.to(w1.device)].contiguous()
-        p2 = get_w2_permute_indices_with_cache(
-            cache, w2[i].view(torch.uint8), epilogue_tile_m
-        )
-        s2 = w2[i].view(torch.uint8)[p2.to(w2.device)].contiguous()
-        w1_views.append(convert_to_block_layout(s1, block_k))
-        w2_views.append(convert_to_block_layout(s2, block_k))
-    return (
-        torch.stack(w1_views).view(torch.bfloat16),
-        torch.stack(w2_views).view(torch.bfloat16),
-    )
-
-
 def _bf16_dense_reference(
     x, w1, w2, selected_experts, final_scales, intermediate_size, expert_offset=0
 ):
@@ -917,14 +876,17 @@ def _make_bf16_packs_and_config(
         final_scales=final_scales,
     )
 
-    w1_view, w2_view = _bf16_kernel_weight_views(w1, w2)
     weight_pack = MoEWeightPack()
     weight_pack.prepare_for(
         "trtllm_bf16_routed",
-        {
-            "gemm1_weights": w1_view,
-            "gemm2_weights": w2_view,
-        },
+        TrtllmBf16Config.prepare_weights(
+            w1,
+            w2,
+            num_local_experts=local_num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            device=device,
+        ),
     )
 
     config = MoEConfig(

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -710,6 +710,8 @@ def _compute_ref(act_pack, tensors, shape):
         hidden_states=tensors["x_bf16"].float().cuda(),
         gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
         gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+        gemm1_alpha=tensors["w1_alpha"],
+        gemm2_alpha=tensors["w2_alpha"],
         token_selected_experts=act_pack.selected_experts,
         token_final_scales=act_pack.final_scales,
         num_tokens=act_pack.num_tokens,

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -804,9 +804,8 @@ def _bf16_dense_reference(
         a = x32[tok] @ w1[local_e].float().t()
         inter = F.silu(a[:, intermediate_size:]) * a[:, :intermediate_size]
         inter = inter.to(torch.bfloat16).float()  # gemm1 output is stored bf16
-        out[tok] += final_scales[tok, nth, None].float() * (
-            inter @ w2[local_e].float().t()
-        )
+        expert_out = (inter @ w2[local_e].float().t()).to(torch.bfloat16).float()
+        out[tok] += final_scales[tok, nth, None].float() * expert_out
     return out
 
 

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -338,7 +338,7 @@ def _bf16_reference(
 ):
     """Dense bf16 MoE authority: same SwiGLU convention as ``_nvfp4_reference``
     but no fp4 requant -- the only intermediate quantization is the bf16 rounding
-    of the gemm1 output, mirrored below.  Routing weights are cast through bf16
+    of the gemm1 and gemm2 outputs, mirrored below.  Routing weights are cast through bf16
     to match the packed-id truncation in pack_inputs, so the tolerance measures
     kernel error, not oracle mismatch."""
     final_scales = final_scales.to(torch.bfloat16).float()
@@ -352,7 +352,8 @@ def _bf16_reference(
         gate, up = w1[local_e][half:, :].float(), w1[local_e][:half, :].float()
         inter = F.silu(x32[tok] @ gate.t()) * (x32[tok] @ up.t())
         inter = inter.to(torch.bfloat16).float()  # gemm1 output is stored bf16
-        out[tok] += final_scales[tok, nth, None] * (inter @ w2[local_e].float().t())
+        expert_out = (inter @ w2[local_e].float().t()).to(torch.bfloat16).float()
+        out[tok] += final_scales[tok, nth, None] * expert_out
     return out
 
 

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -184,15 +184,6 @@ BASE_SEED = int(os.environ.get("FLASHINFER_UMOE_FUZZ_SEED", "0"))
 # abort is root-caused, this suite is opt-in: set FLASHINFER_UMOE_FUZZ=1
 # to run it (developer / nightly / SM100 box). Unset (CI default) -> collected-and-skipped, so it
 # never launches a kernel and cannot abort the job.
-# DETERMINISTIC REPRO for the accumulated-run fault (2026-07-09, bf16 path): running
-#   [bf16_uniform_e256_k8_t256_h1024_i512_s900005] +
-#   [bf16_imbalanced_e128_k6_t2048_h1024_i1024_s900006] +
-#   [bf16_imbalanced_e160_k6_t129_h1536_i256_s0]      (NUM_TESTS=12)
-# in ONE process hits `CUDA error: an illegal memory access` inside the
-# graph-captured trtllm_bf16_routed autotune-profiling replay of s0; each test
-# passes in isolation, so the failure is order/state-dependent (allocator layout,
-# global autotuner cache, or CUDA process state -- root cause UNRESOLVED).
-# CUDA_LAUNCH_BLOCKING cannot localize it (graph replays ignore it).
 pytestmark = pytest.mark.skipif(
     not os.environ.get("FLASHINFER_UMOE_FUZZ"),
     reason="opt-in fuzzer (set FLASHINFER_UMOE_FUZZ=1); waived in CI pending "

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -162,6 +162,7 @@ from flashinfer.fused_moe.api import (
     QuantConfig,
     QuantVariant,
     RoutingConfig,
+    TrtllmBf16Config,
     TrtllmFp4Config,
 )
 from flashinfer.fused_moe.layer import _BACKEND_RUNNERS
@@ -183,6 +184,15 @@ BASE_SEED = int(os.environ.get("FLASHINFER_UMOE_FUZZ_SEED", "0"))
 # abort is root-caused, this suite is opt-in: set FLASHINFER_UMOE_FUZZ=1
 # to run it (developer / nightly / SM100 box). Unset (CI default) -> collected-and-skipped, so it
 # never launches a kernel and cannot abort the job.
+# DETERMINISTIC REPRO for the accumulated-run fault (2026-07-09, bf16 path): running
+#   [bf16_uniform_e256_k8_t256_h1024_i512_s900005] +
+#   [bf16_imbalanced_e128_k6_t2048_h1024_i1024_s900006] +
+#   [bf16_imbalanced_e160_k6_t129_h1536_i256_s0]      (NUM_TESTS=12)
+# in ONE process hits `CUDA error: an illegal memory access` inside the
+# graph-captured trtllm_bf16_routed autotune-profiling replay of s0; each test
+# passes in isolation, so the OOB access is allocator-layout-dependent (a latent
+# kernel/launcher bug, not a harness artifact). CUDA_LAUNCH_BLOCKING cannot
+# localize it (graph replays ignore it).
 pytestmark = pytest.mark.skipif(
     not os.environ.get("FLASHINFER_UMOE_FUZZ"),
     reason="opt-in fuzzer (set FLASHINFER_UMOE_FUZZ=1); waived in CI pending "
@@ -195,6 +205,7 @@ pytestmark = pytest.mark.skipif(
 _DETERMINISTIC = {
     "trtllm_fp4_routed": True,  # bitwise-stable across reruns in calibration
     "cute_dsl_nvfp4": False,  # atomic scatter-add finalize -> non-bit-exact by design
+    "trtllm_bf16_routed": True,  # same trtllm-gen finalize path as fp4_routed; bitwise-stable in calibration
 }
 
 # Known-bug ledger: (backend_key, predicate(cfg)) -> reason. A matching (backend, config) is run but
@@ -255,7 +266,7 @@ class DTypeHandler:
     rtol: float
 
 
-def _nvfp4_poison(buf):
+def _poison_bf16_out(buf):
     """Fill a bf16 output buffer with large garbage + scattered NaN/±Inf. If a kernel reads or
     scatter-adds into an uninitialized output instead of fully writing it, the poison leaks and
     is caught by no-NaN / numeric. This is the torch->JAX buffer-hygiene guard: torch's caching
@@ -306,6 +317,42 @@ def _nvfp4_reference(
     return out
 
 
+def _bf16_snap(t: torch.Tensor) -> torch.Tensor:
+    # bf16 IS the storage grid: the cast is the fixed point (input quant lossless).
+    return t.to(torch.bfloat16)
+
+
+def _bf16_act_pack(x, selected_experts, final_scales):
+    # Raw bf16 activations; the bf16 runner reads hidden_states_q directly and
+    # ignores hidden_states_scale.
+    return MoEActivationPack(
+        hidden_states_q=x,
+        hidden_states_scale=None,
+        selected_experts=selected_experts,
+        final_scales=final_scales,
+    )
+
+
+def _bf16_reference(
+    x, w1, w2, selected_experts, final_scales, intermediate_size, expert_offset=0
+):
+    """Dense bf16 MoE authority: same SwiGLU convention as ``_nvfp4_reference``
+    but no fp4 requant -- the only intermediate quantization is the bf16 rounding
+    of the gemm1 output, mirrored below."""
+    x32, half = x.float(), intermediate_size
+    out = torch.zeros_like(x32)
+    for local_e in range(w1.shape[0]):
+        mask = selected_experts == local_e + expert_offset
+        if not mask.any():
+            continue
+        tok, nth = torch.where(mask)
+        gate, up = w1[local_e][half:, :].float(), w1[local_e][:half, :].float()
+        inter = F.silu(x32[tok] @ gate.t()) * (x32[tok] @ up.t())
+        inter = inter.to(torch.bfloat16).float()  # gemm1 output is stored bf16
+        out[tok] += final_scales[tok, nth, None] * (inter @ w2[local_e].float().t())
+    return out
+
+
 _DTYPE = {
     QuantVariant.NVFP4: DTypeHandler(
         variant=QuantVariant.NVFP4,
@@ -313,13 +360,31 @@ _DTYPE = {
         snap=_snap_to_nvfp4,
         make_act_pack=_nvfp4_act_pack,
         reference=_nvfp4_reference,
-        poison=_nvfp4_poison,
+        poison=_poison_bf16_out,
         out_dtype=torch.bfloat16,
         atol_frac=0.15,  # calibrated: obs ratio ≤0.077 (fp4 intermediate-requant floor)
         rtol=0.1,
     ),
-    # FP8 / MXFP4 / MXINT4 / BF16 add one entry each as their runners are wired upstream.
+    QuantVariant.BF16: DTypeHandler(
+        variant=QuantVariant.BF16,
+        candidate_configs=(TrtllmBf16Config,),
+        snap=_bf16_snap,
+        make_act_pack=_bf16_act_pack,
+        reference=_bf16_reference,
+        poison=_poison_bf16_out,
+        out_dtype=torch.bfloat16,
+        atol_frac=0.05,  # initial; calibrate on SM100 (bf16 rounding floor)
+        rtol=0.05,
+    ),
+    # FP8 / MXFP4 / MXINT4 add one entry each as their runners are wired upstream.
 }
+
+# Cfg.variant string <-> handler lookup (labels stay lowercase enum names).
+_VARIANT_IDS = tuple(v.name.lower() for v in _DTYPE)
+
+
+def _handler_for(cfg):
+    return _DTYPE[QuantVariant[cfg.variant.upper()]]
 
 
 # ---------------------------------------------------------------------------
@@ -418,7 +483,7 @@ def _gen(seed):
         top_k=rng.choice(
             [t for t in _TOPK if t <= local]
         ),  # route within the local shard
-        variant="nvfp4",  # only wired variant today; expands with _DTYPE
+        variant=rng.choice(_VARIANT_IDS),
         route=rng.choice(_ROUTE),
         seed=seed,
         local_experts=local,
@@ -441,6 +506,12 @@ _CURATED = [
     Cfg(
         512, 512, 512, 512, 4, "nvfp4", "hot1", 900_004
     ),  # max expert count (small H/I)
+    Cfg(
+        256, 1024, 512, 256, 8, "bf16", "uniform", 900_005
+    ),  # DeepSeek-ish shape on the bf16 path
+    Cfg(
+        2048, 1024, 1024, 128, 6, "bf16", "imbalanced", 900_006
+    ),  # bf16 mid size + empty-expert load
 ]
 _CONFIGS = _CURATED + [_gen(BASE_SEED + i) for i in range(NUM_TESTS)]
 
@@ -508,7 +579,7 @@ def test_unified_moe_fuzz(cfg):
     sm = get_compute_capability(torch.device("cuda:0"))
     sm = sm[0] * 10 + sm[1]
 
-    handler = _DTYPE[QuantVariant.NVFP4]
+    handler = _handler_for(cfg)
     dev = torch.device("cuda")
     # Backend *config classes* whose runner is registered in the live MoELayer registry AND valid
     # on this arch. A newly-wired backend lands here automatically.
@@ -546,7 +617,7 @@ def test_unified_moe_fuzz(cfg):
 
     config = MoEConfig(
         routing=RoutingConfig(num_experts=cfg.num_experts, top_k=cfg.top_k),
-        quant=QuantConfig(variant=QuantVariant.NVFP4),
+        quant=QuantConfig(variant=handler.variant),
         experts=ExpertConfig(
             intermediate_size=cfg.intermediate,
             local_num_experts=cfg.n_local,
@@ -573,12 +644,24 @@ def test_unified_moe_fuzz(cfg):
         if poison:
             # The output buffer is a kernel-owned `new_empty` tensor inside the inputs list
             # (cute_dsl idx 11, trtllm the `output=`); locate it by dtype+shape and poison it.
+            act_ptrs = {
+                t.data_ptr()
+                for t in (
+                    act_pack.hidden_states_q,
+                    act_pack.hidden_states_scale,
+                    act_pack.selected_experts,
+                    act_pack.final_scales,
+                )
+                if torch.is_tensor(t)
+            }
             bufs = [
                 t
                 for t in inputs
                 if torch.is_tensor(t)
                 and t.dtype == handler.out_dtype
                 and tuple(t.shape) == out_shape
+                and t.data_ptr()
+                not in act_ptrs  # bf16 hidden_states aliases dtype+shape
             ]
             assert bufs, "could not locate the output buffer in pack_inputs to poison"
             for b in bufs:
@@ -706,15 +789,16 @@ _CACHE_TOKEN_SEQ = [
 ]  # buckets + boundaries + cache-hit re-runs
 
 
+@pytest.mark.parametrize("variant", list(_DTYPE), ids=[v.name.lower() for v in _DTYPE])
 @pytest.mark.parametrize(
     "base", _CACHE_BASES, ids=[f"e{e}h{h}i{i}" for e, h, i in _CACHE_BASES]
 )
-def test_autotune_cache_coherence(base):
+def test_autotune_cache_coherence(base, variant):
     if not torch.cuda.is_available():
         pytest.skip("no CUDA")
     sm = get_compute_capability(torch.device("cuda:0"))
     sm = sm[0] * 10 + sm[1]
-    handler = _DTYPE[QuantVariant.NVFP4]
+    handler = _DTYPE[variant]
     dev = torch.device("cuda")
     wired = [
         B
@@ -752,7 +836,7 @@ def test_autotune_cache_coherence(base):
     layer = MoELayer(
         MoEConfig(
             routing=RoutingConfig(num_experts=E, top_k=top_k),
-            quant=QuantConfig(variant=QuantVariant.NVFP4),
+            quant=QuantConfig(variant=variant),
             experts=ExpertConfig(intermediate_size=I, local_num_experts=E),
             activation=ActivationConfig(),
             backend=BackendOptions(candidates=tuple(B() for B in wired)),

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -190,9 +190,9 @@ BASE_SEED = int(os.environ.get("FLASHINFER_UMOE_FUZZ_SEED", "0"))
 #   [bf16_imbalanced_e160_k6_t129_h1536_i256_s0]      (NUM_TESTS=12)
 # in ONE process hits `CUDA error: an illegal memory access` inside the
 # graph-captured trtllm_bf16_routed autotune-profiling replay of s0; each test
-# passes in isolation, so the OOB access is allocator-layout-dependent (a latent
-# kernel/launcher bug, not a harness artifact). CUDA_LAUNCH_BLOCKING cannot
-# localize it (graph replays ignore it).
+# passes in isolation, so the failure is order/state-dependent (allocator layout,
+# global autotuner cache, or CUDA process state -- root cause UNRESOLVED).
+# CUDA_LAUNCH_BLOCKING cannot localize it (graph replays ignore it).
 pytestmark = pytest.mark.skipif(
     not os.environ.get("FLASHINFER_UMOE_FUZZ"),
     reason="opt-in fuzzer (set FLASHINFER_UMOE_FUZZ=1); waived in CI pending "
@@ -338,7 +338,10 @@ def _bf16_reference(
 ):
     """Dense bf16 MoE authority: same SwiGLU convention as ``_nvfp4_reference``
     but no fp4 requant -- the only intermediate quantization is the bf16 rounding
-    of the gemm1 output, mirrored below."""
+    of the gemm1 output, mirrored below.  Routing weights are cast through bf16
+    to match the packed-id truncation in pack_inputs, so the tolerance measures
+    kernel error, not oracle mismatch."""
+    final_scales = final_scales.to(torch.bfloat16).float()
     x32, half = x.float(), intermediate_size
     out = torch.zeros_like(x32)
     for local_e in range(w1.shape[0]):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Follow-up to #3867.

This PR adds first-class BF16 weight preparation and extends the unified MoE fuzzer to cover the BF16 routed runner.

- **`TrtllmBf16Config.prepare_weights`**: adds a reusable library helper for converting canonical BF16 expert weights into the `BlockMajorK` layout required by `trtllm_bf16_routed`.
  - Validates BF16 dtype and GEMM1/GEMM2 shapes.
  - Normalizes CPU/non-contiguous inputs to the requested device and contiguous layout.
  - Applies the gated-activation row reorder and `epilogue_tile_m=128` shuffle for GEMM1, the corresponding GEMM2 shuffle, and `block_k=128` conversion.

- **BF16 unified fuzzer support**:
  - Adds a BF16 `DTypeHandler`.
  - Selects variants from the `_DTYPE` registry instead of hardcoding NVFP4.
  - Adds curated BF16 configurations.
  - Parametrizes the autotune cache-coherence test by variant.
  - Runs BF16 through the existing numerical, determinism, poisoned-output, valid-tactic, autotune, and device-state checks.

- **BF16 reference accuracy**:
  - Rounds canonical weights and routing weights through BF16.
  - Rounds GEMM1 activation output to BF16 before GEMM2.
  - Rounds GEMM2 output to BF16 before finalize.
  - This mirrors the kernel’s storage points so tolerances measure kernel error rather than oracle mismatch.

- **`MoEActivationPack` contract**:
  - Makes `hidden_states_scale` optional.
  - NVFP4 continues to provide block scales.
  - BF16 carries raw activations in `hidden_states_q` with `hidden_states_scale=None`.

### Tests added

`tests/moe/test_unified_moe.py` adds coverage for the new weight-preparation API:

- rejects non-BF16 inputs;
- rejects invalid GEMM1/GEMM2 shapes;
- accepts CPU and non-contiguous inputs;
- verifies normalized inputs produce the same prepared views as contiguous on-device inputs;
- updates the existing BF16 conformance tests to use `TrtllmBf16Config.prepare_weights`.

`tests/moe/test_unified_moe_fuzz.py` adds:

- BF16 randomized configurations;
- two curated BF16 configurations;
- BF16 numerical comparison against the BF16-aware dense reference;
- BF16 determinism, poisoned-output, tactic-sweep, autotune, and device-state checks;
- BF16 autotune cache-coherence coverage.

### Known issue

The unified fuzzer remains opt-in with `FLASHINFER_UMOE_FUZZ=1`.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Ran formatting and lint checks.
- [x] Added tests for the new BF16 weight-preparation contract.
- [x] Added BF16 unified-fuzzer and cache-coherence coverage.

## 🧪 Tests

SM100, at this PR’s head:

```text
pytest tests/moe/test_unified_moe.py -k bf16 -q
17 passed

FLASHINFER_UMOE_FUZZ=1 \
pytest tests/moe/test_unified_moe_fuzz.py -k "s900005 or s900006" -q
2 passed

FLASHINFER_UMOE_FUZZ=1 \
pytest tests/moe/test_unified_moe_fuzz.py -k "coherence and bf16" -q
2 passed
```

## Reviewer Notes

BF16 fuzz tolerances are currently as the following, they should be recalibrated if future kernel changes alter the numerical floor:
```
atol_frac = 0.05
rtol = 0.05
```

Added missing `gemm1_alpha` and `gemm2_alpha` params introduced in PR #3645.