### PR TITLE
feat(moe): add CuTe-DSL GeGLU-tanh and SiTU activations

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -47,29 +47,34 @@ from flashinfer.tllm_enums import (
     DEFAULT_SWIGLU_LIMIT,
 )
 
-from ..moe_utils import normalize_cute_dsl_moe_activation_type
+from ..moe_utils import (
+    normalize_cute_dsl_moe_activation_type,
+    validate_cute_dsl_moe_situ_config,
+)
 from .custom_pipeline import PipelineCpAsyncUmma
 from .utils import (
     fmin,
+    gelu_tanh_f32,
     griddepcontrol_launch_dependents,
     griddepcontrol_wait,
     is_power_of_2,
+    situ_f32,
+    tanh_f32,
 )
 
 """
-High-performance persistent blockscaled contiguous grouped dense GEMM with gather and SwiGLU fusion
-(C = up * silu(gate), where up and gate come from interleaved weight matrix B)
-example for the NVIDIA Blackwell architecture using CUTE DSL.
+High-performance persistent blockscaled contiguous grouped dense GEMM with gather
+and FC1 activation fusion for the NVIDIA Blackwell architecture using CUTE DSL.
 
-This kernel performs FC1 layer computation with SwiGLU activation fusion:
+This kernel performs FC1 layer computation with activation fusion:
 1. GEMM: acc = alpha * (SFA * A[token_ids]) * (SFB * B)
-2. SwiGLU: C = up * silu(gate), where up/gate are extracted from interleaved acc (granularity=64)
+2. Activation: SwiGLU, SiTU, tanh-approximate GeGLU, or ReLU^2
 3. Optional Quant: When c_dtype is Float4E2M1FN, generates scale factor C and quantizes output
 
 - Matrix A is MxKx1, A can be row-major("K"), ValidM is composed of valid m in different groups
 - Matrix B is NxKxL, B can be column-major("K"), L is grouped dimension (number of experts)
   - B weights are interleaved: [up_0:64, gate_64:128, up_128:192, gate_192:256, ...]
-- Matrix C is Mx(N/2)x1, C can be row-major("N"), N is halved due to SwiGLU fusion
+- Matrix C is Mx(N/2)x1 for gated activations and MxNx1 otherwise
 - Matrix SFA layout is filled internally according to A shape and BlockScaledBasicChunk,
   which has M×ceil_div(K, sf_vec_size)×1 elements
 - Matrix SFB layout is filled internally according to B shape and BlockScaledBasicChunk,
@@ -113,7 +118,7 @@ This GEMM works as follows:
 5. EPILOGUE warps (warps 0-3):
     - Load two accumulator subtiles (up and gate) from tensor memory (TMEM) to registers (RMEM) using tcgen05.ld.
     - Apply alpha scaling: up_scaled = alpha * up, gate_scaled = alpha * gate
-    - Compute SwiGLU activation: output = up_scaled * silu(gate_scaled), where silu(x) = x * sigmoid(x)
+    - Compute the configured FC1 activation
     - If c_dtype is Float4E2M1FN: generate scale factor C (SFC) and quantize output
     - Type convert output to c_dtype.
     - Store C matrix from registers (RMEM) to shared memory (SMEM) to global memory (GMEM) with TMA operations.
@@ -324,16 +329,16 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
 
     The computation flow:
     1. GEMM: acc = alpha * (SFA * A[token_ids]) * (SFB * B)
-    2. SwiGLU: C = up * silu(gate), extracted from interleaved acc with granularity=64
+    2. Activation: SwiGLU, SiTU, tanh-approximate GeGLU, or ReLU^2
     3. Optional Quant: When c_dtype is Float4E2M1FN, generates SFC and quantizes output
 
-    Note: Output C has N/2 columns since pairs of (up, gate) are combined by SwiGLU.
+    Note: Output C has N/2 columns for gated activations and N columns otherwise.
 
     Key Features:
     - Uses LDGSTS instructions for loading A and SFA matrices with gather/permutation capability
     - Uses TMA (Tensor Memory Access) for loading B and SFB matrices with multicast
     - Token ID mapping enables efficient gather operation during A/SFA load
-    - SwiGLU activation fusion in epilogue (up * silu(gate) with interleaved weights)
+    - FC1 activation fusion in the epilogue
     - Optional quantization fusion for Float4E2M1FN output with scale factor generation
     - Warp specialization: Scheduler (warp 10), A Sync Transform (warp 11, only used when
       use_2cta_instrs is True), LDGSTS A/SFA (warps 4-7), TMA B/SFB (warp 9), MMA (warp 8),
@@ -415,6 +420,8 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
         swiglu_beta: float = DEFAULT_SWIGLU_BETA,
         swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None,
         gated: bool = True,
         use_a_per_token_scale: bool = False,
     ):
@@ -457,7 +464,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         :param enable_pdl: Enable Programmatic Dependent Launch.
         :type enable_pdl: bool
         :param activation_type: FC1 activation type. Use ActivationType.Swiglu
-            for gated SwiGLU/OAI and ActivationType.Relu2 for non-gated ReLU^2.
+            for gated SwiGLU/OAI/SiTU, ActivationType.GegluTanh for
+            tanh-approximate GeGLU, and ActivationType.Relu2 for non-gated
+            ReLU^2. Setting situ_beta selects SiTU.
         :type activation_type: int
         :param swiglu_alpha: Sigmoid multiplier for parameterized SwiGLU.
         :type swiglu_alpha: float
@@ -465,6 +474,11 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         :type swiglu_beta: float
         :param swiglu_limit: Clamp limit for parameterized SwiGLU.
         :type swiglu_limit: float
+        :param situ_beta: When set, use the SiTU gate
+            ``beta * tanh(gate / beta) * sigmoid(gate)`` instead of SwiGLU.
+        :type situ_beta: Optional[float]
+        :param situ_linear_beta: Optional SiTU tanh clamp for the up branch.
+        :type situ_linear_beta: Optional[float]
         :param gated: Whether GEMM1 output is split into up/gate halves. If
             False, the epilogue computes non-gated ReLU^2.
         :type gated: bool
@@ -561,11 +575,14 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             raise ValueError(
                 f"gated={gated} is inconsistent with activation_type {activation_type!r}"
             )
+        validate_cute_dsl_moe_situ_config(activation_type, situ_beta, situ_linear_beta)
         self.vectorized_f32 = vectorized_f32
         self.activation_type = int(activation_type)
         self.swiglu_alpha = swiglu_alpha
         self.swiglu_beta = swiglu_beta
         self.swiglu_limit = swiglu_limit
+        self.situ_beta = situ_beta
+        self.situ_linear_beta = situ_linear_beta
 
     def _setup_attributes(self):
         """Set up configurations that are dependent on GEMM inputs
@@ -807,13 +824,14 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
              shared memory when use_2cta_instrs is True
            - TMA warp: Load B and SFB with multicast
            - MMA warp: Perform matrix multiply-accumulate
-           - Epilogue warps: Apply SwiGLU activation, optional quantization, and store results
+           - Epilogue warps: Apply the FC1 activation, optional quantization, and store results
 
         :param a: Input tensor A (MxKx1), will be gathered using token_id_mapping
         :type a: cute.Tensor
-        :param b: Input tensor B (NxKxL), L is the number of experts/groups, weights are interleaved for SwiGLU
+        :param b: Input tensor B (NxKxL), L is the number of experts/groups.
+            Weights are interleaved for gated activations.
         :type b: cute.Tensor
-        :param c: Output tensor C (Mx(N/2)x1), N is halved due to SwiGLU fusion
+        :param c: Output tensor C (Mx(N/2)x1 for gated activations, MxNx1 otherwise)
         :type c: cute.Tensor
         :param sfa: Scale factor tensor A, will be gathered using token_id_mapping
         :type sfa: cute.Tensor
@@ -2699,10 +2717,11 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         acc_vec_gate = tTR_rAcc_gate.load()
 
                         #
-                        # Gated activation. Represent standard SwiGLU and the
-                        # OAI variant as ActivationType.Swiglu; the
-                        # alpha/beta/limit parameters specialize the same
-                        # formula:
+                        # Gated activation. SiTU optionally applies smooth tanh
+                        # clamps, while GeGLU uses tanh-approximate GELU.
+                        # Represent standard SwiGLU and the OAI variant as
+                        # ActivationType.Swiglu; the alpha/beta/limit parameters
+                        # specialize the same formula:
                         # gate * sigmoid(swiglu_alpha * gate)
                         # * (up + swiglu_beta).
                         #
@@ -2713,7 +2732,137 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         swiglu_beta = cutlass.Float32(self.swiglu_beta)
                         swiglu_limit = cutlass.Float32(self.swiglu_limit)
                         LOG2_E = cutlass.Float32(1.4426950408889634)
-                        if cutlass.const_expr(self.vectorized_f32):
+                        if cutlass.const_expr(self.situ_beta is not None):
+                            situ_beta = cutlass.Float32(self.situ_beta)
+                            if cutlass.const_expr(self.vectorized_f32):
+                                for i in cutlass.range_constexpr(
+                                    0, cute.size(tTR_rAcc_up), 2
+                                ):
+                                    acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
+                                        (acc_vec_up[i], acc_vec_up[i + 1]),
+                                        (
+                                            cutlass.Float32(alpha_val),
+                                            cutlass.Float32(alpha_val),
+                                        ),
+                                    )
+                                    acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
+                                        (acc_vec_gate[i], acc_vec_gate[i + 1]),
+                                        (
+                                            cutlass.Float32(alpha_val),
+                                            cutlass.Float32(alpha_val),
+                                        ),
+                                    )
+                                    situ_gate_pair = (
+                                        situ_f32(
+                                            acc_vec_gate_alpha[0],
+                                            situ_beta,
+                                            fastmath=True,
+                                        ),
+                                        situ_f32(
+                                            acc_vec_gate_alpha[1],
+                                            situ_beta,
+                                            fastmath=True,
+                                        ),
+                                    )
+                                    if cutlass.const_expr(
+                                        self.situ_linear_beta is not None
+                                    ):
+                                        linear_beta = cutlass.Float32(
+                                            self.situ_linear_beta
+                                        )
+                                        acc_vec_up_alpha = (
+                                            linear_beta
+                                            * tanh_f32(
+                                                acc_vec_up_alpha[0] / linear_beta,
+                                                fastmath=True,
+                                            ),
+                                            linear_beta
+                                            * tanh_f32(
+                                                acc_vec_up_alpha[1] / linear_beta,
+                                                fastmath=True,
+                                            ),
+                                        )
+                                    (
+                                        tCompute[i],
+                                        tCompute[i + 1],
+                                    ) = cute.arch.mul_packed_f32x2(
+                                        acc_vec_up_alpha, situ_gate_pair
+                                    )
+                            else:
+                                for i in cutlass.range_constexpr(
+                                    cute.size(tTR_rAcc_up)
+                                ):
+                                    acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(
+                                        alpha_val
+                                    )
+                                    acc_vec_gate_alpha = acc_vec_gate[
+                                        i
+                                    ] * cutlass.Float32(alpha_val)
+                                    situ_gate_value = situ_f32(
+                                        acc_vec_gate_alpha,
+                                        situ_beta,
+                                        fastmath=True,
+                                    )
+                                    if cutlass.const_expr(
+                                        self.situ_linear_beta is not None
+                                    ):
+                                        linear_beta = cutlass.Float32(
+                                            self.situ_linear_beta
+                                        )
+                                        acc_vec_up_alpha = linear_beta * tanh_f32(
+                                            acc_vec_up_alpha / linear_beta,
+                                            fastmath=True,
+                                        )
+                                    tCompute[i] = acc_vec_up_alpha * situ_gate_value
+                        elif cutlass.const_expr(
+                            self.activation_type == ActivationType.GegluTanh.value
+                        ):
+                            if cutlass.const_expr(self.vectorized_f32):
+                                for i in cutlass.range_constexpr(
+                                    0, cute.size(tTR_rAcc_up), 2
+                                ):
+                                    acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
+                                        (acc_vec_up[i], acc_vec_up[i + 1]),
+                                        (
+                                            cutlass.Float32(alpha_val),
+                                            cutlass.Float32(alpha_val),
+                                        ),
+                                    )
+                                    acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
+                                        (acc_vec_gate[i], acc_vec_gate[i + 1]),
+                                        (
+                                            cutlass.Float32(alpha_val),
+                                            cutlass.Float32(alpha_val),
+                                        ),
+                                    )
+                                    (
+                                        tCompute[i],
+                                        tCompute[i + 1],
+                                    ) = cute.arch.mul_packed_f32x2(
+                                        acc_vec_up_alpha,
+                                        (
+                                            gelu_tanh_f32(
+                                                acc_vec_gate_alpha[0], fastmath=True
+                                            ),
+                                            gelu_tanh_f32(
+                                                acc_vec_gate_alpha[1], fastmath=True
+                                            ),
+                                        ),
+                                    )
+                            else:
+                                for i in cutlass.range_constexpr(
+                                    cute.size(tTR_rAcc_up)
+                                ):
+                                    acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(
+                                        alpha_val
+                                    )
+                                    acc_vec_gate_alpha = acc_vec_gate[
+                                        i
+                                    ] * cutlass.Float32(alpha_val)
+                                    tCompute[i] = acc_vec_up_alpha * gelu_tanh_f32(
+                                        acc_vec_gate_alpha, fastmath=True
+                                    )
+                        elif cutlass.const_expr(self.vectorized_f32):
                             for i in cutlass.range_constexpr(
                                 0, cute.size(tTR_rAcc_up), 2
                             ):

--- a/flashinfer/fused_moe/cute_dsl/blackwell/utils.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/utils.py
@@ -243,6 +243,45 @@ def silu_f32(
     return a * sigmoid_f32(a, fastmath=fastmath)
 
 
+def tanh_f32(
+    a: Union[float, cutlass.Float32], fastmath: bool = False
+) -> Union[float, cutlass.Float32]:
+    """Compute tanh from the existing sigmoid primitive."""
+    return cutlass.Float32(2.0) * sigmoid_f32(
+        cutlass.Float32(2.0) * a, fastmath=fastmath
+    ) - cutlass.Float32(1.0)
+
+
+def situ_f32(
+    a: Union[float, cutlass.Float32],
+    beta: Union[float, cutlass.Float32],
+    fastmath: bool = False,
+) -> Union[float, cutlass.Float32]:
+    """Compute SiTU: beta * tanh(x / beta) * sigmoid(x)."""
+    x = cutlass.Float32(a)
+    beta_f32 = cutlass.Float32(beta)
+    return (
+        beta_f32
+        * tanh_f32(x / beta_f32, fastmath=fastmath)
+        * sigmoid_f32(x, fastmath=fastmath)
+    )
+
+
+def gelu_tanh_f32(
+    a: Union[float, cutlass.Float32], fastmath: bool = False
+) -> Union[float, cutlass.Float32]:
+    """Compute GELU using the tanh approximation."""
+    x = cutlass.Float32(a)
+    inner = cutlass.Float32(0.7978845608028654) * (
+        x + cutlass.Float32(0.044715) * x * x * x
+    )
+    return (
+        cutlass.Float32(0.5)
+        * x
+        * (cutlass.Float32(1.0) + tanh_f32(inner, fastmath=fastmath))
+    )
+
+
 # TODO(zhichenj): try to move these to NVVM wrapper or helper functions
 @dsl_user_op
 def vectorized_atomic_add_bf16x8(

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -20,25 +20,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Contiguous Grouped GEMM kernel with Gather and SwiGLU Fusion for MoE workloads on Blackwell GPUs.
+Contiguous grouped GEMM kernel with gather and FC1 activation fusion for MoE
+workloads on Blackwell GPUs.
 
 This module provides a FlashInfer-style API wrapper around the TensorRT-LLM CuteDSL
-grouped GEMM kernel with fused gather and SwiGLU activation designed for MoE GEMM1 layers:
+grouped GEMM kernel with fused gather and activation designed for MoE GEMM1 layers:
 - Input A: (seq_len, k) - original unpermuted tokens (no need for moe_permute!)
-- Input B: (num_experts, 2*intermediate_size, k) - expert gate and up weights interleaved
-- Output C: (permuted_m, intermediate_size) - SwiGLU activated outputs in permuted order
+- Input B: expert projection weights, interleaved for gated activations
+- Output C: activated outputs in permuted order
 
 Key features:
 - NVFP4 x NVFP4 grouped GEMM with FP8 scale factors
 - Fused gather operation using LDGSTS instructions with token_id_mapping
 - Eliminates the need for a separate moe_permute kernel
-- Fused SwiGLU activation in epilogue: output = up * silu(gate)
+- Fused FC1 activation in the epilogue
 - Optional FP4 quantization of output with scale factor generation
 - Persistent tile scheduling with per-expert group mapping
 - Warp specialization for overlapped memory and compute
 - Support for SM100 (Blackwell) architecture
 
-Comparison with Non-Gather SwiGLU Fusion:
+Comparison with non-gather activation fusion:
 - Non-Gather: Requires separate moe_permute kernel, then uses TMA for contiguous A load
 - Gather: Uses LDGSTS to gather A directly using token_id_mapping, no moe_permute needed
 """
@@ -64,7 +65,10 @@ from flashinfer.cute_dsl.utils import (
     get_max_active_clusters,
     make_ptr,
 )
-from .moe_utils import normalize_cute_dsl_moe_activation_type
+from .moe_utils import (
+    normalize_cute_dsl_moe_activation_type,
+    validate_cute_dsl_moe_situ_config,
+)
 
 from .blackwell.blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
     BlockScaledContiguousGatherGroupedGemmKernel,
@@ -82,7 +86,7 @@ def create_gather_gemm_tensors(
     """Create tensors required for gather grouped GEMM.
 
     This function creates the mapping tensors needed for the fused gather operation
-    in GEMM1 with SwiGLU activation.
+    in GEMM1 with fused activation.
 
     Args:
         seq_len: Number of input tokens (original sequence length before routing)
@@ -232,6 +236,8 @@ def _get_compiled_gather_kernel(
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+    situ_beta: Optional[float] = None,
+    situ_linear_beta: Optional[float] = None,
     gated: bool = True,
     use_a_per_token_scale: bool = False,
 ):
@@ -249,13 +255,17 @@ def _get_compiled_gather_kernel(
     overhead during autotuning.
     """
     global _gather_kernel_cache
-    activation_type, expected_gated = normalize_cute_dsl_moe_activation_type(
+    normalized_activation_type, expected_gated = normalize_cute_dsl_moe_activation_type(
         activation_type
     )
     if gated != expected_gated:
         raise ValueError(
-            f"gated={gated} is inconsistent with activation_type {activation_type!r}"
+            f"gated={gated} is inconsistent with activation_type "
+            f"{normalized_activation_type!r}"
         )
+    validate_cute_dsl_moe_situ_config(
+        normalized_activation_type, situ_beta, situ_linear_beta
+    )
 
     # Cache key includes dtype and tactic parameters, NOT problem dimensions
     cache_key = (
@@ -270,10 +280,12 @@ def _get_compiled_gather_kernel(
         vectorized_f32,
         raster_along_m,
         enable_pdl,
-        activation_type.value,
+        normalized_activation_type.value,
         swiglu_alpha,
         swiglu_beta,
         swiglu_limit,
+        situ_beta,
+        situ_linear_beta,
         gated,
         use_a_per_token_scale,
     )
@@ -288,10 +300,12 @@ def _get_compiled_gather_kernel(
             topk=topk,
             raster_along_m=raster_along_m,
             enable_pdl=enable_pdl,
-            activation_type=activation_type.value,
+            activation_type=normalized_activation_type.value,
             swiglu_alpha=swiglu_alpha,
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
             gated=gated,
             use_a_per_token_scale=use_a_per_token_scale,
         )
@@ -364,26 +378,28 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+    situ_beta: Optional[float] = None,
+    situ_linear_beta: Optional[float] = None,
     gated: bool = True,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
-    """Blockscaled Contiguous Gather Grouped GEMM with SwiGLU Fusion for MoE workloads.
+    """Blockscaled contiguous gather grouped GEMM with fused FC1 activation.
 
-    Performs grouped matrix multiplication with fused gather and SwiGLU activation:
-    C[row] = up * silu(gate), where [gate, up] = alpha[expert] * (A[token_id] @ B[expert])
+    Performs grouped matrix multiplication with fused gather and activation.
 
     This kernel is designed for Mixture of Experts (MoE) GEMM1 layers where:
     - Input tokens are NOT pre-permuted (no need for moe_permute kernel!)
     - The kernel gathers input tokens using token_id_mapping during LDGSTS load
-    - Each expert has gate and up projection weights interleaved
-    - SwiGLU activation is fused into the GEMM epilogue
+    - Gated activations use interleaved gate and up projection weights
+    - The configured activation is fused into the GEMM epilogue
     - Optional FP4 quantization of output
 
     Args:
         a: Input tensor A (original unpermuted tokens), shape (seq_len, k) for FP4
            stored as (seq_len, k//2) uint8. This is the ORIGINAL unpermuted tensor!
-        b: Weight tensor B (expert gate+up weights), shape (num_experts, 2*intermediate_size, k)
-           for FP4 stored as (num_experts, 2*intermediate_size, k//2) uint8
-           The N dimension contains interleaved gate and up projection weights.
+        b: Weight tensor B. Gated activations use shape
+           (num_experts, 2*intermediate_size, k), stored for FP4 as
+           (num_experts, 2*intermediate_size, k//2) uint8, with interleaved
+           gate and up projection weights.
         a_scale: Scale factors for A in MMA-compatible layout
         b_scale: Scale factors for B in MMA-compatible layout
         alpha: Per-expert scaling factors, shape (num_experts,), float32
@@ -399,7 +415,7 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
         global_scale: Global scale factor for FP4 quantization, shape (1,), float32.
         a_per_token_scale: Optional per-token row scale for operand A,
             shape (seq_len,), float32. Indexed by the original token ID and
-            applied before SwiGLU.
+            applied before the fused activation.
         topk: Number of experts per token. Default: 8
         ab_dtype: Data type for A and B matrices. Default: "float4_e2m1fn"
         sf_dtype: Data type for scale factors. Default: "float8_e4m3fn"
@@ -411,12 +427,17 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
         raster_along_m: If True, raster tiles along M dimension. Default: False
         sm_count: Number of SMs to use. Default: max available.
         activation_type: Activation type for the epilogue. Use
-            ActivationType.Swiglu for gated mode and ActivationType.Relu2 for
-            non-gated mode; swiglu_oai is represented as Swiglu with
-            non-default swiglu_alpha/beta/limit.
+            ActivationType.Swiglu for gated SwiGLU/OAI/SiTU,
+            ActivationType.GegluTanh for tanh-approximate GeGLU, and
+            ActivationType.Relu2 for non-gated mode. Setting situ_beta selects
+            SiTU; swiglu_oai is represented as Swiglu with non-default
+            swiglu_alpha/beta/limit.
         swiglu_alpha: SwiGLU sigmoid multiplier.
         swiglu_beta: SwiGLU up-projection bias.
         swiglu_limit: SwiGLU clamp limit.
+        situ_beta: When set with ActivationType.Swiglu, use the SiTU gate
+            ``beta * tanh(gate / beta) * sigmoid(gate)``.
+        situ_linear_beta: Optional SiTU tanh clamp for the up branch.
         gated: Whether to run the gated SwiGLU path. If False, run non-gated
             ReLU2.
 
@@ -427,7 +448,7 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
         - out_scale: Output scale factors if c_dtype is FP4, else None
 
     Notes:
-        - Unlike the Non-Gather SwiGLU kernel, this kernel does NOT require moe_permute!
+        - Unlike the non-gather kernel, this kernel does NOT require moe_permute!
         - The A tensor is the original unpermuted input
         - The output is in permuted order (can be fed directly to GEMM2)
         - Use create_gather_gemm_tensors() to create required mapping tensors
@@ -461,13 +482,17 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
     # Validate inputs
     assert a.device.type == "cuda", "Input tensors must be on CUDA device"
     assert b.device.type == "cuda", "Input tensors must be on CUDA device"
-    activation_type, expected_gated = normalize_cute_dsl_moe_activation_type(
+    normalized_activation_type, expected_gated = normalize_cute_dsl_moe_activation_type(
         activation_type
     )
     if gated != expected_gated:
         raise ValueError(
-            f"gated={gated} is inconsistent with activation_type {activation_type!r}"
+            f"gated={gated} is inconsistent with activation_type "
+            f"{normalized_activation_type!r}"
         )
+    validate_cute_dsl_moe_situ_config(
+        normalized_activation_type, situ_beta, situ_linear_beta
+    )
 
     # Get dimensions
     seq_len = a.shape[0]
@@ -512,7 +537,7 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
     major, minor = get_compute_capability(a.device)
     if major != 10:
         raise ValueError(
-            f"Blockscaled contiguous gather grouped GEMM with SwiGLU requires SM100 family (Blackwell: SM100, SM103). "
+            f"Blockscaled contiguous gather grouped GEMM requires SM100 family (Blackwell: SM100, SM103). "
             f"Got SM{major}{minor}."
         )
 
@@ -675,10 +700,12 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
         vectorized_f32=vectorized_f32,
         raster_along_m=raster_along_m,
         enable_pdl=enable_pdl,
-        activation_type=activation_type.value,
+        activation_type=normalized_activation_type.value,
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
         swiglu_limit=swiglu_limit,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
         gated=gated,
         use_a_per_token_scale=use_a_per_token_scale,
     )

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -79,6 +79,7 @@ from .moe_utils import (
     moe_sort,
     moe_unpermute,
     normalize_cute_dsl_moe_activation_type,
+    validate_cute_dsl_moe_situ_config,
 )
 from .blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
     blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4,
@@ -173,6 +174,8 @@ def _moe_core_impl(
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+    situ_beta: Optional[float] = None,
+    situ_linear_beta: Optional[float] = None,
 ) -> torch.Tensor:
     """Core MoE implementation shared by functional and wrapper APIs.
 
@@ -216,17 +219,22 @@ def _moe_core_impl(
         use_fused_finalize: Use atomic fused finalize; otherwise use the
             deterministic two-stage finalize.
         activation_type: Activation type to apply after GEMM1. Use
-            ActivationType.Swiglu for gated mode and ActivationType.Relu2 for
-            non-gated mode; swiglu_oai is represented as Swiglu with
-            non-default swiglu_alpha/beta/limit.
+            ActivationType.Swiglu for gated SwiGLU/OAI/SiTU,
+            ActivationType.GegluTanh for tanh-approximate GeGLU, and
+            ActivationType.Relu2 for non-gated mode. Setting situ_beta selects
+            SiTU; swiglu_oai is represented as Swiglu with non-default
+            swiglu_alpha/beta/limit.
         swiglu_alpha: SwiGLU sigmoid multiplier.
         swiglu_beta: SwiGLU up-projection bias.
         swiglu_limit: SwiGLU clamp limit.
+        situ_beta: When set with ActivationType.Swiglu, use the SiTU gate.
+        situ_linear_beta: Optional SiTU tanh clamp for the up branch.
 
     Returns:
         Output tensor [num_tokens, hidden_size].
     """
     activation, gated = normalize_cute_dsl_moe_activation_type(activation_type)
+    validate_cute_dsl_moe_situ_config(activation, situ_beta, situ_linear_beta)
 
     num_tokens = token_selected_experts.size(0)
     hidden_size = w2_weight.size(1)
@@ -314,6 +322,8 @@ def _moe_core_impl(
             swiglu_alpha=swiglu_alpha,
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
             gated=gated,
         )
     )
@@ -460,6 +470,8 @@ class CuteDslMoEWrapper:
         swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
         swiglu_beta: float = DEFAULT_SWIGLU_BETA,
         swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None,
         use_fused_finalize: bool = True,
     ):
         r"""Configure the CuTe-DSL NVFP4 fused-MoE wrapper.
@@ -473,7 +485,7 @@ class CuteDslMoEWrapper:
         hidden_size : int
             Hidden dimension size.
         intermediate_size : int
-            Intermediate dimension size (after SwiGLU reduction).
+            Intermediate dimension size after the fused activation.
         use_cuda_graph : bool
             Create persistent CUDA stream/events for async-memset overlap.
             Required for CUDA graph capture, since streams and events must be
@@ -498,15 +510,23 @@ class CuteDslMoEWrapper:
             Enable Programmatic Dependent Launch.  Defaults to ``True``.
         activation_type : int
             FC1 activation type. Use ``ActivationType.Swiglu`` for gated
-            SwiGLU and ``ActivationType.Relu2`` for non-gated ReLU^2.
+            SwiGLU/SiTU, ``ActivationType.GegluTanh`` for tanh-approximate
+            GeGLU, and ``ActivationType.Relu2`` for non-gated ReLU^2. Setting
+            ``situ_beta`` selects SiTU.
         swiglu_alpha, swiglu_beta, swiglu_limit : float
             SwiGLU parameters. ``swiglu_oai`` is represented as
             ``ActivationType.Swiglu`` with non-default values.
+        situ_beta : Optional[float]
+            When set with ``ActivationType.Swiglu``, use the SiTU gate
+            ``beta * tanh(gate / beta) * sigmoid(gate)``.
+        situ_linear_beta : Optional[float]
+            Optional SiTU tanh clamp for the up branch.
         use_fused_finalize : bool
             Use atomic fused finalize; otherwise use the deterministic
             two-stage finalize. Defaults to ``True``.
         """
         activation, gated = normalize_cute_dsl_moe_activation_type(activation_type)
+        validate_cute_dsl_moe_situ_config(activation, situ_beta, situ_linear_beta)
 
         self.num_experts = num_experts
         self.top_k = top_k
@@ -520,11 +540,13 @@ class CuteDslMoEWrapper:
         self.output_dtype = output_dtype
         self.device = device
         self.enable_pdl = enable_pdl
-        self.activation_type = activation
+        self.activation_type: ActivationType = activation
         self.gated = gated
         self.swiglu_alpha = swiglu_alpha
         self.swiglu_beta = swiglu_beta
         self.swiglu_limit = swiglu_limit
+        self.situ_beta = situ_beta
+        self.situ_linear_beta = situ_linear_beta
         self.use_fused_finalize = use_fused_finalize
 
         # Persistent CUDA resources for async-memset / GEMM1 overlap. These
@@ -561,6 +583,8 @@ class CuteDslMoEWrapper:
             swiglu_alpha=swiglu_alpha,
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
             use_per_token_activation=False,
         )
         self._per_token_runner = CuteDslFusedMoENvfp4Runner(
@@ -576,6 +600,8 @@ class CuteDslMoEWrapper:
             swiglu_alpha=swiglu_alpha,
             swiglu_beta=swiglu_beta,
             swiglu_limit=swiglu_limit,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
             use_per_token_activation=True,
         )
 
@@ -652,6 +678,8 @@ class CuteDslMoEWrapper:
             swiglu_alpha=self.swiglu_alpha,
             swiglu_beta=self.swiglu_beta,
             swiglu_limit=self.swiglu_limit,
+            situ_beta=self.situ_beta,
+            situ_linear_beta=self.situ_linear_beta,
         )
 
     @flashinfer_api(trace=cute_dsl_moe_wrapper_run_trace)
@@ -749,8 +777,11 @@ class CuteDslMoEWrapper:
             return runner(inputs, tactic=tactic)
 
         # Let tuner choose tactic
+        activation_name = (
+            "Situ" if self.situ_beta is not None else self.activation_type.name
+        )
         _, best_tactic = tuner.choose_one(
-            f"CuteDslMoEWrapper::run::{self.activation_type.name}",
+            f"CuteDslMoEWrapper::run::{activation_name}",
             [runner],
             runner.tuning_config,
             inputs,
@@ -806,6 +837,8 @@ def _cute_dsl_fused_moe_nvfp4_impl(
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+    situ_beta: Optional[float] = None,
+    situ_linear_beta: Optional[float] = None,
 ) -> torch.Tensor:
     """Internal implementation called by auto-tuner for functional API."""
     return _moe_core_impl(
@@ -840,6 +873,8 @@ def _cute_dsl_fused_moe_nvfp4_impl(
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
         swiglu_limit=swiglu_limit,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
     )
 
 
@@ -870,6 +905,8 @@ def cute_dsl_fused_moe_nvfp4(
     swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
     swiglu_beta: float = DEFAULT_SWIGLU_BETA,
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+    situ_beta: Optional[float] = None,
+    situ_linear_beta: Optional[float] = None,
     *,
     per_token_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
@@ -928,12 +965,18 @@ def cute_dsl_fused_moe_nvfp4(
     enable_pdl : bool
         Enable Programmatic Dependent Launch.  Defaults to ``True``.
     activation_type : int
-        FC1 activation type. Use ``ActivationType.Swiglu`` for gated SwiGLU
-        and ``ActivationType.Relu2`` for non-gated ReLU^2. ``swiglu_oai`` is
-        represented as ``ActivationType.Swiglu`` with non-default
-        ``swiglu_alpha/beta/limit``.
+        FC1 activation type. Use ``ActivationType.Swiglu`` for gated
+        SwiGLU/SiTU, ``ActivationType.GegluTanh`` for tanh-approximate GeGLU,
+        and ``ActivationType.Relu2`` for non-gated ReLU^2. Setting
+        ``situ_beta`` selects SiTU; ``swiglu_oai`` is represented as
+        ``ActivationType.Swiglu`` with non-default ``swiglu_alpha/beta/limit``.
     swiglu_alpha, swiglu_beta, swiglu_limit : float
         SwiGLU parameters.
+    situ_beta : Optional[float]
+        When set with ``ActivationType.Swiglu``, use the SiTU gate
+        ``beta * tanh(gate / beta) * sigmoid(gate)``.
+    situ_linear_beta : Optional[float]
+        Optional SiTU tanh clamp for the up branch.
     per_token_scale : Optional[torch.Tensor]
         Per-token input row scale for GEMM1. Passing this enables the
         per-token activation path.
@@ -944,6 +987,7 @@ def cute_dsl_fused_moe_nvfp4(
         Output tensor of shape ``[num_tokens, hidden_size]``.
     """
     activation, _ = normalize_cute_dsl_moe_activation_type(activation_type)
+    validate_cute_dsl_moe_situ_config(activation, situ_beta, situ_linear_beta)
 
     if num_local_experts is None:
         num_local_experts = num_experts
@@ -974,6 +1018,8 @@ def cute_dsl_fused_moe_nvfp4(
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
         swiglu_limit=swiglu_limit,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
         use_per_token_activation=use_per_token_activation,
     )
 
@@ -994,8 +1040,9 @@ def cute_dsl_fused_moe_nvfp4(
         inputs.append(per_token_scale)
     inputs.append(moe_output)
 
+    activation_name = "Situ" if situ_beta is not None else activation.name
     _, best_tactic = tuner.choose_one(
-        f"CuteDslFusedMoE::run_moe_nvfp4::{activation.name}",
+        f"CuteDslFusedMoE::run_moe_nvfp4::{activation_name}",
         [runner],
         runner.tuning_config,
         inputs,

--- a/flashinfer/fused_moe/cute_dsl/moe_utils.py
+++ b/flashinfer/fused_moe/cute_dsl/moe_utils.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 import functools
+import math
 from enum import IntEnum
 from typing import Dict, Optional, Tuple, Union
 
@@ -38,6 +39,7 @@ def _get_cuda_stream_ptr() -> int:
 
 SUPPORTED_CUTE_DSL_MOE_ACTIVATION_TYPES = (
     ActivationType.Swiglu,
+    ActivationType.GegluTanh,
     ActivationType.Relu2,
 )
 
@@ -52,6 +54,26 @@ def normalize_cute_dsl_moe_activation_type(
             f"Unsupported activation_type {activation_type!r}; expected {expected}"
         )
     return activation_type, is_gated_activation(activation_type)
+
+
+def validate_cute_dsl_moe_situ_config(
+    activation_type: ActivationType,
+    situ_beta: Optional[float],
+    situ_linear_beta: Optional[float],
+) -> None:
+    """Validate the optional SiTU variant of the SwiGLU epilogue."""
+    if situ_beta is None:
+        if situ_linear_beta is not None:
+            raise ValueError("situ_linear_beta requires situ_beta")
+        return
+    if activation_type != ActivationType.Swiglu:
+        raise ValueError("SiTU parameters require ActivationType.Swiglu")
+    if not math.isfinite(situ_beta) or situ_beta <= 0:
+        raise ValueError("situ_beta must be positive and finite")
+    if situ_linear_beta is not None and (
+        not math.isfinite(situ_linear_beta) or situ_linear_beta <= 0
+    ):
+        raise ValueError("situ_linear_beta must be positive and finite when set")
 
 
 def get_max_num_tiles(

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -21,7 +21,7 @@ This module provides a TunableRunner implementation for the CuteDSL NVFP4 MoE
 kernels, enabling automatic performance tuning across different GEMM tactics.
 
 Tactic format follows TRT-LLM's style:
-- GEMM1 (Gather + SwiGLU): (mma_tiler_mn, cluster_shape_mn, raster_along_m)
+- GEMM1 (Gather + FC1 activation): (mma_tiler_mn, cluster_shape_mn, raster_along_m)
 - GEMM2 (Finalize): (mma_tiler_mn, cluster_shape_mn, raster_along_m)
 
 Reference: TensorRT-LLM/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -31,7 +31,7 @@ Reference: TensorRT-LLM/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
 
 import itertools
 import logging
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 
@@ -52,13 +52,16 @@ from ..utils import (
     map_to_hybrid_bucket_uncapped,
 )
 from ._inputs_helper import CuteDslMoEInputsHelper
-from .moe_utils import normalize_cute_dsl_moe_activation_type
+from .moe_utils import (
+    normalize_cute_dsl_moe_activation_type,
+    validate_cute_dsl_moe_situ_config,
+)
 
 logger = logging.getLogger(__name__)
 
 
 # =============================================================================
-# GEMM1 Tactics (Gather + SwiGLU Fusion)
+# GEMM1 Tactics (Gather + FC1 Activation Fusion)
 # =============================================================================
 # Reference: TRT-LLM cute_dsl_custom_ops.py line 1867-1897
 # Sm100BlockScaledContiguousGatherGroupedGemmSwigluFusionRunner.get_valid_tactics
@@ -265,6 +268,8 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         output_dtype: Output data type (default: torch.bfloat16).
         use_per_token_activation: Whether inputs include per-token row scales
             for GEMM1.
+        situ_beta: When set with ActivationType.Swiglu, use the SiTU gate.
+        situ_linear_beta: Optional SiTU tanh clamp for the up branch.
     """
 
     def __init__(
@@ -281,9 +286,12 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         swiglu_alpha: float = DEFAULT_SWIGLU_ALPHA,
         swiglu_beta: float = DEFAULT_SWIGLU_BETA,
         swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None,
         use_per_token_activation: bool = False,
     ):
         activation_type, gated = normalize_cute_dsl_moe_activation_type(activation_type)
+        validate_cute_dsl_moe_situ_config(activation_type, situ_beta, situ_linear_beta)
         self.forward_impl = forward_impl
         self.num_experts = num_experts
         self.top_k = top_k
@@ -297,6 +305,8 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         self.swiglu_alpha = swiglu_alpha
         self.swiglu_beta = swiglu_beta
         self.swiglu_limit = swiglu_limit
+        self.situ_beta = situ_beta
+        self.situ_linear_beta = situ_linear_beta
         self.use_per_token_activation = use_per_token_activation
 
         # Helper that builds a deterministic balanced approx-max-load
@@ -402,6 +412,8 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                 self.swiglu_alpha,
                 self.swiglu_beta,
                 self.swiglu_limit,
+                self.situ_beta,
+                self.situ_linear_beta,
                 self.use_per_token_activation,
             )
         )
@@ -412,6 +424,8 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
             self.swiglu_alpha,
             self.swiglu_beta,
             self.swiglu_limit,
+            self.situ_beta,
+            self.situ_linear_beta,
         )
 
     def get_valid_tactics(  # type: ignore[override]
@@ -632,6 +646,8 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
             swiglu_alpha=self.swiglu_alpha,
             swiglu_beta=self.swiglu_beta,
             swiglu_limit=self.swiglu_limit,
+            situ_beta=self.situ_beta,
+            situ_linear_beta=self.situ_linear_beta,
             **kwargs,
         )
 

--- a/flashinfer/trace/templates/moe.py
+++ b/flashinfer/trace/templates/moe.py
@@ -2072,13 +2072,26 @@ def _moe_bf16_run_experts(
     gemm1_beta=None,
     gemm1_clamp_limit=None,
     activation_type=ActivationType.Swiglu.value,
+    situ_beta=None,
+    situ_linear_beta=None,
 ):
-    """Un-quantized (bf16) MoE expert computation (SwiGLU/OAI or ReLU^2)."""
+    """Un-quantized (bf16) MoE expert computation."""
     activation_type = normalize_activation_type(activation_type)
-    if activation_type not in (ActivationType.Swiglu, ActivationType.Relu2):
+    if situ_beta is not None or situ_linear_beta is not None:
+        from ...fused_moe.cute_dsl.moe_utils import (
+            validate_cute_dsl_moe_situ_config,
+        )
+
+        validate_cute_dsl_moe_situ_config(activation_type, situ_beta, situ_linear_beta)
+    if activation_type not in (
+        ActivationType.Swiglu,
+        ActivationType.GegluTanh,
+        ActivationType.Relu2,
+    ):
         raise ValueError(
             f"Unsupported activation_type {activation_type!r}; "
-            f"expected {ActivationType.Swiglu!r} or {ActivationType.Relu2!r}"
+            f"expected {ActivationType.Swiglu!r}, "
+            f"{ActivationType.GegluTanh!r}, or {ActivationType.Relu2!r}"
         )
     T, H = hidden_states.shape
     E_local, gemm1_out, _ = gemm1_weights.shape
@@ -2103,14 +2116,25 @@ def _moe_bf16_run_experts(
             act = torch.relu(G1) ** 2
         else:
             X1, X2 = G1[:, :I], G1[:, I:]
-            limit = _moe_expert_param(
-                gemm1_clamp_limit, le, DEFAULT_SWIGLU_LIMIT, X1.device
-            )
-            alpha = _moe_expert_param(gemm1_alpha, le, DEFAULT_SWIGLU_ALPHA, X2.device)
-            beta = _moe_expert_param(gemm1_beta, le, DEFAULT_SWIGLU_BETA, X1.device)
-            up = torch.clamp(X1, min=-limit, max=limit)
-            gate = torch.clamp(X2, max=limit)
-            act = gate * torch.sigmoid(alpha * gate) * (up + beta)
+            if situ_beta is not None:
+                gate = situ_beta * torch.tanh(X2 / situ_beta) * torch.sigmoid(X2)
+                up = X1
+                if situ_linear_beta is not None:
+                    up = situ_linear_beta * torch.tanh(up / situ_linear_beta)
+                act = gate * up
+            elif activation_type == ActivationType.GegluTanh:
+                act = torch.nn.functional.gelu(X2, approximate="tanh") * X1
+            else:
+                limit = _moe_expert_param(
+                    gemm1_clamp_limit, le, DEFAULT_SWIGLU_LIMIT, X1.device
+                )
+                alpha = _moe_expert_param(
+                    gemm1_alpha, le, DEFAULT_SWIGLU_ALPHA, X2.device
+                )
+                beta = _moe_expert_param(gemm1_beta, le, DEFAULT_SWIGLU_BETA, X1.device)
+                up = torch.clamp(X1, min=-limit, max=limit)
+                gate = torch.clamp(X2, max=limit)
+                act = gate * torch.sigmoid(alpha * gate) * (up + beta)
         expert_out = act.matmul(W2[le].t())
         w_tok = weights.index_select(0, token_idx)
         match = (topk_idx.index_select(0, token_idx) == ge).float()
@@ -3217,7 +3241,9 @@ cute_dsl_fused_moe_nvfp4_trace = TraceTemplate(
             optional=True,
             description=(
                 "GEMM1 activation type: ActivationType.Swiglu for gated "
-                "SwiGLU/OAI or ActivationType.Relu2 for non-gated ReLU^2. "
+                "SwiGLU/OAI/SiTU, ActivationType.GegluTanh for "
+                "tanh-approximate GeGLU, or ActivationType.Relu2 for "
+                "non-gated ReLU^2. "
                 "Determines gemm1_out_size."
             ),
         ),
@@ -3235,6 +3261,16 @@ cute_dsl_fused_moe_nvfp4_trace = TraceTemplate(
             "float32",
             optional=True,
             description="SwiGLU clamp limit.",
+        ),
+        "situ_beta": Scalar(
+            "float32",
+            optional=True,
+            description="SiTU gate tanh-clamp beta; enables SiTU when set.",
+        ),
+        "situ_linear_beta": Scalar(
+            "float32",
+            optional=True,
+            description="Optional SiTU up-branch tanh-clamp beta.",
         ),
     },
     outputs={
@@ -3278,6 +3314,16 @@ _cute_dsl_wrapper_inputs["swiglu_beta"] = Scalar(
     description="Set at wrapper __init__, not passed to run().",
 )
 _cute_dsl_wrapper_inputs["swiglu_limit"] = Scalar(
+    "float32",
+    optional=True,
+    description="Set at wrapper __init__, not passed to run().",
+)
+_cute_dsl_wrapper_inputs["situ_beta"] = Scalar(
+    "float32",
+    optional=True,
+    description="Set at wrapper __init__, not passed to run().",
+)
+_cute_dsl_wrapper_inputs["situ_linear_beta"] = Scalar(
     "float32",
     optional=True,
     description="Set at wrapper __init__, not passed to run().",
@@ -3467,6 +3513,8 @@ def _cute_dsl_fused_moe_nvfp4_reference(
     swiglu_alpha=DEFAULT_SWIGLU_ALPHA,
     swiglu_beta=DEFAULT_SWIGLU_BETA,
     swiglu_limit=DEFAULT_SWIGLU_LIMIT,
+    situ_beta=None,
+    situ_linear_beta=None,
     per_token_scale=None,
     **_unused,
 ):
@@ -3494,6 +3542,8 @@ def _cute_dsl_fused_moe_nvfp4_reference(
         gemm1_alpha=swiglu_alpha,
         gemm1_beta=swiglu_beta,
         gemm1_clamp_limit=swiglu_limit,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
     )
 
 

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -37,6 +37,7 @@ import torch
 from flashinfer.tllm_enums import ActivationType
 from flashinfer.fused_moe.cute_dsl.moe_utils import (
     normalize_cute_dsl_moe_activation_type,
+    validate_cute_dsl_moe_situ_config,
 )
 from flashinfer.cute_dsl import is_cute_dsl_available
 from .utils import (
@@ -65,6 +66,47 @@ sm100_required = pytest.mark.skipif(
     not is_sm100_family(),
     reason="Requires SM100 family GPU (Blackwell: SM100, SM103, SM110)",
 )
+
+
+def test_geglu_tanh_activation_is_supported():
+    activation_type, gated = normalize_cute_dsl_moe_activation_type(
+        ActivationType.GegluTanh
+    )
+    assert activation_type == ActivationType.GegluTanh
+    assert gated
+
+
+@pytest.mark.parametrize(
+    "activation_type,situ_beta,situ_linear_beta,error",
+    [
+        (ActivationType.Swiglu, None, 1.0, "requires situ_beta"),
+        (ActivationType.Swiglu, 0.0, None, "positive and finite"),
+        (ActivationType.GegluTanh, 1.0, None, "require ActivationType.Swiglu"),
+    ],
+)
+def test_invalid_situ_config(activation_type, situ_beta, situ_linear_beta, error: str):
+    with pytest.raises(ValueError, match=error):
+        validate_cute_dsl_moe_situ_config(activation_type, situ_beta, situ_linear_beta)
+
+
+def test_situ_changes_autotuner_cache_key():
+    from flashinfer.fused_moe.cute_dsl.tuner import CuteDslFusedMoENvfp4Runner
+
+    kwargs = {
+        "forward_impl": lambda *args, **kwargs: None,
+        "num_experts": 8,
+        "top_k": 2,
+        "num_local_experts": 8,
+    }
+    swiglu_runner = CuteDslFusedMoENvfp4Runner(**kwargs)
+    situ_runner = CuteDslFusedMoENvfp4Runner(**kwargs, situ_beta=1.0)
+    situ_beta_runner = CuteDslFusedMoENvfp4Runner(**kwargs, situ_beta=2.0)
+    situ_linear_runner = CuteDslFusedMoENvfp4Runner(
+        **kwargs, situ_beta=1.0, situ_linear_beta=1.5
+    )
+    runners = [swiglu_runner, situ_runner, situ_beta_runner, situ_linear_runner]
+    assert len({hash(runner) for runner in runners}) == len(runners)
+    assert len({runner.get_cache_key_extras([]) for runner in runners}) == len(runners)
 
 
 # =============================================================================
@@ -1087,6 +1129,189 @@ class TestCuteDslFusedMoeFunctional:
             f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
         )
 
+    @pytest.mark.parametrize("use_per_token_activation", [False, True])
+    def test_geglu_tanh_accuracy(self, use_per_token_activation: bool):
+        """Accuracy test for tanh-approximate GeGLU in both scaling modes."""
+        from flashinfer import cute_dsl_fused_moe_nvfp4
+
+        activation_type = ActivationType.GegluTanh
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            gated=True,
+            use_per_token_activation=use_per_token_activation,
+        )
+
+        result = cute_dsl_fused_moe_nvfp4(
+            x=tensors["x"],
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation_type=activation_type,
+            per_token_scale=tensors["x_per_token_scale"],
+        )
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_ref"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            gemm1_alpha=tensors["w1_alpha"],
+            gemm2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            activation_type=activation_type,
+            use_per_token_activation=use_per_token_activation,
+        )
+
+        swiglu_ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_ref"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            gemm1_alpha=tensors["w1_alpha"],
+            gemm2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            activation_type=ActivationType.Swiglu,
+            use_per_token_activation=use_per_token_activation,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+        )
+        geglu_error = torch.mean(torch.abs(result.float() - ref_output)).item()
+        swiglu_error = torch.mean(torch.abs(result.float() - swiglu_ref_output)).item()
+        assert geglu_error < swiglu_error, (
+            f"GeGLU output is not closer to GeGLU reference ({geglu_error:.4f}) "
+            f"than SwiGLU reference ({swiglu_error:.4f})"
+        )
+
+    @pytest.mark.parametrize("use_per_token_activation", [False, True])
+    @pytest.mark.parametrize(
+        "situ_beta,situ_linear_beta",
+        [(1.75, None), (0.8, 1.5)],
+        ids=["gate-clamp", "gate-and-up-clamp"],
+    )
+    def test_situ_accuracy(
+        self,
+        use_per_token_activation: bool,
+        situ_beta: float,
+        situ_linear_beta: float | None,
+    ):
+        """Accuracy test for SiTU with optional smooth up-branch clamping."""
+        from flashinfer import cute_dsl_fused_moe_nvfp4
+
+        num_tokens, hidden_size, intermediate_size = 128, 256, 512
+        num_experts, top_k = 256, 2
+
+        tensors = create_moe_tensors(
+            num_tokens=num_tokens,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_experts=num_experts,
+            num_local_experts=num_experts,
+            top_k=top_k,
+            gated=True,
+            use_per_token_activation=use_per_token_activation,
+        )
+
+        result = cute_dsl_fused_moe_nvfp4(
+            x=tensors["x"],
+            x_sf=tensors["x_sf"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            w1_weight=tensors["w1_weight"],
+            w1_weight_sf=tensors["w1_weight_sf"],
+            w1_alpha=tensors["w1_alpha"],
+            fc2_input_scale=tensors["fc2_input_scale"],
+            w2_weight=tensors["w2_weight"],
+            w2_weight_sf=tensors["w2_weight_sf"],
+            w2_alpha=tensors["w2_alpha"],
+            num_experts=num_experts,
+            top_k=top_k,
+            activation_type=ActivationType.Swiglu,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
+            per_token_scale=tensors["x_per_token_scale"],
+        )
+
+        ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_ref"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            gemm1_alpha=tensors["w1_alpha"],
+            gemm2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            activation_type=ActivationType.Swiglu,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
+            use_per_token_activation=use_per_token_activation,
+        )
+
+        swiglu_ref_output = compute_reference_moe_fp4(
+            hidden_states=tensors["x_ref"].float().cuda(),
+            gemm1_weights=tensors["w1_weight_bf16"].float().cuda(),
+            gemm2_weights=tensors["w2_weight_bf16"].float().cuda(),
+            gemm1_alpha=tensors["w1_alpha"],
+            gemm2_alpha=tensors["w2_alpha"],
+            token_selected_experts=tensors["token_selected_experts"],
+            token_final_scales=tensors["token_final_scales"],
+            num_tokens=num_tokens,
+            num_experts=num_experts,
+            top_k=top_k,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            fc2_input_scale=tensors["fc2_input_scale"],
+            activation_type=ActivationType.Swiglu,
+            use_per_token_activation=use_per_token_activation,
+        )
+
+        passed, percent_within, atol = check_accuracy(result, ref_output)
+        assert passed, (
+            f"Only {percent_within * 100:.2f}% within tolerance (atol={atol:.4f})"
+        )
+        situ_error = torch.mean(torch.abs(result.float() - ref_output)).item()
+        swiglu_error = torch.mean(torch.abs(result.float() - swiglu_ref_output)).item()
+        assert situ_error < swiglu_error, (
+            f"SiTU output is not closer to SiTU reference ({situ_error:.4f}) "
+            f"than SwiGLU reference ({swiglu_error:.4f})"
+        )
+
     def test_with_autotune(self):
         """Test functional API with autotune context."""
         from flashinfer import autotune
@@ -1480,9 +1705,21 @@ class TestCuteDslMoEWrapper:
         )
 
     @pytest.mark.parametrize(
-        "activation_type", [ActivationType.Swiglu, ActivationType.Relu2]
+        "activation_type,situ_beta,situ_linear_beta",
+        [
+            (ActivationType.Swiglu, None, None),
+            (ActivationType.Swiglu, 1.0, 1.5),
+            (ActivationType.GegluTanh, None, None),
+            (ActivationType.Relu2, None, None),
+        ],
+        ids=["swiglu", "situ", "geglu-tanh", "relu2"],
     )
-    def test_wrapper_with_autotune(self, activation_type: ActivationType):
+    def test_wrapper_with_autotune(
+        self,
+        activation_type: ActivationType,
+        situ_beta: float | None,
+        situ_linear_beta: float | None,
+    ):
         """Test wrapper API with autotune context."""
         from flashinfer import autotune
         from flashinfer import CuteDslMoEWrapper
@@ -1508,6 +1745,8 @@ class TestCuteDslMoEWrapper:
             intermediate_size=intermediate_size,
             use_cuda_graph=False,
             activation_type=activation_type,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
         )
 
         with autotune(True):
@@ -1543,6 +1782,8 @@ class TestCuteDslMoEWrapper:
             intermediate_size=intermediate_size,
             fc2_input_scale=tensors["fc2_input_scale"],
             activation_type=activation_type,
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta,
         )
 
         passed, percent_within, atol = check_accuracy(result, ref_output)

--- a/tests/moe/utils.py
+++ b/tests/moe/utils.py
@@ -26,6 +26,7 @@ from flashinfer import RoutingMethodType, is_gated_activation
 from flashinfer.fused_moe import WeightLayout
 from flashinfer.fused_moe.cute_dsl.moe_utils import (
     normalize_cute_dsl_moe_activation_type,
+    validate_cute_dsl_moe_situ_config,
 )
 from flashinfer.tllm_enums import (
     ActivationType,
@@ -335,6 +336,8 @@ def compute_reference_moe_fp4(
     swiglu_alpha: float | None = None,
     swiglu_beta: float | None = None,
     swiglu_limit: float | None = None,
+    situ_beta: float | None = None,
+    situ_linear_beta: float | None = None,
     gemm1_alpha: torch.Tensor | None = None,
     gemm2_alpha: torch.Tensor | None = None,
 ) -> torch.Tensor:
@@ -356,12 +359,16 @@ def compute_reference_moe_fp4(
         num_local_experts: Number of local experts (for EP). Defaults to num_experts.
         local_expert_offset: Starting expert ID for this EP rank. Defaults to 0.
         activation_type: GEMM1 activation type. Use ActivationType.Swiglu for
-            gated SwiGLU/OAI and ActivationType.Relu2 for non-gated ReLU^2.
+            gated SwiGLU/OAI/SiTU, ActivationType.GegluTanh for
+            tanh-approximate GeGLU, and ActivationType.Relu2 for non-gated
+            ReLU^2. Setting situ_beta selects SiTU.
         activation: Optional B12x activation name. When provided, this takes
             precedence over activation_type.
         swiglu_alpha: SwiGLU sigmoid multiplier.
         swiglu_beta: SwiGLU up-projection bias.
         swiglu_limit: SwiGLU clamp limit.
+        situ_beta: When set with ActivationType.Swiglu, use the SiTU gate.
+        situ_linear_beta: Optional SiTU tanh clamp for the linear branch.
         gemm1_alpha: GEMM1 per-expert scalar scales [num_local_experts]
         gemm2_alpha: GEMM2 per-expert scalar scales [num_local_experts]
 
@@ -369,13 +376,23 @@ def compute_reference_moe_fp4(
         Output tensor [num_tokens, hidden_size]
     """
     if activation is None:
-        _, gated = normalize_cute_dsl_moe_activation_type(activation_type)
+        normalized_activation_type, gated = normalize_cute_dsl_moe_activation_type(
+            activation_type
+        )
+        validate_cute_dsl_moe_situ_config(
+            normalized_activation_type, situ_beta, situ_linear_beta
+        )
+        if situ_beta is not None:
+            activation = "situ"
+        elif normalized_activation_type == ActivationType.GegluTanh:
+            activation = "gelu_tanh"
         swiglu_alpha = DEFAULT_SWIGLU_ALPHA if swiglu_alpha is None else swiglu_alpha
         swiglu_beta = DEFAULT_SWIGLU_BETA if swiglu_beta is None else swiglu_beta
         swiglu_limit = DEFAULT_SWIGLU_LIMIT if swiglu_limit is None else swiglu_limit
     else:
         supported_activations = {
             "silu",
+            "situ",
             "gelu_tanh",
             "swigluoai_uninterleave",
         }
@@ -388,6 +405,12 @@ def compute_reference_moe_fp4(
         if activation == "swigluoai_uninterleave":
             swiglu_alpha = 1.702 if swiglu_alpha is None else swiglu_alpha
             swiglu_beta = 1.0 if swiglu_beta is None else swiglu_beta
+        elif activation == "situ":
+            if situ_beta is None:
+                raise ValueError("situ activation requires situ_beta")
+            validate_cute_dsl_moe_situ_config(
+                ActivationType.Swiglu, situ_beta, situ_linear_beta
+            )
 
     if num_local_experts is None:
         num_local_experts = num_experts
@@ -432,7 +455,16 @@ def compute_reference_moe_fp4(
             if gated:
                 linear = gemm1_out[:, :intermediate_size]
                 gate = gemm1_out[:, intermediate_size:]
-                if activation == "gelu_tanh":
+                if activation == "situ":
+                    situ_gate = (
+                        situ_beta * torch.tanh(gate / situ_beta) * torch.sigmoid(gate)
+                    )
+                    if situ_linear_beta is not None:
+                        linear = situ_linear_beta * torch.tanh(
+                            linear / situ_linear_beta
+                        )
+                    act_out = situ_gate * linear
+                elif activation == "gelu_tanh":
                     act_out = F.gelu(gate, approximate="tanh") * linear
                 elif activation == "silu":
                     act_out = silu(gate) * linear


### PR DESCRIPTION
## 📌 Description

Add two gated activation variants to the Blackwell CuTe-DSL NVFP4 fused MoE path:

- `ActivationType.GegluTanh` computes `up * GELU(gate, approximate=\"tanh\")`.
- Supplying `situ_beta` with `ActivationType.Swiglu` selects SiTU: `up * beta * tanh(gate / beta) * sigmoid(gate)`. An optional `situ_linear_beta` applies the smooth tanh clamp to the up branch as well.
- Propagate activation configuration through functional, wrapper, global-scale, per-token, autotuner, compiled-kernel-cache, and trace paths.
- Validate incompatible/non-finite SiTU configurations and add PyTorch numerical references with negative controls against SwiGLU.

SiTU intentionally remains a parameterized `ActivationType.Swiglu` variant rather than adding a value to the TensorRT-LLM-synchronized `ActivationType` enum.

### Architecture / Code Overview

```mermaid
flowchart TD
  A["API: activation type + SiTU betas"] --> B["Validate and select global/per-token runner"]
  B --> C["Cache identity includes activation parameters"]
  C --> D{"Activation"}
  D -->|SiTU| E["tanh-clamped gate; optional up clamp"]
  D -->|GeGLU-tanh| F["up × GELU-tanh(gate)"]
  D -->|SwiGLU| G["parameterized SwiGLU"]
  D -->|ReLU²| H["non-gated ReLU²"]
  E --> I["Packed or scalar epilogue"]
  F --> I
  G --> I
  H --> I
  I --> J["Global or per-token FP4 quantization"]
```

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I ran all hooks on every changed file; all hooks pass.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] Targeted CPU and GPU tests pass, with the exception noted below for the strengthened non-unit-beta rerun.

Commands/results:

- `pre-commit run --files <all 9 changed files>` — passed.
- Activation validation/cache tests plus trace consistency — 442 passed.
- B300 GeGLU global/per-token numerical tests — 2 passed.
- B300 SiTU global/per-token numerical tests — 4 passed with the initial beta matrix.
- B300 SiTU wrapper/autotune test — 1 passed.

The SiTU cases were subsequently strengthened to use non-unit gate betas so missing beta factors cannot pass accidentally. The shared B300s became occupied before that exact parametrization could be rerun locally; CI or the manual repro below should cover it.

## Reviewer Ask

- **Manual repro:** run `CUDA_VISIBLE_DEVICES=0 PYTHONPATH=$PWD python -m pytest 'tests/moe/test_cute_dsl_fused_moe.py::TestCuteDslFusedMoeFunctional::test_situ_accuracy' -q`; expect all four non-unit-beta global/per-token cases to pass.
- **Review focus:** the SiTU API representation (`ActivationType.Swiglu` + `situ_beta`), the packed/scalar epilogue formulas, and activation/beta cache-key isolation.
- **Not requested:** re-evaluation of pre-existing trace-layout limitations or broader MoE dispatch design.

## Perf Evidence

This draft touches a performance-sensitive fused MoE kernel but does not claim a speedup.

- **Trace picture:** not attached; this PR makes no performance claim.
- **CPU overhead:** activation parameters are normalized and validated when constructing runners; no additional per-element or synchronization work is added on the Python request path.
- **GPU fence/stall sanity:** activation remains fused in the existing GEMM1 epilogue. No extra kernel launch, host/device transfer, fence, or synchronization point is introduced.
- **Serving/sharding evidence:** not applicable; this is neither a scheduler nor sharding refactor.

## Reviewer Notes

The scalar and packed activation branches are intentionally kept explicit to match the existing epilogue structure and make formula equivalence reviewable. The branch is based directly on current `flashinfer-ai/flashinfer:main`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SiTU-gated activation support in fused MoE NVFP4, including optional linear tanh clamping parameters.
  * Added GeGLU with tanh approximation as a supported activation.
  * Exposed SiTU configuration end-to-end across fused MoE APIs, wrappers, autotuning, and tracing.
* **Bug Fixes**
  * Improved activation selection and configuration validation consistency across execution paths.
* **Tests**
  * Added accuracy, validation, and autotuning coverage for SiTU and GeGLU-Tanh activations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->