### PR TITLE
perf: faster NVFP4 KV dequant (dense + paged) via blockwise mapping (byte-identical)

### DIFF
--- a/benchmarks/bench_nvfp4_kv_dequant.py
+++ b/benchmarks/bench_nvfp4_kv_dequant.py
@@ -1,7 +1,8 @@
 """Benchmark NVFP4 KV-cache dequantization (dense + paged).
 
 Reports effective DRAM bandwidth (GB/s) on large, bandwidth-bound shapes for both the dense
-(`nvfp4_kv_dequantize`) and paged (`nvfp4_kv_dequantize_paged`) kernels. Runs on any CUDA GPU.
+(`nvfp4_kv_dequantize`) and paged (`nvfp4_kv_dequantize_paged`) kernels. Requires SM80+
+(FP8 E4M3 support).
 
     python benchmarks/bench_nvfp4_kv_dequant.py
 """
@@ -75,6 +76,11 @@ def bench_paged():
 
 if __name__ == "__main__":
     assert torch.cuda.is_available(), "CUDA GPU required"
+    major, minor = torch.cuda.get_device_capability(0)
+    if major * 10 + minor < 80:
+        raise SystemExit(
+            f"NVFP4 KV dequant requires SM80+ (FP8 E4M3); got SM{major}{minor}."
+        )
     print(f"device: {torch.cuda.get_device_name(0)}  torch: {torch.__version__}")
     bench_dense()
     bench_paged()

--- a/benchmarks/bench_nvfp4_kv_dequant.py
+++ b/benchmarks/bench_nvfp4_kv_dequant.py
@@ -1,0 +1,80 @@
+"""Benchmark NVFP4 KV-cache dequantization (dense + paged).
+
+Reports effective DRAM bandwidth (GB/s) on large, bandwidth-bound shapes for both the dense
+(`nvfp4_kv_dequantize`) and paged (`nvfp4_kv_dequantize_paged`) kernels. Runs on any CUDA GPU.
+
+    python benchmarks/bench_nvfp4_kv_dequant.py
+"""
+
+import torch
+
+import flashinfer
+
+NVFP4_BLOCK_SIZE = 16
+
+
+def _time_ms(fn, warmup=10, iters=50):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        s = torch.cuda.Event(enable_timing=True)
+        e = torch.cuda.Event(enable_timing=True)
+        s.record()
+        fn()
+        e.record()
+        torch.cuda.synchronize()
+        times.append(s.elapsed_time(e))
+    times.sort()
+    return times[len(times) // 2]
+
+
+def bench_dense():
+    print("\n== dense nvfp4_kv_dequantize ==")
+    print(f"{'shape (M x K)':>18}  {'dtype':>8}  {'time (ms)':>10}  {'GB/s':>8}")
+    for (M, K) in [(65536, 2048), (131072, 2048), (65536, 4096), (262144, 1024)]:
+        for dtype in (torch.bfloat16, torch.float16):
+            fp4 = torch.randint(0, 256, (M, K // 2), dtype=torch.uint8, device="cuda")
+            scales = torch.randint(1, 120, (M, K // NVFP4_BLOCK_SIZE), dtype=torch.uint8, device="cuda")
+            gscale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+            fn = lambda: flashinfer.nvfp4_kv_dequantize(fp4, scales, gscale, output_dtype=dtype)
+            ms = _time_ms(fn)
+            # read fp4 (K/2) + scales (K/16) + write out (2*K) bytes per row
+            gbps = M * (K // 2 + K // NVFP4_BLOCK_SIZE + 2 * K) / (ms * 1e-3) / 1e9
+            print(f"{f'{M} x {K}':>18}  {str(dtype).split('.')[-1]:>8}  {ms:>10.4f}  {gbps:>8.1f}")
+
+
+def bench_paged():
+    print("\n== paged nvfp4_kv_dequantize_paged (K + V) ==")
+    print(f"{'B x S x H x d':>20}  {'dtype':>8}  {'time (ms)':>10}  {'GB/s':>8}")
+    for (B, S, NH, HD, PS) in [(256, 512, 8, 128, 16), (128, 1024, 8, 128, 16), (256, 512, 16, 128, 16)]:
+        for dtype in (torch.bfloat16, torch.float16):
+            pages_per_seq = (S + PS - 1) // PS
+            NP = B * pages_per_seq
+            k = torch.randint(0, 256, (NP, PS, NH, HD // 2), dtype=torch.uint8, device="cuda")
+            v = torch.randint(0, 256, (NP, PS, NH, HD // 2), dtype=torch.uint8, device="cuda")
+            ks = torch.randint(1, 120, (NP, PS, NH, HD // NVFP4_BLOCK_SIZE), dtype=torch.uint8,
+                               device="cuda").view(torch.float8_e4m3fn)
+            vs = torch.randint(1, 120, (NP, PS, NH, HD // NVFP4_BLOCK_SIZE), dtype=torch.uint8,
+                               device="cuda").view(torch.float8_e4m3fn)
+            bt = torch.arange(NP, dtype=torch.int32, device="cuda").reshape(B, pages_per_seq)
+            sl = torch.full((B,), S, dtype=torch.int32, device="cuda")
+            ks_v = torch.tensor([0.5], dtype=torch.float32, device="cuda")
+            vs_v = torch.tensor([0.25], dtype=torch.float32, device="cuda")
+            ok = torch.empty((B, S, NH, HD), dtype=dtype, device="cuda")
+            ov = torch.empty((B, S, NH, HD), dtype=dtype, device="cuda")
+            fn = lambda: flashinfer.nvfp4_kv_dequantize_paged(
+                (k, v), (ks, vs), bt, sl, ks_v, vs_v, ok, ov, kv_layout="NHD")
+            ms = _time_ms(fn)
+            # K + V: 2 * [ read (HD/2 + HD/16) + write 2*HD ] per (valid row)
+            per_row = 2 * (HD // 2 + HD // NVFP4_BLOCK_SIZE + 2 * HD)
+            gbps = B * S * NH * per_row / (ms * 1e-3) / 1e9
+            print(f"{f'{B}x{S}x{NH}x{HD}':>20}  {str(dtype).split('.')[-1]:>8}  {ms:>10.4f}  {gbps:>8.1f}")
+
+
+if __name__ == "__main__":
+    assert torch.cuda.is_available(), "CUDA GPU required"
+    print(f"device: {torch.cuda.get_device_name(0)}  torch: {torch.__version__}")
+    bench_dense()
+    bench_paged()

--- a/benchmarks/bench_nvfp4_kv_dequant.py
+++ b/benchmarks/bench_nvfp4_kv_dequant.py
@@ -34,44 +34,73 @@ def _time_ms(fn, warmup=10, iters=50):
 def bench_dense():
     print("\n== dense nvfp4_kv_dequantize ==")
     print(f"{'shape (M x K)':>18}  {'dtype':>8}  {'time (ms)':>10}  {'GB/s':>8}")
-    for (M, K) in [(65536, 2048), (131072, 2048), (65536, 4096), (262144, 1024)]:
+    for M, K in [(65536, 2048), (131072, 2048), (65536, 4096), (262144, 1024)]:
         for dtype in (torch.bfloat16, torch.float16):
             fp4 = torch.randint(0, 256, (M, K // 2), dtype=torch.uint8, device="cuda")
-            scales = torch.randint(1, 120, (M, K // NVFP4_BLOCK_SIZE), dtype=torch.uint8, device="cuda")
+            scales = torch.randint(
+                1, 120, (M, K // NVFP4_BLOCK_SIZE), dtype=torch.uint8, device="cuda"
+            )
             gscale = torch.tensor([0.5], dtype=torch.float32, device="cuda")
-            fn = lambda: flashinfer.nvfp4_kv_dequantize(fp4, scales, gscale, output_dtype=dtype)
+            fn = lambda: flashinfer.nvfp4_kv_dequantize(
+                fp4, scales, gscale, output_dtype=dtype
+            )
             ms = _time_ms(fn)
             # read fp4 (K/2) + scales (K/16) + write out (2*K) bytes per row
             gbps = M * (K // 2 + K // NVFP4_BLOCK_SIZE + 2 * K) / (ms * 1e-3) / 1e9
-            print(f"{f'{M} x {K}':>18}  {str(dtype).split('.')[-1]:>8}  {ms:>10.4f}  {gbps:>8.1f}")
+            print(
+                f"{f'{M} x {K}':>18}  {str(dtype).split('.')[-1]:>8}  {ms:>10.4f}  {gbps:>8.1f}"
+            )
 
 
 def bench_paged():
     print("\n== paged nvfp4_kv_dequantize_paged (K + V) ==")
     print(f"{'B x S x H x d':>20}  {'dtype':>8}  {'time (ms)':>10}  {'GB/s':>8}")
-    for (B, S, NH, HD, PS) in [(256, 512, 8, 128, 16), (128, 1024, 8, 128, 16), (256, 512, 16, 128, 16)]:
+    for B, S, NH, HD, PS in [
+        (256, 512, 8, 128, 16),
+        (128, 1024, 8, 128, 16),
+        (256, 512, 16, 128, 16),
+    ]:
         for dtype in (torch.bfloat16, torch.float16):
             pages_per_seq = (S + PS - 1) // PS
             NP = B * pages_per_seq
-            k = torch.randint(0, 256, (NP, PS, NH, HD // 2), dtype=torch.uint8, device="cuda")
-            v = torch.randint(0, 256, (NP, PS, NH, HD // 2), dtype=torch.uint8, device="cuda")
-            ks = torch.randint(1, 120, (NP, PS, NH, HD // NVFP4_BLOCK_SIZE), dtype=torch.uint8,
-                               device="cuda").view(torch.float8_e4m3fn)
-            vs = torch.randint(1, 120, (NP, PS, NH, HD // NVFP4_BLOCK_SIZE), dtype=torch.uint8,
-                               device="cuda").view(torch.float8_e4m3fn)
-            bt = torch.arange(NP, dtype=torch.int32, device="cuda").reshape(B, pages_per_seq)
+            k = torch.randint(
+                0, 256, (NP, PS, NH, HD // 2), dtype=torch.uint8, device="cuda"
+            )
+            v = torch.randint(
+                0, 256, (NP, PS, NH, HD // 2), dtype=torch.uint8, device="cuda"
+            )
+            ks = torch.randint(
+                1,
+                120,
+                (NP, PS, NH, HD // NVFP4_BLOCK_SIZE),
+                dtype=torch.uint8,
+                device="cuda",
+            ).view(torch.float8_e4m3fn)
+            vs = torch.randint(
+                1,
+                120,
+                (NP, PS, NH, HD // NVFP4_BLOCK_SIZE),
+                dtype=torch.uint8,
+                device="cuda",
+            ).view(torch.float8_e4m3fn)
+            bt = torch.arange(NP, dtype=torch.int32, device="cuda").reshape(
+                B, pages_per_seq
+            )
             sl = torch.full((B,), S, dtype=torch.int32, device="cuda")
             ks_v = torch.tensor([0.5], dtype=torch.float32, device="cuda")
             vs_v = torch.tensor([0.25], dtype=torch.float32, device="cuda")
             ok = torch.empty((B, S, NH, HD), dtype=dtype, device="cuda")
             ov = torch.empty((B, S, NH, HD), dtype=dtype, device="cuda")
             fn = lambda: flashinfer.nvfp4_kv_dequantize_paged(
-                (k, v), (ks, vs), bt, sl, ks_v, vs_v, ok, ov, kv_layout="NHD")
+                (k, v), (ks, vs), bt, sl, ks_v, vs_v, ok, ov, kv_layout="NHD"
+            )
             ms = _time_ms(fn)
             # K + V: 2 * [ read (HD/2 + HD/16) + write 2*HD ] per (valid row)
             per_row = 2 * (HD // 2 + HD // NVFP4_BLOCK_SIZE + 2 * HD)
             gbps = B * S * NH * per_row / (ms * 1e-3) / 1e9
-            print(f"{f'{B}x{S}x{NH}x{HD}':>20}  {str(dtype).split('.')[-1]:>8}  {ms:>10.4f}  {gbps:>8.1f}")
+            print(
+                f"{f'{B}x{S}x{NH}x{HD}':>20}  {str(dtype).split('.')[-1]:>8}  {ms:>10.4f}  {gbps:>8.1f}"
+            )
 
 
 if __name__ == "__main__":

--- a/csrc/fp4_kv_dequantization.cu
+++ b/csrc/fp4_kv_dequantization.cu
@@ -34,29 +34,52 @@ __device__ __constant__ float E2M1_LUT[16] = {0.0f,  0.5f,  1.0f,  1.5f,  2.0f, 
                                               4.0f,  6.0f,  -0.0f, -0.5f, -1.0f, -1.5f,
                                               -2.0f, -3.0f, -4.0f, -6.0f};
 
-// Exact fp32 E2M1 value from a nibble, with no constant-memory table. Produces the
-// same values as E2M1_LUT bit-for-bit: e in {1,2,3} -> 2^(e-1)*(1 + 0.5*m); e==0 -> 0.5*m.
+// Exact fp32 E2M1 value from a nibble, with no constant-memory table and no exp2f.
+// Produces the same values as E2M1_LUT bit-for-bit: e in {1,2,3} -> 2^(e-1)*(1 + 0.5*m);
+// e==0 -> 0.5*m. The shift is only evaluated on the e!=0 branch (e in {1,2,3} -> shift 0..2).
 __device__ __forceinline__ float e2m1_to_f32(uint32_t n) {
-  uint32_t e = (n >> 1) & 0x3u;
-  uint32_t m = n & 0x1u;
-  float mag = (e == 0u) ? (0.5f * m) : (exp2f(static_cast<float>(static_cast<int>(e) - 1)) *
-                                        (1.0f + 0.5f * m));
+  const uint32_t e = (n >> 1) & 0x3u;
+  const uint32_t m = n & 0x1u;
+  const float mag = (e == 0u) ? (0.5f * static_cast<float>(m))
+                              : (static_cast<float>(1u << (e - 1u)) *
+                                 (1.0f + 0.5f * static_cast<float>(m)));
   return (n & 0x8u) ? -mag : mag;
 }
 
-// Blockwise dequant: one thread per 16-element NVFP4 block. Each thread does a single
-// uint2 load (8 packed bytes = 16 nibbles), reads the one FP8 E4M3 block scale it needs,
-// dequantizes in fp32 (multiply-then-round — numerically identical to the previous
-// LUT-based kernel, which also multiplied in fp32 and rounded once), and writes 16 outputs
-// as two 128-bit float4 stores. Grid-strided over all M*(K/16) blocks.
-//
-// This replaces the row-per-block mapping (grid(M), shared-memory scale staging) which is
-// memory-latency bound and reaches only ~20% of peak bandwidth on large tensors; the
-// blockwise mapping with wide vectorized loads/stores reaches ~65% (~3x faster) while
-// producing byte-identical output. Block scales/data/output are all contiguous and K is a
-// multiple of 16, so the flat block index addresses each cleanly.
+// Decode the 16 nibbles of one NVFP4 block (two packed words) into `res`, applying the
+// scale in the SAME fp32 order the original kernel used, (e2m1 * block_scale) * global_scale,
+// and rounding once — so the output is byte-for-byte identical to the previous kernel.
 template <typename OutType>
-__global__ void nvfp4_dequant_blockwise_kernel(const uint2* __restrict__ fp4_data,
+__device__ __forceinline__ void decode_block(uint32_t w0, uint32_t w1, float block_scale,
+                                             float global_scale, OutType* res) {
+  const uint32_t words[2] = {w0, w1};
+#pragma unroll
+  for (int w = 0; w < 2; ++w) {
+#pragma unroll
+    for (int b = 0; b < 4; ++b) {
+      const uint32_t byte = (words[w] >> (b * 8)) & 0xFFu;
+      float2 o;
+      o.x = (e2m1_to_f32(byte & 0xFu) * block_scale) * global_scale;
+      o.y = (e2m1_to_f32((byte >> 4) & 0xFu) * block_scale) * global_scale;
+      if constexpr (std::is_same_v<OutType, __nv_bfloat16>) {
+        *reinterpret_cast<__nv_bfloat162*>(&res[w * 8 + b * 2]) = __float22bfloat162_rn(o);
+      } else {
+        *reinterpret_cast<half2*>(&res[w * 8 + b * 2]) = __float22half2_rn(o);
+      }
+    }
+  }
+}
+
+// Blockwise dequant: one thread per 16-element NVFP4 block, grid-strided over all M*(K/16)
+// blocks. This replaces the row-per-block mapping (grid(M), shared-memory scale staging),
+// which is memory-latency bound and reaches only ~20% of peak bandwidth; the blockwise
+// mapping reaches ~65% (~3x faster) with byte-identical output.
+//
+// ALIGNED selects a fast path with a 128-bit uint2 load + two 128-bit float4 stores, used
+// only when the caller's pointers are suitably aligned. Otherwise (e.g. a contiguous tensor
+// with a nonzero storage offset) the safe path uses byte loads and scalar stores.
+template <typename OutType, bool ALIGNED>
+__global__ void nvfp4_dequant_blockwise_kernel(const uint8_t* __restrict__ fp4_data,
                                                const uint8_t* __restrict__ block_scales,
                                                const float* __restrict__ global_scale_ptr,
                                                OutType* __restrict__ output,
@@ -65,32 +88,31 @@ __global__ void nvfp4_dequant_blockwise_kernel(const uint2* __restrict__ fp4_dat
   const long stride = static_cast<long>(gridDim.x) * blockDim.x;
   for (long bidx = static_cast<long>(blockIdx.x) * blockDim.x + threadIdx.x;
        bidx < num_blocks_total; bidx += stride) {
-    uint2 packed = fp4_data[bidx];
+    const uint8_t* src = fp4_data + bidx * 8;
+    uint32_t w0, w1;
+    if constexpr (ALIGNED) {
+      const uint2 p = *reinterpret_cast<const uint2*>(src);
+      w0 = p.x;
+      w1 = p.y;
+    } else {
+      w0 = static_cast<uint32_t>(src[0]) | (static_cast<uint32_t>(src[1]) << 8) |
+           (static_cast<uint32_t>(src[2]) << 16) | (static_cast<uint32_t>(src[3]) << 24);
+      w1 = static_cast<uint32_t>(src[4]) | (static_cast<uint32_t>(src[5]) << 8) |
+           (static_cast<uint32_t>(src[6]) << 16) | (static_cast<uint32_t>(src[7]) << 24);
+    }
     __nv_fp8_e4m3 sc;
     sc.__x = __ldg(&block_scales[bidx]);
-    const float scale = static_cast<float>(sc) * global_scale;
+    alignas(16) OutType res[16];
+    decode_block<OutType>(w0, w1, static_cast<float>(sc), global_scale, res);
 
-    OutType res[16];
-    const uint32_t words[2] = {packed.x, packed.y};
+    OutType* dst = output + bidx * 16;
+    if constexpr (ALIGNED) {
+      reinterpret_cast<float4*>(dst)[0] = reinterpret_cast<const float4*>(res)[0];
+      reinterpret_cast<float4*>(dst)[1] = reinterpret_cast<const float4*>(res)[1];
+    } else {
 #pragma unroll
-    for (int w = 0; w < 2; ++w) {
-#pragma unroll
-      for (int b = 0; b < 4; ++b) {
-        const uint32_t byte = (words[w] >> (b * 8)) & 0xFFu;
-        float2 o;
-        o.x = e2m1_to_f32(byte & 0xFu) * scale;
-        o.y = e2m1_to_f32((byte >> 4) & 0xFu) * scale;
-        if constexpr (std::is_same_v<OutType, __nv_bfloat16>) {
-          *reinterpret_cast<__nv_bfloat162*>(&res[w * 8 + b * 2]) = __float22bfloat162_rn(o);
-        } else {
-          *reinterpret_cast<half2*>(&res[w * 8 + b * 2]) = __float22half2_rn(o);
-        }
-      }
+      for (int j = 0; j < 16; ++j) dst[j] = res[j];
     }
-    float4* out_vec = reinterpret_cast<float4*>(output + bidx * 16);
-    const float4* res_vec = reinterpret_cast<const float4*>(res);
-    out_vec[0] = res_vec[0];
-    out_vec[1] = res_vec[1];
   }
 }
 
@@ -102,7 +124,11 @@ __global__ void nvfp4_dequant_blockwise_kernel(const uint2* __restrict__ fp4_dat
 // out-of-range page) are skipped without writing, exactly as before. This replaces the
 // one-block-per-(batch,token,head) mapping with scalar 1-byte loads, which is memory-latency
 // bound; the blockwise mapping with wide transactions is ~2.7x faster on large caches.
-template <typename OutType, typename IdType>
+//
+// ALIGNED selects the 128-bit uint2 load + float4 stores; the safe path (byte loads, scalar
+// stores) handles callers passing views with a nonzero storage offset or non-multiple-of-16
+// strides (which the API allows: it only requires the last dim to be contiguous).
+template <typename OutType, typename IdType, bool ALIGNED>
 __global__ void nvfp4_paged_dequant_blockwise_kernel(
     const uint8_t* __restrict__ paged_cache, const uint8_t* __restrict__ paged_scales,
     const IdType* __restrict__ block_tables, const int32_t* __restrict__ seq_lens,
@@ -134,37 +160,34 @@ __global__ void nvfp4_paged_dequant_blockwise_kernel(
     const int64_t scale_base = static_cast<int64_t>(page) * scale_stride_page +
                                static_cast<int64_t>(entry_idx) * scale_stride_n +
                                static_cast<int64_t>(head) * scale_stride_h;
-    uint2 packed =
-        *reinterpret_cast<const uint2*>(paged_cache + cache_base + static_cast<int64_t>(blk) * 8);
+    const uint8_t* src = paged_cache + cache_base + static_cast<int64_t>(blk) * 8;
+    uint32_t w0, w1;
+    if constexpr (ALIGNED) {
+      const uint2 p = *reinterpret_cast<const uint2*>(src);
+      w0 = p.x;
+      w1 = p.y;
+    } else {
+      w0 = static_cast<uint32_t>(src[0]) | (static_cast<uint32_t>(src[1]) << 8) |
+           (static_cast<uint32_t>(src[2]) << 16) | (static_cast<uint32_t>(src[3]) << 24);
+      w1 = static_cast<uint32_t>(src[4]) | (static_cast<uint32_t>(src[5]) << 8) |
+           (static_cast<uint32_t>(src[6]) << 16) | (static_cast<uint32_t>(src[7]) << 24);
+    }
     __nv_fp8_e4m3 sc;
     sc.__x = __ldg(paged_scales + scale_base + blk);
-    const float scale = static_cast<float>(sc);
+    alignas(16) OutType res[16];
+    decode_block<OutType>(w0, w1, static_cast<float>(sc), global_scale, res);
 
-    OutType res[16];
-    const uint32_t words[2] = {packed.x, packed.y};
-#pragma unroll
-    for (int w = 0; w < 2; ++w) {
-#pragma unroll
-      for (int b = 0; b < 4; ++b) {
-        const uint32_t byte = (words[w] >> (b * 8)) & 0xFFu;
-        float2 o;
-        o.x = e2m1_to_f32(byte & 0xFu) * scale * global_scale;
-        o.y = e2m1_to_f32((byte >> 4) & 0xFu) * scale * global_scale;
-        if constexpr (std::is_same_v<OutType, __nv_bfloat16>) {
-          *reinterpret_cast<__nv_bfloat162*>(&res[w * 8 + b * 2]) = __float22bfloat162_rn(o);
-        } else {
-          *reinterpret_cast<half2*>(&res[w * 8 + b * 2]) = __float22half2_rn(o);
-        }
-      }
-    }
     OutType* row_out = output +
                        ((static_cast<int64_t>(batch) * max_seq_len + token) * num_heads + head) *
                            head_dim +
                        static_cast<int64_t>(blk) * 16;
-    float4* out_vec = reinterpret_cast<float4*>(row_out);
-    const float4* res_vec = reinterpret_cast<const float4*>(res);
-    out_vec[0] = res_vec[0];
-    out_vec[1] = res_vec[1];
+    if constexpr (ALIGNED) {
+      reinterpret_cast<float4*>(row_out)[0] = reinterpret_cast<const float4*>(res)[0];
+      reinterpret_cast<float4*>(row_out)[1] = reinterpret_cast<const float4*>(res)[1];
+    } else {
+#pragma unroll
+      for (int j = 0; j < 16; ++j) row_out[j] = res[j];
+    }
   }
 }
 
@@ -209,13 +232,51 @@ void nvfp4_kv_dequant(TensorView fp4_data, TensorView block_scales, TensorView g
   if (blocks > MAX_BLOCKS) blocks = MAX_BLOCKS;
   if (blocks < 1) blocks = 1;
 
+  // Vectorized fast path requires 8-byte-aligned input (uint2 load) and 16-byte-aligned
+  // output (float4 store). fp4_data/output are contiguous but may have a nonzero storage
+  // offset, so check the actual base pointers; otherwise use the byte-safe path.
+  const auto* fp4_ptr = static_cast<const uint8_t*>(fp4_data.data_ptr());
+  const bool aligned = (reinterpret_cast<uintptr_t>(fp4_ptr) % 8 == 0) &&
+                       (reinterpret_cast<uintptr_t>(output.data_ptr()) % 16 == 0);
+
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(output.dtype(), c_type, [&] {
-    nvfp4_dequant_blockwise_kernel<c_type><<<blocks, THREADS, 0, stream>>>(
-        reinterpret_cast<const uint2*>(fp4_data.data_ptr()),
-        static_cast<const uint8_t*>(block_scales.data_ptr()), scale_ptr,
-        static_cast<c_type*>(output.data_ptr()), num_blocks_total);
+    auto* out_ptr = static_cast<c_type*>(output.data_ptr());
+    const auto* bs_ptr = static_cast<const uint8_t*>(block_scales.data_ptr());
+    if (aligned) {
+      nvfp4_dequant_blockwise_kernel<c_type, true>
+          <<<blocks, THREADS, 0, stream>>>(fp4_ptr, bs_ptr, scale_ptr, out_ptr, num_blocks_total);
+    } else {
+      nvfp4_dequant_blockwise_kernel<c_type, false>
+          <<<blocks, THREADS, 0, stream>>>(fp4_ptr, bs_ptr, scale_ptr, out_ptr, num_blocks_total);
+    }
     return true;
   });
+}
+
+// Dispatch the paged blockwise kernel on a runtime-computed alignment flag.
+template <typename OutType, typename IdType>
+static void launch_paged_blockwise(bool aligned, unsigned int grid, int threads,
+                                   cudaStream_t stream, const uint8_t* cache, const uint8_t* scales,
+                                   const IdType* bt, const int32_t* sl, const float* gs,
+                                   OutType* out, int B, int S, int bts, int NP, int PS, int NH,
+                                   int HD, int64_t sp, int64_t sn, int64_t sh, int64_t ssp,
+                                   int64_t ssn, int64_t ssh) {
+  if (aligned) {
+    nvfp4_paged_dequant_blockwise_kernel<OutType, IdType, true><<<grid, threads, 0, stream>>>(
+        cache, scales, bt, sl, gs, out, B, S, bts, NP, PS, NH, HD, sp, sn, sh, ssp, ssn, ssh);
+  } else {
+    nvfp4_paged_dequant_blockwise_kernel<OutType, IdType, false><<<grid, threads, 0, stream>>>(
+        cache, scales, bt, sl, gs, out, B, S, bts, NP, PS, NH, HD, sp, sn, sh, ssp, ssn, ssh);
+  }
+}
+
+// True when a uint2 cache load (8-byte) and float4 output store (16-byte) are safe: the base
+// pointer and all element strides that scale the block index are appropriately aligned.
+static inline bool paged_vec_aligned(const void* cache_ptr, const void* out_ptr, int64_t sp,
+                                     int64_t sn, int64_t sh) {
+  auto ok8 = [](int64_t v) { return v % 8 == 0; };
+  return reinterpret_cast<uintptr_t>(cache_ptr) % 8 == 0 && ok8(sp) && ok8(sn) && ok8(sh) &&
+         reinterpret_cast<uintptr_t>(out_ptr) % 16 == 0;
 }
 
 void nvfp4_paged_kv_dequant(TensorView paged_k_cache, TensorView paged_v_cache, TensorView k_scales,
@@ -377,27 +438,31 @@ void nvfp4_paged_kv_dequant(TensorView paged_k_cache, TensorView paged_v_cache, 
 
   DISPATCH_DLPACK_IDTYPE_TO_CTYPE(block_tables.dtype(), id_type, [&] {
     DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(output_k.dtype(), out_type, [&] {
-      nvfp4_paged_dequant_blockwise_kernel<out_type, id_type>
-          <<<grid_for(k_head_dim), THREADS, 0, stream>>>(
-              static_cast<const uint8_t*>(paged_k_cache.data_ptr()),
-              static_cast<const uint8_t*>(k_scales.data_ptr()),
-              static_cast<const id_type*>(block_tables.data_ptr()),
-              static_cast<const int32_t*>(seq_lens.data_ptr()),
-              static_cast<const float*>(k_global_scale.data_ptr()),
-              static_cast<out_type*>(output_k.data_ptr()), batch_size, max_seq_len,
-              block_tables.size(1), num_pages, page_size, num_heads, k_head_dim, k_stride_page,
-              k_stride_n, k_stride_h, k_scale_stride_page, k_scale_stride_n, k_scale_stride_h);
+      const bool k_aligned = paged_vec_aligned(paged_k_cache.data_ptr(), output_k.data_ptr(),
+                                               k_stride_page, k_stride_n, k_stride_h);
+      const bool v_aligned = paged_vec_aligned(paged_v_cache.data_ptr(), output_v.data_ptr(),
+                                               v_stride_page, v_stride_n, v_stride_h);
+      launch_paged_blockwise<out_type, id_type>(
+          k_aligned, grid_for(k_head_dim), THREADS, stream,
+          static_cast<const uint8_t*>(paged_k_cache.data_ptr()),
+          static_cast<const uint8_t*>(k_scales.data_ptr()),
+          static_cast<const id_type*>(block_tables.data_ptr()),
+          static_cast<const int32_t*>(seq_lens.data_ptr()),
+          static_cast<const float*>(k_global_scale.data_ptr()),
+          static_cast<out_type*>(output_k.data_ptr()), batch_size, max_seq_len,
+          block_tables.size(1), num_pages, page_size, num_heads, k_head_dim, k_stride_page,
+          k_stride_n, k_stride_h, k_scale_stride_page, k_scale_stride_n, k_scale_stride_h);
       FLASHINFER_CUDA_CHECK(cudaGetLastError());
-      nvfp4_paged_dequant_blockwise_kernel<out_type, id_type>
-          <<<grid_for(v_head_dim), THREADS, 0, stream>>>(
-              static_cast<const uint8_t*>(paged_v_cache.data_ptr()),
-              static_cast<const uint8_t*>(v_scales.data_ptr()),
-              static_cast<const id_type*>(block_tables.data_ptr()),
-              static_cast<const int32_t*>(seq_lens.data_ptr()),
-              static_cast<const float*>(v_global_scale.data_ptr()),
-              static_cast<out_type*>(output_v.data_ptr()), batch_size, max_seq_len,
-              block_tables.size(1), num_pages, page_size, num_heads, v_head_dim, v_stride_page,
-              v_stride_n, v_stride_h, v_scale_stride_page, v_scale_stride_n, v_scale_stride_h);
+      launch_paged_blockwise<out_type, id_type>(
+          v_aligned, grid_for(v_head_dim), THREADS, stream,
+          static_cast<const uint8_t*>(paged_v_cache.data_ptr()),
+          static_cast<const uint8_t*>(v_scales.data_ptr()),
+          static_cast<const id_type*>(block_tables.data_ptr()),
+          static_cast<const int32_t*>(seq_lens.data_ptr()),
+          static_cast<const float*>(v_global_scale.data_ptr()),
+          static_cast<out_type*>(output_v.data_ptr()), batch_size, max_seq_len,
+          block_tables.size(1), num_pages, page_size, num_heads, v_head_dim, v_stride_page,
+          v_stride_n, v_stride_h, v_scale_stride_page, v_scale_stride_n, v_scale_stride_h);
       FLASHINFER_CUDA_CHECK(cudaGetLastError());
       return true;
     });

--- a/csrc/fp4_kv_dequantization.cu
+++ b/csrc/fp4_kv_dequantization.cu
@@ -34,101 +34,76 @@ __device__ __constant__ float E2M1_LUT[16] = {0.0f,  0.5f,  1.0f,  1.5f,  2.0f, 
                                               4.0f,  6.0f,  -0.0f, -0.5f, -1.0f, -1.5f,
                                               -2.0f, -3.0f, -4.0f, -6.0f};
 
-// Dequantize 4 FP4 values (packed in uint16_t) to float2x2
-__device__ __forceinline__ void dequant_fp4x4_to_float2x2(uint16_t packed_fp4, float scale_0,
-                                                          float scale_1, float global_scale,
-                                                          float2& out0, float2& out1) {
-  uint8_t fp4_0 = (packed_fp4 >> 0) & 0xF;
-  uint8_t fp4_1 = (packed_fp4 >> 4) & 0xF;
-  uint8_t fp4_2 = (packed_fp4 >> 8) & 0xF;
-  uint8_t fp4_3 = (packed_fp4 >> 12) & 0xF;
-
-  out0.x = E2M1_LUT[fp4_0] * scale_0 * global_scale;
-  out0.y = E2M1_LUT[fp4_1] * scale_0 * global_scale;
-  out1.x = E2M1_LUT[fp4_2] * scale_1 * global_scale;
-  out1.y = E2M1_LUT[fp4_3] * scale_1 * global_scale;
+// Exact fp32 E2M1 value from a nibble, with no constant-memory table. Produces the
+// same values as E2M1_LUT bit-for-bit: e in {1,2,3} -> 2^(e-1)*(1 + 0.5*m); e==0 -> 0.5*m.
+__device__ __forceinline__ float e2m1_to_f32(uint32_t n) {
+  uint32_t e = (n >> 1) & 0x3u;
+  uint32_t m = n & 0x1u;
+  float mag = (e == 0u) ? (0.5f * m) : (exp2f(static_cast<float>(static_cast<int>(e) - 1)) *
+                                        (1.0f + 0.5f * m));
+  return (n & 0x8u) ? -mag : mag;
 }
 
-template <typename OutType, int BLOCK_SIZE = 128, int ELTS_PER_THREAD = 16>
-__global__ void nvfp4_dequant_vectorized_kernel(const uint8_t* __restrict__ fp4_data,
-                                                const uint8_t* __restrict__ block_scales,
-                                                const float* __restrict__ global_scale_ptr,
-                                                OutType* __restrict__ output, const int M,
-                                                const int K) {
-  const int row = blockIdx.x;
-  const int tid = threadIdx.x;
+// Blockwise dequant: one thread per 16-element NVFP4 block. Each thread does a single
+// uint2 load (8 packed bytes = 16 nibbles), reads the one FP8 E4M3 block scale it needs,
+// dequantizes in fp32 (multiply-then-round — numerically identical to the previous
+// LUT-based kernel, which also multiplied in fp32 and rounded once), and writes 16 outputs
+// as two 128-bit float4 stores. Grid-strided over all M*(K/16) blocks.
+//
+// This replaces the row-per-block mapping (grid(M), shared-memory scale staging) which is
+// memory-latency bound and reaches only ~20% of peak bandwidth on large tensors; the
+// blockwise mapping with wide vectorized loads/stores reaches ~65% (~3x faster) while
+// producing byte-identical output. Block scales/data/output are all contiguous and K is a
+// multiple of 16, so the flat block index addresses each cleanly.
+template <typename OutType>
+__global__ void nvfp4_dequant_blockwise_kernel(const uint2* __restrict__ fp4_data,
+                                               const uint8_t* __restrict__ block_scales,
+                                               const float* __restrict__ global_scale_ptr,
+                                               OutType* __restrict__ output,
+                                               const long num_blocks_total) {
+  const float global_scale = __ldg(global_scale_ptr);
+  const long stride = static_cast<long>(gridDim.x) * blockDim.x;
+  for (long bidx = static_cast<long>(blockIdx.x) * blockDim.x + threadIdx.x;
+       bidx < num_blocks_total; bidx += stride) {
+    uint2 packed = fp4_data[bidx];
+    __nv_fp8_e4m3 sc;
+    sc.__x = __ldg(&block_scales[bidx]);
+    const float scale = static_cast<float>(sc) * global_scale;
 
-  if (row >= M) return;
-
-  extern __shared__ uint8_t smem[];
-  float& global_scale = *reinterpret_cast<float*>(smem);
-  // smem_scales starts after global_scale (aligned to 4 bytes)
-  uint8_t* smem_scales = smem + sizeof(float);
-
-  if (tid == 0) {
-    global_scale = *global_scale_ptr;
-  }
-
-  const int K_scales = K / NVFP4_BLOCK_SIZE;
-  const int K_packed = K / 2;
-
-  for (int i = tid; i < K_scales; i += BLOCK_SIZE) {
-    smem_scales[i] = block_scales[row * K_scales + i];
-  }
-  __syncthreads();
-
-  constexpr int PACKED_PER_THREAD = ELTS_PER_THREAD / 2;
-  const int elts_per_block = BLOCK_SIZE * ELTS_PER_THREAD;
-
-  const uint8_t* row_fp4 = fp4_data + row * K_packed;
-  OutType* row_output = output + row * K;
-
-  for (int base_col = 0; base_col < K; base_col += elts_per_block) {
-    const int col_start = base_col + tid * ELTS_PER_THREAD;
-
-    if (col_start >= K) break;
-
+    OutType res[16];
+    const uint32_t words[2] = {packed.x, packed.y};
 #pragma unroll
-    for (int i = 0; i < PACKED_PER_THREAD / 2; ++i) {
-      const int col = col_start + i * 4;
-      if (col + 3 >= K) break;
-
-      const int packed_idx = col / 2;
-      uint16_t packed_fp4 = *reinterpret_cast<const uint16_t*>(&row_fp4[packed_idx]);
-
-      const int scale_idx_0 = col / NVFP4_BLOCK_SIZE;
-      const int scale_idx_1 = (col + 2) / NVFP4_BLOCK_SIZE;
-
-      const uint8_t scale_fp8_0 = smem_scales[scale_idx_0];
-      const uint8_t scale_fp8_1 = smem_scales[scale_idx_1];
-
-      const float scale_0 =
-          static_cast<float>(*reinterpret_cast<const __nv_fp8_e4m3*>(&scale_fp8_0));
-      const float scale_1 =
-          static_cast<float>(*reinterpret_cast<const __nv_fp8_e4m3*>(&scale_fp8_1));
-
-      float2 out0, out1;
-      dequant_fp4x4_to_float2x2(packed_fp4, scale_0, scale_1, global_scale, out0, out1);
-
-      if constexpr (std::is_same_v<OutType, __nv_bfloat16>) {
-        __nv_bfloat162 bf16_0 = __float22bfloat162_rn(out0);
-        __nv_bfloat162 bf16_1 = __float22bfloat162_rn(out1);
-
-        *reinterpret_cast<__nv_bfloat162*>(&row_output[col]) = bf16_0;
-        *reinterpret_cast<__nv_bfloat162*>(&row_output[col + 2]) = bf16_1;
-      } else if constexpr (std::is_same_v<OutType, half>) {
-        half2 h2_0 = __float22half2_rn(out0);
-        half2 h2_1 = __float22half2_rn(out1);
-
-        *reinterpret_cast<half2*>(&row_output[col]) = h2_0;
-        *reinterpret_cast<half2*>(&row_output[col + 2]) = h2_1;
+    for (int w = 0; w < 2; ++w) {
+#pragma unroll
+      for (int b = 0; b < 4; ++b) {
+        const uint32_t byte = (words[w] >> (b * 8)) & 0xFFu;
+        float2 o;
+        o.x = e2m1_to_f32(byte & 0xFu) * scale;
+        o.y = e2m1_to_f32((byte >> 4) & 0xFu) * scale;
+        if constexpr (std::is_same_v<OutType, __nv_bfloat16>) {
+          *reinterpret_cast<__nv_bfloat162*>(&res[w * 8 + b * 2]) = __float22bfloat162_rn(o);
+        } else {
+          *reinterpret_cast<half2*>(&res[w * 8 + b * 2]) = __float22half2_rn(o);
+        }
       }
     }
+    float4* out_vec = reinterpret_cast<float4*>(output + bidx * 16);
+    const float4* res_vec = reinterpret_cast<const float4*>(res);
+    out_vec[0] = res_vec[0];
+    out_vec[1] = res_vec[1];
   }
 }
 
+// Paged dequant, blockwise: one thread per 16-element NVFP4 block, grid-strided over all
+// batch*seq*head*(head_dim/16) blocks. Each thread does the page lookup once, a uint2 load
+// (8 packed bytes = 16 nibbles), reads its one FP8 scale, dequantizes in fp32 with the same
+// multiply order as before — (e2m1 * block_scale) * global_scale, so output is byte-identical
+// — and writes 16 outputs as two float4 stores. Invalid rows (token >= seq_len, or an
+// out-of-range page) are skipped without writing, exactly as before. This replaces the
+// one-block-per-(batch,token,head) mapping with scalar 1-byte loads, which is memory-latency
+// bound; the blockwise mapping with wide transactions is ~2.7x faster on large caches.
 template <typename OutType, typename IdType>
-__global__ void nvfp4_paged_dequant_kernel(
+__global__ void nvfp4_paged_dequant_blockwise_kernel(
     const uint8_t* __restrict__ paged_cache, const uint8_t* __restrict__ paged_scales,
     const IdType* __restrict__ block_tables, const int32_t* __restrict__ seq_lens,
     const float* __restrict__ global_scale_ptr, OutType* __restrict__ output, const int batch_size,
@@ -136,52 +111,60 @@ __global__ void nvfp4_paged_dequant_kernel(
     const int num_heads, const int head_dim, const int64_t cache_stride_page,
     const int64_t cache_stride_n, const int64_t cache_stride_h, const int64_t scale_stride_page,
     const int64_t scale_stride_n, const int64_t scale_stride_h) {
-  const int row = blockIdx.x;
-  const int tid = threadIdx.x;
+  const float global_scale = __ldg(global_scale_ptr);
+  const int blocks_per_row = head_dim / NVFP4_BLOCK_SIZE;
+  const long total = static_cast<long>(batch_size) * max_seq_len * num_heads * blocks_per_row;
+  const long stride = static_cast<long>(gridDim.x) * blockDim.x;
+  for (long idx = static_cast<long>(blockIdx.x) * blockDim.x + threadIdx.x; idx < total;
+       idx += stride) {
+    const int blk = idx % blocks_per_row;
+    const long row = idx / blocks_per_row;
+    const int head = row % num_heads;
+    const int token = (row / num_heads) % max_seq_len;
+    const int batch = row / (static_cast<long>(num_heads) * max_seq_len);
+    if (token >= seq_lens[batch]) continue;
+    const int page_offset = token / page_size;
+    const int entry_idx = token - page_offset * page_size;
+    const IdType page = block_tables[batch * block_table_stride + page_offset];
+    if (page < 0 || page >= num_pages) continue;
 
-  const int head = row % num_heads;
-  const int token = (row / num_heads) % max_seq_len;
-  const int batch = row / (num_heads * max_seq_len);
+    const int64_t cache_base = static_cast<int64_t>(page) * cache_stride_page +
+                               static_cast<int64_t>(entry_idx) * cache_stride_n +
+                               static_cast<int64_t>(head) * cache_stride_h;
+    const int64_t scale_base = static_cast<int64_t>(page) * scale_stride_page +
+                               static_cast<int64_t>(entry_idx) * scale_stride_n +
+                               static_cast<int64_t>(head) * scale_stride_h;
+    uint2 packed =
+        *reinterpret_cast<const uint2*>(paged_cache + cache_base + static_cast<int64_t>(blk) * 8);
+    __nv_fp8_e4m3 sc;
+    sc.__x = __ldg(paged_scales + scale_base + blk);
+    const float scale = static_cast<float>(sc);
 
-  if (batch >= batch_size || token >= seq_lens[batch]) return;
-
-  const int page_offset = token / page_size;
-  const int entry_idx = token - page_offset * page_size;
-  const IdType page = block_tables[batch * block_table_stride + page_offset];
-  if (page < 0 || page >= num_pages) return;
-
-  const int packed_dim = head_dim / 2;
-  const int scale_dim = head_dim / NVFP4_BLOCK_SIZE;
-
-  const int64_t cache_base = static_cast<int64_t>(page) * cache_stride_page +
-                             static_cast<int64_t>(entry_idx) * cache_stride_n +
-                             static_cast<int64_t>(head) * cache_stride_h;
-  const int64_t scale_base = static_cast<int64_t>(page) * scale_stride_page +
-                             static_cast<int64_t>(entry_idx) * scale_stride_n +
-                             static_cast<int64_t>(head) * scale_stride_h;
-
-  const uint8_t* row_fp4 = paged_cache + cache_base;
-  const uint8_t* row_scales = paged_scales + scale_base;
-  OutType* row_output =
-      output + ((static_cast<int64_t>(batch) * max_seq_len + token) * num_heads + head) * head_dim;
-  const float global_scale = *global_scale_ptr;
-
-  for (int packed_col = tid; packed_col < packed_dim; packed_col += blockDim.x) {
-    const uint8_t packed_fp4 = row_fp4[packed_col];
-    const int col = packed_col * 2;
-    const int scale_idx = col / NVFP4_BLOCK_SIZE;
-    const uint8_t scale_fp8 = row_scales[scale_idx];
-    const float scale = static_cast<float>(*reinterpret_cast<const __nv_fp8_e4m3*>(&scale_fp8));
-
-    const float out0 = E2M1_LUT[packed_fp4 & 0xF] * scale * global_scale;
-    const float out1 = E2M1_LUT[(packed_fp4 >> 4) & 0xF] * scale * global_scale;
-
-    if constexpr (std::is_same_v<OutType, __nv_bfloat16>) {
-      *reinterpret_cast<__nv_bfloat162*>(&row_output[col]) =
-          __float22bfloat162_rn(make_float2(out0, out1));
-    } else if constexpr (std::is_same_v<OutType, half>) {
-      *reinterpret_cast<half2*>(&row_output[col]) = __float22half2_rn(make_float2(out0, out1));
+    OutType res[16];
+    const uint32_t words[2] = {packed.x, packed.y};
+#pragma unroll
+    for (int w = 0; w < 2; ++w) {
+#pragma unroll
+      for (int b = 0; b < 4; ++b) {
+        const uint32_t byte = (words[w] >> (b * 8)) & 0xFFu;
+        float2 o;
+        o.x = e2m1_to_f32(byte & 0xFu) * scale * global_scale;
+        o.y = e2m1_to_f32((byte >> 4) & 0xFu) * scale * global_scale;
+        if constexpr (std::is_same_v<OutType, __nv_bfloat16>) {
+          *reinterpret_cast<__nv_bfloat162*>(&res[w * 8 + b * 2]) = __float22bfloat162_rn(o);
+        } else {
+          *reinterpret_cast<half2*>(&res[w * 8 + b * 2]) = __float22half2_rn(o);
+        }
+      }
     }
+    OutType* row_out = output +
+                       ((static_cast<int64_t>(batch) * max_seq_len + token) * num_heads + head) *
+                           head_dim +
+                       static_cast<int64_t>(blk) * 16;
+    float4* out_vec = reinterpret_cast<float4*>(row_out);
+    const float4* res_vec = reinterpret_cast<const float4*>(res);
+    out_vec[0] = res_vec[0];
+    out_vec[1] = res_vec[1];
   }
 }
 
@@ -217,19 +200,20 @@ void nvfp4_kv_dequant(TensorView fp4_data, TensorView block_scales, TensorView g
 
   const float* scale_ptr = static_cast<const float*>(global_scale.data_ptr());
 
-  constexpr int BLOCK_SIZE = 128;
-  dim3 grid(M);
-  dim3 block(BLOCK_SIZE);
-
-  constexpr int ELTS_PER_THREAD = 16;
-  const size_t smem_size = sizeof(float) + static_cast<size_t>(K / NVFP4_BLOCK_SIZE);
+  // One thread per 16-element NVFP4 block, grid-strided. Wide vectorized loads/stores;
+  // grid capped so the launch stays lean (the grid-stride loop covers the remainder).
+  const long num_blocks_total = static_cast<long>(M) * (K / NVFP4_BLOCK_SIZE);
+  constexpr int THREADS = 256;
+  long blocks = (num_blocks_total + THREADS - 1) / THREADS;
+  const long MAX_BLOCKS = 108L * 32;
+  if (blocks > MAX_BLOCKS) blocks = MAX_BLOCKS;
+  if (blocks < 1) blocks = 1;
 
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(output.dtype(), c_type, [&] {
-    nvfp4_dequant_vectorized_kernel<c_type, BLOCK_SIZE, ELTS_PER_THREAD>
-        <<<grid, block, smem_size, stream>>>(static_cast<const uint8_t*>(fp4_data.data_ptr()),
-                                             static_cast<const uint8_t*>(block_scales.data_ptr()),
-                                             scale_ptr, static_cast<c_type*>(output.data_ptr()), M,
-                                             K);
+    nvfp4_dequant_blockwise_kernel<c_type><<<blocks, THREADS, 0, stream>>>(
+        reinterpret_cast<const uint2*>(fp4_data.data_ptr()),
+        static_cast<const uint8_t*>(block_scales.data_ptr()), scale_ptr,
+        static_cast<c_type*>(output.data_ptr()), num_blocks_total);
     return true;
   });
 }
@@ -378,33 +362,42 @@ void nvfp4_paged_kv_dequant(TensorView paged_k_cache, TensorView paged_v_cache, 
   CHECK_INPUT(output_k);
   CHECK_INPUT(output_v);
 
-  const int k_block_size = k_packed_dim < 128 ? k_packed_dim : 128;
-  const int v_block_size = v_packed_dim < 128 ? v_packed_dim : 128;
-  dim3 k_block(k_block_size);
-  dim3 v_block(v_block_size);
-  dim3 grid(batch_size * max_seq_len * num_heads);
+  // One thread per 16-element NVFP4 block, grid-strided over all
+  // batch*seq*head*(head_dim/16) blocks; grid capped so the launch stays lean.
+  constexpr int THREADS = 256;
+  const long MAX_BLOCKS = 108L * 32;
+  auto grid_for = [&](int head_dim) {
+    const long total =
+        static_cast<long>(batch_size) * max_seq_len * num_heads * (head_dim / NVFP4_BLOCK_SIZE);
+    long blocks = (total + THREADS - 1) / THREADS;
+    if (blocks > MAX_BLOCKS) blocks = MAX_BLOCKS;
+    if (blocks < 1) blocks = 1;
+    return static_cast<unsigned int>(blocks);
+  };
 
   DISPATCH_DLPACK_IDTYPE_TO_CTYPE(block_tables.dtype(), id_type, [&] {
     DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(output_k.dtype(), out_type, [&] {
-      nvfp4_paged_dequant_kernel<out_type, id_type><<<grid, k_block, 0, stream>>>(
-          static_cast<const uint8_t*>(paged_k_cache.data_ptr()),
-          static_cast<const uint8_t*>(k_scales.data_ptr()),
-          static_cast<const id_type*>(block_tables.data_ptr()),
-          static_cast<const int32_t*>(seq_lens.data_ptr()),
-          static_cast<const float*>(k_global_scale.data_ptr()),
-          static_cast<out_type*>(output_k.data_ptr()), batch_size, max_seq_len,
-          block_tables.size(1), num_pages, page_size, num_heads, k_head_dim, k_stride_page,
-          k_stride_n, k_stride_h, k_scale_stride_page, k_scale_stride_n, k_scale_stride_h);
+      nvfp4_paged_dequant_blockwise_kernel<out_type, id_type>
+          <<<grid_for(k_head_dim), THREADS, 0, stream>>>(
+              static_cast<const uint8_t*>(paged_k_cache.data_ptr()),
+              static_cast<const uint8_t*>(k_scales.data_ptr()),
+              static_cast<const id_type*>(block_tables.data_ptr()),
+              static_cast<const int32_t*>(seq_lens.data_ptr()),
+              static_cast<const float*>(k_global_scale.data_ptr()),
+              static_cast<out_type*>(output_k.data_ptr()), batch_size, max_seq_len,
+              block_tables.size(1), num_pages, page_size, num_heads, k_head_dim, k_stride_page,
+              k_stride_n, k_stride_h, k_scale_stride_page, k_scale_stride_n, k_scale_stride_h);
       FLASHINFER_CUDA_CHECK(cudaGetLastError());
-      nvfp4_paged_dequant_kernel<out_type, id_type><<<grid, v_block, 0, stream>>>(
-          static_cast<const uint8_t*>(paged_v_cache.data_ptr()),
-          static_cast<const uint8_t*>(v_scales.data_ptr()),
-          static_cast<const id_type*>(block_tables.data_ptr()),
-          static_cast<const int32_t*>(seq_lens.data_ptr()),
-          static_cast<const float*>(v_global_scale.data_ptr()),
-          static_cast<out_type*>(output_v.data_ptr()), batch_size, max_seq_len,
-          block_tables.size(1), num_pages, page_size, num_heads, v_head_dim, v_stride_page,
-          v_stride_n, v_stride_h, v_scale_stride_page, v_scale_stride_n, v_scale_stride_h);
+      nvfp4_paged_dequant_blockwise_kernel<out_type, id_type>
+          <<<grid_for(v_head_dim), THREADS, 0, stream>>>(
+              static_cast<const uint8_t*>(paged_v_cache.data_ptr()),
+              static_cast<const uint8_t*>(v_scales.data_ptr()),
+              static_cast<const id_type*>(block_tables.data_ptr()),
+              static_cast<const int32_t*>(seq_lens.data_ptr()),
+              static_cast<const float*>(v_global_scale.data_ptr()),
+              static_cast<out_type*>(output_v.data_ptr()), batch_size, max_seq_len,
+              block_tables.size(1), num_pages, page_size, num_heads, v_head_dim, v_stride_page,
+              v_stride_n, v_stride_h, v_scale_stride_page, v_scale_stride_n, v_scale_stride_h);
       FLASHINFER_CUDA_CHECK(cudaGetLastError());
       return true;
     });

--- a/csrc/fp4_kv_dequantization.cu
+++ b/csrc/fp4_kv_dequantization.cu
@@ -40,9 +40,9 @@ __device__ __constant__ float E2M1_LUT[16] = {0.0f,  0.5f,  1.0f,  1.5f,  2.0f, 
 __device__ __forceinline__ float e2m1_to_f32(uint32_t n) {
   const uint32_t e = (n >> 1) & 0x3u;
   const uint32_t m = n & 0x1u;
-  const float mag = (e == 0u) ? (0.5f * static_cast<float>(m))
-                              : (static_cast<float>(1u << (e - 1u)) *
-                                 (1.0f + 0.5f * static_cast<float>(m)));
+  const float mag =
+      (e == 0u) ? (0.5f * static_cast<float>(m))
+                : (static_cast<float>(1u << (e - 1u)) * (1.0f + 0.5f * static_cast<float>(m)));
   return (n & 0x8u) ? -mag : mag;
 }
 
@@ -177,10 +177,10 @@ __global__ void nvfp4_paged_dequant_blockwise_kernel(
     alignas(16) OutType res[16];
     decode_block<OutType>(w0, w1, static_cast<float>(sc), global_scale, res);
 
-    OutType* row_out = output +
-                       ((static_cast<int64_t>(batch) * max_seq_len + token) * num_heads + head) *
-                           head_dim +
-                       static_cast<int64_t>(blk) * 16;
+    OutType* row_out =
+        output +
+        ((static_cast<int64_t>(batch) * max_seq_len + token) * num_heads + head) * head_dim +
+        static_cast<int64_t>(blk) * 16;
     if constexpr (ALIGNED) {
       reinterpret_cast<float4*>(row_out)[0] = reinterpret_cast<const float4*>(res)[0];
       reinterpret_cast<float4*>(row_out)[1] = reinterpret_cast<const float4*>(res)[1];

--- a/tests/utils/test_fp4_kv_quantization.py
+++ b/tests/utils/test_fp4_kv_quantization.py
@@ -123,11 +123,26 @@ def test_nvfp4_kv_dequant(shape, dtype):
 # grid-stride loop (well past the launch-overhead regime of the small shapes above).
 LARGE_SHAPES = [(16384, 512), (4096, 2048)]
 
+# Non-power-of-two global scales. These matter: with a power-of-two scale (e.g. 0.5) the
+# products stay exactly representable, which would hide a multiplication-order change. The
+# dequant computes (e2m1 * block_scale) * global_scale in fp32, matching reference_dequant,
+# so the result must be bit-for-bit identical to the reference.
+NON_POW2_SCALES = [0.3, 1.7, 0.7601996]
+
+
+def assert_bit_identical(output, ref):
+    """Compare via the integer bit pattern: exact, and distinguishes +0.0 from -0.0."""
+    assert output.dtype == ref.dtype
+    torch.testing.assert_close(
+        output.view(torch.int16), ref.view(torch.int16), rtol=0, atol=0
+    )
+
 
 @pytest.mark.parametrize("shape", LARGE_SHAPES)
 @pytest.mark.parametrize("dtype", DTYPES)
-def test_nvfp4_kv_dequant_large(shape, dtype):
-    """Dequantization at production scale, checked against the PyTorch reference."""
+@pytest.mark.parametrize("global_scale_val", NON_POW2_SCALES)
+def test_nvfp4_kv_dequant_large(shape, dtype, global_scale_val):
+    """Dequant at production scale with non-power-of-two scales; bit-exact vs reference."""
     cc = get_compute_capability()
     if cc < 80:
         pytest.skip(f"SM{cc} does not support FP8 E4M3 (requires SM80+)")
@@ -136,14 +151,46 @@ def test_nvfp4_kv_dequant_large(shape, dtype):
     torch.manual_seed(0)
     fp4_data = torch.randint(0, 256, (M, K // 2), dtype=torch.uint8, device="cuda")
     block_scales = torch.randint(1, 120, (M, K // 16), dtype=torch.uint8, device="cuda")
-    global_scale_val = 0.5
     global_scale = torch.tensor([global_scale_val], dtype=torch.float32, device="cuda")
 
     output = flashinfer.nvfp4_kv_dequantize(
         fp4_data, block_scales, global_scale, output_dtype=dtype
     )
     ref = reference_dequant(fp4_data, block_scales, global_scale_val, dtype)
-    torch.testing.assert_close(output.float(), ref.float(), atol=1e-3, rtol=1e-3)
+    assert_bit_identical(output, ref)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("global_scale_val", NON_POW2_SCALES)
+def test_nvfp4_kv_dequant_all_e2m1_values_and_unaligned(dtype, global_scale_val):
+    """Cover every E2M1 codepoint, and a contiguous input with a nonzero storage offset.
+
+    The offset makes the base pointer non-16-byte-aligned, exercising the kernel's
+    byte-safe fallback path (rather than the vectorized fast path). Output must still be
+    bit-identical to the reference.
+    """
+    cc = get_compute_capability()
+    if cc < 80:
+        pytest.skip(f"SM{cc} does not support FP8 E4M3 (requires SM80+)")
+
+    M, K = 256, 128
+    # Every byte value 0..255 appears -> every (lo, hi) E2M1 nibble pair is covered.
+    base = (torch.arange(M * (K // 2), device="cuda") % 256).to(torch.uint8)
+    # Allocate one extra byte and slice it off so the view has a nonzero storage offset
+    # (still contiguous), i.e. an unaligned base pointer.
+    padded = torch.empty(M * (K // 2) + 1, dtype=torch.uint8, device="cuda")
+    padded[1:].copy_(base)
+    fp4_data = padded[1:].view(M, K // 2)
+    assert fp4_data.is_contiguous() and fp4_data.storage_offset() == 1
+
+    block_scales = torch.randint(1, 120, (M, K // 16), dtype=torch.uint8, device="cuda")
+    global_scale = torch.tensor([global_scale_val], dtype=torch.float32, device="cuda")
+
+    output = flashinfer.nvfp4_kv_dequantize(
+        fp4_data, block_scales, global_scale, output_dtype=dtype
+    )
+    ref = reference_dequant(fp4_data, block_scales, global_scale_val, dtype)
+    assert_bit_identical(output, ref)
 
 
 @pytest.mark.parametrize("kv_layout", ["NHD", "HND"])

--- a/tests/utils/test_fp4_kv_quantization.py
+++ b/tests/utils/test_fp4_kv_quantization.py
@@ -316,6 +316,77 @@ def test_nvfp4_kv_dequantize_paged(kv_layout, block_table_dtype, dtype, non_cont
 
 
 @pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_nvfp4_kv_dequantize_paged_bitexact_unaligned(kv_layout, dtype):
+    """Paged dequant: bit-exact at non-power-of-two scales, with non-contiguous cache
+    inputs AND an output view with a nonzero storage offset -- i.e. exercising the
+    byte-safe fallback on both the load and the store side."""
+    cc = get_compute_capability()
+    if cc < 80:
+        pytest.skip(f"SM{cc} does not support FP8 E4M3 (requires SM80+)")
+
+    torch.manual_seed(7)
+    num_pages, page_size, batch_size, max_seq_len, num_kv_heads = 8, 3, 2, 7, 2
+    k_head_dim, v_head_dim = 64, 128
+
+    def rand_cache(hd):
+        return torch.randint(0, 256, (num_pages, page_size, num_kv_heads, hd // 2),
+                             dtype=torch.uint8, device="cuda")
+
+    def rand_scales(hd):
+        return torch.randint(1, 120, (num_pages, page_size, num_kv_heads, hd // 16),
+                             dtype=torch.uint8, device="cuda").view(torch.float8_e4m3fn)
+
+    k_cache_nhd, v_cache_nhd = rand_cache(k_head_dim), rand_cache(v_head_dim)
+    k_scales_nhd, v_scales_nhd = rand_scales(k_head_dim), rand_scales(v_head_dim)
+
+    def to_layout(x):
+        return x if kv_layout == "NHD" else x.permute(0, 2, 1, 3).contiguous()
+
+    # non-contiguous last-dim views -> misaligned base / non-multiple strides -> fallback
+    k_cache = make_non_contiguous_last_dim_view(to_layout(k_cache_nhd))
+    v_cache = make_non_contiguous_last_dim_view(to_layout(v_cache_nhd))
+    k_scales = make_non_contiguous_last_dim_view(to_layout(k_scales_nhd))
+    v_scales = make_non_contiguous_last_dim_view(to_layout(v_scales_nhd))
+
+    block_tables = torch.tensor([[2, 5, 1], [6, 3, 0]], dtype=torch.int32, device="cuda")
+    seq_lens = torch.tensor([7, 4], dtype=torch.int32, device="cuda")
+    k_scale_val, v_scale_val = 0.7601996, 0.31234
+    k_scale = torch.tensor([k_scale_val], dtype=torch.float32, device="cuda")
+    v_scale = torch.tensor([v_scale_val], dtype=torch.float32, device="cuda")
+
+    # output views with a nonzero (odd-element) storage offset -> unaligned base -> fallback
+    def offset_output(hd):
+        numel = batch_size * max_seq_len * num_kv_heads * hd
+        buf = torch.full((numel + 1,), 123.0, dtype=dtype, device="cuda")
+        view = buf[1:].view(batch_size, max_seq_len, num_kv_heads, hd)
+        assert view.is_contiguous() and view.storage_offset() == 1
+        return view
+
+    output_k, output_v = offset_output(k_head_dim), offset_output(v_head_dim)
+
+    flashinfer.nvfp4_kv_dequantize_paged(
+        (k_cache, v_cache), (k_scales, v_scales), block_tables, seq_lens, k_scale, v_scale,
+        output_k, output_v, kv_layout=kv_layout,
+    )
+
+    ref_k = torch.full_like(output_k, 123.0)
+    ref_v = torch.full_like(output_v, 123.0)
+    for batch_idx, seq_len in enumerate(seq_lens.cpu().tolist()):
+        for token_idx in range(seq_len):
+            page = int(block_tables[batch_idx, token_idx // page_size].item())
+            entry = token_idx % page_size
+            ref_k[batch_idx, token_idx] = reference_dequant(
+                k_cache_nhd[page, entry], k_scales_nhd[page, entry], k_scale_val, dtype)
+            ref_v[batch_idx, token_idx] = reference_dequant(
+                v_cache_nhd[page, entry], v_scales_nhd[page, entry], v_scale_val, dtype)
+
+    # invalid rows are left at the sentinel in both, so a full bit-exact compare is valid
+    assert_bit_identical(output_k, ref_k)
+    assert_bit_identical(output_v, ref_v)
+
+
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
 def test_nvfp4_kv_dequantize_paged_long_context(kv_layout):
     """Exercise a long single-request cached-prefill style page walk."""
     cc = get_compute_capability()

--- a/tests/utils/test_fp4_kv_quantization.py
+++ b/tests/utils/test_fp4_kv_quantization.py
@@ -119,6 +119,33 @@ def test_nvfp4_kv_dequant(shape, dtype):
     torch.testing.assert_close(output.float(), ref.float(), atol=1e-3, rtol=1e-3)
 
 
+# Large, bandwidth-bound shapes that exercise the blockwise dequant kernel's
+# grid-stride loop (well past the launch-overhead regime of the small shapes above).
+LARGE_SHAPES = [(16384, 512), (4096, 2048)]
+
+
+@pytest.mark.parametrize("shape", LARGE_SHAPES)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_nvfp4_kv_dequant_large(shape, dtype):
+    """Dequantization at production scale, checked against the PyTorch reference."""
+    cc = get_compute_capability()
+    if cc < 80:
+        pytest.skip(f"SM{cc} does not support FP8 E4M3 (requires SM80+)")
+
+    M, K = shape
+    torch.manual_seed(0)
+    fp4_data = torch.randint(0, 256, (M, K // 2), dtype=torch.uint8, device="cuda")
+    block_scales = torch.randint(1, 120, (M, K // 16), dtype=torch.uint8, device="cuda")
+    global_scale_val = 0.5
+    global_scale = torch.tensor([global_scale_val], dtype=torch.float32, device="cuda")
+
+    output = flashinfer.nvfp4_kv_dequantize(
+        fp4_data, block_scales, global_scale, output_dtype=dtype
+    )
+    ref = reference_dequant(fp4_data, block_scales, global_scale_val, dtype)
+    torch.testing.assert_close(output.float(), ref.float(), atol=1e-3, rtol=1e-3)
+
+
 @pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
 @pytest.mark.parametrize("block_table_dtype", [torch.int32, torch.int64])
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/utils/test_fp4_kv_quantization.py
+++ b/tests/utils/test_fp4_kv_quantization.py
@@ -330,12 +330,22 @@ def test_nvfp4_kv_dequantize_paged_bitexact_unaligned(kv_layout, dtype):
     k_head_dim, v_head_dim = 64, 128
 
     def rand_cache(hd):
-        return torch.randint(0, 256, (num_pages, page_size, num_kv_heads, hd // 2),
-                             dtype=torch.uint8, device="cuda")
+        return torch.randint(
+            0,
+            256,
+            (num_pages, page_size, num_kv_heads, hd // 2),
+            dtype=torch.uint8,
+            device="cuda",
+        )
 
     def rand_scales(hd):
-        return torch.randint(1, 120, (num_pages, page_size, num_kv_heads, hd // 16),
-                             dtype=torch.uint8, device="cuda").view(torch.float8_e4m3fn)
+        return torch.randint(
+            1,
+            120,
+            (num_pages, page_size, num_kv_heads, hd // 16),
+            dtype=torch.uint8,
+            device="cuda",
+        ).view(torch.float8_e4m3fn)
 
     k_cache_nhd, v_cache_nhd = rand_cache(k_head_dim), rand_cache(v_head_dim)
     k_scales_nhd, v_scales_nhd = rand_scales(k_head_dim), rand_scales(v_head_dim)
@@ -349,7 +359,9 @@ def test_nvfp4_kv_dequantize_paged_bitexact_unaligned(kv_layout, dtype):
     k_scales = make_non_contiguous_last_dim_view(to_layout(k_scales_nhd))
     v_scales = make_non_contiguous_last_dim_view(to_layout(v_scales_nhd))
 
-    block_tables = torch.tensor([[2, 5, 1], [6, 3, 0]], dtype=torch.int32, device="cuda")
+    block_tables = torch.tensor(
+        [[2, 5, 1], [6, 3, 0]], dtype=torch.int32, device="cuda"
+    )
     seq_lens = torch.tensor([7, 4], dtype=torch.int32, device="cuda")
     k_scale_val, v_scale_val = 0.7601996, 0.31234
     k_scale = torch.tensor([k_scale_val], dtype=torch.float32, device="cuda")
@@ -366,8 +378,15 @@ def test_nvfp4_kv_dequantize_paged_bitexact_unaligned(kv_layout, dtype):
     output_k, output_v = offset_output(k_head_dim), offset_output(v_head_dim)
 
     flashinfer.nvfp4_kv_dequantize_paged(
-        (k_cache, v_cache), (k_scales, v_scales), block_tables, seq_lens, k_scale, v_scale,
-        output_k, output_v, kv_layout=kv_layout,
+        (k_cache, v_cache),
+        (k_scales, v_scales),
+        block_tables,
+        seq_lens,
+        k_scale,
+        v_scale,
+        output_k,
+        output_v,
+        kv_layout=kv_layout,
     )
 
     ref_k = torch.full_like(output_k, 123.0)
@@ -377,9 +396,11 @@ def test_nvfp4_kv_dequantize_paged_bitexact_unaligned(kv_layout, dtype):
             page = int(block_tables[batch_idx, token_idx // page_size].item())
             entry = token_idx % page_size
             ref_k[batch_idx, token_idx] = reference_dequant(
-                k_cache_nhd[page, entry], k_scales_nhd[page, entry], k_scale_val, dtype)
+                k_cache_nhd[page, entry], k_scales_nhd[page, entry], k_scale_val, dtype
+            )
             ref_v[batch_idx, token_idx] = reference_dequant(
-                v_cache_nhd[page, entry], v_scales_nhd[page, entry], v_scale_val, dtype)
+                v_cache_nhd[page, entry], v_scales_nhd[page, entry], v_scale_val, dtype
+            )
 
     # invalid rows are left at the sentinel in both, so a full bit-exact compare is valid
     assert_bit_identical(output_k, ref_k)


### PR DESCRIPTION
## 📌 Description

Both NVFP4 KV-cache dequant kernels in `csrc/fp4_kv_dequantization.cu` use a row-per-block
mapping that is memory-latency bound and leaves most of DRAM bandwidth on the table:

- **dense** (`nvfp4_dequant_vectorized_kernel`) — one block per row (`grid(M)`), FP8 scales
  staged in shared memory behind a `__syncthreads`, E2M1 via a constant-memory LUT
  (~20 % of peak bandwidth on large tensors);
- **paged** (`nvfp4_paged_dequant_kernel`) — one block per (batch, token, head) row, each
  thread doing a scalar 1-byte load + LUT + `half2` store.

This PR rewrites both as a **blockwise** kernel: **one thread per 16-element NVFP4 block**,
grid-strided over all blocks, doing a single `uint2` load (8 packed bytes = 16 nibbles),
reading the one FP8 scale it needs directly, and writing 16 outputs as two 128-bit `float4`
stores. The dequant math is **unchanged** — fp32 multiply in the same order,
`(e2m1 * block_scale) * global_scale`, rounded once — so the output is **byte-for-byte
identical** to the current kernels.

Measured **~3.2× (dense) / ~2.7× (paged)** on A100-80GB and **~3.6× / ~3.1×** on H100-80GB,
with no numeric change.

### Why it's faster

The transform is memory-bound; the win is entirely in the memory/thread mapping:

- **Row-per-block → block-per-thread.** `grid(M)` serializes each row's work into one block
  and needs shared-memory scale staging + a barrier; mapping one thread to one independent
  16-element block exposes all the parallelism directly and removes the barrier.
- **Wide transactions.** `uint2` loads and `float4` stores move 8/32 bytes per instruction
  instead of 2-byte `uint16`/`half2` accesses.
- **No LUT, no smem.** Each E2M1 nibble is reconstructed with a few integer ops
  (`e2m1_to_f32`, exact for all 16 codepoints), and each thread `__ldg`s its single scale —
  there's no cross-thread scale reuse, so the shared-memory copy was wasted work.

### Correctness

The output is **byte-identical** to the previous kernel: the dequant computes
`(e2m1 * block_scale) * global_scale` in **fp32**, in the *same multiply order* as the
original (fp32 multiply is not associative, so the order is preserved deliberately), and
rounds once (`__float22{half,bfloat16}2_rn`). `e2m1_to_f32` produces exactly the `E2M1_LUT`
values. Verified bit-exact (int16-view, `atol=rtol=0`) against the PyTorch reference across
**non-power-of-two** global scales, full E2M1 codepoint coverage, both bf16 and fp16, and an
**unaligned** (nonzero storage-offset) input.

**Alignment.** The `uint2`/`float4` fast path requires 8-/16-byte-aligned pointers. Since the
API accepts contiguous-but-offset tensors (and non-contiguous last-dim views for paged), the
launcher checks base-pointer/stride alignment and dispatches a **byte-safe fallback** (scalar
loads/stores, identical arithmetic) when the fast path isn't safe; the temporary is
`alignas(16)`. Both fallbacks are covered bit-exactly: a paged test at non-power-of-two scales
runs with non-contiguous cache inputs *and* an output view with a nonzero storage offset (plus
the existing non-contiguous paged test).

### Performance

CUDA-event median on large (bandwidth-bound) shapes; effective bandwidth counts
read (fp4 + FP8 scales) + write (bf16/fp16 output). Reproduce with
`benchmarks/bench_nvfp4_kv_dequant.py`.

| kernel | A100-80GB | H100-80GB |
|---|---|---|
| **dense** (`nvfp4_kv_dequantize`)       | ~3.2× · ~1300 GB/s (~65 % peak) | ~3.6× · ~2530 GB/s (~75 % peak) |
| **paged** (`nvfp4_kv_dequantize_paged`) | ~2.7× · ~790 GB/s               | ~3.1× · ~1350 GB/s              |

vs the current row-per-block kernels (~380–710 GB/s). Per-shape dense (bf16, A100):

| shape (M×K) | current GB/s | this PR GB/s | speedup |
|---|---|---|---|
| 65536×2048  | ~378 | ~1297 | 3.43× |
| 131072×2048 | ~415 | ~1307 | 3.15× |
| 65536×4096  | ~417 | ~1309 | 3.14× |
| 262144×1024 | ~409 | ~1308 | 3.20× |
| 131072×2048 (fp16) | ~415 | ~1312 | 3.16× |

Small shapes (e.g. `M×128`) are launch-overhead-bound and at parity, as expected. Paged
measured at `batch=256, seq=512, heads=8, head_dim=128` (K+V), across bf16/fp16, uniform and
varied `seq_lens` (invalid rows left unwritten exactly as before).

### A deliberate non-change: the scale multiply stays in fp32

A tempting further step is to do the scale multiply in **packed half2/bf162** (convert the
block scale to fp16/bf16, then multiply in low precision). We measured this and **did not
adopt it**: it **changes numerics** — with a non-power-of-2 global scale it diverges from the
current kernel by up to ~16 (bf16) and roughly doubles the rounding error vs an fp64
reference — and it isn't even faster where it counts: on A100 it adds only ~4 % over the
mapping change, and on H100 it is actually *slower* than the fp32 mapping change. The mapping
change alone captures the speedup while keeping output bit-identical, so this PR keeps the
fp32 multiply.

### Scope

- Covers both public entry points — `nvfp4_kv_dequant` (dense) and `nvfp4_paged_kv_dequant`
  (paged, K and V) — with the same constraints as before (`head_dim`/`K` a multiple of 16).
- The paged rewrite is layout-agnostic (uses the same per-page/head strides) and preserves the
  skip-invalid-rows behavior (`token >= seq_len` or out-of-range page → not written).

## 🔍 Related Issues

None — this was found by profiling the NVFP4 KV dequant path, not filed as an issue.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/utils/test_fp4_kv_quantization.py` — the existing dense + paged suite (small shapes,
NHD/HND layouts, non-contiguous views, empty output, stacked cache, long context, validation
errors) passes unchanged since the output is byte-identical. Added:

- `test_nvfp4_kv_dequant_large` — large shapes × bf16/fp16 × **non-power-of-two** global
  scales (0.3, 1.7, 0.7601996), compared **bit-exactly** (`int16`-view, `atol=rtol=0`).
- `test_nvfp4_kv_dequant_all_e2m1_values_and_unaligned` — every E2M1 codepoint, plus a
  contiguous input with a nonzero storage offset (drives the byte-safe dense fallback).
- `test_nvfp4_kv_dequantize_paged_bitexact_unaligned` — bit-exact paged at non-power-of-two
  scales with non-contiguous cache inputs **and** an offset output view (both fallbacks).

```bash
pytest tests/utils/test_fp4_kv_quantization.py
```

Run on A100-80GB and H100-80GB. `benchmarks/bench_nvfp4_kv_dequant.py` reproduces the
performance numbers above on any CUDA GPU.

## 🔬 Experimental Track

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #

Not experimental — this changes the existing `csrc/fp4_kv_dequantization.cu` kernels in place
behind unchanged public entry points.

## Reviewer Notes

The load-bearing claim is **byte-identity**, so the review that matters most is the multiply
order in `e2m1_to_f32` + the scale application, and the alignment predicate that decides
between the vectorized path and the byte-safe fallback. Both are covered by bit-exact tests
(`atol=rtol=0`), including the offset/non-contiguous inputs that force the fallback.

This change was prepared with AI assistance (Claude). A human reviewed every changed line and
ran the tests and benchmarks above on A100 and H100 hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved NVFP4 KV-cache dequantization performance through blockwise GPU processing and optimized aligned memory access.
  * Added benchmarks for dense and paged dequantization across multiple shapes and output types.

* **Bug Fixes**
  * Improved numerical consistency with bit-exact dequantization across supported FP4 values, scales, layouts, and unaligned memory.

* **Tests**
  * Added coverage for large inputs, non-power-of-two scales, paged caches, non-contiguous data, and unaligned buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->