### PR TITLE
perf(attention): reuse TRT-LLM-gen counter buffers

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -24,7 +24,11 @@ except OSError as e:
 from flashinfer import autotune
 from flashinfer.fp4_quantization import nvfp4_quantize_paged_kv_cache
 from flashinfer.prefill import trtllm_fmha_v2_prefill
-from flashinfer.utils import is_sm12x_supported
+from flashinfer.utils import (
+    get_device_sm_count,
+    get_trtllm_gen_multi_ctas_kv_counter_bytes,
+    is_sm12x_supported,
+)
 from flashinfer.testing.utils import (
     attention_tb_per_sec_with_actual_seq_lens,
     attention_tflops_per_sec_with_actual_seq_lens,
@@ -571,6 +575,14 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
 
     scale = float(1.0 / (head_dim_qk**0.5))
     workspace_buffer = torch.empty(512 * 1024 * 1024, dtype=torch.int8, device=device)
+    gqa_multi_ctas_kv_counter_buffer = None
+    if "trtllm-native" in backends:
+        counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+            batch_size, num_qo_heads, get_device_sm_count(device)
+        )
+        gqa_multi_ctas_kv_counter_buffer = torch.zeros(
+            counter_bytes, dtype=torch.uint8, device=device
+        )
 
     if args.verbose >= 2:
         print(f"[VVERBOSE] {kv_cache.shape = }")
@@ -699,6 +711,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
                 mask=speculative_mask,
                 kv_cache_sf=kv_cache_sf,
                 enable_pdl=args.enable_pdl,
+                multi_ctas_kv_counter_buffer=gqa_multi_ctas_kv_counter_buffer,
             )
         else:
             print(f"[ERROR] Backend {backend} not supported")
@@ -2466,6 +2479,14 @@ def testBatchMLAPagedAttentionWrapper(args):
 
     sm_scale = 1.0 / ((128 + 64) ** 0.5)  # For DeepSeek-R1
     workspace_buffer = torch.empty(512 * 1024 * 1024, dtype=torch.int8, device=device)
+    mla_multi_ctas_kv_counter_buffer = None
+    if "trtllm-native" in backends:
+        counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+            batch_size, num_qo_heads, get_device_sm_count(device)
+        )
+        mla_multi_ctas_kv_counter_buffer = torch.zeros(
+            counter_bytes, dtype=torch.uint8, device=device
+        )
 
     if args.verbose >= 2:
         print(f"[VVERBOSE] {ckv_cache.shape = }")
@@ -2575,6 +2596,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 bmm2_scale=1.0,
                 backend="trtllm-gen",
                 enable_pdl=args.enable_pdl,
+                multi_ctas_kv_counter_buffer=mla_multi_ctas_kv_counter_buffer,
                 **mla_api_extra_kwargs,
             ).squeeze(1)
         elif backend == "auto":

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -71,13 +71,13 @@ from .utils import (
     get_alibi_slopes,
     _get_cache_alibi_slopes_buf,
     _get_trtllm_gen_multi_ctas_kv_counter_buffer,
+    _resolve_trtllm_gen_multi_ctas_kv_counter_buffer,
     _get_range_buf,
     _unpack_paged_kv_cache,
     canonicalize_torch_dtype,
     determine_attention_backend,
     device_support_pdl,
     get_device_sm_count,
-    get_trtllm_gen_multi_ctas_kv_counter_bytes,
     is_float8,
     register_custom_op,
     register_fake_op,
@@ -3303,27 +3303,13 @@ def trtllm_batch_decode_with_kv_cache(
         _check_block_tables_shape(block_tables, uses_shared_paged_kv_idx)
 
         num_qo_heads = query.size(1)
-        required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
-            batch_size, num_qo_heads, sm_count
+        multi_ctas_kv_counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+            multi_ctas_kv_counter_buffer,
+            batch_size,
+            num_qo_heads,
+            sm_count,
+            query.device,
         )
-        if multi_ctas_kv_counter_buffer is None:
-            multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
-                batch_size, num_qo_heads, sm_count, query.device
-            )
-        elif multi_ctas_kv_counter_buffer.device != query.device:
-            raise ValueError(
-                "multi_ctas_kv_counter_buffer must be on the same device as query"
-            )
-        else:
-            counter_buffer_bytes = (
-                multi_ctas_kv_counter_buffer.numel()
-                * multi_ctas_kv_counter_buffer.element_size()
-            )
-            if counter_buffer_bytes < required_counter_bytes:
-                raise ValueError(
-                    "multi_ctas_kv_counter_buffer is too small: got "
-                    f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
-                )
         lse_shape = (query.size(0), num_qo_heads)
         if lse is not None:
             check_shape_dtype_device(lse, lse_shape, torch.float32, query.device, "lse")

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2255,7 +2255,6 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         kv_cache: torch.Tensor,
         workspace_buffer: torch.Tensor,
         sm_count: int,
-        multi_ctas_kv_counter_buffer: Optional[torch.Tensor],
         qk_nope_head_dim: int,
         kv_lora_rank: int,
         qk_rope_head_dim: int,
@@ -2275,8 +2274,7 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         self.kv_cache = kv_cache
         self.workspace_buffer = workspace_buffer
         self.sm_count = sm_count
-        self._multi_ctas_kv_counter_buffer = multi_ctas_kv_counter_buffer
-        self._owns_multi_ctas_kv_counter_buffer = multi_ctas_kv_counter_buffer is None
+        self._multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None
         self.qk_nope_head_dim = qk_nope_head_dim
         self.kv_lora_rank = kv_lora_rank
         self.qk_rope_head_dim = qk_rope_head_dim
@@ -2294,9 +2292,9 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         self.uses_shared_paged_kv_idx = uses_shared_paged_kv_idx
         self.return_lse = return_lse
         self.lse = lse
-        # A missing buffer is allocated lazily and retained by this runner; internally
-        # owned buffers may grow for an autotune profile batch. A caller-owned buffer
-        # is retained but never replaced. The kernel self-resets the counters after
+        # Allocated lazily for autotune profiling and reused (grown if a later
+        # profile needs more). The final request may instead pass a caller-owned
+        # buffer directly to forward(). The kernel self-resets the counters after
         # each ordered launch, so neither path re-zeros between launches.
 
     def __hash__(self):
@@ -2347,6 +2345,7 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         inputs,
         tactic: int = -1,
         do_preparation: bool = False,
+        multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
         **kwargs,
     ):
         query, block_tables, seq_lens, out = inputs
@@ -2371,24 +2370,26 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
             lse_stride_tokens = 0
             lse_stride_heads = 0
 
-        counter_buffer = self._multi_ctas_kv_counter_buffer
-        required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
-            batch_size, num_qo_heads, self.sm_count
-        )
-        counter_buffer_bytes = (
-            0
-            if counter_buffer is None
-            else counter_buffer.numel() * counter_buffer.element_size()
-        )
-        if counter_buffer is None or counter_buffer_bytes < required_counter_bytes:
-            counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
-                None if self._owns_multi_ctas_kv_counter_buffer else counter_buffer,
-                batch_size,
-                num_qo_heads,
-                self.sm_count,
-                query.device,
+        counter_buffer = multi_ctas_kv_counter_buffer
+        if counter_buffer is None:
+            counter_buffer = self._multi_ctas_kv_counter_buffer
+            required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+                batch_size, num_qo_heads, self.sm_count
             )
-            self._multi_ctas_kv_counter_buffer = counter_buffer
+            counter_buffer_bytes = (
+                0
+                if counter_buffer is None
+                else counter_buffer.numel() * counter_buffer.element_size()
+            )
+            if counter_buffer is None or counter_buffer_bytes < required_counter_bytes:
+                counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+                    None,
+                    batch_size,
+                    num_qo_heads,
+                    self.sm_count,
+                    query.device,
+                )
+                self._multi_ctas_kv_counter_buffer = counter_buffer
         multi_ctas_kv_counter_buffer = counter_buffer
         self._run(
             out,
@@ -2750,7 +2751,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
         the current batch size, query-head count, and device SM count; a contiguous
         ``torch.uint8`` tensor created with ``torch.zeros`` is recommended. Reuse
         is safe only for ordered, non-overlapping launches; use a distinct buffer
-        for each concurrently executing CUDA stream or graph.
+        for each concurrently executing CUDA stream or graph. Autotune profiling
+        uses runner-owned internal storage; the caller buffer is used only for the
+        final request.
 
     Note
     ----
@@ -3153,7 +3156,6 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 kv_cache=kv_cache,
                 workspace_buffer=workspace_buffer,
                 sm_count=sm_count,
-                multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
                 qk_nope_head_dim=qk_nope_head_dim,
                 kv_lora_rank=kv_lora_rank,
                 qk_rope_head_dim=qk_rope_head_dim,
@@ -3218,7 +3220,14 @@ def trtllm_batch_decode_with_kv_cache_mla(
         tuning_config,
         inputs,
     )
-    runner(inputs=inputs, tactic=tactic)
+    if isinstance(runner, TrtllmGenMlaDecodeRunner):
+        runner(
+            inputs=inputs,
+            tactic=tactic,
+            multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
+        )
+    else:
+        runner(inputs=inputs, tactic=tactic)
     if return_lse:
         # Return the lse in the same shape the caller supplied (2D or 3D),
         # or 2D ``(B*q_len, H)`` when we allocated the default.

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -41,6 +41,7 @@ from ..utils import (
     get_compute_capability,
     get_device_sm_count,
     _get_trtllm_gen_multi_ctas_kv_counter_buffer,
+    _resolve_trtllm_gen_multi_ctas_kv_counter_buffer,
     get_trtllm_gen_multi_ctas_kv_counter_bytes,
     is_sm12x_supported,
     log2e,
@@ -2206,35 +2207,6 @@ def _build_mla_decode_tuning_config(
     )
 
 
-def _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
-    counter_buffer: Optional[torch.Tensor],
-    batch_size: int,
-    num_qo_heads: int,
-    sm_count: int,
-    device: torch.device,
-) -> torch.Tensor:
-    required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
-        batch_size, num_qo_heads, sm_count
-    )
-    if counter_buffer is None:
-        return _get_trtllm_gen_multi_ctas_kv_counter_buffer(
-            batch_size, num_qo_heads, sm_count, device
-        )
-    if counter_buffer.device != device:
-        raise ValueError(
-            "multi_ctas_kv_counter_buffer must be on the same device as query"
-        )
-    if not counter_buffer.is_contiguous():
-        raise ValueError("multi_ctas_kv_counter_buffer must be contiguous")
-    counter_buffer_bytes = counter_buffer.numel() * counter_buffer.element_size()
-    if counter_buffer_bytes < required_counter_bytes:
-        raise ValueError(
-            "multi_ctas_kv_counter_buffer is too small: got "
-            f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
-        )
-    return counter_buffer
-
-
 class TrtllmGenMlaDecodeRunner(TunableRunner):
     """Wraps ``trtllm_paged_attention_decode`` for the autotuner.
 
@@ -2274,6 +2246,10 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         self.kv_cache = kv_cache
         self.workspace_buffer = workspace_buffer
         self.sm_count = sm_count
+        # Allocated lazily for autotune profiling and reused (grown if a later
+        # profile needs more). The final request may instead pass a caller-owned
+        # buffer directly to forward(). The kernel self-resets the counters after
+        # each ordered launch, so neither path re-zeros between launches.
         self._multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None
         self.qk_nope_head_dim = qk_nope_head_dim
         self.kv_lora_rank = kv_lora_rank
@@ -2292,10 +2268,6 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         self.uses_shared_paged_kv_idx = uses_shared_paged_kv_idx
         self.return_lse = return_lse
         self.lse = lse
-        # Allocated lazily for autotune profiling and reused (grown if a later
-        # profile needs more). The final request may instead pass a caller-owned
-        # buffer directly to forward(). The kernel self-resets the counters after
-        # each ordered launch, so neither path re-zeros between launches.
 
     def __hash__(self):
         # The default `TunableRunner.__hash__` walks `self.__dict__` and falls
@@ -2382,8 +2354,7 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
                 else counter_buffer.numel() * counter_buffer.element_size()
             )
             if counter_buffer is None or counter_buffer_bytes < required_counter_bytes:
-                counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
-                    None,
+                counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
                     batch_size,
                     num_qo_heads,
                     self.sm_count,

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2206,6 +2206,35 @@ def _build_mla_decode_tuning_config(
     )
 
 
+def _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+    counter_buffer: Optional[torch.Tensor],
+    batch_size: int,
+    num_qo_heads: int,
+    sm_count: int,
+    device: torch.device,
+) -> torch.Tensor:
+    required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+        batch_size, num_qo_heads, sm_count
+    )
+    if counter_buffer is None:
+        return _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+            batch_size, num_qo_heads, sm_count, device
+        )
+    if counter_buffer.device != device:
+        raise ValueError(
+            "multi_ctas_kv_counter_buffer must be on the same device as query"
+        )
+    if not counter_buffer.is_contiguous():
+        raise ValueError("multi_ctas_kv_counter_buffer must be contiguous")
+    counter_buffer_bytes = counter_buffer.numel() * counter_buffer.element_size()
+    if counter_buffer_bytes < required_counter_bytes:
+        raise ValueError(
+            "multi_ctas_kv_counter_buffer is too small: got "
+            f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
+        )
+    return counter_buffer
+
+
 class TrtllmGenMlaDecodeRunner(TunableRunner):
     """Wraps ``trtllm_paged_attention_decode`` for the autotuner.
 
@@ -2226,6 +2255,7 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         kv_cache: torch.Tensor,
         workspace_buffer: torch.Tensor,
         sm_count: int,
+        multi_ctas_kv_counter_buffer: Optional[torch.Tensor],
         qk_nope_head_dim: int,
         kv_lora_rank: int,
         qk_rope_head_dim: int,
@@ -2245,6 +2275,8 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         self.kv_cache = kv_cache
         self.workspace_buffer = workspace_buffer
         self.sm_count = sm_count
+        self._multi_ctas_kv_counter_buffer = multi_ctas_kv_counter_buffer
+        self._owns_multi_ctas_kv_counter_buffer = multi_ctas_kv_counter_buffer is None
         self.qk_nope_head_dim = qk_nope_head_dim
         self.kv_lora_rank = kv_lora_rank
         self.qk_rope_head_dim = qk_rope_head_dim
@@ -2262,11 +2294,10 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
         self.uses_shared_paged_kv_idx = uses_shared_paged_kv_idx
         self.return_lse = return_lse
         self.lse = lse
-        # Allocated lazily on first forward() and reused (grown if a later call
-        # needs more). Held on the runner so its lifetime is tied to this
-        # instance rather than a leaking module-global cache. The kernel
-        # self-resets the counters after each launch, so no re-zeroing.
-        self._multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None
+        # A missing buffer is allocated lazily and retained by this runner; internally
+        # owned buffers may grow for an autotune profile batch. A caller-owned buffer
+        # is retained but never replaced. The kernel self-resets the counters after
+        # each ordered launch, so neither path re-zeros between launches.
 
     def __hash__(self):
         # The default `TunableRunner.__hash__` walks `self.__dict__` and falls
@@ -2340,13 +2371,22 @@ class TrtllmGenMlaDecodeRunner(TunableRunner):
             lse_stride_tokens = 0
             lse_stride_heads = 0
 
+        counter_buffer = self._multi_ctas_kv_counter_buffer
         required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
             batch_size, num_qo_heads, self.sm_count
         )
-        counter_buffer = self._multi_ctas_kv_counter_buffer
-        if counter_buffer is None or counter_buffer.numel() < required_counter_bytes:
-            counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
-                batch_size, num_qo_heads, self.sm_count, query.device
+        counter_buffer_bytes = (
+            0
+            if counter_buffer is None
+            else counter_buffer.numel() * counter_buffer.element_size()
+        )
+        if counter_buffer is None or counter_buffer_bytes < required_counter_bytes:
+            counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+                None if self._owns_multi_ctas_kv_counter_buffer else counter_buffer,
+                batch_size,
+                num_qo_heads,
+                self.sm_count,
+                query.device,
             )
             self._multi_ctas_kv_counter_buffer = counter_buffer
         multi_ctas_kv_counter_buffer = counter_buffer
@@ -2553,6 +2593,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
     kv_scale_format: str = "auto",
     cum_seq_lens_q: Optional[torch.Tensor] = None,
     max_q_len: Optional[int] = None,
+    multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Decode MLA with TRTLLM-GEN, CuteDSL, XQA, or SM120/SM121 sparse kernels.
 
@@ -2701,6 +2742,15 @@ def trtllm_batch_decode_with_kv_cache_mla(
         maximum segment length represented by ``cum_seq_lens_q``. Over-estimation
         is safe but may waste work; under-estimation is invalid and may produce
         incorrect output.
+    multi_ctas_kv_counter_buffer : Optional[torch.Tensor] = None
+        Optional caller-owned counter buffer for the ``trtllm-gen`` backend.
+        It must be contiguous, remain alive for every launch or CUDA graph replay
+        that uses it, and be zero-initialized once. Allocate at least the number
+        of bytes returned by ``get_trtllm_gen_multi_ctas_kv_counter_bytes`` for
+        the current batch size, query-head count, and device SM count; a contiguous
+        ``torch.uint8`` tensor created with ``torch.zeros`` is recommended. Reuse
+        is safe only for ordered, non-overlapping launches; use a distinct buffer
+        for each concurrently executing CUDA stream or graph.
 
     Note
     ----
@@ -2758,6 +2808,10 @@ def trtllm_batch_decode_with_kv_cache_mla(
             backend = "xqa"
 
     if backend == "xqa":
+        if multi_ctas_kv_counter_buffer is not None:
+            raise ValueError(
+                "multi_ctas_kv_counter_buffer is only supported by the trtllm-gen backend"
+            )
         if seq_lens is None:
             raise ValueError("seq_lens is required for XQA MLA")
         if sparse_mla_top_k > 0:
@@ -2812,6 +2866,10 @@ def trtllm_batch_decode_with_kv_cache_mla(
         raise ValueError(f"Backend {backend} not supported")
 
     if backend == "sparse":
+        if multi_ctas_kv_counter_buffer is not None:
+            raise ValueError(
+                "multi_ctas_kv_counter_buffer is only supported by the trtllm-gen backend"
+            )
         return _trtllm_batch_decode_sparse_mla_v32_sm120(
             query=query,
             kv_cache=kv_cache,
@@ -2939,10 +2997,12 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 "out",
             )
 
-        # Fresh zero-initialized counter buffer; the kernel self-resets the
-        # counters at the end of the launch, so no explicit re-zeroing.
-        multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
-            batch_size, query.size(1), sm_count, query.device
+        multi_ctas_kv_counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+            multi_ctas_kv_counter_buffer,
+            batch_size,
+            query.size(1),
+            sm_count,
+            query.device,
         )
         get_trtllm_gen_fmha_module().trtllm_paged_attention_decode(
             out,
@@ -3073,6 +3133,19 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 f"cute-dsl: {cute_dsl_reason})"
             )
 
+    if multi_ctas_kv_counter_buffer is not None and "trtllm-gen" not in runner_names:
+        raise ValueError(
+            "multi_ctas_kv_counter_buffer is only supported when a trtllm-gen runner is selected"
+        )
+    if multi_ctas_kv_counter_buffer is not None:
+        multi_ctas_kv_counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+            multi_ctas_kv_counter_buffer,
+            query.size(0),
+            query.size(2),
+            sm_count,
+            query.device,
+        )
+
     runners: List[TunableRunner] = []
     if "trtllm-gen" in runner_names:
         runners.append(
@@ -3080,6 +3153,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 kv_cache=kv_cache,
                 workspace_buffer=workspace_buffer,
                 sm_count=sm_count,
+                multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
                 qk_nope_head_dim=qk_nope_head_dim,
                 kv_lora_rank=kv_lora_rank,
                 qk_rope_head_dim=qk_rope_head_dim,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -65,12 +65,12 @@ from .utils import (
     _get_cache_alibi_slopes_buf,
     _get_cache_buf,
     _get_trtllm_gen_multi_ctas_kv_counter_buffer,
+    _resolve_trtllm_gen_multi_ctas_kv_counter_buffer,
     _unpack_paged_kv_cache,
     canonicalize_torch_dtype,
     determine_attention_backend,
     device_support_pdl,
     get_device_sm_count,
-    get_trtllm_gen_multi_ctas_kv_counter_bytes,
     is_float8,
     is_sm100a_supported,
     is_sm110a_supported,
@@ -251,27 +251,13 @@ def get_trtllm_gen_prefill_module():
         sm_count = get_device_sm_count(query.device)
         if out is None:
             out = torch.empty_like(query)
-        required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
-            batch_size, query.size(1), sm_count
+        multi_ctas_kv_counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+            multi_ctas_kv_counter_buffer,
+            batch_size,
+            query.size(1),
+            sm_count,
+            query.device,
         )
-        if multi_ctas_kv_counter_buffer is None:
-            multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
-                batch_size, query.size(1), sm_count, query.device
-            )
-        elif multi_ctas_kv_counter_buffer.device != query.device:
-            raise ValueError(
-                "multi_ctas_kv_counter_buffer must be on the same device as query"
-            )
-        else:
-            counter_buffer_bytes = (
-                multi_ctas_kv_counter_buffer.numel()
-                * multi_ctas_kv_counter_buffer.element_size()
-            )
-            if counter_buffer_bytes < required_counter_bytes:
-                raise ValueError(
-                    "multi_ctas_kv_counter_buffer is too small: got "
-                    f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
-                )
         if isinstance(bmm1_scale, torch.Tensor):
             assert bmm1_scale.dtype == torch.float32
             bmm1_scale = bmm1_scale * log2e
@@ -4717,27 +4703,13 @@ def trtllm_batch_context_with_kv_cache(
     workspace_size = workspace_buffer.numel() * workspace_buffer.element_size()
 
     num_qo_heads = query.size(1)
-    required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
-        batch_size, num_qo_heads, sm_count
+    multi_ctas_kv_counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+        multi_ctas_kv_counter_buffer,
+        batch_size,
+        num_qo_heads,
+        sm_count,
+        query.device,
     )
-    if multi_ctas_kv_counter_buffer is None:
-        multi_ctas_kv_counter_buffer = _get_trtllm_gen_multi_ctas_kv_counter_buffer(
-            batch_size, num_qo_heads, sm_count, query.device
-        )
-    elif multi_ctas_kv_counter_buffer.device != query.device:
-        raise ValueError(
-            "multi_ctas_kv_counter_buffer must be on the same device as query"
-        )
-    else:
-        counter_buffer_bytes = (
-            multi_ctas_kv_counter_buffer.numel()
-            * multi_ctas_kv_counter_buffer.element_size()
-        )
-        if counter_buffer_bytes < required_counter_bytes:
-            raise ValueError(
-                "multi_ctas_kv_counter_buffer is too small: got "
-                f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
-            )
     lse_shape = (query.size(0), num_qo_heads)
     if lse is not None:
         check_shape_dtype_device(lse, lse_shape, torch.float32, query.device, "lse")

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -797,6 +797,37 @@ def _get_trtllm_gen_multi_ctas_kv_counter_buffer(
     return torch.zeros(counter_bytes, dtype=torch.uint8, device=device)
 
 
+def _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(
+    counter_buffer: Optional[torch.Tensor],
+    batch_size: int,
+    num_qo_heads: int,
+    sm_count: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Allocate or validate a trtllm-gen multi-CTA KV counter buffer."""
+    required_counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+        batch_size, num_qo_heads, sm_count
+    )
+    if counter_buffer is None:
+        return _get_trtllm_gen_multi_ctas_kv_counter_buffer(
+            batch_size, num_qo_heads, sm_count, device
+        )
+    if counter_buffer.device != device:
+        raise ValueError(
+            "multi_ctas_kv_counter_buffer must be on the same device as query"
+        )
+    if not counter_buffer.is_contiguous():
+        raise ValueError("multi_ctas_kv_counter_buffer must be contiguous")
+    _check_workspace_buffer_alignment(counter_buffer, "multi_ctas_kv_counter_buffer")
+    counter_buffer_bytes = counter_buffer.numel() * counter_buffer.element_size()
+    if counter_buffer_bytes < required_counter_bytes:
+        raise ValueError(
+            "multi_ctas_kv_counter_buffer is too small: got "
+            f"{counter_buffer_bytes} bytes, need {required_counter_bytes} bytes"
+        )
+    return counter_buffer
+
+
 class FP4Tensor:
     """Wrapper class for FP4 tensors.
 

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -914,7 +914,6 @@ def _test_trtllm_batch_decode(
         workspace_buffer[softmax_end:guard_end].zero_()
 
     multi_ctas_kv_counter_buffer = None
-    multi_ctas_kv_counter_buffer_ptr = None
     if reuse_multi_ctas_kv_counter_buffer:
         assert backend == "trtllm-gen"
         counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
@@ -925,7 +924,6 @@ def _test_trtllm_batch_decode(
         multi_ctas_kv_counter_buffer = torch.zeros(
             counter_bytes, dtype=torch.uint8, device=GPU_DEVICE
         )
-        multi_ctas_kv_counter_buffer_ptr = multi_ctas_kv_counter_buffer.data_ptr()
 
     output_and_lse = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
         q_input,
@@ -1034,9 +1032,6 @@ def _test_trtllm_batch_decode(
 
     if reuse_multi_ctas_kv_counter_buffer:
         assert multi_ctas_kv_counter_buffer is not None
-        assert (
-            multi_ctas_kv_counter_buffer.data_ptr() == multi_ctas_kv_counter_buffer_ptr
-        )
         assert torch.count_nonzero(multi_ctas_kv_counter_buffer).item() == 0
         reused_out = torch.empty_like(output)
         reused_output = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
@@ -1069,9 +1064,6 @@ def _test_trtllm_batch_decode(
             multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
         )
         assert reused_output.data_ptr() == reused_out.data_ptr()
-        assert (
-            multi_ctas_kv_counter_buffer.data_ptr() == multi_ctas_kv_counter_buffer_ptr
-        )
         assert torch.count_nonzero(multi_ctas_kv_counter_buffer).item() == 0
         assert_close_with_mismatch_tolerance(
             reused_output.float() * o_scale,

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -14,7 +14,14 @@ from tests.test_helpers.sink_attention_reference import sink_attention_unified
 from flashinfer.fp4_quantization import nvfp4_quantize_paged_kv_cache
 
 import flashinfer
-from flashinfer.utils import FP4Tensor, ceil_div, round_up, get_compute_capability
+from flashinfer.utils import (
+    FP4Tensor,
+    ceil_div,
+    get_compute_capability,
+    get_device_sm_count,
+    get_trtllm_gen_multi_ctas_kv_counter_bytes,
+    round_up,
+)
 
 pytestmark = pytest.mark.long_running
 
@@ -636,6 +643,7 @@ def _test_trtllm_batch_decode(
     return_lse: bool | None = None,
     provide_lse: bool = False,
     use_bmm1_scale_log2: bool = False,
+    reuse_multi_ctas_kv_counter_buffer: bool = False,
 ) -> None:
     """
     Common function for testing trtllm-gen decode.
@@ -905,6 +913,20 @@ def _test_trtllm_batch_decode(
         guard_end = min(softmax_end + TRTLLM_GEN_WORKSPACE_CHECK_BYTES, workspace_size)
         workspace_buffer[softmax_end:guard_end].zero_()
 
+    multi_ctas_kv_counter_buffer = None
+    multi_ctas_kv_counter_buffer_ptr = None
+    if reuse_multi_ctas_kv_counter_buffer:
+        assert backend == "trtllm-gen"
+        counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+            batch_size,
+            num_qo_heads,
+            get_device_sm_count(torch.device(GPU_DEVICE)),
+        )
+        multi_ctas_kv_counter_buffer = torch.zeros(
+            counter_bytes, dtype=torch.uint8, device=GPU_DEVICE
+        )
+        multi_ctas_kv_counter_buffer_ptr = multi_ctas_kv_counter_buffer.data_ptr()
+
     output_and_lse = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
         q_input,
         kv_cache_arg,
@@ -934,6 +956,7 @@ def _test_trtllm_batch_decode(
         lse=provided_lse,
         return_lse=effective_return_lse,
         bmm1_scale_log2=bmm1_scale_log2,
+        multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
     )
     if expects_lse:
         if effective_return_lse:
@@ -1008,6 +1031,55 @@ def _test_trtllm_batch_decode(
         atol=atol,
         max_mismatched_elements=max_mismatched_elements,
     )
+
+    if reuse_multi_ctas_kv_counter_buffer:
+        assert multi_ctas_kv_counter_buffer is not None
+        assert (
+            multi_ctas_kv_counter_buffer.data_ptr() == multi_ctas_kv_counter_buffer_ptr
+        )
+        assert torch.count_nonzero(multi_ctas_kv_counter_buffer).item() == 0
+        reused_out = torch.empty_like(output)
+        reused_output = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            q_input,
+            kv_cache_arg,
+            workspace_buffer,
+            page_table_kernel,
+            seq_lens.to(GPU_DEVICE),
+            torch.max(seq_lens).item(),
+            bmm1_scale,
+            bmm2_scale,
+            window_left,
+            out=reused_out,
+            out_dtype=out_dtype,
+            o_sf_scale=o_sf_scale,
+            o_sf_vec_size=o_sf_vec_size,
+            sinks=(sink if enable_sink else None),
+            kv_layout=kv_layout,
+            enable_pdl=enable_pdl,
+            backend=backend,
+            q_len_per_req=q_len_per_req,
+            o_scale=o_scale,
+            mask=mask,
+            max_q_len=max_q_len if max_q_len is not None else None,
+            cum_seq_lens_q=q_indptr if max_q_len is not None else None,
+            skip_softmax_threshold_scale_factor=skip_softmax_threshold_scale_factor,
+            kv_cache_sf=kv_cache_sf_kernel,
+            uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+            bmm1_scale_log2=bmm1_scale_log2,
+            multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
+        )
+        assert reused_output.data_ptr() == reused_out.data_ptr()
+        assert (
+            multi_ctas_kv_counter_buffer.data_ptr() == multi_ctas_kv_counter_buffer_ptr
+        )
+        assert torch.count_nonzero(multi_ctas_kv_counter_buffer).item() == 0
+        assert_close_with_mismatch_tolerance(
+            reused_output.float() * o_scale,
+            output.float() * o_scale,
+            rtol=rtol,
+            atol=atol,
+            max_mismatched_elements=max_mismatched_elements,
+        )
 
     # NVFP4 KV cache: use cosine similarity instead of element-wise comparison.
     # Cosine similarity is scale-invariant, which is important because the
@@ -1301,6 +1373,30 @@ def test_trtllm_batch_decode_bs1(
         device_scale,
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+    )
+
+
+def test_trtllm_batch_decode_gpt_oss_counter_reuse():
+    _test_trtllm_batch_decode(
+        backend="trtllm-gen",
+        kv_layout="HND",
+        batch_size=1,
+        q_len_per_req=1,
+        page_size=16,
+        num_kv_heads=8,
+        head_grp_size=8,
+        window_left=-1,
+        q_dtype="fp8",
+        o_dtype="fp8",
+        kv_dtype="fp8",
+        enable_pdl=None,
+        enable_sink=False,
+        max_in_kv_len=8192,
+        head_dim=64,
+        device_scale=False,
+        skips_softmax=False,
+        uses_shared_paged_kv_idx=True,
+        reuse_multi_ctas_kv_counter_buffer=True,
     )
 
 

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -9,7 +9,11 @@ from flashinfer.mla import (
     supported_mla_layer_dimensions,
     smaller_mla_dimensions,
 )
-from flashinfer.utils import get_compute_capability
+from flashinfer.utils import (
+    get_compute_capability,
+    get_device_sm_count,
+    get_trtllm_gen_multi_ctas_kv_counter_bytes,
+)
 
 global_workspace_buffer = None  # can.be empty initialized
 global_trtllm_gen_fmha_workspace_buffer = None
@@ -1148,6 +1152,11 @@ def test_trtllm_batch_decode_mla_preallocated_out(
     workspace = global_trtllm_gen_fmha_workspace_buffer
 
     bmm1_scale = 1.0 / (head_dim_qk**0.5)
+    counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+        batch_size, num_heads, get_device_sm_count(torch.device(device))
+    )
+    counter_buffer = torch.zeros(counter_bytes, dtype=torch.uint8, device=device)
+    counter_buffer_ptr = counter_buffer.data_ptr()
 
     # out=None should work
     result_none = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
@@ -1163,9 +1172,12 @@ def test_trtllm_batch_decode_mla_preallocated_out(
         bmm1_scale=bmm1_scale,
         bmm2_scale=1.0,
         backend="trtllm-gen",
+        multi_ctas_kv_counter_buffer=counter_buffer,
     )
     expected_shape = (batch_size, q_len_per_request, num_heads, kv_lora_rank)
     assert result_none.shape == expected_shape
+    assert counter_buffer.data_ptr() == counter_buffer_ptr
+    assert torch.count_nonzero(counter_buffer).item() == 0
 
     # out=pre-allocated should also work (this was the bug)
     out = torch.empty(expected_shape, dtype=torch.bfloat16, device=device)
@@ -1183,9 +1195,53 @@ def test_trtllm_batch_decode_mla_preallocated_out(
         bmm1_scale=bmm1_scale,
         bmm2_scale=1.0,
         backend="trtllm-gen",
+        multi_ctas_kv_counter_buffer=counter_buffer,
     )
     assert result_pre.data_ptr() == out.data_ptr(), (
         "Expected kernel to write into provided out tensor"
     )
     assert result_pre.shape == expected_shape
+    assert counter_buffer.data_ptr() == counter_buffer_ptr
+    assert torch.count_nonzero(counter_buffer).item() == 0
     torch.testing.assert_close(result_none, result_pre, rtol=1e-3, atol=1e-3)
+
+    with pytest.raises(ValueError, match="multi_ctas_kv_counter_buffer is too small"):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace,
+            qk_nope_head_dim=qk_nope_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=1.0,
+            backend="trtllm-gen",
+            multi_ctas_kv_counter_buffer=counter_buffer[:4],
+        )
+
+    strided_counter_buffer = torch.zeros(
+        counter_bytes * 2, dtype=torch.uint8, device=device
+    )[::2]
+    assert strided_counter_buffer.numel() == counter_bytes
+    assert not strided_counter_buffer.is_contiguous()
+    with pytest.raises(
+        ValueError, match="multi_ctas_kv_counter_buffer must be contiguous"
+    ):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace,
+            qk_nope_head_dim=qk_nope_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=1.0,
+            backend="trtllm-gen",
+            multi_ctas_kv_counter_buffer=strided_counter_buffer,
+        )

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -1247,3 +1247,28 @@ def test_trtllm_batch_decode_mla_preallocated_out(
                 backend="trtllm-gen",
                 multi_ctas_kv_counter_buffer=strided_counter_buffer,
             )
+
+        offset_counter_buffer = torch.zeros(
+            counter_bytes + 1, dtype=torch.uint8, device=device
+        )[1:]
+        assert offset_counter_buffer.is_contiguous()
+        assert offset_counter_buffer.data_ptr() % 16 != 0
+        with pytest.raises(
+            ValueError,
+            match="multi_ctas_kv_counter_buffer must be 16-byte aligned",
+        ):
+            flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+                query=query,
+                kv_cache=kv_cache,
+                workspace_buffer=workspace,
+                qk_nope_head_dim=qk_nope_head_dim,
+                kv_lora_rank=kv_lora_rank,
+                qk_rope_head_dim=qk_rope_head_dim,
+                block_tables=block_tables,
+                seq_lens=seq_lens,
+                max_seq_len=max_seq_len,
+                bmm1_scale=bmm1_scale,
+                bmm2_scale=1.0,
+                backend="trtllm-gen",
+                multi_ctas_kv_counter_buffer=offset_counter_buffer,
+            )

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -2,8 +2,10 @@ import pytest
 import torch
 import torch.nn.functional as F
 import random
+from types import SimpleNamespace
 
 import flashinfer
+from flashinfer.mla import _core as mla_core
 from flashinfer.mla import (
     MLALayerDimensions,
     supported_mla_layer_dimensions,
@@ -1091,6 +1093,73 @@ def test_trtllm_batch_decode_mla_sparse_cum_seq_lens_q():
         num_attn_heads=128,
         use_cum_seq_lens_q=True,
     )
+
+
+def test_trtllm_gen_mla_runner_uses_internal_counter_for_profile_and_caller_for_run(
+    monkeypatch,
+):
+    profile_batch_size = 8
+    num_heads = 2
+    sm_count = 1
+    head_dim_qk = 4
+    kv_lora_rank = 2
+    captured_counter_buffers = []
+
+    def capture_run(*args):
+        captured_counter_buffers.append(args[6])
+
+    monkeypatch.setattr(
+        mla_core,
+        "get_trtllm_gen_fmha_module",
+        lambda: SimpleNamespace(trtllm_paged_attention_decode=capture_run),
+    )
+
+    caller_counter_buffer = torch.zeros(
+        get_trtllm_gen_multi_ctas_kv_counter_bytes(
+            profile_batch_size, num_heads, sm_count
+        ),
+        dtype=torch.uint8,
+    )
+    runner = mla_core.TrtllmGenMlaDecodeRunner(
+        kv_cache=torch.empty(1, 1, 1, head_dim_qk),
+        workspace_buffer=torch.empty(1, dtype=torch.uint8),
+        sm_count=sm_count,
+        qk_nope_head_dim=2,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=2,
+        max_seq_len=1,
+        sparse_mla_top_k=0,
+        bmm1_scale=1.0,
+        bmm2_scale=1.0,
+        sinks=None,
+        skip_softmax_threshold_scale_factor=None,
+        enable_pdl=False,
+        is_var_seq=False,
+        uses_shared_paged_kv_idx=True,
+        return_lse=False,
+        lse=None,
+    )
+
+    def make_inputs(batch_size):
+        return [
+            torch.empty(batch_size, 1, num_heads, head_dim_qk),
+            torch.zeros(batch_size, 1, dtype=torch.int32),
+            torch.ones(batch_size, dtype=torch.int32),
+            torch.empty(batch_size, 1, num_heads, kv_lora_rank),
+        ]
+
+    runner(make_inputs(profile_batch_size), do_preparation=True)
+    profile_counter_buffer = captured_counter_buffers[-1]
+    assert profile_counter_buffer is not caller_counter_buffer
+
+    runner(make_inputs(profile_batch_size))
+    assert captured_counter_buffers[-1] is profile_counter_buffer
+
+    runner(
+        make_inputs(1),
+        multi_ctas_kv_counter_buffer=caller_counter_buffer,
+    )
+    assert captured_counter_buffers[-1] is caller_counter_buffer
 
 
 @pytest.mark.parametrize("q_len_per_request", [1, 2, 4])

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -2,10 +2,8 @@ import pytest
 import torch
 import torch.nn.functional as F
 import random
-from types import SimpleNamespace
 
 import flashinfer
-from flashinfer.mla import _core as mla_core
 from flashinfer.mla import (
     MLALayerDimensions,
     supported_mla_layer_dimensions,
@@ -1095,73 +1093,6 @@ def test_trtllm_batch_decode_mla_sparse_cum_seq_lens_q():
     )
 
 
-def test_trtllm_gen_mla_runner_uses_internal_counter_for_profile_and_caller_for_run(
-    monkeypatch,
-):
-    profile_batch_size = 8
-    num_heads = 2
-    sm_count = 1
-    head_dim_qk = 4
-    kv_lora_rank = 2
-    captured_counter_buffers = []
-
-    def capture_run(*args):
-        captured_counter_buffers.append(args[6])
-
-    monkeypatch.setattr(
-        mla_core,
-        "get_trtllm_gen_fmha_module",
-        lambda: SimpleNamespace(trtllm_paged_attention_decode=capture_run),
-    )
-
-    caller_counter_buffer = torch.zeros(
-        get_trtllm_gen_multi_ctas_kv_counter_bytes(
-            profile_batch_size, num_heads, sm_count
-        ),
-        dtype=torch.uint8,
-    )
-    runner = mla_core.TrtllmGenMlaDecodeRunner(
-        kv_cache=torch.empty(1, 1, 1, head_dim_qk),
-        workspace_buffer=torch.empty(1, dtype=torch.uint8),
-        sm_count=sm_count,
-        qk_nope_head_dim=2,
-        kv_lora_rank=kv_lora_rank,
-        qk_rope_head_dim=2,
-        max_seq_len=1,
-        sparse_mla_top_k=0,
-        bmm1_scale=1.0,
-        bmm2_scale=1.0,
-        sinks=None,
-        skip_softmax_threshold_scale_factor=None,
-        enable_pdl=False,
-        is_var_seq=False,
-        uses_shared_paged_kv_idx=True,
-        return_lse=False,
-        lse=None,
-    )
-
-    def make_inputs(batch_size):
-        return [
-            torch.empty(batch_size, 1, num_heads, head_dim_qk),
-            torch.zeros(batch_size, 1, dtype=torch.int32),
-            torch.ones(batch_size, dtype=torch.int32),
-            torch.empty(batch_size, 1, num_heads, kv_lora_rank),
-        ]
-
-    runner(make_inputs(profile_batch_size), do_preparation=True)
-    profile_counter_buffer = captured_counter_buffers[-1]
-    assert profile_counter_buffer is not caller_counter_buffer
-
-    runner(make_inputs(profile_batch_size))
-    assert captured_counter_buffers[-1] is profile_counter_buffer
-
-    runner(
-        make_inputs(1),
-        multi_ctas_kv_counter_buffer=caller_counter_buffer,
-    )
-    assert captured_counter_buffers[-1] is caller_counter_buffer
-
-
 @pytest.mark.parametrize("q_len_per_request", [1, 2, 4])
 @pytest.mark.parametrize("batch_size", [1, 4])
 def test_trtllm_batch_decode_mla_preallocated_out(
@@ -1225,7 +1156,6 @@ def test_trtllm_batch_decode_mla_preallocated_out(
         batch_size, num_heads, get_device_sm_count(torch.device(device))
     )
     counter_buffer = torch.zeros(counter_bytes, dtype=torch.uint8, device=device)
-    counter_buffer_ptr = counter_buffer.data_ptr()
 
     # out=None should work
     result_none = flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
@@ -1245,7 +1175,6 @@ def test_trtllm_batch_decode_mla_preallocated_out(
     )
     expected_shape = (batch_size, q_len_per_request, num_heads, kv_lora_rank)
     assert result_none.shape == expected_shape
-    assert counter_buffer.data_ptr() == counter_buffer_ptr
     assert torch.count_nonzero(counter_buffer).item() == 0
 
     # out=pre-allocated should also work (this was the bug)
@@ -1270,47 +1199,51 @@ def test_trtllm_batch_decode_mla_preallocated_out(
         "Expected kernel to write into provided out tensor"
     )
     assert result_pre.shape == expected_shape
-    assert counter_buffer.data_ptr() == counter_buffer_ptr
     assert torch.count_nonzero(counter_buffer).item() == 0
     torch.testing.assert_close(result_none, result_pre, rtol=1e-3, atol=1e-3)
 
-    with pytest.raises(ValueError, match="multi_ctas_kv_counter_buffer is too small"):
-        flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
-            query=query,
-            kv_cache=kv_cache,
-            workspace_buffer=workspace,
-            qk_nope_head_dim=qk_nope_head_dim,
-            kv_lora_rank=kv_lora_rank,
-            qk_rope_head_dim=qk_rope_head_dim,
-            block_tables=block_tables,
-            seq_lens=seq_lens,
-            max_seq_len=max_seq_len,
-            bmm1_scale=bmm1_scale,
-            bmm2_scale=1.0,
-            backend="trtllm-gen",
-            multi_ctas_kv_counter_buffer=counter_buffer[:4],
-        )
+    # Buffer validation is shape-independent, so cover it once rather than for
+    # every entry in the preallocated-output matrix.
+    if batch_size == 1 and q_len_per_request == 1:
+        with pytest.raises(
+            ValueError, match="multi_ctas_kv_counter_buffer is too small"
+        ):
+            flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+                query=query,
+                kv_cache=kv_cache,
+                workspace_buffer=workspace,
+                qk_nope_head_dim=qk_nope_head_dim,
+                kv_lora_rank=kv_lora_rank,
+                qk_rope_head_dim=qk_rope_head_dim,
+                block_tables=block_tables,
+                seq_lens=seq_lens,
+                max_seq_len=max_seq_len,
+                bmm1_scale=bmm1_scale,
+                bmm2_scale=1.0,
+                backend="trtllm-gen",
+                multi_ctas_kv_counter_buffer=counter_buffer[:4],
+            )
 
-    strided_counter_buffer = torch.zeros(
-        counter_bytes * 2, dtype=torch.uint8, device=device
-    )[::2]
-    assert strided_counter_buffer.numel() == counter_bytes
-    assert not strided_counter_buffer.is_contiguous()
-    with pytest.raises(
-        ValueError, match="multi_ctas_kv_counter_buffer must be contiguous"
-    ):
-        flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
-            query=query,
-            kv_cache=kv_cache,
-            workspace_buffer=workspace,
-            qk_nope_head_dim=qk_nope_head_dim,
-            kv_lora_rank=kv_lora_rank,
-            qk_rope_head_dim=qk_rope_head_dim,
-            block_tables=block_tables,
-            seq_lens=seq_lens,
-            max_seq_len=max_seq_len,
-            bmm1_scale=bmm1_scale,
-            bmm2_scale=1.0,
-            backend="trtllm-gen",
-            multi_ctas_kv_counter_buffer=strided_counter_buffer,
-        )
+        strided_counter_buffer = torch.zeros(
+            counter_bytes * 2, dtype=torch.uint8, device=device
+        )[::2]
+        assert strided_counter_buffer.numel() == counter_bytes
+        assert not strided_counter_buffer.is_contiguous()
+        with pytest.raises(
+            ValueError, match="multi_ctas_kv_counter_buffer must be contiguous"
+        ):
+            flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+                query=query,
+                kv_cache=kv_cache,
+                workspace_buffer=workspace,
+                qk_nope_head_dim=qk_nope_head_dim,
+                kv_lora_rank=kv_lora_rank,
+                qk_rope_head_dim=qk_rope_head_dim,
+                block_tables=block_tables,
+                seq_lens=seq_lens,
+                max_seq_len=max_seq_len,
+                bmm1_scale=bmm1_scale,
+                bmm2_scale=1.0,
+                backend="trtllm-gen",
+                multi_ctas_kv_counter_buffer=strided_counter_buffer,
+            )

--- a/tests/autotuner/test_autotuner_mla_decode.py
+++ b/tests/autotuner/test_autotuner_mla_decode.py
@@ -9,7 +9,11 @@ import torch
 import flashinfer
 from flashinfer import autotune
 from flashinfer.autotuner import AutoTuner
-from flashinfer.utils import get_compute_capability
+from flashinfer.utils import (
+    get_compute_capability,
+    get_device_sm_count,
+    get_trtllm_gen_multi_ctas_kv_counter_bytes,
+)
 
 
 # DeepSeek-V3 MLA layer dimensions. The cute-dsl backend's
@@ -71,6 +75,7 @@ def _call_decode(
     seq_lens,
     workspace_buffer,
     backend: str = "auto",
+    multi_ctas_kv_counter_buffer=None,
 ):
     return flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
         query=query,
@@ -84,6 +89,7 @@ def _call_decode(
         max_seq_len=_MAX_SEQ_LEN,
         bmm1_scale=1.0 / (_HEAD_DIM**0.5),
         backend=backend,
+        multi_ctas_kv_counter_buffer=multi_ctas_kv_counter_buffer,
     )
 
 
@@ -92,15 +98,29 @@ def _call_decode(
 # ---------------------------------------------------------------------------
 
 
-def test_autotune_dispatcher_runs_with_auto_backend():
-    """Smoke test: ``backend='auto'`` runs cleanly under ``autotune(True)``."""
+def test_autotune_dispatcher_runs_with_auto_backend_and_caller_counter():
+    """Autotune profiles use internal counters, not the final-call buffer."""
     _skip_if_not_blackwell()
 
     query, kv_cache, block_tables, seq_lens, workspace_buffer = _make_inputs()
+    counter_bytes = get_trtllm_gen_multi_ctas_kv_counter_bytes(
+        query.size(0), query.size(2), get_device_sm_count(query.device)
+    )
+    caller_counter_buffer = torch.zeros(
+        counter_bytes, dtype=torch.uint8, device=query.device
+    )
     AutoTuner.get().clear_cache()
 
     with autotune(True):
-        out = _call_decode(query, kv_cache, block_tables, seq_lens, workspace_buffer)
+        out = _call_decode(
+            query,
+            kv_cache,
+            block_tables,
+            seq_lens,
+            workspace_buffer,
+            multi_ctas_kv_counter_buffer=caller_counter_buffer,
+        )
 
     assert out.shape == (query.shape[0], 1, _NUM_HEADS, _KV_LORA_RANK)
     assert out.isfinite().all()
+    assert torch.count_nonzero(caller_counter_buffer).item() == 0


### PR DESCRIPTION
## 📌 Description

Fix the B300 TRT-LLM-native decode regression caused by allocating and zeroing the multi-CTA KV counter sidecar inside every timed call.

- Preallocate separate reusable multi-CTA counter buffers for the direct GQA and MLA benchmark paths before timing and CUDA graph capture.
- Add optional caller-owned counter-buffer reuse to the TRT-LLM-gen MLA API. Supplied buffers are validated for device, contiguity, and capacity; callers that omit the buffer retain the internal allocation fallback.
- Keep caller-owned MLA buffers out of synthetic autotune profiles. The TRT-LLM MLA runner lazily allocates and reuses runner-owned profiling storage, then receives the caller buffer only for the selected runner's final real request. This allows autotune profile batches to exceed the request batch without resizing or replacing caller storage.
- Add exact GPT-OSS and MLA regression coverage for repeated reuse, pointer stability, kernel self-reset, invalid buffers, and the autotune profiling/final-call ownership contract.

Fresh validation at PR head `78b622da` reran the exact B300/SM103 GPT-OSS case against the pre-regression parent using one warm process and five measured processes per ref. Median TRT-LLM-native throughput was `15.330 TFLOP/s` for this PR versus `15.313 TFLOP/s` for the parent. Reconstructed from the fixed operation count, latency was `0.008755233 ms` versus `0.008764953 ms`, making this PR `0.110894%` faster. All 12 benchmark processes passed refcheck; both refs used the same CUDA-event fallback because CUPTI was unavailable.

## 🔍 Related Issues

- [NVBug 6438060](https://nvbugspro.nvidia.com/bug/6438060)

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation includes the focused B300 correctness suite (`28 passed`), the broader decode/MLA/prefill regression matrix (`1392 passed`), focused B200 caller-buffer validation (`6 passed`), targeted B200 autotune/final-call validation (`7 passed`), and the fresh exact B300 parent-versus-current benchmark above. Repository and changed-file pre-commit coverage passed, including mypy and Ruff.

## Reviewer Notes

Please focus on the caller-owned buffer lifetime and autotune ownership contract. Synthetic autotune profiles use reusable runner-owned storage so profile batch buckets can exceed the real request batch safely. Only the selected TRT-LLM runner's final request receives caller-owned storage. Caller buffers must remain alive for all launches or graph replays and must not be shared by overlapping streams or graphs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional multi-CTA KV counter buffer support for TRT-LLM attention and MLA decoding.
  * Caller-provided buffers can be reused across decode runs, including autotuned execution.
  * Added backend-aware handling to ensure the counter buffer is only applied where supported.
* **Bug Fixes**
  * Improved correctness when using preallocated output tensors for MLA decoding (including in-place behavior).
* **Tests**
  * Expanded tests to verify counter-buffer reuse, all-zero preservation, validation errors, and autotune behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->