### PR TITLE
Fix the routing inconsistency for num_groups > 1

### DIFF
--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_routing_deepseek.cu
@@ -335,7 +335,7 @@ __global__ void routingMainKernel(KernelParams params) {
 
       float scoreNorm = laneIdx < params.mTopK ? smemScoreSigmoid[expertIdx] : 0.F;
       auto redNorm = cg::reduce(warp, scoreNorm, cg::plus<float>{});
-      auto finalScore = OutputT{scoreNorm * params.mRouteScale / redNorm};
+      auto finalScore = OutputT{scoreNorm * params.mRouteScale / (redNorm + params.mSumEpsilon)};
 
       // write expert idx out already
       auto idxTopK = blockIdx.x * params.mTotalExpertsPerToken + laneIdx;

--- a/csrc/moe_utils_binding.cu
+++ b/csrc/moe_utils_binding.cu
@@ -393,6 +393,7 @@ void moe_sort(
   routingData.mNumExpertGroups = 1;
   routingData.mNumLimitedGroups = 1;
   routingData.mRouteScale = 1.0f;
+  routingData.mSumEpsilon = 1e-20f;
   routingData.mUseRoutingSoftmax = false;
 
   // Run the routing kernel

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -194,6 +194,7 @@ void Runner::run(void* routingLogits, void* routingBias, int32_t numTokens, int3
     routingData.mLocalExpertsStrideLog2 = 0;
     routingData.mNumLocalExperts = localNumExperts;
     routingData.mRouteScale = routedScalingFactor;
+    routingData.mSumEpsilon = 1e-20f;
     routingData.mUseRoutingSoftmax = false;
 
     int32_t const numDevices = (localNumExperts > 0) ? numExperts / localNumExperts : 1;

--- a/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/RoutingKernel.h
@@ -211,6 +211,7 @@ struct Data : public DataBase {
   int32_t mNumLimitedGroups;
 
   float mRouteScale;
+  float mSumEpsilon{0.0f};
   bool mUseRoutingSoftmax;
 };
 
@@ -239,6 +240,7 @@ struct KernelParams
 
   trtllm::dev::IntFastDiv mTopK;
   float mRouteScale = 0.f;
+  float mSumEpsilon = 0.f;
 
   static KernelParams setKernelParams(Data const& data) {
     KernelParams params;
@@ -254,6 +256,7 @@ struct KernelParams
     params.mNumLimitedGroups = data.mNumLimitedGroups;
     params.mTopK = trtllm::dev::IntFastDiv(data.mTopK);
     params.mRouteScale = data.mRouteScale;
+    params.mSumEpsilon = data.mSumEpsilon;
 
     return params;
   }


### PR DESCRIPTION
(For example, this epsilon is in official DSV3.2 inference demo https://github.com/deepseek-ai/DeepSeek-V3.2-Exp, and it's currently applied when num_groups = 1 (GLM 5.x), but not this path. Add it for potential fix for instability when using f32 expert correction bias.