### PR TITLE
fix(gemm): exclude cuDNN 9.23.0 SM90 split-k bf16 plans from the autotune space

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -4021,7 +4021,25 @@ def _cudnn_gemm_bf16_runner(
                     policy=cudnn.build_plan_policy.HEURISTICS_CHOICE,
                 )
 
-            return list(range(graph.get_execution_plan_count()))
+            tactics = list(range(graph.get_execution_plan_count()))
+            # cuDNN 9.23.0 miscomputes bf16 GEMM/BMM split-k plans on SM90 (the same
+            # split-k output-layout bug _cudnn_bf16_gemm_usable_or_skip hard-bans for
+            # fp16 output). For bf16 output the DEFAULT plan is correct and only the
+            # split-k plans (knob k17 = CUDNN_KNOB_TYPE_SPLIT_K_SLC) are broken -- but
+            # they win the autotuner's timing race on tall-K shapes and then silently
+            # return garbage (verified per-plan: exactly the eng7_k17=4_* plans fail,
+            # ratio ~1.4; all plans correct on 9.23.1+). Drop them from the tuning
+            # space instead of banning the whole backend. Plan names need
+            # cudnn-frontend >= 1.25; without the API, fall back to the full list.
+            if (
+                cudnn.backend_version() == 92300
+                and get_compute_capability(a.device)[0] == 9
+                and hasattr(graph, "get_plan_name_at_index")
+            ):
+                tactics = [
+                    t for t in tactics if "k17=" not in graph.get_plan_name_at_index(t)
+                ]
+            return tactics
 
         def forward(
             self,


### PR DESCRIPTION
## What

`CudnnBf16GemmRunner.get_valid_tactics` now excludes cuDNN split-k execution plans (structured plan name containing `k17=`, i.e. `CUDNN_KNOB_TYPE_SPLIT_K_SLC`) from the autotuning space when running on **SM90 with cuDNN 9.23.0 exactly** (`backend_version() == 92300`). One file, ~15 lines.

## Why

cuDNN 9.23.0 miscomputes bf16 GEMM/BMM **split-k** plans on SM90/Hopper — the same split-k output-layout bug that `_cudnn_bf16_gemm_usable_or_skip` (landed in #3539) already hard-bans for **fp16 output**, where even the default plan is broken. For **bf16 output** the default plan is correct, so a wholesale ban would kill a working path; the broken plans only execute when `autotune(True)` picks one — which it does, because split-k wins the timing race on tall-K shapes, and then **silently returns garbage**.

Found by the #3539 fuzzer's autotune-ON winner validation (`mm_bf16` m63 n32 k2688: autotuned ratio 0.98 vs 0.0022 at the default plan). Full analysis with the per-plan matrix: [#3539 (comment)](https://github.com/flashinfer-ai/flashinfer/pull/3539#issuecomment-4972138007).

Per-plan enumeration on H100 + 9.23.0.39: exactly the five `eng7_k17=4_*` plans fail (ratio ~1.4); every other plan is correct. The same matrix on 9.23.1.3 and 9.23.2.1 is all-correct, so the version gate is exactly `==92300`. Note 9.23.0.39 is a **public PyPI** `nvidia-cudnn-cu12`/`cu13` release, so the silent-garbage window is reachable by real users.

## Why tactic-level (not an envelope ban)

- Default (non-autotuned) execution is correct and stays untouched.
- Explicit `backend="cudnn"` users keep a working backend instead of a raise.
- `autotune(True)` still tunes — just among the correct plans.

Plan names require cudnn-frontend ≥ 1.25 (`get_plan_name_at_index`); without the API the filter falls back to the full list, where the #3539 fuzzer's numeric-only ledger entry still catches a bad winner. This is also a concrete argument for #3707's structured plan names: `eng7_k17=4` is a stable identifier where an integer plan index is version-fragile.

## Validation (H100 + cuDNN 9.23.0.39)

- Offered plans for the repro shape: 15 → 10, all `k17=` plans dropped (names verified).
- 6/6 fresh-cache `autotune(True)` runs correct (worst ratio 0.0026; previously intermittently 1.39).
- Fuzzer seed `1834712400` passes 3/3 deterministically (previously xfail-on-trip).
- SM100: gate inactive, 15/15 plans offered — no behavior change on any other arch/version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bfloat16 GEMM tactic selection for compatible cuDNN and GPU configurations.
  * Prevented known-broken split-k execution plans from being selected, improving reliability.
  * Preserved fallback behavior when plan details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->