### PR TITLE
CuTe-DSL modular prefill: sliding-window support + band-mask performance

### DIFF
--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -400,8 +400,14 @@ def cute_dsl_fmha_ragged_prefill(
 
     if kernel_fn is None:
         gpu_arch = _get_gpu_arch(q.device)
+        # Q and K feed the same GEMM operand dtype: neither the prebuilt
+        # artifacts nor the JIT compile (single qk_dtype) support q != k.
+        if q.dtype != k.dtype:
+            raise ValueError(
+                f"cute-dsl FMHA requires q.dtype == k.dtype, got {q.dtype} and {k.dtype}"
+            )
         try:
-            if q.dtype != k.dtype or k.dtype != v.dtype:
+            if k.dtype != v.dtype:
                 raise RuntimeError("Separate dtype_qk / dtype_vo requires JIT")
             if window_left != -1 or window_right != -1:
                 # The exported artifact matrix has no window axis: every

--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -403,6 +403,13 @@ def cute_dsl_fmha_ragged_prefill(
         try:
             if q.dtype != k.dtype or k.dtype != v.dtype:
                 raise RuntimeError("Separate dtype_qk / dtype_vo requires JIT")
+            if window_left != -1 or window_right != -1:
+                # The exported artifact matrix has no window axis: every
+                # prebuilt variant is traced with window_size_left=None (and
+                # window_size_right present only for causal), so a windowed
+                # call into one fails the FFI signature check.  The causal
+                # artifact lookup would falsely succeed here — force JIT.
+                raise RuntimeError("windowed DSL FMHA variants are not exported")
             kernel_fn = get_cute_dsl_fmha_kernel(
                 gpu_arch,
                 q.dtype,
@@ -439,6 +446,8 @@ def cute_dsl_fmha_ragged_prefill(
                 use_skip_softmax,
                 enable_pdl,
                 q.device,
+                has_window_left=window_left != -1,
+                has_window_right=is_causal or window_right != -1,
             )
             # JIT kernels are compiled with --enable-tvm-ffi; the CuTe-native branch
             # would not accept them.

--- a/flashinfer/cute_dsl/attention/__init__.py
+++ b/flashinfer/cute_dsl/attention/__init__.py
@@ -32,7 +32,7 @@ from .mainloop_spec import (
     make_mla_mainloop_spec,
     make_mla_fp8_mainloop_spec,
 )
-from .fusion.mask import MaskType
+from .fusion.mask import MaskSpec
 from .fusion.variant import (
     tanh_approx,
     AttentionVariant,

--- a/flashinfer/cute_dsl/attention/collective_builder.py
+++ b/flashinfer/cute_dsl/attention/collective_builder.py
@@ -103,10 +103,12 @@ def build_fmha_launch_params(
         k_dtype,
         mainloop.kv_stages,
     )
+    # P is the A operand of the PV MMA, so its layout follows v_dtype
+    # (softmax converts P to v_dtype before the TMEM store).
     p_tmem_layout_staged = sm100_utils.make_smem_layout_a(
         pv_tiled_mma,
         config.pv_mma_tiler,
-        q_dtype,
+        v_dtype,
         mainloop.acc_stage,
     )
     v_smem_layout_staged = sm100_utils.make_smem_layout_b(
@@ -115,6 +117,28 @@ def build_fmha_launch_params(
         v_dtype,
         mainloop.kv_stages,
     )
+    # K and V share one smem allocation (sV is a recast view of sK), so a
+    # mixed-width V needs its stage stride padded to the larger operand's
+    # tile footprint, expressed in its own element units — the same scheme
+    # as the vendored FMHA kernel.
+    sK_cosize = cute.cosize(k_smem_layout_staged)
+    if k_dtype.width > v_dtype.width:
+        k_tile_cosize = cute.cosize(cute.select(k_smem_layout_staged, mode=[0, 1, 2]))
+        v_stage_stride = k_tile_cosize * k_dtype.width // v_dtype.width
+        v_smem_layout_staged = cute.append(
+            cute.select(v_smem_layout_staged, mode=[0, 1, 2]),
+            cute.make_layout(mainloop.kv_stages, stride=v_stage_stride),
+        )
+    elif v_dtype.width > k_dtype.width:
+        v_tile_cosize = cute.cosize(cute.select(v_smem_layout_staged, mode=[0, 1, 2]))
+        k_stage_stride = v_tile_cosize * v_dtype.width // k_dtype.width
+        k_smem_layout_staged = cute.append(
+            cute.select(k_smem_layout_staged, mode=[0, 1, 2]),
+            cute.make_layout(mainloop.kv_stages, stride=k_stage_stride),
+        )
+        # Every stage slot must also fit a full V tile, which is larger
+        # than the K tile the last slot's cosize accounts for.
+        sK_cosize = mainloop.kv_stages * k_stage_stride
     o_smem_layout_staged = sm100_utils.make_smem_layout_epi(
         o_dtype,
         o_layout,
@@ -163,6 +187,7 @@ def build_fmha_launch_params(
 
     tma_copy_q_bytes = cute.size_in_bytes(q_dtype, q_smem_layout)
     tma_copy_kv_bytes = cute.size_in_bytes(k_dtype, k_smem_layout)
+    tma_copy_v_bytes = cute.size_in_bytes(v_dtype, v_smem_layout)
 
     # SharedStorage struct
     align = mainloop.buffer_align_bytes
@@ -203,7 +228,7 @@ def build_fmha_launch_params(
             align,
         ]
         sK: cute.struct.Align[
-            cute.struct.MemRange[k_dtype, cute.cosize(k_smem_layout_staged)],
+            cute.struct.MemRange[k_dtype, sK_cosize],
             align,
         ]
 
@@ -229,6 +254,7 @@ def build_fmha_launch_params(
         SharedStorage=SharedStorage,
         tma_copy_q_bytes=tma_copy_q_bytes,
         tma_copy_kv_bytes=tma_copy_kv_bytes,
+        tma_copy_v_bytes=tma_copy_v_bytes,
         cluster_shape_mnk=cluster_shape_mnk,
         cluster_layout_vmnk=cluster_layout_vmnk,
         epi_tile=epi_tile,

--- a/flashinfer/cute_dsl/attention/config.py
+++ b/flashinfer/cute_dsl/attention/config.py
@@ -18,7 +18,7 @@ import enum
 from dataclasses import dataclass
 from typing import Tuple, Any
 
-from .fusion.mask import MaskType
+from .fusion.mask import MaskSpec
 from .fusion.variant import AttentionVariant, StandardAttention
 
 
@@ -68,9 +68,8 @@ class AttentionConfig:
     pv_acc_dtype: Any
     mma_tiler: Tuple[int, int, int]
     is_persistent: bool
-    mask_type: MaskType
+    mask_spec: MaskSpec
     num_repeat_kv_heads: int = 1
-    window_left: int = -1
 
     # Reserved for decode — unused by prefill. Decode kernels pack heads into
     # MMA M/N dimensions; prefill maps heads via the grid (HeadMapping.GRID).

--- a/flashinfer/cute_dsl/attention/fmha/compile.py
+++ b/flashinfer/cute_dsl/attention/fmha/compile.py
@@ -79,15 +79,26 @@ def compile_cute_dsl_fmha_kernel(
     enable_skip_softmax: bool,
     use_pdl: bool,
     device: torch.device,
+    has_window_left: bool = False,
+    has_window_right=None,
 ):
     """Compile (and cache) the trtllm FMHA kernel for a static config.
 
     Compiles with the TVM-FFI ABI (the handle takes ``torch.Tensor`` args on the env
     stream) and symbolic batch/seqlen dims, so a single compile serves all shapes for the
     given dtypes / head counts / head_dim / mask.
+
+    Sliding-window bounds follow a presence/value split: only bound *presence*
+    (``has_window_left`` / ``has_window_right``) specializes the kernel — the
+    DSL traces ``Optional[Int32]`` window args as present-or-None — while the
+    bound values are runtime arguments, so one compile serves every window
+    size.  ``has_window_right=None`` derives presence from ``is_causal``
+    (causal is a right bound with runtime value 0).
     """
     from .fmha import BlackwellFusedMultiHeadAttentionForward
 
+    if has_window_right is None:
+        has_window_right = is_causal
     enable_ex2_emulation = _ex2_emulation_enabled(device)
     qk = _CUTLASS_DTYPE[qk_dtype]
     pv = _CUTLASS_DTYPE[v_dtype]
@@ -102,7 +113,8 @@ def compile_cute_dsl_fmha_kernel(
         mma_tiler=(128, 128),
         head_dim=head_dim_arg,
         is_persistent=False,  # varlen ragged
-        mask_type=_mask_type(is_causal),
+        # Any band bound (causal or sliding window) uses the window mask.
+        mask_type=_mask_type(has_window_left or has_window_right),
         enable_ex2_emulation=enable_ex2_emulation,
         enable_skip_correction=True,
         use_tma_store=False,  # varlen -> STG
@@ -161,7 +173,10 @@ def compile_cute_dsl_fmha_kernel(
     problem_size = (1, 1, 1, 1, num_qo_heads, num_kv_heads, d, dv)
     scale_softmax = 1.0 / math.sqrt(d)
     skip_threshold_log2 = Float32(0.0) if enable_skip_softmax else None
-    ws_right = Int32(0) if is_causal else None
+    # Trace-time presence only; the traced 0s are placeholders and the real
+    # bound values arrive as runtime arguments on each call.
+    ws_left = Int32(0) if has_window_left else None
+    ws_right = Int32(0) if has_window_right else None
     stream_fake = make_fake_stream(use_tvm_ffi_env_stream=True)
 
     return cute.compile(
@@ -179,7 +194,7 @@ def compile_cute_dsl_fmha_kernel(
         scale_softmax,
         1.0,
         skip_threshold_log2,
-        None,
+        ws_left,
         ws_right,
         None,
         None,

--- a/flashinfer/cute_dsl/attention/fusion/__init__.py
+++ b/flashinfer/cute_dsl/attention/fusion/__init__.py
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .mask import (
-    MaskType,
+    MaskSpec,
     apply_mask,
+    get_kv_block_range,
     get_trip_count,
-    get_masked_trip_count,
-    get_unmasked_trip_count,
-    get_kv_start_block_idx,
+    get_trip_segments,
 )
 from .variant import (
     tanh_approx,

--- a/flashinfer/cute_dsl/attention/fusion/mask.py
+++ b/flashinfer/cute_dsl/attention/fusion/mask.py
@@ -1,20 +1,233 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Mask types and masking helper functions for attention kernels.
+"""Composable band-mask helpers for attention kernels.
 
-All helpers are standalone @cute.jit functions that take mask_type and
-window_left as compile-time parameters, so they can be reused across
-different kernel variants (prefill, decode).
+The set of KV positions a query row attends to is modeled as a contiguous
+band.  With ``offset = seqlen_k - seqlen_q`` (queries right-aligned to the
+end of KV, the append/prefill-with-cache convention), row ``q`` sees::
+
+    k in [ lo(q), hi(q) )
+    lo(q) = max(0, q + offset - window_left)                if window_left >= 0 else 0
+    hi(q) = min(seqlen_k, q + offset + 1)                   if causal
+          = min(seqlen_k, q + offset + window_right + 1)    elif window_right >= 0
+          = seqlen_k                                        otherwise
+
+``MaskSpec`` describes which bounds exist.  The spec is a compile-time
+parameter: absent bounds compile away via ``cutlass.const_expr``, so e.g. a
+no-mask kernel contains no masking code.  ``causal`` and ``window_left`` are
+independent, matching the FlashInfer convention elsewhere
+(``include/flashinfer/attention/variants.cuh``): ``window_left`` bounds
+lookback and composes with ``causal``; ``window_right`` bounds lookahead for
+non-causal masks (e.g. symmetric windows) and is mutually exclusive with
+``causal``.
+
+All helpers are standalone ``@cute.jit`` functions so they can be reused
+across kernel variants (prefill, decode).
 """
 
-import enum
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, is_dataclass
 
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.typing import Int32, Float32, Optional
+
+
+@dataclass(frozen=True)
+class MaskSpec:
+    """Compile-time description of the attention mask band.
+
+    Attributes:
+        causal: right bound follows the diagonal (``k <= q + offset``).
+        window_left: max lookback distance; ``-1`` = unbounded.
+        window_right: max lookahead distance for non-causal masks;
+            ``-1`` = unbounded.  Mutually exclusive with ``causal``.
+        check_kv_bounds: some ``seqlen_k`` is not a multiple of the KV tile,
+            so the trailing partial tile needs ``k < seqlen_k`` masking even
+            when no other bound is active.
+    """
+
+    causal: bool = False
+    window_left: int = -1
+    window_right: int = -1
+    check_kv_bounds: bool = False
+
+    def __post_init__(self):
+        if self.causal and self.window_right >= 0:
+            raise ValueError(
+                "window_right is mutually exclusive with causal "
+                "(causal already bounds lookahead at 0)"
+            )
+
+    @property
+    def has_left_bound(self) -> bool:
+        return self.window_left >= 0
+
+    @property
+    def has_right_bound(self) -> bool:
+        return self.causal or self.window_right >= 0
+
+    @property
+    def needs_masking(self) -> bool:
+        return self.has_left_bound or self.has_right_bound or self.check_kv_bounds
+
+
+@cute.jit
+def get_kv_block_range(
+    spec: MaskSpec,
+    blk_coord: cute.Coord,
+    tile_shape: cute.Shape,
+    seqlen_k: Int32,
+    seqlen_q: Int32,
+) -> tuple[Int32, Int32]:
+    """[start, end) KV block range visited for this Q tile (union over rows).
+
+    ``start`` is nonzero only with window_left; ``end`` shrinks with causal
+    or window_right.
+    """
+    qk_offset = seqlen_k - seqlen_q
+    start_block = 0
+    if cutlass.const_expr(spec.window_left >= 0):
+        first_q = blk_coord[0] * tile_shape[0] + qk_offset
+        min_kv = cutlass.max(0, first_q - spec.window_left)
+        start_block = min_kv // tile_shape[1]
+    last_q = (blk_coord[0] + 1) * tile_shape[0] - 1 + qk_offset
+    end_elem = seqlen_k
+    if cutlass.const_expr(spec.causal):
+        end_elem = cutlass.min(seqlen_k, last_q + 1)
+    elif cutlass.const_expr(spec.window_right >= 0):
+        end_elem = cutlass.min(seqlen_k, last_q + spec.window_right + 1)
+    end_block = cute.ceil_div(end_elem, tile_shape[1])
+    return start_block, end_block
+
+
+@cute.jit
+def get_trip_count(
+    spec: MaskSpec,
+    blk_coord: cute.Coord,
+    tile_shape: cute.Shape,
+    seqlen_k: Int32,
+    seqlen_q: Int32,
+) -> Int32:
+    """Number of KV tile blocks to process for this Q tile."""
+    start_block, end_block = get_kv_block_range(
+        spec, blk_coord, tile_shape, seqlen_k, seqlen_q
+    )
+    return end_block - start_block
+
+
+@cute.jit
+def get_trip_segments(
+    spec: MaskSpec,
+    blk_coord: cute.Coord,
+    tile_shape: cute.Shape,
+    seqlen_k: Int32,
+    seqlen_q: Int32,
+) -> tuple[Int32, Int32, Int32, Int32]:
+    """KV trip structure: (start_block, masked_left, unmasked, masked_right).
+
+    ``start_block`` is the first KV block visited; the three counts partition
+    the visited range and always sum to get_trip_count().  A block is
+    unmasked when every row of the Q tile sees every column of the block;
+    boundary blocks (window left edge, causal diagonal / right edge,
+    seqlen_k tail) need apply_mask.
+    """
+    start_block, end_block = get_kv_block_range(
+        spec, blk_coord, tile_shape, seqlen_k, seqlen_q
+    )
+    if cutlass.const_expr(not spec.needs_masking):
+        return start_block, 0, end_block - start_block, 0
+    else:
+        qk_offset = seqlen_k - seqlen_q
+        first_q = blk_coord[0] * tile_shape[0] + qk_offset
+        last_q = first_q + tile_shape[0] - 1
+        # Intersection over all rows of the tile: blocks fully inside
+        # [lo_max, hi_min) are visible to every row.
+        lo_max = 0
+        if cutlass.const_expr(spec.window_left >= 0):
+            lo_max = cutlass.max(0, last_q - spec.window_left)
+        hi_min = seqlen_k
+        if cutlass.const_expr(spec.causal):
+            hi_min = cutlass.min(seqlen_k, first_q + 1)
+        elif cutlass.const_expr(spec.window_right >= 0):
+            hi_min = cutlass.min(seqlen_k, first_q + spec.window_right + 1)
+        unmasked_start = cute.ceil_div(lo_max, tile_shape[1])
+        unmasked_end = hi_min // tile_shape[1]
+        unmasked_start = cutlass.min(
+            cutlass.max(unmasked_start, start_block), end_block
+        )
+        unmasked_end = cutlass.min(cutlass.max(unmasked_end, unmasked_start), end_block)
+        return (
+            start_block,
+            unmasked_start - start_block,
+            unmasked_end - unmasked_start,
+            end_block - unmasked_end,
+        )
+
+
+@cute.jit
+def apply_mask(
+    spec: MaskSpec,
+    acc_qk: cute.Tensor,
+    index_qk: cute.Tensor,
+    seqlen_k: Int32,
+    causal_offset: Int32,
+) -> None:
+    """Apply the band mask to scores.  ``pos = (q, k)`` are logical coords.
+
+    For specs with a left bound (sliding windows — the regime where every
+    visited block is a boundary block), the row's visible band ``[lo, hi)``
+    is hoisted out of the element loop: a thread's accumulator fragment
+    covers exactly one Q row under the tcgen05 TMEM-load partitioning (the
+    softmax's scalar row_max reduction relies on the same fact), so only
+    the K coordinate needs comparing per element.  ``hi`` folds the
+    ``seqlen_k`` tail bound.  Measured: masked-block cost drops ~2x and the
+    sliding-window kernel gains ~25% end-to-end.
+
+    The no-left-bound specs (plain causal, right-window, residual) keep the
+    per-element two-coordinate predicate.  Do NOT rewrite them as a compare
+    against a hoisted scalar bound: when the DSL can fold the mask predicate
+    into a single element-index-vs-invariant-threshold compare (``k >= hi``
+    directly, or ``hi <= k or k >= seqlen_k`` after or-folding), MLIR lowers
+    each element's conditional -inf write as a select over the ENTIRE packed
+    f32x2 accumulator chunk instead of a per-element select (observed: 16
+    selp.b64 per element, 8320 vs 512 kernel-wide), which ptxas cannot
+    allocate — ~1850 local-memory spills and a kernel-wide ~2.5x slowdown,
+    unmasked steps included.  The two-sided band compare above is immune
+    because opposite-direction compares don't fold to one threshold
+    (1024 selp.b64, no spills).  Seen with cutlass-dsl 4.x / CUDA 13.5.
+    """
+    if cutlass.const_expr(spec.needs_masking):
+        if cutlass.const_expr(spec.window_left >= 0):
+            row_q = index_qk[0][0] + causal_offset
+            lo = row_q - spec.window_left
+            hi = seqlen_k
+            if cutlass.const_expr(spec.causal):
+                hi = cutlass.min(row_q + 1, seqlen_k)
+            elif cutlass.const_expr(spec.window_right >= 0):
+                hi = cutlass.min(row_q + spec.window_right + 1, seqlen_k)
+            for i in range(cute.size(acc_qk)):
+                k = index_qk[i][1]
+                if k < lo or k >= hi:
+                    acc_qk[i] = -Float32.inf
+        elif cutlass.const_expr(spec.causal):
+            for i in range(cute.size(acc_qk)):
+                pos = index_qk[i]
+                if pos[0] + causal_offset < pos[1] or pos[1] >= seqlen_k:
+                    acc_qk[i] = -Float32.inf
+        elif cutlass.const_expr(spec.window_right >= 0):
+            for i in range(cute.size(acc_qk)):
+                pos = index_qk[i]
+                if (
+                    pos[1] - pos[0] - causal_offset > spec.window_right
+                    or pos[1] >= seqlen_k
+                ):
+                    acc_qk[i] = -Float32.inf
+        else:
+            for i in range(cute.size(acc_qk)):
+                if index_qk[i][1] >= seqlen_k:
+                    acc_qk[i] = -Float32.inf
 
 
 # JIT-extendable masking configurations
@@ -281,169 +494,3 @@ class SlidingWindowMask(AttentionMask):
         masked_stop = num_tiles_kv
         masked_step = warpgroups_kv * kv_splits
         return ((masked_start, masked_stop, masked_step, True),)
-
-
-#
-# Legacy enum-based masking configuration
-# only supports GQA/MHA prefill kernel
-#
-class MaskType(enum.Enum):
-    NO_MASK = enum.auto()
-    RESIDUAL_MASK = enum.auto()
-    CAUSAL_MASK = enum.auto()
-    SLIDING_WINDOW_MASK = enum.auto()
-
-
-@cute.jit
-def get_trip_count(
-    mask_type: MaskType,
-    window_left: int,
-    blk_coord: cute.Coord,
-    tile_shape: cute.Shape,
-    seqlen_k: Int32,
-    seqlen_q: Int32 = 0,
-) -> Int32:
-    """Number of KV tile blocks to process for this Q tile."""
-    result = 0
-    if mask_type == MaskType.NO_MASK or mask_type == MaskType.RESIDUAL_MASK:
-        result = cute.ceil_div(seqlen_k, tile_shape[1])
-    elif mask_type == MaskType.CAUSAL_MASK:
-        max_blocks_k = cute.ceil_div(seqlen_k, tile_shape[1])
-        causal_offset = seqlen_k - seqlen_q
-        max_blocks_q = cute.ceil_div(
-            (blk_coord[0] + 1) * tile_shape[0] + causal_offset, tile_shape[1]
-        )
-        result = cutlass.min(max_blocks_k, max_blocks_q)
-    elif mask_type == MaskType.SLIDING_WINDOW_MASK:
-        qk_offset = seqlen_k - seqlen_q
-        first_q = blk_coord[0] * tile_shape[0] + qk_offset
-        last_q = (blk_coord[0] + 1) * tile_shape[0] - 1 + qk_offset
-        min_kv = cutlass.max(0, first_q - window_left)
-        max_kv = cutlass.min(seqlen_k - 1, last_q + window_left)
-        start_block = min_kv // tile_shape[1]
-        end_block = cute.ceil_div(max_kv + 1, tile_shape[1])
-        result = end_block - start_block
-    return result
-
-
-@cute.jit
-def get_masked_trip_count(
-    mask_type: MaskType,
-    window_left: int,
-    blk_coord: cute.Coord,
-    tile_shape: cute.Shape,
-    seqlen_k: Int32,
-    seqlen_q: Int32 = 0,
-) -> Int32:
-    """Number of masked (boundary) KV tile blocks."""
-    result = 0
-    if mask_type == MaskType.NO_MASK:
-        result = 0
-    elif mask_type == MaskType.RESIDUAL_MASK:
-        if seqlen_k % tile_shape[1] != 0:
-            result = 1
-        else:
-            result = 0
-    elif mask_type == MaskType.CAUSAL_MASK:
-        trip_count = get_trip_count(
-            mask_type, window_left, blk_coord, tile_shape, seqlen_k, seqlen_q
-        )
-        causal_offset = seqlen_k - seqlen_q
-        first_boundary = (blk_coord[0] * tile_shape[0] + causal_offset) // tile_shape[1]
-        last_boundary = (
-            (blk_coord[0] + 1) * tile_shape[0] - 1 + causal_offset
-        ) // tile_shape[1]
-        result = cutlass.min(
-            trip_count,
-            last_boundary - first_boundary + 1,
-        )
-    elif mask_type == MaskType.SLIDING_WINDOW_MASK:
-        trip_count = get_trip_count(
-            mask_type, window_left, blk_coord, tile_shape, seqlen_k, seqlen_q
-        )
-        result = trip_count
-    return result
-
-
-@cute.jit
-def get_unmasked_trip_count(
-    mask_type: MaskType,
-    window_left: int,
-    blk_coord: cute.Coord,
-    tile_shape: cute.Shape,
-    seqlen_k: Int32,
-    seqlen_q: Int32 = 0,
-) -> Int32:
-    """Number of fully unmasked KV tile blocks."""
-    result = 0
-    if mask_type == MaskType.NO_MASK:
-        result = get_trip_count(mask_type, window_left, blk_coord, tile_shape, seqlen_k)
-    elif mask_type == MaskType.RESIDUAL_MASK:
-        if seqlen_k % tile_shape[1] != 0:
-            result = (
-                get_trip_count(mask_type, window_left, blk_coord, tile_shape, seqlen_k)
-                - 1
-            )
-        else:
-            result = get_trip_count(
-                mask_type, window_left, blk_coord, tile_shape, seqlen_k
-            )
-    elif mask_type == MaskType.CAUSAL_MASK:
-        result = get_trip_count(
-            mask_type, window_left, blk_coord, tile_shape, seqlen_k, seqlen_q
-        ) - get_masked_trip_count(
-            mask_type, window_left, blk_coord, tile_shape, seqlen_k, seqlen_q
-        )
-    elif mask_type == MaskType.SLIDING_WINDOW_MASK:
-        result = 0
-    return result
-
-
-@cute.jit
-def get_kv_start_block_idx(
-    mask_type: MaskType,
-    window_left: int,
-    blk_coord: cute.Coord,
-    tile_shape: cute.Shape,
-    seqlen_k: Int32,
-    seqlen_q: Int32 = 0,
-) -> Int32:
-    """Starting KV block index (nonzero only for sliding window)."""
-    if cutlass.const_expr(mask_type == MaskType.SLIDING_WINDOW_MASK):
-        qk_offset = seqlen_k - seqlen_q
-        first_q = blk_coord[0] * tile_shape[0] + qk_offset
-        min_kv = cutlass.max(0, first_q - window_left)
-        return min_kv // tile_shape[1]
-    else:
-        return 0
-
-
-@cute.jit
-def apply_mask(
-    mask_type: MaskType,
-    window_left: int,
-    acc_qk: cute.Tensor,
-    index_qk: cute.Tensor,
-    seqlen_k: Int32,
-    causal_offset: Int32 = 0,
-):
-    """Apply attention mask (causal, residual, or sliding window) to scores."""
-    if mask_type == MaskType.RESIDUAL_MASK:
-        for i in range(cute.size(acc_qk)):
-            pos = index_qk[i]
-            if pos[1] >= seqlen_k:
-                acc_qk[i] = -Float32.inf
-    elif mask_type == MaskType.CAUSAL_MASK:
-        for i in range(cute.size(acc_qk)):
-            pos = index_qk[i]
-            if pos[0] + causal_offset < pos[1] or pos[1] >= seqlen_k:
-                acc_qk[i] = -Float32.inf
-    elif mask_type == MaskType.SLIDING_WINDOW_MASK:
-        for i in range(cute.size(acc_qk)):
-            pos = index_qk[i]
-            if (
-                pos[1] - pos[0] - causal_offset > window_left
-                or pos[0] + causal_offset - pos[1] > window_left
-                or pos[1] >= seqlen_k
-            ):
-                acc_qk[i] = -Float32.inf

--- a/flashinfer/cute_dsl/attention/fusion/mask.py
+++ b/flashinfer/cute_dsl/attention/fusion/mask.py
@@ -36,41 +36,38 @@ from cutlass.cute.typing import Int32, Float32, Optional
 
 @dataclass(frozen=True)
 class MaskSpec:
-    """Compile-time description of the attention mask band.
+    """Compile-time description of WHICH band bounds exist.
+
+    Only bound *presence* is compile-time (it drives dead-code
+    elimination: a no-window kernel contains no window instructions).
+    The bound *values* (``window_left``/``window_right``) are runtime
+    kernel arguments, so one compiled kernel serves every window size.
+    Causal masking is a right bound with a runtime value of 0, not a
+    separate spec kind.  The ``k < seqlen_k`` tail bound is always on:
+    the trip-segment math yields zero masked blocks at runtime when
+    every ``seqlen_k`` is tile-aligned, so alignment does not change
+    which kernel is compiled (and cannot trigger recompiles).
 
     Attributes:
-        causal: right bound follows the diagonal (``k <= q + offset``).
-        window_left: max lookback distance; ``-1`` = unbounded.
-        window_right: max lookahead distance for non-causal masks;
-            ``-1`` = unbounded.  Mutually exclusive with ``causal``.
-        check_kv_bounds: some ``seqlen_k`` is not a multiple of the KV tile,
-            so the trailing partial tile needs ``k < seqlen_k`` masking even
-            when no other bound is active.
+        has_window_left: a max-lookback bound exists.
+        has_window_right: a max-lookahead bound exists (0 = causal).
     """
 
-    causal: bool = False
-    window_left: int = -1
-    window_right: int = -1
-    check_kv_bounds: bool = False
-
-    def __post_init__(self):
-        if self.causal and self.window_right >= 0:
-            raise ValueError(
-                "window_right is mutually exclusive with causal "
-                "(causal already bounds lookahead at 0)"
-            )
+    has_window_left: bool = False
+    has_window_right: bool = False
 
     @property
     def has_left_bound(self) -> bool:
-        return self.window_left >= 0
+        return self.has_window_left
 
     @property
     def has_right_bound(self) -> bool:
-        return self.causal or self.window_right >= 0
+        return self.has_window_right
 
     @property
     def needs_masking(self) -> bool:
-        return self.has_left_bound or self.has_right_bound or self.check_kv_bounds
+        # The seqlen_k tail bound is unconditional; see class docstring.
+        return True
 
 
 @cute.jit
@@ -80,6 +77,8 @@ def get_kv_block_range(
     tile_shape: cute.Shape,
     seqlen_k: Int32,
     seqlen_q: Int32,
+    window_left: Int32,
+    window_right: Int32,
 ) -> tuple[Int32, Int32]:
     """[start, end) KV block range visited for this Q tile (union over rows).
 
@@ -88,16 +87,14 @@ def get_kv_block_range(
     """
     qk_offset = seqlen_k - seqlen_q
     start_block = 0
-    if cutlass.const_expr(spec.window_left >= 0):
+    if cutlass.const_expr(spec.has_window_left):
         first_q = blk_coord[0] * tile_shape[0] + qk_offset
-        min_kv = cutlass.max(0, first_q - spec.window_left)
+        min_kv = cutlass.max(0, first_q - window_left)
         start_block = min_kv // tile_shape[1]
     last_q = (blk_coord[0] + 1) * tile_shape[0] - 1 + qk_offset
     end_elem = seqlen_k
-    if cutlass.const_expr(spec.causal):
-        end_elem = cutlass.min(seqlen_k, last_q + 1)
-    elif cutlass.const_expr(spec.window_right >= 0):
-        end_elem = cutlass.min(seqlen_k, last_q + spec.window_right + 1)
+    if cutlass.const_expr(spec.has_window_right):
+        end_elem = cutlass.min(seqlen_k, last_q + window_right + 1)
     end_block = cute.ceil_div(end_elem, tile_shape[1])
     return start_block, end_block
 
@@ -109,10 +106,12 @@ def get_trip_count(
     tile_shape: cute.Shape,
     seqlen_k: Int32,
     seqlen_q: Int32,
+    window_left: Int32,
+    window_right: Int32,
 ) -> Int32:
     """Number of KV tile blocks to process for this Q tile."""
     start_block, end_block = get_kv_block_range(
-        spec, blk_coord, tile_shape, seqlen_k, seqlen_q
+        spec, blk_coord, tile_shape, seqlen_k, seqlen_q, window_left, window_right
     )
     return end_block - start_block
 
@@ -124,6 +123,8 @@ def get_trip_segments(
     tile_shape: cute.Shape,
     seqlen_k: Int32,
     seqlen_q: Int32,
+    window_left: Int32,
+    window_right: Int32,
 ) -> tuple[Int32, Int32, Int32, Int32]:
     """KV trip structure: (start_block, masked_left, unmasked, masked_right).
 
@@ -134,7 +135,7 @@ def get_trip_segments(
     seqlen_k tail) need apply_mask.
     """
     start_block, end_block = get_kv_block_range(
-        spec, blk_coord, tile_shape, seqlen_k, seqlen_q
+        spec, blk_coord, tile_shape, seqlen_k, seqlen_q, window_left, window_right
     )
     if cutlass.const_expr(not spec.needs_masking):
         return start_block, 0, end_block - start_block, 0
@@ -145,13 +146,11 @@ def get_trip_segments(
         # Intersection over all rows of the tile: blocks fully inside
         # [lo_max, hi_min) are visible to every row.
         lo_max = 0
-        if cutlass.const_expr(spec.window_left >= 0):
-            lo_max = cutlass.max(0, last_q - spec.window_left)
+        if cutlass.const_expr(spec.has_window_left):
+            lo_max = cutlass.max(0, last_q - window_left)
         hi_min = seqlen_k
-        if cutlass.const_expr(spec.causal):
-            hi_min = cutlass.min(seqlen_k, first_q + 1)
-        elif cutlass.const_expr(spec.window_right >= 0):
-            hi_min = cutlass.min(seqlen_k, first_q + spec.window_right + 1)
+        if cutlass.const_expr(spec.has_window_right):
+            hi_min = cutlass.min(seqlen_k, first_q + window_right + 1)
         unmasked_start = cute.ceil_div(lo_max, tile_shape[1])
         unmasked_end = hi_min // tile_shape[1]
         unmasked_start = cutlass.min(
@@ -173,61 +172,70 @@ def apply_mask(
     index_qk: cute.Tensor,
     seqlen_k: Int32,
     causal_offset: Int32,
+    index_qk_static: cute.Tensor,
+    window_left: Int32,
+    window_right: Int32,
 ) -> None:
-    """Apply the band mask to scores.  ``pos = (q, k)`` are logical coords.
+    """Set out-of-band scores to -inf.
 
-    For specs with a left bound (sliding windows — the regime where every
-    visited block is a boundary block), the row's visible band ``[lo, hi)``
-    is hoisted out of the element loop: a thread's accumulator fragment
-    covers exactly one Q row under the tcgen05 TMEM-load partitioning (the
-    softmax's scalar row_max reduction relies on the same fact), so only
-    the K coordinate needs comparing per element.  ``hi`` folds the
-    ``seqlen_k`` tail bound.  Measured: masked-block cost drops ~2x and the
-    sliding-window kernel gains ~25% end-to-end.
+    The row's visible band ``[lo, hi)`` (see module docstring) is hoisted
+    out of the element loop, so each element only compares its K
+    coordinate against row-invariant bounds.  ``index_qk`` is the
+    identity partition of the score tile carrying global ``(q, k)``
+    coordinates; ``index_qk_static`` is the same partition of the
+    unshifted identity tensor, so its coordinates are trace-time
+    constants.
 
-    The no-left-bound specs (plain causal, right-window, residual) keep the
-    per-element two-coordinate predicate.  Do NOT rewrite them as a compare
-    against a hoisted scalar bound: when the DSL can fold the mask predicate
-    into a single element-index-vs-invariant-threshold compare (``k >= hi``
-    directly, or ``hi <= k or k >= seqlen_k`` after or-folding), MLIR lowers
-    each element's conditional -inf write as a select over the ENTIRE packed
-    f32x2 accumulator chunk instead of a per-element select (observed: 16
-    selp.b64 per element, 8320 vs 512 kernel-wide), which ptxas cannot
-    allocate — ~1850 local-memory spills and a kernel-wide ~2.5x slowdown,
-    unmasked steps included.  The two-sided band compare above is immune
-    because opposite-direction compares don't fold to one threshold
-    (1024 selp.b64, no spills).  Seen with cutlass-dsl 4.x / CUDA 13.5.
+    Layout assumptions:
+    - One Q row per thread fragment, so the band bounds are uniform
+      across a thread's elements (the softmax's scalar row_max reduction
+      relies on the same fact).
+    - ``index_qk[i] == index_qk_static[i] + domain_offset`` for all i,
+      so the tile's dynamic base folds into the hoisted bounds.
+    Fragment layouts that break these (e.g. head-packed decode rows, or
+    a gathered/sparse KV axis) cannot use this function as-is; they need
+    per-element two-coordinate predicates instead of hoisted bounds.
+
+    Codegen rules — both are required to avoid register spills:
+    - Masked writes use ``cutlass.select_``, never a traced ``if``.
+      Register data is immutable SSA values in the IR, so a traced
+      conditional element write is recorded as an ``scf.if`` that
+      yields the whole fragment, and the backend does not reliably
+      reduce that to a single-element select.  ``cutlass.select_``
+      emits one scalar ``arith.select`` per element and is safe for
+      any predicate shape.
+    - Per-element K reads come from ``index_qk_static``: its
+      coordinates are compile-time constants that lower to immediate
+      operands, whereas reading the shifted partition materializes
+      each global coordinate through per-element address arithmetic
+      that inflates register pressure.
     """
     if cutlass.const_expr(spec.needs_masking):
-        if cutlass.const_expr(spec.window_left >= 0):
-            row_q = index_qk[0][0] + causal_offset
-            lo = row_q - spec.window_left
-            hi = seqlen_k
-            if cutlass.const_expr(spec.causal):
-                hi = cutlass.min(row_q + 1, seqlen_k)
-            elif cutlass.const_expr(spec.window_right >= 0):
-                hi = cutlass.min(row_q + spec.window_right + 1, seqlen_k)
+        base_k = index_qk[0][1] - index_qk_static[0][1]
+        row_q = index_qk[0][0] + causal_offset
+        hi = seqlen_k
+        if cutlass.const_expr(spec.has_window_right):
+            hi = cutlass.min(row_q + window_right + 1, seqlen_k)
+        hi_rel = hi - base_k
+        if cutlass.const_expr(spec.has_window_left):
+            lo_rel = row_q - window_left - base_k
             for i in range(cute.size(acc_qk)):
-                k = index_qk[i][1]
-                if k < lo or k >= hi:
-                    acc_qk[i] = -Float32.inf
-        elif cutlass.const_expr(spec.causal):
-            for i in range(cute.size(acc_qk)):
-                pos = index_qk[i]
-                if pos[0] + causal_offset < pos[1] or pos[1] >= seqlen_k:
-                    acc_qk[i] = -Float32.inf
-        elif cutlass.const_expr(spec.window_right >= 0):
-            for i in range(cute.size(acc_qk)):
-                pos = index_qk[i]
-                if (
-                    pos[1] - pos[0] - causal_offset > spec.window_right
-                    or pos[1] >= seqlen_k
-                ):
-                    acc_qk[i] = -Float32.inf
+                k = index_qk_static[i][1]
+                acc_qk[i] = cutlass.select_(
+                    (k < lo_rel) | (k >= hi_rel),
+                    -Float32.inf,
+                    acc_qk[i],
+                )
         else:
+            # Right-bound-only specs (causal, right window, seqlen_k
+            # tail): single-direction compare — safe here because
+            # select_ has no scf.if region for MLIR to fold.
             for i in range(cute.size(acc_qk)):
-                if index_qk[i][1] >= seqlen_k:
-                    acc_qk[i] = -Float32.inf
+                acc_qk[i] = cutlass.select_(
+                    index_qk_static[i][1] >= hi_rel,
+                    -Float32.inf,
+                    acc_qk[i],
+                )
 
 
 # JIT-extendable masking configurations

--- a/flashinfer/cute_dsl/attention/fusion/mask.py
+++ b/flashinfer/cute_dsl/attention/fusion/mask.py
@@ -117,6 +117,120 @@ def get_trip_count(
 
 
 @cute.jit
+def get_peel_sections(
+    spec: MaskSpec,
+    blk_coord: cute.Coord,
+    tile_shape: cute.Shape,
+    seqlen_k: Int32,
+    seqlen_q: Int32,
+    window_left: Int32,
+    window_right: Int32,
+) -> tuple[Int32, Int32, Int32, Int32, Int32]:
+    """Head/main/tail split of the union KV range across the two 128-row halves.
+
+    Returns ``(kv_start, head, main, tail, stage1_lo_extra)``:
+
+    - ``kv_start`` — first union block (== stage 0's band start).
+    - ``head``     — leading blocks visited only by stage 0 (its band starts
+      earlier: ``lo`` is nondecreasing in the row).
+    - ``main``     — blocks visited by both halves.
+    - ``tail``     — trailing blocks visited only by stage 1.
+    - ``stage1_lo_extra`` — blocks by which stage 1's band start was clamped
+      down to keep the three sections contiguous (nonzero only when stage 1's
+      rows are entirely out of the valid Q range and its raw band start lands
+      beyond stage 0's band end).  Stage 1 treats these as extra masked-left
+      blocks; their rows see an empty band and mask to -inf.
+
+    ``head + main + tail`` equals the full-tile ``get_trip_count`` by
+    construction — every role deriving its loop counts from this one helper
+    agrees with the loader's union fetch.
+    """
+    stage_tiler = (tile_shape[0] // 2, tile_shape[1])
+    lo0, hi0 = get_kv_block_range(
+        spec,
+        (blk_coord[0] * 2, blk_coord[1], blk_coord[2]),
+        stage_tiler,
+        seqlen_k,
+        seqlen_q,
+        window_left,
+        window_right,
+    )
+    lo1, hi1 = get_kv_block_range(
+        spec,
+        (blk_coord[0] * 2 + 1, blk_coord[1], blk_coord[2]),
+        stage_tiler,
+        seqlen_k,
+        seqlen_q,
+        window_left,
+        window_right,
+    )
+    # lo is nondecreasing and hi is nondecreasing in the row, so lo0 <= lo1
+    # and hi0 <= hi1; only lo1 can escape past hi0 (OOB stage-1 rows).
+    lo1_clamped = cutlass.min(lo1, hi0)
+    head = lo1_clamped - lo0
+    main = hi0 - lo1_clamped
+    # Borrow one head block into main when the bands don't overlap
+    # (window_left == 0, or fully-OOB stage-1 rows): main >= 1 lets every
+    # consumer keep a straight-line main prologue/epilogue, and stage 1
+    # masks the borrowed block to -inf (it is outside its band).  head >= 1
+    # whenever main == 0, since stage 0's band is never empty.
+    borrow = cutlass.min(head, cutlass.max(0, 1 - main))
+    return (
+        lo0,
+        head - borrow,
+        main + borrow,
+        hi1 - hi0,
+        (lo1 - lo1_clamped) + borrow,
+    )
+
+
+@cute.jit
+def get_stage_peel_segments(
+    spec: MaskSpec,
+    blk_coord: cute.Coord,
+    stage: int,
+    tile_shape: cute.Shape,
+    seqlen_k: Int32,
+    seqlen_q: Int32,
+    window_left: Int32,
+    window_right: Int32,
+) -> tuple[Int32, Int32, Int32, Int32, Int32, Int32]:
+    """One 128-row stage's iteration plan under the head/tail peel.
+
+    Returns ``(start_block, masked_left, unmasked, masked_right,
+    token_pre_consume, token_post_produce)``: the stage's own band segments
+    (stage 0 iterates the union's head+main blocks, stage 1 the main+tail
+    blocks, starting from the clamped band start so blocks folded in by
+    get_peel_sections mask to -inf), plus the sequence-token dummy counts
+    that keep the s0->s1 token ring balanced (stage 1 pre-consumes stage 0's
+    ``head`` tokens; stage 0 post-produces ``tail`` tokens).
+    """
+    union_start, head, _, tail, stage1_extra = get_peel_sections(
+        spec, blk_coord, tile_shape, seqlen_k, seqlen_q, window_left, window_right
+    )
+    _, masked_left, unmasked, masked_right = get_trip_segments(
+        spec,
+        (blk_coord[0] * 2 + stage, blk_coord[1], blk_coord[2]),
+        (tile_shape[0] // 2, tile_shape[1]),
+        seqlen_k,
+        seqlen_q,
+        window_left,
+        window_right,
+    )
+    if cutlass.const_expr(stage == 0):
+        return union_start, masked_left, unmasked, masked_right, Int32(0), tail
+    else:
+        return (
+            union_start + head,
+            masked_left + stage1_extra,
+            unmasked,
+            masked_right,
+            head,
+            Int32(0),
+        )
+
+
+@cute.jit
 def get_trip_segments(
     spec: MaskSpec,
     blk_coord: cute.Coord,

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -87,6 +87,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         window_left: Int32,
         window_right: Int32,
         params_in: cute.Tensor | None,
+        lse_in: cute.Tensor | None,
         stream,
     ):
         """Execute the Fused Multi-Head Attention operation on the provided tensors.
@@ -154,6 +155,18 @@ class BlackwellFusedMultiHeadAttentionForward:
             if self.fusion.has_params
             else None
         )
+
+        # (total_q, h_q) f32 log-sum-exp output, written by the correction
+        # warps (log2 domain, matching the flashinfer LSE convention).
+        mLSE = None
+        if cutlass.const_expr(lse_in is not None):
+            lse_rows = (
+                s_q_all if cutlass.const_expr(cum_seqlen_q is not None) else s_q * b
+            )
+            mLSE = cute.make_tensor(
+                lse_in.iterator,
+                cute.make_layout((lse_rows, h_r * h_k), stride=(h_r * h_k, 1)),
+            )
 
         # setup static attributes before smem/grid/tma computation
         self.q_dtype = q.element_type
@@ -274,6 +287,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             window_left,
             window_right,
             params,
+            mLSE,
             lp.q_smem_layout_staged,
             lp.k_smem_layout_staged,
             lp.p_tmem_layout_staged,
@@ -382,6 +396,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         window_left: Int32,
         window_right: Int32,
         params: cute.Tensor | None,
+        mLSE: cute.Tensor | None,
         q_smem_layout_staged: cute.ComposedLayout,
         k_smem_layout_staged: cute.ComposedLayout,
         p_tmem_layout_staged: cute.ComposedLayout,
@@ -649,6 +664,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                     scale_output,
                     window_left,
                     window_right,
+                    mLSE,
                     s0_corr_consumer,
                     s1_corr_consumer,
                     mma_corr_consumer,

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -204,6 +204,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             tmem_alloc_sync_bar_id=self.schedule.tmem_alloc_sync_bar_id,
             threads_per_warp=self.schedule.threads_per_warp,
             has_logits_transform=self.has_logits_transform,
+            has_statistics_update=self.fusion.variant.has_statistics_update,
         )
         self.mma_role.set_dtypes(
             self.q_dtype,

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -192,12 +192,15 @@ class BlackwellFusedMultiHeadAttentionForward:
         if cutlass.const_expr(self.v_major_mode != cute.nvgpu.OperandMajorMode.MN):
             raise RuntimeError("The layout of v is not supported")
 
-        # check type consistency
+        # check type consistency: Q and K feed the same GEMM operand dtype;
+        # V (and with it P, the PV MMA A-operand) may differ.
         if cutlass.const_expr(self.q_dtype != self.k_dtype):
             raise TypeError(f"Type mismatch: {self.q_dtype} != {self.k_dtype}")
-        if cutlass.const_expr(self.q_dtype != self.v_dtype):
-            raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
-        self.mainloop = self.mainloop.resolve(self.q_dtype.width)
+        # Stage counts are sized for the wider K/V operand (the shared
+        # K/V smem ring must fit both tiles per slot).
+        self.mainloop = self.mainloop.resolve(
+            max(self.q_dtype.width, self.v_dtype.width)
+        )
 
         self.softmax_role = SoftmaxRole(
             self.config,
@@ -232,7 +235,7 @@ class BlackwellFusedMultiHeadAttentionForward:
             self.k_major_mode,
             self.v_major_mode,
         )
-        self.softmax_role.set_dtypes(self.q_dtype, self.o_dtype)
+        self.softmax_role.set_dtypes(self.q_dtype, self.o_dtype, self.v_dtype)
 
         lp = build_fmha_launch_params(
             self.mainloop,
@@ -263,6 +266,13 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         self.tma_copy_q_bytes = lp.tma_copy_q_bytes
         self.tma_copy_kv_bytes = lp.tma_copy_kv_bytes
+        # The shared K/V ring's barriers are initialized with K's byte
+        # count; with mixed K/V dtypes the loader re-arms each V slot with
+        # V's byte count (None means uniform: plain acquires).
+        self.loader_role.set_v_tx_bytes(
+            lp.tma_copy_v_bytes if self.k_dtype.width != self.v_dtype.width else None,
+            self.mainloop.kv_stages,
+        )
 
         if cutlass.const_expr(not self.has_logits_transform):
             self.correction_role.set_call_attrs(self.o_dtype, lp.o_layout, lp.epi_tile)
@@ -352,7 +362,7 @@ class BlackwellFusedMultiHeadAttentionForward:
 
         tP = cute.make_tensor(tStS.iterator, p_tmem_layout_staged.outer)
         tOrP = pv_thr_mma.make_fragment_A(tP)[None, None, None, 0]
-        p_scale = self.config.qk_acc_dtype.width // self.q_dtype.width
+        p_scale = self.config.qk_acc_dtype.width // self.v_dtype.width
         tOrP0 = cute.make_tensor(
             tOrP.iterator + p_scale * self.tmem.p0_offset, tOrP.layout
         )
@@ -457,8 +467,13 @@ class BlackwellFusedMultiHeadAttentionForward:
         sK = storage.sK.get_tensor(
             k_smem_layout_staged.outer, swizzle=k_smem_layout_staged.inner
         )
+        # V reuses K's smem buffer; recast the element type first so the
+        # MMA descriptor matches v_dtype when K and V dtypes differ.
         sV = cute.make_tensor(
-            cute.recast_ptr(sK.iterator, v_smem_layout_staged.inner),
+            cute.recast_ptr(
+                cute.recast_ptr(sK.iterator, dtype=self.v_dtype),
+                v_smem_layout_staged.inner,
+            ),
             v_smem_layout_staged.outer,
         )
         sO = storage.sO.get_tensor(
@@ -521,6 +536,7 @@ class BlackwellFusedMultiHeadAttentionForward:
                 load_q_producer,
                 load_kv_producer,
                 tile_sched_params,
+                storage.load_kv_mbar_ptr.data_ptr(),
             )
 
         # ///////////////////////////////////////////////////////////////////////////////

--- a/flashinfer/cute_dsl/attention/prefill.py
+++ b/flashinfer/cute_dsl/attention/prefill.py
@@ -84,6 +84,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         s_k_all: Int32,
         scale_softmax_log2: Float32,
         scale_output: Float32,
+        window_left: Int32,
+        window_right: Int32,
         params_in: cute.Tensor | None,
         stream,
     ):
@@ -98,6 +100,10 @@ class BlackwellFusedMultiHeadAttentionForward:
         :param cum_seqlen_k: Cumulative KV sequence lengths, or None
         :param scale_softmax_log2: ``log2(e) * sm_scale``
         :param scale_output: Output scaling factor
+        :param window_left: runtime lookback bound (read only when the
+            compile-time ``MaskSpec.has_window_left`` is set)
+        :param window_right: runtime lookahead bound (read only when the
+            compile-time ``MaskSpec.has_window_right`` is set)
         :param params_in: Variant runtime data tensor, or None
         :param stream: CUDA stream
         """
@@ -265,6 +271,8 @@ class BlackwellFusedMultiHeadAttentionForward:
             cum_seqlen_k,
             scale_softmax_log2,
             scale_output,
+            window_left,
+            window_right,
             params,
             lp.q_smem_layout_staged,
             lp.k_smem_layout_staged,
@@ -371,6 +379,8 @@ class BlackwellFusedMultiHeadAttentionForward:
         cum_seqlen_k: cute.Tensor | None,
         scale_softmax_log2: Float32,
         scale_output: Float32,
+        window_left: Int32,
+        window_right: Int32,
         params: cute.Tensor | None,
         q_smem_layout_staged: cute.ComposedLayout,
         k_smem_layout_staged: cute.ComposedLayout,
@@ -491,6 +501,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                 sV,
                 cum_seqlen_q,
                 cum_seqlen_k,
+                window_left,
+                window_right,
                 load_q_producer,
                 load_kv_producer,
                 tile_sched_params,
@@ -516,6 +528,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                 mK_kdl.shape[0],
                 cum_seqlen_q,
                 cum_seqlen_k,
+                window_left,
+                window_right,
                 load_q_consumer,
                 load_kv_consumer,
                 mma_s0_producer,
@@ -557,6 +571,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                 cum_seqlen_k=cum_seqlen_k,
                 scale_softmax_log2=scale_softmax_log2,
                 scale_output=scale_output,
+                window_left=window_left,
+                window_right=window_right,
                 qk_thr_mma=qk_thr_mma,
                 pv_thr_mma=pv_thr_mma,
                 tStS=tStS,
@@ -591,6 +607,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                 cum_seqlen_k=cum_seqlen_k,
                 scale_softmax_log2=scale_softmax_log2,
                 scale_output=scale_output,
+                window_left=window_left,
+                window_right=window_right,
                 qk_thr_mma=qk_thr_mma,
                 pv_thr_mma=pv_thr_mma,
                 tStS=tStS,
@@ -629,6 +647,8 @@ class BlackwellFusedMultiHeadAttentionForward:
                     cum_seqlen_k,
                     scale_softmax_log2,
                     scale_output,
+                    window_left,
+                    window_right,
                     s0_corr_consumer,
                     s1_corr_consumer,
                     mma_corr_consumer,

--- a/flashinfer/cute_dsl/attention/roles/correction.py
+++ b/flashinfer/cute_dsl/attention/roles/correction.py
@@ -23,7 +23,7 @@ from cutlass.pipeline import PipelineProducer, PipelineConsumer
 
 from ..config import AttentionConfig, AttentionFusion
 from ..tmem_layout import TmemLayout
-from ..fusion.mask import get_trip_count
+from ..fusion.mask import get_kv_block_range, get_trip_count
 from ..scheduler.persistent import (
     FmhaStaticTileScheduler,
     FmhaStaticTileSchedulerParams,
@@ -63,6 +63,7 @@ class CorrectionRole:
         self.variant = fusion.variant
         self.has_logits_transform = fusion.variant.has_logits_transform
         self.has_output_transform = fusion.variant.has_output_transform
+        self.has_statistics_update = fusion.variant.has_statistics_update
 
         # Warp config
         self.correction_warp_ids = correction_warp_ids
@@ -367,7 +368,59 @@ class CorrectionRole:
                     )
                     - 1
                 )
+                # Per-stage 128-row bands, mirroring SoftmaxRole.run(): for
+                # trips outside a stage's band the softmax dead_step()
+                # published a no-change vec (rescale factor exactly 1), so
+                # the O rescale is skipped.  Same variant gating as the
+                # softmax dead path.
+                kv_start_block = 0
+                stage0_lo = 0
+                stage0_hi = 0
+                stage1_lo = 0
+                stage1_hi = 0
+                if cutlass.const_expr(
+                    not self.has_logits_transform and not self.has_statistics_update
+                ):
+                    kv_start_block, _ = get_kv_block_range(
+                        self.mask_spec,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_k,
+                        seqlen_q_,
+                    )
+                    stage0_lo, stage0_hi = get_kv_block_range(
+                        self.mask_spec,
+                        (
+                            curr_block_coord[0] * 2,
+                            curr_block_coord[1],
+                            curr_block_coord[2],
+                        ),
+                        (self.qk_mma_tiler[0], self.cta_tiler[1]),
+                        seqlen_k,
+                        seqlen_q_,
+                    )
+                    stage1_lo, stage1_hi = get_kv_block_range(
+                        self.mask_spec,
+                        (
+                            curr_block_coord[0] * 2 + 1,
+                            curr_block_coord[1],
+                            curr_block_coord[2],
+                        ),
+                        (self.qk_mma_tiler[0], self.cta_tiler[1]),
+                        seqlen_k,
+                        seqlen_q_,
+                    )
                 for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
+                    # Iteration _i consumes the vec of KV trip _i + 1 (the
+                    # first trip's vec was released above, pre-loop).
+                    live0 = True
+                    live1 = True
+                    if cutlass.const_expr(
+                        not self.has_logits_transform and not self.has_statistics_update
+                    ):
+                        blk = kv_start_block + _i + 1
+                        live0 = not (blk < stage0_lo or blk >= stage0_hi)
+                        live1 = not (blk < stage1_lo or blk >= stage1_hi)
                     # wait for vec0 (row_wise current max & previous max)
                     vec0_handle = s0_corr_consumer.wait_and_advance()
                     tTMEM_LOAD_VECrS = cute.make_rmem_tensor(
@@ -382,7 +435,8 @@ class CorrectionRole:
                     # wait for o0
                     o0_handle_consumer = mma_corr_consumer.wait_and_advance()
                     if cutlass.const_expr(not self.has_logits_transform):
-                        self.rescale(pv_thr_mma, tOtO0, scale)
+                        if live0:
+                            self.rescale(pv_thr_mma, tOtO0, scale)
                     # release vec1 & o0
                     vec1_handle.release()
                     cute.arch.fence_view_async_tmem_store()
@@ -398,7 +452,8 @@ class CorrectionRole:
 
                     o1_handle_consumer = mma_corr_consumer.wait_and_advance()
                     if cutlass.const_expr(not self.has_logits_transform):
-                        self.rescale(pv_thr_mma, tOtO1, scale)
+                        if live1:
+                            self.rescale(pv_thr_mma, tOtO1, scale)
                     vec0_handle.release()
                     cute.arch.fence_view_async_tmem_store()
                     o1_handle_consumer.release()

--- a/flashinfer/cute_dsl/attention/roles/correction.py
+++ b/flashinfer/cute_dsl/attention/roles/correction.py
@@ -53,8 +53,7 @@ class CorrectionRole:
         self.pv_mma_tiler = config.pv_mma_tiler
         self.pv_acc_dtype = config.pv_acc_dtype
         self.cta_tiler = config.cta_tiler
-        self.mask_type = config.mask_type
-        self.window_left = config.window_left
+        self.mask_spec = config.mask_spec
 
         # From TMEM layout
         self.tmem_vec0_offset = tmem.vec0_offset
@@ -360,8 +359,7 @@ class CorrectionRole:
                 vec1_handle = s1_corr_consumer.wait_and_advance()
                 seqlen_kv_loop_steps = (
                     get_trip_count(
-                        self.mask_type,
-                        self.window_left,
+                        self.mask_spec,
                         curr_block_coord,
                         self.cta_tiler,
                         seqlen_k,

--- a/flashinfer/cute_dsl/attention/roles/correction.py
+++ b/flashinfer/cute_dsl/attention/roles/correction.py
@@ -23,7 +23,7 @@ from cutlass.pipeline import PipelineProducer, PipelineConsumer
 
 from ..config import AttentionConfig, AttentionFusion
 from ..tmem_layout import TmemLayout
-from ..fusion.mask import get_trip_count
+from ..fusion.mask import get_peel_sections, get_trip_count
 from ..scheduler.persistent import (
     FmhaStaticTileScheduler,
     FmhaStaticTileSchedulerParams,
@@ -360,12 +360,15 @@ class CorrectionRole:
                 if cutlass.const_expr(cum_seqlen_k is not None):
                     cuseqlen_k = cum_seqlen_k[batch_coord]
                     seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
-                # Ignore first signal from softmax as no correction is required
-                vec0_handle = s0_corr_consumer.wait_and_advance()
-                vec0_handle.release()
-                vec1_handle = s1_corr_consumer.wait_and_advance()
-                seqlen_kv_loop_steps = (
-                    get_trip_count(
+                # Head / main / tail split (see fusion/mask.py
+                # get_peel_sections and MmaRole.run): stage 0 runs
+                # head+main trips, stage 1 main+tail trips.  The shared
+                # mma_corr ring's commit order is [o0]*head, o0, (o1,o0)*
+                # (main-1), o1, [o1]*tail — consumption below must match it,
+                # which is also why O0's epilog runs before the tail loop
+                # (letting the O0 drain overlap stage 1's tail trips).
+                if cutlass.const_expr(not self.has_statistics_update):
+                    _, head_cnt, main_cnt, tail_cnt, _ = get_peel_sections(
                         self.mask_spec,
                         curr_block_coord,
                         self.cta_tiler,
@@ -374,20 +377,57 @@ class CorrectionRole:
                         window_left,
                         window_right,
                     )
-                    - 1
-                )
-                for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
-                    # Iteration _i consumes the vec of KV trip _i + 1 (the
-                    # first trip's vec was released above, pre-loop).
+                else:
+                    head_cnt = Int32(0)
+                    tail_cnt = Int32(0)
+                    main_cnt = get_trip_count(
+                        self.mask_spec,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_k,
+                        seqlen_q_,
+                        window_left,
+                        window_right,
+                    )
+                # Ignore first vec0 from softmax as no correction is required
+                vec0_handle = s0_corr_consumer.wait_and_advance()
+                vec0_handle.release()
+                # HEAD: O0-only rescale trips (stage 1 has no traffic yet).
+                for _h in cutlass.range(0, head_cnt, 1, unroll=1):
+                    vec0_handle = s0_corr_consumer.wait_and_advance()
+                    tTMEM_LOAD_VECrS = cute.make_rmem_tensor(
+                        tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype
+                    )
+                    cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtS0, tTMEM_LOAD_VECrS)
+                    scale_ = scale_softmax_log2 * (
+                        tTMEM_LOAD_VECrS[0] - tTMEM_LOAD_VECrS[1]
+                    )
+                    scale = cute.arch.exp2(scale_)
+                    rescale_ballot = cute.arch.vote_ballot_sync(
+                        tTMEM_LOAD_VECrS[0] != tTMEM_LOAD_VECrS[1]
+                    )
+                    o0_handle_consumer = mma_corr_consumer.wait_and_advance()
+                    if cutlass.const_expr(not self.has_logits_transform):
+                        if rescale_ballot != 0:
+                            self.rescale(pv_thr_mma, tOtO0, scale)
+                    vec0_handle.release()
+                    cute.arch.fence_view_async_tmem_store()
+                    o0_handle_consumer.release()
+                    # Drain the MMA's alternation-keeping empty o1 slot.
+                    o1_dummy_consumer = mma_corr_consumer.wait_and_advance()
+                    o1_dummy_consumer.release()
+                vec1_handle = s1_corr_consumer.wait_and_advance()
+                for _i in cutlass.range(0, main_cnt - 1, 1, unroll=1):
+                    # Iteration _i consumes the vec of the NEXT trip in each
+                    # stage's own stream (the first trips' vecs were handled
+                    # above).
                     #
                     # Rescale skip: a warp-wide ballot on old_max != new_max
                     # skips the O TMEM roundtrip when the rescale factor is
                     # exactly 1 for all 32 rows the warp covers (equal maxes
-                    # => exp2(0) == 1.0, so the skip is exact).  Covers both
-                    # dead trips (dead_step publishes old == new) and live
-                    # trips that raised no row max.  Per-warp divergence is
-                    # safe: the TMEM copies are warp-local (each warp owns
-                    # its 32-row slice of O).
+                    # => exp2(0) == 1.0, so the skip is exact).  Per-warp
+                    # divergence is safe: the TMEM copies are warp-local
+                    # (each warp owns its 32-row slice of O).
                     # wait for vec0 (row_wise current max & previous max)
                     vec0_handle = s0_corr_consumer.wait_and_advance()
                     tTMEM_LOAD_VECrS = cute.make_rmem_tensor(
@@ -462,8 +502,42 @@ class CorrectionRole:
                 o0_handle_consumer.release()
                 o0_final_handle.commit()
 
+                # TAIL: O1-only rescale trips (runs after — and overlapped
+                # with — the O0 epilog above; the shared o-ring's commit
+                # order requires exactly this placement).
+                for _t in cutlass.range(0, tail_cnt, 1, unroll=1):
+                    vec1_handle = s1_corr_consumer.wait_and_advance()
+                    tTMEM_LOAD_VECrS = cute.make_rmem_tensor(
+                        tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype
+                    )
+                    cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtS1, tTMEM_LOAD_VECrS)
+                    scale_ = scale_softmax_log2 * (
+                        tTMEM_LOAD_VECrS[0] - tTMEM_LOAD_VECrS[1]
+                    )
+                    scale = cute.arch.exp2(scale_)
+                    rescale_ballot = cute.arch.vote_ballot_sync(
+                        tTMEM_LOAD_VECrS[0] != tTMEM_LOAD_VECrS[1]
+                    )
+                    o1_handle_consumer = mma_corr_consumer.wait_and_advance()
+                    if cutlass.const_expr(not self.has_logits_transform):
+                        if rescale_ballot != 0:
+                            self.rescale(pv_thr_mma, tOtO1, scale)
+                    vec1_handle.release()
+                    cute.arch.fence_view_async_tmem_store()
+                    o1_handle_consumer.release()
+                    # Drain the MMA's alternation-keeping empty o0 slot.
+                    o0_dummy_consumer = mma_corr_consumer.wait_and_advance()
+                    o0_dummy_consumer.release()
+
                 # wait for vec1 (row_wise global sum)
                 vec1_handle = s1_corr_consumer.wait_and_advance()
+                # Fresh rmem tensor: reusing the O0-final one would thread it
+                # through the TAIL loop above as a loop-carried memref (the
+                # tail body assigns the same name), which defeats mem2reg and
+                # demotes the vec values to a local-memory depot.
+                tTMEM_LOAD_VECrS = cute.make_rmem_tensor(
+                    tTMEM_LOAD_VECcS.shape, self.qk_acc_dtype
+                )
                 cute.copy(tiled_tmem_load_vec, tTMEM_LOAD_VECtS1, tTMEM_LOAD_VECrS)
                 cute.arch.fence_view_async_tmem_load()
                 vec1_handle.release()

--- a/flashinfer/cute_dsl/attention/roles/correction.py
+++ b/flashinfer/cute_dsl/attention/roles/correction.py
@@ -23,7 +23,7 @@ from cutlass.pipeline import PipelineProducer, PipelineConsumer
 
 from ..config import AttentionConfig, AttentionFusion
 from ..tmem_layout import TmemLayout
-from ..fusion.mask import get_kv_block_range, get_trip_count
+from ..fusion.mask import get_trip_count
 from ..scheduler.persistent import (
     FmhaStaticTileScheduler,
     FmhaStaticTileSchedulerParams,
@@ -92,6 +92,10 @@ class CorrectionRole:
         When processing attention in blocks, the softmax normalization factors may change
         as new blocks are processed. This method rescales previously computed partial
         output values to account for updated normalization factors.
+
+        Each TMEM tile gets its own register buffer, so the per-tile
+        load->mul->store chains have no cross-dependencies and the
+        compiler is free to overlap their TMEM round trips.
         """
         pv_tiled_mma_shape = (
             self.pv_mma_tiler[0],
@@ -280,6 +284,8 @@ class CorrectionRole:
         cum_seqlen_k: cute.Tensor | None,
         scale_softmax_log2: Float32,
         scale_output: Float32,
+        window_left: Int32,
+        window_right: Int32,
         s0_corr_consumer: PipelineConsumer,
         s1_corr_consumer: PipelineConsumer,
         mma_corr_consumer: PipelineConsumer,
@@ -365,62 +371,23 @@ class CorrectionRole:
                         self.cta_tiler,
                         seqlen_k,
                         seqlen_q_,
+                        window_left,
+                        window_right,
                     )
                     - 1
                 )
-                # Per-stage 128-row bands, mirroring SoftmaxRole.run(): for
-                # trips outside a stage's band the softmax dead_step()
-                # published a no-change vec (rescale factor exactly 1), so
-                # the O rescale is skipped.  Same variant gating as the
-                # softmax dead path.
-                kv_start_block = 0
-                stage0_lo = 0
-                stage0_hi = 0
-                stage1_lo = 0
-                stage1_hi = 0
-                if cutlass.const_expr(
-                    not self.has_logits_transform and not self.has_statistics_update
-                ):
-                    kv_start_block, _ = get_kv_block_range(
-                        self.mask_spec,
-                        curr_block_coord,
-                        self.cta_tiler,
-                        seqlen_k,
-                        seqlen_q_,
-                    )
-                    stage0_lo, stage0_hi = get_kv_block_range(
-                        self.mask_spec,
-                        (
-                            curr_block_coord[0] * 2,
-                            curr_block_coord[1],
-                            curr_block_coord[2],
-                        ),
-                        (self.qk_mma_tiler[0], self.cta_tiler[1]),
-                        seqlen_k,
-                        seqlen_q_,
-                    )
-                    stage1_lo, stage1_hi = get_kv_block_range(
-                        self.mask_spec,
-                        (
-                            curr_block_coord[0] * 2 + 1,
-                            curr_block_coord[1],
-                            curr_block_coord[2],
-                        ),
-                        (self.qk_mma_tiler[0], self.cta_tiler[1]),
-                        seqlen_k,
-                        seqlen_q_,
-                    )
                 for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
                     # Iteration _i consumes the vec of KV trip _i + 1 (the
                     # first trip's vec was released above, pre-loop).
-                    live0 = True
-                    live1 = True
-                    if cutlass.const_expr(
-                        not self.has_logits_transform and not self.has_statistics_update
-                    ):
-                        blk = kv_start_block + _i + 1
-                        live0 = not (blk < stage0_lo or blk >= stage0_hi)
-                        live1 = not (blk < stage1_lo or blk >= stage1_hi)
+                    #
+                    # Rescale skip: a warp-wide ballot on old_max != new_max
+                    # skips the O TMEM roundtrip when the rescale factor is
+                    # exactly 1 for all 32 rows the warp covers (equal maxes
+                    # => exp2(0) == 1.0, so the skip is exact).  Covers both
+                    # dead trips (dead_step publishes old == new) and live
+                    # trips that raised no row max.  Per-warp divergence is
+                    # safe: the TMEM copies are warp-local (each warp owns
+                    # its 32-row slice of O).
                     # wait for vec0 (row_wise current max & previous max)
                     vec0_handle = s0_corr_consumer.wait_and_advance()
                     tTMEM_LOAD_VECrS = cute.make_rmem_tensor(
@@ -431,11 +398,14 @@ class CorrectionRole:
                         tTMEM_LOAD_VECrS[0] - tTMEM_LOAD_VECrS[1]
                     )
                     scale = cute.arch.exp2(scale_)
+                    rescale_ballot = cute.arch.vote_ballot_sync(
+                        tTMEM_LOAD_VECrS[0] != tTMEM_LOAD_VECrS[1]
+                    )
 
                     # wait for o0
                     o0_handle_consumer = mma_corr_consumer.wait_and_advance()
                     if cutlass.const_expr(not self.has_logits_transform):
-                        if live0:
+                        if rescale_ballot != 0:
                             self.rescale(pv_thr_mma, tOtO0, scale)
                     # release vec1 & o0
                     vec1_handle.release()
@@ -449,10 +419,13 @@ class CorrectionRole:
                         tTMEM_LOAD_VECrS[0] - tTMEM_LOAD_VECrS[1]
                     )
                     scale = cute.arch.exp2(scale_)
+                    rescale_ballot = cute.arch.vote_ballot_sync(
+                        tTMEM_LOAD_VECrS[0] != tTMEM_LOAD_VECrS[1]
+                    )
 
                     o1_handle_consumer = mma_corr_consumer.wait_and_advance()
                     if cutlass.const_expr(not self.has_logits_transform):
-                        if live1:
+                        if rescale_ballot != 0:
                             self.rescale(pv_thr_mma, tOtO1, scale)
                     vec0_handle.release()
                     cute.arch.fence_view_async_tmem_store()

--- a/flashinfer/cute_dsl/attention/roles/correction.py
+++ b/flashinfer/cute_dsl/attention/roles/correction.py
@@ -286,6 +286,7 @@ class CorrectionRole:
         scale_output: Float32,
         window_left: Int32,
         window_right: Int32,
+        mLSE: cute.Tensor | None,
         s0_corr_consumer: PipelineConsumer,
         s1_corr_consumer: PipelineConsumer,
         mma_corr_consumer: PipelineConsumer,
@@ -355,6 +356,11 @@ class CorrectionRole:
                         seqlen_q_,
                     )
                 )
+
+            # Base row of this sequence in the (total_q, h_q) LSE tensor.
+            lse_row_base = batch_coord * seqlen_q_global
+            if cutlass.const_expr(cum_seqlen_q is not None):
+                lse_row_base = cuseqlen_q
 
             if not continue_cond:
                 if cutlass.const_expr(cum_seqlen_k is not None):
@@ -488,6 +494,18 @@ class CorrectionRole:
                 epilogue_scale = scale_output
                 d = tTMEM_LOAD_VECrS[0]  # row sum
                 m = tTMEM_LOAD_VECrS[1]  # row max
+                # Each correction thread owns one Q row of this 128-row
+                # stage (the vec partition's identity coordinate); a fully
+                # masked row has d = 0, m = -inf and stores -inf.
+                # LSE is emitted in log2 domain (flashinfer convention):
+                # (ln(row_sum) + sm_scale * row_max) * log2(e)
+                #   == log2(row_sum) + scale_softmax_log2 * row_max.
+                if cutlass.const_expr(mLSE is not None):
+                    lse_row = qo_idx_offset + tTMEM_LOAD_VECcS[0][0]
+                    if lse_row < seqlen_q_:
+                        mLSE[lse_row_base + lse_row, head_coord] = (
+                            cute.math.log2(d, fastmath=True) + scale_softmax_log2 * m
+                        )
                 self.epilog(
                     pv_thr_mma,
                     tOtO0,
@@ -548,6 +566,14 @@ class CorrectionRole:
                 epilogue_scale = scale_output
                 d = tTMEM_LOAD_VECrS[0]  # row sum
                 m = tTMEM_LOAD_VECrS[1]  # row max
+                if cutlass.const_expr(mLSE is not None):
+                    lse_row = (
+                        qo_idx_offset + self.qk_mma_tiler[0] + tTMEM_LOAD_VECcS[0][0]
+                    )
+                    if lse_row < seqlen_q_:
+                        mLSE[lse_row_base + lse_row, head_coord] = (
+                            cute.math.log2(d, fastmath=True) + scale_softmax_log2 * m
+                        )
                 self.epilog(
                     pv_thr_mma,
                     tOtO1,

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -20,7 +20,7 @@ from cutlass.cute.typing import Int32
 from cutlass.pipeline import PipelineProducer
 
 from ..config import AttentionConfig
-from ..fusion.mask import get_trip_count, get_kv_start_block_idx
+from ..fusion.mask import get_kv_block_range
 from ..scheduler.persistent import (
     FmhaStaticTileScheduler,
     FmhaStaticTileSchedulerParams,
@@ -38,8 +38,7 @@ class LoaderRole:
         self.cta_tiler = config.cta_tiler
         self.qk_mma_tiler = config.qk_mma_tiler
         self.pv_mma_tiler = config.pv_mma_tiler
-        self.mask_type = config.mask_type
-        self.window_left = config.window_left
+        self.mask_spec = config.mask_spec
 
     # =========================================================================
     #  Reusable primitives — for composing new kernel variants
@@ -266,14 +265,14 @@ class LoaderRole:
                     tma_bar_ptr=q0_handle_producer.barrier,
                 )
                 # K0
-                kv_coord = get_kv_start_block_idx(
-                    self.mask_type,
-                    self.window_left,
+                kv_block_start, kv_block_end = get_kv_block_range(
+                    self.mask_spec,
                     curr_block_coord,
                     self.cta_tiler,
                     seqlen_k,
                     seqlen_q,
                 )
+                kv_coord = kv_block_start
                 k_handle_producer = load_kv_producer.acquire_and_advance()
                 cute.copy(
                     tma_atom_k,
@@ -300,17 +299,7 @@ class LoaderRole:
                 )
                 kv_coord += 1
 
-                seqlen_kv_loop_steps = (
-                    get_trip_count(
-                        self.mask_type,
-                        self.window_left,
-                        curr_block_coord,
-                        self.cta_tiler,
-                        seqlen_k,
-                        seqlen_q,
-                    )
-                    - 1
-                )
+                seqlen_kv_loop_steps = kv_block_end - kv_block_start - 1
                 for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
                     # Ki
                     k_handle_producer = load_kv_producer.acquire_and_advance()

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -156,6 +156,8 @@ class LoaderRole:
         sV: cute.Tensor,
         cum_seqlen_q: cute.Tensor | None,
         cum_seqlen_k: cute.Tensor | None,
+        window_left: Int32,
+        window_right: Int32,
         load_q_producer: PipelineProducer,
         load_kv_producer: PipelineProducer,
         tile_sched_params: FmhaStaticTileSchedulerParams,
@@ -271,6 +273,8 @@ class LoaderRole:
                     self.cta_tiler,
                     seqlen_k,
                     seqlen_q,
+                    window_left,
+                    window_right,
                 )
                 kv_coord = kv_block_start
                 k_handle_producer = load_kv_producer.acquire_and_advance()

--- a/flashinfer/cute_dsl/attention/roles/loader_tma.py
+++ b/flashinfer/cute_dsl/attention/roles/loader_tma.py
@@ -39,6 +39,44 @@ class LoaderRole:
         self.qk_mma_tiler = config.qk_mma_tiler
         self.pv_mma_tiler = config.pv_mma_tiler
         self.mask_spec = config.mask_spec
+        # Populated by set_v_tx_bytes() once dtypes are known at __call__
+        # time.  None means K and V have the same width (plain acquires).
+        self.v_tx_bytes = None
+        self.kv_stages = None
+
+    def set_v_tx_bytes(self, v_tx_bytes, kv_stages) -> None:
+        """Set V's TMA byte count for mixed K/V dtype builds.
+
+        The shared K/V ring's barriers are initialized with K's byte
+        count; when the widths differ, each V acquire must re-arm its
+        slot with V's byte count instead (pass None for uniform builds).
+        """
+        self.v_tx_bytes = v_tx_bytes
+        self.kv_stages = kv_stages
+
+    def _acquire_v(self, load_kv_producer: PipelineProducer, load_kv_mbar_base_ptr):
+        """Acquire a V slot on the shared K/V ring.
+
+        Returns (slot index, barrier pointer for the TMA copy).  With
+        mixed K/V dtypes this bypasses acquire_and_advance() to arm the
+        full barrier with V's byte count — the same scheme as the
+        vendored FMHA kernel's kv_producer_update_tx_acquire_and_advance.
+        Undecorated on purpose: it is inlined at trace time (like the
+        vendored helper) because it handles pipeline participant objects.
+        """
+        if self.v_tx_bytes is None:
+            handle = load_kv_producer.acquire_and_advance()
+            return handle.index, handle.barrier
+        state = load_kv_producer._PipelineProducer__state.clone()
+        cute.arch.mbarrier_wait(
+            load_kv_mbar_base_ptr + self.kv_stages + state.index, state.phase
+        )
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_arrive_and_expect_tx(
+                load_kv_mbar_base_ptr + state.index, self.v_tx_bytes
+            )
+        load_kv_producer.advance()
+        return state.index, load_kv_mbar_base_ptr + state.index
 
     # =========================================================================
     #  Reusable primitives — for composing new kernel variants
@@ -161,6 +199,7 @@ class LoaderRole:
         load_q_producer: PipelineProducer,
         load_kv_producer: PipelineProducer,
         tile_sched_params: FmhaStaticTileSchedulerParams,
+        load_kv_mbar_base_ptr,
     ):
         """Loader warp orchestration loop (prefill-specific).
 
@@ -294,12 +333,14 @@ class LoaderRole:
                     tma_bar_ptr=q1_handle_producer.barrier,
                 )
                 # V0
-                v_handle_producer = load_kv_producer.acquire_and_advance()
+                v_index, v_bar_ptr = self._acquire_v(
+                    load_kv_producer, load_kv_mbar_base_ptr
+                )
                 cute.copy(
                     tma_atom_v,
                     tVgV[None, kv_coord],
-                    tVsV[None, v_handle_producer.index],
-                    tma_bar_ptr=v_handle_producer.barrier,
+                    tVsV[None, v_index],
+                    tma_bar_ptr=v_bar_ptr,
                 )
                 kv_coord += 1
 
@@ -314,12 +355,14 @@ class LoaderRole:
                         tma_bar_ptr=k_handle_producer.barrier,
                     )
                     # Vi
-                    v_handle_producer = load_kv_producer.acquire_and_advance()
+                    v_index, v_bar_ptr = self._acquire_v(
+                        load_kv_producer, load_kv_mbar_base_ptr
+                    )
                     cute.copy(
                         tma_atom_v,
                         tVgV[None, kv_coord],
-                        tVsV[None, v_handle_producer.index],
-                        tma_bar_ptr=v_handle_producer.barrier,
+                        tVsV[None, v_index],
+                        tma_bar_ptr=v_bar_ptr,
                     )
                     kv_coord += 1
 

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -32,7 +32,7 @@ from cutlass.cute.typing import Int32, Float32
 from cutlass.pipeline import PipelineProducer, PipelineConsumer
 
 from ..config import AttentionConfig
-from ..fusion.mask import get_trip_count
+from ..fusion.mask import get_peel_sections, get_trip_count
 from ..scheduler.persistent import (
     FmhaStaticTileScheduler,
     FmhaStaticTileSchedulerParams,
@@ -241,6 +241,10 @@ class MmaRole:
         """
         # Alloc tmem buffer
         self.alloc_tmem(storage)
+        # Tracks O0's "first PV0 overwrites, rest accumulate" state, mirroring
+        # pv_tiled_mma's role for O1 (see the comment at the loop below).  A
+        # separate instance because both flags are live at once.
+        pv0_tiled_mma = self._make_local_pv_mma()
         tile_sched = create_fmha_static_tile_scheduler(
             tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
         )
@@ -268,35 +272,18 @@ class MmaRole:
                     cuseqlen_k = cum_seqlen_k[batch_coord]
                     seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
 
-                # GEMM_QK00 (Q0 * K0 -> S0)
-                q0_handle_consumer = load_q_consumer.wait_and_advance()
-                tSrQ0 = tSrQ[None, None, None, q0_handle_consumer.index]
-                k_handle_consumer = load_kv_consumer.wait_and_advance()
-                tSrK0 = tSrK[None, None, None, k_handle_consumer.index]
-                s0_handle_producer = mma_s0_producer.acquire_and_advance()
-                self.gemm_qk(tStS0, tSrQ0, tSrK0)
-                s0_handle_producer.commit()
-
-                # GEMM_QK10 (Q1 * K0 -> S1)
-                q1_handle_consumer = load_q_consumer.wait_and_advance()
-                tSrQ1 = tSrQ[None, None, None, q1_handle_consumer.index]
-                s1_handle_producer = mma_s1_producer.acquire_and_advance()
-                self.gemm_qk(tStS1, tSrQ1, tSrK0)
-                s1_handle_producer.commit()
-                k_handle_consumer.release()
-
-                # GEMM_PV00 (P0 * V0 -> O0_partial)
-                v_handle_consumer = load_kv_consumer.wait_and_advance()
-                tOrVi = tOrV[None, None, None, v_handle_consumer.index]
-                if cutlass.const_expr(not self.has_logits_transform):
-                    o0_handle_producer = mma_corr_producer.acquire_and_advance()
-                s0_handle_producer = mma_s0_producer.acquire_and_advance()
-                self.gemm_pv(tOtO0, tOrP0, tOrVi, False)
-                if cutlass.const_expr(not self.has_logits_transform):
-                    o0_handle_producer.commit()
-
-                seqlen_kv_loop_steps = (
-                    get_trip_count(
+                # Head / main / tail split (get_peel_sections): banded masks
+                # give the two 128-row halves KV bands offset by one block at
+                # each bound, so the leading `head` blocks are stage-0-only
+                # and the trailing `tail` blocks are stage-1-only.  main >= 1
+                # always (the helper borrows a head block if the bands don't
+                # overlap), so the main prologue/epilogue stay straight-line.
+                # Variants with per-step side effects keep full union
+                # lockstep (head = tail = 0).
+                if cutlass.const_expr(
+                    not self.has_logits_transform and not self.has_statistics_update
+                ):
+                    _, head_cnt, main_cnt, tail_cnt, _ = get_peel_sections(
                         self.mask_spec,
                         curr_block_coord,
                         self.cta_tiler,
@@ -305,19 +292,94 @@ class MmaRole:
                         window_left,
                         window_right,
                     )
-                    - 1
-                )
+                else:
+                    head_cnt = Int32(0)
+                    tail_cnt = Int32(0)
+                    main_cnt = get_trip_count(
+                        self.mask_spec,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_k,
+                        seqlen_q_,
+                        window_left,
+                        window_right,
+                    )
 
-                # Track the PV1 "first-iter overwrite, then accumulate" state on
-                # pv_tiled_mma's ACCUMULATE field rather than a Python bool.
-                # Stored on the TiledMma type, the cute-DSL JIT propagates the
-                # value as a per-iteration compile-time constant so the
-                # `accumulate or kphase_idx > 0` expression inside gemm_pv
-                # folds statically and each tcgen05.mma issues with its
-                # ACCUMULATE bit baked into the opcode.  A Python bool would
-                # be demoted to a runtime register through the kv loop.
+                q0_handle_consumer = load_q_consumer.wait_and_advance()
+                tSrQ0 = tSrQ[None, None, None, q0_handle_consumer.index]
+                # Track each O tile's "first PV overwrites, then accumulate"
+                # state on a TiledMma ACCUMULATE field rather than a Python
+                # bool.  Stored on the TiledMma type, the cute-DSL JIT
+                # propagates the value so the `accumulate or kphase_idx > 0`
+                # expression inside gemm_pv folds per issue site; a Python
+                # bool would be demoted to a runtime register through the kv
+                # loops.  pv0_tiled_mma tracks O0 (its first PV0 lands in the
+                # head loop or the main prologue depending on runtime head
+                # count); pv_tiled_mma tracks O1 as before.
+                pv0_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
                 pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
+                s0_handle_producer = mma_s0_producer.acquire_and_advance()
+
+                # HEAD: stage-0-only trips.  Per trip: QK0 commits the
+                # previously acquired S0 slot; the re-acquire doubles as the
+                # P-ready wait for this trip's PV0 (same slot discipline as
+                # the main loop).  K/V have no stage-1 consumer here.
+                #
+                # The empty o1 commit keeps the shared mma_corr ring strictly
+                # o0/o1-alternating: with the ring's depth of 2, PV_X(t)'s
+                # acquire then waits on correction's release of oX(t-1),
+                # which correction performs at rescale(X, t) — the ordering
+                # that keeps a PV from accumulating into an O tile before
+                # that trip's rescale.  Consecutive same-stage commits would
+                # break it.
+                for _h in cutlass.range(0, head_cnt, 1, unroll=1):
+                    k_handle_consumer = load_kv_consumer.wait_and_advance()
+                    tSrKh = tSrK[None, None, None, k_handle_consumer.index]
+                    self.gemm_qk(tStS0, tSrQ0, tSrKh)
+                    s0_handle_producer.commit()
+                    k_handle_consumer.release()
+                    v_handle_consumer = load_kv_consumer.wait_and_advance()
+                    tOrVh = tOrV[None, None, None, v_handle_consumer.index]
+                    if cutlass.const_expr(not self.has_logits_transform):
+                        o0_handle_producer = mma_corr_producer.acquire_and_advance()
+                    s0_handle_producer = mma_s0_producer.acquire_and_advance()
+                    pv0_acc = pv0_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                    self.gemm_pv(tOtO0, tOrP0, tOrVh, pv0_acc)
+                    pv0_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                    if cutlass.const_expr(not self.has_logits_transform):
+                        o0_handle_producer.commit()
+                        o1_dummy_producer = mma_corr_producer.acquire_and_advance()
+                        o1_dummy_producer.commit()
+                    v_handle_consumer.release()
+
+                # MAIN prologue: first block visited by both halves.
+                # GEMM_QK0 (Q0 * K -> S0)
+                k_handle_consumer = load_kv_consumer.wait_and_advance()
+                tSrK0 = tSrK[None, None, None, k_handle_consumer.index]
+                self.gemm_qk(tStS0, tSrQ0, tSrK0)
+                s0_handle_producer.commit()
+
+                # GEMM_QK1 (Q1 * K -> S1)
+                q1_handle_consumer = load_q_consumer.wait_and_advance()
+                tSrQ1 = tSrQ[None, None, None, q1_handle_consumer.index]
+                s1_handle_producer = mma_s1_producer.acquire_and_advance()
+                self.gemm_qk(tStS1, tSrQ1, tSrK0)
+                s1_handle_producer.commit()
+                k_handle_consumer.release()
+
+                # GEMM_PV0 (P0 * V -> O0)
+                v_handle_consumer = load_kv_consumer.wait_and_advance()
+                tOrVi = tOrV[None, None, None, v_handle_consumer.index]
+                if cutlass.const_expr(not self.has_logits_transform):
+                    o0_handle_producer = mma_corr_producer.acquire_and_advance()
+                s0_handle_producer = mma_s0_producer.acquire_and_advance()
+                pv0_acc = pv0_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                self.gemm_pv(tOtO0, tOrP0, tOrVi, pv0_acc)
+                pv0_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                if cutlass.const_expr(not self.has_logits_transform):
+                    o0_handle_producer.commit()
+
+                for _i in cutlass.range(0, main_cnt - 1, 1, unroll=1):
                     # GEMM_QK0i
                     k_handle_consumer = load_kv_consumer.wait_and_advance()
                     tSrKi = tSrK[None, None, None, k_handle_consumer.index]
@@ -351,21 +413,55 @@ class MmaRole:
                     if cutlass.const_expr(not self.has_logits_transform):
                         o0_handle_producer.commit()
 
-                # release Q0 & Q1
-                q0_handle_consumer.release()
-                q1_handle_consumer.release()
-
-                # GEMM_PV1(end) — same pattern: read the propagated flag.
+                # MAIN epilogue: PV1 of the last shared block.
                 if cutlass.const_expr(not self.has_logits_transform):
                     o1_handle = mma_corr_producer.acquire_and_advance()
                 s1_handle_producer = mma_s1_producer.acquire_and_advance()
                 pv_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
                 self.gemm_pv(tOtO1, tOrP1, tOrVi, pv_acc)
+                pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
                 if cutlass.const_expr(not self.has_logits_transform):
                     o1_handle.commit()
                 v_handle_consumer.release()
 
+                # Stage 0's stream is complete: commit its tile-end S slot
+                # NOW, before the tail.  Softmax 0's end-of-item wait pairs
+                # with this commit, and its final vec publish gates the tail
+                # tokens it produces for stage 1 — committing after the tail
+                # would close a dependency cycle (tail PV1 -> softmax1 tail
+                # step -> stage-0 tail token -> softmax0 final -> this
+                # commit -> tail PV1) and deadlock.  Early commit also lets
+                # the O0 drain overlap the tail trips.
                 s0_handle_producer.commit()
+
+                # TAIL: stage-1-only trips (same slot discipline as HEAD;
+                # the empty o0 commit preserves o-ring alternation — see the
+                # HEAD comment).
+                for _t in cutlass.range(0, tail_cnt, 1, unroll=1):
+                    k_handle_consumer = load_kv_consumer.wait_and_advance()
+                    tSrKt = tSrK[None, None, None, k_handle_consumer.index]
+                    self.gemm_qk(tStS1, tSrQ1, tSrKt)
+                    s1_handle_producer.commit()
+                    k_handle_consumer.release()
+                    if cutlass.const_expr(not self.has_logits_transform):
+                        o0_dummy_producer = mma_corr_producer.acquire_and_advance()
+                        o0_dummy_producer.commit()
+                    v_handle_consumer = load_kv_consumer.wait_and_advance()
+                    tOrVt = tOrV[None, None, None, v_handle_consumer.index]
+                    if cutlass.const_expr(not self.has_logits_transform):
+                        o1_handle = mma_corr_producer.acquire_and_advance()
+                    s1_handle_producer = mma_s1_producer.acquire_and_advance()
+                    pv_acc = pv_tiled_mma.get(tcgen05.Field.ACCUMULATE)
+                    self.gemm_pv(tOtO1, tOrP1, tOrVt, pv_acc)
+                    pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+                    if cutlass.const_expr(not self.has_logits_transform):
+                        o1_handle.commit()
+                    v_handle_consumer.release()
+
+                # release Q0 & Q1 (Q1 is read by TAIL QK1 gemms)
+                q0_handle_consumer.release()
+                q1_handle_consumer.release()
+
                 s1_handle_producer.commit()
 
             # Advance to next tile

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -220,6 +220,8 @@ class MmaRole:
         seqlen_k_global: Int32,
         cum_seqlen_q: cute.Tensor | None,
         cum_seqlen_k: cute.Tensor | None,
+        window_left: Int32,
+        window_right: Int32,
         load_q_consumer: PipelineConsumer,
         load_kv_consumer: PipelineConsumer,
         mma_s0_producer: PipelineProducer,
@@ -270,10 +272,14 @@ class MmaRole:
                 # gemms for KV blocks outside a stage's band are skipped —
                 # the softmax dead_step never reads that S tile, and
                 # committing a handle without a gemm is the same pattern as
-                # the tile-end commits below.  PV gemms are NOT skipped:
-                # PV1's ACCUMULATE overwrite->accumulate transition happens
-                # at the first trip, exactly where stage 1's dead block
-                # sits, and the softmax dead_step stores a zero P for them.
+                # the tile-end commits below.  PV asymmetry: PV0 for stage
+                # 0's dead trip (always the union's LAST trip) is skipped
+                # together with its zero-P store in dead_step — its
+                # ACCUMULATE bit is True mid-stream, so skipping leaves O0
+                # untouched.  PV1 for stage 1's dead trip (always the
+                # union's FIRST trip) is KEPT: it is the ACCUMULATE=False
+                # overwrite that initializes O1, so dead_step stores a zero
+                # P for it.
                 kv_start_block = 0
                 stage0_lo = 0
                 stage0_hi = 0
@@ -290,6 +296,8 @@ class MmaRole:
                         self.cta_tiler,
                         seqlen_k,
                         seqlen_q_,
+                        window_left,
+                        window_right,
                     )
                     stage0_lo, stage0_hi = get_kv_block_range(
                         self.mask_spec,
@@ -301,6 +309,8 @@ class MmaRole:
                         stage_tiler,
                         seqlen_k,
                         seqlen_q_,
+                        window_left,
+                        window_right,
                     )
                     stage1_lo, stage1_hi = get_kv_block_range(
                         self.mask_spec,
@@ -312,6 +322,8 @@ class MmaRole:
                         stage_tiler,
                         seqlen_k,
                         seqlen_q_,
+                        window_left,
+                        window_right,
                     )
                     qk1_live_prologue = not (
                         kv_start_block < stage1_lo or kv_start_block >= stage1_hi
@@ -354,6 +366,8 @@ class MmaRole:
                         self.cta_tiler,
                         seqlen_k,
                         seqlen_q_,
+                        window_left,
+                        window_right,
                     )
                     - 1
                 )
@@ -401,13 +415,16 @@ class MmaRole:
                     s1_handle_producer.commit()
                     k_handle_consumer.release()
 
-                    # GEMM_PV0i
+                    # GEMM_PV0i — consumes P0 of trip _i+1, the same trip
+                    # qk0_live gates, so a dead trip skips both its QK and
+                    # its PV (ACCUMULATE is True mid-stream; O0 unchanged).
                     v_handle_consumer = load_kv_consumer.wait_and_advance()
                     tOrVi = tOrV[None, None, None, v_handle_consumer.index]
                     if cutlass.const_expr(not self.has_logits_transform):
                         o0_handle_producer = mma_corr_producer.acquire_and_advance()
                     s0_handle_producer = mma_s0_producer.acquire_and_advance()
-                    self.gemm_pv(tOtO0, tOrP0, tOrVi, True)
+                    if qk0_live:
+                        self.gemm_pv(tOtO0, tOrP0, tOrVi, True)
                     if cutlass.const_expr(not self.has_logits_transform):
                         o0_handle_producer.commit()
 

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -55,8 +55,7 @@ class MmaRole:
         has_logits_transform: bool = False,
     ):
         self.cta_tiler = config.cta_tiler
-        self.mask_type = config.mask_type
-        self.window_left = config.window_left
+        self.mask_spec = config.mask_spec
         self.tmem_alloc_cols = tmem_alloc_cols
         self.tmem_alloc_sync_bar_id = tmem_alloc_sync_bar_id
         self.threads_per_warp = threads_per_warp
@@ -294,8 +293,7 @@ class MmaRole:
 
                 seqlen_kv_loop_steps = (
                     get_trip_count(
-                        self.mask_type,
-                        self.window_left,
+                        self.mask_spec,
                         curr_block_coord,
                         self.cta_tiler,
                         seqlen_k,

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -32,7 +32,7 @@ from cutlass.cute.typing import Int32, Float32
 from cutlass.pipeline import PipelineProducer, PipelineConsumer
 
 from ..config import AttentionConfig
-from ..fusion.mask import get_kv_block_range, get_trip_count
+from ..fusion.mask import get_trip_count
 from ..scheduler.persistent import (
     FmhaStaticTileScheduler,
     FmhaStaticTileSchedulerParams,
@@ -268,70 +268,7 @@ class MmaRole:
                     cuseqlen_k = cum_seqlen_k[batch_coord]
                     seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
 
-                # Per-stage 128-row bands (mirrors SoftmaxRole.run()): QK
-                # gemms for KV blocks outside a stage's band are skipped —
-                # the softmax dead_step never reads that S tile, and
-                # committing a handle without a gemm is the same pattern as
-                # the tile-end commits below.  PV asymmetry: PV0 for stage
-                # 0's dead trip (always the union's LAST trip) is skipped
-                # together with its zero-P store in dead_step — its
-                # ACCUMULATE bit is True mid-stream, so skipping leaves O0
-                # untouched.  PV1 for stage 1's dead trip (always the
-                # union's FIRST trip) is KEPT: it is the ACCUMULATE=False
-                # overwrite that initializes O1, so dead_step stores a zero
-                # P for it.
-                kv_start_block = 0
-                stage0_lo = 0
-                stage0_hi = 0
-                stage1_lo = 0
-                stage1_hi = 0
-                qk1_live_prologue = True
-                if cutlass.const_expr(
-                    not self.has_logits_transform and not self.has_statistics_update
-                ):
-                    stage_tiler = (self.cta_tiler[0] // 2, self.cta_tiler[1])
-                    kv_start_block, _ = get_kv_block_range(
-                        self.mask_spec,
-                        curr_block_coord,
-                        self.cta_tiler,
-                        seqlen_k,
-                        seqlen_q_,
-                        window_left,
-                        window_right,
-                    )
-                    stage0_lo, stage0_hi = get_kv_block_range(
-                        self.mask_spec,
-                        (
-                            curr_block_coord[0] * 2,
-                            curr_block_coord[1],
-                            curr_block_coord[2],
-                        ),
-                        stage_tiler,
-                        seqlen_k,
-                        seqlen_q_,
-                        window_left,
-                        window_right,
-                    )
-                    stage1_lo, stage1_hi = get_kv_block_range(
-                        self.mask_spec,
-                        (
-                            curr_block_coord[0] * 2 + 1,
-                            curr_block_coord[1],
-                            curr_block_coord[2],
-                        ),
-                        stage_tiler,
-                        seqlen_k,
-                        seqlen_q_,
-                        window_left,
-                        window_right,
-                    )
-                    qk1_live_prologue = not (
-                        kv_start_block < stage1_lo or kv_start_block >= stage1_hi
-                    )
-
                 # GEMM_QK00 (Q0 * K0 -> S0)
-                # Never dead: lo(q) is non-decreasing in q, so the union's
-                # start block always lies inside stage 0's band.
                 q0_handle_consumer = load_q_consumer.wait_and_advance()
                 tSrQ0 = tSrQ[None, None, None, q0_handle_consumer.index]
                 k_handle_consumer = load_kv_consumer.wait_and_advance()
@@ -344,8 +281,7 @@ class MmaRole:
                 q1_handle_consumer = load_q_consumer.wait_and_advance()
                 tSrQ1 = tSrQ[None, None, None, q1_handle_consumer.index]
                 s1_handle_producer = mma_s1_producer.acquire_and_advance()
-                if qk1_live_prologue:
-                    self.gemm_qk(tStS1, tSrQ1, tSrK0)
+                self.gemm_qk(tStS1, tSrQ1, tSrK0)
                 s1_handle_producer.commit()
                 k_handle_consumer.release()
 
@@ -382,19 +318,10 @@ class MmaRole:
                 # be demoted to a runtime register through the kv loop.
                 pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
                 for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
-                    qk0_live = True
-                    qk1_live = True
-                    if cutlass.const_expr(
-                        not self.has_logits_transform and not self.has_statistics_update
-                    ):
-                        blk = kv_start_block + _i + 1
-                        qk0_live = not (blk < stage0_lo or blk >= stage0_hi)
-                        qk1_live = not (blk < stage1_lo or blk >= stage1_hi)
                     # GEMM_QK0i
                     k_handle_consumer = load_kv_consumer.wait_and_advance()
                     tSrKi = tSrK[None, None, None, k_handle_consumer.index]
-                    if qk0_live:
-                        self.gemm_qk(tStS0, tSrQ0, tSrKi)
+                    self.gemm_qk(tStS0, tSrQ0, tSrKi)
                     s0_handle_producer.commit()
 
                     # GEMM_PV1(i-1) — read the constant-folded ACCUMULATE
@@ -410,21 +337,17 @@ class MmaRole:
                     v_handle_consumer.release()
 
                     # GEMM_QK1i
-                    if qk1_live:
-                        self.gemm_qk(tStS1, tSrQ1, tSrKi)
+                    self.gemm_qk(tStS1, tSrQ1, tSrKi)
                     s1_handle_producer.commit()
                     k_handle_consumer.release()
 
-                    # GEMM_PV0i — consumes P0 of trip _i+1, the same trip
-                    # qk0_live gates, so a dead trip skips both its QK and
-                    # its PV (ACCUMULATE is True mid-stream; O0 unchanged).
+                    # GEMM_PV0i
                     v_handle_consumer = load_kv_consumer.wait_and_advance()
                     tOrVi = tOrV[None, None, None, v_handle_consumer.index]
                     if cutlass.const_expr(not self.has_logits_transform):
                         o0_handle_producer = mma_corr_producer.acquire_and_advance()
                     s0_handle_producer = mma_s0_producer.acquire_and_advance()
-                    if qk0_live:
-                        self.gemm_pv(tOtO0, tOrP0, tOrVi, True)
+                    self.gemm_pv(tOtO0, tOrP0, tOrVi, True)
                     if cutlass.const_expr(not self.has_logits_transform):
                         o0_handle_producer.commit()
 

--- a/flashinfer/cute_dsl/attention/roles/mma.py
+++ b/flashinfer/cute_dsl/attention/roles/mma.py
@@ -32,7 +32,7 @@ from cutlass.cute.typing import Int32, Float32
 from cutlass.pipeline import PipelineProducer, PipelineConsumer
 
 from ..config import AttentionConfig
-from ..fusion.mask import get_trip_count
+from ..fusion.mask import get_kv_block_range, get_trip_count
 from ..scheduler.persistent import (
     FmhaStaticTileScheduler,
     FmhaStaticTileSchedulerParams,
@@ -53,6 +53,7 @@ class MmaRole:
         tmem_alloc_sync_bar_id,
         threads_per_warp,
         has_logits_transform: bool = False,
+        has_statistics_update: bool = False,
     ):
         self.cta_tiler = config.cta_tiler
         self.mask_spec = config.mask_spec
@@ -60,6 +61,7 @@ class MmaRole:
         self.tmem_alloc_sync_bar_id = tmem_alloc_sync_bar_id
         self.threads_per_warp = threads_per_warp
         self.has_logits_transform = has_logits_transform
+        self.has_statistics_update = has_statistics_update
         # Used to (re)construct local TiledMma instances inside gemm_qk /
         # gemm_pv so the helper's .set(ACCUMULATE, ...) mutations don't
         # leak SSA values into the caller's persistent loop.
@@ -264,7 +266,60 @@ class MmaRole:
                     cuseqlen_k = cum_seqlen_k[batch_coord]
                     seqlen_k = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
 
+                # Per-stage 128-row bands (mirrors SoftmaxRole.run()): QK
+                # gemms for KV blocks outside a stage's band are skipped —
+                # the softmax dead_step never reads that S tile, and
+                # committing a handle without a gemm is the same pattern as
+                # the tile-end commits below.  PV gemms are NOT skipped:
+                # PV1's ACCUMULATE overwrite->accumulate transition happens
+                # at the first trip, exactly where stage 1's dead block
+                # sits, and the softmax dead_step stores a zero P for them.
+                kv_start_block = 0
+                stage0_lo = 0
+                stage0_hi = 0
+                stage1_lo = 0
+                stage1_hi = 0
+                qk1_live_prologue = True
+                if cutlass.const_expr(
+                    not self.has_logits_transform and not self.has_statistics_update
+                ):
+                    stage_tiler = (self.cta_tiler[0] // 2, self.cta_tiler[1])
+                    kv_start_block, _ = get_kv_block_range(
+                        self.mask_spec,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_k,
+                        seqlen_q_,
+                    )
+                    stage0_lo, stage0_hi = get_kv_block_range(
+                        self.mask_spec,
+                        (
+                            curr_block_coord[0] * 2,
+                            curr_block_coord[1],
+                            curr_block_coord[2],
+                        ),
+                        stage_tiler,
+                        seqlen_k,
+                        seqlen_q_,
+                    )
+                    stage1_lo, stage1_hi = get_kv_block_range(
+                        self.mask_spec,
+                        (
+                            curr_block_coord[0] * 2 + 1,
+                            curr_block_coord[1],
+                            curr_block_coord[2],
+                        ),
+                        stage_tiler,
+                        seqlen_k,
+                        seqlen_q_,
+                    )
+                    qk1_live_prologue = not (
+                        kv_start_block < stage1_lo or kv_start_block >= stage1_hi
+                    )
+
                 # GEMM_QK00 (Q0 * K0 -> S0)
+                # Never dead: lo(q) is non-decreasing in q, so the union's
+                # start block always lies inside stage 0's band.
                 q0_handle_consumer = load_q_consumer.wait_and_advance()
                 tSrQ0 = tSrQ[None, None, None, q0_handle_consumer.index]
                 k_handle_consumer = load_kv_consumer.wait_and_advance()
@@ -277,7 +332,8 @@ class MmaRole:
                 q1_handle_consumer = load_q_consumer.wait_and_advance()
                 tSrQ1 = tSrQ[None, None, None, q1_handle_consumer.index]
                 s1_handle_producer = mma_s1_producer.acquire_and_advance()
-                self.gemm_qk(tStS1, tSrQ1, tSrK0)
+                if qk1_live_prologue:
+                    self.gemm_qk(tStS1, tSrQ1, tSrK0)
                 s1_handle_producer.commit()
                 k_handle_consumer.release()
 
@@ -312,10 +368,19 @@ class MmaRole:
                 # be demoted to a runtime register through the kv loop.
                 pv_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
                 for _i in cutlass.range(0, seqlen_kv_loop_steps, 1, unroll=1):
+                    qk0_live = True
+                    qk1_live = True
+                    if cutlass.const_expr(
+                        not self.has_logits_transform and not self.has_statistics_update
+                    ):
+                        blk = kv_start_block + _i + 1
+                        qk0_live = not (blk < stage0_lo or blk >= stage0_hi)
+                        qk1_live = not (blk < stage1_lo or blk >= stage1_hi)
                     # GEMM_QK0i
                     k_handle_consumer = load_kv_consumer.wait_and_advance()
                     tSrKi = tSrK[None, None, None, k_handle_consumer.index]
-                    self.gemm_qk(tStS0, tSrQ0, tSrKi)
+                    if qk0_live:
+                        self.gemm_qk(tStS0, tSrQ0, tSrKi)
                     s0_handle_producer.commit()
 
                     # GEMM_PV1(i-1) — read the constant-folded ACCUMULATE
@@ -331,7 +396,8 @@ class MmaRole:
                     v_handle_consumer.release()
 
                     # GEMM_QK1i
-                    self.gemm_qk(tStS1, tSrQ1, tSrKi)
+                    if qk1_live:
+                        self.gemm_qk(tStS1, tSrQ1, tSrKi)
                     s1_handle_producer.commit()
                     k_handle_consumer.release()
 

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -88,13 +88,19 @@ class SoftmaxRole:
         # Set later via set_dtypes() / set_call_attrs()
         self.q_dtype: Optional[Type[cutlass.Numeric]] = None
         self.o_dtype: Optional[Type[cutlass.Numeric]] = None
+        self.p_dtype: Optional[Type[cutlass.Numeric]] = None
         self.o_layout = None
         self.epi_tile = None
 
-    def set_dtypes(self, q_dtype, o_dtype):
-        """Set tensor-type attributes known only at call time."""
+    def set_dtypes(self, q_dtype, o_dtype, p_dtype=None):
+        """Set tensor-type attributes known only at call time.
+
+        P (the PV MMA A-operand) follows V's dtype, which may differ
+        from Q/K's; defaults to q_dtype for uniform-dtype callers.
+        """
         self.q_dtype = q_dtype
         self.o_dtype = o_dtype
+        self.p_dtype = p_dtype if p_dtype is not None else q_dtype
 
     def set_call_attrs(self, o_layout, epi_tile):
         """Set epilog attributes for transform path (replaces CorrectionRole)."""
@@ -258,7 +264,7 @@ class SoftmaxRole:
 
         tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.qk_acc_dtype)
         tTMEM_STORErS_x4_e = cute.make_tensor(
-            cute.recast_ptr(tTMEM_STORErS_x4.iterator, dtype=self.q_dtype),
+            cute.recast_ptr(tTMEM_STORErS_x4.iterator, dtype=self.p_dtype),
             tTMEM_LOADrS.layout,
         )
 
@@ -279,7 +285,7 @@ class SoftmaxRole:
             for j in range(frg_cnt):
                 self.variant.transform_logits_vec(tTMEM_LOADrS_frg[None, j])
                 s_vec = tTMEM_LOADrS_frg[None, j].load()
-                tTMEM_STORErS_x4_e_frg[None, j].store(s_vec.to(self.q_dtype))
+                tTMEM_STORErS_x4_e_frg[None, j].store(s_vec.to(self.p_dtype))
 
         elif cutlass.const_expr(self.has_logits_transform):
             if cutlass.const_expr(self.has_params and not self.has_score_mod):
@@ -290,13 +296,13 @@ class SoftmaxRole:
                         tTMEM_LOADrS_frg[k, j],
                     )
                 s_vec = tTMEM_LOADrS_frg[None, j].load()
-                tTMEM_STORErS_x4_e_frg[None, j].store(s_vec.to(self.q_dtype))
+                tTMEM_STORErS_x4_e_frg[None, j].store(s_vec.to(self.p_dtype))
 
         else:
             for j in range(frg_cnt):
                 exp2_scale(tTMEM_LOADrS_frg[None, j], scale, row_max_safe)
                 s_vec = tTMEM_LOADrS_frg[None, j].load()
-                tTMEM_STORErS_x4_e_frg[None, j].store(s_vec.to(self.q_dtype))
+                tTMEM_STORErS_x4_e_frg[None, j].store(s_vec.to(self.p_dtype))
 
         if cutlass.const_expr(not self.has_logits_transform):
             if cutlass.const_expr(stage == 0):

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -28,9 +28,7 @@ from ..config import AttentionConfig, AttentionFusion
 from ..tmem_layout import TmemLayout
 from ..fusion.mask import (
     apply_mask,
-    get_unmasked_trip_count,
-    get_masked_trip_count,
-    get_kv_start_block_idx,
+    get_trip_segments,
 )
 from ..scheduler.persistent import (
     FmhaStaticTileScheduler,
@@ -61,8 +59,7 @@ class SoftmaxRole:
         self.pv_mma_tiler = config.pv_mma_tiler
         self.pv_acc_dtype = config.pv_acc_dtype
         self.cta_tiler = config.cta_tiler
-        self.mask_type = config.mask_type
-        self.window_left = config.window_left
+        self.mask_spec = config.mask_spec
         self.num_repeat_kv_heads = config.num_repeat_kv_heads
 
         # From TMEM layout
@@ -196,8 +193,7 @@ class SoftmaxRole:
         cute.copy(tiled_tmem_load, tTMEM_LOADtS, tTMEM_LOADrS)
         if need_apply_mask:
             apply_mask(
-                self.mask_type,
-                self.window_left,
+                self.mask_spec,
                 tTMEM_LOADrS,
                 tTMEM_LOADcS,
                 seqlen_k,
@@ -228,8 +224,7 @@ class SoftmaxRole:
             # for out-of-bounds positions so they get zero softmax weight.
             if need_apply_mask:
                 apply_mask(
-                    self.mask_type,
-                    self.window_left,
+                    self.mask_spec,
                     tTMEM_LOADrS,
                     tTMEM_LOADcS,
                     seqlen_k,
@@ -579,17 +574,19 @@ class SoftmaxRole:
                     tTMEM_STOREtS_x4,
                 )
 
-                kv_start_offset = (
-                    get_kv_start_block_idx(
-                        self.mask_type,
-                        self.window_left,
-                        curr_block_coord,
-                        self.cta_tiler,
-                        seqlen_k_,
-                        seqlen_q_,
-                    )
-                    * self.qk_mma_tiler[1]
+                (
+                    kv_start_block,
+                    masked_left,
+                    unmask_count,
+                    masked_right,
+                ) = get_trip_segments(
+                    self.mask_spec,
+                    curr_block_coord,
+                    self.cta_tiler,
+                    seqlen_k_,
+                    seqlen_q_,
                 )
+                kv_start_offset = kv_start_block * self.qk_mma_tiler[1]
                 logical_offset = (
                     curr_block_coord[0] * self.cta_tiler[0]
                     + stage * self.qk_mma_tiler[0],
@@ -599,17 +596,48 @@ class SoftmaxRole:
                 vec_i_handle = None
                 if cutlass.const_expr(not self.has_logits_transform):
                     vec_i_handle = si_corr_producer.acquire_and_advance()
-                unmask_count = get_unmasked_trip_count(
-                    self.mask_type,
-                    self.window_left,
-                    curr_block_coord,
-                    self.cta_tiler,
-                    seqlen_k_,
-                    seqlen_q_,
-                )
                 batch_coord = curr_block_coord[2][1]
                 head_coord = curr_block_coord[2][0]
-                for i in cutlass.range(0, unmask_count, 1, unroll=1):
+                # Left boundary blocks (window left edge) — masked.
+                for i in cutlass.range(0, masked_left, 1, unroll=1):
+                    cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
+                    iter_args = (
+                        cS_iter,
+                        row_max,
+                        row_sum,
+                        vec_i_handle,
+                        batch_coord,
+                        head_coord,
+                    )
+                    pipeline_args = (
+                        mma_si_consumer,
+                        si_corr_producer,
+                        s0_s1_sequence_consumer,
+                        s0_s1_sequence_producer,
+                    )
+                    (
+                        row_max,
+                        row_sum,
+                        vec_i_handle,
+                        mma_si_consumer,
+                        si_corr_producer,
+                        s0_s1_sequence_consumer,
+                        s0_s1_sequence_producer,
+                    ) = self.step(
+                        stage,
+                        True,
+                        iter_args,
+                        value_args,
+                        pipeline_args,
+                        atom_args,
+                        tensor_args,
+                        params,
+                    )
+
+                # Interior blocks fully inside the band — no masking.
+                for i in cutlass.range(
+                    masked_left, masked_left + unmask_count, 1, unroll=1
+                ):
                     cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
                     iter_args = (
                         cS_iter,
@@ -644,17 +672,13 @@ class SoftmaxRole:
                         params,
                     )
 
-                mask_count = get_masked_trip_count(
-                    self.mask_type,
-                    self.window_left,
-                    curr_block_coord,
-                    self.cta_tiler,
-                    seqlen_k_,
-                    seqlen_q_,
-                )
-
+                # Right boundary blocks (causal diagonal, window right edge,
+                # or seqlen_k tail) — masked.
                 for i in cutlass.range(
-                    unmask_count, unmask_count + mask_count, 1, unroll=1
+                    masked_left + unmask_count,
+                    masked_left + unmask_count + masked_right,
+                    1,
+                    unroll=1,
                 ):
                     cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
                     iter_args = (

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -376,7 +376,6 @@ class SoftmaxRole:
     def dead_step(
         self,
         stage: int,
-        store_zero_p: bool,
         cS: cute.Tensor,
         row_max: Float32,
         row_sum: Float32,
@@ -394,12 +393,6 @@ class SoftmaxRole:
         max, so the correction rescale factor is exactly 1), honor the
         s0/s1 sequence tokens, and store a zero P so the still-running PV
         gemm accumulates nothing.  row_max/row_sum pass through unchanged.
-
-        ``store_zero_p`` (compile-time): dead-prefix blocks (stage 1's first
-        trip) keep the zero-P store because their PV gemm is the
-        ACCUMULATE=False overwrite that initializes O1; dead-suffix blocks
-        (stage 0's last trip) pass False — the MMA skips their PV gemm
-        entirely (see MmaRole.run), so nothing reads that P tile.
 
         Standard path only (callers gate on not has_logits_transform and
         not has_statistics_update).  Kept as a separate function so the
@@ -456,21 +449,19 @@ class SoftmaxRole:
             sequence_consumer_handle = s0_s1_sequence_consumer.wait_and_advance()
 
         # P = 0 so the PV gemm adds nothing (zero f32 backing = packed
-        # bf16/fp16 zeros).  Skipped when the MMA skips the PV gemm.
-        if cutlass.const_expr(store_zero_p):
-            tTMEM_STORErS_x4 = cute.make_rmem_tensor(
-                tTMEM_STOREcS.shape, self.qk_acc_dtype
-            )
-            for idx in range(cute.size(tTMEM_STORErS_x4)):
-                tTMEM_STORErS_x4[idx] = 0.0
+        # bf16/fp16 zeros).
+        tTMEM_STORErS_x4 = cute.make_rmem_tensor(
+            tTMEM_STOREcS.shape, self.qk_acc_dtype
+        )
+        for idx in range(cute.size(tTMEM_STORErS_x4)):
+            tTMEM_STORErS_x4[idx] = 0.0
 
         if cutlass.const_expr(stage == 0):
             sequence_producer_handle.commit()
         else:
             sequence_consumer_handle.release()
-        if cutlass.const_expr(store_zero_p):
-            cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
-            cute.arch.fence_view_async_tmem_store()
+        cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
+        cute.arch.fence_view_async_tmem_store()
         si_handle.release()
 
         vec_i_handle = si_corr_producer.acquire_and_advance()
@@ -784,7 +775,6 @@ class SoftmaxRole:
                             s0_s1_sequence_producer,
                         ) = self.dead_step(
                             stage,
-                            True,  # store_zero_p: prefix PV1 is the O1 init
                             cS_iter,
                             row_max,
                             row_sum,
@@ -935,7 +925,6 @@ class SoftmaxRole:
                             s0_s1_sequence_producer,
                         ) = self.dead_step(
                             stage,
-                            False,  # store_zero_p: MMA skips the suffix PV0
                             cS_iter,
                             row_max,
                             row_sum,

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -28,6 +28,7 @@ from ..config import AttentionConfig, AttentionFusion
 from ..tmem_layout import TmemLayout
 from ..fusion.mask import (
     apply_mask,
+    get_kv_block_range,
     get_trip_segments,
 )
 from ..scheduler.persistent import (
@@ -363,6 +364,108 @@ class SoftmaxRole:
         )
 
     @cute.jit
+    def dead_step(
+        self,
+        stage: int,
+        cS: cute.Tensor,
+        row_max: Float32,
+        row_sum: Float32,
+        vec_i_handle,
+        pipeline_args: tuple,
+        atom_args: tuple,
+        tensor_args: tuple,
+    ):
+        """Fast path for a KV block entirely outside this stage's 128-row band.
+
+        The union trip range covers both 128-row stages; blocks outside this
+        stage's own band contribute nothing (every score would be masked).
+        This step performs only the pipeline obligations of a full step, in
+        the same order: consume Si, publish a no-change vec (old == new row
+        max, so the correction rescale factor is exactly 1), honor the
+        s0/s1 sequence tokens, and store a zero P so the still-running PV
+        gemm accumulates nothing.  row_max/row_sum pass through unchanged.
+
+        Standard path only (callers gate on not has_logits_transform and
+        not has_statistics_update).  Kept as a separate function so the
+        live step() contains no dynamic control flow — guarding the step
+        body with a runtime is-dead branch forces the accumulator fragment
+        across MLIR region boundaries and regresses every masked step.
+        """
+        assert self.q_dtype is not None
+        assert self.o_dtype is not None
+        (
+            mma_si_consumer,
+            si_corr_producer,
+            s0_s1_sequence_consumer,
+            s0_s1_sequence_producer,
+        ) = pipeline_args
+        qk_thr_mma = atom_args[0]
+        tiled_tmem_store = atom_args[2]
+        tiled_tmem_store_vec = atom_args[3]
+        thr_tmem_store = atom_args[5]
+        thr_tmem_store_vec = atom_args[6]
+        tTMEM_STORE_VECtS = tensor_args[1]
+        tTMEM_STOREtS_x4 = tensor_args[2]
+
+        tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.o_dtype.width
+        tScS = qk_thr_mma.partition_C(cS)
+        tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
+        tScS_vec = cute.make_tensor(tScS.iterator, tScS_vec_layout)
+        tScS_P_layout = cute.composition(
+            tScS.layout, cute.make_layout((128, tilePlikeFP32))
+        )
+        tScS_P = cute.make_tensor(tScS.iterator, tScS_P_layout)
+        tTMEM_STORE_VECcS = thr_tmem_store_vec.partition_S(tScS_vec)
+        tTMEM_STOREcS = thr_tmem_store.partition_S(tScS_P)
+
+        # Wait for Si (release below doubles as "P ready" for the PV gemm)
+        si_handle = mma_si_consumer.wait_and_advance()
+
+        # No-change vec: old == new row max => correction factor 1
+        row_max_safe = row_max
+        if row_max == -cutlass.Float32.inf:
+            row_max_safe = 0.0
+        tTMEM_STORE_VECrS = cute.make_rmem_tensor(
+            tTMEM_STORE_VECcS.shape, self.qk_acc_dtype
+        )
+        tTMEM_STORE_VECrS[0] = row_max
+        tTMEM_STORE_VECrS[1] = row_max_safe
+        cute.copy(tiled_tmem_store_vec, tTMEM_STORE_VECrS, tTMEM_STORE_VECtS)
+        cute.arch.fence_view_async_tmem_store()
+        vec_i_handle.commit()
+
+        if cutlass.const_expr(stage == 0):
+            sequence_producer_handle = s0_s1_sequence_producer.acquire_and_advance()
+        else:
+            sequence_consumer_handle = s0_s1_sequence_consumer.wait_and_advance()
+
+        # P = 0 so the PV gemm adds nothing (zero f32 backing = packed
+        # bf16/fp16 zeros).
+        tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.qk_acc_dtype)
+        for idx in range(cute.size(tTMEM_STORErS_x4)):
+            tTMEM_STORErS_x4[idx] = 0.0
+
+        if cutlass.const_expr(stage == 0):
+            sequence_producer_handle.commit()
+        else:
+            sequence_consumer_handle.release()
+        cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
+        cute.arch.fence_view_async_tmem_store()
+        si_handle.release()
+
+        vec_i_handle = si_corr_producer.acquire_and_advance()
+
+        return (
+            row_max,
+            row_sum,
+            vec_i_handle,
+            mma_si_consumer,
+            si_corr_producer,
+            s0_s1_sequence_consumer,
+            s0_s1_sequence_producer,
+        )
+
+    @cute.jit
     def softmax_epilog(
         self,
         stage: int,
@@ -587,6 +690,37 @@ class SoftmaxRole:
                     seqlen_q_,
                 )
                 kv_start_offset = kv_start_block * self.qk_mma_tiler[1]
+                # Dead-step split: the trip range above is the union over
+                # both 128-row stages' rows.  Union blocks entirely outside
+                # THIS stage's own band contribute nothing; they always form
+                # a prefix (stage 1) and/or suffix (stage 0) of the masked
+                # segments and are routed to dead_step() below, keeping the
+                # live step() free of dynamic control flow.
+                dead_prefix = 0
+                dead_suffix = 0
+                if cutlass.const_expr(
+                    not self.has_logits_transform and not self.has_statistics_update
+                ):
+                    stage_lo, stage_hi = get_kv_block_range(
+                        self.mask_spec,
+                        (
+                            curr_block_coord[0] * 2 + stage,
+                            curr_block_coord[1],
+                            curr_block_coord[2],
+                        ),
+                        (self.qk_mma_tiler[0], self.cta_tiler[1]),
+                        seqlen_k_,
+                        seqlen_q_,
+                    )
+                    kv_end_block = (
+                        kv_start_block + masked_left + unmask_count + masked_right
+                    )
+                    dead_prefix = cutlass.min(
+                        cutlass.max(stage_lo - kv_start_block, 0), masked_left
+                    )
+                    dead_suffix = cutlass.min(
+                        cutlass.max(kv_end_block - stage_hi, 0), masked_right
+                    )
                 logical_offset = (
                     curr_block_coord[0] * self.cta_tiler[0]
                     + stage * self.qk_mma_tiler[0],
@@ -598,8 +732,37 @@ class SoftmaxRole:
                     vec_i_handle = si_corr_producer.acquire_and_advance()
                 batch_coord = curr_block_coord[2][1]
                 head_coord = curr_block_coord[2][0]
+                # Dead prefix (stage 1 only): blocks below this stage's band.
+                if cutlass.const_expr(
+                    not self.has_logits_transform and not self.has_statistics_update
+                ):
+                    for i in cutlass.range(0, dead_prefix, 1, unroll=1):
+                        cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
+                        (
+                            row_max,
+                            row_sum,
+                            vec_i_handle,
+                            mma_si_consumer,
+                            si_corr_producer,
+                            s0_s1_sequence_consumer,
+                            s0_s1_sequence_producer,
+                        ) = self.dead_step(
+                            stage,
+                            cS_iter,
+                            row_max,
+                            row_sum,
+                            vec_i_handle,
+                            (
+                                mma_si_consumer,
+                                si_corr_producer,
+                                s0_s1_sequence_consumer,
+                                s0_s1_sequence_producer,
+                            ),
+                            atom_args,
+                            tensor_args,
+                        )
                 # Left boundary blocks (window left edge) — masked.
-                for i in cutlass.range(0, masked_left, 1, unroll=1):
+                for i in cutlass.range(dead_prefix, masked_left, 1, unroll=1):
                     cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
                     iter_args = (
                         cS_iter,
@@ -676,7 +839,7 @@ class SoftmaxRole:
                 # or seqlen_k tail) — masked.
                 for i in cutlass.range(
                     masked_left + unmask_count,
-                    masked_left + unmask_count + masked_right,
+                    masked_left + unmask_count + masked_right - dead_suffix,
                     1,
                     unroll=1,
                 ):
@@ -713,6 +876,41 @@ class SoftmaxRole:
                         tensor_args,
                         params,
                     )
+
+                # Dead suffix (stage 0 only): blocks above this stage's band.
+                if cutlass.const_expr(
+                    not self.has_logits_transform and not self.has_statistics_update
+                ):
+                    for i in cutlass.range(
+                        masked_left + unmask_count + masked_right - dead_suffix,
+                        masked_left + unmask_count + masked_right,
+                        1,
+                        unroll=1,
+                    ):
+                        cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
+                        (
+                            row_max,
+                            row_sum,
+                            vec_i_handle,
+                            mma_si_consumer,
+                            si_corr_producer,
+                            s0_s1_sequence_consumer,
+                            s0_s1_sequence_producer,
+                        ) = self.dead_step(
+                            stage,
+                            cS_iter,
+                            row_max,
+                            row_sum,
+                            vec_i_handle,
+                            (
+                                mma_si_consumer,
+                                si_corr_producer,
+                                s0_s1_sequence_consumer,
+                                s0_s1_sequence_producer,
+                            ),
+                            atom_args,
+                            tensor_args,
+                        )
                 si_handle = mma_si_consumer.wait_and_advance()
                 if cutlass.const_expr(not self.has_logits_transform):
                     tTMEM_STORE_VECrS = cute.make_rmem_tensor(

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -28,7 +28,7 @@ from ..config import AttentionConfig, AttentionFusion
 from ..tmem_layout import TmemLayout
 from ..fusion.mask import (
     apply_mask,
-    get_kv_block_range,
+    get_stage_peel_segments,
     get_trip_segments,
 )
 from ..scheduler.persistent import (
@@ -371,108 +371,6 @@ class SoftmaxRole:
         )
 
     @cute.jit
-    def dead_step(
-        self,
-        stage: int,
-        cS: cute.Tensor,
-        row_max: Float32,
-        row_sum: Float32,
-        vec_i_handle,
-        pipeline_args: tuple,
-        atom_args: tuple,
-        tensor_args: tuple,
-    ):
-        """Fast path for a KV block entirely outside this stage's 128-row band.
-
-        The union trip range covers both 128-row stages; blocks outside this
-        stage's own band contribute nothing (every score would be masked).
-        This step performs only the pipeline obligations of a full step, in
-        the same order: consume Si, publish a no-change vec (old == new row
-        max, so the correction rescale factor is exactly 1), honor the
-        s0/s1 sequence tokens, and store a zero P so the still-running PV
-        gemm accumulates nothing.  row_max/row_sum pass through unchanged.
-
-        Standard path only (callers gate on not has_logits_transform and
-        not has_statistics_update).  Kept as a separate function so the
-        live step() contains no dynamic control flow — guarding the step
-        body with a runtime is-dead branch forces the accumulator fragment
-        across MLIR region boundaries and regresses every masked step.
-        """
-        assert self.q_dtype is not None
-        assert self.o_dtype is not None
-        (
-            mma_si_consumer,
-            si_corr_producer,
-            s0_s1_sequence_consumer,
-            s0_s1_sequence_producer,
-        ) = pipeline_args
-        qk_thr_mma = atom_args[0]
-        tiled_tmem_store = atom_args[2]
-        tiled_tmem_store_vec = atom_args[3]
-        thr_tmem_store = atom_args[5]
-        thr_tmem_store_vec = atom_args[6]
-        tTMEM_STORE_VECtS = tensor_args[1]
-        tTMEM_STOREtS_x4 = tensor_args[2]
-
-        tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.o_dtype.width
-        tScS = qk_thr_mma.partition_C(cS)
-        tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
-        tScS_vec = cute.make_tensor(tScS.iterator, tScS_vec_layout)
-        tScS_P_layout = cute.composition(
-            tScS.layout, cute.make_layout((128, tilePlikeFP32))
-        )
-        tScS_P = cute.make_tensor(tScS.iterator, tScS_P_layout)
-        tTMEM_STORE_VECcS = thr_tmem_store_vec.partition_S(tScS_vec)
-        tTMEM_STOREcS = thr_tmem_store.partition_S(tScS_P)
-
-        # Wait for Si (release below doubles as "P ready" for the PV gemm)
-        si_handle = mma_si_consumer.wait_and_advance()
-
-        # No-change vec: old == new row max => correction factor 1
-        row_max_safe = row_max
-        if row_max == -cutlass.Float32.inf:
-            row_max_safe = 0.0
-        tTMEM_STORE_VECrS = cute.make_rmem_tensor(
-            tTMEM_STORE_VECcS.shape, self.qk_acc_dtype
-        )
-        tTMEM_STORE_VECrS[0] = row_max
-        tTMEM_STORE_VECrS[1] = row_max_safe
-        cute.copy(tiled_tmem_store_vec, tTMEM_STORE_VECrS, tTMEM_STORE_VECtS)
-        cute.arch.fence_view_async_tmem_store()
-        vec_i_handle.commit()
-
-        if cutlass.const_expr(stage == 0):
-            sequence_producer_handle = s0_s1_sequence_producer.acquire_and_advance()
-        else:
-            sequence_consumer_handle = s0_s1_sequence_consumer.wait_and_advance()
-
-        # P = 0 so the PV gemm adds nothing (zero f32 backing = packed
-        # bf16/fp16 zeros).
-        tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.qk_acc_dtype)
-        for idx in range(cute.size(tTMEM_STORErS_x4)):
-            tTMEM_STORErS_x4[idx] = 0.0
-
-        if cutlass.const_expr(stage == 0):
-            sequence_producer_handle.commit()
-        else:
-            sequence_consumer_handle.release()
-        cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
-        cute.arch.fence_view_async_tmem_store()
-        si_handle.release()
-
-        vec_i_handle = si_corr_producer.acquire_and_advance()
-
-        return (
-            row_max,
-            row_sum,
-            vec_i_handle,
-            mma_si_consumer,
-            si_corr_producer,
-            s0_s1_sequence_consumer,
-            s0_s1_sequence_producer,
-        )
-
-    @cute.jit
     def softmax_epilog(
         self,
         stage: int,
@@ -696,54 +594,53 @@ class SoftmaxRole:
                     tTMEM_LOADcS_static,
                 )
 
-                (
-                    kv_start_block,
-                    masked_left,
-                    unmask_count,
-                    masked_right,
-                ) = get_trip_segments(
-                    self.mask_spec,
-                    curr_block_coord,
-                    self.cta_tiler,
-                    seqlen_k_,
-                    seqlen_q_,
-                    window_left,
-                    window_right,
-                )
-                kv_start_offset = kv_start_block * self.qk_mma_tiler[1]
-                # Dead-step split: the trip range above is the union over
-                # both 128-row stages' rows.  Union blocks entirely outside
-                # THIS stage's own band contribute nothing; they always form
-                # a prefix (stage 1) and/or suffix (stage 0) of the masked
-                # segments and are routed to dead_step() below, keeping the
-                # live step() free of dynamic control flow.
-                dead_prefix = 0
-                dead_suffix = 0
+                # Per-stage band iteration (head/tail peel): each 128-row
+                # stage runs exactly its own band's trips — stage 0 the
+                # union's head+main blocks, stage 1 the main+tail blocks
+                # (see fusion/mask.py get_peel_sections).  No dead trips
+                # exist; the s0<->s1 sequence tokens stay balanced because
+                # stage 1 pre-consumes stage 0's `head` tokens and stage 0
+                # post-produces `tail` tokens after its final vec (dummies,
+                # a few instructions each).  Variants with per-step side
+                # effects keep full union lockstep (head = tail = 0).
+                seq_dummy_head = Int32(0)
+                seq_dummy_tail = Int32(0)
                 if cutlass.const_expr(
                     not self.has_logits_transform and not self.has_statistics_update
                 ):
-                    stage_lo, stage_hi = get_kv_block_range(
+                    (
+                        kv_start_block,
+                        masked_left,
+                        unmask_count,
+                        masked_right,
+                        seq_dummy_head,
+                        seq_dummy_tail,
+                    ) = get_stage_peel_segments(
                         self.mask_spec,
-                        (
-                            curr_block_coord[0] * 2 + stage,
-                            curr_block_coord[1],
-                            curr_block_coord[2],
-                        ),
-                        (self.qk_mma_tiler[0], self.cta_tiler[1]),
+                        curr_block_coord,
+                        stage,
+                        self.cta_tiler,
                         seqlen_k_,
                         seqlen_q_,
                         window_left,
                         window_right,
                     )
-                    kv_end_block = (
-                        kv_start_block + masked_left + unmask_count + masked_right
+                else:
+                    (
+                        kv_start_block,
+                        masked_left,
+                        unmask_count,
+                        masked_right,
+                    ) = get_trip_segments(
+                        self.mask_spec,
+                        curr_block_coord,
+                        self.cta_tiler,
+                        seqlen_k_,
+                        seqlen_q_,
+                        window_left,
+                        window_right,
                     )
-                    dead_prefix = cutlass.min(
-                        cutlass.max(stage_lo - kv_start_block, 0), masked_left
-                    )
-                    dead_suffix = cutlass.min(
-                        cutlass.max(kv_end_block - stage_hi, 0), masked_right
-                    )
+                kv_start_offset = kv_start_block * self.qk_mma_tiler[1]
                 logical_offset = (
                     curr_block_coord[0] * self.cta_tiler[0]
                     + stage * self.qk_mma_tiler[0],
@@ -755,37 +652,18 @@ class SoftmaxRole:
                     vec_i_handle = si_corr_producer.acquire_and_advance()
                 batch_coord = curr_block_coord[2][1]
                 head_coord = curr_block_coord[2][0]
-                # Dead prefix (stage 1 only): blocks below this stage's band.
+                # Stage 1: consume stage 0's head-trip tokens (it has no
+                # steps of its own for those blocks).
                 if cutlass.const_expr(
-                    not self.has_logits_transform and not self.has_statistics_update
+                    stage == 1
+                    and not self.has_logits_transform
+                    and not self.has_statistics_update
                 ):
-                    for i in cutlass.range(0, dead_prefix, 1, unroll=1):
-                        cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
-                        (
-                            row_max,
-                            row_sum,
-                            vec_i_handle,
-                            mma_si_consumer,
-                            si_corr_producer,
-                            s0_s1_sequence_consumer,
-                            s0_s1_sequence_producer,
-                        ) = self.dead_step(
-                            stage,
-                            cS_iter,
-                            row_max,
-                            row_sum,
-                            vec_i_handle,
-                            (
-                                mma_si_consumer,
-                                si_corr_producer,
-                                s0_s1_sequence_consumer,
-                                s0_s1_sequence_producer,
-                            ),
-                            atom_args,
-                            tensor_args,
-                        )
+                    for _d in cutlass.range(0, seq_dummy_head, 1, unroll=1):
+                        seq_handle = s0_s1_sequence_consumer.wait_and_advance()
+                        seq_handle.release()
                 # Left boundary blocks (window left edge) — masked.
-                for i in cutlass.range(dead_prefix, masked_left, 1, unroll=1):
+                for i in cutlass.range(0, masked_left, 1, unroll=1):
                     cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
                     iter_args = (
                         cS_iter,
@@ -862,7 +740,7 @@ class SoftmaxRole:
                 # or seqlen_k tail) — masked.
                 for i in cutlass.range(
                     masked_left + unmask_count,
-                    masked_left + unmask_count + masked_right - dead_suffix,
+                    masked_left + unmask_count + masked_right,
                     1,
                     unroll=1,
                 ):
@@ -900,40 +778,6 @@ class SoftmaxRole:
                         params,
                     )
 
-                # Dead suffix (stage 0 only): blocks above this stage's band.
-                if cutlass.const_expr(
-                    not self.has_logits_transform and not self.has_statistics_update
-                ):
-                    for i in cutlass.range(
-                        masked_left + unmask_count + masked_right - dead_suffix,
-                        masked_left + unmask_count + masked_right,
-                        1,
-                        unroll=1,
-                    ):
-                        cS_iter = cute.domain_offset((0, i * self.qk_mma_tiler[1]), cS)
-                        (
-                            row_max,
-                            row_sum,
-                            vec_i_handle,
-                            mma_si_consumer,
-                            si_corr_producer,
-                            s0_s1_sequence_consumer,
-                            s0_s1_sequence_producer,
-                        ) = self.dead_step(
-                            stage,
-                            cS_iter,
-                            row_max,
-                            row_sum,
-                            vec_i_handle,
-                            (
-                                mma_si_consumer,
-                                si_corr_producer,
-                                s0_s1_sequence_consumer,
-                                s0_s1_sequence_producer,
-                            ),
-                            atom_args,
-                            tensor_args,
-                        )
                 si_handle = mma_si_consumer.wait_and_advance()
                 if cutlass.const_expr(not self.has_logits_transform):
                     tTMEM_STORE_VECrS = cute.make_rmem_tensor(
@@ -946,6 +790,16 @@ class SoftmaxRole:
                     )
                     cute.arch.fence_view_async_tmem_store()
                     vec_i_handle.commit()
+                    # Stage 0: produce stage 1's tail-trip tokens (it has no
+                    # steps of its own for those blocks).  After the final
+                    # vec commit so the O0 drain is not gated on stage 1's
+                    # progress.
+                    if cutlass.const_expr(
+                        stage == 0 and not self.has_statistics_update
+                    ):
+                        for _d in cutlass.range(0, seq_dummy_tail, 1, unroll=1):
+                            seq_handle = s0_s1_sequence_producer.acquire_and_advance()
+                            seq_handle.commit()
                     si_corr_producer.acquire()
                     si_handle.release()
                 else:

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -182,6 +182,12 @@ class SoftmaxRole:
                 scale_softmax_log2,
             )
 
+        # P-store extent keyed on o_dtype, NOT p_dtype: o is 16-bit in every
+        # dtype combo where they differ (fp8 in -> fp16 out), so this always
+        # covers >= P's extent.  With fp8 P the store's upper half is unread
+        # over-provision inside the reserved P region — same behavior as the
+        # uniform-fp8 build and the vendored kernel; the PV MMA reads P
+        # through p_tmem_layout_staged (v_dtype-keyed) only.
         tilePlikeFP32 = self.qk_mma_tiler[1] // Float32.width * self.o_dtype.width
         tScS = qk_thr_mma.partition_C(cS)
         tScS_vec_layout = cute.composition(tScS.layout, cute.make_layout((128, 2)))
@@ -502,6 +508,8 @@ class SoftmaxRole:
         cS_base = cute.make_identity_tensor(
             (self.qk_mma_tiler[0], self.qk_mma_tiler[1])
         )
+        # o_dtype-keyed on purpose (>= P's extent in every combo); see the
+        # comment at step()'s tilePlikeFP32 site.
         tilePlikeFP32 = self.qk_mma_tiler[1] // 32 * self.o_dtype.width
         tScS = qk_thr_mma.partition_C(cS_base)
         tStS_vec_layout = cute.composition(tStS.layout, cute.make_layout((128, 2)))

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -143,7 +143,9 @@ class SoftmaxRole:
         kv_head_idx = qo_head_idx // self.num_repeat_kv_heads
         kv_tile_idx = cS[0][1] // self.qk_mma_tiler[1]
 
-        seqlen_q, seqlen_k, scale_softmax_log2 = value_args
+        seqlen_q, seqlen_k, scale_softmax_log2, window_left, window_right = (
+            value_args
+        )
         (
             mma_si_consumer,
             si_corr_producer,
@@ -163,6 +165,7 @@ class SoftmaxRole:
             tTMEM_LOADtS,
             tTMEM_STORE_VECtS,
             tTMEM_STOREtS_x4,
+            tTMEM_LOADcS_static,
         ) = tensor_args
 
         if cutlass.const_expr(self.has_statistics_update):
@@ -199,6 +202,9 @@ class SoftmaxRole:
                 tTMEM_LOADcS,
                 seqlen_k,
                 seqlen_k - seqlen_q,
+                tTMEM_LOADcS_static,
+                window_left,
+                window_right,
             )
 
         frg_cnt = 4
@@ -230,6 +236,9 @@ class SoftmaxRole:
                     tTMEM_LOADcS,
                     seqlen_k,
                     seqlen_k - seqlen_q,
+                    tTMEM_LOADcS_static,
+                    window_left,
+                    window_right,
                 )
 
         if cutlass.const_expr(not self.has_logits_transform):
@@ -367,6 +376,7 @@ class SoftmaxRole:
     def dead_step(
         self,
         stage: int,
+        store_zero_p: bool,
         cS: cute.Tensor,
         row_max: Float32,
         row_sum: Float32,
@@ -384,6 +394,12 @@ class SoftmaxRole:
         max, so the correction rescale factor is exactly 1), honor the
         s0/s1 sequence tokens, and store a zero P so the still-running PV
         gemm accumulates nothing.  row_max/row_sum pass through unchanged.
+
+        ``store_zero_p`` (compile-time): dead-prefix blocks (stage 1's first
+        trip) keep the zero-P store because their PV gemm is the
+        ACCUMULATE=False overwrite that initializes O1; dead-suffix blocks
+        (stage 0's last trip) pass False — the MMA skips their PV gemm
+        entirely (see MmaRole.run), so nothing reads that P tile.
 
         Standard path only (callers gate on not has_logits_transform and
         not has_statistics_update).  Kept as a separate function so the
@@ -440,17 +456,21 @@ class SoftmaxRole:
             sequence_consumer_handle = s0_s1_sequence_consumer.wait_and_advance()
 
         # P = 0 so the PV gemm adds nothing (zero f32 backing = packed
-        # bf16/fp16 zeros).
-        tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.qk_acc_dtype)
-        for idx in range(cute.size(tTMEM_STORErS_x4)):
-            tTMEM_STORErS_x4[idx] = 0.0
+        # bf16/fp16 zeros).  Skipped when the MMA skips the PV gemm.
+        if cutlass.const_expr(store_zero_p):
+            tTMEM_STORErS_x4 = cute.make_rmem_tensor(
+                tTMEM_STOREcS.shape, self.qk_acc_dtype
+            )
+            for idx in range(cute.size(tTMEM_STORErS_x4)):
+                tTMEM_STORErS_x4[idx] = 0.0
 
         if cutlass.const_expr(stage == 0):
             sequence_producer_handle.commit()
         else:
             sequence_consumer_handle.release()
-        cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
-        cute.arch.fence_view_async_tmem_store()
+        if cutlass.const_expr(store_zero_p):
+            cute.copy(tiled_tmem_store, tTMEM_STORErS_x4, tTMEM_STOREtS_x4)
+            cute.arch.fence_view_async_tmem_store()
         si_handle.release()
 
         vec_i_handle = si_corr_producer.acquire_and_advance()
@@ -555,6 +575,8 @@ class SoftmaxRole:
         cum_seqlen_k: cute.Tensor | None,
         scale_softmax_log2: Float32,
         scale_output: Float32,
+        window_left: Int32,
+        window_right: Int32,
         qk_thr_mma: cute.ThrMma,
         pv_thr_mma: cute.ThrMma | None,
         tStS: cute.Tensor,
@@ -616,6 +638,9 @@ class SoftmaxRole:
         )
         thr_tmem_load = tiled_tmem_load.get_slice(thread_idx)
         tTMEM_LOADtS = thr_tmem_load.partition_S(tStSi)
+        # Unshifted identity partition: per-element coordinates with no
+        # dynamic domain offset; apply_mask requires it (see fusion/mask.py).
+        tTMEM_LOADcS_static = thr_tmem_load.partition_D(tScS)
         tmem_store_vec_atom = cute.make_copy_atom(
             tcgen05.copy.St32x32bOp(tcgen05.copy.Repetition(2)),
             self.qk_acc_dtype,
@@ -661,7 +686,13 @@ class SoftmaxRole:
                     seqlen_k_ = cum_seqlen_k[batch_coord + 1] - cuseqlen_k
                 row_max = -Float32.inf
                 row_sum = 0.0
-                value_args = (seqlen_q_, seqlen_k_, scale_softmax_log2)
+                value_args = (
+                    seqlen_q_,
+                    seqlen_k_,
+                    scale_softmax_log2,
+                    window_left,
+                    window_right,
+                )
                 atom_args = (
                     qk_thr_mma,
                     tiled_tmem_load,
@@ -675,6 +706,7 @@ class SoftmaxRole:
                     tTMEM_LOADtS,
                     tTMEM_STORE_VECtS,
                     tTMEM_STOREtS_x4,
+                    tTMEM_LOADcS_static,
                 )
 
                 (
@@ -688,6 +720,8 @@ class SoftmaxRole:
                     self.cta_tiler,
                     seqlen_k_,
                     seqlen_q_,
+                    window_left,
+                    window_right,
                 )
                 kv_start_offset = kv_start_block * self.qk_mma_tiler[1]
                 # Dead-step split: the trip range above is the union over
@@ -711,6 +745,8 @@ class SoftmaxRole:
                         (self.qk_mma_tiler[0], self.cta_tiler[1]),
                         seqlen_k_,
                         seqlen_q_,
+                        window_left,
+                        window_right,
                     )
                     kv_end_block = (
                         kv_start_block + masked_left + unmask_count + masked_right
@@ -748,6 +784,7 @@ class SoftmaxRole:
                             s0_s1_sequence_producer,
                         ) = self.dead_step(
                             stage,
+                            True,  # store_zero_p: prefix PV1 is the O1 init
                             cS_iter,
                             row_max,
                             row_sum,
@@ -898,6 +935,7 @@ class SoftmaxRole:
                             s0_s1_sequence_producer,
                         ) = self.dead_step(
                             stage,
+                            False,  # store_zero_p: MMA skips the suffix PV0
                             cS_iter,
                             row_max,
                             row_sum,

--- a/flashinfer/cute_dsl/attention/roles/softmax.py
+++ b/flashinfer/cute_dsl/attention/roles/softmax.py
@@ -143,9 +143,7 @@ class SoftmaxRole:
         kv_head_idx = qo_head_idx // self.num_repeat_kv_heads
         kv_tile_idx = cS[0][1] // self.qk_mma_tiler[1]
 
-        seqlen_q, seqlen_k, scale_softmax_log2, window_left, window_right = (
-            value_args
-        )
+        seqlen_q, seqlen_k, scale_softmax_log2, window_left, window_right = value_args
         (
             mma_si_consumer,
             si_corr_producer,
@@ -450,9 +448,7 @@ class SoftmaxRole:
 
         # P = 0 so the PV gemm adds nothing (zero f32 backing = packed
         # bf16/fp16 zeros).
-        tTMEM_STORErS_x4 = cute.make_rmem_tensor(
-            tTMEM_STOREcS.shape, self.qk_acc_dtype
-        )
+        tTMEM_STORErS_x4 = cute.make_rmem_tensor(tTMEM_STOREcS.shape, self.qk_acc_dtype)
         for idx in range(cute.size(tTMEM_STORErS_x4)):
             tTMEM_STORErS_x4[idx] = 0.0
 

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -24,7 +24,7 @@ from flashinfer.api_logging import flashinfer_api
 from flashinfer.trace.templates.attention import cute_dsl_batch_prefill_run_trace
 
 from ..config import AttentionConfig, AttentionFusion
-from ..fusion.mask import MaskType
+from ..fusion.mask import MaskSpec
 from ..fusion.variant import AttentionVariant, StandardAttention
 from ..prefill import BlackwellFusedMultiHeadAttentionForward
 
@@ -36,8 +36,7 @@ def _get_compiled_prefill_kernel(
     num_qo_heads,
     num_kv_heads,
     head_dim,
-    mask_type,
-    window_left,
+    mask_spec,
     is_persistent,
     variant,
     params_shape,
@@ -65,9 +64,8 @@ def _get_compiled_prefill_kernel(
         pv_acc_dtype=cutlass.Float32,
         mma_tiler=(128, 128, head_dim),
         is_persistent=is_persistent,
-        mask_type=mask_type,
+        mask_spec=mask_spec,
         num_repeat_kv_heads=h_r,
-        window_left=window_left,
     )
     _dtype_width_map = {
         cutlass.Float16: 16,
@@ -210,6 +208,7 @@ class BatchPrefillCuteDSLWrapper:
         q_data_type=torch.float16,
         kv_data_type=torch.float16,
         window_left: int = -1,
+        window_right: int = -1,
         variant: AttentionVariant | None = None,
     ) -> None:
         """Compile the FMHA prefill kernel for the given configuration.
@@ -237,7 +236,13 @@ class BatchPrefillCuteDSLWrapper:
         kv_data_type : torch.dtype
             Data type for keys/values.
         window_left : int
-            Sliding window size. -1 disables sliding window.
+            Max lookback distance: query ``q`` attends to keys
+            ``k >= q + (kv_len - qo_len) - window_left``. -1 = unbounded.
+            Composes with ``causal`` (causal sliding window attention).
+        window_right : int
+            Max lookahead distance for non-causal masks: query ``q`` attends
+            to keys ``k <= q + (kv_len - qo_len) + window_right``. -1 =
+            unbounded. Mutually exclusive with ``causal=True``.
         variant : Optional[AttentionVariant]
             Attention variant (ALiBi, RPE, Sigmoid, etc.). None uses standard softmax.
         """
@@ -303,15 +308,14 @@ class BatchPrefillCuteDSLWrapper:
 
         mma_tiler_n = 128
 
-        # Determine mask type
-        self._mask_type = MaskType.NO_MASK
-        if self._causal:
-            self._mask_type = MaskType.CAUSAL_MASK
-        elif window_left > 0:
-            self._mask_type = MaskType.SLIDING_WINDOW_MASK
-        else:
-            if torch.any(s_k % mma_tiler_n != 0).item():
-                self._mask_type = MaskType.RESIDUAL_MASK
+        # Mask band: causal and window bounds are independent, composable
+        # parameters (MaskSpec validates causal/window_right exclusivity).
+        self._mask_spec = MaskSpec(
+            causal=self._causal,
+            window_left=window_left,
+            window_right=window_right,
+            check_kv_bounds=bool(torch.any(s_k % mma_tiler_n != 0).item()),
+        )
 
         self._problem_size = (
             self._batch_size,
@@ -337,8 +341,7 @@ class BatchPrefillCuteDSLWrapper:
             num_qo_heads,
             num_kv_heads,
             self._head_dim,
-            self._mask_type,
-            window_left,
+            self._mask_spec,
             self._is_persistent,
             cache_variant,
             params_shape,

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -12,6 +12,7 @@ and reused across batches of any size.
 
 import functools
 import math
+import os
 from typing import Optional
 
 import torch
@@ -141,6 +142,8 @@ def _get_compiled_prefill_kernel(
         1,
         0.0,
         1.0,
+        0,
+        0,
         params_fake,
         stream_fake,
         options="--enable-tvm-ffi --opt-level 2",
@@ -262,8 +265,6 @@ class BatchPrefillCuteDSLWrapper:
         self._causal = causal
         self._sm_scale = sm_scale
         self._device = qo_indptr.device
-        self._is_persistent = True
-
         if variant is None:
             variant = StandardAttention()
         self._variant = variant
@@ -306,16 +307,25 @@ class BatchPrefillCuteDSLWrapper:
                 )
             self._params_torch = ep
 
-        mma_tiler_n = 128
-
         # Mask band: causal and window bounds are independent, composable
-        # parameters (MaskSpec validates causal/window_right exclusivity).
+        # parameters.
+        if self._causal and window_right >= 0:
+            raise ValueError(
+                "window_right is mutually exclusive with causal "
+                "(causal already bounds lookahead at 0)"
+            )
+        # Causal is a right bound with runtime value 0; window VALUES are
+        # runtime kernel arguments (only their presence is compiled in),
+        # so one cached kernel serves every window size and the causal /
+        # right-window cases share a kernel.
         self._mask_spec = MaskSpec(
-            causal=self._causal,
-            window_left=window_left,
-            window_right=window_right,
-            check_kv_bounds=bool(torch.any(s_k % mma_tiler_n != 0).item()),
+            has_window_left=window_left >= 0,
+            has_window_right=self._causal or window_right >= 0,
         )
+        self._window_left = max(window_left, 0)
+        self._window_right = 0 if self._causal else max(window_right, 0)
+
+        self._is_persistent = True
 
         self._problem_size = (
             self._batch_size,
@@ -449,6 +459,8 @@ class BatchPrefillCuteDSLWrapper:
             self._s_k_all,
             self._scale_softmax_log2,
             self._scale_output,
+            self._window_left,
+            self._window_right,
             self._params_torch if self._has_params else None,
         )
 

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -325,7 +325,22 @@ class BatchPrefillCuteDSLWrapper:
         self._window_left = max(window_left, 0)
         self._window_right = 0 if self._causal else max(window_right, 0)
 
-        self._is_persistent = True
+        # Scheduling: the persistent kernel assigns work items to SMs
+        # statically at launch; the non-persistent kernel launches one CTA
+        # per item and lets the hardware dispatch dynamically.  Banded
+        # masks (causal / windows) run faster non-persistent: their items
+        # are short or heterogeneous, and the static assignment's
+        # imbalance costs more than the per-CTA prologue it saves.
+        # Unmasked items are uniform, so the static schedule is free and
+        # the amortized prologue wins.
+        # FLASHINFER_CUTE_PREFILL_PERSISTENT=0/1 overrides.
+        _persistent_env = os.environ.get("FLASHINFER_CUTE_PREFILL_PERSISTENT")
+        if _persistent_env is not None:
+            self._is_persistent = _persistent_env == "1"
+        else:
+            self._is_persistent = not (
+                self._mask_spec.has_left_bound or self._mask_spec.has_right_bound
+            )
 
         self._problem_size = (
             self._batch_size,

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -41,6 +41,7 @@ def _get_compiled_prefill_kernel(
     is_persistent,
     variant,
     params_shape,
+    with_lse=False,
 ):
     """Compile and cache the prefill kernel.
 
@@ -126,6 +127,15 @@ def _get_compiled_prefill_kernel(
             assumed_align=16,
         )
 
+    lse_fake = None
+    if with_lse:
+        lse_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (sym_s_q, num_qo_heads),
+            stride_order=(1, 0),
+            assumed_align=16,
+        )
+
     problem_size = (1, 1, 1, num_qo_heads, num_kv_heads, head_dim)
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
@@ -145,6 +155,7 @@ def _get_compiled_prefill_kernel(
         0,
         0,
         params_fake,
+        lse_fake,
         stream_fake,
         options="--enable-tvm-ffi --opt-level 2",
     )
@@ -363,7 +374,9 @@ class BatchPrefillCuteDSLWrapper:
         )
         params_shape = tuple(self._params_torch.shape) if self._has_params else None
 
-        self._compiled_fmha = _get_compiled_prefill_kernel(
+        # Stashed so run(return_lse=True) can lazily compile the LSE
+        # variant (return_lse is a run-time argument).
+        self._compile_key = (
             self._in_dtype,
             self._out_dtype,
             num_qo_heads,
@@ -374,6 +387,9 @@ class BatchPrefillCuteDSLWrapper:
             cache_variant,
             params_shape,
         )
+        self._cache_variant = cache_variant
+        self._compiled_fmha = _get_compiled_prefill_kernel(*self._compile_key)
+        self._compiled_fmha_lse = None
 
         # Pre-allocate padded output scratch buffer.  The kernel uses a
         # negative pointer offset into the output tensor for TMA varlen
@@ -441,7 +457,9 @@ class BatchPrefillCuteDSLWrapper:
         k: torch.Tensor,
         v: torch.Tensor,
         out: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+        return_lse: bool = False,
+        lse: Optional[torch.Tensor] = None,
+    ):
         r"""Run the prefill attention computation.
 
         Parameters
@@ -454,18 +472,55 @@ class BatchPrefillCuteDSLWrapper:
             The value tensor with shape [total_kv_len, num_heads, head_dim].
         out : Optional[torch.Tensor], optional
             The output tensor. If None, a new tensor will be created.
+        return_lse : bool
+            Whether to also return the per-row log-sum-exp, shape
+            [total_q_len, num_heads], float32, log2 domain (flashinfer
+            convention).  Standard attention only.  The LSE kernel variant
+            is JIT-compiled on the first such call.
+        lse : Optional[torch.Tensor], optional
+            Pre-allocated LSE tensor. If None, a new tensor is created.
 
         Returns
         -------
-        torch.Tensor
-            The output tensor with shape [total_q_len, num_heads, head_dim].
+        torch.Tensor or (torch.Tensor, torch.Tensor)
+            The output tensor with shape [total_q_len, num_heads, head_dim],
+            plus the LSE tensor when ``return_lse=True``.
         """
         if self._compiled_fmha is None:
             raise RuntimeError("Plan the prefill attention computation first!")
 
         self._validate_run_inputs(q, k, v, out)
 
-        self._compiled_fmha(
+        if return_lse:
+            if self._cache_variant is not None and (
+                self._cache_variant.has_logits_transform
+                or self._cache_variant.has_vectorized_logits_transform
+            ):
+                # The transform path has no correction warp (softmax warps
+                # own the epilogs) and no softmax normalization — LSE is
+                # undefined there.  score_mod and statistics-update
+                # variants use the standard path and their finals already
+                # reflect the modification (sinks fold into row_sum at
+                # tile 0), so LSE is exact for them.
+                raise NotImplementedError(
+                    "return_lse is not supported with logits-transform variants"
+                )
+            if self._compiled_fmha_lse is None:
+                self._compiled_fmha_lse = _get_compiled_prefill_kernel(
+                    *self._compile_key, with_lse=True
+                )
+            if lse is None:
+                lse = torch.empty(
+                    (self._s_q_all, self._num_qo_heads),
+                    dtype=torch.float32,
+                    device=self._device,
+                )
+            kernel_fn = self._compiled_fmha_lse
+        else:
+            lse = None
+            kernel_fn = self._compiled_fmha
+
+        kernel_fn(
             q,
             k,
             v,
@@ -480,9 +535,13 @@ class BatchPrefillCuteDSLWrapper:
             self._window_left,
             self._window_right,
             self._params_torch if self._has_params else None,
+            lse,
         )
 
         if out is not None:
             out.copy_(self._o_scratch_view)
-            return out
-        return self._o_scratch_view.clone()
+        else:
+            out = self._o_scratch_view.clone()
+        if return_lse:
+            return out, lse
+        return out

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -207,7 +207,7 @@ class BatchPrefillCuteDSLWrapper:
         head_dim_qk,
         head_dim_vo=None,
         causal=True,
-        sm_scale=1.0,
+        sm_scale=None,
         q_data_type=torch.float16,
         kv_data_type=torch.float16,
         window_left: int = -1,
@@ -232,8 +232,9 @@ class BatchPrefillCuteDSLWrapper:
             Head dimension for values and output. Must equal head_dim_qk if set.
         causal : bool
             Whether to apply causal masking.
-        sm_scale : float
-            Softmax scale factor (typically 1/sqrt(head_dim)).
+        sm_scale : Optional[float]
+            Softmax scale factor.  Defaults to ``1/sqrt(head_dim_qk)``
+            when None (matching the top-level flashinfer wrappers).
         q_data_type : torch.dtype
             Data type for queries (float16, bfloat16, or float8_e4m3fn).
         kv_data_type : torch.dtype
@@ -263,6 +264,8 @@ class BatchPrefillCuteDSLWrapper:
             "head_dim_vo must be None or equal to head_dim_qk"
         )
         self._causal = causal
+        if sm_scale is None:
+            sm_scale = 1.0 / math.sqrt(head_dim_qk)
         self._sm_scale = sm_scale
         self._device = qo_indptr.device
         if variant is None:

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -211,8 +211,8 @@ class BatchPrefillCuteDSLWrapper:
         q_data_type=torch.float16,
         kv_data_type=torch.float16,
         window_left: int = -1,
-        window_right: int = -1,
         variant: AttentionVariant | None = None,
+        window_right: int = -1,
     ) -> None:
         """Compile the FMHA prefill kernel for the given configuration.
 

--- a/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
+++ b/flashinfer/cute_dsl/attention/wrappers/batch_prefill.py
@@ -29,6 +29,14 @@ from ..fusion.mask import MaskSpec
 from ..fusion.variant import AttentionVariant, StandardAttention
 from ..prefill import BlackwellFusedMultiHeadAttentionForward
 
+# V dtypes accepted when v.dtype differs from the planned q/k dtype
+# (mixed-dtype PV path: P converts to V's dtype for the PV MMA).
+_V_DTYPE_MAP = {
+    torch.float16: cutlass.Float16,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+}
+
 
 @functools.cache
 def _get_compiled_prefill_kernel(
@@ -42,6 +50,7 @@ def _get_compiled_prefill_kernel(
     variant,
     params_shape,
     with_lse=False,
+    v_in_dtype=None,
 ):
     """Compile and cache the prefill kernel.
 
@@ -94,7 +103,7 @@ def _get_compiled_prefill_kernel(
         assumed_align=16,
     )
     v_fake = cute.runtime.make_fake_compact_tensor(
-        in_dtype,
+        v_in_dtype if v_in_dtype is not None else in_dtype,
         (sym_s_k, num_kv_heads, head_dim),
         stride_order=(2, 1, 0),
         assumed_align=16,
@@ -389,7 +398,9 @@ class BatchPrefillCuteDSLWrapper:
         )
         self._cache_variant = cache_variant
         self._compiled_fmha = _get_compiled_prefill_kernel(*self._compile_key)
-        self._compiled_fmha_lse = None
+        # Lazily compiled kernel variants, keyed by (with_lse, v_in_dtype):
+        # return_lse and a mixed V dtype are both run()-time properties.
+        self._kernel_cache = {(False, None): self._compiled_fmha}
 
         # Pre-allocate padded output scratch buffer.  The kernel uses a
         # negative pointer offset into the output tensor for TMA varlen
@@ -417,12 +428,20 @@ class BatchPrefillCuteDSLWrapper:
         out: Optional[torch.Tensor],
     ) -> None:
         """Check that run() inputs are consistent with the plan() configuration."""
-        for name, tensor in [("q", q), ("k", k), ("v", v)]:
+        for name, tensor in [("q", q), ("k", k)]:
             if tensor.dtype != self._q_data_type:
                 raise ValueError(
                     f"{name}.dtype={tensor.dtype} does not match the planned "
                     f"q_data_type={self._q_data_type}"
                 )
+        # V may differ from Q/K (mixed-dtype PV path, e.g. fp8 V with
+        # bf16 Q/K); the kernel variant is selected per V dtype in run().
+        if v.dtype != self._q_data_type and v.dtype not in _V_DTYPE_MAP:
+            raise ValueError(
+                f"v.dtype={v.dtype} is not supported; expected "
+                f"{self._q_data_type} or one of {sorted(map(str, _V_DTYPE_MAP))}"
+            )
+        for name, tensor in [("q", q), ("k", k), ("v", v)]:
             if tensor.device != self._device:
                 raise ValueError(
                     f"{name}.device={tensor.device} does not match the planned "
@@ -470,6 +489,8 @@ class BatchPrefillCuteDSLWrapper:
             The key tensor with shape [total_kv_len, num_heads, head_dim].
         v : torch.Tensor
             The value tensor with shape [total_kv_len, num_heads, head_dim].
+            May use a different dtype than q/k (e.g. fp8 V with bf16 Q/K);
+            the matching kernel variant is JIT-compiled on first use.
         out : Optional[torch.Tensor], optional
             The output tensor. If None, a new tensor will be created.
         return_lse : bool
@@ -505,20 +526,23 @@ class BatchPrefillCuteDSLWrapper:
                 raise NotImplementedError(
                     "return_lse is not supported with logits-transform variants"
                 )
-            if self._compiled_fmha_lse is None:
-                self._compiled_fmha_lse = _get_compiled_prefill_kernel(
-                    *self._compile_key, with_lse=True
-                )
             if lse is None:
                 lse = torch.empty(
                     (self._s_q_all, self._num_qo_heads),
                     dtype=torch.float32,
                     device=self._device,
                 )
-            kernel_fn = self._compiled_fmha_lse
         else:
             lse = None
-            kernel_fn = self._compiled_fmha
+
+        v_in_dtype = _V_DTYPE_MAP[v.dtype] if v.dtype != self._q_data_type else None
+        kernel_key = (return_lse, v_in_dtype)
+        kernel_fn = self._kernel_cache.get(kernel_key)
+        if kernel_fn is None:
+            kernel_fn = _get_compiled_prefill_kernel(
+                *self._compile_key, with_lse=return_lse, v_in_dtype=v_in_dtype
+            )
+            self._kernel_cache[kernel_key] = kernel_fn
 
         kernel_fn(
             q,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3501,16 +3501,16 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             _sm_scale = (
                 sm_scale if sm_scale is not None else 1.0 / math.sqrt(head_dim_qk)
             )
-            # Variant-less head-128 plans can be served by the trtllm CuTe
-            # DSL FMHA kernel.  Sliding-window plans default to the modular
-            # cute-dsl path, which measures faster on windows (banded masks
-            # skip dead work).
-            self._cute_dsl_fmha_capable = variant is None and head_dim_qk == 128
-            self._cute_dsl_use_fmha = self._cute_dsl_fmha_capable and window_left < 0
-            if self._cute_dsl_fmha_capable:
-                # Built even when the modular path is the default route:
-                # run() falls back to the FMHA kernel for requests the
-                # modular kernel cannot serve (mixed V dtype).
+            # Variant-less head-128 dense/causal plans route to the trtllm
+            # CuTe DSL FMHA kernel (prebuilt artifacts).  Sliding-window
+            # plans use the modular cute-dsl path, which measures faster on
+            # windows (banded masks skip dead work) for every V dtype —
+            # mixed V (e.g. fp8 V with bf16 Q/K) forces the FMHA path onto
+            # JIT compilation, where the modular kernel wins.
+            self._cute_dsl_use_fmha = (
+                variant is None and head_dim_qk == 128 and window_left < 0
+            )
+            if self._cute_dsl_use_fmha:
                 q_lens = qo_indptr[1:] - qo_indptr[:-1]
                 k_lens = kv_indptr[1:] - kv_indptr[:-1]
                 self._cute_dsl_fmha_plan = {
@@ -3524,11 +3524,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     "causal": causal,
                     "window_left": window_left,
                 }
-            if not self._cute_dsl_use_fmha:
-                # The modular kernel requires one uniform dtype; reject
-                # mismatched plan dtypes here with a clear error (they
-                # would otherwise surface as an opaque FFI signature
-                # mismatch at run()).
+            else:
+                # The modular kernel requires q and k to share one dtype
+                # (kv_data_type covers both K and V; a V-only mismatch is a
+                # run()-time property served natively).  Reject mismatched
+                # plan dtypes here with a clear error — they would otherwise
+                # surface as an opaque FFI signature mismatch at run().
                 if kv_data_type is not None and q_data_type != kv_data_type:
                     raise ValueError(
                         "cute-dsl modular prefill requires q_data_type == "
@@ -3834,13 +3835,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 raise NotImplementedError(
                     "cute-dsl backend does not support FP8 scale parameters"
                 )
-            if self._cute_dsl_use_fmha or (
-                self._cute_dsl_fmha_capable and v.dtype != q.dtype
-            ):
-                # Delegate to the trtllm CuTe DSL FMHA kernel.  Windowed
-                # plans default to the modular path but take this route for
-                # mixed V dtype, which the modular kernel cannot serve (the
-                # FMHA kernel JIT-compiles separate-V-dtype variants).
+            if self._cute_dsl_use_fmha:
+                # Delegate dense/causal plans to the trtllm CuTe DSL FMHA
+                # kernel (mixed V dtype included: it JIT-compiles
+                # separate-V-dtype variants).  Windowed plans stay on the
+                # modular path for every V dtype.
                 p = self._cute_dsl_fmha_plan
                 return trtllm_ragged_attention_deepseek(
                     query=q,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3502,7 +3502,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 sm_scale if sm_scale is not None else 1.0 / math.sqrt(head_dim_qk)
             )
             # Route compatible calls to faster trtllm CuTe DSL FMHA kernels.
-            self._cute_dsl_use_fmha = variant is None and head_dim_qk == 128
+            # Sliding-window plans stay on the modular cute-dsl path: it
+            # measures faster than the FMHA route on windows (its banded
+            # masks skip dead work), and the FMHA route's prebuilt artifact
+            # matrix has no windowed variants (windowed calls there need a
+            # JIT compile).
+            self._cute_dsl_use_fmha = (
+                variant is None and head_dim_qk == 128 and window_left < 0
+            )
             if self._cute_dsl_use_fmha:
                 q_lens = qo_indptr[1:] - qo_indptr[:-1]
                 k_lens = kv_indptr[1:] - kv_indptr[:-1]

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3835,6 +3835,13 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 raise NotImplementedError(
                     "cute-dsl backend does not support FP8 scale parameters"
                 )
+            if kv_cache_sf is not None:
+                raise NotImplementedError(
+                    "cute-dsl backend does not support NVFP4 packed KV cache "
+                    "(kv_cache_sf)"
+                )
+            # enable_pdl is a launch-latency hint: forwarded on the FMHA
+            # route below; the modular kernel has no PDL support.
             if self._cute_dsl_use_fmha:
                 # Delegate dense/causal plans to the trtllm CuTe DSL FMHA
                 # kernel (mixed V dtype included: it JIT-compiles

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3501,16 +3501,16 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             _sm_scale = (
                 sm_scale if sm_scale is not None else 1.0 / math.sqrt(head_dim_qk)
             )
-            # Route compatible calls to faster trtllm CuTe DSL FMHA kernels.
-            # Sliding-window plans stay on the modular cute-dsl path: it
-            # measures faster than the FMHA route on windows (its banded
-            # masks skip dead work), and the FMHA route's prebuilt artifact
-            # matrix has no windowed variants (windowed calls there need a
-            # JIT compile).
-            self._cute_dsl_use_fmha = (
-                variant is None and head_dim_qk == 128 and window_left < 0
-            )
-            if self._cute_dsl_use_fmha:
+            # Variant-less head-128 plans can be served by the trtllm CuTe
+            # DSL FMHA kernel.  Sliding-window plans default to the modular
+            # cute-dsl path, which measures faster on windows (banded masks
+            # skip dead work).
+            self._cute_dsl_fmha_capable = variant is None and head_dim_qk == 128
+            self._cute_dsl_use_fmha = self._cute_dsl_fmha_capable and window_left < 0
+            if self._cute_dsl_fmha_capable:
+                # Built even when the modular path is the default route:
+                # run() falls back to the FMHA kernel for requests the
+                # modular kernel cannot serve (return_lse, mixed V dtype).
                 q_lens = qo_indptr[1:] - qo_indptr[:-1]
                 k_lens = kv_indptr[1:] - kv_indptr[:-1]
                 self._cute_dsl_fmha_plan = {
@@ -3524,7 +3524,16 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     "causal": causal,
                     "window_left": window_left,
                 }
-            else:
+            if not self._cute_dsl_use_fmha:
+                # The modular kernel requires one uniform dtype; reject
+                # mismatched plan dtypes here with a clear error (they
+                # would otherwise surface as an opaque FFI signature
+                # mismatch at run()).
+                if kv_data_type is not None and q_data_type != kv_data_type:
+                    raise ValueError(
+                        "cute-dsl modular prefill requires q_data_type == "
+                        f"kv_data_type, got {q_data_type} and {kv_data_type}"
+                    )
                 self._cute_dsl_wrapper.plan(
                     qo_indptr,
                     kv_indptr,
@@ -3825,8 +3834,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 raise NotImplementedError(
                     "cute-dsl backend does not support FP8 scale parameters"
                 )
-            if self._cute_dsl_use_fmha:
-                # Delegate to the trtllm CuTe DSL FMHA kernel (supports LSE).
+            if self._cute_dsl_use_fmha or (
+                self._cute_dsl_fmha_capable and (return_lse or v.dtype != q.dtype)
+            ):
+                # Delegate to the trtllm CuTe DSL FMHA kernel.  Windowed
+                # plans default to the modular path but take this route for
+                # requests the modular kernel cannot serve: return_lse and
+                # mixed V dtype (the FMHA kernel JIT-compiles windowed /
+                # separate-V-dtype variants).
                 p = self._cute_dsl_fmha_plan
                 return trtllm_ragged_attention_deepseek(
                     query=q,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3510,7 +3510,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             if self._cute_dsl_fmha_capable:
                 # Built even when the modular path is the default route:
                 # run() falls back to the FMHA kernel for requests the
-                # modular kernel cannot serve (return_lse, mixed V dtype).
+                # modular kernel cannot serve (mixed V dtype).
                 q_lens = qo_indptr[1:] - qo_indptr[:-1]
                 k_lens = kv_indptr[1:] - kv_indptr[:-1]
                 self._cute_dsl_fmha_plan = {
@@ -3835,13 +3835,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     "cute-dsl backend does not support FP8 scale parameters"
                 )
             if self._cute_dsl_use_fmha or (
-                self._cute_dsl_fmha_capable and (return_lse or v.dtype != q.dtype)
+                self._cute_dsl_fmha_capable and v.dtype != q.dtype
             ):
                 # Delegate to the trtllm CuTe DSL FMHA kernel.  Windowed
                 # plans default to the modular path but take this route for
-                # requests the modular kernel cannot serve: return_lse and
-                # mixed V dtype (the FMHA kernel JIT-compiles windowed /
-                # separate-V-dtype variants).
+                # mixed V dtype, which the modular kernel cannot serve (the
+                # FMHA kernel JIT-compiles separate-V-dtype variants).
                 p = self._cute_dsl_fmha_plan
                 return trtllm_ragged_attention_deepseek(
                     query=q,
@@ -3865,10 +3864,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     lse=lse,
                     backend="cute-dsl",
                 )
-            # Generic JIT (ALiBi / soft-cap): prefill.py-based wrapper (no LSE).
             if return_lse:
-                raise NotImplementedError(
-                    "cute-dsl backend does not support return_lse with ALiBi / soft-cap"
+                # Standard-path modular kernel computes LSE natively; the
+                # wrapper raises NotImplementedError for attention variants.
+                return self._cute_dsl_wrapper.run(
+                    q, k, v, out=out, return_lse=True, lse=lse
                 )
             out = self._cute_dsl_wrapper.run(q, k, v, out=out)
             return out

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -1051,6 +1051,77 @@ def test_attention_prefill_sliding_window_top_level_wrapper(causal):
     torch.testing.assert_close(o, o_ref, rtol=RTOL, atol=ATOL)
 
 
+# Mixed per-sequence lengths: every sequence in a batch gets its own band
+# geometry (kv_start, head/main/tail peel counts, borrow rule) and short
+# sequences exercise the item-skip path — none of which uniform batches
+# cover.  Patterns include a tiny sequence, uneven multi-sequence batches,
+# and non-tile-aligned lengths.
+WINDOW_VARLEN_INDPTR_PARAMS = [
+    [0, 7, 1291, 1547, 3083],  # tiny seq + uneven lengths
+    [0, 1350, 2667, 4003, 5347, 6631, 7919, 9208, 10524],  # 8 uneven seqs
+    [0, 300, 556, 2604],  # non-tile-aligned mix
+]
+
+
+@pytest.mark.parametrize("indptr", WINDOW_VARLEN_INDPTR_PARAMS)
+@pytest.mark.parametrize(
+    "causal,window_left,window_right",
+    [
+        (True, 100, -1),  # causal + sliding window (serving SWA)
+        (False, 64, -1),  # left-bound-only window
+    ],
+)
+def test_attention_prefill_sliding_window_varlen(
+    indptr,
+    causal,
+    window_left,
+    window_right,
+):
+    """Windowed masks over mixed-length ragged batches."""
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    num_kv_heads = 8
+
+    torch.manual_seed(42)
+    q = torch.randn(indptr[-1], NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda")
+    k = torch.randn(indptr[-1], num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda")
+    v = torch.randn_like(k)
+    qo_indptr = torch.tensor(indptr, device="cuda", dtype=torch.int32)
+    kv_indptr = qo_indptr
+
+    wrapper = BatchPrefillCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        NUM_QO_HEADS,
+        num_kv_heads,
+        HEAD_DIM,
+        head_dim_vo=HEAD_DIM,
+        causal=causal,
+        sm_scale=SM_SCALE,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+        window_left=window_left,
+        window_right=window_right,
+    )
+    o = wrapper.run(q, k, v)
+
+    # Per-sequence reference: the band mask depends only on each
+    # sequence's own lengths, so apply the uniform-batch reference to
+    # each slice with batch_size=1.
+    o_ref = torch.empty_like(o)
+    for i in range(len(indptr) - 1):
+        lo, hi = indptr[i], indptr[i + 1]
+        o_ref[lo:hi] = attention_band_mask_ref(
+            1, q[lo:hi], k[lo:hi], v[lo:hi], SM_SCALE, causal,
+            window_left, window_right,
+        )
+
+    torch.testing.assert_close(o, o_ref, rtol=RTOL, atol=ATOL)
+
+
 # ---------------------------------------------------------------------------
 #  8. Head dimension 64
 # ---------------------------------------------------------------------------

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -5,7 +5,8 @@
 
 Covers: basic prefill (various q/kv/batch combos, GQA vs MHA, causal),
 variable-length sequences, output transform, logits transform (sigmoid),
-and attention sink.
+attention sink, and band masks (causal sliding window, symmetric window,
+left-bound-only window).
 
 Each unique (mask_type, fusion) combination triggers one JIT compilation
 (~30s). The test matrix is designed to reuse compiled kernels across
@@ -792,18 +793,23 @@ def test_attention_prefill_fp16(
 # ---------------------------------------------------------------------------
 
 
-def attention_sliding_window_ref(
+def attention_band_mask_ref(
     batch_size,
     q,
     k,
     v,
-    window_left,
     sm_scale,
+    causal,
+    window_left,
+    window_right,
 ):
-    """Reference for symmetric sliding window: |kv_idx - (q_idx + offset)| <= window_left.
+    """Band-mask reference. With offset = kv_len - qo_len (Q right-aligned
+    to KV), row q sees k in::
 
-    When qo_len != kv_len, Q positions are right-aligned to KV: q_idx maps
-    to kv position q_idx + (kv_len - qo_len).
+        max(0, q + offset - window_left) <= k <= q + offset            (causal)
+        max(0, q + offset - window_left) <= k <= q + offset + window_right
+
+    where a window value of -1 means unbounded on that side.
     """
     qo_len = q.shape[0] // batch_size
     kv_len = k.shape[0] // batch_size
@@ -829,7 +835,13 @@ def attention_sliding_window_ref(
     qk_offset = kv_len - qo_len
     q_idx = torch.arange(qo_len, device=q.device).unsqueeze(1)
     k_idx = torch.arange(kv_len, device=q.device).unsqueeze(0)
-    mask = torch.abs(k_idx - (q_idx + qk_offset)) <= window_left
+    mask = torch.ones(qo_len, kv_len, dtype=torch.bool, device=q.device)
+    if causal:
+        mask &= k_idx <= q_idx + qk_offset
+    elif window_right >= 0:
+        mask &= k_idx - (q_idx + qk_offset) <= window_right
+    if window_left >= 0:
+        mask &= (q_idx + qk_offset) - k_idx <= window_left
     logits = logits.masked_fill(mask.unsqueeze(0).unsqueeze(0) == 0, float("-inf"))
 
     p = torch.softmax(logits, dim=-1)
@@ -846,29 +858,7 @@ def attention_sliding_window_ref(
     return o_ref
 
 
-SLIDING_WINDOW_PARAMS = [
-    # (batch, qo_len, kv_len, window_left)
-    (1, 256, 256, 64),
-    (1, 256, 256, 128),
-    (9, 256, 256, 100),
-    (1, 512, 512, 200),
-    # qo_len != kv_len (Q right-aligned to KV, as in append/prefill-with-cache)
-    (1, 128, 256, 64),
-    (1, 128, 512, 100),
-    (1, 256, 512, 128),
-    (3, 128, 384, 80),
-]
-
-
-@pytest.mark.parametrize("batch_size,qo_len,kv_len,window_left", SLIDING_WINDOW_PARAMS)
-def test_attention_prefill_sliding_window(
-    batch_size,
-    qo_len,
-    kv_len,
-    window_left,
-):
-    if not is_sm100a_supported(torch.device("cuda")):
-        pytest.skip("SM100A is not supported on this device")
+def _run_band_mask_case(batch_size, qo_len, kv_len, causal, window_left, window_right):
     num_kv_heads = 8
 
     torch.manual_seed(42)
@@ -898,16 +888,116 @@ def test_attention_prefill_sliding_window(
         num_kv_heads,
         HEAD_DIM,
         head_dim_vo=HEAD_DIM,
-        causal=False,
+        causal=causal,
         sm_scale=SM_SCALE,
         q_data_type=DTYPE,
         kv_data_type=DTYPE,
         window_left=window_left,
+        window_right=window_right,
     )
     o = wrapper.run(q, k, v)
-    o_ref = attention_sliding_window_ref(batch_size, q, k, v, window_left, SM_SCALE)
+    o_ref = attention_band_mask_ref(
+        batch_size, q, k, v, SM_SCALE, causal, window_left, window_right
+    )
 
     torch.testing.assert_close(o, o_ref, rtol=RTOL, atol=ATOL)
+
+
+SLIDING_WINDOW_PARAMS = [
+    # (batch, qo_len, kv_len, window_left)
+    (1, 256, 256, 64),
+    (1, 256, 256, 128),
+    (9, 256, 256, 100),
+    (1, 512, 512, 200),
+    # qo_len != kv_len (Q right-aligned to KV, as in append/prefill-with-cache)
+    (1, 128, 256, 64),
+    (1, 128, 512, 100),
+    (1, 256, 512, 128),
+    (3, 128, 384, 80),
+]
+
+# Causal sliding window (the serving configuration, e.g. Mistral/Gemma SWA).
+# Window values reuse the symmetric list's to share compiled kernels where
+# possible; includes a non-tile-aligned kv_len to exercise the seqlen_k tail
+# combined with the window left edge.
+CAUSAL_SLIDING_WINDOW_PARAMS = [
+    # (batch, qo_len, kv_len, window_left)
+    (1, 256, 256, 64),
+    (1, 512, 512, 128),
+    (9, 256, 256, 100),
+    (1, 128, 512, 100),  # qo_len != kv_len
+    (1, 256, 300, 64),  # kv_len not tile-aligned
+]
+
+
+@pytest.mark.parametrize("batch_size,qo_len,kv_len,window_left", SLIDING_WINDOW_PARAMS)
+def test_attention_prefill_sliding_window_symmetric(
+    batch_size,
+    qo_len,
+    kv_len,
+    window_left,
+):
+    """Non-causal symmetric window: k in [q+off-w, q+off+w]."""
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    _run_band_mask_case(
+        batch_size,
+        qo_len,
+        kv_len,
+        causal=False,
+        window_left=window_left,
+        window_right=window_left,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch_size,qo_len,kv_len,window_left", CAUSAL_SLIDING_WINDOW_PARAMS
+)
+def test_attention_prefill_causal_sliding_window(
+    batch_size,
+    qo_len,
+    kv_len,
+    window_left,
+):
+    """Causal + window_left: k in [q+off-w, q+off] (regression: the window
+    used to be silently ignored when causal=True)."""
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    _run_band_mask_case(
+        batch_size,
+        qo_len,
+        kv_len,
+        causal=True,
+        window_left=window_left,
+        window_right=-1,
+    )
+
+
+@pytest.mark.parametrize(
+    "batch_size,qo_len,kv_len,window_left",
+    [
+        (1, 256, 256, 64),
+        (1, 128, 512, 100),
+    ],
+)
+def test_attention_prefill_left_window_only(
+    batch_size,
+    qo_len,
+    kv_len,
+    window_left,
+):
+    """Non-causal left-bound-only window: k in [q+off-w, kv_len), matching
+    the FlashInfer window_left convention (variants.cuh)."""
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    _run_band_mask_case(
+        batch_size,
+        qo_len,
+        kv_len,
+        causal=False,
+        window_left=window_left,
+        window_right=-1,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -807,6 +807,262 @@ def test_attention_prefill_fp8(batch_size, qo_len, kv_len, causal, window_left):
     torch.testing.assert_close(o.float(), o_ref.float(), rtol=1e-2, atol=8e-2)
 
 
+def _band_mask_lse_ref(batch_size, q, k, causal, window_left, sm_scale):
+    """Log2-domain LSE reference over band-masked logits (per uniform batch)."""
+    qo_len = q.shape[0] // batch_size
+    kv_len = k.shape[0] // batch_size
+    group_size = q.shape[1] // k.shape[1]
+    kk = torch.repeat_interleave(k, group_size, dim=1)
+    logits = (
+        torch.einsum(
+            "bmhd,bnhd->bhmn",
+            q.view(batch_size, qo_len, q.shape[1], -1).float(),
+            kk.view(batch_size, kv_len, q.shape[1], -1).float(),
+        )
+        * sm_scale
+    )
+    qk_offset = kv_len - qo_len
+    q_idx = torch.arange(qo_len, device=q.device).unsqueeze(1)
+    k_idx = torch.arange(kv_len, device=q.device).unsqueeze(0)
+    mask = torch.ones(qo_len, kv_len, dtype=torch.bool, device=q.device)
+    if causal:
+        mask &= k_idx <= q_idx + qk_offset
+    if window_left >= 0:
+        mask &= (q_idx + qk_offset) - k_idx <= window_left
+    logits = logits.masked_fill(~mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    # (b, h, m) -> (b*m, h), log2 domain
+    lse = torch.logsumexp(logits, dim=-1) * math.log2(math.e)
+    return lse.transpose(1, 2).reshape(batch_size * qo_len, q.shape[1])
+
+
+@pytest.mark.parametrize(
+    "batch_size,qo_len,kv_len,causal,window_left",
+    [
+        (1, 2048, 2048, True, -1),
+        (1, 2048, 2048, True, 127),
+        (3, 512, 512, False, -1),
+        (1, 128, 512, True, 100),
+    ],
+)
+def test_attention_prefill_lse(batch_size, qo_len, kv_len, causal, window_left):
+    """return_lse on the standard path: log2-domain (total_q, h_q) f32."""
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    num_kv_heads = 8
+
+    torch.manual_seed(42)
+    q = torch.randn(
+        batch_size * qo_len, NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    k = torch.randn(
+        batch_size * kv_len, num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    v = torch.randn_like(k)
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * kv_len
+    )
+
+    wrapper = BatchPrefillCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        NUM_QO_HEADS,
+        num_kv_heads,
+        HEAD_DIM,
+        head_dim_vo=HEAD_DIM,
+        causal=causal,
+        sm_scale=SM_SCALE,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+        window_left=window_left,
+    )
+    o_plain = wrapper.run(q, k, v)
+    o, lse = wrapper.run(q, k, v, return_lse=True)
+
+    # The LSE variant must not perturb the attention output.
+    torch.testing.assert_close(o, o_plain, rtol=0, atol=0)
+    o_ref = attention_band_mask_ref(
+        batch_size, q, k, v, SM_SCALE, causal, window_left, window_right=-1
+    )
+    torch.testing.assert_close(o, o_ref, rtol=RTOL, atol=ATOL)
+    lse_ref = _band_mask_lse_ref(batch_size, q, k, causal, window_left, SM_SCALE)
+    torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("indptr", [[0, 7, 1291, 1547, 3083]])
+def test_attention_prefill_lse_varlen(indptr):
+    """LSE row indexing over a mixed-length ragged batch (causal+window)."""
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    num_kv_heads = 8
+    window_left = 100
+
+    torch.manual_seed(42)
+    q = torch.randn(indptr[-1], NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda")
+    k = torch.randn(indptr[-1], num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda")
+    v = torch.randn_like(k)
+    qo_indptr = torch.tensor(indptr, device="cuda", dtype=torch.int32)
+
+    wrapper = BatchPrefillCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+    )
+    wrapper.plan(
+        qo_indptr,
+        qo_indptr,
+        NUM_QO_HEADS,
+        num_kv_heads,
+        HEAD_DIM,
+        head_dim_vo=HEAD_DIM,
+        causal=True,
+        sm_scale=SM_SCALE,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+        window_left=window_left,
+    )
+    o, lse = wrapper.run(q, k, v, return_lse=True)
+
+    for i in range(len(indptr) - 1):
+        lo, hi = indptr[i], indptr[i + 1]
+        o_ref = attention_band_mask_ref(
+            1, q[lo:hi], k[lo:hi], v[lo:hi], SM_SCALE, True, window_left, -1
+        )
+        lse_ref = _band_mask_lse_ref(1, q[lo:hi], k[lo:hi], True, window_left, SM_SCALE)
+        torch.testing.assert_close(o[lo:hi], o_ref, rtol=RTOL, atol=ATOL)
+        torch.testing.assert_close(lse[lo:hi], lse_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_attention_prefill_lse_alibi():
+    """LSE with a score_mod variant (standard path): LSE over ALiBi logits."""
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    batch_size, qo_len, kv_len = 9, 256, 256
+    num_kv_heads = 8
+
+    torch.manual_seed(42)
+    q = torch.randn(
+        batch_size * qo_len, NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    k = torch.randn(
+        batch_size * kv_len, num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    v = torch.randn_like(k)
+    indptr = torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * qo_len
+    alibi_slopes = ALiBiAttention.get_slopes(NUM_QO_HEADS).cuda()
+
+    wrapper = BatchPrefillCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+    )
+    wrapper.plan(
+        indptr,
+        indptr.clone(),
+        NUM_QO_HEADS,
+        num_kv_heads,
+        HEAD_DIM,
+        head_dim_vo=HEAD_DIM,
+        causal=True,
+        sm_scale=SM_SCALE,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+        variant=ALiBiAttention(alibi_slopes),
+    )
+    o, lse = wrapper.run(q, k, v, return_lse=True)
+
+    o_ref = attention_alibi_ref(batch_size, q, k, v, True, SM_SCALE, alibi_slopes)
+    torch.testing.assert_close(o, o_ref, rtol=RTOL, atol=ATOL)
+
+    # LSE over the ALiBi-modified logits (mirrors attention_alibi_ref).
+    kk = torch.repeat_interleave(k, NUM_QO_HEADS // num_kv_heads, dim=1)
+    logits = torch.einsum(
+        "bmhd,bnhd->bhmn",
+        q.view(batch_size, qo_len, NUM_QO_HEADS, HEAD_DIM).float(),
+        kk.view(batch_size, kv_len, NUM_QO_HEADS, HEAD_DIM).float(),
+    )
+    qo_pos = torch.arange(qo_len, device=q.device).view(1, 1, -1, 1)
+    kv_pos = torch.arange(kv_len, device=q.device).view(1, 1, 1, -1)
+    logits = (logits + alibi_slopes.view(1, -1, 1, 1) * (kv_pos - qo_pos)) * SM_SCALE
+    mask = torch.arange(kv_len - qo_len, kv_len, device=q.device).unsqueeze(
+        1
+    ) >= torch.arange(0, kv_len, device=q.device).unsqueeze(0)
+    logits = logits.masked_fill(mask.unsqueeze(0).unsqueeze(0) == 0, float("-inf"))
+    lse_ref = (
+        (torch.logsumexp(logits, dim=-1) * math.log2(math.e))
+        .transpose(1, 2)
+        .reshape(batch_size * qo_len, NUM_QO_HEADS)
+    )
+    torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_attention_prefill_lse_sink():
+    """LSE with attention sinks: the sink term is part of the denominator."""
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    batch_size, qo_len, kv_len = 1, 256, 256
+    num_kv_heads = 8
+
+    torch.manual_seed(42)
+    q = torch.randn(
+        batch_size * qo_len, NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    k = torch.randn(
+        batch_size * kv_len, num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    v = torch.randn_like(k)
+    indptr = torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * qo_len
+    sink = torch.randn((NUM_QO_HEADS,), dtype=DTYPE, device="cuda")
+
+    wrapper = BatchPrefillCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+    )
+    wrapper.plan(
+        indptr,
+        indptr.clone(),
+        NUM_QO_HEADS,
+        num_kv_heads,
+        HEAD_DIM,
+        head_dim_vo=HEAD_DIM,
+        causal=True,
+        sm_scale=SM_SCALE,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+        variant=AttentionWithSink(sink),
+    )
+    o, lse = wrapper.run(q, k, v, return_lse=True)
+
+    o_ref, _ = attention_ref(batch_size, q, k, v, True, SM_SCALE, sink=sink)
+    torch.testing.assert_close(o, o_ref, rtol=RTOL, atol=ATOL)
+
+    # With-sink LSE: log of the actual normalization denominator,
+    # log2(sum_k exp(s_k) + exp(sink)) — attention_ref's lse is sink-less.
+    kk = torch.repeat_interleave(k, NUM_QO_HEADS // num_kv_heads, dim=1)
+    logits = (
+        torch.einsum(
+            "bmhd,bnhd->bhmn",
+            q.view(batch_size, qo_len, NUM_QO_HEADS, HEAD_DIM).float(),
+            kk.view(batch_size, kv_len, NUM_QO_HEADS, HEAD_DIM).float(),
+        )
+        * SM_SCALE
+    )
+    mask = torch.arange(kv_len - qo_len, kv_len, device=q.device).unsqueeze(
+        1
+    ) >= torch.arange(0, kv_len, device=q.device).unsqueeze(0)
+    logits = logits.masked_fill(mask.unsqueeze(0).unsqueeze(0) == 0, float("-inf"))
+    logits_with_sink = torch.cat(
+        [logits, sink.float().view(1, -1, 1, 1).expand(batch_size, -1, qo_len, 1)],
+        dim=-1,
+    )
+    lse_ref = (
+        (torch.logsumexp(logits_with_sink, dim=-1) * math.log2(math.e))
+        .transpose(1, 2)
+        .reshape(batch_size * qo_len, NUM_QO_HEADS)
+    )
+    torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
+
+
 @pytest.mark.parametrize("batch_size,qo_len,kv_len", FP16_SHAPE_PARAMS)
 @pytest.mark.parametrize("causal", [False, True])
 def test_attention_prefill_fp16(

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -807,6 +807,86 @@ def test_attention_prefill_fp8(batch_size, qo_len, kv_len, causal, window_left):
     torch.testing.assert_close(o.float(), o_ref.float(), rtol=1e-2, atol=8e-2)
 
 
+@pytest.mark.parametrize(
+    "batch_size,qo_len,kv_len,causal,window_left",
+    [
+        (1, 2048, 2048, True, -1),
+        (1, 2048, 2048, True, 127),
+        (3, 512, 512, False, -1),
+    ],
+)
+def test_attention_prefill_mixed_v_dtype(
+    batch_size, qo_len, kv_len, causal, window_left
+):
+    """Mixed dtypes: bf16 Q/K with fp8 (e4m3) V on the modular kernel.
+
+    P (the softmax weights) converts to V's dtype for the PV GEMM, so the
+    tolerance matches the uniform-fp8 test's fp8-P calibration.  The same
+    wrapper serves the uniform bf16 kernel first to exercise the per-V-dtype
+    kernel cache, and LSE (a Q@K quantity, independent of V) must match the
+    bf16 reference exactly within f32 tolerance.
+    """
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    num_kv_heads = 8
+
+    torch.manual_seed(42)
+    q = torch.randn(
+        batch_size * qo_len, NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    k = torch.randn(
+        batch_size * kv_len, num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    v_bf16 = torch.randn(
+        batch_size * kv_len, num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    v = v_bf16.to(torch.float8_e4m3fn)
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * kv_len
+    )
+
+    wrapper = BatchPrefillCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        NUM_QO_HEADS,
+        num_kv_heads,
+        HEAD_DIM,
+        head_dim_vo=HEAD_DIM,
+        causal=causal,
+        sm_scale=SM_SCALE,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+        window_left=window_left,
+    )
+    # Uniform kernel first: the mixed run below must not disturb it.
+    o_uniform = wrapper.run(q, k, v_bf16)
+    o_ref_uniform = attention_band_mask_ref(
+        batch_size, q, k, v_bf16, SM_SCALE, causal, window_left, window_right=-1
+    )
+    torch.testing.assert_close(o_uniform, o_ref_uniform, rtol=RTOL, atol=ATOL)
+
+    o, lse = wrapper.run(q, k, v, return_lse=True)
+    o_ref = attention_band_mask_ref(
+        batch_size,
+        q.to(torch.float32),
+        k.to(torch.float32),
+        v.to(torch.float32),
+        SM_SCALE,
+        causal,
+        window_left,
+        window_right=-1,
+    )
+    torch.testing.assert_close(o.float(), o_ref.float(), rtol=1e-2, atol=8e-2)
+    lse_ref = _band_mask_lse_ref(batch_size, q, k, causal, window_left, SM_SCALE)
+    torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
+
+
 def _band_mask_lse_ref(batch_size, q, k, causal, window_left, sm_scale):
     """Log2-domain LSE reference over band-masked logits (per uniform batch)."""
     qo_len = q.shape[0] // batch_size

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -1025,9 +1025,7 @@ def test_attention_prefill_sliding_window_top_level_wrapper(causal):
         batch_size * seq_len, num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda"
     )
     v = torch.randn_like(k)
-    indptr = (
-        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * seq_len
-    )
+    indptr = torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * seq_len
 
     wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
         torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -738,6 +738,75 @@ FP16_SHAPE_PARAMS = [
 ]
 
 
+@pytest.mark.parametrize(
+    "batch_size,qo_len,kv_len,causal,window_left",
+    [
+        (1, 2048, 2048, True, -1),
+        (1, 2048, 2048, True, 127),
+        (3, 512, 512, False, -1),
+    ],
+)
+def test_attention_prefill_fp8(batch_size, qo_len, kv_len, causal, window_left):
+    """Uniform fp8 (e4m3) inputs on the modular kernel.
+
+    The tolerance reflects fp8's inherent error — P (the softmax weights)
+    is stored in e4m3 for the PV GEMM — and was calibrated against the
+    trtllm CuTe DSL FMHA kernel's fp8 output on identical inputs (both
+    kernels reach max_err ~0.066 vs an f32 reference at these shapes).
+    """
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    num_kv_heads = 8
+
+    torch.manual_seed(42)
+    q = torch.randn(
+        batch_size * qo_len, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    ).to(torch.float8_e4m3fn)
+    k = torch.randn(
+        batch_size * kv_len, num_kv_heads, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    ).to(torch.float8_e4m3fn)
+    v = torch.randn(
+        batch_size * kv_len, num_kv_heads, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    ).to(torch.float8_e4m3fn)
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * kv_len
+    )
+
+    wrapper = BatchPrefillCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        NUM_QO_HEADS,
+        num_kv_heads,
+        HEAD_DIM,
+        head_dim_vo=HEAD_DIM,
+        causal=causal,
+        sm_scale=SM_SCALE,
+        q_data_type=torch.float8_e4m3fn,
+        kv_data_type=torch.float8_e4m3fn,
+        window_left=window_left,
+    )
+    o = wrapper.run(q, k, v)
+
+    # f32 reference over the dequantized fp8 inputs.
+    o_ref = attention_band_mask_ref(
+        batch_size,
+        q.to(torch.float32),
+        k.to(torch.float32),
+        v.to(torch.float32),
+        SM_SCALE,
+        causal,
+        window_left,
+        window_right=-1,
+    )
+    torch.testing.assert_close(o.float(), o_ref.float(), rtol=1e-2, atol=8e-2)
+
+
 @pytest.mark.parametrize("batch_size,qo_len,kv_len", FP16_SHAPE_PARAMS)
 @pytest.mark.parametrize("causal", [False, True])
 def test_attention_prefill_fp16(
@@ -836,10 +905,11 @@ def attention_band_mask_ref(
     q_idx = torch.arange(qo_len, device=q.device).unsqueeze(1)
     k_idx = torch.arange(kv_len, device=q.device).unsqueeze(0)
     mask = torch.ones(qo_len, kv_len, dtype=torch.bool, device=q.device)
-    if causal:
-        mask &= k_idx <= q_idx + qk_offset
-    elif window_right >= 0:
-        mask &= k_idx - (q_idx + qk_offset) <= window_right
+    # Causal is a right bound of 0 (the kernel's own folding); it must come
+    # from the flag because callers pass causal=True with window_right=-1.
+    wr = 0 if causal else window_right
+    if wr >= 0:
+        mask &= k_idx - (q_idx + qk_offset) <= wr
     if window_left >= 0:
         mask &= (q_idx + qk_offset) - k_idx <= window_left
     logits = logits.masked_fill(mask.unsqueeze(0).unsqueeze(0) == 0, float("-inf"))

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -1000,6 +1000,58 @@ def test_attention_prefill_left_window_only(
     )
 
 
+@pytest.mark.parametrize("causal", [False, True])
+def test_attention_prefill_sliding_window_top_level_wrapper(causal):
+    """Windowed plans through the public ragged wrapper (backend="cute-dsl").
+
+    Guards the backend routing in flashinfer/prefill.py: windowed plans
+    must reach the modular cute-dsl path.  The trtllm CuTe DSL FMHA route
+    (taken for variant-less head-128 plans) measures slower on sliding
+    windows, and its prebuilt artifact matrix has no windowed variants —
+    a mis-routed windowed plan either JIT-compiles a slower kernel or, on
+    older glue, fails the FFI signature check outright.
+    """
+    if not is_sm100a_supported(torch.device("cuda")):
+        pytest.skip("SM100A is not supported on this device")
+    import flashinfer
+
+    batch_size, seq_len, window_left = 1, 512, 128
+    num_kv_heads = 8
+    torch.manual_seed(42)
+    q = torch.randn(
+        batch_size * seq_len, NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    k = torch.randn(
+        batch_size * seq_len, num_kv_heads, HEAD_DIM, dtype=DTYPE, device="cuda"
+    )
+    v = torch.randn_like(k)
+    indptr = (
+        torch.arange(0, batch_size + 1, device="cuda", dtype=torch.int32) * seq_len
+    )
+
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, device="cuda", dtype=torch.uint8),
+        backend="cute-dsl",
+    )
+    wrapper.plan(
+        indptr,
+        indptr.clone(),
+        NUM_QO_HEADS,
+        num_kv_heads,
+        HEAD_DIM,
+        causal=causal,
+        sm_scale=SM_SCALE,
+        window_left=window_left,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+    )
+    o = wrapper.run(q, k, v)
+    o_ref = attention_band_mask_ref(
+        batch_size, q, k, v, SM_SCALE, causal, window_left, window_right=-1
+    )
+    torch.testing.assert_close(o, o_ref, rtol=RTOL, atol=ATOL)
+
+
 # ---------------------------------------------------------------------------
 #  8. Head dimension 64
 # ---------------------------------------------------------------------------

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -922,6 +922,7 @@ SLIDING_WINDOW_PARAMS = [
 # combined with the window left edge.
 CAUSAL_SLIDING_WINDOW_PARAMS = [
     # (batch, qo_len, kv_len, window_left)
+    (1, 256, 256, 0),  # attend-self-only: exercises the head-borrow path
     (1, 256, 256, 64),
     (1, 512, 512, 128),
     (9, 256, 256, 100),

--- a/tests/attention/test_modular_fmha_prefill.py
+++ b/tests/attention/test_modular_fmha_prefill.py
@@ -1115,8 +1115,14 @@ def test_attention_prefill_sliding_window_varlen(
     for i in range(len(indptr) - 1):
         lo, hi = indptr[i], indptr[i + 1]
         o_ref[lo:hi] = attention_band_mask_ref(
-            1, q[lo:hi], k[lo:hi], v[lo:hi], SM_SCALE, causal,
-            window_left, window_right,
+            1,
+            q[lo:hi],
+            k[lo:hi],
+            v[lo:hi],
+            SM_SCALE,
+            causal,
+            window_left,
+            window_right,
         )
 
     torch.testing.assert_close(o, o_ref, rtol=RTOL, atol=ATOL)


### PR DESCRIPTION
# CuTe-DSL modular prefill: sliding-window support + band-mask performance

## Summary

The modular CuTe-DSL prefill (SM100) mapped `causal=True + window_left >= 0`
to a plain causal mask — wrong results, and full O(s²/2) work. This PR fixes
the mask semantics with composable per-row bands, removes the banded regime's
dead work, makes window sizes runtime arguments (one compiled kernel per mask
kind), and routes windowed plans to this path. It also adds native LSE
output and mixed K/V dtype support (bf16/fp16 Q/K + fp8 V) to the modular
kernel, so windowed plans never leave it at run time.

## Changes

- **Composable band masks (correctness fix)**: the `MaskType` enum becomes a
  band `[lo(q), hi(q))` — causal composes with `window_left`; `window_left`
  alone is a left-bounded non-causal window (FA2 semantics); new
  `window_right` plan() parameter for symmetric windows. Loader / MMA /
  softmax / correction all derive trip counts from the same band helpers.
- **Dead work removal**: per-half band iteration (head/tail peel) — each
  128-row half of the CTA runs exactly its own band's trips instead of the
  union with ~1 dead step per stage; warp-ballot rescale skip in correction
  (skips the O-tile TMEM roundtrip when the factor is exactly 1).
- **Mask codegen**: hoisted row-invariant bounds, trace-time-constant K
  coordinates, `cutlass.select_` for masked writes; one shared path for all
  four mask kinds (avoids an MLIR lowering pathology that caused register
  spills on the release toolchain).
- **Runtime window values**: `MaskSpec` is two presence bits; window sizes
  are runtime `Int32` kernel args, causal is a right bound with value 0, and
  the `k < seqlen_k` tail check is always on. Mask compile matrix: 4 kernels.
- **Scheduling by mask kind**: banded masks default to non-persistent launch,
  unmasked stays persistent (`FLASHINFER_CUTE_PREFILL_PERSISTENT` overrides).
- **`sm_scale` default fix**: cute-dsl wrapper plan() now defaults to
  `1/sqrt(head_dim_qk)` (was 1.0, silently unscaled).
- **Vendored FMHA windowed compile fix**: the #3857 path crashed on any
  `window_left >= 0` (no window axis in the trace signature, compile cache,
  or artifact names); it now JIT-compiles with window-presence bits.
- **Native LSE**: `run(return_lse=True)` is computed in the correction warp
  from the final (row_sum, row_max) — log2-domain, matching the vendored
  kernel's convention. Zero cost when off (the non-LSE kernel's SASS is
  byte-identical) and ≲1% when on. Supported for score-mod and sink
  variants; logits-transform variants (no softmax) raise.
- **Mixed K/V dtypes**: bf16/fp16 Q/K with fp8 V. P converts to V's dtype
  for the PV MMA, V slots on the shared K/V smem ring re-arm their barrier
  with V's byte count, and the wrapper JIT-compiles per-V-dtype kernel
  variants at run time (V's dtype is a run-time property; plan()'s
  `kv_data_type` declares K and V together).
- **Routing**: `variant is None and head_dim_qk == 128 and window_left < 0`
  routes to the #3857 vendored kernel; everything else — windows, variants,
  other head dims, any V dtype, `return_lse` — runs the modular path. The
  gate is decided entirely at plan(); there is no run-time fallback.

## Correctness

New causal+window, left-only, and symmetric-window tests in
`tests/attention/test_modular_fmha_prefill.py`, including windowed masks
over mixed-length ragged batches (each sequence gets its own band
geometry; short sequences exercise the item-skip path). Validated on B200 against an
exact f32 reference over {8/8, 32/8, 64/8, 32/32} heads × 5 shapes × 4 masks
in both scheduler modes (152/152), with bitwise-identical outputs across
scheduler modes.

Also new: uniform-fp8 (e4m3) tests calibrated against the vendored kernel's
fp8 error on identical inputs (both ~0.066 max vs f32); mixed bf16-QK/fp8-V
tests against a dequantized-V f32 reference (~0.05 max — S stays bf16-exact);
LSE tests (log2-domain, f32 logsumexp references) covering windowed, ragged
varlen, ALiBi, and sink variants, with the output tensor bit-identical
between LSE and non-LSE runs.

## Performance vs trtllm-gen

B200 (SM100a), torch 2.11+cu130, `nvidia-cutlass-dsl` 4.6.0. CUPTI
kernel-only, median of 30 iters, cold L2; each cell benches both backends
back-to-back in one process, median of 3 passes, single node and session.
GQA 32/8 heads, head_dim 128, bf16. cute-dsl =
`BatchPrefillWithRaggedKVCacheWrapper(backend="cute-dsl")`, i.e. what the
public wrapper runs per mask kind: vendored route for unmasked/causal,
modular kernel for windows. trtllm-gen = paged wrapper, HND, page 16,
preallocated output. Ratio = cute-dsl / trtllm (< 1: cute-dsl faster).
GPU clocks are not lockable on these nodes, so absolute times are only
comparable within a table (each table is built from back-to-back
same-process measurements; the ratios are clock-robust).

Modular vs vendored, why windows route to the modular kernel (B=1 S=16K,
median of 3 passes):

| config | modular (µs) | vendored (µs) | modular/vendored |
|--|--:|--:|:--:|
| unmasked | 3540.4 | 2893.8 | 1.22 |
| causal | 1808.3 | 1532.7 | 1.18 |
| causal + w=127 | 265.0 | 359.8 | 0.74 |
| causal + w=511 | 314.4 | 620.9 | 0.51 |
| causal + w=1023 | 412.0 | 748.1 | 0.55 |

Shape grid (increasing S; per shape: unmasked, causal, windows in increasing
size). The kernel column shows which kernel the wrapper routes to: windowed
rows run this PR's modular path; unmasked/causal rows run the #3857 vendored
kernel and are included for context only.

| B | S | mask | kernel | cute-dsl (µs) | trtllm (µs) | ratio |
|--:|--:|--|--|--:|--:|:--:|
| 64 | 512 | unmasked | vendored | 330.9 | 280.8 | 1.18 |
| 64 | 512 | causal | vendored | 511.7 | 269.4 | 1.90 |
| 64 | 512 | w=256 | modular | 570.9 | 300.6 | 1.90 |
| 16 | 1024 | unmasked | vendored | 249.9 | 236.4 | 1.06 |
| 16 | 1024 | causal | vendored | 318.9 | 185.7 | 1.72 |
| 16 | 1024 | w=256 | modular | 302.7 | 169.2 | 1.79 |
| 1 | 4096 | unmasked | vendored | 201.8 | 227.4 | 0.89 |
| 1 | 4096 | causal | vendored | 159.3 | 150.0 | 1.06 |
| 1 | 4096 | w=256 | modular | 76.4 | 52.5 | 1.46 |
| 1 | 4096 | w=1024 | modular | 115.6 | 87.9 | 1.32 |
| 1 | 4096 | w=2048 | modular | 151.1 | 121.0 | 1.25 |
| 4 | 4096 | unmasked | vendored | 824.4 | 825.0 | 0.99 |
| 4 | 4096 | causal | vendored | 557.9 | 483.7 | 1.15 |
| 4 | 4096 | w=256 | modular | 288.3 | 172.4 | 1.67 |
| 4 | 4096 | w=1024 | modular | 428.5 | 284.5 | 1.51 |
| 4 | 4096 | w=2048 | modular | 519.2 | 399.7 | 1.30 |
| 1 | 16384 | unmasked | vendored | 2845.0 | 3376.5 | 0.86 |
| 1 | 16384 | causal | vendored | 1568.4 | 1758.7 | 0.86 |
| 1 | 16384 | w=256 | modular | 292.8 | 178.1 | 1.62 |
| 1 | 16384 | w=1024 | modular | 415.0 | 304.8 | 1.36 |
| 1 | 16384 | w=2048 | modular | 576.9 | 480.3 | 1.20 |
| 1 | 16384 | w=4096 | modular | 881.7 | 808.0 | 1.09 |
| 1 | 16384 | w=8192 | modular | 1402.0 | 1314.6 | 1.06 |
| 1 | 32768 | unmasked | vendored | 12151.0 | 13847.2 | 0.88 |
| 1 | 32768 | causal | vendored | 6353.5 | 7176.0 | 0.89 |
| 1 | 32768 | w=256 | modular | 580.1 | 334.8 | 1.77 |
| 1 | 32768 | w=1024 | modular | 798.7 | 603.6 | 1.33 |
| 1 | 32768 | w=2048 | modular | 1145.3 | 983.6 | 1.16 |
| 1 | 32768 | w=4096 | modular | 1955.4 | 1740.8 | 1.11 |
| 1 | 32768 | w=8192 | modular | 3443.3 | 3392.4 | 1.01 |

Window-size sweep (B=1, S=16384):

| window | cute-dsl (µs) | trtllm (µs) | ratio |
|--:|--:|--:|:--:|
| 127 | 236.2 | 145.6 | 1.62 |
| 255 | 269.7 | 167.9 | 1.61 |
| 511 | 312.9 | 216.8 | 1.44 |
| 1023 | 411.3 | 304.6 | 1.35 |
| 2047 | 578.0 | 480.0 | 1.20 |
| 4095 | 883.8 | 804.9 | 1.10 |
| 8191 | 1387.7 | 1320.7 | 1.04 |

Mixed V dtype (bf16 Q/K + fp8 V, B=1 S=8192, same protocol): mixed inputs
force the vendored path onto JIT compilation (its prebuilt artifact matrix
has no mixed-dtype axis), where the modular kernel also wins causal:

| config | modular (µs) | vendored-JIT (µs) | modular/vendored |
|--|--:|--:|:--:|
| unmasked | 739.4 | 706.3 | 1.05 |
| causal | 481.8 | 548.1 | 0.88 |
| causal + w=127 | 117.7 | 183.9 | 0.64 |
| causal + w=1023 | 208.4 | 395.2 | 0.53 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible attention band masking, including causal, symmetric, left-only, and right-bounded sliding windows.
  * Added optional log-sum-exp (LSE) output, including variable-length, ALiBi, and attention-sink scenarios.
  * Added support for mixed Q/K/V data types in prefill attention.
  * Added automatic scale selection when no scale is provided.
* **Bug Fixes**
  * Improved kernel selection and fallback behavior for windowed attention and unsupported data-type combinations.
* **Tests**
  * Expanded coverage for masking, FP8, mixed dtypes, LSE results, and ragged inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->