### PR TITLE
fix(gemm): skip low-latency FP8 path for K-major m=32 on SM100

### DIFF
--- a/csrc/gemm_groupwise_sm100.cu
+++ b/csrc/gemm_groupwise_sm100.cu
@@ -117,8 +117,10 @@ void CutlassGemmGroupwiseScaledSM100(TensorView float_workspace_buffer, TensorVi
               cudaError_t status;
               // Small-batch-size kernel is not compatible with (scale_granularity_m=128).
               constexpr bool can_use_small_batch = (SCALE_GRANULARITY_M == 1);
-              // Low-latency path has a K-major cluster-launch misconfig (flashinfer#3944); MN only.
-              if (can_use_small_batch && !SCALE_MAJOR_K && m <= 32) {
+              // Low-latency path produces wrong results for K-major scales at m==32
+              // (flashinfer#3944).
+              const bool low_latency_k_major_m32_unsupported = SCALE_MAJOR_K && m == 32;
+              if (can_use_small_batch && m <= 32 && !low_latency_k_major_m32_unsupported) {
                 status = flashinfer::gemm::CutlassGroupwiseScaledGEMMSM100LowLatency<
                     SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, SCALE_MAJOR_K,
                     MMA_SM>(

--- a/csrc/gemm_groupwise_sm100.cu
+++ b/csrc/gemm_groupwise_sm100.cu
@@ -117,9 +117,7 @@ void CutlassGemmGroupwiseScaledSM100(TensorView float_workspace_buffer, TensorVi
               cudaError_t status;
               // Small-batch-size kernel is not compatible with (scale_granularity_m=128).
               constexpr bool can_use_small_batch = (SCALE_GRANULARITY_M == 1);
-              // The transpose trick maps original M to transposed N. CUTLASS blockwise
-              // kernels need extra SFB/TMEM handling when transposed N == 32; the
-              // low-latency path is incorrect for K-major scales there (flashinfer#3944).
+              // Low-latency path is incorrect for K-major scales at m==32 (flashinfer#3944).
               const bool low_latency_k_major_n32_unsupported = SCALE_MAJOR_K && m == 32;
               if (can_use_small_batch && m <= 32 && !low_latency_k_major_n32_unsupported) {
                 status = flashinfer::gemm::CutlassGroupwiseScaledGEMMSM100LowLatency<

--- a/csrc/gemm_groupwise_sm100.cu
+++ b/csrc/gemm_groupwise_sm100.cu
@@ -117,9 +117,8 @@ void CutlassGemmGroupwiseScaledSM100(TensorView float_workspace_buffer, TensorVi
               cudaError_t status;
               // Small-batch-size kernel is not compatible with (scale_granularity_m=128).
               constexpr bool can_use_small_batch = (SCALE_GRANULARITY_M == 1);
-              // Low-latency path is incorrect for K-major scales at m==32 (flashinfer#3944).
-              const bool low_latency_k_major_n32_unsupported = SCALE_MAJOR_K && m == 32;
-              if (can_use_small_batch && m <= 32 && !low_latency_k_major_n32_unsupported) {
+              // Low-latency path has a K-major cluster-launch misconfig (flashinfer#3944); MN only.
+              if (can_use_small_batch && !SCALE_MAJOR_K && m <= 32) {
                 status = flashinfer::gemm::CutlassGroupwiseScaledGEMMSM100LowLatency<
                     SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, SCALE_MAJOR_K,
                     MMA_SM>(

--- a/csrc/gemm_groupwise_sm100.cu
+++ b/csrc/gemm_groupwise_sm100.cu
@@ -117,7 +117,11 @@ void CutlassGemmGroupwiseScaledSM100(TensorView float_workspace_buffer, TensorVi
               cudaError_t status;
               // Small-batch-size kernel is not compatible with (scale_granularity_m=128).
               constexpr bool can_use_small_batch = (SCALE_GRANULARITY_M == 1);
-              if (can_use_small_batch && m <= 32) {
+              // The transpose trick maps original M to transposed N. CUTLASS blockwise
+              // kernels need extra SFB/TMEM handling when transposed N == 32; the
+              // low-latency path is incorrect for K-major scales there (flashinfer#3944).
+              constexpr bool low_latency_k_major_n32_unsupported = SCALE_MAJOR_K && m == 32;
+              if (can_use_small_batch && m <= 32 && !low_latency_k_major_n32_unsupported) {
                 status = flashinfer::gemm::CutlassGroupwiseScaledGEMMSM100LowLatency<
                     SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, SCALE_MAJOR_K,
                     MMA_SM>(

--- a/csrc/gemm_groupwise_sm100.cu
+++ b/csrc/gemm_groupwise_sm100.cu
@@ -120,7 +120,7 @@ void CutlassGemmGroupwiseScaledSM100(TensorView float_workspace_buffer, TensorVi
               // The transpose trick maps original M to transposed N. CUTLASS blockwise
               // kernels need extra SFB/TMEM handling when transposed N == 32; the
               // low-latency path is incorrect for K-major scales there (flashinfer#3944).
-              constexpr bool low_latency_k_major_n32_unsupported = SCALE_MAJOR_K && m == 32;
+              const bool low_latency_k_major_n32_unsupported = SCALE_MAJOR_K && m == 32;
               if (can_use_small_batch && m <= 32 && !low_latency_k_major_n32_unsupported) {
                 status = flashinfer::gemm::CutlassGroupwiseScaledGEMMSM100LowLatency<
                     SCALE_GRANULARITY_M, SCALE_GRANULARITY_N, SCALE_GRANULARITY_K, SCALE_MAJOR_K,


### PR DESCRIPTION
## Summary
Fixes the intermittent B300 CI failure `test_fp8_groupwise_gemm_small_batch_size[K-256-*-32]` (closes #3944).

The small-batch transpose fast path (`CutlassGroupwiseScaledGEMMSM100LowLatency`, added in #2327) computes `Dᵀ = Bᵀ @ Aᵀ` so it can use a small N tile for `m <= 32`. When the original `m == 32`, the transposed problem has `N == 32` (two 16-wide N-tiles) and, with **K-major** scales, the kernel produces incorrect results. This guard routes that one shape to the standard `CutlassGroupwiseScaledGEMMSM100` kernel; every other small-batch case keeps the #2327 fast path.

```cpp
const bool low_latency_k_major_m32_unsupported = SCALE_MAJOR_K && m == 32;
if (can_use_small_batch && m <= 32 && !low_latency_k_major_m32_unsupported) { ... }
```

## Nature of the failure
- **Real numeric corruption, not a tolerance issue:** when it fires, 124 elements are wrong (max abs 1.71875, max rel 90.0), always at the same indices.
- **Intermittent:** failed two nightlies, passed a third, and does not reproduce on-demand on a dev box. Verification therefore rests on the *mechanism* (the guard removes the buggy path), not on a green run.
- **Scope:** SM100, `cutlass` backend, K-major, `scale_granularity_m == 1`, `m == 32`. Observed on B300 + cu130; not seen on cu129.

## Investigation notes
- `compute-sanitizer --tool memcheck` reports `cudaErrorInvalidClusterSize` on `cudaOccupancyMaxActiveClusters` inside the low-latency kernel. This was investigated and **ruled out as the root cause**: it is a benign, m-independent *occupancy-query* error that CUTLASS handles (fallback cluster `{1,1,1}`); m=1/4/16/32 all raise it yet pass numerically. `initcheck`/`synccheck` are clean; the `racecheck` hazard is in a PyTorch ATen reduction, not FlashInfer.
- The corruption is consistent with the known CUTLASS N=32 blockwise SFB/TMEM limitation (NVIDIA/cutlass#2923).

## Guard scope
Intentionally narrow (`K-major && m == 32`) — the only shape with demonstrated wrong output. A broader guard was tried and reverted because its justification (the cluster error) turned out to be benign.

## Test plan
- [ ] `pytest tests/gemm/test_groupwise_scaled_gemm_fp8.py -q` on B300/SM100 (full file, fresh build)
- Note: because the failure is intermittent, a single green run is not proof; the fix is justified by removing the affected code path.

## Follow-ups (separate, non-blocking)
- Implement a correct N=32 blockwise SFB kernel to recover the #2327 perf for K-major m=32.
- Clean up the low-latency kernel's cluster config so `cudaOccupancyMaxActiveClusters` no longer raises a swallowed error.