### PR TITLE
fix(comm): restore MNNVL flags under inference mode

### DIFF
--- a/flashinfer/comm/trtllm_mnnvl_ar.py
+++ b/flashinfer/comm/trtllm_mnnvl_ar.py
@@ -247,13 +247,15 @@ class MNNVLAllReduceFusionWorkspace(AllReduceFusionWorkspace):
     def _initialize_protocol(self) -> None:
         self.handle.lamport_initialize(self.rank, torch.float32)
         num_bytes_to_clear = [0] * 4
-        self.buffer_flags.copy_(
-            torch.tensor(
-                [0, 2, self.buffer_size_bytes, 0, *num_bytes_to_clear, 0],
-                dtype=torch.uint32,
-                device=self.buffer_flags.device,
+        # The workspace may be created under inference mode and restored outside it.
+        with torch.inference_mode():
+            self.buffer_flags.copy_(
+                torch.tensor(
+                    [0, 2, self.buffer_size_bytes, 0, *num_bytes_to_clear, 0],
+                    dtype=torch.uint32,
+                    device=self.buffer_flags.device,
+                )
             )
-        )
         torch.cuda.synchronize()
 
     @flashinfer_api

--- a/tests/comm/test_trtllm_allreduce_checkpoint.py
+++ b/tests/comm/test_trtllm_allreduce_checkpoint.py
@@ -6,6 +6,33 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 
+def test_protocol_restore_resets_inference_flags(monkeypatch) -> None:
+    from flashinfer.comm.allreduce import MNNVLAllReduceFusionWorkspace
+    from flashinfer.comm.workspace_base import AllReduceFusionWorkspace
+
+    workspace = object.__new__(MNNVLAllReduceFusionWorkspace)
+    AllReduceFusionWorkspace.__init__(workspace, world_size=1, rank=0)
+    workspace.handle = type(
+        "Handle",
+        (),
+        {"lamport_initialize": lambda self, rank, dtype: None},
+    )()
+    workspace.buffer_size_bytes = 1024
+    with torch.inference_mode():
+        workspace.buffer_flags = torch.ones(9, dtype=torch.uint32)
+    workspace._destroyed = True
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+    assert torch.is_inference(workspace.buffer_flags)
+    assert not torch.is_inference_mode_enabled()
+    workspace._initialize_protocol()
+    assert not torch.is_inference_mode_enabled()
+    assert torch.equal(
+        workspace.buffer_flags,
+        torch.tensor([0, 2, 1024, 0, 0, 0, 0, 0, 0], dtype=torch.uint32),
+    )
+
+
 def test_checkpoint_lifecycle_rejects_torch_symmetric_memory_backing() -> None:
     from flashinfer.comm.allreduce import (
         MNNVLAllReduceFusionWorkspace,


### PR DESCRIPTION
## Description

vLLM can create the FlashInfer MNNVL all-reduce fusion workspace while running graph warmup under `torch.inference_mode()`. That makes `buffer_flags` an inference tensor. A later checkpoint restore can run outside inference mode and calls `_initialize_protocol()`, whose in-place `copy_` then fails with:

```text
RuntimeError: Inplace update to inference tensor outside InferenceMode is not allowed.
```

This was reproduced during Dynamo Snapshot + GMS restore of GLM-5.2 with TEP8 after vLLM selected the MNNVL FlashInfer all-reduce backend. The restore failed after remapping the stable workspace VA, while reinitializing the protocol flags.

Run the protocol flag reset inside a narrowly scoped `torch.inference_mode()` context. This is the mutation site that requires inference mode, so the change:

- supports workspaces created either inside or outside inference mode;
- does not change tensor allocation or stable-VA ownership;
- does not disable inference mode or enable autograd; and
- restores the caller's inference-mode state when the context exits.

The regression test creates `buffer_flags` under inference mode, invokes protocol initialization from normal mode, verifies the expected flag contents, and verifies the caller remains outside inference mode afterward.

## Related Issues

No associated issue. Related checkpointable MNNVL all-reduce work: #3745.

## Checklist

- [x] I have added tests to cover my changes.
- [x] I have run `pre-commit run --all-files` and all hooks pass.
- [x] My commit includes a DCO sign-off.

## Tests

Passed:

```bash
PYTHONPATH="$PWD" python -m pytest \
  tests/comm/test_trtllm_allreduce_checkpoint.py \
  -k 'protocol_restore or lifecycle_rejects' -vv
# 2 passed, 2 deselected

pre-commit run --all-files
# all hooks passed
```

The focused regression test also passed independently.

## Reviewer Notes

The earlier workaround allocated `buffer_flags` outside inference mode. This version instead fixes the operation that has the constraint: mutating a potentially inference-created tensor during protocol restore. It avoids a separate allocation helper and avoids changing allocation semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protocol restoration so communication buffers are reset safely without changing the surrounding inference-mode state.
  * Enhanced reliability when restoring checkpointed communication state.

* **Tests**
  * Added coverage verifying buffer flags are correctly reset during protocol restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->