### PR TITLE
perf(jit): drop dead SM12x gencode from SM10x-serving modules

### DIFF
--- a/flashinfer/jit/fused_moe.py
+++ b/flashinfer/jit/fused_moe.py
@@ -86,7 +86,7 @@ def gen_cutlass_fused_moe_sm103_module(use_fast_build: bool = False) -> JitSpec:
     ]
 
     nvcc_flags += current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10, 12]
+        supported_major_versions=[10]
     )
 
     return gen_cutlass_fused_moe_module(nvcc_flags, "103", use_fast_build)
@@ -104,7 +104,7 @@ def gen_cutlass_fused_moe_sm100_module(use_fast_build: bool = False) -> JitSpec:
     ]
 
     nvcc_flags += current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10, 11, 12]
+        supported_major_versions=[10, 11]
     )
 
     return gen_cutlass_fused_moe_module(nvcc_flags, "100", use_fast_build)

--- a/flashinfer/jit/gemm/core.py
+++ b/flashinfer/jit/gemm/core.py
@@ -114,7 +114,7 @@ def gen_gemm_sm100_module_cutlass_fp4() -> JitSpec:
                 write_if_different(dest_path, source)
 
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10, 11, 12]
+        supported_major_versions=[10, 11]
     )
     return gen_jit_spec(
         "fp4_gemm_cutlass",
@@ -182,7 +182,7 @@ def gen_gemm_sm103_module_cutlass_fp4() -> JitSpec:
                 write_if_different(dest_path, source)
 
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10, 11, 12]
+        supported_major_versions=[10, 11]
     )
     return gen_jit_spec(
         "fp4_gemm_cutlass_sm103",
@@ -287,7 +287,7 @@ def gen_gemm_sm100_module_cutlass_fp8() -> JitSpec:
                 write_if_different(dest_path, source)
 
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10, 11, 12]
+        supported_major_versions=[10, 11]
     )
 
     return gen_jit_spec(
@@ -337,7 +337,7 @@ def gen_gemm_sm100_module_cutlass_bf16() -> JitSpec:
                 write_if_different(dest_path, source)
 
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10, 11, 12]
+        supported_major_versions=[10, 11]
     )
 
     return gen_jit_spec(
@@ -523,7 +523,7 @@ def gen_gemm_sm100_module() -> JitSpec:
         write_if_different(dest_path, source)
 
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[10, 11, 12]
+        supported_major_versions=[10, 11]
     )
     return gen_jit_spec(
         "gemm_sm100",

--- a/flashinfer/jit/mamba/selective_state_update.py
+++ b/flashinfer/jit/mamba/selective_state_update.py
@@ -173,7 +173,7 @@ def gen_selective_state_update_module(
     # "No supported CUDA architectures found" instead of failing in nvcc.
     compilation_context = CompilationContext()
     nvcc_flags = compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[8, 9, 10, 11, 12]
+        supported_major_versions=[8, 9, 10, 11]
     )
     return _gen_module(
         uri,
@@ -226,7 +226,7 @@ def gen_selective_state_update_sm90_module(
     )
     compilation_context = CompilationContext()
     nvcc_flags = compilation_context.get_nvcc_flags_list(
-        supported_major_versions=[9, 10, 11, 12]
+        supported_major_versions=[9, 10, 11]
     )
     nvcc_flags += ["-DFLASHINFER_MAMBA_ENABLE_SM90"]
     return _gen_module(


### PR DESCRIPTION
## 📌 Description

Resolves cross-cutting item 10 of the SM121 support audit (#3170): several SM10x-serving
JIT module generators include major version 12 in `supported_major_versions`, so wheel
builds whose arch list contains a 12.x entry compile their kernels for SM12x too. That
SM12x machine code can never run: on a compute capability 12.x device, dispatch always
selects the dedicated sm120 module (cutlass fused-moe, groupwise gemm, cutlass
fp4/fp8/bf16 gemm) or the sm100 variant (mamba `selective_state_update`), and on SM10x
devices the CUDA loader picks the matching sm_100a/sm_103a code from the fatbin.

Measured in the published v0.6.9 cu130 aarch64 jit-cache wheel (per-module
readelf/cuobjdump accounting), this dead code is **1,046 MB installed, 52% of all SM12x
bytes** in the wheel:

| module | dead SM12x bytes |
|---|---|
| `fused_moe_103` | 430 MB |
| `fused_moe_100` | 409 MB |
| `gemm_sm100` | 48 MB |
| `fp8_gemm_cutlass` | 8 MB |
| `fp4_gemm_cutlass` | 5 MB |
| `selective_state_update` base/sm90 variants (100 modules) | ~147 MB |

Fixes:

- Remove `12` from `supported_major_versions` at the nine dead sites:
  `gen_cutlass_fused_moe_sm100_module`, `gen_cutlass_fused_moe_sm103_module`
  (`flashinfer/jit/fused_moe.py`); `gen_gemm_sm100_module`,
  `gen_gemm_sm100_module_cutlass_fp4`, `gen_gemm_sm103_module_cutlass_fp4`,
  `gen_gemm_sm100_module_cutlass_fp8`, `gen_gemm_sm100_module_cutlass_bf16`
  (`flashinfer/jit/gemm/core.py`); `gen_selective_state_update_module`,
  `gen_selective_state_update_sm90_module` (`flashinfer/jit/mamba/selective_state_update.py`).

This matters for the release pipeline right now: the cu130 wheels sit just under GitHub's
2 GiB release-asset cap (aarch64 at 2.117 GB, x86_64 at 2.133 GB, cap 2.147 GB), so any
module growth breaks the next upload. This change shrinks the aarch64 wheel to roughly
1.88 GB zipped (x86_64 similar).

## 🔍 Related Issues

#3170 (cross-cutting item 10).

## 🧪 Tests

- A dispatch audit shows that CC 12.x never reaches the nine changed generator sites.
- The change was verified at runtime on both SM121 (DGX Spark, GB10) and SM120
  (RTX 5080). Starting from an empty JIT cache, the test
  suites for all six affected op families (mamba selective state update, bmm_fp8,
  mm_fp4, mm_bf16, groupwise-scaled fp8 GEMM, and cutlass fused MoE) pass on both
  machines, and the cache afterwards contains none of the nine modules this PR edits.
  This confirms that SM12x dispatch never loads them.
- `pre-commit run` on the changed files is clean.

## Reviewer Notes

- The dead verdicts depend on today's dispatch gates (`get_cutlass_fused_moe_module`'s
  backend strings, `is_sm12x_supported` branches preceding `is_sm100a_supported`, the
  bmm_fp8 heuristic preferring `cutlass_sm12x`, and the mamba `_get_module` ordering).
  If a future change routes SM12x to one of these modules, its generator needs 12 back.
- The mamba base/sm90 variants also embed SM9x/SM10x code that the same dispatch logic
  never loads (base only serves SM8x, sm90 only SM9x). Not touched here to keep this PR
  scoped to the SM12x audit; a follow-up could prune those the same way.
- No runtime behavior changes on any device: no dispatch path is modified, only the set
  of arch targets each module is compiled for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA architecture compatibility for fused MoE, GEMM, and selective state update operations.
  * Prevented unsupported CUDA 12 compilation targets for selected GPU kernels, while preserving CUDA 12 support where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->