### PR TITLE
Autotuner mem leak follow up 2

### DIFF
--- a/docs/autotuning.rst
+++ b/docs/autotuning.rst
@@ -230,12 +230,25 @@ The ``_metadata`` key records the environment that created the cache file
 
 On load, ``_metadata`` is compared against the current environment.  If any
 field differs (e.g. different GPU, FlashInfer version, or cuBLAS version),
-the **entire cache is skipped** — no configs are loaded, and the file will
-not be overwritten on exit; i.e. the autotuner would behave as if the cache
-file input was not provided (cache=None). This prevents silently using invalid
-tactics and avoids destroying configs tuned for a different environment.  A
-warning is logged with the mismatch details and a suggestion to use a
-different cache path for the current environment.
+the **entire cache is skipped** — no configs are loaded.  This prevents
+silently using invalid tactics.  A warning is logged once per process with
+the mismatch details; repeats for further cache files are logged at DEBUG.
+
+What happens to the file on the next save depends on the kind of mismatch:
+
+* The saved value is **definite** (e.g. ``"cudnn_version": "91900"`` vs
+  current ``92101``): the file belongs to a different environment sharing
+  this cache path.  It is never overwritten — the autotuner behaves as if
+  ``cache=None`` — so configs tuned for that environment survive.  Use a
+  different cache path for the current environment, or delete the file to
+  re-prime it.
+* The saved value is **indeterminate** (``"unknown"``, recorded when the
+  writer could not detect e.g. its cuDNN version, or a field missing from
+  files written by older FlashInfer versions): the file's configs cannot
+  be attributed to any environment, so the next tuned save **replaces**
+  the file with freshly tuned configs stamped with the current
+  environment's metadata.  The cache heals itself instead of forcing a
+  full re-tune on every startup forever.
 
 Advanced users can bypass individual checks by manually editing the JSON file
 and setting a metadata field to ``"*"``.  For example, setting

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -179,6 +179,13 @@ def make_bucket_mapper(
 
 _METADATA_KEY = "_metadata"
 
+# Metadata values a writer records when it cannot determine a field.
+# ("None" covers files written by versions that stringified a null version
+# report.)  A cache carrying these values is ignored on load, but — unlike a
+# genuine environment mismatch — may be overwritten on save, so a poisoned
+# file heals on the next tuned run instead of forcing a re-tune forever.
+_INDETERMINATE_META_VALUES = (None, "unknown", "None")
+
 
 def _get_cublas_version() -> str:
     """Return the cuBLAS version as ``major.minor.patch``.
@@ -261,6 +268,32 @@ def _get_cublas_version() -> str:
     return "unknown"
 
 
+def _get_cudnn_backend_version() -> str:
+    """Return the cuDNN backend version as a string, or ``"unknown"``.
+
+    ``torch.backends.cudnn.version()`` returns ``None`` (or raises) when
+    torch has not loaded cuDNN in this process — e.g. before torch's lazy
+    cuDNN initialization, or in a CPU-only context.  Fall back to the
+    cudnn-frontend's ``backend_version()``, which queries libcudnn directly
+    without torch's lazy init (the same gate ``gemm_base`` uses).
+    """
+    try:
+        version = torch.backends.cudnn.version()
+        if version:
+            return str(version)
+    except Exception:
+        pass
+    try:
+        import cudnn as _cudnn_frontend
+
+        version = _cudnn_frontend.backend_version()
+        if version:
+            return str(version)
+    except Exception:
+        pass
+    return "unknown"
+
+
 def _collect_metadata() -> dict[str, str]:
     """Collect environment metadata that can affect tactic-to-kernel mappings.
 
@@ -288,10 +321,7 @@ def _collect_metadata() -> dict[str, str]:
     meta["flashinfer_version"] = _flashinfer_version
     meta["cuda_version"] = getattr(torch.version, "cuda", None) or "unknown"
     meta["cublas_version"] = _get_cublas_version()
-    try:
-        meta["cudnn_version"] = str(torch.backends.cudnn.version())
-    except Exception:
-        meta["cudnn_version"] = "unknown"
+    meta["cudnn_version"] = _get_cudnn_backend_version()
     try:
         # cudnn-frontend is an optional dependency; failing to import is
         # not fatal -- we just record "unknown" and let the metadata
@@ -308,6 +338,45 @@ def _collect_metadata() -> dict[str, str]:
     except Exception:
         meta["gpu"] = "unknown"
     return meta
+
+
+def _classify_metadata_mismatches(
+    saved_meta: dict[str, Any], current_meta: dict[str, str]
+) -> tuple[dict[str, tuple[Any, str]], dict[str, tuple[Any, str]]]:
+    """Split saved-vs-current metadata mismatches by severity.
+
+    Returns ``(hard, soft)``, each mapping ``key -> (saved, current)``:
+
+      * ``hard`` — the writer recorded a definite value that differs from
+        the current environment: a genuine environment conflict.  Neither
+        reading the file's configs nor overwriting the file is safe.
+      * ``soft`` — the writer recorded an indeterminate value (or the key
+        is missing, for files from older flashinfer versions): the configs
+        cannot be trusted, but replacing the file with freshly tuned
+        configs and the current environment's metadata is safe.
+
+    A saved value of ``"*"`` is a wildcard and never mismatches.  Keys in
+    ``saved_meta`` that ``current_meta`` does not track are ignored.  A
+    corrupt (non-dict) ``saved_meta`` is treated as all-keys-missing: the
+    file is unattributable, i.e. every mismatch is soft.
+    """
+    if not isinstance(saved_meta, dict):
+        saved_meta = {}
+    hard: dict[str, tuple[Any, str]] = {}
+    soft: dict[str, tuple[Any, str]] = {}
+    for key, current in current_meta.items():
+        saved = saved_meta.get(key)
+        if saved in (current, "*"):
+            continue
+        target = soft if saved in _INDETERMINATE_META_VALUES else hard
+        target[key] = (saved, current)
+    return hard, soft
+
+
+def _format_meta_mismatches(mismatches: dict[str, tuple[Any, str]]) -> str:
+    return ", ".join(
+        f"{k}: saved={old} vs current={new}" for k, (old, new) in mismatches.items()
+    )
 
 
 def get_config_path(is_module: bool):
@@ -712,17 +781,16 @@ def autotune(
             "pass None (or omit) to inherit the current buckets"
         )
 
-    # Load configs from cache file on entry (if it exists).
-    # cache_valid is False when the file exists but has a metadata mismatch;
-    # in that case we skip saving on exit to avoid overwriting configs from
-    # a different environment.
-    cache_valid = True
+    # Load configs from cache file on entry (if it exists).  A file with
+    # mismatched metadata is ignored here; whether it may be overwritten on
+    # exit is decided by save_configs at save time (it re-reads the file,
+    # so a heal or replacement by another process is re-evaluated).
     if cache is not None:
         with tuner._lock:
             tuner._file_configs.clear()
             tuner._logged_file_hits.clear()
         if os.path.isfile(cache):
-            cache_valid = tuner.load_configs(cache)
+            tuner.load_configs(cache)
 
     # Push skip_ops onto per-thread stack.  Each entry is the cumulative
     # union so that _effective_skip_ops is an O(1) read from the top.
@@ -783,10 +851,12 @@ def autotune(
         if autotune_enabled:
             logger.info("[Autotuner]: Autotuning process ends")
 
-        # Save configs on exit when tuning with a cache path,
-        # but only if new profiling results were added this session
-        # and the cache file was valid (no environment mismatch).
-        if cache is not None and cache_valid and tune_mode and tuner._dirty:
+        # Save configs on exit when tuning with a cache path, but only if
+        # new profiling results were added this session.  save_configs
+        # itself refuses to overwrite a file that belongs to a genuinely
+        # different environment, and replaces one whose recorded
+        # environment is indeterminate.
+        if cache is not None and tune_mode and tuner._dirty:
             tuner.save_configs(cache)
 
 
@@ -1052,6 +1122,10 @@ class AutoTuner:
         self._file_configs: dict[str, tuple[str, Any]] = {}
         # Track which file config keys have been logged (to avoid per-call spam)
         self._logged_file_hits: set[tuple[str, str]] = set()
+        # Cache-metadata mismatch severities ("hard"/"soft") already logged at
+        # WARNING; repeats for further cache files are logged at DEBUG (a
+        # deployment can touch dozens of cache files per process).
+        self._warned_cache_mismatch: set[str] = set()
         # Track which (custom_op, profile-shape signature) pairs have already
         # produced an out-of-range cache-miss warning, so we warn at most
         # once per unique missing shape.
@@ -2049,6 +2123,21 @@ class AutoTuner:
         results taking priority for overlapping keys). This ensures the saved
         file is always a complete, self-contained config.
 
+        If a file already exists at ``path``, its ``_metadata`` decides how
+        the save proceeds:
+
+            * matches the current environment (or the file predates
+              metadata) — on-disk entries are merged with this process's
+              entries and the original "created by" record is preserved;
+            * indeterminate (``"unknown"`` values, or keys missing from
+              files written by older flashinfer versions) — the on-disk
+              entries were tuned in an environment the writer could not
+              identify, so the file is **replaced** with this process's
+              configs stamped with the current metadata (healing the file);
+            * definite conflict — the file belongs to a different
+              environment sharing this path; the save is skipped with a
+              warning so that environment's configs survive.
+
         Note:
             This is called automatically on exit from
             ``with autotune(True, cache=path):``. Direct calls are only needed
@@ -2094,16 +2183,48 @@ class AutoTuner:
 
         # Re-read the file from disk and merge to reduce lost updates when
         # multiple processes save to the same path.  Entries from this
-        # process take priority over on-disk entries.
+        # process take priority over on-disk entries.  The decision is made
+        # here, at save time, so that a file healed or replaced by another
+        # process since our load_configs() call is re-evaluated against its
+        # current on-disk metadata.
         abs_path = os.path.abspath(path)
         original_metadata = None
         try:
             with open(abs_path, "r") as f:
                 disk_configs = json.load(f)
-            # Preserve the original _metadata from disk (the "created by" record).
-            original_metadata = disk_configs.pop(_METADATA_KEY, None)
-            disk_configs.update(configs)
-            configs = disk_configs
+            disk_meta = disk_configs.pop(_METADATA_KEY, None)
+            hard, soft = (
+                _classify_metadata_mismatches(disk_meta, current_meta)
+                if disk_meta is not None
+                else ({}, {})
+            )
+            if hard:
+                # Genuine environment conflict: leave the other
+                # environment's file untouched (mirrors load_configs).
+                message = (
+                    f"[Autotuner]: Not saving configs to {path}: the file "
+                    f"was created in a different environment "
+                    f"({_format_meta_mismatches(hard)}). Use a different "
+                    f"cache path for the current environment, or delete "
+                    f"the file to re-prime it."
+                )
+                if "hard" in self._warned_cache_mismatch:
+                    logger.debug(message)
+                else:
+                    self._warned_cache_mismatch.add("hard")
+                    logger.warning(message)
+                return
+            if not soft:
+                # Same environment: merge on-disk entries and preserve the
+                # original "created by" record.
+                disk_configs.update(configs)
+                configs = disk_configs
+                original_metadata = disk_meta
+            # else: the on-disk entries were tuned in an environment the
+            # writer could not identify ("unknown") — drop them and replace
+            # the file, stamping the current metadata.  This heals caches
+            # poisoned by e.g. cudnn_version="unknown", which would
+            # otherwise be ignored by every future load_configs() forever.
         except (FileNotFoundError, json.JSONDecodeError):
             pass  # file doesn't exist yet or is being replaced -- proceed with what we have
 
@@ -2165,10 +2286,21 @@ class AutoTuner:
               ``policy=ALL`` plan_index ordering independent of backend)
             * ``gpu`` (different SM may expose different engines)
 
-        Caches saved by older flashinfer versions that predate the
-        ``cudnn_frontend_version`` metadata field will fail this check
-        (since saved metadata does not contain the field) and need to
-        be regenerated.  See :func:`_collect_metadata` for the exact list.
+        A skipped cache is handled in one of two ways by the next
+        :meth:`save_configs` on the same path:
+
+            * the saved metadata records a **definite** conflicting value —
+              a genuine environment conflict; the file is never
+              overwritten.  Use a different cache path, or delete the file
+              to re-prime it for this environment.
+            * the saved metadata is **indeterminate** — ``"unknown"``
+              values (the writer could not detect e.g. its cuDNN version),
+              or keys missing entirely from files written by older
+              flashinfer versions.  The file is replaced with freshly
+              tuned configs and the current environment's metadata, so the
+              cache heals instead of being re-tuned forever.
+
+        See :func:`_collect_metadata` for the exact field list.
 
         Note:
             This is called automatically on entry to
@@ -2206,24 +2338,34 @@ class AutoTuner:
         # entirely to avoid silently using invalid or suboptimal tactics.
         if saved_meta is not None:
             current_meta = _collect_metadata()
-            mismatches = {
-                k: (saved_meta.get(k), current_meta.get(k))
-                for k in current_meta
-                if saved_meta.get(k) not in (current_meta.get(k), "*")
-            }
-            if mismatches:
-                details = ", ".join(
-                    f"{k}: saved={old} vs current={new}"
-                    for k, (old, new) in mismatches.items()
+            hard, soft = _classify_metadata_mismatches(saved_meta, current_meta)
+            if hard or soft:
+                if hard:
+                    severity = "hard"
+                    consequence = (
+                        "Results will not be saved to this file to avoid "
+                        "overwriting configs from a different environment. "
+                        "Use a different cache path for the current "
+                        "environment, or delete the file to re-prime it."
+                    )
+                else:
+                    severity = "soft"
+                    consequence = (
+                        "The file's recorded environment is indeterminate, "
+                        "so the next save will replace it with freshly "
+                        "tuned configs for the current environment."
+                    )
+                message = (
+                    f"[Autotuner]: Cache file {path} was created in a "
+                    f"different environment "
+                    f"({_format_meta_mismatches({**hard, **soft})}). "
+                    f"Ignoring cached configs. {consequence}"
                 )
-                logger.warning(
-                    f"[Autotuner]: Cache file {path} was created in a different "
-                    f"environment ({details}). Ignoring cached configs. "
-                    f"Results will not be saved to this file to avoid "
-                    f"overwriting configs from a different environment. "
-                    f"Use a different cache path to save configs for the "
-                    f"current environment."
-                )
+                if severity in self._warned_cache_mismatch:
+                    logger.debug(message)
+                else:
+                    self._warned_cache_mismatch.add(severity)
+                    logger.warning(message)
                 return False
 
         skipped_legacy_cudnn_tactics = 0

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -2192,6 +2192,8 @@ class AutoTuner:
         try:
             with open(abs_path, "r") as f:
                 disk_configs = json.load(f)
+            if not isinstance(disk_configs, dict):
+                disk_configs = {}
             disk_meta = disk_configs.pop(_METADATA_KEY, None)
             hard, soft = (
                 _classify_metadata_mismatches(disk_meta, current_meta)
@@ -2208,11 +2210,12 @@ class AutoTuner:
                     f"cache path for the current environment, or delete "
                     f"the file to re-prime it."
                 )
-                if "hard" in self._warned_cache_mismatch:
-                    logger.debug(message)
-                else:
-                    self._warned_cache_mismatch.add("hard")
-                    logger.warning(message)
+                with self._lock:
+                    if "hard" in self._warned_cache_mismatch:
+                        logger.debug(message)
+                    else:
+                        self._warned_cache_mismatch.add("hard")
+                        logger.warning(message)
                 return
             if not soft:
                 # Same environment: merge on-disk entries and preserve the
@@ -2361,11 +2364,12 @@ class AutoTuner:
                     f"({_format_meta_mismatches({**hard, **soft})}). "
                     f"Ignoring cached configs. {consequence}"
                 )
-                if severity in self._warned_cache_mismatch:
-                    logger.debug(message)
-                else:
-                    self._warned_cache_mismatch.add(severity)
-                    logger.warning(message)
+                with self._lock:
+                    if severity in self._warned_cache_mismatch:
+                        logger.debug(message)
+                    else:
+                        self._warned_cache_mismatch.add(severity)
+                        logger.warning(message)
                 return False
 
         skipped_legacy_cudnn_tactics = 0

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -24,7 +24,13 @@ from typing import List, Literal, Optional, Sequence, Tuple, Union, cast, overlo
 import torch
 
 from ..api_logging import flashinfer_api
-from ..autotuner import AutoTuner, TunableRunner
+from flashinfer.autotuner import (
+    AutoTuner,
+    TunableRunner,
+    TuningConfig,
+    make_bucket_mapper,
+    DynamicTensorSpec,
+)
 from ..trace.templates.attention import (
     mla_paged_decode_trace,
     trtllm_batch_decode_mla_trace_dispatch,
@@ -2010,7 +2016,7 @@ def _cute_dsl_max_supported_batch(
 
 def _compute_mla_decode_buckets(
     workspace_buffer: torch.Tensor,
-    runner_names: List[str],
+    runner_names: Sequence[str],
     q_len: int,
     num_heads: int,
     kv_lora_rank: int,
@@ -2144,44 +2150,27 @@ def _cute_dsl_incompatibility_reason(
     return None
 
 
-def _build_mla_decode_tuning_config(
-    kv_cache: torch.Tensor,
-    block_tables: torch.Tensor,
-    workspace_buffer: torch.Tensor,
-    runner_names: List[str],
-    q_len: int,
-    num_heads: int,
-    kv_lora_rank: int,
-    max_seq_len: int,
-    device: torch.device,
-):
-    """Per-call TuningConfig with bucket-capped batch sweep and closure-based initializers.
+@functools.cache
+def _mla_decode_tuning_config(
+    buckets: tuple[int, ...],
+    num_pages: int,
+    profile_seq_len: int,
+) -> TuningConfig:
+    """One TuningConfig (and one pair of initializer closures) per key.
+
+    Memoized because ``AutoTuner._find_nearest_profile`` lru-caches on
+    ``(shapes, tuning_config)``: a fresh config per dispatcher call shares
+    its hash with all previous ones (``DynamicTensorSpec.__hash__`` skips
+    ``tensor_initializers``) but never compares equal (closures compare by
+    identity), so would result in a leak.
 
     The DynamicTensorSpec sweeps batch dim across all four ``inputs`` tensors
     (query, block_tables, seq_lens, out). ``block_tables`` is initialized via
     ``random_(0, num_pages)`` which wraps mod kv_cache size — safe for autotune
     profiling because MLA decode reads kv_cache and never writes it, so aliased
     page reads give correct timing measurements. ``seq_lens`` is filled
-    homogeneously with ``min(max_seq_len, provisioned_max_seq_len)``.
+    homogeneously with ``profile_seq_len``.
     """
-    from ..autotuner import DynamicTensorSpec, TuningConfig, make_bucket_mapper
-
-    # kv_cache may be 3D [num_pages, page_size, D] or 4D
-    # [num_pages, 1, page_size, D] after `_check_trtllm_gen_mla_shape` —
-    # page_size is the second-to-last dim in both layouts.
-    page_size = kv_cache.shape[-2]
-    provisioned_max_seq_len = block_tables.shape[-1] * page_size
-    profile_seq_len = min(max_seq_len, provisioned_max_seq_len)
-    num_pages = kv_cache.shape[0]
-
-    buckets = _compute_mla_decode_buckets(
-        workspace_buffer,
-        runner_names,
-        q_len,
-        num_heads,
-        kv_lora_rank,
-        device,
-    )
 
     def init_block_tables(shapes, dtype, device):
         tensor = torch.empty(shapes, dtype=dtype, device=device)
@@ -2200,12 +2189,50 @@ def _build_mla_decode_tuning_config(
                 dim_idx=(0, 0, 0, 0),
                 gen_tuning_buckets=buckets,
                 map_to_tuning_buckets=make_bucket_mapper(buckets, round_map=False),
-                tensor_initializers=[None, init_block_tables, init_seq_lens, None],
+                tensor_initializers=(None, init_block_tables, init_seq_lens, None),
             ),
         ),
         use_cuda_graph=True,
         use_cold_l2_cache=True,
     )
+
+
+def _build_mla_decode_tuning_config(
+    kv_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    runner_names: Sequence[str],
+    q_len: int,
+    num_heads: int,
+    kv_lora_rank: int,
+    max_seq_len: int,
+    device: torch.device,
+) -> TuningConfig:
+    """Reduce call args to the memoization key of ``_mla_decode_tuning_config``.
+
+    Key stability: num_pages and profile_seq_len are fixed per KV-cache
+    allocation. A caller that varies max_seq_len or block-table width per
+    call gets one cached config per distinct value (bounded, unlike the
+    per-call configs this replaces).
+    """
+    # kv_cache may be 3D [num_pages, page_size, D] or 4D
+    # [num_pages, 1, page_size, D] after `_check_trtllm_gen_mla_shape` —
+    # page_size is the second-to-last dim in both layouts.
+    page_size = kv_cache.shape[-2]
+    provisioned_max_seq_len = block_tables.shape[-1] * page_size
+    profile_seq_len = min(max_seq_len, provisioned_max_seq_len)
+    num_pages = kv_cache.shape[0]
+
+    buckets = _compute_mla_decode_buckets(
+        workspace_buffer,
+        runner_names,
+        q_len,
+        num_heads,
+        kv_lora_rank,
+        device,
+    )
+
+    return _mla_decode_tuning_config(buckets, num_pages, profile_seq_len)
 
 
 class TrtllmGenMlaDecodeRunner(TunableRunner):

--- a/tests/autotuner/test_autotuner_configs.py
+++ b/tests/autotuner/test_autotuner_configs.py
@@ -9,11 +9,16 @@ the profiling cache and verify serialization behavior.
 """
 
 import json
+import logging
 import os
+import sys
 import tempfile
+import types
 
 import pytest
+import torch
 
+import flashinfer.autotuner.autotuner as autotuner_module
 from flashinfer.autotuner import (
     AutoTuner,
     TunableRunner,
@@ -983,3 +988,283 @@ class TestThreadSafety:
         assert not tuner.is_tuning_mode, "is_tuning_mode was not properly restored"
         assert tuner._active_tuning_contexts == 0, "reference count leak"
         assert len(errors) == 0, f"Errors in threads: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Metadata compatibility: hard vs soft mismatch, cache healing
+# ---------------------------------------------------------------------------
+
+
+_FAKE_META = {
+    "flashinfer_version": "0.6.13",
+    "cuda_version": "13.0",
+    "cublas_version": "13.0.2",
+    "cudnn_version": "92101",
+    "cudnn_frontend_version": "1.14.1",
+    "gpu": "NVIDIA B200",
+}
+
+_OLD_KEY = "('old_op', 'FakeRunnerA', ((1, 1),))"
+
+
+def _write_cache_file(path, metadata):
+    data = {_METADATA_KEY: metadata} if metadata is not None else {}
+    data[_OLD_KEY] = ("FakeRunnerA", 3)
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def _read_cache_file(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+class _RecordingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class TestClassifyMetadataMismatches:
+    def test_exact_match(self):
+        hard, soft = autotuner_module._classify_metadata_mismatches(
+            dict(_FAKE_META), dict(_FAKE_META)
+        )
+        assert hard == {} and soft == {}
+
+    def test_wildcard_matches_anything(self):
+        saved = dict(_FAKE_META, cudnn_version="*")
+        hard, soft = autotuner_module._classify_metadata_mismatches(saved, _FAKE_META)
+        assert hard == {} and soft == {}
+
+    def test_definite_conflict_is_hard(self):
+        saved = dict(_FAKE_META, cudnn_version="91900")
+        hard, soft = autotuner_module._classify_metadata_mismatches(saved, _FAKE_META)
+        assert set(hard) == {"cudnn_version"} and soft == {}
+
+    def test_unknown_is_soft(self):
+        saved = dict(_FAKE_META, cudnn_version="unknown")
+        hard, soft = autotuner_module._classify_metadata_mismatches(saved, _FAKE_META)
+        assert hard == {} and set(soft) == {"cudnn_version"}
+
+    def test_stringified_none_is_soft(self):
+        saved = dict(_FAKE_META, cudnn_version="None")
+        hard, soft = autotuner_module._classify_metadata_mismatches(saved, _FAKE_META)
+        assert hard == {} and set(soft) == {"cudnn_version"}
+
+    def test_missing_key_is_soft(self):
+        saved = dict(_FAKE_META)
+        del saved["cudnn_frontend_version"]
+        hard, soft = autotuner_module._classify_metadata_mismatches(saved, _FAKE_META)
+        assert hard == {} and set(soft) == {"cudnn_frontend_version"}
+
+    def test_unknown_matches_unknown(self):
+        saved = dict(_FAKE_META, cudnn_version="unknown")
+        current = dict(_FAKE_META, cudnn_version="unknown")
+        hard, soft = autotuner_module._classify_metadata_mismatches(saved, current)
+        assert hard == {} and soft == {}
+
+    def test_extra_saved_key_ignored(self):
+        saved = dict(_FAKE_META, future_field="whatever")
+        hard, soft = autotuner_module._classify_metadata_mismatches(saved, _FAKE_META)
+        assert hard == {} and soft == {}
+
+    def test_hard_and_soft_split(self):
+        saved = dict(_FAKE_META, cudnn_version="unknown", gpu="NVIDIA H100")
+        hard, soft = autotuner_module._classify_metadata_mismatches(saved, _FAKE_META)
+        assert set(hard) == {"gpu"} and set(soft) == {"cudnn_version"}
+
+    def test_non_dict_metadata_is_all_soft(self):
+        hard, soft = autotuner_module._classify_metadata_mismatches(
+            "garbage", _FAKE_META
+        )
+        assert hard == {} and set(soft) == set(_FAKE_META)
+
+
+class TestMetadataCompatibility:
+    def setup_method(self):
+        AutoTuner._instance = None
+        self.tuner = AutoTuner.get()
+
+    def teardown_method(self):
+        AutoTuner._instance = None
+
+    @pytest.fixture(autouse=True)
+    def _fixed_current_meta(self, monkeypatch):
+        monkeypatch.setattr(
+            autotuner_module, "_collect_metadata", lambda: dict(_FAKE_META)
+        )
+
+    def _populate_new_entry(self):
+        _populate_cache(self.tuner, FakeRunnerA(), "new_op", ((4, 8),), tactic=5)
+
+    def test_corrupt_metadata_rejected_on_load_then_healed_on_save(self):
+        """A file whose _metadata is not a dict (corruption) must be rejected
+        gracefully on load — not crash — and replaced on save."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "configs.json")
+            _write_cache_file(path, "not-a-dict")
+
+            assert self.tuner.load_configs(path) is False
+            assert self.tuner._file_configs == {}
+
+            self._populate_new_entry()
+            self.tuner.save_configs(path)
+
+            data = _read_cache_file(path)
+            assert data[_METADATA_KEY] == _FAKE_META
+            assert _OLD_KEY not in data
+
+    def test_soft_mismatch_rejected_on_load_then_healed_on_save(self):
+        """A cache poisoned with cudnn_version="unknown" is ignored, but the
+        next save replaces it with fresh configs + real metadata."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "configs.json")
+            _write_cache_file(path, dict(_FAKE_META, cudnn_version="unknown"))
+
+            assert self.tuner.load_configs(path) is False
+            assert self.tuner._file_configs == {}
+
+            self._populate_new_entry()
+            self.tuner.save_configs(path)
+
+            data = _read_cache_file(path)
+            assert data[_METADATA_KEY] == _FAKE_META
+            assert _OLD_KEY not in data
+            assert len(_config_entries(data)) == 1
+
+            AutoTuner._instance = None
+            tuner2 = AutoTuner.get()
+            assert tuner2.load_configs(path) is True
+            assert len(tuner2._file_configs) == 1
+
+    def test_hard_mismatch_rejected_on_load_and_never_overwritten(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "configs.json")
+            saved_meta = dict(_FAKE_META, cudnn_version="91900")
+            _write_cache_file(path, saved_meta)
+
+            assert self.tuner.load_configs(path) is False
+            assert self.tuner._file_configs == {}
+
+            self._populate_new_entry()
+            self.tuner.save_configs(path)
+
+            data = _read_cache_file(path)
+            assert data[_METADATA_KEY] == saved_meta
+            assert _OLD_KEY in data
+            assert len(_config_entries(data)) == 1
+
+    def test_missing_metadata_key_is_healed_on_save(self):
+        """Files from flashinfer versions predating a metadata field are
+        rejected on load but replaced (not stranded) on save."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "configs.json")
+            old_meta = dict(_FAKE_META)
+            del old_meta["cudnn_frontend_version"]
+            _write_cache_file(path, old_meta)
+
+            assert self.tuner.load_configs(path) is False
+
+            self._populate_new_entry()
+            self.tuner.save_configs(path)
+
+            data = _read_cache_file(path)
+            assert data[_METADATA_KEY] == _FAKE_META
+            assert _OLD_KEY not in data
+
+    def test_matching_metadata_merges_and_preserves_record(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "configs.json")
+            _write_cache_file(path, dict(_FAKE_META))
+
+            assert self.tuner.load_configs(path) is True
+            assert len(self.tuner._file_configs) == 1
+
+            self._populate_new_entry()
+            self.tuner.save_configs(path)
+
+            data = _read_cache_file(path)
+            assert data[_METADATA_KEY] == _FAKE_META
+            assert _OLD_KEY in data
+            assert len(_config_entries(data)) == 2
+
+    def test_wildcard_metadata_loads(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "configs.json")
+            _write_cache_file(path, dict(_FAKE_META, cudnn_version="*"))
+            assert self.tuner.load_configs(path) is True
+            assert len(self.tuner._file_configs) == 1
+
+    def test_autotune_context_heals_poisoned_cache(self):
+        """End-to-end regression for the poisoned-cache deadlock: previously
+        the exit save was suppressed on any metadata mismatch, so a file
+        with cudnn_version="unknown" was never read NOR overwritten and
+        every future process re-autotuned from scratch."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "configs.json")
+            _write_cache_file(path, dict(_FAKE_META, cudnn_version="unknown"))
+
+            with autotune(True, cache=path):
+                self._populate_new_entry()
+
+            data = _read_cache_file(path)
+            assert data[_METADATA_KEY] == _FAKE_META
+            assert _OLD_KEY not in data
+            assert len(_config_entries(data)) == 1
+
+            AutoTuner._instance = None
+            tuner2 = AutoTuner.get()
+            with autotune(False, cache=path):
+                assert len(tuner2._file_configs) == 1
+
+    def test_mismatch_warning_logged_once_per_process(self):
+        handler = _RecordingHandler()
+        tuner_logger = autotuner_module.logger
+        tuner_logger.addHandler(handler)
+        try:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                for name in ("a.json", "b.json", "c.json"):
+                    path = os.path.join(tmp_dir, name)
+                    _write_cache_file(path, dict(_FAKE_META, cudnn_version="unknown"))
+                    assert self.tuner.load_configs(path) is False
+        finally:
+            tuner_logger.removeHandler(handler)
+
+        warnings = tuple(
+            r
+            for r in handler.records
+            if r.levelno == logging.WARNING
+            and "different environment" in r.getMessage()
+        )
+        assert len(warnings) == 1
+        # Repeats are demoted to DEBUG; the dedup state records the severity.
+        assert self.tuner._warned_cache_mismatch == {"soft"}
+
+
+class TestCudnnVersionDetection:
+    def test_falls_back_to_cudnn_frontend(self, monkeypatch):
+        monkeypatch.setattr(torch.backends.cudnn, "version", lambda: None)
+        fake = types.SimpleNamespace(backend_version=lambda: 92101)
+        monkeypatch.setitem(sys.modules, "cudnn", fake)
+        assert autotuner_module._get_cudnn_backend_version() == "92101"
+
+    def test_prefers_torch_report(self, monkeypatch):
+        monkeypatch.setattr(torch.backends.cudnn, "version", lambda: 91900)
+        fake = types.SimpleNamespace(backend_version=lambda: 92101)
+        monkeypatch.setitem(sys.modules, "cudnn", fake)
+        assert autotuner_module._get_cudnn_backend_version() == "91900"
+
+    def test_unknown_when_undeterminable(self, monkeypatch):
+        monkeypatch.setattr(torch.backends.cudnn, "version", lambda: None)
+        monkeypatch.setitem(sys.modules, "cudnn", None)
+        assert autotuner_module._get_cudnn_backend_version() == "unknown"
+
+    def test_never_records_stringified_none(self, monkeypatch):
+        monkeypatch.setattr(torch.backends.cudnn, "version", lambda: None)
+        monkeypatch.setitem(sys.modules, "cudnn", None)
+        meta = autotuner_module._collect_metadata()
+        assert meta["cudnn_version"] == "unknown"

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -1,9 +1,23 @@
 import random
+import tracemalloc
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 
+import flashinfer.fused_moe.core as core_mod
 from flashinfer import autotune
+from flashinfer.autotuner.initializers import autotuner_initializer_randn
+from flashinfer.fused_moe.core import MoeRunnerInputs, _moe_topk_ids_init
+from flashinfer.fused_moe.utils import (
+    get_hybrid_num_tokens_buckets,
+    make_hybrid_bucket_mapper,
+)
+from flashinfer.mla._core import (
+    _build_mla_decode_tuning_config,
+    _mla_decode_tuning_config,
+)
+from flashinfer.tllm_enums import DtypeTrtllmGen, Fp8QuantizationType
 from flashinfer.autotuner import (
     AutoTuner,
     ConstraintSpec,
@@ -1117,8 +1131,6 @@ def test_find_nearest_profile_cache_grows_with_fresh_callable():
     though the shape and bucketing logic are identical, so the cache grows by
     exactly N — the original memory leak.
     """
-    import tracemalloc
-
     AutoTuner._find_nearest_profile.cache_clear()
 
     shapes = ((1024, 128),)
@@ -1162,12 +1174,6 @@ def _build_moe_style_tuning_config(topk_ids_initializer):
     """Build a config with tensor_initializers present, MoE-style.
     Mimics ``_make_tuning_config`` in fused_moe/core.py.
     """
-    from flashinfer.autotuner.initializers import autotuner_initializer_randn
-    from flashinfer.fused_moe.utils import (
-        get_hybrid_num_tokens_buckets,
-        make_hybrid_bucket_mapper,
-    )
-
     return TuningConfig(
         dynamic_tensor_specs=(
             DynamicTensorSpec(
@@ -1188,8 +1194,6 @@ def test_find_nearest_profile_cache_dedups_moe_config_with_initializers():
     """Regression test: rebuilt MoE-style configs with tensor_initializers
     must collapse to a single cache entry.
     """
-    from flashinfer.fused_moe.core import _moe_topk_ids_init
-
     # The factory must return the identical object for the same expert count.
     assert _moe_topk_ids_init(128) is _moe_topk_ids_init(128)
 
@@ -1219,12 +1223,6 @@ def test_make_tuning_config_reuses_topk_ids_initializer():
     """_make_tuning_config must return configs whose topk_ids initializer is the
     same object across calls for the same num_experts.
     """
-    from unittest.mock import MagicMock, patch
-
-    import flashinfer.fused_moe.core as core_mod
-    from flashinfer.fused_moe.core import MoeRunnerInputs
-    from flashinfer.tllm_enums import DtypeTrtllmGen, Fp8QuantizationType
-
     fn = core_mod.get_trtllm_moe_sm100_module
     fn.cache_clear()
     try:
@@ -1312,3 +1310,80 @@ def test_find_nearest_profile_cache_grows_with_fresh_closure_initializer():
     assert cache_growth == N, (
         f"Expected {N} new cache entries (one per fresh closure), got {cache_growth}."
     )
+
+
+def _call_build_mla_decode_tuning_config():
+    """Call _build_mla_decode_tuning_config with fresh (equivalent) tensors.
+
+    runner_names is restricted to trtllm-gen so bucket computation stays
+    host-only (no SM count query), letting the test run without a GPU.
+    """
+    num_pages, page_size, head_dim = 128, 32, 576
+    return _build_mla_decode_tuning_config(
+        kv_cache=torch.empty((num_pages, page_size, head_dim)),
+        block_tables=torch.zeros((8, 64), dtype=torch.int32),
+        workspace_buffer=torch.empty(1024, dtype=torch.uint8),
+        runner_names=("trtllm-gen",),
+        q_len=4,
+        num_heads=128,
+        kv_lora_rank=512,
+        max_seq_len=1024,
+        device=torch.device("cpu"),
+    )
+
+
+def test_mla_decode_tuning_config_is_memoized():
+    """Equivalent MLA-decode dispatcher calls must reuse one TuningConfig object.
+
+    A fresh config per call embeds two fresh initializer closures; those hash
+    identically to but never compare equal with previous ones, so each call
+    would leak one _find_nearest_profile cache entry and lookups would scan the
+    whole collision chain (observed as GC gen-2 pause growth and decaying
+    decode throughput in serving).
+    """
+    _mla_decode_tuning_config.cache_clear()
+    try:
+        config_a = _call_build_mla_decode_tuning_config()
+        config_b = _call_build_mla_decode_tuning_config()
+
+        assert config_a is config_b, (
+            "_build_mla_decode_tuning_config returned a different TuningConfig "
+            "object for equivalent arguments. It must memoize on "
+            "(buckets, num_pages, profile_seq_len) so rebuilt configs collapse to "
+            "the same _find_nearest_profile lru_cache key — a per-call config "
+            "reintroduces the memory leak."
+        )
+    finally:
+        _mla_decode_tuning_config.cache_clear()
+
+
+def test_find_nearest_profile_cache_dedups_mla_decode_config():
+    """Regression test: rebuilt MLA-decode configs must collapse to a single
+    _find_nearest_profile cache entry.
+    """
+    AutoTuner._find_nearest_profile.cache_clear()
+    _mla_decode_tuning_config.cache_clear()
+    try:
+        # [query, block_tables, seq_lens, out] as passed by the MLA dispatcher.
+        shapes = ((8, 4, 128, 576), (8, 64), (8,), (8, 4, 128, 512))
+
+        AutoTuner._find_nearest_profile(shapes, _call_build_mla_decode_tuning_config())
+        cache_before = AutoTuner._find_nearest_profile.cache_info().currsize
+
+        N = 1_000
+        for _ in range(N):
+            AutoTuner._find_nearest_profile(
+                shapes, _call_build_mla_decode_tuning_config()
+            )
+
+        cache_growth = (
+            AutoTuner._find_nearest_profile.cache_info().currsize - cache_before
+        )
+
+        assert cache_growth == 0, (
+            f"Cache grew by {cache_growth} entries across {N} rebuilds of an "
+            "equivalent MLA-decode tuning config with a fixed shape."
+        )
+    finally:
+        AutoTuner._find_nearest_profile.cache_clear()
+        _mla_decode_tuning_config.cache_clear()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR fixes two autotuner cache issues that can degrade long-running MLA decode workloads or leave on-disk tuning caches permanently unusable.

- Memoizes MLA decode `TuningConfig` objects using the stable `(buckets, num_pages, profile_seq_len)` inputs. This reuses initializer closures across equivalent dispatcher calls and prevents unbounded growth in `_find_nearest_profile` caused by fresh, unequal closures on every call.
- Distinguishes hard metadata mismatches from indeterminate metadata in persisted autotuner caches:
  - Definite environment conflicts remain protected from reads and overwrites.
  - Missing, `unknown`, or legacy `None` metadata is ignored on load and replaced with freshly tuned configurations on the next save, allowing the cache to heal.
- Re-checks cache metadata at save time so concurrent cache replacements are evaluated against the latest on-disk state.
- Improves cuDNN version detection by falling back to the cuDNN frontend when PyTorch has not initialized cuDNN.
- Deduplicates repeated metadata-mismatch warnings by severity while retaining details at debug level.
- Updates the autotuning documentation and adds regression coverage for MLA config reuse, cache growth, metadata classification, cache healing, hard-mismatch protection, concurrent save behavior, and cuDNN version detection.

## 🔍 Related Issues

- Follow-up to #3912

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [X] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [X] I have installed the hooks with `pre-commit install`.
- [X] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Added and updated tests cover:

- Stable MLA decode tuning-config identity and `_find_nearest_profile` cache size.
- Hard, soft, missing, wildcard, and corrupt metadata handling.
- Healing indeterminate cache files while preserving definite cross-environment conflicts.
- Save-time metadata revalidation and warning deduplication.
- PyTorch and cuDNN frontend version-detection paths.

## Reviewer Notes

Please focus on the hard-versus-indeterminate metadata classification and the save-time behavior: a definite mismatch must never overwrite another environment's cache, while an indeterminate cache must be replaceable so it does not force repeated retuning. For the MLA change, please verify that `(buckets, num_pages, profile_seq_len)` fully captures the values used by the memoized tuning configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autotuning cache compatibility by distinguishing hard vs soft environment-metadata mismatches.
  * Hard conflicts now skip cache usage; soft/indeterminate mismatches trigger “cache healing” on the next tuned save.
  * Added clearer, one-time-per-process warnings for mismatch details, and ensures poisoned caches can be overwritten.
  * Autotuning now records the cuDNN **backend** version for more reliable compatibility checks.
* **Performance**
  * Reuses memoized MLA decode tuning configurations for equivalent inputs.
* **Documentation**
  * Updated autotuning docs to describe hard/soft mismatch and cache healing behavior.
* **Tests**
  * Expanded coverage for mismatch classification, healing behavior, warning deduplication, and cuDNN backend detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->