### PR TITLE
fix(cutile): skip C loads in the mm_bf16 beta-zero epilogue

### DIFF
--- a/flashinfer/gemm/kernels/cutile/mm_bf16_cutile.py
+++ b/flashinfer/gemm/kernels/cutile/mm_bf16_cutile.py
@@ -145,15 +145,19 @@ def _gemm_alpha_beta_kernel_cutile(
             acc0 = ct.extract(acc, index=(0, 0), shape=(BLOCK_M, BLOCK_N // 2))
             acc1 = ct.extract(acc, index=(0, 1), shape=(BLOCK_M, BLOCK_N // 2))
 
-            c_load0 = ct.load(
-                c_ptr,
-                index=(pid_m, pid_n * 2),
-                shape=(BLOCK_M, BLOCK_N // 2),
-                order=(0, 1),
-                padding_mode=zero_pad,
-            )
-            c_load0_f32 = ct.astype(c_load0, ct.float32)
-            result0 = alpha * acc0 + beta * c_load0_f32
+            # beta is a compile-time constant, so beta=0 specializes away C loads.
+            if beta == 0.0:
+                result0 = alpha * acc0
+            else:
+                c_load0 = ct.load(
+                    c_ptr,
+                    index=(pid_m, pid_n * 2),
+                    shape=(BLOCK_M, BLOCK_N // 2),
+                    order=(0, 1),
+                    padding_mode=zero_pad,
+                )
+                c_load0_f32 = ct.astype(c_load0, ct.float32)
+                result0 = alpha * acc0 + beta * c_load0_f32
             c_block0 = ct.astype(result0, c_ptr.dtype)
             ct.store(
                 c_ptr,
@@ -162,15 +166,18 @@ def _gemm_alpha_beta_kernel_cutile(
                 order=(0, 1),
             )
 
-            c_load1 = ct.load(
-                c_ptr,
-                index=(pid_m, pid_n * 2 + 1),
-                shape=(BLOCK_M, BLOCK_N // 2),
-                order=(0, 1),
-                padding_mode=zero_pad,
-            )
-            c_load1_f32 = ct.astype(c_load1, ct.float32)
-            result1 = alpha * acc1 + beta * c_load1_f32
+            if beta == 0.0:
+                result1 = alpha * acc1
+            else:
+                c_load1 = ct.load(
+                    c_ptr,
+                    index=(pid_m, pid_n * 2 + 1),
+                    shape=(BLOCK_M, BLOCK_N // 2),
+                    order=(0, 1),
+                    padding_mode=zero_pad,
+                )
+                c_load1_f32 = ct.astype(c_load1, ct.float32)
+                result1 = alpha * acc1 + beta * c_load1_f32
             c_block1 = ct.astype(result1, c_ptr.dtype)
             ct.store(
                 c_ptr,
@@ -179,15 +186,19 @@ def _gemm_alpha_beta_kernel_cutile(
                 order=(0, 1),
             )
         else:
-            c_load = ct.load(
-                c_ptr,
-                index=(pid_m, pid_n),
-                shape=(BLOCK_M, BLOCK_N),
-                order=(0, 1),
-                padding_mode=zero_pad,
-            )
-            c_load_f32 = ct.astype(c_load, ct.float32)
-            result = alpha * acc + beta * c_load_f32
+            # beta is a compile-time constant, so beta=0 specializes away the C load.
+            if beta == 0.0:
+                result = alpha * acc
+            else:
+                c_load = ct.load(
+                    c_ptr,
+                    index=(pid_m, pid_n),
+                    shape=(BLOCK_M, BLOCK_N),
+                    order=(0, 1),
+                    padding_mode=zero_pad,
+                )
+                c_load_f32 = ct.astype(c_load, ct.float32)
+                result = alpha * acc + beta * c_load_f32
             c_block = ct.astype(result, c_ptr.dtype)
             ct.store(
                 c_ptr,
@@ -328,7 +339,8 @@ def _compute_grid_and_programs(
 
 
 # Module-level tune cache:
-#   key: (M, N, K, transpose_a_int, transpose_b_int, dtype, num_sms, str(device))
+#   key: (M, N, K, transpose_a_int, transpose_b_int, beta_is_zero,
+#         input_dtype, output_dtype, num_sms, str(device))
 #   value: (best_cfg, ct.kernel(...) bound to the chosen num_ctas/occupancy)
 _TUNE_CACHE: dict = {}
 
@@ -489,13 +501,15 @@ def _gemm_alpha_beta_cutile(
 
         # Include ``c.dtype`` because the kernel's store dtype is determined by
         # ``c_ptr.dtype`` — different output dtypes produce different specialized
-        # kernels, so they must autotune separately.
+        # kernels, so they must autotune separately. Likewise, beta=0 removes all
+        # C loads and has a different epilogue cost from beta!=0.
         cache_key = (
             M,
             N,
             K,
             transpose_a_int,
             transpose_b_int,
+            beta == 0.0,
             a.dtype,
             c.dtype,
             num_sms,
@@ -699,26 +713,10 @@ def mm_bf16_cutile(
     cheaply via ``b.transpose(-2, -1)`` (zero-copy on the storage layer that
     `mm_bf16` itself produced).
     """
-    # NaN-poisoning guard: the underlying alpha-beta GEMM kernel computes
-    #   result = alpha * acc + beta * c_load_f32
-    # Even with ``beta == 0.0``, IEEE 754 specifies ``0 * NaN == NaN`` (and
-    # likewise ``0 * Inf == NaN``), so any NaN already sitting in the storage
-    # backing ``out`` poisons every output element.
-    #
-    # ``mm_bf16`` callers typically allocate ``out`` via ``torch.empty(...)``,
-    # which leaves the buffer uninitialized. CUDA's caching allocator may
-    # return memory whose previous occupant left NaN bits — which then leak
-    # through the beta=0 epilogue path and produce all-NaN output non-
-    # deterministically (depending on allocator state).
-    #
-    # Zeroing ``out`` here costs ~one fused memset; on B200 BF16 GEMM shapes
-    # this is well under 1% of total kernel time. The proper long-term fix is
-    # a beta=0 specialization that skips the c_load entirely (follow-up).
     if a.dtype != torch.bfloat16 or b.dtype != torch.bfloat16:
         raise ValueError(
             f"mm_bf16_cutile requires bf16 a and b; got a.dtype={a.dtype}, b.dtype={b.dtype}"
         )
-    out.zero_()
 
     # Recover (N, K) row-major contiguous view that the kernel expects.
     # The upstream caller produces b as `(N, K).transpose(-2, -1)`, so undoing

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -100,6 +100,52 @@ def test_mm_bf16(
     assert cos_sim > 0.99
 
 
+@pytest.mark.parametrize("epilogue_subtile", [False, True])
+@pytest.mark.parametrize("beta", [0.0, 0.5])
+def test_gemm_alpha_beta_cutile_epilogue(beta, epilogue_subtile):
+    """beta=0 must ignore a NaN-poisoned C; beta!=0 must still accumulate C."""
+    compute_capability = get_compute_capability(torch.device("cuda"))
+    cc_num = compute_capability[0] * 10 + compute_capability[1]
+    if not mm_bf16.is_backend_supported("cutile", cc_num):
+        pytest.skip("cuTile backend not supported on current compute capability.")
+    if not is_cuda_tile_available():
+        pytest.skip("cuda-tile / tileiras compiler not available in this environment.")
+    if epilogue_subtile and cc_num != 100:
+        pytest.skip("Epilogue subtiling is only validated on SM100.")
+
+    from flashinfer.gemm.kernels.cutile.mm_bf16_cutile import (
+        _gemm_alpha_beta_cutile,
+    )
+
+    torch.manual_seed(42)
+    a = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16) * 0.1
+    b = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16) * 0.1
+    if beta == 0.0:
+        c = torch.full((128, 128), float("nan"), device="cuda", dtype=torch.bfloat16)
+    else:
+        # Make the C contribution dominate so accidentally dropping the C load
+        # cannot still pass a loose similarity check.
+        c = torch.full((128, 128), 2.0, device="cuda", dtype=torch.bfloat16)
+    c_before = c.clone()
+    reference = torch.addmm(c_before, a, b.T, beta=beta, alpha=0.5)
+
+    result = _gemm_alpha_beta_cutile(
+        a,
+        b,
+        c,
+        trans_a=False,
+        trans_b=True,
+        alpha=0.5,
+        beta=beta,
+        use_autotune=False,
+        kernel_configs={"EPILOGUE_SUBTILE": int(epilogue_subtile)},
+    )
+
+    assert result.data_ptr() == c.data_ptr()
+    assert torch.isfinite(result).all()
+    torch.testing.assert_close(result, reference, rtol=0.02, atol=0.02)
+
+
 def test_mm_bf16_cutile_rejects_bias_and_pdl():
     """The v1 cuTile path is alpha=1/beta=0 and ignores bias / pdl — must raise.
 


### PR DESCRIPTION

## 📌 Description

Specialize the cuTile `mm_bf16` epilogue for `beta == 0` to skip loading `C`

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the pre-commit hooks.
- [x] I have run `pre-commit run --all-files`, and all checks passed.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] The targeted tests pass on (SM90、SM100).

```bash
python -m pytest -q \
  tests/gemm/test_mm_bf16.py::test_gemm_alpha_beta_cutile_epilogue
```


## Reviewer Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved BF16 matrix multiplication when `beta` is zero by avoiding unnecessary reads from the existing output matrix.
  - Prevented invalid or uninitialized output values from affecting results in this scenario.
  - Ensured tuned performance configurations remain accurate for different `beta` values.

- **Tests**
  - Added coverage for alpha/beta behavior, including NaN-containing inputs and multiple epilogue configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->