### PR TITLE
[feat] Add TRTLLM/SageAttention quantization routine

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/common/sageQuant.cu
+++ b/csrc/nv_internal/tensorrt_llm/common/sageQuant.cu
@@ -1,0 +1,342 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION &
+ * AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cutlass/array.h>
+#include <cutlass/numeric_conversion.h>
+#include <flashinfer/exception.h>
+#include <flashinfer/trtllm/common/sageQuant.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cute/tensor.hpp>
+#include <type_traits>
+
+namespace flashinfer::trtllm {
+
+// SageAttention quantization kernel. Tensors are interpreted as column-major
+// [D, H, S], which is the same physical layout as contiguous PyTorch [S, H, D].
+// Each launch quantizes Q or K. It can simultaneously collect V scales
+// (VStage=1) or quantize V using scales collected by an earlier launch
+// (VStage=2).
+template <typename Element, typename ElementQuantized, int TokenPerScale, int HeadDim, bool KSmooth,
+          int VStage>
+__global__ void sageQuantQkvKernel(int sumSeqLensQk, void const* ptrQk, void* ptrQkQuant,
+                                   float* ptrQkScale, float* ptrKMean, int sumSeqLensV,
+                                   int numHeadsV, void const* ptrV, void* ptrVQuant,
+                                   float* ptrVScale) {
+  using namespace cute;
+  using namespace cutlass;
+  static_assert(!KSmooth, "K-smoothing not implemented yet");
+  static_assert(std::is_same_v<ElementQuantized, float_e4m3_t> ||
+                    std::is_same_v<ElementQuantized, std::int8_t>,
+                "Unrecognized target dtype for quantization");
+  constexpr float TypeMax =
+      cute::is_same_v<ElementQuantized, float_e4m3_t> ? 448.0f : static_cast<float>(126.9f);
+  constexpr int BestVL = 128 / sizeof_bits_v<Element>;
+  using VL = Int<BestVL>;
+
+  (void)ptrKMean;
+
+  int const numHeads = gridDim.y;
+  int const headIdx = blockIdx.y;
+  int const numWarpsPerCta = blockDim.x / 32;
+  int const numWarps = gridDim.x * numWarpsPerCta;
+  int const warpId = blockIdx.x * numWarpsPerCta + threadIdx.x / 32;
+  int const thrId = threadIdx.x % 32;
+
+  if (blockIdx.z == 0) {
+    Tensor gQk = make_tensor(reinterpret_cast<Element const*>(ptrQk),
+                             make_shape(Int<HeadDim>{}, numHeads, sumSeqLensQk));
+    Tensor gQkQuant = make_tensor(reinterpret_cast<ElementQuantized*>(ptrQkQuant),
+                                  make_shape(Int<HeadDim>{}, numHeads, sumSeqLensQk));
+    Tensor gQkScale =
+        make_tensor(ptrQkScale, make_shape(ceil_div(sumSeqLensQk, TokenPerScale), numHeads));
+
+    Tensor gQkSeq = gQk(_, headIdx, _);
+    Tensor gQkSeqQuant = gQkQuant(_, headIdx, _);
+    Tensor gQkSeqScale = gQkScale(_, headIdx);
+    Tensor gQkVecs = tiled_divide(gQkSeq, Shape<VL, Int<TokenPerScale>>{});
+    Tensor gQkVecsQuant = tiled_divide(gQkSeqQuant, Shape<VL, Int<TokenPerScale>>{});
+
+    Tensor rQk = make_tensor<Element>(Shape<VL, Int<TokenPerScale>>{});
+    Tensor rQkQuant = make_tensor<ElementQuantized>(Shape<VL, Int<TokenPerScale>>{});
+    Tensor rQkCompute = make_tensor<float>(Shape<VL, Int<TokenPerScale>>{});
+    Tensor rQk_x2 = recast<Array<Element, 2>>(rQk);
+    Tensor rQkCompute_x2 = recast<Array<float, 2>>(rQkCompute);
+    Tensor rQk_x4 = recast<Array<Element, 4>>(rQk);
+    Tensor rQkQuant_x4 = recast<Array<ElementQuantized, 4>>(rQkQuant);
+
+    constexpr int threadsPerScale = size<1>(gQkVecs);
+    static_assert(threadsPerScale <= 32, "One token block should never exceed warp scope");
+    int const numScalesPerWarp = 32 / threadsPerScale;
+    int const numScalesPerWave = numWarps * numScalesPerWarp;
+    int const numWholeScales = sumSeqLensQk / TokenPerScale;
+    int tokBlkIdx = warpId * numScalesPerWarp + thrId / threadsPerScale;
+    int const threadInScaleIdx = thrId % threadsPerScale;
+
+    for (; tokBlkIdx < numWholeScales; tokBlkIdx += numScalesPerWave) {
+      cute::copy(AutoVectorizingCopy{}, gQkVecs(_, threadInScaleIdx, tokBlkIdx), rQk);
+      cute::transform(rQk_x2, rQkCompute_x2, NumericArrayConverter<float, Element, 2>::convert);
+
+      float maxScale = 1e-3f;
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(rQk); ++i) {
+        maxScale = ::fmaxf(maxScale, ::fabsf(rQkCompute(i)));
+      }
+      CUTLASS_PRAGMA_UNROLL
+      for (int delta = 1; delta < threadsPerScale; delta <<= 1) {
+        maxScale = ::fmaxf(maxScale, __shfl_xor_sync(0xffffffffu, maxScale, delta));
+      }
+
+      maxScale /= TypeMax;
+      gQkSeqScale(tokBlkIdx) = maxScale;
+      Array<Element, 2> scaleQuant =
+          NumericArrayConverter<Element, float, 2>::convert(Array<float, 2>{maxScale, maxScale});
+      scaleQuant = cutlass::reciprocal_approximate<Array<Element, 2>>{}(scaleQuant);
+      cutlass::multiplies<Array<Element, 2>> scaleQuantOp;
+      cute::transform(rQk_x2, rQk_x2, [&](auto& x) { return scaleQuantOp(x, scaleQuant); });
+      cute::transform(rQk_x4, rQkQuant_x4,
+                      NumericArrayConverter<ElementQuantized, Element, 4>::convert);
+      cute::copy(AutoVectorizingCopy{}, rQkQuant, gQkVecsQuant(_, threadInScaleIdx, tokBlkIdx));
+    }
+
+    int const lastIterTokenIdx = tokBlkIdx * TokenPerScale;
+    if (lastIterTokenIdx < sumSeqLensQk) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size<1>(rQk); ++i) {
+        if (lastIterTokenIdx + i < sumSeqLensQk) {
+          cute::copy(AutoVectorizingCopy{}, gQkVecs(make_tuple(_, i), threadInScaleIdx, tokBlkIdx),
+                     rQk(_, i));
+        } else {
+          CUTLASS_PRAGMA_UNROLL
+          for (int j = 0; j < BestVL; ++j) {
+            rQk(j, i) = static_cast<Element>(0);
+          }
+        }
+      }
+      cute::transform(rQk_x2, rQkCompute_x2, NumericArrayConverter<float, Element, 2>::convert);
+
+      float maxScale = 1e-3f;
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(rQk); ++i) {
+        maxScale = ::fmaxf(maxScale, ::fabsf(rQkCompute(i)));
+      }
+      CUTLASS_PRAGMA_UNROLL
+      for (int delta = 1; delta < threadsPerScale; delta <<= 1) {
+        maxScale = ::fmaxf(maxScale, __shfl_xor_sync(0xffffffffu, maxScale, delta));
+      }
+
+      maxScale /= TypeMax;
+      gQkSeqScale(tokBlkIdx) = maxScale;
+      Array<Element, 2> scaleQuant =
+          NumericArrayConverter<Element, float, 2>::convert(Array<float, 2>{maxScale, maxScale});
+      scaleQuant = cutlass::reciprocal_approximate<Array<Element, 2>>{}(scaleQuant);
+      cutlass::multiplies<Array<Element, 2>> scaleQuantOp;
+      cute::transform(rQk_x2, rQk_x2, [&](auto& x) { return scaleQuantOp(x, scaleQuant); });
+      cute::transform(rQk_x4, rQkQuant_x4,
+                      NumericArrayConverter<ElementQuantized, Element, 4>::convert);
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size<1>(rQk); ++i) {
+        if (lastIterTokenIdx + i < sumSeqLensQk) {
+          cute::copy(AutoVectorizingCopy{}, rQkQuant(_, i),
+                     gQkVecsQuant(make_tuple(_, i), threadInScaleIdx, tokBlkIdx));
+        }
+      }
+    }
+  } else if (blockIdx.z == 1) {
+    using ElementQuantizedV = cutlass::float_e4m3_t;
+    constexpr int threadsPerHead = HeadDim / BestVL;
+    static_assert(HeadDim % BestVL == 0, "VL must divide HeadDim");
+    static_assert(threadsPerHead <= 32, "One token block should never exceed warp scope");
+    Tensor gV = make_tensor(reinterpret_cast<Element const*>(ptrV),
+                            make_shape(VL{}, Int<threadsPerHead>{}, numHeadsV, sumSeqLensV));
+    Tensor gVQuant = make_tensor(reinterpret_cast<ElementQuantizedV*>(ptrVQuant),
+                                 make_shape(VL{}, Int<threadsPerHead>{}, numHeadsV, sumSeqLensV));
+    Tensor gVScale = make_tensor(ptrVScale, make_shape(VL{}, Int<threadsPerHead>{}, numHeadsV));
+
+    Tensor rV = make_tensor<Element>(Shape<VL>{});
+    Tensor rVMax = make_tensor<Element>(Shape<VL>{});
+    Tensor rVQuant = make_tensor<ElementQuantizedV>(Shape<VL>{});
+    Tensor rVScale = make_tensor<float>(Shape<VL>{});
+    Tensor rVCompute = make_tensor<float>(Shape<VL>{});
+    Tensor rV_x2 = recast<Array<Element, 2>>(rV);
+    Tensor rVMax_x2 = recast<Array<Element, 2>>(rVMax);
+    Tensor rVScale_x2 = recast<Array<float, 2>>(rVScale);
+    Tensor rVCompute_x2 = recast<Array<float, 2>>(rVCompute);
+    Tensor rVCompute_x4 = recast<Array<float, 4>>(rVCompute);
+    Tensor rVQuant_x4 = recast<Array<ElementQuantizedV, 4>>(rVQuant);
+
+    if (headIdx < numHeadsV) {
+      int const numToksPerWarp = 32 / threadsPerHead;
+      int tokIdx = warpId * numToksPerWarp + thrId / threadsPerHead;
+      int const threadInTokIdx = thrId % threadsPerHead;
+      Tensor gVSeq = gV(_, threadInTokIdx, headIdx, _);
+      Tensor gVSeqQuant = gVQuant(_, threadInTokIdx, headIdx, _);
+      Tensor gVSeqScale = gVScale(_, threadInTokIdx, headIdx);
+
+      if constexpr (VStage == 1) {
+        int const numWarpsToUse = cutlass::fast_min(numWarps, 256);
+        int const numToksPerWave = numWarpsToUse * numToksPerWarp;
+        if (warpId >= numWarpsToUse) {
+          return;
+        }
+        CUTLASS_PRAGMA_UNROLL
+        for (int i = 0; i < size(rVScale); ++i) {
+          rVScale(i) = 1e-3f;
+        }
+        cute::transform(rVScale_x2, rVMax_x2,
+                        cutlass::NumericArrayConverter<Element, float, 2>::convert);
+        for (; tokIdx < sumSeqLensV; tokIdx += numToksPerWave) {
+          cute::copy(AutoVectorizingCopy{}, gVSeq(_, tokIdx), rV);
+          cute::transform(rV_x2, rV_x2, cutlass::absolute_value_op<Array<Element, 2>>{});
+          cute::transform(rV_x2, rVMax_x2, rVMax_x2, cutlass::maximum<Array<Element, 2>>{});
+        }
+        cute::transform(rVMax_x2, rVScale_x2,
+                        cutlass::NumericArrayConverter<float, Element, 2>::convert);
+        cute::transform(rVScale_x2, rVScale_x2, cutlass::scale<Array<float, 2>>{1 / 448.0f});
+        for (int delta = threadsPerHead; delta < 32; delta <<= 1) {
+          cute::transform(rVScale, rVScale, [&](auto const& x) {
+            return ::fmaxf(x, __shfl_xor_sync(0xffffffffu, x, delta));
+          });
+        }
+        if (threadInTokIdx == thrId) {
+          CUTLASS_PRAGMA_UNROLL
+          for (int i = 0; i < BestVL; ++i) {
+            atomicMax(reinterpret_cast<int32_t*>(&gVSeqScale(i)),
+                      *reinterpret_cast<int32_t const*>(&rVScale(i)));
+          }
+        }
+      } else if constexpr (VStage == 2) {
+        int const numToksPerWave = numWarps * numToksPerWarp;
+        cute::copy(AutoVectorizingCopy{}, gVSeqScale, rVScale);
+        cute::transform(rVScale_x2, rVScale_x2, cutlass::reciprocal_approximate<Array<float, 2>>{});
+        for (; tokIdx < sumSeqLensV; tokIdx += numToksPerWave) {
+          cute::copy(AutoVectorizingCopy{}, gVSeq(_, tokIdx), rV);
+          cute::transform(rV_x2, rVCompute_x2,
+                          cutlass::NumericArrayConverter<float, Element, 2>::convert);
+          cute::transform(rVCompute_x2, rVScale_x2, rVCompute_x2,
+                          cutlass::multiplies<Array<float, 2>>{});
+          cute::transform(rVCompute_x4, rVQuant_x4,
+                          cutlass::NumericArrayConverter<ElementQuantizedV, float, 4>::convert);
+          cute::copy(AutoVectorizingCopy{}, rVQuant, gVSeqQuant(_, tokIdx));
+        }
+      }
+    }
+  }
+}
+
+template <typename Element>
+void invokeSageQuantQkvImpl(SageQuantParams const& params) {
+  using namespace cute;
+  FLASHINFER_CHECK(params.sumSeqLensQk > 0 && params.numHeads > 0 && params.headDim > 0 &&
+                       params.tokenBlockSize > 0 && params.ptrQk != nullptr &&
+                       params.ptrQkQuant != nullptr && params.ptrQkScale != nullptr &&
+                       params.smCount > 0,
+                   "Invalid SageQuantQk parameters");
+  FLASHINFER_CHECK(params.vStage == 0 ||
+                       (params.sumSeqLensV > 0 && params.numHeadsV > 0 && params.ptrV != nullptr &&
+                        params.ptrVQuant != nullptr && params.ptrVScale != nullptr),
+                   "Invalid SageQuantV parameters");
+  FLASHINFER_CHECK(!params.kSmooth, "SageQuantQk K-smoothing is not supported yet");
+
+  auto invokeKernel = [&](auto headDimStatic, auto tokenBlockSizeStatic) {
+    constexpr int HeadDim_ = headDimStatic;
+    constexpr int TokenBlockSize_ = tokenBlockSizeStatic;
+    SageQuantParams kernelParams = params;
+    void* kernelArgs[] = {&kernelParams.sumSeqLensQk, &kernelParams.ptrQk,
+                          &kernelParams.ptrQkQuant,   &kernelParams.ptrQkScale,
+                          &kernelParams.ptrKMean,     &kernelParams.sumSeqLensV,
+                          &kernelParams.numHeadsV,    &kernelParams.ptrV,
+                          &kernelParams.ptrVQuant,    &kernelParams.ptrVScale};
+
+    auto launchWithVStage = [&](auto vStageStatic) {
+      constexpr int VStage_ = vStageStatic;
+      void const* kernelFunc = nullptr;
+      if (params.quantType == DATA_TYPE_E4M3) {
+        kernelFunc = reinterpret_cast<void const*>(
+            sageQuantQkvKernel<Element, cutlass::float_e4m3_t, TokenBlockSize_, HeadDim_, false,
+                               VStage_>);
+      } else if (params.quantType == DATA_TYPE_INT8) {
+        kernelFunc = reinterpret_cast<void const*>(
+            sageQuantQkvKernel<Element, std::int8_t, TokenBlockSize_, HeadDim_, false, VStage_>);
+      } else {
+        FLASHINFER_ERROR("SageQuant Q/K output must be INT8 or FP8 E4M3");
+      }
+      uint32_t const gridX =
+          static_cast<uint32_t>(std::max(1, (params.smCount * 32) / params.numHeads));
+      dim3 const launchGrid{gridX, static_cast<uint32_t>(params.numHeads), VStage_ > 0 ? 2U : 1U};
+      auto status =
+          cudaLaunchKernel(kernelFunc, launchGrid, dim3{64U, 1U, 1U}, kernelArgs, 0, params.stream);
+      FLASHINFER_CHECK(status == cudaSuccess, cudaGetErrorString(status));
+      status = cudaPeekAtLastError();
+      FLASHINFER_CHECK(status == cudaSuccess, cudaGetErrorString(status));
+    };
+
+    switch (params.vStage) {
+      case 0:
+        launchWithVStage(Int<0>{});
+        return;
+      case 1:
+        launchWithVStage(Int<1>{});
+        return;
+      case 2:
+        launchWithVStage(Int<2>{});
+        return;
+      default:
+        FLASHINFER_ERROR("Unsupported SageQuantV stage");
+    }
+  };
+
+#define FLASHINFER_SAGE_DISPATCH_HEAD_DIM(HEAD_DIM) \
+  if (params.headDim == HEAD_DIM) {                 \
+    switch (params.tokenBlockSize) {                \
+      case 1:                                       \
+        invokeKernel(Int<HEAD_DIM>{}, Int<1>{});    \
+        return;                                     \
+      case 4:                                       \
+        invokeKernel(Int<HEAD_DIM>{}, Int<4>{});    \
+        return;                                     \
+      case 16:                                      \
+        invokeKernel(Int<HEAD_DIM>{}, Int<16>{});   \
+        return;                                     \
+      default:                                      \
+        break;                                      \
+    }                                               \
+  }
+  FLASHINFER_SAGE_DISPATCH_HEAD_DIM(64)
+  FLASHINFER_SAGE_DISPATCH_HEAD_DIM(128)
+  FLASHINFER_SAGE_DISPATCH_HEAD_DIM(256)
+#undef FLASHINFER_SAGE_DISPATCH_HEAD_DIM
+  FLASHINFER_ERROR(
+      "Unsupported SageQuant dispatch config (head_dim must be 64, 128, or 256; "
+      "token_block_size must be 1, 4, or 16)");
+}
+
+void invokeSageQuant(SageQuantParams const& params) {
+  if (params.inputType == DATA_TYPE_FP16) {
+    invokeSageQuantQkvImpl<cutlass::half_t>(params);
+    return;
+  }
+  if (params.inputType == DATA_TYPE_BF16) {
+    invokeSageQuantQkvImpl<cutlass::bfloat16_t>(params);
+    return;
+  }
+  FLASHINFER_ERROR("SageQuant input must be FP16 or BF16");
+}
+
+}  // namespace flashinfer::trtllm

--- a/csrc/trtllm_sage_quant.cu
+++ b/csrc/trtllm_sage_quant.cu
@@ -78,6 +78,7 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
   TVM_FFI_ICHECK_EQ(v_scale.numel(), value.size(1) * value.size(2));
   TVM_FFI_ICHECK_GT(sm_count, 0);
 
+  ffi::CUDADeviceGuard device_guard(query.device().device_id);
   auto const stream = get_stream(query.device());
   auto const memset_status =
       cudaMemsetAsync(v_scale.data_ptr(), 0, v_scale.numel() * sizeof(float), stream);

--- a/csrc/trtllm_sage_quant.cu
+++ b/csrc/trtllm_sage_quant.cu
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <flashinfer/trtllm/common.h>
+#include <flashinfer/trtllm/common/sageQuant.h>
+
+#include "tvm_ffi_utils.h"
+
+namespace flashinfer {
+
+using trtllm::invokeSageQuant;
+using trtllm::SageQuantParams;
+
+void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, TensorView v_quant,
+                                    TensorView q_scale, TensorView k_scale, TensorView v_scale,
+                                    TensorView query, TensorView key, TensorView value,
+                                    int64_t q_block_size, int64_t k_block_size, int64_t sm_count) {
+  TVM_FFI_ICHECK_EQ(query.ndim(), 3) << "query must have shape [tokens, heads, head_dim]";
+  TVM_FFI_ICHECK_EQ(key.ndim(), 3) << "key must have shape [tokens, heads, head_dim]";
+  TVM_FFI_ICHECK_EQ(value.ndim(), 3) << "value must have shape [tokens, heads, head_dim]";
+  TVM_FFI_ICHECK_EQ(query.dtype(), key.dtype()) << "query and key must have the same dtype";
+  TVM_FFI_ICHECK_EQ(query.dtype(), value.dtype()) << "query and value must have the same dtype";
+  TVM_FFI_ICHECK(query.dtype() == dl_float16 || query.dtype() == dl_bfloat16)
+      << "SageQuant inputs must be float16 or bfloat16";
+  TVM_FFI_ICHECK_EQ(query.size(2), key.size(2))
+      << "query and key must have the same head dimension";
+  TVM_FFI_ICHECK_EQ(key.size(2), value.size(2))
+      << "key and value must have the same head dimension";
+  TVM_FFI_ICHECK_EQ(key.size(0), value.size(0)) << "key and value must have the same token count";
+  TVM_FFI_ICHECK_EQ(key.size(1), value.size(1)) << "key and value must have the same head count";
+  auto const is_contiguous_3d = [](TensorView tensor) {
+    return tensor.stride(2) == 1 && tensor.stride(1) == tensor.size(2) &&
+           tensor.stride(0) == tensor.size(1) * tensor.size(2);
+  };
+  TVM_FFI_ICHECK(is_contiguous_3d(query)) << "query must be contiguous";
+  TVM_FFI_ICHECK(is_contiguous_3d(key)) << "key must be contiguous";
+  TVM_FFI_ICHECK(is_contiguous_3d(value)) << "value must be contiguous";
+
+  TVM_FFI_ICHECK_EQ(q_quant.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(k_quant.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(v_quant.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(q_quant.numel(), query.numel());
+  TVM_FFI_ICHECK_EQ(k_quant.numel(), key.numel());
+  TVM_FFI_ICHECK_EQ(v_quant.numel(), value.numel());
+  TVM_FFI_ICHECK_EQ(q_quant.dtype(), k_quant.dtype());
+  TVM_FFI_ICHECK(q_quant.dtype() == dl_int8 || q_quant.dtype() == dl_float8_e4m3fn)
+      << "quantized Q/K tensors must be int8 or float8_e4m3fn";
+  TVM_FFI_ICHECK_EQ(v_quant.dtype(), dl_float8_e4m3fn)
+      << "quantized V tensor must be float8_e4m3fn";
+  TVM_FFI_ICHECK(is_contiguous_3d(q_quant) && is_contiguous_3d(k_quant) &&
+                 is_contiguous_3d(v_quant))
+      << "quantized outputs must be contiguous";
+
+  TVM_FFI_ICHECK_EQ(q_scale.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(k_scale.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(v_scale.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(q_scale.numel(),
+                    query.size(1) * ((query.size(0) + q_block_size - 1) / q_block_size));
+  TVM_FFI_ICHECK_EQ(k_scale.numel(),
+                    key.size(1) * ((key.size(0) + k_block_size - 1) / k_block_size));
+  TVM_FFI_ICHECK_EQ(v_scale.numel(), value.size(1) * value.size(2));
+  TVM_FFI_ICHECK(q_block_size == 1 || q_block_size == 4 || q_block_size == 16)
+      << "q_block_size must be 1, 4, or 16";
+  TVM_FFI_ICHECK(k_block_size == 1 || k_block_size == 4 || k_block_size == 16)
+      << "k_block_size must be 1, 4, or 16";
+  TVM_FFI_ICHECK_GT(sm_count, 0);
+
+  auto const stream = get_stream(query.device());
+  auto const memset_status =
+      cudaMemsetAsync(v_scale.data_ptr(), 0, v_scale.numel() * sizeof(float), stream);
+  TVM_FFI_ICHECK_EQ(memset_status, cudaSuccess) << cudaGetErrorString(memset_status);
+
+  SageQuantParams params{};
+  params.headDim = query.size(2);
+  params.inputType = query.dtype() == dl_float16 ? DATA_TYPE_FP16 : DATA_TYPE_BF16;
+  params.quantType = q_quant.dtype() == dl_int8 ? DATA_TYPE_INT8 : DATA_TYPE_E4M3;
+  params.sumSeqLensV = value.size(0);
+  params.numHeadsV = value.size(1);
+  params.ptrV = value.data_ptr();
+  params.ptrVQuant = v_quant.data_ptr();
+  params.ptrVScale = static_cast<float*>(v_scale.data_ptr());
+  params.smCount = sm_count;
+  params.stream = stream;
+
+  params.sumSeqLensQk = query.size(0);
+  params.numHeads = query.size(1);
+  params.tokenBlockSize = q_block_size;
+  params.ptrQk = query.data_ptr();
+  params.ptrQkQuant = q_quant.data_ptr();
+  params.ptrQkScale = static_cast<float*>(q_scale.data_ptr());
+  params.vStage = 1;
+  invokeSageQuant(params);
+
+  params.sumSeqLensQk = key.size(0);
+  params.numHeads = key.size(1);
+  params.tokenBlockSize = k_block_size;
+  params.ptrQk = key.data_ptr();
+  params.ptrQkQuant = k_quant.data_ptr();
+  params.ptrQkScale = static_cast<float*>(k_scale.data_ptr());
+  params.vStage = 2;
+  invokeSageQuant(params);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_sage_attention_quantize, trtllm_sage_attention_quantize);
+
+}  // namespace flashinfer

--- a/csrc/trtllm_sage_quant.cu
+++ b/csrc/trtllm_sage_quant.cu
@@ -64,6 +64,10 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
                  is_contiguous_3d(v_quant))
       << "quantized outputs must be contiguous";
 
+  TVM_FFI_ICHECK(q_block_size == 1 || q_block_size == 4 || q_block_size == 16)
+      << "q_block_size must be 1, 4, or 16";
+  TVM_FFI_ICHECK(k_block_size == 1 || k_block_size == 4 || k_block_size == 16)
+      << "k_block_size must be 1, 4, or 16";
   TVM_FFI_ICHECK_EQ(q_scale.dtype(), dl_float32);
   TVM_FFI_ICHECK_EQ(k_scale.dtype(), dl_float32);
   TVM_FFI_ICHECK_EQ(v_scale.dtype(), dl_float32);
@@ -72,10 +76,6 @@ void trtllm_sage_attention_quantize(TensorView q_quant, TensorView k_quant, Tens
   TVM_FFI_ICHECK_EQ(k_scale.numel(),
                     key.size(1) * ((key.size(0) + k_block_size - 1) / k_block_size));
   TVM_FFI_ICHECK_EQ(v_scale.numel(), value.size(1) * value.size(2));
-  TVM_FFI_ICHECK(q_block_size == 1 || q_block_size == 4 || q_block_size == 16)
-      << "q_block_size must be 1, 4, or 16";
-  TVM_FFI_ICHECK(k_block_size == 1 || k_block_size == 4 || k_block_size == 16)
-      << "k_block_size must be 1, 4, or 16";
   TVM_FFI_ICHECK_GT(sm_count, 0);
 
   auto const stream = get_stream(query.device());

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -181,6 +181,9 @@ from .prefill import (
     single_prefill_with_kv_cache_return_lse as single_prefill_with_kv_cache_return_lse,
 )
 from .prefill import trtllm_fmha_v2_prefill as trtllm_fmha_v2_prefill
+from .prefill import (
+    trtllm_sage_attention_quantize as trtllm_sage_attention_quantize,
+)
 from .quantization import packbits as packbits
 from .quantization import segment_packbits as segment_packbits
 from .rope import apply_llama31_rope as apply_llama31_rope

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1886,6 +1886,9 @@ def gen_trtllm_gen_fmha_module():
         [
             jit_env.FLASHINFER_CSRC_DIR / "trtllm_fmha_kernel_launcher.cu",
             jit_env.FLASHINFER_CSRC_DIR / "fmhaReduction.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "trtllm_sage_quant.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "nv_internal/tensorrt_llm/common/sageQuant.cu",
         ],
         # link "include" sub-directory in cache
         extra_include_paths=[jit_env.FLASHINFER_CUBIN_DIR / include_path],

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4302,6 +4302,108 @@ def get_trtllm_gen_fmha_module():
     return op
 
 
+def trtllm_sage_attention_quantize(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    q_block_size: int = 1,
+    k_block_size: int = 16,
+    qk_quant_dtype: torch.dtype = torch.int8,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Quantize Q/K/V into the layout consumed by TRTLLM SageAttention.
+
+    Q and K use per-token-block scaling and can be quantized to INT8 or FP8
+    E4M3. V is always quantized to FP8 E4M3 with one scale per head channel.
+    All inputs use contiguous ``[tokens, heads, head_dim]`` layout.
+
+    Parameters
+    ----------
+    query, key, value : torch.Tensor
+        FP16 or BF16 CUDA tensors. Key and value must have matching token and
+        head counts, and all three tensors must have the same head dimension.
+    q_block_size, k_block_size : int
+        Number of tokens sharing each Q or K scale. Supported values are 1, 4,
+        and 16.
+    qk_quant_dtype : torch.dtype
+        ``torch.int8`` (the SageAttention INT8 path) or
+        ``torch.float8_e4m3fn``.
+
+    Returns
+    -------
+    (q_quant, k_quant, v_quant, q_scale, k_scale, v_scale)
+        Quantized Q/K/V followed by their FP32 dequantization scales. Q and K
+        scales have shapes ``[q_heads, ceil(q_tokens / q_block_size)]`` and
+        ``[kv_heads, ceil(kv_tokens / k_block_size)]``. V scales have shape
+        ``[kv_heads, head_dim]``. These outputs can be passed directly to
+        :func:`trtllm_ragged_attention_deepseek`.
+    """
+    if query.dtype not in (torch.float16, torch.bfloat16):
+        raise ValueError(f"query must be float16 or bfloat16, got {query.dtype}")
+    if key.dtype != query.dtype or value.dtype != query.dtype:
+        raise ValueError("query, key, and value must have the same dtype")
+    if query.device.type != "cuda":
+        raise ValueError("query, key, and value must be CUDA tensors")
+    if key.device != query.device or value.device != query.device:
+        raise ValueError("query, key, and value must be on the same CUDA device")
+    if query.ndim != 3 or key.ndim != 3 or value.ndim != 3:
+        raise ValueError("query, key, and value must be 3D [tokens, heads, head_dim]")
+    if query.shape[2] != key.shape[2] or key.shape[2] != value.shape[2]:
+        raise ValueError("query, key, and value must have the same head dimension")
+    if key.shape[:2] != value.shape[:2]:
+        raise ValueError("key and value must have matching token and head counts")
+    if query.shape[2] not in (64, 128, 256):
+        raise ValueError("head_dim must be 64, 128, or 256")
+    if q_block_size not in (1, 4, 16) or k_block_size not in (1, 4, 16):
+        raise ValueError("q_block_size and k_block_size must be 1, 4, or 16")
+    if qk_quant_dtype not in (torch.int8, torch.float8_e4m3fn):
+        raise ValueError("qk_quant_dtype must be torch.int8 or torch.float8_e4m3fn")
+
+    query = query.contiguous()
+    key = key.contiguous()
+    value = value.contiguous()
+    q_quant = torch.empty_like(query, dtype=qk_quant_dtype)
+    k_quant = torch.empty_like(key, dtype=qk_quant_dtype)
+    v_quant = torch.empty_like(value, dtype=torch.float8_e4m3fn)
+    q_scale = torch.empty(
+        (query.shape[1], ceil_div(query.shape[0], q_block_size)),
+        dtype=torch.float32,
+        device=query.device,
+    )
+    k_scale = torch.empty(
+        (key.shape[1], ceil_div(key.shape[0], k_block_size)),
+        dtype=torch.float32,
+        device=query.device,
+    )
+    v_scale = torch.empty(
+        (value.shape[1], value.shape[2]),
+        dtype=torch.float32,
+        device=query.device,
+    )
+
+    get_trtllm_gen_fmha_module().trtllm_sage_attention_quantize(
+        q_quant,
+        k_quant,
+        v_quant,
+        q_scale,
+        k_scale,
+        v_scale,
+        query,
+        key,
+        value,
+        q_block_size,
+        k_block_size,
+        get_device_sm_count(query.device),
+    )
+    return q_quant, k_quant, v_quant, q_scale, k_scale, v_scale
+
+
 @flashinfer_api(trace=trtllm_ragged_attention_deepseek_trace)
 def trtllm_ragged_attention_deepseek(
     query: torch.Tensor,
@@ -4388,10 +4490,10 @@ def trtllm_ragged_attention_deepseek(
     lse : Optional[torch.Tensor]
         lse tensor, if not provided, will be allocated with shape [query.shape[0], query.shape[1]]
     sage_attn_sfs : Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]
-        SageAttention scale-factor tensors for the four sub-blocks
-        ``(q_sf, k_sf, v_block_sum, p_block_sum)``.  Defaults to ``(None, None,
-        None, None)`` which disables SageAttention.  Currently only consulted by
-        the ``trtllm-gen`` backend.
+        SageAttention scale-factor tensors for the four sub-blocks ``(q_sf, k_sf, p_sf, v_sf)``.
+        The outputs from :func:`trtllm_sage_attention_quantize` can be supplied as Q, K, and V scales (with ``p_sf=None``).
+        Defaults to ``(None, None, None, None)`` which disables SageAttention.
+        Currently only consulted by the ``trtllm-gen`` backend.
     num_elts_per_sage_attn_blk : Tuple[int, int, int, int]
         Per-block element counts for the SageAttention scale-factor tensors,
         matching the order of ``sage_attn_sfs``.  Defaults to ``(0, 0, 0, 0)``,

--- a/include/flashinfer/trtllm/common/sageQuant.h
+++ b/include/flashinfer/trtllm/common/sageQuant.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION &
+ * AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <flashinfer/trtllm/common.h>
+
+namespace flashinfer::trtllm {
+
+struct SageQuantParams {
+  // Required arguments for SageQuantQk (Q or K).
+  int sumSeqLensQk{};
+  int numHeads{};
+  int headDim{};
+  int tokenBlockSize{};
+  bool kSmooth{false};
+  void const* ptrQk{nullptr};
+  void* ptrQkQuant{nullptr};
+  Data_type inputType{DATA_TYPE_FP16};
+  Data_type quantType{DATA_TYPE_E4M3};
+  float* ptrQkScale{nullptr};
+  float* ptrKMean{nullptr};
+  // Optional arguments for SageQuantV.
+  // vStage: 0: disabled, 1: collect scales, 2: quantize.
+  int vStage{};
+  int sumSeqLensV{};
+  int numHeadsV{};
+  void const* ptrV{nullptr};
+  void* ptrVQuant{nullptr};
+  float* ptrVScale{nullptr};
+  // Hardware information.
+  int smCount{};
+  cudaStream_t stream{};
+};
+
+void invokeSageQuant(SageQuantParams const& params);
+
+}  // namespace flashinfer::trtllm

--- a/tests/attention/test_trtllm_ragged_dit.py
+++ b/tests/attention/test_trtllm_ragged_dit.py
@@ -4,7 +4,7 @@ Tests for DiT (Diffusion Transformer) oriented ragged attention kernels.
 Covers three variants:
 1. Q/K/V all FP8 E4M3 (standard case)
 2. Q/K in BF16, V in FP8 E4M3 (DiT: BMM1 in BF16, BMM2 in FP8)
-3. Q/K in INT8, V in FP8 E4M3, with SageAttention scaling factors
+3. BF16 Q/K/V quantized on GPU to SageAttention INT8/FP8, then run by attention
 
 All tests run on SM100/SM103 only (Blackwell).
 """
@@ -34,36 +34,6 @@ def _to_float8(x: torch.Tensor, dtype: torch.dtype = torch.float8_e4m3fn):
     scale = finfo.max / amax * 0.1
     x_sat = (x * scale).clamp(min=finfo.min, max=finfo.max)
     return x_sat.to(dtype), scale.float().reciprocal()
-
-
-def _to_int8_blocked(x: torch.Tensor, block_size: int):
-    """
-    Quantize float tensor to INT8 with per-block scaling.
-
-    x: [tokens, heads, head_dim]
-    block_size: number of elements per block along tokens
-
-    Returns:
-        x_q: INT8 tensor same shape as x
-        sfs: float32 per-block scales [heads * (tokens // block_size)]
-              (inverse scales / dequant scales)
-    """
-    tokens, heads, head_dim = x.shape
-    assert tokens % block_size == 0
-    num_blocks = tokens // block_size
-    x_blocks = x.reshape(num_blocks, block_size, heads, head_dim)
-    amax = (
-        x_blocks.abs()
-        .amax(dim=-1, keepdim=True)
-        .amax(dim=1, keepdim=True)
-        .clamp(min=1e-12)
-    )
-    scale = 127.0 / amax  # per-block quantization scale
-    x_sat = (x_blocks * scale).round().clamp(-128, 127)
-    x_q = x_sat.reshape(tokens, heads, head_dim).to(torch.int8)
-    # inv_scale (dequant scale): 1/scale = amax / 127
-    inv_scale = (amax / 127.0).reshape(num_blocks, heads).T.flatten().contiguous()
-    return x_q, inv_scale
 
 
 def _ragged_reference_bf16(
@@ -299,7 +269,7 @@ def test_trtllm_ragged_dit_qk_bf16_v_fp8(
 
 
 # ---------------------------------------------------------------------------
-# Test 3: Q/K in INT8, V in FP8 E4M3, with SageAttention block scaling
+# Test 3: Q/K quantized to INT8, V to FP8 E4M3, with SageAttention block scaling
 # ---------------------------------------------------------------------------
 
 
@@ -314,7 +284,7 @@ def test_trtllm_ragged_dit_qk_bf16_v_fp8(
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("sage_blk_q", [1])
 @pytest.mark.parametrize("sage_blk_k", [4, 16])
-def test_trtllm_ragged_dit_sage_qk_int8_v_fp8(
+def test_trtllm_ragged_dit_sage_qdq(
     causal: bool,
     batch_size: int,
     s_qo: int,
@@ -332,31 +302,44 @@ def test_trtllm_ragged_dit_sage_qk_int8_v_fp8(
     total_q = int(q_lens.sum())
     total_kv = int(kv_lens.sum())
 
-    q_f = torch.randn(total_q, num_heads, head_dim, device=device)
-    k_f = torch.randn(total_kv, num_heads, head_dim, device=device)
-    v_f = torch.randn(total_kv, num_heads, head_dim, device=device)
+    q = torch.randn(total_q, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    k = torch.randn(total_kv, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    v = torch.randn(total_kv, num_heads, head_dim, device=device, dtype=torch.bfloat16)
 
-    # Per-block INT8 quantization for Q and K
-    q_int8, q_sfs = _to_int8_blocked(q_f.cpu(), sage_blk_q)
-    k_int8, k_sfs = _to_int8_blocked(k_f.cpu(), sage_blk_k)
-    q_int8 = q_int8.to(device)
-    k_int8 = k_int8.to(device)
-    q_sfs = q_sfs.to(device)
-    k_sfs = k_sfs.to(device)
+    q_int8, k_int8, v_fp8, q_sfs, k_sfs, v_sfs = (
+        flashinfer.trtllm_sage_attention_quantize(
+            q,
+            k,
+            v,
+            q_block_size=sage_blk_q,
+            k_block_size=sage_blk_k,
+            qk_quant_dtype=torch.int8,
+        )
+    )
+
+    assert q_sfs.shape == (
+        num_heads,
+        (total_q + sage_blk_q - 1) // sage_blk_q,
+    )
+    assert k_sfs.shape == (
+        num_heads,
+        (total_kv + sage_blk_k - 1) // sage_blk_k,
+    )
+    assert v_sfs.shape == (num_heads, head_dim)
+    assert torch.isfinite(q_sfs).all()
+    assert torch.isfinite(k_sfs).all()
+    assert torch.isfinite(v_sfs).all()
 
     sage_blk_v = 1
-    v_fp8, v_inv_scale = _to_float8(v_f)
-    v_sfs = torch.ones((num_heads * head_dim), device=device)
 
     # For SageAttention, bmm1_scale encodes 1/sqrt(head_dim) only;
     # per-block Q/K dequant is handled via sage_attn_sfs_q/k
     scale = 1.0 / math.sqrt(head_dim)
-    # INT8 range is [-127,127] so per-block inv_scale is amax/127;
-    # the effective per-block scale that the kernel uses is
-    # sfs_q[i] * sfs_k[j] * (1/sqrt(head_dim)), but bmm1_scale here is 1.0
-    # because the kernel multiplies by sfs_q * sfs_k internally.
+    # Per-block Q/K dequantization is handled inside the attention kernel, so
+    # bmm1_scale only contains the usual attention normalization.
     bmm1_scale = 1.0 / math.sqrt(head_dim)
-    bmm2_scale = float(v_inv_scale)
+    # All dequantization scales are supplied through SageAttention scale tensors.
+    bmm2_scale = 1.0
 
     qo_indptr = torch.cat(
         [torch.zeros(1, dtype=torch.int32, device=device), q_lens.cumsum(0).int()]
@@ -393,9 +376,9 @@ def test_trtllm_ragged_dit_sage_qk_int8_v_fp8(
     assert out_trtllm.dtype == torch.bfloat16
 
     out_ref = _ragged_reference_bf16(
-        q_f,
-        k_f,
-        v_f,
+        q,
+        k,
+        v,
         q_lens,
         kv_lens,
         scale,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

#2711 added SageAttention kernels for Blackwell SM100, but didn't provide a corresponding quantization routine. We expected users to create their own quantization kernel according to the examples in tests/, but absence of a directly importable GPU quantization routine still causes much inconvenience.

This PR tries to add quantization routine for TRTLLM SageAttention as a direct importable module of flashinfer. Please let me know if the added API is appropriate (naming, file location, ...)

- `sageQuant.cu` imported from [TRTLLM/cpp/...](https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/common/sageQuant.cu)
- Routine is specific to TRTLLM's SageAttention for Blackwell SM100
- Must be used with trtllm_ragged_attention_deepseek
- See added tests for use example

## 🔍 Related Issues

<!-- Link any related issues here -->
N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TensorRT-LLM SageAttention quantization for **Q/K** (INT8 or FP8 E4M3) and **V** (FP8 E4M3).
  * Introduced `trtllm_sage_attention_quantize` to produce quantized Q/K/V tensors and the required SageAttention scale tensors.
  * Re-exported `trtllm_sage_attention_quantize` at the package top level for easier access.
* **Documentation**
  * Clarified `sage_attn_sfs` usage and wiring for the SageAttention quantization outputs in ragged attention.
* **Tests**
  * Updated DiT ragged-attention coverage to use the new SageAttention quantization workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->