### PR TITLE
perf(FMHAv2): balanced scheduling for FP16/BF16 causal cases in run_separate_q_and_kv() in DMA

### DIFF
--- a/csrc/fmha_v2/fmha/warpspec/dma.h
+++ b/csrc/fmha_v2/fmha/warpspec/dma.h
@@ -381,11 +381,24 @@ struct DMA {
           }
           local_q_tile_offset = q_step_offset * STEP_Q;
         } else if (SCHEDULING_MODE == 1) {
-          bidb = tile_id_ / (params.h * params.num_tiles_per_head);
-          tmp = tile_id_ % (params.h * params.num_tiles_per_head);
-          bidh = tmp / params.num_tiles_per_head;
-          local_q_tile_offset = (tmp % params.num_tiles_per_head) * NUM_COMPUTE_GROUPS * STEP_Q;
-          q_steps = NUM_COMPUTE_GROUPS;
+          // Balanced scheduling: heaviest Q tiles first, interleaved across heads.
+          // Mirrors run_packed_qkv's use_balanced_scheduling logic.
+          // Benefit: last wave consists of lightest tiles, minimising SM idle at tail.
+          if (CAUSAL_MASK && !SLIDING_OR_CHUNKED_ATTENTION && params.use_balanced_scheduling) {
+            local_q_tile_offset =
+                (params.num_tiles_per_head - 1 - tile_id_ / (params.b * params.h)) *
+                NUM_COMPUTE_GROUPS * STEP_Q;
+            tmp = tile_id_ % (params.b * params.h);
+            bidh = tmp / params.b;
+            bidb = tmp % params.b;
+            q_steps = NUM_COMPUTE_GROUPS;
+          } else {
+            bidb = tile_id_ / (params.h * params.num_tiles_per_head);
+            tmp = tile_id_ % (params.h * params.num_tiles_per_head);
+            bidh = tmp / params.num_tiles_per_head;
+            local_q_tile_offset = (tmp % params.num_tiles_per_head) * NUM_COMPUTE_GROUPS * STEP_Q;
+            q_steps = NUM_COMPUTE_GROUPS;
+          }
         } else {  // SCHEDULING_MODE == 2
           local_q_tile_offset = (params.num_tiles_per_head - 1 - tile_id_ / (params.b * params.h)) *
                                 NUM_COMPUTE_GROUPS * STEP_Q;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved tile scheduling for separate query and key/value processing in causal attention scenarios.
  * Added balanced scheduling behavior to improve workload distribution and processing efficiency.
  * Preserved existing behavior for sliding-window, chunked, packed, and other scheduling modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->