### PR TITLE
feat: add collect-env environment report tool + issue templates (bug, feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,17 @@
 name: 🐛 Bug Report
-description: Report a correctness, crash, or performance bug in FlashInfer
+description: >
+  Report something broken, wrong, or slower than it used to be — correctness
+  issues, crashes, build/install failures, or performance regressions. For new
+  capabilities or speedups, use 🚀 Kernel / Feature Request instead.
 labels: ["bug"]
 body:
+  - type: checkboxes
+    id: presubmit
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have searched existing issues and did not find a solution or an existing report.
+          required: true
   - type: textarea
     id: environment
     attributes:
@@ -38,10 +48,12 @@ body:
     attributes:
       label: Minimal reproduction
       description: >
-        Smallest self-contained script or command that reproduces the issue.
-        Include exact shapes/dtypes and the backend selected (fa2/fa3/cudnn/
-        trtllm/cutlass/...). If the failure involves JIT compilation, re-run
-        with `FLASHINFER_JIT_VERBOSE=1` and attach the log.
+        Smallest self-contained script that reproduces the issue — a short
+        standalone Python script is far more actionable than a full
+        `vllm serve ...` invocation. Include exact shapes/dtypes and the
+        backend selected (fa2/fa3/cudnn/trtllm/cutlass/...). If the failure
+        involves JIT compilation, re-run with `FLASHINFER_JIT_VERBOSE=1` and
+        attach the log.
       render: python
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,15 +25,8 @@ body:
         The report includes which cuDNN/cuBLAS/CUDA libraries are *actually
         loaded* vs merely installed — this resolves most "works on my machine"
         divergence, so please don't trim it.
-      value: |
-        <details>
-        <summary>Output of python -m flashinfer.collect_env</summary>
-
-        ```text
-        PASTE OUTPUT HERE
-        ```
-
-        </details>
+      render: text
+      placeholder: Paste the full output of `python -m flashinfer.collect_env` here.
     validations:
       required: true
   - type: textarea
@@ -51,14 +44,23 @@ body:
         Smallest self-contained script that reproduces the issue — a short
         standalone Python script is far more actionable than a full
         `vllm serve ...` invocation. Include exact shapes/dtypes and the
-        backend selected (fa2/fa3/cudnn/trtllm/cutlass/...). If the failure
-        involves JIT compilation, re-run with `FLASHINFER_JIT_VERBOSE=1` and
-        attach the log.
+        backend selected (fa2/fa3/cudnn/trtllm/cutlass/...).
       render: python
     validations:
       required: true
   - type: textarea
+    id: logs
+    attributes:
+      label: Error messages / logs
+      description: >
+        Stack trace, error output, or logs. If the failure involves JIT
+        compilation, re-run with `FLASHINFER_JIT_VERBOSE=1` and include that
+        log.
+      render: text
+    validations:
+      required: false
+  - type: textarea
     id: extra
     attributes:
       label: Additional context
-      description: Stack traces, logs, related issues, workarounds you tried.
+      description: Related issues, workarounds you tried, anything else useful.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: 🐛 Bug Report
+description: Report a correctness, crash, or performance bug in FlashInfer
+labels: ["bug"]
+body:
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        Run `python -m flashinfer.collect_env` (or `flashinfer collect-env`)
+        in the exact environment (same venv/container) where the bug
+        reproduces and paste the full output below. If `import flashinfer` itself is broken, download the
+        standalone script and run it with plain Python:
+        `curl -OL https://raw.githubusercontent.com/flashinfer-ai/flashinfer/main/flashinfer/collect_env.py && python collect_env.py`.
+        The report includes which cuDNN/cuBLAS/CUDA libraries are *actually
+        loaded* vs merely installed — this resolves most "works on my machine"
+        divergence, so please don't trim it.
+      value: |
+        <details>
+        <summary>Output of python -m flashinfer.collect_env</summary>
+
+        ```text
+        PASTE OUTPUT HERE
+        ```
+
+        </details>
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What happened, and what did you expect to happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Minimal reproduction
+      description: >
+        Smallest self-contained script or command that reproduces the issue.
+        Include exact shapes/dtypes and the backend selected (fa2/fa3/cudnn/
+        trtllm/cutlass/...). If the failure involves JIT compilation, re-run
+        with `FLASHINFER_JIT_VERBOSE=1` and attach the log.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Stack traces, logs, related issues, workarounds you tried.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -56,11 +56,12 @@ body:
       description: Select every confirmed target.
       multiple: true
       options:
-        - SM80 / SM86 (A100, A30, RTX 30-series)
+        - SM80 / SM86 / SM87 (A100, A30, RTX 30-series, Jetson Orin)
         - SM89 (L4, L40S, RTX 40-series)
         - SM90 (H100, H200, H20)
         - SM100 (B200, GB200)
         - SM103 (B300, GB300)
+        - SM110 (Jetson AGX Thor, DRIVE AGX Thor)
         - SM120 (RTX PRO 6000, RTX 50-series)
         - SM121 (GB10 — DGX Spark, RTX Spark)
         - Future architecture

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,186 @@
+name: 🚀 Kernel / Feature Request
+description: >
+  Request a kernel, hardware enablement, framework integration, API, or
+  performance improvement. For something broken, wrong, or slower than it
+  used to be, use 🐛 Bug Report instead.
+title: "[Feature]: "
+labels: ["feature request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us understand the request and its impact. Please use
+        public, non-confidential information. **Only the first four fields are
+        required** — the optional fields below them help the team scope and
+        prioritize faster, so fill in what you can.
+
+  - type: checkboxes
+    id: presubmit
+    attributes:
+      label: Before submitting
+      options:
+        - label: I have searched existing issues and this request has not been filed yet.
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: >
+        Describe the problem and what is blocked or inefficient today. If you
+        have a trace/profile or a minimal script that demonstrates it, link or
+        attach it here.
+      placeholder: |
+        Today, users cannot...
+        The current behavior is...
+    validations:
+      required: true
+
+  - type: textarea
+    id: requested-outcome
+    attributes:
+      label: Requested outcome
+      description: >
+        Describe the capability or behavior you want. Focus on the outcome
+        rather than prescribing an implementation.
+      placeholder: |
+        Add support for...
+        The public API or framework should be able to...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hardware
+    attributes:
+      label: Target hardware
+      description: Select every confirmed target.
+      multiple: true
+      options:
+        - SM80 / SM86 - Ampere (A100, A30, RTX 30)
+        - SM89 - Ada (L4, L40S, RTX 40)
+        - SM90 - Hopper (H100, H200, or H20)
+        - SM100 - Blackwell datacenter (B200 or GB200)
+        - SM103 - Blackwell Ultra datacenter (B300 or GB300)
+        - SM120 - RTX PRO 6000 Blackwell or GeForce Blackwell
+        - SM121 - GB10 or DGX Spark
+        - Future architecture
+        - Hardware-independent
+        - Other or unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: inference-engine
+    attributes:
+      label: Inference engine
+      description: Select every engine or integration path this applies to.
+      multiple: true
+      options:
+        - vLLM
+        - SGLang
+        - TRT-LLM
+        - PyTorch native
+        - Custom / other
+        - Not applicable
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Everything below is optional** — the more you fill in, the faster the
+        team can act on the request.
+
+  - type: input
+    id: models
+    attributes:
+      label: Affected model or model family
+      description: >
+        Exact checkpoint or family with a public link, if the request is
+        model-driven.
+      placeholder: "Example: Qwen3.5-397B-A17B-NVFP4 - https://huggingface.co/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: workload
+    attributes:
+      label: Workload and configuration
+      description: >
+        The single most useful section for kernel/performance requests — enough
+        detail to identify the operator path and representative shapes. For the
+        environment line, paste the output of `python -m flashinfer.collect_env`.
+      value: |
+        - Data type and quantization:
+        - Batch size or request concurrency:
+        - Sequence lengths or token counts:
+        - Parallelism: TP / EP / DP / PP / disaggregated
+        - Relevant shapes: heads, head dimension, hidden size, experts, top-k, page size, or other
+        - Environment: output of `python -m flashinfer.collect_env`
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current workaround
+      description: >
+        The workaround, fallback, or alternative currently used and its
+        limitations.
+      placeholder: "Example: We currently use Marlin, but it is slower for these shapes and requires an extra repack."
+    validations:
+      required: false
+
+  - type: dropdown
+    id: impact-type
+    attributes:
+      label: Impact
+      description: Select all outcomes that apply.
+      multiple: true
+      options:
+        - Missing model or hardware support
+        - Production deployment blocker
+        - Correctness or numerical-quality risk
+        - Crash, hang, or reliability risk
+        - Throughput
+        - Latency
+        - Memory capacity or bandwidth
+        - Startup, compilation, or autotuning time
+        - API usability or integration complexity
+        - Testing, maintainability, or documentation
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: >
+        How maintainers can verify completion — measurable thresholds for
+        performance requests, correctness tests for new functionality.
+      placeholder: |
+        - Passes ... correctness tests across ... shapes and dtypes.
+        - Achieves at least ... with no more than ... regression elsewhere.
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope-and-dependencies
+    attributes:
+      label: Related work, dependencies, or suggested scope
+      description: >
+        Related issues/PRs, upstream dependencies, prerequisite kernels/APIs,
+        or an implementation outline.
+    validations:
+      required: false
+
+  - type: input
+    id: timing
+    attributes:
+      label: Timing or release need
+      description: A concrete external milestone or required release, only if one exists.
+      placeholder: "Example: Needed for v0.7.x or public launch on 2026-10-15"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -56,13 +56,13 @@ body:
       description: Select every confirmed target.
       multiple: true
       options:
-        - SM80 / SM86 - Ampere (A100, A30, RTX 30)
-        - SM89 - Ada (L4, L40S, RTX 40)
-        - SM90 - Hopper (H100, H200, or H20)
-        - SM100 - Blackwell datacenter (B200 or GB200)
-        - SM103 - Blackwell Ultra datacenter (B300 or GB300)
-        - SM120 - RTX PRO 6000 Blackwell or GeForce Blackwell
-        - SM121 - GB10 or DGX Spark
+        - SM80 / SM86 (A100, A30, RTX 30-series)
+        - SM89 (L4, L40S, RTX 40-series)
+        - SM90 (H100, H200, H20)
+        - SM100 (B200, GB200)
+        - SM103 (B300, GB300)
+        - SM120 (RTX PRO 6000, RTX 50-series)
+        - SM121 (GB10 — DGX Spark, RTX Spark)
         - Future architecture
         - Hardware-independent
         - Other or unknown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ FlashInfer is a GPU kernel library for LLM serving that uses **JIT (Just-In-Time
 | Run multi-GPU test | `mpirun -np 4 pytest tests/comm/test_allreduce_unified_api.py` |
 | Run benchmark | `python benchmarks/flashinfer_benchmark.py --routine <name> <flags>` |
 | Run linting | `pre-commit run -a` |
+| Dump environment report (bug reports) | `python -m flashinfer.collect_env` (or `flashinfer collect-env [--json]`) |
 | Install pre-commit hooks | `pre-commit install` |
 | Clear JIT cache | `rm -rf ~/.cache/flashinfer/` |
 | Enable API logging (basic) | `export FLASHINFER_LOGLEVEL=1` |

--- a/flashinfer/__main__.py
+++ b/flashinfer/__main__.py
@@ -90,6 +90,25 @@ except Exception:
     found_nvcc = False
 
 
+@cli.command("collect-env")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of text")
+def collect_env_cmd(as_json):
+    """Dump a full environment report for bug reports.
+
+    Covers versions (flashinfer/torch/vllm/sglang/cudnn/...), GPU and driver
+    properties, and loaded-vs-installed GPU library disambiguation. Paste the
+    output into GitHub issues.
+    """
+    from .collect_env import collect_env_info, format_report
+    import json as json_mod
+
+    report = collect_env_info()
+    if as_json:
+        click.echo(json_mod.dumps(report, indent=2))
+    else:
+        click.echo(format_report(report))
+
+
 @cli.command("show-config")
 def show_config_cmd():
     """Show configuration"""

--- a/flashinfer/collect_env.py
+++ b/flashinfer/collect_env.py
@@ -134,7 +134,9 @@ def _installed_distributions():
     for dist in importlib.metadata.distributions():
         name = (dist.metadata.get("Name") or "").strip()
         if name:
-            dists[name.lower()] = dist.version
+            # Same canonicalization as _check_pin, so metadata names like
+            # flashinfer_python / sgl_kernel resolve.
+            dists[re.sub(r"[-_.]+", "-", name).lower()] = dist.version
     return dists
 
 
@@ -444,7 +446,7 @@ def _describe_lib_dir(family, dirpath, paths, dists):
     tags = []
     versions = set()
     for p in paths:
-        m = re.search(r"\.so\.(\d+(?:\.\d+)+)$", p)
+        m = re.search(r"\.so\.(\d+(?:\.\d+)*)$", p)
         if m:
             versions.add(m.group(1))
     if versions:
@@ -539,10 +541,16 @@ def _get_relevant_packages():
 
 
 def _get_env_vars():
+    # Reports are pasted into public issues; redact anything credential-like
+    # (the broad prefixes can match e.g. NVIDIA_API_KEY).
+    secret_markers = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL")
     info = {}
     for k in sorted(os.environ):
         if k.startswith(_ENV_PREFIXES) or k in _ENV_EXACT:
-            info[k] = os.environ[k]
+            if any(m in k.upper() for m in secret_markers):
+                info[k] = "<redacted>"
+            else:
+                info[k] = os.environ[k]
     return info or {"(none set)": ""}
 
 

--- a/flashinfer/collect_env.py
+++ b/flashinfer/collect_env.py
@@ -1,0 +1,619 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Collect environment information for FlashInfer bug reports.
+
+Usage (any of):
+
+    python -m flashinfer.collect_env
+    flashinfer collect-env
+    # If `import flashinfer` itself is broken, download and run standalone:
+    curl -OL https://raw.githubusercontent.com/flashinfer-ai/flashinfer/main/flashinfer/collect_env.py
+    python collect_env.py
+
+Design constraints (please preserve when editing):
+- Only stdlib imports at module level, so the file runs standalone even when
+  flashinfer / torch are broken or absent.
+- Every probe is individually guarded; a failure becomes a value in the
+  report, never an exception. The report must always print.
+- Beyond versions, the report disambiguates *loaded* vs *installed* GPU
+  libraries (via /proc/self/maps) and lists every on-disk copy it can find,
+  because "multiple cuDNN/cuBLAS copies, the loaded one is not the one you
+  think" is the most common unreproducible-issue root cause.
+"""
+
+import argparse
+import glob
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+
+# Library families whose loaded-vs-installed identity we disambiguate.
+# Keys are display names, values are regexes matched against .so basenames.
+_LIB_FAMILIES = {
+    "libcudnn": r"libcudnn(?:_[a-z_]+)?\.so",
+    "libcublas": r"libcublas(?:Lt)?\.so",
+    "libcudart": r"libcudart\.so",
+    "libnvrtc": r"libnvrtc\.so",
+    "libnccl": r"libnccl\.so",
+    "libcuda (driver)": r"libcuda\.so",
+}
+
+# Distribution-name patterns for the "Relevant packages" section.
+_PACKAGE_PATTERNS = [
+    r"^flashinfer",
+    r"^torch",
+    r"^triton",
+    r"^nvidia-",
+    r"^cuda-",
+    r"^cupti",
+    r"^cudnn",  # cudnn-frontend python bindings
+    r"^apache-tvm-ffi$",
+    r"^tvm",
+    r"^vllm",
+    r"^sglang",
+    r"^sgl-kernel",
+    r"^lmdeploy",
+    r"^tensorrt",
+    r"^numpy$",
+    r"^ninja$",
+    r"^transformers$",
+]
+
+# Environment variable prefixes worth reporting (plus a few exact names).
+_ENV_PREFIXES = (
+    "FLASHINFER_",
+    "CUDA_",
+    "CUDNN_",
+    "NVIDIA_",
+    "NCCL_",
+    "NVSHMEM_",
+    "TORCH_",
+    "PYTORCH_",
+    "TRITON_",
+    "VLLM_",
+    "SGLANG_",
+    "SGL_",
+)
+_ENV_EXACT = (
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "PATH",
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+    "MAX_JOBS",
+)
+
+
+def _run(cmd, timeout=30):
+    """Run a shell command, return stdout on success else None."""
+    try:
+        out = subprocess.run(
+            cmd,
+            shell=isinstance(cmd, str),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if out.returncode != 0:
+            return None
+        # Strip ANSI escapes (e.g. nvidia-smi topo underlines) for clean paste.
+        return re.sub(r"\x1b\[[0-9;]*m", "", out.stdout).strip()
+    except Exception:
+        return None
+
+
+def _guard(fn, default="<probe failed>"):
+    try:
+        return fn()
+    except Exception as e:
+        return f"{default}: {type(e).__name__}: {e}"
+
+
+def _installed_distributions():
+    """{normalized_name: version} for every installed distribution."""
+    import importlib.metadata
+
+    dists = {}
+    for dist in importlib.metadata.distributions():
+        name = (dist.metadata.get("Name") or "").strip()
+        if name:
+            dists[name.lower()] = dist.version
+    return dists
+
+
+def _get_platform_info():
+    info = {}
+    info["Python"] = sys.version.replace("\n", " ")
+    info["Python executable"] = sys.executable
+    if sys.prefix != getattr(sys, "base_prefix", sys.prefix):
+        info["Virtual env"] = sys.prefix
+    info["Platform"] = platform.platform()
+    libc = platform.libc_ver()
+    info["libc"] = " ".join(v for v in libc if v) or "n/a"
+    os_release = _run("grep PRETTY_NAME /etc/os-release")
+    if os_release:
+        info["OS"] = os_release.split("=", 1)[-1].strip('"')
+    in_container = os.path.exists("/.dockerenv") or bool(
+        _run("grep -sq -e docker -e containerd -e kubepods /proc/1/cgroup && echo 1")
+    )
+    info["Container"] = "yes" if in_container else "no / not detected"
+    return info
+
+
+def _get_gpu_info():
+    """Per-GPU properties. torch is authoritative for enumeration order
+    (CUDA order != nvidia-smi order); nvidia-smi is the no-torch fallback and
+    supplies the driver version."""
+    info = {}
+    smi = _run(
+        "nvidia-smi --query-gpu=index,name,compute_cap,memory.total,driver_version"
+        " --format=csv,noheader"
+    )
+    driver = None
+    if smi:
+        driver = smi.splitlines()[0].rsplit(",", 1)[-1].strip()
+    info["Driver version"] = driver or "<nvidia-smi unavailable>"
+    info["CUDA_VISIBLE_DEVICES"] = os.environ.get("CUDA_VISIBLE_DEVICES", "<unset>")
+
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            info["GPUs (torch)"] = "torch.cuda.is_available() == False"
+            if smi:
+                for line in smi.splitlines():
+                    idx, rest = line.split(",", 1)
+                    info[f"GPU {idx.strip()} (nvidia-smi order)"] = rest.strip()
+            return info
+        for i in range(torch.cuda.device_count()):
+            p = torch.cuda.get_device_properties(i)
+            info[f"GPU {i} (CUDA order)"] = (
+                f"{p.name} | SM{p.major}{p.minor} | {p.multi_processor_count} SMs"
+                f" | {p.total_memory / (1 << 30):.1f} GiB"
+            )
+    except Exception as e:
+        info["GPUs (torch)"] = f"<torch probe failed: {type(e).__name__}: {e}>"
+        if smi:
+            for line in smi.splitlines():
+                idx, rest = line.split(",", 1)
+                info[f"GPU {idx.strip()} (nvidia-smi order)"] = rest.strip()
+    return info
+
+
+def _get_cuda_toolkit_info():
+    info = {}
+    import shutil
+
+    nvcc_on_path = shutil.which("nvcc")
+    info["nvcc on PATH"] = nvcc_on_path or "not found"
+
+    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+    info["CUDA_HOME (env)"] = cuda_home or "<unset>"
+
+    # What flashinfer's JIT will actually use, which may differ from the env.
+    def _fi_cuda():
+        from flashinfer.jit.cpp_ext import get_cuda_path, get_cuda_version
+
+        return f"{get_cuda_path()} (version {get_cuda_version()})"
+
+    info["CUDA toolkit resolved by flashinfer JIT"] = _guard(
+        _fi_cuda, "<flashinfer not importable>"
+    )
+
+    nvcc = nvcc_on_path
+    if not nvcc and cuda_home:
+        cand = os.path.join(cuda_home, "bin", "nvcc")
+        nvcc = cand if os.path.isfile(cand) else None
+    if nvcc:
+        out = _run([nvcc, "-V"])
+        if out:
+            m = re.search(r"release [\d.]+, V[\d.]+", out)
+            info["nvcc version"] = m.group(0) if m else out.splitlines()[-1]
+    return info
+
+
+def _get_torch_info():
+    info = {}
+    try:
+        import torch
+    except Exception as e:
+        info["torch"] = f"<import failed: {type(e).__name__}: {e}>"
+        return info
+    info["torch"] = torch.__version__
+    info["torch.version.cuda"] = str(torch.version.cuda)
+    info["torch CXX11 ABI"] = str(_guard(lambda: torch._C._GLIBCXX_USE_CXX11_ABI, "?"))
+    info["torch compiled archs"] = _guard(
+        lambda: " ".join(torch.cuda.get_arch_list()), "?"
+    )
+    info["torch.backends.cudnn.version()"] = str(
+        _guard(lambda: torch.backends.cudnn.version(), "?")
+    )
+    info["torch file"] = _guard(lambda: torch.__file__, "?")
+    return info
+
+
+def _get_flashinfer_info():
+    info = {}
+    try:
+        import flashinfer
+    except Exception as e:
+        info["flashinfer"] = f"<import failed: {type(e).__name__}: {e}>"
+        return info
+    info["flashinfer"] = _guard(lambda: flashinfer.__version__, "?")
+    info["flashinfer file"] = _guard(lambda: flashinfer.__file__, "?")
+
+    dists = _guard(_installed_distributions, None)
+    if isinstance(dists, dict):
+        fi_version = dists.get("flashinfer-python")
+        for pkg in ("flashinfer-cubin", "flashinfer-jit-cache"):
+            ver = dists.get(pkg)
+            if ver is None:
+                info[pkg] = "not installed"
+            elif fi_version and ver != fi_version:
+                # Classic screwup: flashinfer-python upgraded but the AOT
+                # companion package kept at the old version (sometimes with
+                # FLASHINFER_DISABLE_VERSION_CHECK to silence the guard).
+                info[pkg] = f"{ver}  ⚠ MISMATCH vs flashinfer-python=={fi_version}"
+            else:
+                info[pkg] = ver
+
+    def _cache_dir():
+        from flashinfer.jit.env import FLASHINFER_CACHE_DIR
+
+        n_cached = len(
+            glob.glob(str(FLASHINFER_CACHE_DIR) + "/**/*.so", recursive=True)
+        )
+        return f"{FLASHINFER_CACHE_DIR} ({n_cached} compiled .so)"
+
+    info["JIT cache"] = _guard(_cache_dir)
+
+    def _cubin_store():
+        # Offline probe only: count what is present locally. Deliberately NOT
+        # get_artifacts_status(), which downloads checksum files as a side
+        # effect — a bug-report tool must be read-only and work air-gapped.
+        from flashinfer.jit.env import FLASHINFER_CUBIN_DIR
+
+        n, size = 0, 0
+        for root, _, files in os.walk(FLASHINFER_CUBIN_DIR):
+            for f in files:
+                if f.endswith((".cubin", ".so")):
+                    n += 1
+                    size += os.path.getsize(os.path.join(root, f))
+        return f"{FLASHINFER_CUBIN_DIR} ({n} cubins, {size / (1 << 20):.0f} MiB)"
+
+    info["Cubin store (local)"] = _guard(_cubin_store)
+
+    def _archs():
+        from flashinfer.jit.core import current_compilation_context
+
+        return str(current_compilation_context.TARGET_CUDA_ARCHS)
+
+    info["Target CUDA archs (resolved)"] = _guard(_archs)
+    return info
+
+
+# Serving frameworks whose flashinfer version pin we annotate in the
+# Relevant Packages section.
+_HOST_FRAMEWORKS = ("vllm", "sglang", "lmdeploy", "tensorrt-llm")
+
+
+def _check_pin(req_line, dists):
+    """Evaluate one Requires-Dist line against installed versions.
+    Returns (satisfied, installed_version) or None if not evaluable
+    (packaging unavailable, target not installed, no specifier)."""
+    try:
+        from packaging.requirements import Requirement
+
+        req = Requirement(req_line.split(";")[0].strip())
+        target = re.sub(r"[-_.]+", "-", req.name).lower()
+        installed = dists.get(target)
+        if installed is None or not req.specifier:
+            return None
+        return bool(req.specifier.contains(installed, prereleases=True)), installed
+    except Exception:
+        return None
+
+
+def _framework_pin_note(name, dists):
+    """For an installed serving framework, render its declared flashinfer
+    version pin vs what is installed — upstream/flashinfer version skew is
+    the most common "flashinfer bug" that is not a flashinfer bug."""
+    import importlib.metadata
+
+    reqs = _guard(lambda: importlib.metadata.requires(name), None) or []
+    rendered = []
+    for pin in [r for r in reqs if "flashinfer" in r.lower()]:
+        verdict = _check_pin(pin, dists)
+        suffix = ""
+        if verdict is not None:
+            ok, installed = verdict
+            if not ok:
+                # Facts only — no warning and no reassurance; mixing versions
+                # is often intentional and judging it is not this tool's job.
+                suffix = f"; installed {installed}"
+        rendered.append(pin + suffix)
+    return f"  (declares {'; '.join(rendered)})" if rendered else ""
+
+
+def _get_cudnn_frontend_info():
+    info = {}
+    try:
+        import cudnn  # cudnn-frontend python bindings; loads libcudnn on import
+
+        info["cudnn-frontend"] = _guard(lambda: cudnn.__version__, "?")
+        info["cudnn backend (loaded, via frontend)"] = _guard(
+            lambda: cudnn.backend_version_string(), "?"
+        )
+        info["cudnn-frontend file"] = _guard(lambda: cudnn.__file__, "?")
+    except Exception as e:
+        info["cudnn-frontend"] = f"<not importable: {type(e).__name__}: {e}>"
+    return info
+
+
+def _force_load_gpu_libs():
+    """Trigger lazy loading of the GPU libraries torch actually uses, so that
+    /proc/self/maps reflects reality. Every step is optional."""
+
+    def _f():
+        import torch
+
+        torch.backends.cudnn.version()  # loads libcudnn
+        if torch.cuda.is_available():
+            x = torch.randn(8, 8, device="cuda", dtype=torch.float16)
+            torch.mm(x, x)  # loads libcublas/Lt
+            y = torch.randn(1, 1, 8, 8, device="cuda")
+            w = torch.randn(1, 1, 3, 3, device="cuda")
+            torch.nn.functional.conv2d(y, w)  # exercises cudnn
+            torch.cuda.synchronize()
+
+    _guard(_f, None)
+
+
+def _loaded_gpu_libs():
+    """{family: set of realpaths} of GPU libraries mapped into this process."""
+    loaded = {name: set() for name in _LIB_FAMILIES}
+    try:
+        with open("/proc/self/maps") as f:
+            maps = f.read()
+    except OSError:
+        return loaded
+    for path in set(re.findall(r"\S*/lib\S+\.so\S*", maps)):
+        base = os.path.basename(path)
+        for family, pat in _LIB_FAMILIES.items():
+            if re.match(pat, base):
+                loaded[family].add(os.path.realpath(path))
+    return loaded
+
+
+def _candidate_lib_dirs():
+    """Directories where conflicting copies of GPU libraries typically hide."""
+    dirs = []
+    for d in os.environ.get("LD_LIBRARY_PATH", "").split(":"):
+        if d:
+            dirs.append(d)
+    try:
+        import site
+        import sysconfig
+
+        sp = set(site.getsitepackages() + [site.getusersitepackages()])
+        sp.add(sysconfig.get_paths()["purelib"])
+        for p in sp:
+            dirs.extend(glob.glob(os.path.join(p, "nvidia", "*", "lib")))
+            dirs.append(os.path.join(p, "torch", "lib"))
+    except Exception:
+        pass
+    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+    if cuda_home:
+        dirs.append(os.path.join(cuda_home, "lib64"))
+    return [d for d in dict.fromkeys(dirs) if os.path.isdir(d)]
+
+
+# For pip provenance of a directory holding a family's .so files. The plain
+# names (no -cuXX suffix) are the CUDA 13 mega-wheel packages installed under
+# site-packages/nvidia/cu13/lib.
+_FAMILY_PIP_NAMES = {
+    "libcudnn": ["cudnn"],
+    "libcublas": ["cublas"],
+    "libcudart": ["cuda-runtime"],
+    "libnvrtc": ["cuda-nvrtc"],
+    "libnccl": ["nccl"],
+    "libcuda (driver)": [],
+}
+
+
+def _describe_lib_dir(family, dirpath, paths, dists):
+    """One line of provenance for a directory holding this family's .so files:
+    filename-embedded version and/or the owning pip package."""
+    tags = []
+    versions = set()
+    for p in paths:
+        m = re.search(r"\.so\.(\d+(?:\.\d+)+)$", p)
+        if m:
+            versions.add(m.group(1))
+    if versions:
+        tags.append("v" + " / v".join(sorted(versions)))
+    if isinstance(dists, dict) and "/site-packages/" in dirpath:
+        for base in _FAMILY_PIP_NAMES.get(family, []):
+            for pkg in (
+                f"nvidia-{base}-cu13",
+                f"nvidia-{base}-cu12",
+                f"nvidia-{base}-cu11",
+                f"nvidia-{base}",
+            ):
+                if pkg in dists:
+                    tags.append(f"pip {pkg}=={dists[pkg]}")
+                    break
+            else:
+                continue
+            break
+    return f"{dirpath}/" + (f"  [{', '.join(tags)}]" if tags else "")
+
+
+def _get_gpu_library_conflicts():
+    """The headline section: for each library family, list where the copies
+    actually loaded into this process live and every other install visible on
+    disk. Aggregated by directory — the .so files of one install (e.g. the
+    libcudnn_* sublibraries) share a directory, so distinct directories are
+    the unit of "conflicting copies"."""
+    _force_load_gpu_libs()
+    _guard(_get_cudnn_frontend_info, None)  # frontend import also loads libcudnn
+    loaded = _loaded_gpu_libs()
+    dists = _guard(_installed_distributions, None)
+
+    on_disk = {name: set() for name in _LIB_FAMILIES}
+    for d in _candidate_lib_dirs():
+        try:
+            entries = os.listdir(d)
+        except OSError:
+            continue
+        for base in entries:
+            for family, pat in _LIB_FAMILIES.items():
+                if re.match(pat, base):
+                    on_disk[family].add(os.path.realpath(os.path.join(d, base)))
+    ldconfig = _run("ldconfig -p") or ""
+    for line in ldconfig.splitlines():
+        base = line.strip().split(" ", 1)[0]
+        path = line.rsplit("=> ", 1)[-1].strip() if "=> " in line else None
+        if not path:
+            continue
+        for family, pat in _LIB_FAMILIES.items():
+            if re.match(pat, base):
+                on_disk[family].add(os.path.realpath(path))
+
+    info = {}
+    for family in _LIB_FAMILIES:
+        by_dir = {}
+        for p in loaded[family] | on_disk[family]:
+            by_dir.setdefault(os.path.dirname(p), set()).add(p)
+        if not by_dir:
+            continue
+        loaded_dirs = {os.path.dirname(p) for p in loaded[family]}
+        lines = []
+        for d in sorted(by_dir, key=lambda d: (d not in loaded_dirs, d)):
+            state = "LOADED " if d in loaded_dirs else "on disk"
+            lines.append(f"{state}  {_describe_lib_dir(family, d, by_dir[d], dists)}")
+        header = family
+        if len(loaded_dirs) > 1:
+            header += "  ⚠ LOADED FROM MULTIPLE DIRECTORIES (likely conflict)"
+        elif loaded_dirs and len(by_dir) > 1:
+            header += "  ⚠ other installs on disk (check which one you expect)"
+        elif len(by_dir) > 1:
+            header += "  ⚠ multiple installs on disk"
+        info[header] = "\n" + "\n".join(f"    {line}" for line in lines)
+    if not info:
+        info["note"] = "no GPU libraries loaded or found (torch missing / CPU-only?)"
+    return info
+
+
+def _get_relevant_packages():
+    dists = _guard(_installed_distributions, None)
+    if not isinstance(dists, dict):
+        return {"packages": str(dists)}
+    pats = [re.compile(p) for p in _PACKAGE_PATTERNS]
+    pkgs = {
+        name: ver
+        for name, ver in sorted(dists.items())
+        if any(p.search(name) for p in pats)
+    }
+    for name in _HOST_FRAMEWORKS:
+        if name in pkgs:
+            pkgs[name] += _framework_pin_note(name, dists)
+    return pkgs
+
+
+def _get_env_vars():
+    info = {}
+    for k in sorted(os.environ):
+        if k.startswith(_ENV_PREFIXES) or k in _ENV_EXACT:
+            info[k] = os.environ[k]
+    return info or {"(none set)": ""}
+
+
+def _get_topology():
+    topo = _run("nvidia-smi topo -m", timeout=60)
+    if not topo:
+        return {}
+    # Drop the static legend boilerplate; keep just the matrix.
+    return {"nvidia-smi topo -m": "\n" + topo.split("\n\nLegend:")[0].rstrip()}
+
+
+def collect_env_info():
+    """Collect everything into an ordered {section: {key: value}} dict."""
+    sections = [
+        ("FlashInfer", _get_flashinfer_info),
+        ("Python / Platform", _get_platform_info),
+        ("GPU / Driver", _get_gpu_info),
+        ("CUDA Toolkit", _get_cuda_toolkit_info),
+        ("PyTorch", _get_torch_info),
+        ("cuDNN Frontend", _get_cudnn_frontend_info),
+        ("GPU Libraries: loaded vs on disk", _get_gpu_library_conflicts),
+        ("Relevant Packages", _get_relevant_packages),
+        ("Environment Variables", _get_env_vars),
+        ("GPU Topology", _get_topology),
+    ]
+    report = {}
+    for title, fn in sections:
+        result = _guard(fn, None)
+        report[title] = result if isinstance(result, dict) else {"error": str(result)}
+    return report
+
+
+def format_report(report):
+    lines = [
+        "### FlashInfer environment report",
+        "<!-- generated by `python -m flashinfer.collect_env`; paste into your issue -->",
+    ]
+    for title, entries in report.items():
+        if not entries:
+            continue
+        lines.append("")
+        lines.append(f"==== {title} ====")
+        width = max((len(k) for k in entries), default=0)
+        for k, v in entries.items():
+            v = str(v)
+            if v.startswith("\n"):
+                lines.append(f"{k}:{v}")
+            else:
+                lines.append(f"{k:<{width}} : {v}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect environment information for FlashInfer bug reports."
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+    report = collect_env_info()
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(format_report(report))
+
+
+if __name__ == "__main__":
+    # When invoked by path from a source checkout (python flashinfer/collect_env.py),
+    # sys.path[0] is this file's directory — the flashinfer package dir — where
+    # flashinfer/cudnn/ shadows the real cudnn-frontend module (and any future
+    # sibling could shadow other probes). Probe with a clean path; nothing is
+    # imported from this script's own directory.
+    _here = os.path.dirname(os.path.abspath(__file__))
+    sys.path[:] = [p for p in sys.path if os.path.abspath(p or os.getcwd()) != _here]
+    main()

--- a/tests/utils/test_collect_env.py
+++ b/tests/utils/test_collect_env.py
@@ -1,0 +1,59 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+
+import pytest
+
+from flashinfer.collect_env import collect_env_info, format_report
+
+
+@pytest.fixture(scope="module")
+def report():
+    # The core contract: collection never raises, regardless of environment
+    # (no GPU, missing optional packages, ...). Collect once for all tests.
+    return collect_env_info()
+
+
+def test_sections_present(report):
+    for section in (
+        "FlashInfer",
+        "Python / Platform",
+        "GPU / Driver",
+        "CUDA Toolkit",
+        "PyTorch",
+        "GPU Libraries: loaded vs on disk",
+        "Relevant Packages",
+        "Environment Variables",
+    ):
+        assert section in report
+        assert isinstance(report[section], dict)
+
+
+def test_report_has_flashinfer_version(report):
+    import flashinfer
+
+    assert report["FlashInfer"]["flashinfer"] == flashinfer.__version__
+
+
+def test_format_report(report):
+    text = format_report(report)
+    assert "FlashInfer environment report" in text
+    assert "==== Relevant Packages ====" in text
+
+
+def test_json_serializable(report):
+    json.dumps(report)


### PR DESCRIPTION
## 📌 Description

Issue reporters often can't state their environment precisely, and the most common unreproducible-issue root cause is version confusion — multiple copies of cuDNN/cuBLAS/CUDA runtime installed where the **loaded** one is not the one the user assumes.

This PR adds an environment-forensics tool and wires it into a new (first) GitHub issue template:

```bash
python -m flashinfer.collect_env        # or: flashinfer collect-env [--json]
```

**What the report covers**

- flashinfer / flashinfer-cubin / flashinfer-jit-cache versions (with explicit mismatch flag), JIT cache + local cubin store stats, resolved target CUDA archs
- GPU/driver properties in **CUDA enumeration order** (nvidia-smi order as no-torch fallback), CUDA toolkit **as resolved by flashinfer's JIT** vs `CUDA_HOME`
- **Loaded vs installed GPU libraries**: force-loads the libs torch actually uses, parses `/proc/self/maps` for what is truly mapped, scans `LD_LIBRARY_PATH` / site-packages / `CUDA_HOME` / ldconfig for other on-disk installs; aggregated per directory with pip provenance, ⚠ on real conflicts
- torch build info, cuDNN frontend + loaded backend version, relevant packages (incl. vLLM/SGLang and their declared flashinfer pins, stated factually), `FLASHINFER_*`/`CUDA*`/… env vars, GPU topology

**Design constraints** (documented in the module docstring)

- stdlib-only at module level and every probe individually guarded → still produces a report when `import flashinfer` or torch is broken; the file can be `curl`-ed and run standalone with bare Python
- strictly offline/read-only (no downloads, unlike `show-config`'s artifact status), ~7 s wall clock

Example of the headline section on a box with a pip-wheel CUDA stack plus a local toolkit:

```text
==== GPU Libraries: loaded vs on disk ====
libcublas  ⚠ other installs on disk (check which one you expect):
    LOADED   .../.venv/lib/python3.12/site-packages/nvidia/cu13/lib/  [pip nvidia-cublas==13.0.0.19]
    on disk  /usr/local/cuda-13.2/targets/x86_64-linux/lib/  [v13.3.0.5]
```

## 🔍 Related Issues

Improves triage for env-dependent reports in general (e.g. the recurring "works on my machine" class).

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/utils/test_collect_env.py` asserts the core contract (collection never raises, sections present, JSON-serializable) and runs GPU-less. Manually verified on a multi-arch box (A100/L40S/H100/B200-class, driver 595.71.05): full run in a venv, standalone run with bare `/usr/bin/python3` (no torch/flashinfer — degrades gracefully), `--json` parses.

## Reviewer Notes

- `/proc/self/maps` is Linux-only; on other platforms that section degrades to the on-disk scan.
- AI-assisted (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `collect-env` CLI command to generate detailed environment reports (runtime, CUDA/GPU details, loaded libraries, and version info).
  * Supports formatted text or pretty-printed JSON output.
  * Added GitHub issue forms for bug reports and feature requests with prompts for reproducible steps and environment output.

* **Documentation**
  * Updated quick-reference materials with environment-report commands, including an optional `--json` mode.

* **Tests**
  * Added tests covering report section presence/structure, FlashInfer↔flashinfer version consistency, text formatting, and JSON-serializability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Update (2026-07-17):** also adds `🚀 Kernel / Feature Request` (`feature_request.yml`), a slimmed revision of the template draft circulated on Slack, incorporating the thread feedback (thanks @Kaustubh, Brian, Jingfan):

- Two clean templates with an explicit routing rule in each description: *broken / wrong / slower than before* → Bug Report; *new capability / speedup* → Feature Request
- Required fields: 4 (+ a "searched existing issues" checkbox on both templates); the remaining fields are grouped under a visible "everything below is optional" divider
- Hardware dropdown gains Ampere/Ada; inference engine is multi-select; Evidence dropdown folded into the Problem field; Impact label/multi-select contradiction fixed
- Both templates reference the same environment tool: `python -m flashinfer.collect_env`; bug-template reproducer guidance now asks for a short standalone script rather than a full `vllm serve` run
