### PR TITLE
Yanqinz/fix autotuner using autotuning plan from other runners

### DIFF
--- a/benchmarks/bench_cutlass_fused_moe.py
+++ b/benchmarks/bench_cutlass_fused_moe.py
@@ -221,8 +221,10 @@ if __name__ == "__main__":
     if args.update_config and configs:
         # ProfilingCacheKey.file_key excludes the runner's hash, which might be
         # different across machines, and matches the lookup format used by
-        # load_from_file. v[0] and v[1] are the runner id and the tactic.
-        converted = {k.file_key: (v[0], v[1]) for k, v in configs.items()}
+        # load_from_file. Cache values are (tactic, profile); the runner-id
+        # slot is written as 0 for file-format compatibility — lookups resolve
+        # the runner from the class name embedded in file_key, not this slot.
+        converted = {k.file_key: (0, v[0]) for k, v in configs.items()}
         config_path = get_config_path(is_module=False)
         with open(config_path, "w") as f:
             f.write("best_configs = ")

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -1229,34 +1229,33 @@ class AutoTuner:
             synthesis-invariant; see: TunableRunner.get_cache_key_extras.
         """
         with self._lock:
-            for r_id, r in enumerate(runners):
-                extras = r.get_cache_key_extras(inputs) if inputs is not None else ()
-                cache_key = AutoTuner._get_cache_key(
-                    custom_op, r, input_shapes, tuning_config, extras
+            runner_keys = [
+                (
+                    r_id,
+                    AutoTuner._get_cache_key(
+                        custom_op,
+                        r,
+                        input_shapes,
+                        tuning_config,
+                        r.get_cache_key_extras(inputs) if inputs is not None else (),
+                    ),
                 )
-                # 1. In-memory cache (from live tuning)
+                for r_id, r in enumerate(runners)
+            ]
+
+            # 1. In-memory cache (from live tuning)
+            for r_id, cache_key in runner_keys:
                 if cache_key in self.profiling_cache:
                     tactic, stored_profile = self.profiling_cache[cache_key]
                     return True, r_id, tactic, stored_profile
 
-                # Build the hash-free file key used by both user configs and bundled configs.
-                # Include extras (index 4) so that runner specific parameters
-                # are not lost on disk.
+            # 2. User-loaded configs (from load_configs or autotune(cache=...))
+            for r_id, cache_key in runner_keys:
                 file_key = cache_key.file_key
-
-                # 2. User-loaded configs (from load_configs or autotune(cache=...))
-                #    Always consulted, even during tuning mode — loaded configs take priority
-                #    so that already-tuned shapes are never re-profiled.
                 if file_key in self._file_configs:
                     runner_name, tactic = self._file_configs[file_key]
-                    runner_id = next(
-                        (
-                            i
-                            for i, runner in enumerate(runners)
-                            if runner.__class__.__name__ == runner_name
-                        ),
-                        0,  # fallback to first runner if name not found
-                    )
+                    if runner_name != runners[r_id].__class__.__name__:
+                        continue
                     log_key = (custom_op, runner_name)
                     if log_key not in self._logged_file_hits:
                         self._logged_file_hits.add(log_key)
@@ -1264,13 +1263,14 @@ class AutoTuner:
                             f"[Autotuner]: Config cache hit for {custom_op} "
                             f"(runner={runner_name}, source=config file)"
                         )
-                    return True, runner_id, tactic, None
+                    return True, r_id, tactic, None
 
-                # 3. Bundled package configs (legacy .py files)
-                if (
-                    os.environ.get("FLASHINFER_AUTOTUNER_LOAD_FROM_FILE", "0") == "1"
-                    and not self.is_tuning_mode
-                ):
+            # 3. Bundled package configs (legacy .py files)
+            if (
+                os.environ.get("FLASHINFER_AUTOTUNER_LOAD_FROM_FILE", "0") == "1"
+                and not self.is_tuning_mode
+            ):
+                for r_id, cache_key in runner_keys:
                     is_hit, _, file_tactic, _ = load_from_file(cache_key.file_key)
                     if is_hit:
                         return True, r_id, file_tactic, None

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -959,7 +959,10 @@ class AutoTunerStatistics:
 
 
 @functools.lru_cache(maxsize=16384)
-def load_from_file(file_key: str) -> tuple[bool, int, int, None]:
+def load_from_file(file_key: str) -> tuple[bool, int, Any, None]:
+    # Returns (is_cache_hit, runner_id, tactic, profile). The runner_id slot
+    # is a legacy placeholder from the on-disk format; the caller resolves
+    # the runner from the file_key and ignores this slot.
     module_name = get_config_path(is_module=True)
     try:
         module = importlib.import_module(module_name)
@@ -1019,7 +1022,7 @@ class AutoTuner:
         self.warmup = warmup
         self.stream_delay_micro_secs = stream_delay_micro_secs
         self.profiling_cache: dict[
-            ProfilingCacheKey, tuple[int, int, OptimizationProfile]
+            ProfilingCacheKey, tuple[Any, OptimizationProfile | None]
         ] = {}
         self.is_tuning_mode = False
         self._active_tuning_contexts = 0
@@ -1194,7 +1197,7 @@ class AutoTuner:
         input_shapes: tuple[tuple[int, ...], ...],
         tuning_config: TuningConfig,
         inputs: list[torch.Tensor] | None = None,
-    ) -> tuple[bool, int, int, OptimizationProfile | None]:
+    ) -> tuple[bool, int, Any, OptimizationProfile | None]:
         """Search for cached profiling results matching the current configuration.
 
         Searches the following sources in priority order:
@@ -1226,14 +1229,15 @@ class AutoTuner:
             synthesis-invariant; see: TunableRunner.get_cache_key_extras.
         """
         with self._lock:
-            for r in runners:
+            for r_id, r in enumerate(runners):
                 extras = r.get_cache_key_extras(inputs) if inputs is not None else ()
                 cache_key = AutoTuner._get_cache_key(
                     custom_op, r, input_shapes, tuning_config, extras
                 )
                 # 1. In-memory cache (from live tuning)
                 if cache_key in self.profiling_cache:
-                    return True, *self.profiling_cache[cache_key]
+                    tactic, stored_profile = self.profiling_cache[cache_key]
+                    return True, r_id, tactic, stored_profile
 
                 # Build the hash-free file key used by both user configs and bundled configs.
                 # Include extras (index 4) so that runner specific parameters
@@ -1267,9 +1271,9 @@ class AutoTuner:
                     os.environ.get("FLASHINFER_AUTOTUNER_LOAD_FROM_FILE", "0") == "1"
                     and not self.is_tuning_mode
                 ):
-                    output = load_from_file(cache_key.file_key)
-                    if output[0]:  # is_cache_hit
-                        return output
+                    is_hit, _, file_tactic, _ = load_from_file(cache_key.file_key)
+                    if is_hit:
+                        return True, r_id, file_tactic, None
 
             # 4. Fallback
             return False, 0, -1, None
@@ -1634,8 +1638,7 @@ class AutoTuner:
                                 tuning_config,
                                 runners[runner_id].get_cache_key_extras(tensors),
                             )
-                            # inspect call stack
-                            self.profiling_cache[cache_key] = (runner_id, tactic, p)
+                            self.profiling_cache[cache_key] = (tactic, p)
                             self._dirty = True
                             self._dirty_seq += 1
                             self.stats.tuned_op_successful_configs[custom_op] = (
@@ -2080,7 +2083,7 @@ class AutoTuner:
 
             # Overlay in-memory profiling results (take priority over loaded configs)
             for cache_key, cache_value in self.profiling_cache.items():
-                _, tactic, _ = cache_value
+                tactic, _ = cache_value
 
                 # Use hash-free key including extras so runner specific parameters
                 # are preserved across save or load.

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -1229,22 +1229,20 @@ class AutoTuner:
             synthesis-invariant; see: TunableRunner.get_cache_key_extras.
         """
         with self._lock:
-            runner_keys = [
-                (
-                    r_id,
-                    AutoTuner._get_cache_key(
-                        custom_op,
-                        r,
-                        input_shapes,
-                        tuning_config,
-                        r.get_cache_key_extras(inputs) if inputs is not None else (),
-                    ),
+            # 1. In-memory cache (from live tuning). Keys are built lazily so
+            #    the common warm path (hit here) pays for exactly one key per
+            #    runner visited; a full miss leaves runner_keys complete for
+            #    the passes below.
+            runner_keys: list[tuple[int, ProfilingCacheKey]] = []
+            for r_id, r in enumerate(runners):
+                cache_key = AutoTuner._get_cache_key(
+                    custom_op,
+                    r,
+                    input_shapes,
+                    tuning_config,
+                    r.get_cache_key_extras(inputs) if inputs is not None else (),
                 )
-                for r_id, r in enumerate(runners)
-            ]
-
-            # 1. In-memory cache (from live tuning)
-            for r_id, cache_key in runner_keys:
+                runner_keys.append((r_id, cache_key))
                 if cache_key in self.profiling_cache:
                     tactic, stored_profile = self.profiling_cache[cache_key]
                     return True, r_id, tactic, stored_profile

--- a/tests/autotuner/test_autotuner_configs.py
+++ b/tests/autotuner/test_autotuner_configs.py
@@ -68,10 +68,12 @@ class FakeRunnerB(TunableRunner):
 _TUNING_CONFIG = TuningConfig()
 
 
-def _populate_cache(tuner, runner, custom_op, profile, tactic, runner_id=0):
+def _populate_cache(tuner, runner, custom_op, profile, tactic, extras=()):
     """Insert a fake entry into the profiling cache."""
-    cache_key = AutoTuner._get_cache_key(custom_op, runner, profile, _TUNING_CONFIG)
-    tuner.profiling_cache[cache_key] = (runner_id, tactic, None)
+    cache_key = AutoTuner._get_cache_key(
+        custom_op, runner, profile, _TUNING_CONFIG, extras
+    )
+    tuner.profiling_cache[cache_key] = (tactic, None)
     tuner._dirty = True
 
 
@@ -478,15 +480,8 @@ class TestFileCacheKeyCollision:
 
         # Simulate two cache entries that differ only in extras
         # (e.g. use_8x4_sf_layout=True vs False)
-        cache_key_a = AutoTuner._get_cache_key(
-            "fp4_gemm", runner, profile, _TUNING_CONFIG, extras=(True,)
-        )
-        cache_key_b = AutoTuner._get_cache_key(
-            "fp4_gemm", runner, profile, _TUNING_CONFIG, extras=(False,)
-        )
-        self.tuner.profiling_cache[cache_key_a] = (0, 42, None)
-        self.tuner.profiling_cache[cache_key_b] = (0, 17, None)
-        self.tuner._dirty = True
+        _populate_cache(self.tuner, runner, "fp4_gemm", profile, 42, extras=(True,))
+        _populate_cache(self.tuner, runner, "fp4_gemm", profile, 17, extras=(False,))
 
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
             tmp_path = f.name
@@ -511,15 +506,8 @@ class TestFileCacheKeyCollision:
         runner = FakeRunnerA(value=1)
         profile = ((128, 3584), (3584, 7168))
 
-        cache_key_a = AutoTuner._get_cache_key(
-            "fp4_gemm", runner, profile, _TUNING_CONFIG, extras=(True,)
-        )
-        cache_key_b = AutoTuner._get_cache_key(
-            "fp4_gemm", runner, profile, _TUNING_CONFIG, extras=(False,)
-        )
-        self.tuner.profiling_cache[cache_key_a] = (0, 42, None)
-        self.tuner.profiling_cache[cache_key_b] = (0, 17, None)
-        self.tuner._dirty = True
+        _populate_cache(self.tuner, runner, "fp4_gemm", profile, 42, extras=(True,))
+        _populate_cache(self.tuner, runner, "fp4_gemm", profile, 17, extras=(False,))
 
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
             tmp_path = f.name

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -264,6 +264,37 @@ def test_search_cache_hit_resolves_runner_id_against_current_list():
     assert tactic == tuple_tactic
 
 
+def test_search_cache_in_memory_beats_file_config_across_runners():
+    """An in-memory tuning result must win over a file config that matches an
+    earlier-listed runner: sources are searched in priority order across all
+    runners, not per-runner."""
+
+    class OtherDummyRunner(DummyRunner):
+        pass
+
+    tuner = reset_autotuner()
+    config = TuningConfig()
+    a = DummyRunner()
+    b = OtherDummyRunner()
+    shapes = (torch.Size([8, 16]),)
+
+    # File config matches runner `a` (position 0); fresher in-memory result
+    # matches runner `b` (position 1).
+    key_a = AutoTuner._get_cache_key("dummy", a, shapes, config)
+    tuner._file_configs[key_a.file_key] = ("DummyRunner", 3)
+    key_b = AutoTuner._get_cache_key("dummy", b, shapes, config)
+    tuner.profiling_cache[key_b] = (5, None)
+
+    hit = tuner.search_cache("dummy", [a, b], shapes, config)
+    assert hit == (True, 1, 5, None)
+
+    # Without the in-memory entry, the file config is used and resolves to
+    # `a`'s position in the current list.
+    tuner.profiling_cache.clear()
+    hit = tuner.search_cache("dummy", [a, b], shapes, config)
+    assert hit == (True, 0, 3, None)
+
+
 def test_search_cache_preserving_leading_dims_hits_while_flattened_misses(monkeypatch):
     """Shape-preserving reshape keeps cache-hit behavior; full flatten can change bucket/key."""
     tuner = reset_autotuner()

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -231,9 +231,37 @@ def test_search_cache_hit_and_miss():
     assert miss == (False, 0, -1, None)
 
     key = AutoTuner._get_cache_key("dummy", runner, shapes, config)
-    tuner.profiling_cache[key] = (0, 1, None)
+    tuner.profiling_cache[key] = (1, None)
     hit = tuner.search_cache("dummy", [runner], shapes, config)
     assert hit == (True, 0, 1, None)
+
+
+def test_search_cache_hit_resolves_runner_id_against_current_list():
+    """A cache hit must dispatch to the runner matching its key, not to a
+    position recorded at tuning time (issue #3999 regression test)."""
+
+    class OtherDummyRunner(DummyRunner):
+        pass
+
+    tuner = reset_autotuner()
+    config = TuningConfig()
+    winner = DummyRunner()
+    other = OtherDummyRunner()
+    shapes = (torch.Size([8, 16]),)
+    tuple_tactic = (7, ((1, 2),))  # non-int tactic, like cuDNN engine/knobs
+
+    # Entry recorded when `winner` was tuned alone (position 0 at tuning time).
+    key = AutoTuner._get_cache_key("dummy", winner, shapes, config)
+    tuner.profiling_cache[key] = (tuple_tactic, None)
+
+    # A later call sees a longer runner list where `winner` sits at position 1.
+    hit = tuner.search_cache("dummy", [other, winner], shapes, config)
+    assert hit == (True, 1, tuple_tactic, None)
+
+    inputs = [torch.zeros(8, 16)]
+    chosen_runner, tactic = tuner.choose_one("dummy", [other, winner], config, inputs)
+    assert chosen_runner is winner
+    assert tactic == tuple_tactic
 
 
 def test_search_cache_preserving_leading_dims_hits_while_flattened_misses(monkeypatch):
@@ -306,7 +334,7 @@ def test_choose_one_inference_uses_cache_or_fallback():
 
     # Seed cache -> cache hit.
     key = AutoTuner._get_cache_key("dummy", runner, (inputs[0].shape,), config)
-    tuner.profiling_cache[key] = (0, 2, None)
+    tuner.profiling_cache[key] = (2, None)
     chosen_runner, tactic = tuner.choose_one("dummy", [runner], config, inputs)
     assert chosen_runner is runner
     assert tactic == 2

--- a/tests/autotuner/test_trtllm_fused_moe_autotuner_integration.py
+++ b/tests/autotuner/test_trtllm_fused_moe_autotuner_integration.py
@@ -56,9 +56,9 @@ def _overwrite_cached_tactic_for_op(custom_op: str, new_tactic):
     """Overwrite cached tactics for one op key."""
     tuner = AutoTuner.get()
     updated = 0
-    for key, (runner_id, _tactic, profile) in list(tuner.profiling_cache.items()):
+    for key, (_tactic, profile) in list(tuner.profiling_cache.items()):
         if key.custom_op == custom_op:
-            tuner.profiling_cache[key] = (runner_id, new_tactic, profile)
+            tuner.profiling_cache[key] = (new_tactic, profile)
             updated += 1
     assert updated > 0, f"No autotuner cache entries found for {custom_op}"
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR removes the explicit runner position index used in autotuner to prevent it using autotuning plan from other runners, which can cause either silent perf loss, or even crash

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/3999

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autotuning cache lookup reliability across runner configurations.
  * Preserved distinct tuning results for configurations with different extra parameters.
  * Added support for non-integer tactic values in tuning configurations.
  * Ensured cached tactics are matched to the correct runner rather than relying on runner order.
  * Improved compatibility when loading and saving existing tuning configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->