### PR TITLE
Disable TMA kernel for nvfp4 quantize

### DIFF
--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -1486,12 +1486,9 @@ _TMA_LOG2_MK_THRESHOLD = 25
 
 
 def _should_use_tma(m: int, k: int, dtype: torch.dtype) -> bool:
-    """Determine if the TMA kernel should be used based on problem dimensions.
+    """TODO: disabled TMA for now due to perf sweep showing the vectorized-load
+    kernel is as fast/at parity.
 
-    The TMA path is disabled by default: a full M/K sweep across all three SF
-    layouts on B200/SM100 found the vectorized-load kernel to be as fast or
-    faster than the TMA kernel everywhere, with the old ``log2(M)+log2(K) >= 25``
-    gate selecting TMA in regions where it was up to ~21% slower (flashinfer#3905).
     Set ``FLASHINFER_NVFP4_QUANTIZE_USE_TMA=1`` to re-enable the heuristic for
     re-tuning on other hardware.
     """

--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -1482,16 +1482,21 @@ def _get_compiled_kernel_nvfp4_per_token(
 
 
 _TMA_MIN_M = 1024
-# TMA wins when the total problem is large enough to amortize pipeline overhead.
-# Empirically, floor(log2(M)) + floor(log2(K)) >= 25 is the crossover where TMA
-# outperforms the default vectorized-load kernel, validated on B200 and SM120.
-# We use bit_length()-1 (i.e., floor(log2)) rather than m*k to keep the boundary
-# aligned with the power-of-2 grid it was tuned on.
 _TMA_LOG2_MK_THRESHOLD = 25
 
 
 def _should_use_tma(m: int, k: int, dtype: torch.dtype) -> bool:
-    """Determine if TMA kernel should be used based on problem dimensions."""
+    """Determine if the TMA kernel should be used based on problem dimensions.
+
+    The TMA path is disabled by default: a full M/K sweep across all three SF
+    layouts on B200/SM100 found the vectorized-load kernel to be as fast or
+    faster than the TMA kernel everywhere, with the old ``log2(M)+log2(K) >= 25``
+    gate selecting TMA in regions where it was up to ~21% slower (flashinfer#3905).
+    Set ``FLASHINFER_NVFP4_QUANTIZE_USE_TMA=1`` to re-enable the heuristic for
+    re-tuning on other hardware.
+    """
+    if not _env_flag_enabled("FLASHINFER_NVFP4_QUANTIZE_USE_TMA"):
+        return False
     if dtype == torch.float8_e4m3fn:
         return False
     if k % _TMA_COLS_PER_STAGE != 0:

--- a/tests/utils/test_fp4_quantize.py
+++ b/tests/utils/test_fp4_quantize.py
@@ -1271,12 +1271,17 @@ def test_nvfp4_quantize_tma_backend_parity(
     shape: tuple[int, int],
     sf_layout: SfLayout,
     device: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that TMA-based CuTe-DSL kernel matches the CUDA backend for large problems."""
     if not _is_fp4_supported(torch.device(device)):
         pytest.skip("Nvfp4 Requires compute capability >= 10 and CUDA >= 12.8")
     if not _is_cute_dsl_available():
         pytest.skip("CuTe-DSL not available")
+
+    # TMA is disabled by default (flashinfer#3905); force it on so this test
+    # still exercises the CuTe-DSL TMA kernel.
+    monkeypatch.setenv("FLASHINFER_NVFP4_QUANTIZE_USE_TMA", "1")
 
     torch.set_default_device(device)
     torch.manual_seed(42)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Quick fix for https://github.com/flashinfer-ai/flashinfer/issues/3905 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * NVFP4 quantization now uses the TMA-based path only when explicitly enabled, providing a more predictable default behavior.
  * Existing TMA selection remains available through the `FLASHINFER_NVFP4_QUANTIZE_USE_TMA` environment setting.

* **Tests**
  * Added coverage to verify parity when the TMA-based NVFP4 quantization path is explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->