### PR TITLE
docs: add fused_moe LoRA delta APIs to rst

### DIFF
--- a/docs/api/fused_moe.rst
+++ b/docs/api/fused_moe.rst
@@ -40,6 +40,8 @@ top of a Mixture-of-Experts layer (shrink + expand).
     bgmv_moe
     bgmv_moe_shrink
     bgmv_moe_expand
+    bgmv_moe_gemm1_lora_delta
+    bgmv_moe_gemm2_lora_delta
 
 CUTLASS Fused MoE
 -----------------


### PR DESCRIPTION
Adds the missing `flashinfer.fused_moe` LoRA delta APIs to `docs/api/fused_moe.rst` so the documentation coverage check includes them.

Fixes the 4 new documentation issues reported by the nightly doc check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation entries for two Multi-LoRA MoE BGMV kernel operations.
  * These operations are now included in the public `flashinfer.fused_moe` API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->