### PR TITLE
docs: cover remaining @flashinfer_api symbols missing from rst

### DIFF
--- a/docs/api/concat_ops.rst
+++ b/docs/api/concat_ops.rst
@@ -3,11 +3,11 @@
 flashinfer.concat_ops
 =====================
 
+.. currentmodule:: flashinfer.concat_ops
+
 Helpers that concatenate / pack tensors for MLA-style attention layouts.
 ``flashinfer.dsv3_ops`` re-exports :func:`concat_mla_k` for DeepSeek-V3 call
 sites.
-
-.. currentmodule:: flashinfer.concat_ops
 
 .. autosummary::
     :toctree: ../generated

--- a/docs/api/concat_ops.rst
+++ b/docs/api/concat_ops.rst
@@ -1,0 +1,15 @@
+.. _apiconcat_ops:
+
+flashinfer.concat_ops
+=====================
+
+Helpers that concatenate / pack tensors for MLA-style attention layouts.
+``flashinfer.dsv3_ops`` re-exports :func:`concat_mla_k` for DeepSeek-V3 call
+sites.
+
+.. currentmodule:: flashinfer.concat_ops
+
+.. autosummary::
+    :toctree: ../generated
+
+    concat_mla_k

--- a/docs/api/cute_dsl.rst
+++ b/docs/api/cute_dsl.rst
@@ -63,3 +63,16 @@ CuTe-DSL implementations of the batch attention wrappers.
     :members:
 
     .. automethod:: __init__
+
+Block Sparse Attention
+----------------------
+
+CuTe-DSL block-sparse attention forward kernels.
+
+.. currentmodule:: flashinfer.cute_dsl.sparse
+
+.. autosummary::
+    :toctree: ../generated
+
+    bsa_attn_fwd
+    bsa_attn_blk64_fwd

--- a/docs/api/fused_moe.rst
+++ b/docs/api/fused_moe.rst
@@ -16,6 +16,18 @@ Types and Enums
     RoutingMethodType
     WeightLayout
 
+Shared activation helpers live in :mod:`flashinfer.tllm_enums` and are used by
+both the TRT-LLM and CuteDSL MoE paths.
+
+.. currentmodule:: flashinfer.tllm_enums
+
+.. autosummary::
+    :toctree: ../generated
+
+    is_gated_activation
+
+.. currentmodule:: flashinfer.fused_moe
+
 Utility Functions
 -----------------
 

--- a/docs/api/gemm.rst
+++ b/docs/api/gemm.rst
@@ -57,6 +57,18 @@ FP8 GEMM
     batch_deepgemm_fp8_nt_groupwise
     fp8_blockscale_gemm_sm90
 
+Low-latency TRT-LLM FP8 GEMM weight prep (also exported from ``flashinfer``):
+
+.. currentmodule:: flashinfer.trtllm_low_latency_gemm
+
+.. autosummary::
+    :toctree: ../generated
+
+    prepare_low_latency_gemm_weights
+
+.. currentmodule:: flashinfer.gemm
+
+
 Mixed Precision GEMM (fp8 x fp4)
 --------------------------------
 

--- a/docs/api/kda_decode.rst
+++ b/docs/api/kda_decode.rst
@@ -1,0 +1,14 @@
+.. _apikda_decode:
+
+flashinfer.kda_decode
+=====================
+
+Key-Driven Attention (KDA) decode API. The CuTe-DSL kernel lives under
+``flashinfer.kda_kernels``; this module is the public entry point.
+
+.. currentmodule:: flashinfer.kda_decode
+
+.. autosummary::
+    :toctree: ../generated
+
+    recurrent_kda

--- a/docs/api/mhc.rst
+++ b/docs/api/mhc.rst
@@ -1,0 +1,16 @@
+.. _apimhc:
+
+flashinfer.mhc
+==============
+
+Multi-head residual Combination (mHC) kernels used by Agentic-style residual
+mixing with a fixed ``HC=4`` sub-head layout.
+
+.. currentmodule:: flashinfer.mhc
+
+.. autosummary::
+    :toctree: ../generated
+
+    mhc_post
+    mhc_pre_big_fuse
+    mhc_pre_big_fuse_with_prenorm

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    api/pod
    api/cudnn
    api/cute_dsl
+   api/concat_ops
    api/page
    api/sampling
    api/topk
@@ -52,7 +53,9 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    api/activation
    api/gdn_decode
    api/gdn_prefill
+   api/kda_decode
    api/mamba
+   api/mhc
    api/quantization
    api/green_ctx
    api/fp4_quantization

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -1378,14 +1378,11 @@ def _top_k_first_fast_path(
     to the masked full-vocab path (validated TV ~0.01) but far cheaper at small batch.
     """
     # Local import avoids a module-level cycle between sampling and topk.
-    # Import the module (not ``top_k as _radix_top_k``) so doc-checkers that
-    # walk nested ImportFrom aliases do not treat ``_radix_top_k`` as a public
-    # ``@flashinfer_api`` re-export of this module.
-    from . import topk as _topk_mod
+    from .topk import top_k as _radix_top_k
 
     # deterministic=True makes top-k reproducible (its radix deterministic-collect path is
     # stable even at ties). We do not enforce a tie break that requires 128KB smem/block.
-    values, gathered_indices = _topk_mod.top_k(
+    values, gathered_indices = _radix_top_k(
         x, top_k, sorted=True, deterministic=deterministic
     )
     values = values.float()

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -1378,11 +1378,14 @@ def _top_k_first_fast_path(
     to the masked full-vocab path (validated TV ~0.01) but far cheaper at small batch.
     """
     # Local import avoids a module-level cycle between sampling and topk.
-    from .topk import top_k as _radix_top_k
+    # Import the module (not ``top_k as _radix_top_k``) so doc-checkers that
+    # walk nested ImportFrom aliases do not treat ``_radix_top_k`` as a public
+    # ``@flashinfer_api`` re-export of this module.
+    from . import topk as _topk_mod
 
     # deterministic=True makes top-k reproducible (its radix deterministic-collect path is
     # stable even at ties). We do not enforce a tie break that requires 128KB smem/block.
-    values, gathered_indices = _radix_top_k(
+    values, gathered_indices = _topk_mod.top_k(
         x, top_k, sorted=True, deterministic=deterministic
     )
     values = values.float()


### PR DESCRIPTION
## Summary
- Add API reference coverage for the remaining nightly doc-check MISSING symbols not handled by #3911 / #3941: `concat_mla_k`, CuTe-DSL BSA kernels, `mhc_*`, `recurrent_kda`, `is_gated_activation`, and `prepare_low_latency_gemm_weights`.
- Fix a false-positive `flashinfer.sampling._radix_top_k` finding by importing the `topk` module instead of aliasing `top_k as _radix_top_k` inside the sampling fast path.
- Wire new pages (`concat_ops`, `kda_decode`, `mhc`) into `docs/index.rst`.

## Out of scope (covered elsewhere)
- #3911: `hash_topk`, `checkpoint_restore` Parameters, `CLAUDE.md` autotuner path
- #3941: `bgmv_moe_gemm1/2_lora_delta`

## Test plan
- [x] Local MISSING-check simulation: remaining target symbols are present in `docs/api/*.rst` / no longer aliased
- [ ] Nightly / PR doc coverage check should drop the corresponding MISSING entries after merge (alongside #3911/#3941)
- [ ] Spot-check Sphinx API pages build for the new/updated `.rst` files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added API reference pages for tensor concatenation, key-driven attention decoding, and multi-head convolution operations.
  - Expanded documentation for block-sparse attention, gated activations, and low-latency FP8 GEMM weight preparation.
  - Updated the API navigation to include the new reference pages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->