### PR TITLE
fix(moe): unify the NVFP4 profiler workspace predicate and fix gated fc1 SF sizing

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4680,6 +4680,8 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
   bool is_fp8_act_quant = mDType == nvinfer1::DataType::kFP8;
   bool is_fp8_w_quant = mWType == nvinfer1::DataType::kFP8;
   bool const is_native_wfp4afp8_family = isNativeWfp4Afp8Family();
+  // NVFP4 uses the same six quant workspaces as wfp4afp8 (issue #4003).
+  bool const is_native_wfp4afp4_family = isNativeWfp4Afp4Family();
   // This predicate identifies the SM90 FP8 activation x packed-MXFP4 storage
   // family.  Sm90Wfp4Afp8ScaleMode selects Humming/pre-MMA vs future post-MMA
   // semantics; do not infer the semantic path from dtype/layout alone.
@@ -4714,24 +4716,15 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
   // FP4 sizes
   bool const use_humming_pre_mma = isHummingPreMmaScaleMode();
   size_t const fp8_mxfp4_token_scale_size = num_expanded_tokens * sizeof(float);
-  bool const is_nvfp4_quant =
-      mSM >= 100 && (mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
-      (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
   size_t quant_5_size = 0;
   size_t quant_6_size = 0;
-  if (is_nvfp4_quant) {
+  if (is_native_wfp4afp8_family || is_native_wfp4afp4_family) {
     quant_1_size = sizeof(float);
-    quant_2_size = getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
-                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
-    quant_3_size = num_experts_per_node * sizeof(float);
-    quant_4_size = sizeof(float);
-    quant_5_size = getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
-                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
-    quant_6_size = num_experts_per_node * sizeof(float);
-  } else if (is_native_wfp4afp8_family) {
-    quant_1_size = sizeof(float);
-    quant_2_size = getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
-                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
+    // fc1 scale factors span fc1_out_size rows (2x inter_size when gated),
+    // matching the gemm1_n the profiler consumes them with.
+    quant_2_size =
+        getOffsetWeightSF(num_experts_per_node, fc1_out_size, hidden_size, mScalingType) *
+        sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
     quant_3_size = num_experts_per_node * sizeof(float);
     quant_4_size = sizeof(float);
     quant_5_size = getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
@@ -5040,8 +5033,7 @@ void GemmProfilerBackend::prepareQuantParams(int num_tokens, char* workspace_ptr
         static_cast<float const*>(quant_3), static_cast<float const*>(quant_4),
         static_cast<TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF const*>(quant_5),
         static_cast<float const*>(quant_6));
-  } else if ((mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
-             (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64)) {
+  } else if (isNativeWfp4Afp4Family()) {
     // nvllm still uses int64 because torch doesn't have fp4 yet.
     TLLM_CHECK(quant_1 && quant_2 && quant_3 && quant_4 && quant_5 && quant_6);
     mQuantParams = QuantParams::FP4(

--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -4784,6 +4784,8 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
   bool is_fp8_act_quant = mDType == nvinfer1::DataType::kFP8;
   bool is_fp8_w_quant = mWType == nvinfer1::DataType::kFP8;
   bool const is_native_wfp4afp8_family = isNativeWfp4Afp8Family();
+  // NVFP4 uses the same six quant workspaces as wfp4afp8 (issue #4003).
+  bool const is_native_wfp4afp4_family = isNativeWfp4Afp4Family();
   // This predicate identifies the SM90 FP8 activation x packed-MXFP4 storage
   // family.  Sm90Wfp4Afp8ScaleMode selects Humming/pre-MMA vs future post-MMA
   // semantics; do not infer the semantic path from dtype/layout alone.
@@ -4817,22 +4819,12 @@ std::map<std::string, std::pair<size_t, size_t>> GemmProfilerBackend::getProfile
 
   // FP4 sizes
   bool const use_humming_pre_mma = isHummingPreMmaScaleMode();
-  bool const is_nvfp4_quant =
-      mSM >= 100 && (mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
-      (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
   size_t quant_5_size = 0;
   size_t quant_6_size = 0;
-  if (is_nvfp4_quant) {
+  if (is_native_wfp4afp8_family || is_native_wfp4afp4_family) {
     quant_1_size = sizeof(float);
-    quant_2_size = getOffsetWeightSF(num_experts_per_node, inter_size, hidden_size, mScalingType) *
-                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
-    quant_3_size = num_experts_per_node * sizeof(float);
-    quant_4_size = sizeof(float);
-    quant_5_size = getOffsetWeightSF(num_experts_per_node, hidden_size, inter_size, mScalingType) *
-                   sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
-    quant_6_size = num_experts_per_node * sizeof(float);
-  } else if (is_native_wfp4afp8_family) {
-    quant_1_size = sizeof(float);
+    // fc1 scale factors span fc1_out_size rows (2x inter_size when gated),
+    // matching the gemm1_n the profiler consumes them with.
     quant_2_size =
         getOffsetWeightSF(num_experts_per_node, fc1_out_size, hidden_size, mScalingType) *
         sizeof(TmaWarpSpecializedGroupedGemmInput::ElementSF);
@@ -5160,8 +5152,7 @@ void GemmProfilerBackend::prepareQuantParams(int num_tokens, char* workspace_ptr
           static_cast<TmaWarpSpecializedGroupedGemmInput::MXFPXElementSF const*>(quant_5),
           static_cast<float const*>(quant_6));
     }
-  } else if ((mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
-             (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64)) {
+  } else if (isNativeWfp4Afp4Family()) {
     // nvllm still uses int64 because torch doesn't have fp4 yet.
     TLLM_CHECK(quant_1 && quant_2 && quant_3 && quant_4 && quant_5 && quant_6);
     mQuantParams = QuantParams::FP4(

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -1154,6 +1154,13 @@ struct GemmProfilerBackend {
            (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
   }
 
+  // Native NVFP4: FP4 activations x FP4 weights. Shared by workspace
+  // allocation and consumption so the two never disagree (issue #4003).
+  bool isNativeWfp4Afp4Family() const {
+    return (mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
+           (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
+  }
+
   bool isSm90Wfp4Afp8Family() const {
     return mSM == 90 && mDType == nvinfer1::DataType::kFP8 &&
            mWType == nvinfer1::DataType::kUINT8 &&

--- a/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -1158,6 +1158,13 @@ struct GemmProfilerBackend {
            (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
   }
 
+  // Native NVFP4: FP4 activations x FP4 weights. Shared by workspace
+  // allocation and consumption so the two never disagree (issue #4003).
+  bool isNativeWfp4Afp4Family() const {
+    return (mDType == nvinfer1::DataType::kFP4 || mDType == nvinfer1::DataType::kINT64) &&
+           (mWType == nvinfer1::DataType::kFP4 || mWType == nvinfer1::DataType::kINT64);
+  }
+
   bool isSm90Wfp4Afp8Family() const {
     return mSM == 90 && mDType == nvinfer1::DataType::kFP8 &&
            mWType == nvinfer1::DataType::kUINT8 &&

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -713,6 +713,8 @@ def test_moe_fp8(
     ids=["swiglu", "swiglustep", "relu2"],
 )
 @pytest.mark.parametrize("use_4over6", [False, True])
+# use_autotune=True is regression coverage for issue #4003 (NVFP4 autotune crash).
+@pytest.mark.parametrize("use_autotune", [False, True])
 @pytest.mark.skipif(
     torch.cuda.get_device_capability()[0] not in [10, 11, 12],
     reason="NVFP4 is only supported on SM100, SM110 and SM120/SM121",
@@ -728,6 +730,7 @@ def test_moe_nvfp4(
     quantized_input,
     activation_type,
     use_4over6,
+    use_autotune,
 ):
     # Skip invalid configurations
     if top_k > num_experts:
@@ -818,19 +821,20 @@ def test_moe_nvfp4(
     input_sf = None
     if quantized_input:
         hidden_states, input_sf = fp4_quantize(x, a1_gs)
-    _ = fused_moe.cutlass_fused_moe(
-        hidden_states,
-        selected_experts.to(torch.int),
-        routing_weights,
-        w1_q.contiguous().view(torch.long),
-        w2_q.contiguous().view(torch.long),
-        otype,
-        quant_scales=quant_scales,
-        input_sf=input_sf,
-        output=flash_output,
-        activation_type=activation_type,
-        swiglu_limit=swiglu_limit,
-    )
+    with autotune(True) if use_autotune else nullcontext():
+        _ = fused_moe.cutlass_fused_moe(
+            hidden_states,
+            selected_experts.to(torch.int),
+            routing_weights,
+            w1_q.contiguous().view(torch.long),
+            w2_q.contiguous().view(torch.long),
+            otype,
+            quant_scales=quant_scales,
+            input_sf=input_sf,
+            output=flash_output,
+            activation_type=activation_type,
+            swiglu_limit=swiglu_limit,
+        )
 
     # Ref check
     a_fp4, a_scale_interleaved = fp4_quantize(x, a1_gs)


### PR DESCRIPTION
## 📌 Description

Autotuning a native NVFP4 (FP4 activations x FP4 weights) CUTLASS MoE crashed with `Assertion failed: quant_1 && quant_2 && quant_3 && quant_4 && quant_5 && quant_6` (#4003): after #3738, the gemm profiler only allocated its scratch quant-scale buffers for the FP8-activation FP4 flavor, so native NVFP4 got none. #4080 has since fixed that crash on main. This PR is rebased on top of it and adds what's still missing:

- Replace the ad-hoc `is_nvfp4_quant` check with an `isNativeWfp4Afp4Family()` helper used by both the allocation site (`getProfilerWorkspaces`) and the consumption site (`prepareQuantParams`), so the two can't drift apart again. This also drops the `mSM >= 100` guard that the allocation side had but the consumption side didn't.
- Size the fc1 weight scale-factor buffer (`quant_2`) with `fc1_out_size` instead of `inter_size`. Gated activations make fc1 output 2x `inter_size`, so the old size under-allocated. #4308 has since landed this sizing for the wfp4afp8 flavor; this PR applies it to native NVFP4 and merges the two sizing branches so they cannot diverge.
- Add autotune coverage to `test_moe_nvfp4`, the regression test that would have caught #4003.

Credit to @eugr for the proposed patch this builds on.

## 🔍 Related Issues

Fixes #4003 (crash itself already fixed on main by #4080). Regressed by #3738.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`test_moe_nvfp4` is now parametrized with `use_autotune`, same approach as #3558. Pre-rebase on a GB10 (SM121): every autotune case died with the assertion without the fix, and all 48 cases passed with it. Post-rebase, re-ran gated and non-gated autotune cases plus a non-autotune case on an RTX 5080 (SM120), all passing. After rebasing onto current main (post-#4308), all 48 cases pass on an RTX 5080 (SM120).

## Reviewer Notes

The predicate deliberately has no SM version check, unlike its wfp4afp8 sibling: it must exactly match the consuming branch in `prepareQuantParams`, which checks dtypes only. FP4 x FP4 doesn't exist below SM100 anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Native NVFP4 fused Mixture-of-Experts (MoE) execution by correcting workspace and scaling-factor handling.
  * Fixed NVFP4 behavior when autotuning is enabled, preventing related execution failures.

* **Tests**
  * Expanded NVFP4 coverage to validate both autotuned and non-autotuned execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
