### PR TITLE
Correct the NVLink all-up detection in MnnvlMemory for B300.

### DIFF
--- a/flashinfer/comm/mnnvl.py
+++ b/flashinfer/comm/mnnvl.py
@@ -715,15 +715,16 @@ class MnnvlMemory:  # type: ignore[no-redef]
         available_links = 0
         for link_idx in range(link_count):
             try:
-                if pynvml.nvmlDeviceGetNvLinkCapability(
+                if not pynvml.nvmlDeviceGetNvLinkCapability(
                     handle, link_idx, pynvml.NVML_NVLINK_CAP_P2P_SUPPORTED
                 ):
-                    available_links += 1
-                    is_active = pynvml.nvmlDeviceGetNvLinkState(handle, link_idx)
-                    if is_active:
-                        active_links += 1
+                    continue
+                is_active = pynvml.nvmlDeviceGetNvLinkState(handle, link_idx)
             except pynvml.NVMLError_NotSupported:
                 continue
+            available_links += 1
+            if is_active:
+                active_links += 1
         return (
             active_links == available_links and available_links > 0
             if need_all_up


### PR DESCRIPTION
On B300, nvmlDeviceGetNvLinkCapability reports 36 link slots. Which is not correct (then it checks 18 active vs 36)
Only count a link as available once its state can actually be read. I think GB does not have this problem. Otherwise, the following A2A test will fail, even though it works.

<!-- .github/pull_request_template.md -->

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

```
OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 mpirun -np 8 --allow-run-as-root pytest tests/comm/test_mnnvl_moe_alltoall.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: ai-dynamo-1.3.0.dev20260701, typeguard-4.5.2, anyio-4.14.1
collecting ... =========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: ai-dynamo-1.3.0.dev20260701, typeguard-4.5.2, anyio-4.14.1
collecting ... =========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: ai-dynamo-1.3.0.dev20260701, typeguard-4.5.2, anyio-4.14.1
collecting ... =========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: ai-dynamo-1.3.0.dev20260701, typeguard-4.5.2, anyio-4.14.1
collecting ... =========================================================================================================== test session starts ===========================================================================================================
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: ai-dynamo-1.3.0.dev20260701, typeguard-4.5.2, anyio-4.14.1
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: ai-dynamo-1.3.0.dev20260701, typeguard-4.5.2, anyio-4.14.1
collecting ... collecting ... =========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: ai-dynamo-1.3.0.dev20260701, typeguard-4.5.2, anyio-4.14.1
collecting ... rootdir: /sgl-workspace/flashinfer
configfile: pytest.ini
plugins: ai-dynamo-1.3.0.dev20260701, typeguard-4.5.2, anyio-4.14.1
collected 16 items                                                                                                                                                                                                                        
collected 16 items                                                                                                                                                                                                                        

collected 16 items                                                                                                                                                                                                                        

tests/comm/test_mnnvl_moe_alltoall.py 
collected 16 items                                                                                                                                                                                                                        

collected 16 items                                                                                                                                                                                                                        

collected 16 items                                                                                                                                                                                                                        

collected 16 items                                                                                                                                                                                                                        
collected 16 items                                                                                                                                                                                                                        

tests/comm/test_mnnvl_moe_alltoall.py 
tests/comm/test_mnnvl_moe_alltoall.py ................................................................................................................................                                                                                                                                                                              [100%]                                                                                                                                                                              [100%]                                                                                                                                                                              [100%]                                                                                                                                                                              [100%]                                                                                                                                                                              [100%]                                                                                                                                                                              [100%]                                                                                                                                                                              [100%]                                                                                                                                                                              [100%]



============================================================================================================ warnings summary =============================================================================================================
============================================================================================================ warnings summary =============================================================================================================
tests/conftest.py:16
tests/conftest.py:16
  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

tests/conftest.py:16
tests/conftest.py:16
  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html


-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================== 16 passed, 2 warnings in 100.00s (0:01:39) ================================================================================================
================================================================================================ 16 passed, 2 warnings in 99.96s (0:01:39) ================================================================================================




============================================================================================================ warnings summary =============================================================================================================


============================================================================================================ warnings summary =============================================================================================================
============================================================================================================ warnings summary =============================================================================================================
tests/conftest.py:16
tests/conftest.py:16
  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
tests/conftest.py:16
tests/conftest.py:16
  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
tests/conftest.py:16
tests/conftest.py:16
  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================ 16 passed, 2 warnings in 99.96s (0:01:39) ================================================================================================
================================================================================================ 16 passed, 2 warnings in 99.96s (0:01:39) ================================================================================================
================================================================================================ 16 passed, 2 warnings in 99.97s (0:01:39) ================================================================================================



============================================================================================================ warnings summary =============================================================================================================

============================================================================================================ warnings summary =============================================================================================================
tests/conftest.py:16
tests/conftest.py:16


  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================================ 16 passed, 2 warnings in 99.97s (0:01:39) ================================================================================================
============================================================================================================ warnings summary =============================================================================================================
tests/conftest.py:16
tests/conftest.py:16
  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================== 16 passed, 2 warnings in 100.46s (0:01:40) ================================================================================================
tests/conftest.py:16
tests/conftest.py:16
  /sgl-workspace/flashinfer/tests/conftest.py:16: DeprecationWarning: tcgen05.OperandMajorMode is deprecated, use cute.nvgpu.OperandMajorMode instead
    from cutlass.cute.nvgpu.tcgen05 import OperandMajorMode

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================== 16 passed, 2 warnings in 100.29s (0:01:40) ================================================================================================
```

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVLink availability detection to correctly count supported and active links.
  * Preserved graceful handling for systems where NVLink status is not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->