### PR TITLE
[fix] Disable 2cta trtllmgen MOE kernel 

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -141,9 +141,13 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
         if (config.mSm != tg::CudaArch::Sm100a && config.mSm != tg::CudaArch::Sm100f) continue;
       }
       if (mOptions.transposeMmaOutput && options.mEpilogueTileM == mOptions.epilogueTileM) {
-        // Disable 2-CTA kernels due to the random hang tracked in
+        // Disable FP4 2-CTA kernels due to the random hang tracked in
         // https://github.com/flashinfer-ai/flashinfer/issues/3971
-        if (options.mClusterDimX > 1) continue;
+        bool const isFp4Kernel = options.mDtypeA == tg::Dtype::E2m1 ||
+                                 options.mDtypeA == tg::Dtype::MxE2m1 ||
+                                 options.mDtypeB == tg::Dtype::E2m1 ||
+                                 options.mDtypeB == tg::Dtype::MxE2m1;
+        if (isFp4Kernel && options.mClusterDimX > 1) continue;
         // Skip cubins with clusterZ > 1 due to correctness issues described in
         // https://github.com/flashinfer-ai/flashinfer/issues/3197
         if (options.mClusterDimZ > 1) continue;

--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -141,6 +141,9 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
         if (config.mSm != tg::CudaArch::Sm100a && config.mSm != tg::CudaArch::Sm100f) continue;
       }
       if (mOptions.transposeMmaOutput && options.mEpilogueTileM == mOptions.epilogueTileM) {
+        // Disable 2-CTA kernels due to the random hang tracked in
+        // https://github.com/flashinfer-ai/flashinfer/issues/3971
+        if (options.mClusterDimX > 1) continue;
         // Skip cubins with clusterZ > 1 due to correctness issues described in
         // https://github.com/flashinfer-ai/flashinfer/issues/3197
         if (options.mClusterDimZ > 1) continue;

--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -144,8 +144,8 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
         // Disable FP4 2-CTA kernels due to the random hang tracked in
         // https://github.com/flashinfer-ai/flashinfer/issues/3971
         bool const isFp4Kernel =
-            options.mDtypeA == tg::Dtype::E2m1 || options.mDtypeA == tg::Dtype::MxE2m1 ||
-            options.mDtypeB == tg::Dtype::E2m1 || options.mDtypeB == tg::Dtype::MxE2m1;
+            (options.mDtypeA == tg::Dtype::E2m1 && options.mDtypeB == tg::Dtype::E2m1) ||
+            (options.mDtypeA == tg::Dtype::MxE2m1 && options.mDtypeB == tg::Dtype::MxE2m1);
         if (isFp4Kernel && options.mClusterDimX > 1) continue;
         // Skip cubins with clusterZ > 1 due to correctness issues described in
         // https://github.com/flashinfer-ai/flashinfer/issues/3197

--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -143,10 +143,9 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
       if (mOptions.transposeMmaOutput && options.mEpilogueTileM == mOptions.epilogueTileM) {
         // Disable FP4 2-CTA kernels due to the random hang tracked in
         // https://github.com/flashinfer-ai/flashinfer/issues/3971
-        bool const isFp4Kernel = options.mDtypeA == tg::Dtype::E2m1 ||
-                                 options.mDtypeA == tg::Dtype::MxE2m1 ||
-                                 options.mDtypeB == tg::Dtype::E2m1 ||
-                                 options.mDtypeB == tg::Dtype::MxE2m1;
+        bool const isFp4Kernel =
+            options.mDtypeA == tg::Dtype::E2m1 || options.mDtypeA == tg::Dtype::MxE2m1 ||
+            options.mDtypeB == tg::Dtype::E2m1 || options.mDtypeB == tg::Dtype::MxE2m1;
         if (isFp4Kernel && options.mClusterDimX > 1) continue;
         // Skip cubins with clusterZ > 1 due to correctness issues described in
         // https://github.com/flashinfer-ai/flashinfer/issues/3197


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Disable 2CTA trtllmgen MOE kernel because of https://github.com/flashinfer-ai/flashinfer/issues/3971 

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated kernel selection to recognize FP4 GEMM kernels and skip configurations where the cluster dimension X is greater than 1.
  * Improved batched matrix multiplication reliability by preventing unsupported FP4 GEMM configurations from being considered during selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->