### PR TITLE
feat(attention): cuTile paged/ragged prefill + paged/MLA decode

### DIFF
--- a/benchmarks/bench_gqa_decode_backend_comparison.py
+++ b/benchmarks/bench_gqa_decode_backend_comparison.py
@@ -1,0 +1,470 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Benchmark: GQA Decode Backend Comparison (cuTile vs trtllm-gen SOTA)
+
+Compares FlashInfer's cuTile GQA-decode backend against the trtllm-gen SOTA
+kernel over ocean-eval's DecodePaged workload (LLaMA-style GQA: 128 query heads
+/ 8 KV heads, head_dim=128, bf16), sweeping batch x s_kv x page_size:
+
+  - ``cutile`` : this checkout's ``BatchDecodeWithPagedKVCacheWrapper`` planned/run
+                 with ``backend="cutile"`` (pure cuda.tile kernel, kv_layout="NHD").
+  - ``trtllm`` : ``flashinfer.decode.trtllm_batch_decode_with_kv_cache`` (trtllm-gen,
+                 kv_layout="HND"), the ocean-eval dashboard SOTA baseline.
+
+TWO-FLASHINFER NOTE: the two providers are meant to be measured in SEPARATE
+processes (this checkout for ``cutile``; the image's installed flashinfer for
+``trtllm`` -- this checkout's trtllm path may crash on some arches). Each
+provider independently try/except-es and degrades to N/A (NaN), so the two
+result CSVs can be produced separately and merged. Baseline default = trtllm.
+
+Usage (typical two-run merge):
+    python3 bench_gqa_decode_backend_comparison.py --providers cutile --csv cutile.csv
+    python3 bench_gqa_decode_backend_comparison.py --providers trtllm --csv trtllm.csv
+    # then concatenate cutile.csv + trtllm.csv (drop the duplicate header)
+
+Requirements:
+    - cuda.tile toolchain (cutile provider)
+    - flashinfer with trtllm-gen cubins (trtllm provider)
+    - matplotlib for the optional heatmap
+"""
+
+import argparse
+import csv as _csv
+import math
+import numpy as np
+import torch
+from typing import Callable, Dict, List, Tuple
+
+from flashinfer.testing.utils import bench_gpu_time
+
+# LLaMA-style GQA problem geometry (fixed).
+NUM_QO_HEADS = 128
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+DTYPE = torch.bfloat16
+
+
+# --------------------------------------------------------------------------- #
+# Provider availability
+# --------------------------------------------------------------------------- #
+def _has_cutile() -> bool:
+    try:
+        import cuda.tile  # noqa: F401
+        from flashinfer.decode import (  # noqa: F401
+            BatchDecodeWithPagedKVCacheWrapper,
+        )
+
+        return True
+    except Exception:
+        return False
+
+
+def _has_trtllm() -> bool:
+    try:
+        from flashinfer.decode import trtllm_batch_decode_with_kv_cache  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+ALL_PROVIDERS = ["cutile", "trtllm"]
+_AVAIL = {
+    "cutile": _has_cutile,
+    "trtllm": _has_trtllm,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Shared paged-GQA input generation
+# --------------------------------------------------------------------------- #
+class _GQAInputs:
+    """Raw tensors shared by both providers (identical values -> comparable outputs).
+
+    KV cache is generated in NHD layout ``[num_pages, page, num_kv_heads, head_dim]``;
+    the trtllm (HND) path takes a transposed view of the same values.
+    """
+
+    def __init__(self, batch: int, s_kv: int, page_size: int, device):
+        torch.manual_seed(0)
+        pages_per_batch = math.ceil(s_kv / page_size)
+        total_pages = max(batch * pages_per_batch + 8, 64)
+
+        self.batch = batch
+        self.s_kv = s_kv
+        self.page_size = page_size
+        self.pages_per_batch = pages_per_batch
+        self.total_pages = total_pages
+        self.sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+        # q: [batch, num_qo_heads, head_dim] (one query token per request).
+        self.q = torch.randn(
+            batch, NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device=device
+        )
+        # NHD KV cache.
+        self.k_cache = torch.randn(
+            total_pages, page_size, NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=device
+        )
+        self.v_cache = torch.randn(
+            total_pages, page_size, NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=device
+        )
+        self.kv_lens = torch.full((batch,), s_kv, dtype=torch.int32, device=device)
+        # Dense block table [batch, pages_per_batch], int32.
+        self.page_table = (
+            torch.arange(batch * pages_per_batch, dtype=torch.int32, device=device)
+            .reshape(batch, pages_per_batch)
+            % total_pages
+        )
+        # CSR plan state for the paged-KV wrapper (cutile path).
+        rem = s_kv % page_size
+        last = rem if rem != 0 else page_size
+        self.indptr = (
+            torch.arange(batch + 1, dtype=torch.int32, device=device) * pages_per_batch
+        )
+        self.indices = self.page_table.reshape(-1).to(torch.int32)
+        self.last_page_len = torch.full(
+            (batch,), last, dtype=torch.int32, device=device
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Per-provider callables
+# --------------------------------------------------------------------------- #
+def _make_execute(provider: str, inp: _GQAInputs) -> Callable[[], torch.Tensor]:
+    device = inp.q.device
+
+    if provider == "cutile":
+        # This checkout's BatchDecodeWithPagedKVCacheWrapper(..., backend="cutile").
+        # cuTile decode requires kv_layout="NHD" and materializes the block table at
+        # plan() time from indptr/indices (the cutile branch of the paged-decode wrapper).
+        from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper
+
+        workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+        wrapper = BatchDecodeWithPagedKVCacheWrapper(
+            workspace, kv_layout="NHD", backend="cutile"
+        )
+        wrapper.plan(
+            inp.indptr,
+            inp.indices,
+            inp.last_page_len,
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            inp.page_size,
+            q_data_type=inp.q.dtype,
+            kv_data_type=inp.k_cache.dtype,
+            sm_scale=inp.sm_scale,
+        )
+
+        def run():
+            return wrapper.run(inp.q, (inp.k_cache, inp.v_cache))
+
+    elif provider == "trtllm":
+        # SOTA: flashinfer.decode.trtllm_batch_decode_with_kv_cache (trtllm-gen).
+        # Call body follows the trtllm-gen GQA decode reference.
+        # HND cache is a transposed (contiguous) view of the same NHD values.
+        from flashinfer.decode import trtllm_batch_decode_with_kv_cache
+
+        workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.int8, device=device)
+        k_hnd = inp.k_cache.transpose(1, 2).contiguous()  # [pages, kv_heads, page, dim]
+        v_hnd = inp.v_cache.transpose(1, 2).contiguous()
+
+        def run():
+            return trtllm_batch_decode_with_kv_cache(
+                query=inp.q,
+                kv_cache=(k_hnd, v_hnd),
+                workspace_buffer=workspace,
+                block_tables=inp.page_table,
+                seq_lens=inp.kv_lens.view(-1),
+                max_seq_len=inp.s_kv,
+                bmm1_scale=inp.sm_scale,
+                bmm2_scale=1.0,
+                kv_layout="HND",
+            )
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run
+
+
+def _canonical_out(out) -> torch.Tensor:
+    """Reduce a provider output to [batch, num_qo_heads, head_dim] for comparison."""
+    if isinstance(out, (list, tuple)):
+        out = out[0]
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Correctness + timing
+# --------------------------------------------------------------------------- #
+def verify_correctness(
+    batch: int, s_kv: int, page_size: int, providers: List[str]
+) -> Tuple[bool, float]:
+    """Cosine similarity of cutile vs trtllm GQA-decode output (both must be available)."""
+    if not ("cutile" in providers and "trtllm" in providers):
+        print("  correctness: need both cutile and trtllm selected -> SKIP")
+        return False, float("nan")
+    if not (_AVAIL["cutile"]() and _AVAIL["trtllm"]()):
+        return False, float("nan")
+    try:
+        device = torch.device("cuda")
+        inp = _GQAInputs(batch, s_kv, page_size, device)
+        a = _canonical_out(_make_execute("cutile", inp)())
+        b = _canonical_out(_make_execute("trtllm", inp)())
+        torch.cuda.synchronize()
+        cos = torch.nn.functional.cosine_similarity(
+            a.float().reshape(1, -1), b.float().reshape(1, -1)
+        ).item()
+        return cos > 0.99, cos
+    except Exception:
+        return False, float("nan")
+
+
+def bench_one(batch: int, s_kv: int, page_size: int, provider: str) -> float:
+    """Median latency (ms) for one (config, provider); NaN if unavailable/failed."""
+    if not _AVAIL[provider]():
+        return float("nan")
+    try:
+        device = torch.device("cuda")
+        inp = _GQAInputs(batch, s_kv, page_size, device)
+        run = _make_execute(provider, inp)
+        run()  # warmup / compile
+        torch.cuda.synchronize()
+        times = bench_gpu_time(
+            fn=run,
+            enable_cupti=True,
+            dry_run_iters=5,
+            repeat_iters=30,
+            cold_l2_cache=True,
+            use_cuda_graph=False,
+        )
+        return float(np.median(times))
+    except Exception:
+        return float("nan")
+
+
+# --------------------------------------------------------------------------- #
+# Sweep
+# --------------------------------------------------------------------------- #
+def run_benchmark_sweep(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    page_size_values: List[int],
+    providers: List[str],
+) -> Dict[str, Dict[Tuple[int, int, int], float]]:
+    """Return {provider: {(batch, s_kv, page_size): median_ms}}."""
+    results: Dict[str, Dict[Tuple[int, int, int], float]] = {p: {} for p in providers}
+    configs = [
+        (b, s, p) for b in batch_values for s in s_kv_values for p in page_size_values
+    ]
+    total = len(configs)
+
+    print(
+        f"\nBenchmarking GQA decode  qo_heads={NUM_QO_HEADS} kv_heads={NUM_KV_HEADS} "
+        f"head_dim={HEAD_DIM}  bf16"
+    )
+    print("=" * (34 + 12 * len(providers)))
+    header = f"{'batch':>6} {'s_kv':>7} {'page':>5} |"
+    for p in providers:
+        header += f" {p:>10}"
+    print(header)
+    print("-" * (34 + 12 * len(providers)))
+
+    for current, (b, s, ps) in enumerate(configs, 1):
+        row = f"{b:>6} {s:>7} {ps:>5} |"
+        for p in providers:
+            ms = bench_one(b, s, ps, p)
+            results[p][(b, s, ps)] = ms
+            row += f" {ms:>10.5f}" if ms == ms else f" {'--':>10}"
+        print(f"[{current:3d}/{total}] " + row)
+
+    return results
+
+
+def print_summary_table(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    page_size_values: List[int],
+    results: Dict[str, Dict[Tuple[int, int, int], float]],
+    providers: List[str],
+    baseline: str,
+):
+    """Speedup of each provider vs baseline (>1 = provider faster)."""
+    if baseline not in results:
+        return
+    for p in providers:
+        if p == baseline:
+            continue
+        print(f"\n{'=' * 72}")
+        print(f"Speedup: {p} vs {baseline} (baseline_ms / {p}_ms;  >1 = {p} faster)")
+        print(f"{'=' * 72}")
+        print(f"{'batch':>6} {'s_kv':>7} {'page':>5} {'speedup':>10}")
+        print("-" * 32)
+        ratios = []
+        for b in batch_values:
+            for s in s_kv_values:
+                for ps in page_size_values:
+                    bt = results[baseline].get((b, s, ps), float("nan"))
+                    pt = results[p].get((b, s, ps), float("nan"))
+                    if pt == pt and bt == bt and pt > 0:
+                        r = bt / pt
+                        ratios.append(r)
+                        print(f"{b:>6} {s:>7} {ps:>5} {r:>10.2f}")
+                    else:
+                        print(f"{b:>6} {s:>7} {ps:>5} {'N/A':>10}")
+        if ratios:
+            print(
+                f"\n  geomean {np.exp(np.mean(np.log(ratios))):.2f}x  "
+                f"min {min(ratios):.2f}x  max {max(ratios):.2f}x  "
+                f"({sum(1 for r in ratios if r > 1)}/{len(ratios)} configs {p} faster)"
+            )
+
+
+def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int, int], float]]):
+    with open(path, "w", newline="") as f:
+        w = _csv.writer(f)
+        w.writerow(
+            ["provider", "config", "batch", "s_kv", "page_size", "num_heads", "median_ms"]
+        )
+        for provider, d in results.items():
+            for (b, s, ps), ms in sorted(d.items()):
+                config = f"b{b}_s{s}_p{ps}"
+                w.writerow([provider, config, b, s, ps, NUM_QO_HEADS, f"{ms:.6f}"])
+    print(f"\nWrote {path}")
+
+
+def create_heatmap(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    page_size: int,
+    results: Dict[str, Dict[Tuple[int, int, int], float]],
+    provider: str,
+    baseline: str,
+    output_file: str,
+):
+    """Heatmap of `provider` speedup vs `baseline` over (batch x s_kv) at one page_size."""
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as mcolors
+    except ImportError:
+        print("matplotlib not installed, skipping heatmap")
+        return
+    if provider not in results or baseline not in results:
+        return
+    mat = np.full((len(batch_values), len(s_kv_values)), np.nan)
+    for i, b in enumerate(batch_values):
+        for j, s in enumerate(s_kv_values):
+            bt = results[baseline].get((b, s, page_size), float("nan"))
+            pt = results[provider].get((b, s, page_size), float("nan"))
+            if pt == pt and bt == bt and pt > 0:
+                mat[i, j] = bt / pt
+    if np.all(np.isnan(mat)):
+        return
+    fig, ax = plt.subplots(
+        figsize=(max(6, 1.5 * len(s_kv_values)), max(5, 0.5 * len(batch_values)))
+    )
+    norm = mcolors.TwoSlopeNorm(
+        vmin=min(0.5, np.nanmin(mat)), vcenter=1.0, vmax=max(1.5, np.nanmax(mat))
+    )
+    im = ax.imshow(mat, cmap="RdYlGn", norm=norm, aspect="auto")
+    cbar = ax.figure.colorbar(im, ax=ax, shrink=0.8)
+    cbar.ax.set_ylabel(f"{baseline}_ms / {provider}_ms", rotation=-90, va="bottom")
+    ax.set_xticks(np.arange(len(s_kv_values)))
+    ax.set_yticks(np.arange(len(batch_values)))
+    ax.set_xticklabels([str(s) for s in s_kv_values])
+    ax.set_yticklabels([str(b) for b in batch_values])
+    for i in range(len(batch_values)):
+        for j in range(len(s_kv_values)):
+            if not np.isnan(mat[i, j]):
+                ax.text(
+                    j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                    color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
+                )
+    ax.set_xlabel("s_kv")
+    ax.set_ylabel("batch")
+    ax.set_title(
+        f"GQA decode (page_size={page_size}): {provider} speedup vs {baseline}\n"
+        f"(>1.0 = {provider} faster)"
+    )
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    print(f"Saved heatmap to {output_file}")
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark GQA decode: cuTile vs trtllm-gen SOTA"
+    )
+    parser.add_argument(
+        "--providers",
+        type=str,
+        default=",".join(ALL_PROVIDERS),
+        help=f"Comma-separated subset of {ALL_PROVIDERS}",
+    )
+    parser.add_argument(
+        "--baseline", type=str, default="trtllm", help="Speedup baseline provider"
+    )
+    parser.add_argument("--output-prefix", type=str, default="gqa_decode_backend")
+    parser.add_argument("--csv", type=str, default=None, help="Write medians to CSV")
+    args = parser.parse_args()
+
+    requested = [p.strip() for p in args.providers.split(",") if p.strip()]
+    providers = [p for p in requested if p in ALL_PROVIDERS]
+    available = [p for p in providers if _AVAIL[p]()]
+    print(f"Requested providers: {providers}")
+    print(f"Available here:      {available}  (unavailable are skipped as N/A)")
+
+    # Ocean DecodePaged workload (GQA).
+    batch_values = [1, 16, 64, 128, 256]
+    s_kv_values = [1024, 2048, 4096, 8192]
+    page_size_values = [32, 64]
+
+    # Correctness only runs when BOTH providers are importable in this process.
+    print("\nCorrectness (cutile vs trtllm cosine-sim, at batch=16 s_kv=2048 page=64):")
+    ok, cos = verify_correctness(16, 2048, 64, providers)
+    if cos == cos:
+        print(f"  {'OK ' if ok else 'FAIL'} cos={cos:.4f}")
+    else:
+        print("  N/A (need both cutile and trtllm in one process)")
+
+    results = run_benchmark_sweep(
+        batch_values, s_kv_values, page_size_values, providers
+    )
+    baseline = args.baseline if args.baseline in providers else providers[0]
+    print_summary_table(
+        batch_values, s_kv_values, page_size_values, results, providers, baseline
+    )
+
+    if args.csv:
+        write_csv(args.csv, results)
+
+    for p in providers:
+        if p != baseline:
+            for ps in page_size_values:
+                create_heatmap(
+                    batch_values, s_kv_values, ps, results, p, baseline,
+                    f"{args.output_prefix}_{p}_vs_{baseline}_p{ps}.png",
+                )
+
+    print("\n" + "=" * 72)
+    print("BENCHMARK COMPLETE")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_gqa_decode_backend_comparison.py
+++ b/benchmarks/bench_gqa_decode_backend_comparison.py
@@ -111,9 +111,7 @@ class _GQAInputs:
         self.sm_scale = 1.0 / math.sqrt(HEAD_DIM)
 
         # q: [batch, num_qo_heads, head_dim] (one query token per request).
-        self.q = torch.randn(
-            batch, NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device=device
-        )
+        self.q = torch.randn(batch, NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device=device)
         # NHD KV cache.
         self.k_cache = torch.randn(
             total_pages, page_size, NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=device
@@ -124,8 +122,9 @@ class _GQAInputs:
         self.kv_lens = torch.full((batch,), s_kv, dtype=torch.int32, device=device)
         # Dense block table [batch, pages_per_batch], int32.
         self.page_table = (
-            torch.arange(batch * pages_per_batch, dtype=torch.int32, device=device)
-            .reshape(batch, pages_per_batch)
+            torch.arange(
+                batch * pages_per_batch, dtype=torch.int32, device=device
+            ).reshape(batch, pages_per_batch)
             % total_pages
         )
         # CSR plan state for the paged-KV wrapper (cutile path).
@@ -338,7 +337,15 @@ def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int, int], float]]):
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(
-            ["provider", "config", "batch", "s_kv", "page_size", "num_heads", "median_ms"]
+            [
+                "provider",
+                "config",
+                "batch",
+                "s_kv",
+                "page_size",
+                "num_heads",
+                "median_ms",
+            ]
         )
         for provider, d in results.items():
             for (b, s, ps), ms in sorted(d.items()):
@@ -391,7 +398,12 @@ def create_heatmap(
         for j in range(len(s_kv_values)):
             if not np.isnan(mat[i, j]):
                 ax.text(
-                    j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                    j,
+                    i,
+                    f"{mat[i, j]:.2f}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
                     color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
                 )
     ax.set_xlabel("s_kv")
@@ -457,7 +469,12 @@ def main():
         if p != baseline:
             for ps in page_size_values:
                 create_heatmap(
-                    batch_values, s_kv_values, ps, results, p, baseline,
+                    batch_values,
+                    s_kv_values,
+                    ps,
+                    results,
+                    p,
+                    baseline,
                     f"{args.output_prefix}_{p}_vs_{baseline}_p{ps}.png",
                 )
 

--- a/benchmarks/bench_gqa_decode_backend_comparison.py
+++ b/benchmarks/bench_gqa_decode_backend_comparison.py
@@ -61,6 +61,7 @@ DTYPE = torch.bfloat16
 # Provider availability
 # --------------------------------------------------------------------------- #
 def _has_cutile() -> bool:
+    """True if this checkout can run the cuTile paged-decode backend."""
     try:
         import cuda.tile  # noqa: F401
         from flashinfer.decode import (  # noqa: F401
@@ -73,6 +74,7 @@ def _has_cutile() -> bool:
 
 
 def _has_trtllm() -> bool:
+    """True if the installed flashinfer exposes the trtllm-gen decode entry point."""
     try:
         from flashinfer.decode import trtllm_batch_decode_with_kv_cache  # noqa: F401
 
@@ -99,6 +101,7 @@ class _GQAInputs:
     """
 
     def __init__(self, batch: int, s_kv: int, page_size: int, device):
+        """Build the paged-GQA tensors for one (batch, s_kv, page_size) case."""
         torch.manual_seed(0)
         pages_per_batch = math.ceil(s_kv / page_size)
         total_pages = max(batch * pages_per_batch + 8, 64)
@@ -143,6 +146,7 @@ class _GQAInputs:
 # Per-provider callables
 # --------------------------------------------------------------------------- #
 def _make_execute(provider: str, inp: _GQAInputs) -> Callable[[], torch.Tensor]:
+    """Return a zero-arg callable running `provider`'s GQA decode on `inp`."""
     device = inp.q.device
 
     if provider == "cutile":
@@ -169,6 +173,7 @@ def _make_execute(provider: str, inp: _GQAInputs) -> Callable[[], torch.Tensor]:
         )
 
         def run():
+            """Run cuTile paged GQA decode through the planned wrapper."""
             return wrapper.run(inp.q, (inp.k_cache, inp.v_cache))
 
     elif provider == "trtllm":
@@ -182,6 +187,7 @@ def _make_execute(provider: str, inp: _GQAInputs) -> Callable[[], torch.Tensor]:
         v_hnd = inp.v_cache.transpose(1, 2).contiguous()
 
         def run():
+            """Run trtllm-gen paged GQA decode on the HND cache view."""
             return trtllm_batch_decode_with_kv_cache(
                 query=inp.q,
                 kv_cache=(k_hnd, v_hnd),
@@ -334,6 +340,7 @@ def print_summary_table(
 
 
 def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int, int], float]]):
+    """Write the raw per-provider medians to `path` as CSV."""
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(
@@ -419,6 +426,7 @@ def create_heatmap(
 
 
 def main():
+    """Parse args, sweep the shapes, and emit table / CSV / heatmap."""
     parser = argparse.ArgumentParser(
         description="Benchmark GQA decode: cuTile vs trtllm-gen SOTA"
     )

--- a/benchmarks/bench_mla_decode_backend_comparison.py
+++ b/benchmarks/bench_mla_decode_backend_comparison.py
@@ -1,0 +1,487 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Benchmark: MLA Decode Backend Comparison (cuTile vs trtllm-gen SOTA)
+
+Compares FlashInfer's cuTile MLA-decode backend against the trtllm-gen SOTA
+kernel over ocean-eval's MLADecodePaged workload (DeepSeek MLA:
+head_dim_ckv=512, head_dim_kpe=64, num_heads=32, bf16), sweeping
+batch x s_kv x page_size:
+
+  - ``cutile`` : this checkout's ``flashinfer.mla.BatchMLAPagedAttentionWrapper``
+                 planned/run with ``backend="cutile"`` (pure cuda.tile kernel).
+  - ``trtllm`` : ``flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla``
+                 (trtllm-gen), the ocean-eval dashboard SOTA baseline.
+
+TWO-FLASHINFER NOTE: the two providers are measured in SEPARATE processes
+(two-flashinfer): this checkout for ``cutile``; the image's installed flashinfer
+for ``trtllm``. Each
+provider independently try/except-es and degrades to N/A (NaN), so the two
+result CSVs can be produced separately and merged. Baseline default = trtllm.
+
+Usage (typical two-run merge):
+    python3 bench_mla_decode_backend_comparison.py --providers cutile --csv cutile.csv
+    python3 bench_mla_decode_backend_comparison.py --providers trtllm --csv trtllm.csv
+    # then concatenate cutile.csv + trtllm.csv (drop the duplicate header)
+
+Requirements:
+    - cuda.tile toolchain (cutile provider)
+    - flashinfer with trtllm-gen cubins (trtllm provider)
+    - matplotlib for the optional heatmap
+"""
+
+import argparse
+import csv as _csv
+import math
+import numpy as np
+import torch
+from typing import Callable, Dict, List, Tuple
+
+from flashinfer.testing.utils import bench_gpu_time
+
+# DeepSeek MLA problem geometry (fixed).
+HEAD_DIM_CKV = 512  # kv_lora_rank
+HEAD_DIM_KPE = 64  # qk_rope_head_dim
+QK_NOPE_HEAD_DIM = 128  # informational; passed to the trtllm-gen kernel
+DTYPE = torch.bfloat16
+
+
+# --------------------------------------------------------------------------- #
+# Provider availability
+# --------------------------------------------------------------------------- #
+def _has_cutile() -> bool:
+    try:
+        import cuda.tile  # noqa: F401
+        from flashinfer.mla import BatchMLAPagedAttentionWrapper  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _has_trtllm() -> bool:
+    try:
+        from flashinfer.decode import (  # noqa: F401
+            trtllm_batch_decode_with_kv_cache_mla,
+        )
+
+        return True
+    except Exception:
+        return False
+
+
+ALL_PROVIDERS = ["cutile", "trtllm"]
+_AVAIL = {
+    "cutile": _has_cutile,
+    "trtllm": _has_trtllm,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Shared paged-MLA input generation
+# --------------------------------------------------------------------------- #
+class _MLAInputs:
+    """Raw tensors shared by both providers (identical values -> comparable outputs)."""
+
+    def __init__(self, batch: int, s_kv: int, page_size: int, num_heads: int, device):
+        torch.manual_seed(0)
+        pages_per_batch = math.ceil(s_kv / page_size)
+        total_pages = max(batch * pages_per_batch + 8, 64)
+
+        self.batch = batch
+        self.s_kv = s_kv
+        self.page_size = page_size
+        self.num_heads = num_heads
+        self.pages_per_batch = pages_per_batch
+        self.total_pages = total_pages
+        self.sm_scale = 1.0 / math.sqrt(HEAD_DIM_CKV + HEAD_DIM_KPE)
+
+        # q_nope: [batch, num_heads, 512], q_pe: [batch, num_heads, 64]
+        self.q_nope = torch.randn(
+            batch, num_heads, HEAD_DIM_CKV, dtype=DTYPE, device=device
+        )
+        self.q_pe = torch.randn(
+            batch, num_heads, HEAD_DIM_KPE, dtype=DTYPE, device=device
+        )
+        # Compressed-latent KV cache (K and V share ckv): [num_pages, page, 512]/[..., 64]
+        self.ckv = torch.randn(
+            total_pages, page_size, HEAD_DIM_CKV, dtype=DTYPE, device=device
+        )
+        self.kpe = torch.randn(
+            total_pages, page_size, HEAD_DIM_KPE, dtype=DTYPE, device=device
+        )
+        self.kv_lens = torch.full((batch,), s_kv, dtype=torch.int32, device=device)
+        # Dense block table [batch, pages_per_batch], int32.
+        self.page_table = (
+            torch.arange(batch * pages_per_batch, dtype=torch.int32, device=device)
+            .reshape(batch, pages_per_batch)
+            % total_pages
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Per-provider callables
+# --------------------------------------------------------------------------- #
+def _make_execute(provider: str, inp: _MLAInputs) -> Callable[[], torch.Tensor]:
+    device = inp.q_nope.device
+
+    if provider == "cutile":
+        # This checkout's BatchMLAPagedAttentionWrapper(..., backend="cutile").
+        # cuTile MLA plan() only stashes metadata; run() consumes kv_len + page_table
+        # directly (the cutile branch of the MLA paged-attention wrapper).
+        from flashinfer.mla import BatchMLAPagedAttentionWrapper
+
+        workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+        wrapper = BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
+
+        # plan()'s kv_indptr/kv_indices are unused by the cutile path but the
+        # signature is shared; build consistent CSR to be safe.
+        qo_indptr = torch.arange(inp.batch + 1, dtype=torch.int32, device=device)
+        kv_indptr = (
+            torch.arange(inp.batch + 1, dtype=torch.int32, device=device)
+            * inp.pages_per_batch
+        )
+        kv_indices = inp.page_table.reshape(-1).to(torch.int32)
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            inp.kv_lens,
+            inp.num_heads,
+            HEAD_DIM_CKV,
+            HEAD_DIM_KPE,
+            inp.page_size,
+            False,  # causal (decode: single query token)
+            inp.sm_scale,
+            inp.q_nope.dtype,
+            inp.ckv.dtype,
+        )
+
+        def run():
+            return wrapper.run(
+                inp.q_nope,
+                inp.q_pe,
+                inp.ckv,
+                inp.kpe,
+                kv_len=inp.kv_lens,
+                page_table=inp.page_table,
+            )
+
+    elif provider == "trtllm":
+        # SOTA: flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla (trtllm-gen).
+        # Call body follows the trtllm-gen MLA decode reference.
+        from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+
+        workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.int8, device=device)
+        # query: [batch, 1, num_heads, 576]; kv_cache: [num_pages, 1, page, 576]
+        mla_query = torch.cat([inp.q_nope, inp.q_pe], dim=-1).unsqueeze(1).contiguous()
+        mla_kv = torch.cat([inp.ckv, inp.kpe], dim=-1).unsqueeze(1).contiguous()
+
+        def run():
+            return trtllm_batch_decode_with_kv_cache_mla(
+                query=mla_query,
+                kv_cache=mla_kv,
+                workspace_buffer=workspace,
+                qk_nope_head_dim=QK_NOPE_HEAD_DIM,
+                kv_lora_rank=HEAD_DIM_CKV,
+                qk_rope_head_dim=HEAD_DIM_KPE,
+                block_tables=inp.page_table,
+                seq_lens=inp.kv_lens.view(-1),
+                max_seq_len=inp.s_kv,
+                bmm1_scale=inp.sm_scale,
+                bmm2_scale=1.0,
+            )
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run
+
+
+def _canonical_out(provider: str, out) -> torch.Tensor:
+    """Reduce a provider output to [batch, num_heads, head_dim_ckv] for comparison."""
+    if isinstance(out, (list, tuple)):
+        out = out[0]
+    # trtllm-gen returns [batch, 1, num_heads, 512]; cutile returns [batch, heads, 512].
+    if out.dim() == 4 and out.shape[1] == 1:
+        out = out.squeeze(1)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Correctness + timing
+# --------------------------------------------------------------------------- #
+def verify_correctness(
+    batch: int, s_kv: int, page_size: int, num_heads: int, providers: List[str]
+) -> Tuple[bool, float]:
+    """Cosine similarity of cutile vs trtllm MLA-decode output (both must be available)."""
+    if not ("cutile" in providers and "trtllm" in providers):
+        print("  correctness: need both cutile and trtllm selected -> SKIP")
+        return False, float("nan")
+    if not (_AVAIL["cutile"]() and _AVAIL["trtllm"]()):
+        return False, float("nan")
+    try:
+        device = torch.device("cuda")
+        inp = _MLAInputs(batch, s_kv, page_size, num_heads, device)
+        a = _canonical_out("cutile", _make_execute("cutile", inp)())
+        b = _canonical_out("trtllm", _make_execute("trtllm", inp)())
+        torch.cuda.synchronize()
+        cos = torch.nn.functional.cosine_similarity(
+            a.float().reshape(1, -1), b.float().reshape(1, -1)
+        ).item()
+        return cos > 0.99, cos
+    except Exception:
+        return False, float("nan")
+
+
+def bench_one(
+    batch: int, s_kv: int, page_size: int, num_heads: int, provider: str
+) -> float:
+    """Median latency (ms) for one (config, provider); NaN if unavailable/failed."""
+    if not _AVAIL[provider]():
+        return float("nan")
+    try:
+        device = torch.device("cuda")
+        inp = _MLAInputs(batch, s_kv, page_size, num_heads, device)
+        run = _make_execute(provider, inp)
+        run()  # warmup / compile
+        torch.cuda.synchronize()
+        times = bench_gpu_time(
+            fn=run,
+            enable_cupti=True,
+            dry_run_iters=5,
+            repeat_iters=30,
+            cold_l2_cache=True,
+            use_cuda_graph=False,
+        )
+        return float(np.median(times))
+    except Exception:
+        return float("nan")
+
+
+# --------------------------------------------------------------------------- #
+# Sweep
+# --------------------------------------------------------------------------- #
+def run_benchmark_sweep(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    page_size_values: List[int],
+    num_heads: int,
+    providers: List[str],
+) -> Dict[str, Dict[Tuple[int, int, int], float]]:
+    """Return {provider: {(batch, s_kv, page_size): median_ms}}."""
+    results: Dict[str, Dict[Tuple[int, int, int], float]] = {p: {} for p in providers}
+    configs = [
+        (b, s, p) for b in batch_values for s in s_kv_values for p in page_size_values
+    ]
+    total = len(configs)
+
+    print(f"\nBenchmarking MLA decode  num_heads={num_heads}  bf16  ckv=512 kpe=64")
+    print("=" * (34 + 12 * len(providers)))
+    header = f"{'batch':>6} {'s_kv':>7} {'page':>5} |"
+    for p in providers:
+        header += f" {p:>10}"
+    print(header)
+    print("-" * (34 + 12 * len(providers)))
+
+    for current, (b, s, ps) in enumerate(configs, 1):
+        row = f"{b:>6} {s:>7} {ps:>5} |"
+        for p in providers:
+            ms = bench_one(b, s, ps, num_heads, p)
+            results[p][(b, s, ps)] = ms
+            row += f" {ms:>10.5f}" if ms == ms else f" {'--':>10}"
+        print(f"[{current:3d}/{total}] " + row)
+
+    return results
+
+
+def print_summary_table(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    page_size_values: List[int],
+    results: Dict[str, Dict[Tuple[int, int, int], float]],
+    providers: List[str],
+    baseline: str,
+):
+    """Speedup of each provider vs baseline (>1 = provider faster)."""
+    if baseline not in results:
+        return
+    for p in providers:
+        if p == baseline:
+            continue
+        print(f"\n{'=' * 72}")
+        print(f"Speedup: {p} vs {baseline} (baseline_ms / {p}_ms;  >1 = {p} faster)")
+        print(f"{'=' * 72}")
+        print(f"{'batch':>6} {'s_kv':>7} {'page':>5} {'speedup':>10}")
+        print("-" * 32)
+        ratios = []
+        for b in batch_values:
+            for s in s_kv_values:
+                for ps in page_size_values:
+                    bt = results[baseline].get((b, s, ps), float("nan"))
+                    pt = results[p].get((b, s, ps), float("nan"))
+                    if pt == pt and bt == bt and pt > 0:
+                        r = bt / pt
+                        ratios.append(r)
+                        print(f"{b:>6} {s:>7} {ps:>5} {r:>10.2f}")
+                    else:
+                        print(f"{b:>6} {s:>7} {ps:>5} {'N/A':>10}")
+        if ratios:
+            print(
+                f"\n  geomean {np.exp(np.mean(np.log(ratios))):.2f}x  "
+                f"min {min(ratios):.2f}x  max {max(ratios):.2f}x  "
+                f"({sum(1 for r in ratios if r > 1)}/{len(ratios)} configs {p} faster)"
+            )
+
+
+def write_csv(
+    path: str,
+    results: Dict[str, Dict[Tuple[int, int, int], float]],
+    num_heads: int,
+):
+    with open(path, "w", newline="") as f:
+        w = _csv.writer(f)
+        w.writerow(
+            ["provider", "config", "batch", "s_kv", "page_size", "num_heads", "median_ms"]
+        )
+        for provider, d in results.items():
+            for (b, s, ps), ms in sorted(d.items()):
+                config = f"b{b}_s{s}_p{ps}"
+                w.writerow([provider, config, b, s, ps, num_heads, f"{ms:.6f}"])
+    print(f"\nWrote {path}")
+
+
+def create_heatmap(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    page_size: int,
+    results: Dict[str, Dict[Tuple[int, int, int], float]],
+    provider: str,
+    baseline: str,
+    output_file: str,
+):
+    """Heatmap of `provider` speedup vs `baseline` over (batch x s_kv) at one page_size."""
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as mcolors
+    except ImportError:
+        print("matplotlib not installed, skipping heatmap")
+        return
+    if provider not in results or baseline not in results:
+        return
+    mat = np.full((len(batch_values), len(s_kv_values)), np.nan)
+    for i, b in enumerate(batch_values):
+        for j, s in enumerate(s_kv_values):
+            bt = results[baseline].get((b, s, page_size), float("nan"))
+            pt = results[provider].get((b, s, page_size), float("nan"))
+            if pt == pt and bt == bt and pt > 0:
+                mat[i, j] = bt / pt
+    if np.all(np.isnan(mat)):
+        return
+    fig, ax = plt.subplots(
+        figsize=(max(6, 1.5 * len(s_kv_values)), max(5, 0.5 * len(batch_values)))
+    )
+    norm = mcolors.TwoSlopeNorm(
+        vmin=min(0.5, np.nanmin(mat)), vcenter=1.0, vmax=max(1.5, np.nanmax(mat))
+    )
+    im = ax.imshow(mat, cmap="RdYlGn", norm=norm, aspect="auto")
+    cbar = ax.figure.colorbar(im, ax=ax, shrink=0.8)
+    cbar.ax.set_ylabel(f"{baseline}_ms / {provider}_ms", rotation=-90, va="bottom")
+    ax.set_xticks(np.arange(len(s_kv_values)))
+    ax.set_yticks(np.arange(len(batch_values)))
+    ax.set_xticklabels([str(s) for s in s_kv_values])
+    ax.set_yticklabels([str(b) for b in batch_values])
+    for i in range(len(batch_values)):
+        for j in range(len(s_kv_values)):
+            if not np.isnan(mat[i, j]):
+                ax.text(
+                    j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                    color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
+                )
+    ax.set_xlabel("s_kv")
+    ax.set_ylabel("batch")
+    ax.set_title(
+        f"MLA decode (page_size={page_size}): {provider} speedup vs {baseline}\n"
+        f"(>1.0 = {provider} faster)"
+    )
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    print(f"Saved heatmap to {output_file}")
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark MLA decode: cuTile vs trtllm-gen SOTA"
+    )
+    parser.add_argument(
+        "--providers",
+        type=str,
+        default=",".join(ALL_PROVIDERS),
+        help=f"Comma-separated subset of {ALL_PROVIDERS}",
+    )
+    parser.add_argument(
+        "--baseline", type=str, default="trtllm", help="Speedup baseline provider"
+    )
+    parser.add_argument("--num-heads", type=int, default=32)
+    parser.add_argument("--output-prefix", type=str, default="mla_decode_backend")
+    parser.add_argument("--csv", type=str, default=None, help="Write medians to CSV")
+    args = parser.parse_args()
+
+    requested = [p.strip() for p in args.providers.split(",") if p.strip()]
+    providers = [p for p in requested if p in ALL_PROVIDERS]
+    available = [p for p in providers if _AVAIL[p]()]
+    print(f"Requested providers: {providers}")
+    print(f"Available here:      {available}  (unavailable are skipped as N/A)")
+
+    # Ocean MLADecodePaged workload (perf/dashboard suite uses num_heads=32).
+    batch_values = [1, 16, 64, 128, 256]
+    s_kv_values = [1024, 2048, 4096, 8192]
+    page_size_values = [32, 64]
+
+    # Correctness only runs when BOTH providers are importable in this process.
+    print("\nCorrectness (cutile vs trtllm cosine-sim, at batch=16 s_kv=2048 page=64):")
+    ok, cos = verify_correctness(16, 2048, 64, args.num_heads, providers)
+    if cos == cos:
+        print(f"  {'OK ' if ok else 'FAIL'} cos={cos:.4f}")
+    else:
+        print("  N/A (need both cutile and trtllm in one process)")
+
+    results = run_benchmark_sweep(
+        batch_values, s_kv_values, page_size_values, args.num_heads, providers
+    )
+    baseline = args.baseline if args.baseline in providers else providers[0]
+    print_summary_table(
+        batch_values, s_kv_values, page_size_values, results, providers, baseline
+    )
+
+    if args.csv:
+        write_csv(args.csv, results, args.num_heads)
+
+    for p in providers:
+        if p != baseline:
+            for ps in page_size_values:
+                create_heatmap(
+                    batch_values, s_kv_values, ps, results, p, baseline,
+                    f"{args.output_prefix}_{p}_vs_{baseline}_p{ps}.png",
+                )
+
+    print("\n" + "=" * 72)
+    print("BENCHMARK COMPLETE")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_mla_decode_backend_comparison.py
+++ b/benchmarks/bench_mla_decode_backend_comparison.py
@@ -62,6 +62,7 @@ DTYPE = torch.bfloat16
 # Provider availability
 # --------------------------------------------------------------------------- #
 def _has_cutile() -> bool:
+    """True if this checkout can run the cuTile paged-MLA decode backend."""
     try:
         import cuda.tile  # noqa: F401
         from flashinfer.mla import BatchMLAPagedAttentionWrapper  # noqa: F401
@@ -72,6 +73,7 @@ def _has_cutile() -> bool:
 
 
 def _has_trtllm() -> bool:
+    """True if the installed flashinfer exposes the trtllm-gen MLA decode entry point."""
     try:
         from flashinfer.decode import (  # noqa: F401
             trtllm_batch_decode_with_kv_cache_mla,
@@ -96,6 +98,7 @@ class _MLAInputs:
     """Raw tensors shared by both providers (identical values -> comparable outputs)."""
 
     def __init__(self, batch: int, s_kv: int, page_size: int, num_heads: int, device):
+        """Build the paged-MLA tensors for one (batch, s_kv, page_size, num_heads) case."""
         torch.manual_seed(0)
         pages_per_batch = math.ceil(s_kv / page_size)
         total_pages = max(batch * pages_per_batch + 8, 64)
@@ -136,6 +139,7 @@ class _MLAInputs:
 # Per-provider callables
 # --------------------------------------------------------------------------- #
 def _make_execute(provider: str, inp: _MLAInputs) -> Callable[[], torch.Tensor]:
+    """Return a zero-arg callable running `provider`'s MLA decode on `inp`."""
     device = inp.q_nope.device
 
     if provider == "cutile":
@@ -171,6 +175,7 @@ def _make_execute(provider: str, inp: _MLAInputs) -> Callable[[], torch.Tensor]:
         )
 
         def run():
+            """Run cuTile paged MLA decode through the planned wrapper."""
             return wrapper.run(
                 inp.q_nope,
                 inp.q_pe,
@@ -191,6 +196,7 @@ def _make_execute(provider: str, inp: _MLAInputs) -> Callable[[], torch.Tensor]:
         mla_kv = torch.cat([inp.ckv, inp.kpe], dim=-1).unsqueeze(1).contiguous()
 
         def run():
+            """Run trtllm-gen paged MLA decode on the concatenated [ckv|kpe] cache."""
             return trtllm_batch_decode_with_kv_cache_mla(
                 query=mla_query,
                 kv_cache=mla_kv,
@@ -352,6 +358,7 @@ def write_csv(
     results: Dict[str, Dict[Tuple[int, int, int], float]],
     num_heads: int,
 ):
+    """Write the raw per-provider medians to `path` as CSV."""
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(
@@ -437,6 +444,7 @@ def create_heatmap(
 
 
 def main():
+    """Parse args, sweep the shapes, and emit table / CSV / heatmap."""
     parser = argparse.ArgumentParser(
         description="Benchmark MLA decode: cuTile vs trtllm-gen SOTA"
     )

--- a/benchmarks/bench_mla_decode_backend_comparison.py
+++ b/benchmarks/bench_mla_decode_backend_comparison.py
@@ -125,8 +125,9 @@ class _MLAInputs:
         self.kv_lens = torch.full((batch,), s_kv, dtype=torch.int32, device=device)
         # Dense block table [batch, pages_per_batch], int32.
         self.page_table = (
-            torch.arange(batch * pages_per_batch, dtype=torch.int32, device=device)
-            .reshape(batch, pages_per_batch)
+            torch.arange(
+                batch * pages_per_batch, dtype=torch.int32, device=device
+            ).reshape(batch, pages_per_batch)
             % total_pages
         )
 
@@ -354,7 +355,15 @@ def write_csv(
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(
-            ["provider", "config", "batch", "s_kv", "page_size", "num_heads", "median_ms"]
+            [
+                "provider",
+                "config",
+                "batch",
+                "s_kv",
+                "page_size",
+                "num_heads",
+                "median_ms",
+            ]
         )
         for provider, d in results.items():
             for (b, s, ps), ms in sorted(d.items()):
@@ -407,7 +416,12 @@ def create_heatmap(
         for j in range(len(s_kv_values)):
             if not np.isnan(mat[i, j]):
                 ax.text(
-                    j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                    j,
+                    i,
+                    f"{mat[i, j]:.2f}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
                     color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
                 )
     ax.set_xlabel("s_kv")
@@ -474,7 +488,12 @@ def main():
         if p != baseline:
             for ps in page_size_values:
                 create_heatmap(
-                    batch_values, s_kv_values, ps, results, p, baseline,
+                    batch_values,
+                    s_kv_values,
+                    ps,
+                    results,
+                    p,
+                    baseline,
                     f"{args.output_prefix}_{p}_vs_{baseline}_p{ps}.png",
                 )
 

--- a/benchmarks/bench_mla_decode_backend_comparison.py
+++ b/benchmarks/bench_mla_decode_backend_comparison.py
@@ -143,46 +143,38 @@ def _make_execute(provider: str, inp: _MLAInputs) -> Callable[[], torch.Tensor]:
     device = inp.q_nope.device
 
     if provider == "cutile":
-        # This checkout's BatchMLAPagedAttentionWrapper(..., backend="cutile").
-        # cuTile MLA plan() only stashes metadata; run() consumes kv_len + page_table
-        # directly (the cutile branch of the MLA paged-attention wrapper).
-        from flashinfer.mla import BatchMLAPagedAttentionWrapper
+        # This checkout's planned cuTile MLA wrapper backend.
+        from flashinfer.mla import BatchMLAPagedAttentionWrapper, MLAPlanMetadata
 
         workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
         wrapper = BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
 
-        # plan()'s kv_indptr/kv_indices are unused by the cutile path but the
-        # signature is shared; build consistent CSR to be safe.
-        qo_indptr = torch.arange(inp.batch + 1, dtype=torch.int32, device=device)
-        kv_indptr = (
-            torch.arange(inp.batch + 1, dtype=torch.int32, device=device)
-            * inp.pages_per_batch
+        metadata = MLAPlanMetadata.dense(
+            cum_seq_lens_q=torch.arange(
+                inp.batch + 1, dtype=torch.int32, device=device
+            ),
+            block_tables=inp.page_table,
+            seq_lens=inp.kv_lens,
         )
-        kv_indices = inp.page_table.reshape(-1).to(torch.int32)
         wrapper.plan(
-            qo_indptr,
-            kv_indptr,
-            kv_indices,
-            inp.kv_lens,
-            inp.num_heads,
-            HEAD_DIM_CKV,
-            HEAD_DIM_KPE,
-            inp.page_size,
-            False,  # causal (decode: single query token)
-            inp.sm_scale,
-            inp.q_nope.dtype,
-            inp.ckv.dtype,
+            metadata=metadata,
+            num_heads=inp.num_heads,
+            head_dim_ckv=HEAD_DIM_CKV,
+            head_dim_kpe=HEAD_DIM_KPE,
+            page_size=inp.page_size,
+            causal=False,
+            sm_scale=inp.sm_scale,
+            q_data_type=inp.q_nope.dtype,
+            kv_data_type=inp.ckv.dtype,
+            query_layout="split",
+            kv_cache_layout="split",
         )
 
         def run():
             """Run cuTile paged MLA decode through the planned wrapper."""
             return wrapper.run(
-                inp.q_nope,
-                inp.q_pe,
-                inp.ckv,
-                inp.kpe,
-                kv_len=inp.kv_lens,
-                page_table=inp.page_table,
+                query=(inp.q_nope, inp.q_pe),
+                kv_cache=(inp.ckv, inp.kpe),
             )
 
     elif provider == "trtllm":

--- a/benchmarks/bench_paged_prefill_backend_comparison.py
+++ b/benchmarks/bench_paged_prefill_backend_comparison.py
@@ -1,0 +1,442 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Benchmark: Paged Prefill Attention Backend Comparison (cuTile vs trtllm SOTA)
+
+Compares FlashInfer's cuTile paged-prefill backend against the trtllm-gen SOTA
+kernel over ocean-eval's PrefillPaged workload, swept across page sizes:
+
+  - ``cutile`` : this checkout's ``prefill_attention_kv_paged_cutile`` cuTile kernel
+  - ``trtllm`` : ``flashinfer.prefill.trtllm_batch_context_with_kv_cache`` (SOTA
+                 baseline used by ocean-eval's dashboard for paged prefill)
+
+NOTE: paged prefill is NOT (yet) wired into ``BatchPrefillWithPagedKVCacheWrapper``
+in this checkout (only ragged is — commit a0600669f). The cuTile provider therefore
+calls the raw kernel ``prefill_attention_kv_paged_cutile`` directly, mirroring how
+ocean-eval's ``flashinfer_ops.prefill_attention_kv_paged`` dispatches.
+
+TWO-FLASHINFER NOTE: the cuTile backend lives only in THIS checkout, while the
+image's INSTALLED flashinfer carries the working trtllm path (the checkout's
+trtllm path can crash with atomic_fmax). Each provider independently try/excepts
+and degrades to NaN, so the bench is typically RUN TWICE and merged:
+
+    python3 bench_paged_prefill_backend_comparison.py --providers cutile --csv cutile.csv
+    python3 bench_paged_prefill_backend_comparison.py --providers trtllm --csv trtllm.csv
+
+Workload: bf16, causal, head_dim=128, num_qo_heads=128, num_kv_heads=8 (GQA),
+page_size sweep {16,64}. Metric = kernel self-time median (ms).
+Speedup = trtllm_ms / cutile_ms  (>1 == cutile faster).
+
+Requirements:
+    - cuda.tile toolchain (cutile provider); flashinfer trtllm-gen (trtllm provider)
+    - matplotlib for the heatmap
+"""
+
+import argparse
+import csv as _csv
+import math
+import numpy as np
+import torch
+from typing import Callable, Dict, List, Tuple
+
+from flashinfer.testing.utils import bench_gpu_time
+
+# --------------------------------------------------------------------------- #
+# Fixed workload (ocean PrefillPaged): head_dim=128, heads 128/8 (GQA), causal.
+# --------------------------------------------------------------------------- #
+DEV = torch.device("cuda")
+DT = torch.bfloat16
+NUM_QO_HEADS = 128
+NUM_KV_HEADS = 8
+HEAD_DIM = 128  # head_dim_qk == head_dim_vo
+
+
+# --------------------------------------------------------------------------- #
+# Provider availability
+# --------------------------------------------------------------------------- #
+def _has_cutile() -> bool:
+    try:
+        import cuda.tile  # noqa: F401
+        from flashinfer.attention.kernels.cutile.fmha_prefill_bsr_cutile import (  # noqa: F401
+            prefill_attention_kv_paged_cutile,
+        )
+
+        return True
+    except Exception:
+        return False
+
+
+def _has_trtllm() -> bool:
+    try:
+        from flashinfer.prefill import trtllm_batch_context_with_kv_cache  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+ALL_PROVIDERS = ["cutile", "trtllm"]
+_AVAIL = {
+    "cutile": _has_cutile,
+    "trtllm": _has_trtllm,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Input generation + per-provider callables
+# --------------------------------------------------------------------------- #
+def _make_inputs(batch: int, seq: int, page: int):
+    """Build a shared paged KV in HND layout plus the derived NHD (cuTile) layout.
+
+    HND (trtllm): k/v_cache [total_pages, num_kv_heads, page_size, head_dim]
+    NHD (cuTile): k/v_cache [total_pages, page_size, num_kv_heads, head_dim]
+    Both hold identical values (NHD is HND transposed) so the two providers can be
+    correctness-compared.
+    """
+    torch.manual_seed(0)
+    total_q = batch * seq
+    ppb = math.ceil(seq / page)
+    total_pages = batch * ppb
+
+    q = torch.randn(total_q, NUM_QO_HEADS, HEAD_DIM, dtype=DT, device=DEV)
+    k_hnd = torch.randn(total_pages, NUM_KV_HEADS, page, HEAD_DIM, dtype=DT, device=DEV)
+    v_hnd = torch.randn(total_pages, NUM_KV_HEADS, page, HEAD_DIM, dtype=DT, device=DEV)
+    # cuTile expects [total_pages, page_size, num_kv_heads, head_dim].
+    k_nhd = k_hnd.transpose(1, 2).contiguous()
+    v_nhd = v_hnd.transpose(1, 2).contiguous()
+
+    block_tables = torch.arange(
+        total_pages, dtype=torch.int32, device=DEV
+    ).reshape(batch, ppb)
+    seq_lens = torch.full((batch,), seq, dtype=torch.int32, device=DEV)
+    # Exclusive-prefix-sum q offsets; cum[:-1] is the per-request q start row.
+    cum = torch.arange(batch + 1, dtype=torch.int32, device=DEV) * seq
+    seq_offset = cum[:-1].contiguous()
+    return q, k_hnd, v_hnd, k_nhd, v_nhd, block_tables, seq_lens, cum, seq_offset
+
+
+def _make_execute(provider: str, batch: int, seq: int, page: int) -> Callable[[], torch.Tensor]:
+    (q, k_hnd, v_hnd, k_nhd, v_nhd, block_tables, seq_lens, cum, seq_offset) = (
+        _make_inputs(batch, seq, page)
+    )
+    scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    if provider == "cutile":
+        from flashinfer.attention.kernels.cutile.fmha_prefill_bsr_cutile import (
+            prefill_attention_kv_paged_cutile,
+        )
+
+        def run():
+            return prefill_attention_kv_paged_cutile(
+                q=q,
+                k_cache=k_nhd,
+                v_cache=v_nhd,
+                actual_seq_lens_q=seq_lens,
+                actual_seq_lens_kv=seq_lens,
+                actual_seq_offset=seq_offset,
+                block_tables=block_tables,
+                k_scale=scale,  # folds the softmax scale
+                v_scale=1.0,
+                num_batch=batch,
+                max_seq_len=seq,
+                is_causal=True,
+            )
+
+    elif provider == "trtllm":
+        from flashinfer.prefill import trtllm_batch_context_with_kv_cache
+
+        ws = torch.zeros(256 * 1024 * 1024, dtype=torch.int8, device=DEV)
+
+        def run():
+            # NOTE: no `causal=` kwarg — the image's INSTALLED flashinfer signature
+            # does not accept it (matches sota_bench/bench_prefill_paged_trtllm.py).
+            return trtllm_batch_context_with_kv_cache(
+                query=q,
+                kv_cache=(k_hnd, v_hnd),
+                workspace_buffer=ws,
+                block_tables=block_tables,
+                seq_lens=seq_lens,
+                max_q_len=seq,
+                max_kv_len=seq,
+                bmm1_scale=scale,
+                bmm2_scale=1.0,
+                batch_size=batch,
+                cum_seq_lens_q=cum,
+                cum_seq_lens_kv=cum,
+                kv_layout="HND",
+            )
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run
+
+
+def _as_output(out) -> torch.Tensor:
+    return out[0] if isinstance(out, (list, tuple)) else out
+
+
+# --------------------------------------------------------------------------- #
+# Correctness + timing
+# --------------------------------------------------------------------------- #
+def verify_correctness(batch: int, seq: int, page: int, providers: List[str]) -> None:
+    """Cosine-sim of cutile vs trtllm output when both are available; else skip."""
+    if not ("cutile" in providers and "trtllm" in providers):
+        print("  correctness: need both cutile and trtllm available -> SKIP")
+        return
+    if not (_AVAIL["cutile"]() and _AVAIL["trtllm"]()):
+        print("  correctness: both providers not importable here -> SKIP")
+        return
+    try:
+        out_c = _as_output(_make_execute("cutile", batch, seq, page)()).float().reshape(1, -1)
+        out_t = _as_output(_make_execute("trtllm", batch, seq, page)()).float().reshape(1, -1)
+        cos = torch.nn.functional.cosine_similarity(out_c, out_t).item()
+        print(f"  correctness @ batch={batch} s_kv={seq} page={page}: cos={cos:.4f} "
+              f"{'OK' if cos > 0.99 else 'CHECK'}")
+    except Exception as e:
+        print(f"  correctness: FAILED ({repr(e)[:80]})")
+
+
+def bench_one(batch: int, seq: int, page: int, provider: str) -> float:
+    """Median kernel self-time (ms) for one (shape, provider); NaN if unavailable."""
+    if not _AVAIL[provider]():
+        return float("nan")
+    try:
+        run = _make_execute(provider, batch, seq, page)
+        run()  # warmup / compile
+        torch.cuda.synchronize()
+        times = bench_gpu_time(
+            fn=run,
+            enable_cupti=True,
+            dry_run_iters=5,
+            repeat_iters=30,
+            cold_l2_cache=True,
+            use_cuda_graph=False,
+        )
+        return float(np.median(times))
+    except Exception:
+        return float("nan")
+
+
+# --------------------------------------------------------------------------- #
+# Sweep
+# --------------------------------------------------------------------------- #
+def run_benchmark_sweep(
+    page_values: List[int],
+    batch_values: List[int],
+    s_kv_values: List[int],
+    providers: List[str],
+) -> Dict[str, Dict[Tuple[int, int, int], float]]:
+    """Return {provider: {(page, batch, s_kv): median_ms}}."""
+    results: Dict[str, Dict[Tuple[int, int, int], float]] = {p: {} for p in providers}
+    configs = [
+        (pg, b, s) for pg in page_values for b in batch_values for s in s_kv_values
+    ]
+    total = len(configs)
+
+    print(f"\nPaged prefill (head_dim={HEAD_DIM}, heads {NUM_QO_HEADS}/{NUM_KV_HEADS}, "
+          f"bf16, causal)")
+    print("=" * (32 + 12 * len(providers)))
+    header = f"{'page':>5} {'batch':>6} {'s_kv':>7} |"
+    for p in providers:
+        header += f" {p:>10}"
+    print(header)
+    print("-" * (32 + 12 * len(providers)))
+
+    for i, (page, batch, seq) in enumerate(configs, 1):
+        row = f"{page:>5} {batch:>6} {seq:>7} |"
+        for p in providers:
+            ms = bench_one(batch, seq, page, p)
+            results[p][(page, batch, seq)] = ms
+            row += f" {ms:>10.5f}" if ms == ms else f" {'--':>10}"
+        print(f"[{i:3d}/{total}] " + row)
+        torch.cuda.empty_cache()
+
+    return results
+
+
+def print_summary_table(
+    page_values: List[int],
+    batch_values: List[int],
+    s_kv_values: List[int],
+    results: Dict[str, Dict[Tuple[int, int, int], float]],
+    providers: List[str],
+    baseline: str,
+):
+    """Speedup of each provider vs the baseline (>1 = provider faster), per page."""
+    if baseline not in results:
+        return
+    for p in providers:
+        if p == baseline:
+            continue
+        for page in page_values:
+            print(f"\n{'=' * 72}")
+            print(f"Speedup [page={page}]: {p} vs {baseline} "
+                  f"({baseline}_ms / {p}_ms;  >1 = {p} faster)")
+            print(f"{'=' * 72}")
+            header = "batch\\s_kv".ljust(12)
+            for s in s_kv_values:
+                header += f"{s:>10}"
+            print(header)
+            print("-" * (12 + 10 * len(s_kv_values)))
+            ratios = []
+            for batch in batch_values:
+                row = f"{batch:<12}"
+                for s in s_kv_values:
+                    bt = results[baseline].get((page, batch, s), float("nan"))
+                    pt = results[p].get((page, batch, s), float("nan"))
+                    if pt == pt and bt == bt and pt > 0:
+                        r = bt / pt
+                        ratios.append(r)
+                        row += f"{r:>10.2f}"
+                    else:
+                        row += f"{'N/A':>10}"
+                print(row)
+            if ratios:
+                print(
+                    f"\n  geomean {np.exp(np.mean(np.log(ratios))):.2f}x  "
+                    f"min {min(ratios):.2f}x  max {max(ratios):.2f}x  "
+                    f"({sum(1 for r in ratios if r > 1)}/{len(ratios)} shapes {p} faster)"
+                )
+
+
+def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int, int], float]]):
+    with open(path, "w", newline="") as f:
+        w = _csv.writer(f)
+        w.writerow(
+            ["provider", "config", "batch", "s_kv", "page_size", "head_dim", "median_ms"]
+        )
+        for provider, d in results.items():
+            for (page, batch, seq), ms in sorted(d.items()):
+                w.writerow(
+                    [provider, "paged", batch, seq, page, HEAD_DIM, f"{ms:.6f}"]
+                )
+    print(f"\nWrote {path}")
+
+
+def create_heatmap(
+    page: int,
+    batch_values: List[int],
+    s_kv_values: List[int],
+    results: Dict[str, Dict[Tuple[int, int, int], float]],
+    provider: str,
+    baseline: str,
+    output_file: str,
+):
+    """Heatmap of `provider` speedup vs `baseline` over (batch x s_kv) for one page."""
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as mcolors
+    except ImportError:
+        print("matplotlib not installed, skipping heatmap")
+        return
+    if provider not in results or baseline not in results:
+        return
+    mat = np.full((len(batch_values), len(s_kv_values)), np.nan)
+    for i, batch in enumerate(batch_values):
+        for j, s in enumerate(s_kv_values):
+            bt = results[baseline].get((page, batch, s), float("nan"))
+            pt = results[provider].get((page, batch, s), float("nan"))
+            if pt == pt and bt == bt and pt > 0:
+                mat[i, j] = bt / pt
+    if np.all(np.isnan(mat)):
+        return
+    fig, ax = plt.subplots(
+        figsize=(max(6, 1.5 * len(s_kv_values)), max(5, 0.5 * len(batch_values)))
+    )
+    norm = mcolors.TwoSlopeNorm(
+        vmin=min(0.5, np.nanmin(mat)), vcenter=1.0, vmax=max(1.5, np.nanmax(mat))
+    )
+    im = ax.imshow(mat, cmap="RdYlGn", norm=norm, aspect="auto")
+    cbar = ax.figure.colorbar(im, ax=ax, shrink=0.8)
+    cbar.ax.set_ylabel(f"{baseline}_ms / {provider}_ms", rotation=-90, va="bottom")
+    ax.set_xticks(np.arange(len(s_kv_values)))
+    ax.set_yticks(np.arange(len(batch_values)))
+    ax.set_xticklabels([str(s) for s in s_kv_values])
+    ax.set_yticklabels([str(b) for b in batch_values])
+    for i in range(len(batch_values)):
+        for j in range(len(s_kv_values)):
+            if not np.isnan(mat[i, j]):
+                ax.text(j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                        color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black")
+    ax.set_xlabel("s_kv")
+    ax.set_ylabel("batch")
+    ax.set_title(
+        f"paged prefill (page={page}): {provider} speedup vs {baseline}\n"
+        f"(>1.0 = {provider} faster)"
+    )
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    print(f"Saved heatmap to {output_file}")
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark paged prefill backends (cuTile vs trtllm SOTA)"
+    )
+    parser.add_argument(
+        "--providers",
+        type=str,
+        default=",".join(ALL_PROVIDERS),
+        help=f"Comma-separated subset of {ALL_PROVIDERS}",
+    )
+    parser.add_argument(
+        "--baseline", type=str, default="trtllm", help="Speedup baseline provider"
+    )
+    parser.add_argument(
+        "--output-prefix", type=str, default="paged_prefill_backend_comparison"
+    )
+    parser.add_argument("--csv", type=str, default=None, help="Write raw medians to CSV")
+    args = parser.parse_args()
+
+    requested = [p.strip() for p in args.providers.split(",") if p.strip()]
+    providers = [p for p in requested if p in ALL_PROVIDERS]
+    available = [p for p in providers if _AVAIL[p]()]
+    print(f"Requested providers: {providers}")
+    print(f"Available here:      {available}  (unavailable are skipped as N/A)")
+
+    # Ocean PrefillPaged workload: page {16,64} x batch {1,16} x s_kv {1024..8192}.
+    page_values = [16, 64]
+    batch_values = [1, 16]
+    s_kv_values = [1024, 2048, 4096, 8192]
+
+    print("\nCorrectness check (cutile vs trtllm output):")
+    verify_correctness(1, 1024, 16, providers)
+
+    results = run_benchmark_sweep(page_values, batch_values, s_kv_values, providers)
+    baseline = args.baseline if args.baseline in providers else providers[0]
+    print_summary_table(
+        page_values, batch_values, s_kv_values, results, providers, baseline
+    )
+
+    if args.csv:
+        write_csv(args.csv, results)
+
+    for p in providers:
+        if p != baseline:
+            for page in page_values:
+                create_heatmap(
+                    page, batch_values, s_kv_values, results, p, baseline,
+                    f"{args.output_prefix}_{p}_vs_{baseline}_page{page}.png",
+                )
+
+    print("\n" + "=" * 72)
+    print("BENCHMARK COMPLETE")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_paged_prefill_backend_comparison.py
+++ b/benchmarks/bench_paged_prefill_backend_comparison.py
@@ -117,9 +117,9 @@ def _make_inputs(batch: int, seq: int, page: int):
     k_nhd = k_hnd.transpose(1, 2).contiguous()
     v_nhd = v_hnd.transpose(1, 2).contiguous()
 
-    block_tables = torch.arange(
-        total_pages, dtype=torch.int32, device=DEV
-    ).reshape(batch, ppb)
+    block_tables = torch.arange(total_pages, dtype=torch.int32, device=DEV).reshape(
+        batch, ppb
+    )
     seq_lens = torch.full((batch,), seq, dtype=torch.int32, device=DEV)
     # Exclusive-prefix-sum q offsets; cum[:-1] is the per-request q start row.
     cum = torch.arange(batch + 1, dtype=torch.int32, device=DEV) * seq
@@ -127,7 +127,9 @@ def _make_inputs(batch: int, seq: int, page: int):
     return q, k_hnd, v_hnd, k_nhd, v_nhd, block_tables, seq_lens, cum, seq_offset
 
 
-def _make_execute(provider: str, batch: int, seq: int, page: int) -> Callable[[], torch.Tensor]:
+def _make_execute(
+    provider: str, batch: int, seq: int, page: int
+) -> Callable[[], torch.Tensor]:
     (q, k_hnd, v_hnd, k_nhd, v_nhd, block_tables, seq_lens, cum, seq_offset) = (
         _make_inputs(batch, seq, page)
     )
@@ -200,11 +202,21 @@ def verify_correctness(batch: int, seq: int, page: int, providers: List[str]) ->
         print("  correctness: both providers not importable here -> SKIP")
         return
     try:
-        out_c = _as_output(_make_execute("cutile", batch, seq, page)()).float().reshape(1, -1)
-        out_t = _as_output(_make_execute("trtllm", batch, seq, page)()).float().reshape(1, -1)
+        out_c = (
+            _as_output(_make_execute("cutile", batch, seq, page)())
+            .float()
+            .reshape(1, -1)
+        )
+        out_t = (
+            _as_output(_make_execute("trtllm", batch, seq, page)())
+            .float()
+            .reshape(1, -1)
+        )
         cos = torch.nn.functional.cosine_similarity(out_c, out_t).item()
-        print(f"  correctness @ batch={batch} s_kv={seq} page={page}: cos={cos:.4f} "
-              f"{'OK' if cos > 0.99 else 'CHECK'}")
+        print(
+            f"  correctness @ batch={batch} s_kv={seq} page={page}: cos={cos:.4f} "
+            f"{'OK' if cos > 0.99 else 'CHECK'}"
+        )
     except Exception as e:
         print(f"  correctness: FAILED ({repr(e)[:80]})")
 
@@ -246,8 +258,10 @@ def run_benchmark_sweep(
     ]
     total = len(configs)
 
-    print(f"\nPaged prefill (head_dim={HEAD_DIM}, heads {NUM_QO_HEADS}/{NUM_KV_HEADS}, "
-          f"bf16, causal)")
+    print(
+        f"\nPaged prefill (head_dim={HEAD_DIM}, heads {NUM_QO_HEADS}/{NUM_KV_HEADS}, "
+        f"bf16, causal)"
+    )
     print("=" * (32 + 12 * len(providers)))
     header = f"{'page':>5} {'batch':>6} {'s_kv':>7} |"
     for p in providers:
@@ -283,8 +297,10 @@ def print_summary_table(
             continue
         for page in page_values:
             print(f"\n{'=' * 72}")
-            print(f"Speedup [page={page}]: {p} vs {baseline} "
-                  f"({baseline}_ms / {p}_ms;  >1 = {p} faster)")
+            print(
+                f"Speedup [page={page}]: {p} vs {baseline} "
+                f"({baseline}_ms / {p}_ms;  >1 = {p} faster)"
+            )
             print(f"{'=' * 72}")
             header = "batch\\s_kv".ljust(12)
             for s in s_kv_values:
@@ -316,13 +332,19 @@ def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int, int], float]]):
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(
-            ["provider", "config", "batch", "s_kv", "page_size", "head_dim", "median_ms"]
+            [
+                "provider",
+                "config",
+                "batch",
+                "s_kv",
+                "page_size",
+                "head_dim",
+                "median_ms",
+            ]
         )
         for provider, d in results.items():
             for (page, batch, seq), ms in sorted(d.items()):
-                w.writerow(
-                    [provider, "paged", batch, seq, page, HEAD_DIM, f"{ms:.6f}"]
-                )
+                w.writerow([provider, "paged", batch, seq, page, HEAD_DIM, f"{ms:.6f}"])
     print(f"\nWrote {path}")
 
 
@@ -369,8 +391,15 @@ def create_heatmap(
     for i in range(len(batch_values)):
         for j in range(len(s_kv_values)):
             if not np.isnan(mat[i, j]):
-                ax.text(j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
-                        color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black")
+                ax.text(
+                    j,
+                    i,
+                    f"{mat[i, j]:.2f}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
+                    color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
+                )
     ax.set_xlabel("s_kv")
     ax.set_ylabel("batch")
     ax.set_title(
@@ -399,7 +428,9 @@ def main():
     parser.add_argument(
         "--output-prefix", type=str, default="paged_prefill_backend_comparison"
     )
-    parser.add_argument("--csv", type=str, default=None, help="Write raw medians to CSV")
+    parser.add_argument(
+        "--csv", type=str, default=None, help="Write raw medians to CSV"
+    )
     args = parser.parse_args()
 
     requested = [p.strip() for p in args.providers.split(",") if p.strip()]
@@ -429,7 +460,12 @@ def main():
         if p != baseline:
             for page in page_values:
                 create_heatmap(
-                    page, batch_values, s_kv_values, results, p, baseline,
+                    page,
+                    batch_values,
+                    s_kv_values,
+                    results,
+                    p,
+                    baseline,
                     f"{args.output_prefix}_{p}_vs_{baseline}_page{page}.png",
                 )
 

--- a/benchmarks/bench_paged_prefill_backend_comparison.py
+++ b/benchmarks/bench_paged_prefill_backend_comparison.py
@@ -67,6 +67,7 @@ HEAD_DIM = 128  # head_dim_qk == head_dim_vo
 # Provider availability
 # --------------------------------------------------------------------------- #
 def _has_cutile() -> bool:
+    """True if this checkout can run the cuTile paged-prefill kernel."""
     try:
         import cuda.tile  # noqa: F401
         from flashinfer.attention.kernels.cutile.fmha_prefill_bsr_cutile import (  # noqa: F401
@@ -79,6 +80,7 @@ def _has_cutile() -> bool:
 
 
 def _has_trtllm() -> bool:
+    """True if the installed flashinfer exposes the trtllm-gen context entry point."""
     try:
         from flashinfer.prefill import trtllm_batch_context_with_kv_cache  # noqa: F401
 
@@ -130,6 +132,7 @@ def _make_inputs(batch: int, seq: int, page: int):
 def _make_execute(
     provider: str, batch: int, seq: int, page: int
 ) -> Callable[[], torch.Tensor]:
+    """Return a zero-arg callable running `provider`'s paged prefill on one shape."""
     (q, k_hnd, v_hnd, k_nhd, v_nhd, block_tables, seq_lens, cum, seq_offset) = (
         _make_inputs(batch, seq, page)
     )
@@ -141,6 +144,7 @@ def _make_execute(
         )
 
         def run():
+            """Run cuTile paged prefill on the NHD cache."""
             return prefill_attention_kv_paged_cutile(
                 q=q,
                 k_cache=k_nhd,
@@ -164,6 +168,7 @@ def _make_execute(
         def run():
             # NOTE: no `causal=` kwarg — the image's INSTALLED flashinfer signature
             # does not accept it (matches sota_bench/bench_prefill_paged_trtllm.py).
+            """Run trtllm-gen paged prefill on the HND cache."""
             return trtllm_batch_context_with_kv_cache(
                 query=q,
                 kv_cache=(k_hnd, v_hnd),
@@ -187,6 +192,7 @@ def _make_execute(
 
 
 def _as_output(out) -> torch.Tensor:
+    """Unwrap a provider result that may be an (output, lse) tuple."""
     return out[0] if isinstance(out, (list, tuple)) else out
 
 
@@ -329,6 +335,7 @@ def print_summary_table(
 
 
 def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int, int], float]]):
+    """Write the raw per-provider medians to `path` as CSV."""
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(
@@ -413,6 +420,7 @@ def create_heatmap(
 
 
 def main():
+    """Parse args, sweep the shapes, and emit table / CSV / heatmap."""
     parser = argparse.ArgumentParser(
         description="Benchmark paged prefill backends (cuTile vs trtllm SOTA)"
     )

--- a/benchmarks/bench_ragged_prefill_backend_comparison.py
+++ b/benchmarks/bench_ragged_prefill_backend_comparison.py
@@ -1,0 +1,420 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Benchmark: Ragged Prefill Attention Backend Comparison (cuTile vs trtllm SOTA)
+
+Compares FlashInfer's cuTile ragged-prefill backend against the trtllm-gen SOTA
+kernel over ocean-eval's PrefillRagged (DeepSeek) workload:
+
+  - ``cutile`` : this checkout's ``BatchPrefillWithRaggedKVCacheWrapper(backend="cutile")``
+  - ``trtllm`` : ``flashinfer.prefill.trtllm_ragged_attention_deepseek`` (SOTA baseline
+                 used by ocean-eval's dashboard for head_dim_qk=192 ragged prefill)
+
+TWO-FLASHINFER NOTE: the cuTile backend lives only in THIS checkout, while the
+image's INSTALLED flashinfer carries the working trtllm path (the checkout's
+trtllm path can crash with atomic_fmax). Each provider independently try/excepts
+and degrades to NaN, so the bench is typically RUN TWICE and merged:
+
+    python3 bench_ragged_prefill_backend_comparison.py --providers cutile --csv cutile.csv
+    python3 bench_ragged_prefill_backend_comparison.py --providers trtllm --csv trtllm.csv
+
+Workload (DeepSeek MLA prefill): bf16, causal, head_dim_qk=192 head_dim_vo=128,
+num_qo_heads=128, num_kv_heads=8 (GQA). Metric = kernel self-time median (ms).
+Speedup = trtllm_ms / cutile_ms  (>1 == cutile faster).
+
+Requirements:
+    - cuda.tile toolchain (cutile provider); flashinfer trtllm-gen (trtllm provider)
+    - matplotlib for the heatmap
+"""
+
+import argparse
+import csv as _csv
+import math
+import numpy as np
+import torch
+from typing import Callable, Dict, List, Tuple
+
+from flashinfer.testing.utils import bench_gpu_time
+
+# --------------------------------------------------------------------------- #
+# Fixed workload (ocean PrefillRagged / DeepSeek):
+#   head_dim_qk=192, head_dim_vo=128, num_qo_heads=128, num_kv_heads=8, causal.
+# --------------------------------------------------------------------------- #
+DEV = torch.device("cuda")
+DT = torch.bfloat16
+NUM_QO_HEADS = 128
+NUM_KV_HEADS = 8
+HEAD_DIM_QK = 192
+HEAD_DIM_VO = 128
+
+
+# --------------------------------------------------------------------------- #
+# Provider availability
+# --------------------------------------------------------------------------- #
+def _has_cutile() -> bool:
+    try:
+        import cuda.tile  # noqa: F401
+        from flashinfer.attention.kernels.cutile.fmha_prefill_bsr_cutile import (  # noqa: F401
+            prefill_attention_kv_ragged_cutile,
+        )
+        from flashinfer import BatchPrefillWithRaggedKVCacheWrapper  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _has_trtllm() -> bool:
+    try:
+        from flashinfer.prefill import trtllm_ragged_attention_deepseek  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+ALL_PROVIDERS = ["cutile", "trtllm"]
+_AVAIL = {
+    "cutile": _has_cutile,
+    "trtllm": _has_trtllm,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Input generation + per-provider callables
+# --------------------------------------------------------------------------- #
+def _make_inputs(batch: int, seq: int):
+    torch.manual_seed(0)
+    total = batch * seq
+    q = torch.randn(total, NUM_QO_HEADS, HEAD_DIM_QK, dtype=DT, device=DEV)
+    k = torch.randn(total, NUM_KV_HEADS, HEAD_DIM_QK, dtype=DT, device=DEV)
+    v = torch.randn(total, NUM_KV_HEADS, HEAD_DIM_VO, dtype=DT, device=DEV)
+    seq_lens = torch.full((batch,), seq, dtype=torch.int32, device=DEV)
+    # Shared exclusive-prefix-sum offsets == qo_indptr == kv_indptr (full prefill).
+    cum = torch.arange(batch + 1, dtype=torch.int32, device=DEV) * seq
+    return q, k, v, seq_lens, cum
+
+
+def _make_execute(provider: str, batch: int, seq: int) -> Callable[[], torch.Tensor]:
+    q, k, v, seq_lens, cum = _make_inputs(batch, seq)
+    scale = 1.0 / math.sqrt(HEAD_DIM_QK)
+
+    if provider == "cutile":
+        from flashinfer import BatchPrefillWithRaggedKVCacheWrapper
+
+        workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=DEV)
+        wrapper = BatchPrefillWithRaggedKVCacheWrapper(
+            workspace, kv_layout="NHD", backend="cutile"
+        )
+        wrapper.plan(
+            cum,  # qo_indptr
+            cum,  # kv_indptr (== qo_indptr: equal-length full prefill)
+            num_qo_heads=NUM_QO_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim_qk=HEAD_DIM_QK,
+            head_dim_vo=HEAD_DIM_VO,
+            causal=True,
+            sm_scale=scale,
+            q_data_type=DT,
+            kv_data_type=DT,
+        )
+
+        def run():
+            return wrapper.run(q, k, v)
+
+    elif provider == "trtllm":
+        from flashinfer.prefill import trtllm_ragged_attention_deepseek
+
+        # DeepSeek trtllm-gen path needs a larger workspace for big batches.
+        ws_sz = 2 * 1024 * 1024 * 1024
+        ws = torch.zeros(ws_sz, dtype=torch.int8, device=DEV)
+
+        def run():
+            return trtllm_ragged_attention_deepseek(
+                query=q,
+                key=k,
+                value=v,
+                workspace_buffer=ws,
+                seq_lens=seq_lens,
+                max_q_len=seq,
+                max_kv_len=seq,
+                bmm1_scale=scale,
+                bmm2_scale=1.0,
+                o_sf_scale=-1,
+                batch_size=batch,
+                window_left=-1,
+                cum_seq_lens_q=cum,
+                cum_seq_lens_kv=cum,
+                enable_pdl=True,
+                is_causal=True,
+                return_lse=False,
+            )
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run
+
+
+def _as_output(out) -> torch.Tensor:
+    return out[0] if isinstance(out, (list, tuple)) else out
+
+
+# --------------------------------------------------------------------------- #
+# Correctness + timing
+# --------------------------------------------------------------------------- #
+def verify_correctness(batch: int, seq: int, providers: List[str]) -> None:
+    """Cosine-sim of cutile vs trtllm output when both are available; else skip."""
+    if not ("cutile" in providers and "trtllm" in providers):
+        print("  correctness: need both cutile and trtllm available -> SKIP")
+        return
+    if not (_AVAIL["cutile"]() and _AVAIL["trtllm"]()):
+        print("  correctness: both providers not importable here -> SKIP")
+        return
+    try:
+        out_c = _as_output(_make_execute("cutile", batch, seq)()).float().reshape(1, -1)
+        out_t = _as_output(_make_execute("trtllm", batch, seq)()).float().reshape(1, -1)
+        cos = torch.nn.functional.cosine_similarity(out_c, out_t).item()
+        print(f"  correctness @ batch={batch} s_kv={seq}: cos={cos:.4f} "
+              f"{'OK' if cos > 0.99 else 'CHECK'}")
+    except Exception as e:
+        print(f"  correctness: FAILED ({repr(e)[:80]})")
+
+
+def bench_one(batch: int, seq: int, provider: str) -> float:
+    """Median kernel self-time (ms) for one (shape, provider); NaN if unavailable."""
+    if not _AVAIL[provider]():
+        return float("nan")
+    try:
+        run = _make_execute(provider, batch, seq)
+        run()  # warmup / compile
+        torch.cuda.synchronize()
+        times = bench_gpu_time(
+            fn=run,
+            enable_cupti=True,
+            dry_run_iters=5,
+            repeat_iters=30,
+            cold_l2_cache=True,
+            use_cuda_graph=False,
+        )
+        return float(np.median(times))
+    except Exception:
+        return float("nan")
+
+
+# --------------------------------------------------------------------------- #
+# Sweep
+# --------------------------------------------------------------------------- #
+def run_benchmark_sweep(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    providers: List[str],
+) -> Dict[str, Dict[Tuple[int, int], float]]:
+    """Return {provider: {(batch, s_kv): median_ms}}."""
+    results: Dict[str, Dict[Tuple[int, int], float]] = {p: {} for p in providers}
+    configs = [(b, s) for b in batch_values for s in s_kv_values]
+    total = len(configs)
+
+    print(f"\nRagged prefill (DeepSeek hd_qk={HEAD_DIM_QK}/hd_vo={HEAD_DIM_VO}, "
+          f"heads {NUM_QO_HEADS}/{NUM_KV_HEADS}, bf16, causal)")
+    print("=" * (26 + 12 * len(providers)))
+    header = f"{'batch':>6} {'s_kv':>7} |"
+    for p in providers:
+        header += f" {p:>10}"
+    print(header)
+    print("-" * (26 + 12 * len(providers)))
+
+    for i, (batch, seq) in enumerate(configs, 1):
+        row = f"{batch:>6} {seq:>7} |"
+        for p in providers:
+            ms = bench_one(batch, seq, p)
+            results[p][(batch, seq)] = ms
+            row += f" {ms:>10.5f}" if ms == ms else f" {'--':>10}"
+        print(f"[{i:3d}/{total}] " + row)
+        torch.cuda.empty_cache()
+
+    return results
+
+
+def print_summary_table(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    results: Dict[str, Dict[Tuple[int, int], float]],
+    providers: List[str],
+    baseline: str,
+):
+    """Speedup of each provider vs the baseline (>1 = provider faster)."""
+    if baseline not in results:
+        return
+    for p in providers:
+        if p == baseline:
+            continue
+        print(f"\n{'=' * 72}")
+        print(f"Speedup: {p} vs {baseline} ({baseline}_ms / {p}_ms;  >1 = {p} faster)")
+        print(f"{'=' * 72}")
+        header = "batch\\s_kv".ljust(12)
+        for s in s_kv_values:
+            header += f"{s:>10}"
+        print(header)
+        print("-" * (12 + 10 * len(s_kv_values)))
+        ratios = []
+        for batch in batch_values:
+            row = f"{batch:<12}"
+            for s in s_kv_values:
+                bt = results[baseline].get((batch, s), float("nan"))
+                pt = results[p].get((batch, s), float("nan"))
+                if pt == pt and bt == bt and pt > 0:
+                    r = bt / pt
+                    ratios.append(r)
+                    row += f"{r:>10.2f}"
+                else:
+                    row += f"{'N/A':>10}"
+            print(row)
+        if ratios:
+            print(
+                f"\n  geomean {np.exp(np.mean(np.log(ratios))):.2f}x  "
+                f"min {min(ratios):.2f}x  max {max(ratios):.2f}x  "
+                f"({sum(1 for r in ratios if r > 1)}/{len(ratios)} shapes {p} faster)"
+            )
+
+
+def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int], float]]):
+    with open(path, "w", newline="") as f:
+        w = _csv.writer(f)
+        w.writerow(
+            ["provider", "config", "batch", "s_kv", "page_size", "head_dim", "median_ms"]
+        )
+        for provider, d in results.items():
+            for (batch, seq), ms in sorted(d.items()):
+                w.writerow(
+                    [
+                        provider,
+                        "ragged",
+                        batch,
+                        seq,
+                        0,  # ragged: no paging
+                        HEAD_DIM_QK,
+                        f"{ms:.6f}",
+                    ]
+                )
+    print(f"\nWrote {path}")
+
+
+def create_heatmap(
+    batch_values: List[int],
+    s_kv_values: List[int],
+    results: Dict[str, Dict[Tuple[int, int], float]],
+    provider: str,
+    baseline: str,
+    output_file: str,
+):
+    """Heatmap of `provider` speedup vs `baseline` over (batch x s_kv)."""
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as mcolors
+    except ImportError:
+        print("matplotlib not installed, skipping heatmap")
+        return
+    if provider not in results or baseline not in results:
+        return
+    mat = np.full((len(batch_values), len(s_kv_values)), np.nan)
+    for i, batch in enumerate(batch_values):
+        for j, s in enumerate(s_kv_values):
+            bt = results[baseline].get((batch, s), float("nan"))
+            pt = results[provider].get((batch, s), float("nan"))
+            if pt == pt and bt == bt and pt > 0:
+                mat[i, j] = bt / pt
+    if np.all(np.isnan(mat)):
+        return
+    fig, ax = plt.subplots(
+        figsize=(max(6, 1.5 * len(s_kv_values)), max(5, 0.5 * len(batch_values)))
+    )
+    norm = mcolors.TwoSlopeNorm(
+        vmin=min(0.5, np.nanmin(mat)), vcenter=1.0, vmax=max(1.5, np.nanmax(mat))
+    )
+    im = ax.imshow(mat, cmap="RdYlGn", norm=norm, aspect="auto")
+    cbar = ax.figure.colorbar(im, ax=ax, shrink=0.8)
+    cbar.ax.set_ylabel(f"{baseline}_ms / {provider}_ms", rotation=-90, va="bottom")
+    ax.set_xticks(np.arange(len(s_kv_values)))
+    ax.set_yticks(np.arange(len(batch_values)))
+    ax.set_xticklabels([str(s) for s in s_kv_values])
+    ax.set_yticklabels([str(b) for b in batch_values])
+    for i in range(len(batch_values)):
+        for j in range(len(s_kv_values)):
+            if not np.isnan(mat[i, j]):
+                ax.text(j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                        color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black")
+    ax.set_xlabel("s_kv")
+    ax.set_ylabel("batch")
+    ax.set_title(f"ragged prefill: {provider} speedup vs {baseline}\n(>1.0 = {provider} faster)")
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    print(f"Saved heatmap to {output_file}")
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark ragged prefill backends (cuTile vs trtllm SOTA)"
+    )
+    parser.add_argument(
+        "--providers",
+        type=str,
+        default=",".join(ALL_PROVIDERS),
+        help=f"Comma-separated subset of {ALL_PROVIDERS}",
+    )
+    parser.add_argument(
+        "--baseline", type=str, default="trtllm", help="Speedup baseline provider"
+    )
+    parser.add_argument(
+        "--output-prefix", type=str, default="ragged_prefill_backend_comparison"
+    )
+    parser.add_argument("--csv", type=str, default=None, help="Write raw medians to CSV")
+    args = parser.parse_args()
+
+    requested = [p.strip() for p in args.providers.split(",") if p.strip()]
+    providers = [p for p in requested if p in ALL_PROVIDERS]
+    available = [p for p in providers if _AVAIL[p]()]
+    print(f"Requested providers: {providers}")
+    print(f"Available here:      {available}  (unavailable are skipped as N/A)")
+
+    # Ocean PrefillRagged workload: batch {1,16} x s_kv {1024,2048,4096,8192}.
+    batch_values = [1, 16]
+    s_kv_values = [1024, 2048, 4096, 8192]
+
+    print("\nCorrectness check (cutile vs trtllm output):")
+    verify_correctness(1, 1024, providers)
+
+    results = run_benchmark_sweep(batch_values, s_kv_values, providers)
+    baseline = args.baseline if args.baseline in providers else providers[0]
+    print_summary_table(batch_values, s_kv_values, results, providers, baseline)
+
+    if args.csv:
+        write_csv(args.csv, results)
+
+    for p in providers:
+        if p != baseline:
+            create_heatmap(
+                batch_values, s_kv_values, results, p, baseline,
+                f"{args.output_prefix}_{p}_vs_{baseline}.png",
+            )
+
+    print("\n" + "=" * 72)
+    print("BENCHMARK COMPLETE")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_ragged_prefill_backend_comparison.py
+++ b/benchmarks/bench_ragged_prefill_backend_comparison.py
@@ -64,6 +64,7 @@ HEAD_DIM_VO = 128
 # Provider availability
 # --------------------------------------------------------------------------- #
 def _has_cutile() -> bool:
+    """True if this checkout can run the cuTile ragged-prefill backend."""
     try:
         import cuda.tile  # noqa: F401
         from flashinfer.attention.kernels.cutile.fmha_prefill_bsr_cutile import (  # noqa: F401
@@ -77,6 +78,7 @@ def _has_cutile() -> bool:
 
 
 def _has_trtllm() -> bool:
+    """True if the installed flashinfer exposes the trtllm-gen DeepSeek ragged entry point."""
     try:
         from flashinfer.prefill import trtllm_ragged_attention_deepseek  # noqa: F401
 
@@ -96,6 +98,7 @@ _AVAIL = {
 # Input generation + per-provider callables
 # --------------------------------------------------------------------------- #
 def _make_inputs(batch: int, seq: int):
+    """Build the packed ragged q/k/v and the shared prefix-sum offsets for one shape."""
     torch.manual_seed(0)
     total = batch * seq
     q = torch.randn(total, NUM_QO_HEADS, HEAD_DIM_QK, dtype=DT, device=DEV)
@@ -108,6 +111,7 @@ def _make_inputs(batch: int, seq: int):
 
 
 def _make_execute(provider: str, batch: int, seq: int) -> Callable[[], torch.Tensor]:
+    """Return a zero-arg callable running `provider`'s ragged prefill on one shape."""
     q, k, v, seq_lens, cum = _make_inputs(batch, seq)
     scale = 1.0 / math.sqrt(HEAD_DIM_QK)
 
@@ -132,6 +136,7 @@ def _make_execute(provider: str, batch: int, seq: int) -> Callable[[], torch.Ten
         )
 
         def run():
+            """Run cuTile ragged prefill through the planned wrapper."""
             return wrapper.run(q, k, v)
 
     elif provider == "trtllm":
@@ -142,6 +147,7 @@ def _make_execute(provider: str, batch: int, seq: int) -> Callable[[], torch.Ten
         ws = torch.zeros(ws_sz, dtype=torch.int8, device=DEV)
 
         def run():
+            """Run trtllm-gen DeepSeek ragged prefill."""
             return trtllm_ragged_attention_deepseek(
                 query=q,
                 key=k,
@@ -169,6 +175,7 @@ def _make_execute(provider: str, batch: int, seq: int) -> Callable[[], torch.Ten
 
 
 def _as_output(out) -> torch.Tensor:
+    """Unwrap a provider result that may be an (output, lse) tuple."""
     return out[0] if isinstance(out, (list, tuple)) else out
 
 
@@ -295,6 +302,7 @@ def print_summary_table(
 
 
 def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int], float]]):
+    """Write the raw per-provider medians to `path` as CSV."""
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(
@@ -387,6 +395,7 @@ def create_heatmap(
 
 
 def main():
+    """Parse args, sweep the shapes, and emit table / CSV / heatmap."""
     parser = argparse.ArgumentParser(
         description="Benchmark ragged prefill backends (cuTile vs trtllm SOTA)"
     )

--- a/benchmarks/bench_ragged_prefill_backend_comparison.py
+++ b/benchmarks/bench_ragged_prefill_backend_comparison.py
@@ -187,8 +187,10 @@ def verify_correctness(batch: int, seq: int, providers: List[str]) -> None:
         out_c = _as_output(_make_execute("cutile", batch, seq)()).float().reshape(1, -1)
         out_t = _as_output(_make_execute("trtllm", batch, seq)()).float().reshape(1, -1)
         cos = torch.nn.functional.cosine_similarity(out_c, out_t).item()
-        print(f"  correctness @ batch={batch} s_kv={seq}: cos={cos:.4f} "
-              f"{'OK' if cos > 0.99 else 'CHECK'}")
+        print(
+            f"  correctness @ batch={batch} s_kv={seq}: cos={cos:.4f} "
+            f"{'OK' if cos > 0.99 else 'CHECK'}"
+        )
     except Exception as e:
         print(f"  correctness: FAILED ({repr(e)[:80]})")
 
@@ -227,8 +229,10 @@ def run_benchmark_sweep(
     configs = [(b, s) for b in batch_values for s in s_kv_values]
     total = len(configs)
 
-    print(f"\nRagged prefill (DeepSeek hd_qk={HEAD_DIM_QK}/hd_vo={HEAD_DIM_VO}, "
-          f"heads {NUM_QO_HEADS}/{NUM_KV_HEADS}, bf16, causal)")
+    print(
+        f"\nRagged prefill (DeepSeek hd_qk={HEAD_DIM_QK}/hd_vo={HEAD_DIM_VO}, "
+        f"heads {NUM_QO_HEADS}/{NUM_KV_HEADS}, bf16, causal)"
+    )
     print("=" * (26 + 12 * len(providers)))
     header = f"{'batch':>6} {'s_kv':>7} |"
     for p in providers:
@@ -294,7 +298,15 @@ def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int], float]]):
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(
-            ["provider", "config", "batch", "s_kv", "page_size", "head_dim", "median_ms"]
+            [
+                "provider",
+                "config",
+                "batch",
+                "s_kv",
+                "page_size",
+                "head_dim",
+                "median_ms",
+            ]
         )
         for provider, d in results.items():
             for (batch, seq), ms in sorted(d.items()):
@@ -354,11 +366,20 @@ def create_heatmap(
     for i in range(len(batch_values)):
         for j in range(len(s_kv_values)):
             if not np.isnan(mat[i, j]):
-                ax.text(j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
-                        color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black")
+                ax.text(
+                    j,
+                    i,
+                    f"{mat[i, j]:.2f}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
+                    color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
+                )
     ax.set_xlabel("s_kv")
     ax.set_ylabel("batch")
-    ax.set_title(f"ragged prefill: {provider} speedup vs {baseline}\n(>1.0 = {provider} faster)")
+    ax.set_title(
+        f"ragged prefill: {provider} speedup vs {baseline}\n(>1.0 = {provider} faster)"
+    )
     plt.tight_layout()
     plt.savefig(output_file, dpi=150, bbox_inches="tight")
     print(f"Saved heatmap to {output_file}")
@@ -381,7 +402,9 @@ def main():
     parser.add_argument(
         "--output-prefix", type=str, default="ragged_prefill_backend_comparison"
     )
-    parser.add_argument("--csv", type=str, default=None, help="Write raw medians to CSV")
+    parser.add_argument(
+        "--csv", type=str, default=None, help="Write raw medians to CSV"
+    )
     args = parser.parse_args()
 
     requested = [p.strip() for p in args.providers.split(",") if p.strip()]
@@ -407,7 +430,11 @@ def main():
     for p in providers:
         if p != baseline:
             create_heatmap(
-                batch_values, s_kv_values, results, p, baseline,
+                batch_values,
+                s_kv_values,
+                results,
+                p,
+                baseline,
                 f"{args.output_prefix}_{p}_vs_{baseline}.png",
             )
 

--- a/flashinfer/attention/kernels/__init__.py
+++ b/flashinfer/attention/kernels/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/flashinfer/attention/kernels/cutile/__init__.py
+++ b/flashinfer/attention/kernels/cutile/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
@@ -29,6 +29,22 @@ def _next_power_of_2(n: int) -> int:
     return 1 << (n - 1).bit_length()
 
 
+def _supports_trans_qk(device=None) -> bool:
+    """Datacenter-Blackwell predicate for the MLA TRANS_QK fast path.
+
+    The MLA TRANS_QK swap gives the QK-GEMM an M-dim of BLOCK_N (128) to fill the
+    wide WGMMA tile — a large win on sm100/sm103, but the transposed accumulator
+    is [BLOCK_D=512, BLOCK_H] which spills / cuts occupancy on the smaller SMs of
+    sm120 / SM89 / A100, regressing there. Gate it to datacenter Blackwell.
+    """
+    from flashinfer.utils import get_compute_capability
+
+    major, minor = get_compute_capability(
+        device if device is not None else torch.device("cuda")
+    )
+    return major >= 10 and (major, minor) not in ((12, 0), (12, 1))
+
+
 # Module-level tune caches for paged decode and MLA decode
 _decode_kv_paged_tune_cache: dict = {}
 _decode_mla_paged_tune_cache: dict = {}
@@ -818,6 +834,7 @@ def _decode_mla_kv_paged_kernel(
     stride_block_table,
     LOAD_BLOCK_N: ConstInt,
     NUM_PAGES_PER_BLOCK: ConstInt,
+    TRANS_QK: ConstBool,
 ):
     batch_id = ct.bid(0)
     head_block_id = ct.bid(1)
@@ -869,7 +886,14 @@ def _decode_mla_kv_paged_kernel(
 
     m_i = ct.full((BLOCK_H,), -math.inf, dtype=ct.float32)
     l_i = ct.full((BLOCK_H,), 1.0, dtype=ct.float32)
-    acc = ct.full((BLOCK_H, BLOCK_D), 0.0, dtype=ct.float32)
+    # TRANS_QK=True swaps the QK/PV MMA operands so the GEMM M-dim is BLOCK_N
+    # (large, fills the Blackwell WGMMA tile) instead of BLOCK_H (16/32). Only
+    # pays on datacenter Blackwell (sm100/sm103) wide MMA; the host gates it off
+    # elsewhere. The accumulator is transposed to match: [BLOCK_D, BLOCK_H].
+    if TRANS_QK:
+        acc = ct.full((BLOCK_D, BLOCK_H), 0.0, dtype=ct.float32)
+    else:
+        acc = ct.full((BLOCK_H, BLOCK_D), 0.0, dtype=ct.float32)
 
     for iter_idx in range(num_iters):
         curr_n = start_n + iter_idx * BLOCK_N
@@ -928,27 +952,55 @@ def _decode_mla_kv_paged_kernel(
                 LOAD_BLOCK_N,
             )
 
-        qk = ct.mma(
-            q_nope_tile,
-            ct.transpose(k_tile),
-            acc=ct.full((BLOCK_H, BLOCK_N), 0.0, dtype=ct.float32),
-        )
-        if BLOCK_R > 0:
-            qk = ct.mma(q_rope_tile, ct.transpose(k_rope_tile), acc=qk)
+        # QK: TRANS_QK swaps operands so M=BLOCK_N (large) instead of M=BLOCK_H.
+        if TRANS_QK:
+            qk = ct.mma(
+                k_tile,
+                ct.transpose(q_nope_tile),
+                acc=ct.full((BLOCK_N, BLOCK_H), 0.0, dtype=ct.float32),
+            )
+            if BLOCK_R > 0:
+                qk = ct.mma(k_rope_tile, ct.transpose(q_rope_tile), acc=qk)
+        else:
+            qk = ct.mma(
+                q_nope_tile,
+                ct.transpose(k_tile),
+                acc=ct.full((BLOCK_H, BLOCK_N), 0.0, dtype=ct.float32),
+            )
+            if BLOCK_R > 0:
+                qk = ct.mma(q_rope_tile, ct.transpose(k_rope_tile), acc=qk)
 
         if curr_n >= tail_n:
             offs_n = curr_n + offs_n_base
-            mask = ct.reshape((offs_n < end_n), (1, BLOCK_N))
-            qk = ct.where(
-                mask, qk, ct.full((BLOCK_H, BLOCK_N), -1.0e6, dtype=ct.float32)
+            if TRANS_QK:
+                mask = ct.reshape((offs_n < end_n), (BLOCK_N, 1))
+                qk = ct.where(
+                    mask, qk, ct.full((BLOCK_N, BLOCK_H), -1.0e6, dtype=ct.float32)
+                )
+            else:
+                mask = ct.reshape((offs_n < end_n), (1, BLOCK_N))
+                qk = ct.where(
+                    mask, qk, ct.full((BLOCK_H, BLOCK_N), -1.0e6, dtype=ct.float32)
+                )
+
+        # Online-softmax reduces over the N-dim: axis 0 when TRANS_QK (qk is
+        # [BLOCK_N, BLOCK_H]), axis 1 otherwise ([BLOCK_H, BLOCK_N]).
+        if TRANS_QK:
+            qk_max = ct.max(qk, axis=0, keepdims=False)
+            m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+            p = ct.exp2(
+                qk * qk_scale - ct.reshape(m_ij, (1, BLOCK_H)), flush_to_zero=True
             )
-
-        qk_max = ct.max(qk, axis=1, keepdims=False)
-        m_ij = ct.maximum(m_i, (qk_max * qk_scale))
-        p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_H, 1)), flush_to_zero=True)
-
-        alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
-        l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+            alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+            l_i = l_i * alpha + ct.sum(p, axis=0, keepdims=False)
+        else:
+            qk_max = ct.max(qk, axis=1, keepdims=False)
+            m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+            p = ct.exp2(
+                qk * qk_scale - ct.reshape(m_ij, (BLOCK_H, 1)), flush_to_zero=True
+            )
+            alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+            l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
 
         if NUM_PAGES_PER_BLOCK == 1:
             # Reuse page_id from K load
@@ -975,15 +1027,31 @@ def _decode_mla_kv_paged_kernel(
                 LOAD_BLOCK_N,
             )
 
-        acc = acc * ct.reshape(alpha, (BLOCK_H, 1))
-        acc = ct.mma(ct.astype(p, q_nope.dtype), v_tile, acc=acc)
+        # PV: TRANS_QK keeps acc as [BLOCK_D, BLOCK_H] via mma(V^T, p).
+        if TRANS_QK:
+            acc = acc * ct.reshape(alpha, (1, BLOCK_H))
+            acc = ct.mma(ct.transpose(v_tile), ct.astype(p, q_nope.dtype), acc=acc)
+        else:
+            acc = acc * ct.reshape(alpha, (BLOCK_H, 1))
+            acc = ct.mma(ct.astype(p, q_nope.dtype), v_tile, acc=acc)
         m_i = m_ij
 
-    l_i_expanded = ct.reshape(l_i, (BLOCK_H, 1))
-    acc = ct.truediv(
-        (acc * V_SCALE), l_i_expanded, flush_to_zero=True, rounding_mode=RMd.APPROX
-    )
-    acc_out = ct.astype(acc, output.dtype)
+    # Epilogue: normalize by l_i, then (TRANS_QK) transpose [BLOCK_D, BLOCK_H] ->
+    # [BLOCK_H, BLOCK_D] so the store layout matches the non-transposed path.
+    if TRANS_QK:
+        acc = ct.truediv(
+            (acc * V_SCALE),
+            ct.reshape(l_i, (1, BLOCK_H)),
+            flush_to_zero=True,
+            rounding_mode=RMd.APPROX,
+        )
+        acc_out = ct.astype(ct.transpose(acc), output.dtype)
+    else:
+        l_i_expanded = ct.reshape(l_i, (BLOCK_H, 1))
+        acc = ct.truediv(
+            (acc * V_SCALE), l_i_expanded, flush_to_zero=True, rounding_mode=RMd.APPROX
+        )
+        acc_out = ct.astype(acc, output.dtype)
 
     acc_4d = ct.reshape(acc_out, (1, 1, BLOCK_H, BLOCK_D))
     ct.store(
@@ -1329,9 +1397,13 @@ def fmha_decode_bsr_cutile(
     return outputs
 
 
-def _mla_decode_autotune_configs():
+def _mla_decode_autotune_configs(trans_qk: bool = False):
     for bh in [16, 32]:
         for bn in [16, 32, 64, 128]:
+            if trans_qk and bn < 64:
+                # With TRANS_QK the QK-GEMM M-dim = BLOCK_N; Blackwell WGMMA needs
+                # M >= 64, so BLOCK_N < 64 defeats the whole point — skip it.
+                continue
             for occupancy in [1, 2]:
                 yield SimpleNamespace(BLOCK_H=bh, BLOCK_N=bn, occupancy=occupancy)
 
@@ -1359,6 +1431,7 @@ def _mla_decode_autotune_base(
     kv_len_per_split,
     HAS_LSE_OUT,
     stride_block_table,
+    TRANS_QK,
 ):
     mla_cache_key = (
         num_batch,
@@ -1370,12 +1443,13 @@ def _mla_decode_autotune_base(
         NUM_KV_SPLITS,
         kv_len_per_split,
         HAS_LSE_OUT,
+        TRANS_QK,
         q.dtype,
         str(q.device),
     )
     if mla_cache_key not in _decode_mla_paged_tune_cache:
         result = exhaustive_search(
-            list(_mla_decode_autotune_configs()),
+            list(_mla_decode_autotune_configs(TRANS_QK)),
             stream,
             lambda cfg: (
                 num_batch,
@@ -1407,6 +1481,7 @@ def _mla_decode_autotune_base(
                 stride_block_table,
                 min(cfg.BLOCK_N, page_size),
                 max(cfg.BLOCK_N // page_size, 1),
+                TRANS_QK,
             ),
             lambda cfg: {"occupancy": cfg.occupancy},
         )
@@ -1448,6 +1523,7 @@ def _mla_decode_autotune_base(
             stride_block_table,
             min(best_cfg.BLOCK_N, page_size),
             max(best_cfg.BLOCK_N // page_size, 1),
+            TRANS_QK,
         ),
     )
     return Att_Out
@@ -1475,6 +1551,10 @@ def decode_mla_kv_paged_cutile(
     page_size = kv_cache.shape[1]
 
     QUERY_GROUP_SIZE = num_qo_heads
+    # TRANS_QK swaps the QK/PV MMA operands so the GEMM M-dim is BLOCK_N; it only
+    # pays on datacenter Blackwell wide WGMMA (see _supports_trans_qk). Off the
+    # gate this stays False = the original M=BLOCK_H path (no regression).
+    TRANS_QK = QUERY_GROUP_SIZE < 64 and _supports_trans_qk(q.device)
 
     use_autotune = not _AUTOTUNE_DISABLED
     if use_autotune:
@@ -1567,6 +1647,7 @@ def decode_mla_kv_paged_cutile(
             kv_len_per_split,
             HAS_LSE_OUT,
             stride_block_table,
+            TRANS_QK,
         )
 
         if should_use_split_kv:
@@ -1712,6 +1793,7 @@ def decode_mla_kv_paged_cutile(
             stride_block_table,
             LOAD_BLOCK_N,
             NUM_PAGES_PER_BLOCK,
+            TRANS_QK,
         ),
     )
 

--- a/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
@@ -114,10 +114,16 @@ def _splitk_reduce_kernel(
     weights_sum = ct.sum(weights)
     weights = weights / weights_sum
 
+    # attn_splitk_out has NUM_KV_SPLITS (<= POW2) splits on axis 0; only lse is
+    # padded to POW2 by the caller. Zero-fill the out-of-range split rows here so
+    # a non-power-of-two NUM_KV_SPLITS cannot read past the buffer. Those rows
+    # carry weight 0 (their lse is padded to -inf), so the zeros do not affect
+    # the weighted reduction below.
     out_all = ct.load(
         attn_splitk_out,
         (0, batch_id, head_id, 0),
         shape=(NUM_KV_SPLITS_POW2, 1, 1, BLOCK_D),
+        padding_mode=ct.PaddingMode.ZERO,
     )
     out_all = ct.reshape(out_all, (NUM_KV_SPLITS_POW2, BLOCK_D))
     out_all = ct.astype(out_all, ct.float32)

--- a/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
@@ -1,0 +1,1723 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Paged / MLA decode attention (block-sparse-row layout) using the public
+# cuda.tile API, with split-KV reduction and persistent scheduling.
+
+import math
+import os
+from types import SimpleNamespace
+from typing import Optional
+from typing import TypeAlias
+
+import cuda.tile as ct
+import torch
+from cuda.tile import RoundingMode as RMd
+from cuda.tile.tune import exhaustive_search
+
+# Set FLASHINFER_CUTILE_AUTOTUNE_DISABLED=1 to skip exhaustive search
+_AUTOTUNE_DISABLED = os.getenv("FLASHINFER_CUTILE_AUTOTUNE_DISABLED", "0") != "0"
+
+
+def _is_power_of_2(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def _next_power_of_2(n: int) -> int:
+    if n <= 0:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+# Module-level tune caches for paged decode and MLA decode
+_decode_kv_paged_tune_cache: dict = {}
+_decode_mla_paged_tune_cache: dict = {}
+
+INV_LOG_2 = 1.0 / math.log(2)
+
+# Max pages loaded per KV block. _load_page unrolls a balanced ct.cat tree of this
+# many per-page TMA loads; capping it bounds kernel size / autotune compile time
+# (e.g. page_size=1 + BLOCK_N=128 would otherwise build a 128-page tree).
+_MAX_LOAD_PAGES = 8
+
+ConstInt: TypeAlias = ct.Constant[int]
+ConstBool: TypeAlias = ct.Constant[bool]
+ConstFloat: TypeAlias = ct.Constant[float]
+
+
+def _tileiras_supports_advanced_indexing() -> bool:
+    """True iff the active cuTile toolchain can compile ``ct.load_advanced_indexing``.
+
+    That op requires tileiras >= 13.3. ``_get_max_supported_bytecode_version`` returns
+    >= 13.3 only when BOTH the cuda-tile Python frontend lists 13.3 in its supported
+    versions AND the resolved tileiras binary accepts it — exactly the condition under
+    which the gather-TMA loader below will compile. Any probe failure falls back to the
+    per-page tree loader (works on 13.2), so decode never hard-fails on older toolchains.
+    """
+    try:
+        import tempfile
+
+        from cuda.tile._bytecode.version import BytecodeVersion
+        from cuda.tile._compile import _get_max_supported_bytecode_version
+
+        return (
+            _get_max_supported_bytecode_version(tempfile.gettempdir())
+            >= BytecodeVersion.V_13_3
+        )
+    except Exception:
+        return False
+
+
+# Computed once at import. When True, _load_page uses the single gather-TMA
+# ct.load_advanced_indexing (handles arbitrary NUM_PAGES incl. page_size==1);
+# otherwise it falls back to the per-page ct.cat tree loader.
+_SUPPORTS_ADVANCED_INDEXING = _tileiras_supports_advanced_indexing()
+
+
+@ct.kernel
+def _splitk_reduce_kernel(
+    attn_splitk_out,
+    lse_splitk_out,
+    attn_out,
+    actual_seq_lens,
+    NUM_HEADS: ConstInt,
+    NUM_KV_LEN_PER_SPLIT: ConstInt,
+    NUM_KV_SPLITS: ConstInt,
+    NUM_KV_SPLITS_POW2: ConstInt,
+    BLOCK_D: ConstInt,
+):
+    batch_id = ct.bid(0)
+    head_id = ct.bid(1)
+    dtype = attn_out.dtype
+
+    seq_len_tile = ct.load(actual_seq_lens, (batch_id,), shape=(1,))
+    seq_len = seq_len_tile.item()
+    actual_num_splits = (seq_len + NUM_KV_LEN_PER_SPLIT - 1) // NUM_KV_LEN_PER_SPLIT
+    actual_num_splits = ct.minimum(actual_num_splits, NUM_KV_SPLITS)
+
+    lse_vals = ct.load(
+        lse_splitk_out, (batch_id, head_id, 0), shape=(1, 1, NUM_KV_SPLITS_POW2)
+    )
+    lse_vals = ct.reshape(lse_vals, (NUM_KV_SPLITS_POW2,))
+
+    split_indices = ct.arange(NUM_KV_SPLITS_POW2, dtype=ct.int32)
+    valid_mask = split_indices < actual_num_splits
+    lse_vals = ct.where(
+        valid_mask, lse_vals, ct.full((NUM_KV_SPLITS_POW2,), -1e30, dtype=ct.float32)
+    )
+
+    lse_max = ct.max(lse_vals)
+    weights = ct.exp2(lse_vals - lse_max)
+    weights = ct.where(
+        valid_mask, weights, ct.zeros((NUM_KV_SPLITS_POW2,), dtype=ct.float32)
+    )
+    weights_sum = ct.sum(weights)
+    weights = weights / weights_sum
+
+    out_all = ct.load(
+        attn_splitk_out,
+        (0, batch_id, head_id, 0),
+        shape=(NUM_KV_SPLITS_POW2, 1, 1, BLOCK_D),
+    )
+    out_all = ct.reshape(out_all, (NUM_KV_SPLITS_POW2, BLOCK_D))
+    out_all = ct.astype(out_all, ct.float32)
+
+    weights_row = ct.reshape(weights, (1, NUM_KV_SPLITS_POW2))
+    acc = ct.mma(weights_row, out_all, ct.zeros((1, BLOCK_D), dtype=ct.float32))
+    acc = ct.reshape(acc, (BLOCK_D,))
+
+    result = ct.astype(acc, dtype)
+    ct.store(attn_out, (batch_id, head_id, 0), ct.reshape(result, (1, 1, BLOCK_D)))
+
+
+def _splitk_reduce_with_seq_len(
+    attn_splitk_out,
+    lse_splitk_out,
+    actual_seq_lens,
+    num_kv_len_per_split,
+    attn_out=None,
+):
+    NUM_KV_SPLITS, B, num_heads, head_dim = attn_splitk_out.shape
+
+    if attn_out is None:
+        attn_out = torch.empty(
+            (B, num_heads, head_dim),
+            device=attn_splitk_out.device,
+            dtype=attn_splitk_out.dtype,
+        )
+
+    if NUM_KV_SPLITS == 1:
+        attn_out.copy_(attn_splitk_out[0])
+        return attn_out
+
+    if NUM_KV_SPLITS == 2:
+        lse_0, lse_1 = lse_splitk_out[:, :, 0], lse_splitk_out[:, :, 1]
+        lse_max = torch.maximum(lse_0, lse_1)
+        w0, w1 = torch.exp2(lse_0 - lse_max), torch.exp2(lse_1 - lse_max)
+        w_sum = w0 + w1
+        result = (
+            attn_splitk_out[0].float() * w0.unsqueeze(-1)
+            + attn_splitk_out[1].float() * w1.unsqueeze(-1)
+        ) / w_sum.unsqueeze(-1)
+        attn_out.copy_(result.to(attn_out.dtype))
+        return attn_out
+
+    NUM_KV_SPLITS_POW2 = _next_power_of_2(NUM_KV_SPLITS)
+    BLOCK_D = _next_power_of_2(head_dim)
+
+    if NUM_KV_SPLITS < NUM_KV_SPLITS_POW2:
+        lse_padded = torch.full(
+            (B, num_heads, NUM_KV_SPLITS_POW2),
+            float("-inf"),
+            device=lse_splitk_out.device,
+            dtype=lse_splitk_out.dtype,
+        )
+        lse_padded[:, :, :NUM_KV_SPLITS] = lse_splitk_out
+    else:
+        lse_padded = lse_splitk_out
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        (B, num_heads, 1),
+        _splitk_reduce_kernel,
+        (
+            attn_splitk_out,
+            lse_padded,
+            attn_out,
+            actual_seq_lens,
+            num_heads,
+            num_kv_len_per_split,
+            NUM_KV_SPLITS,
+            NUM_KV_SPLITS_POW2,
+            BLOCK_D,
+        ),
+    )
+    return attn_out
+
+
+def _load_page(
+    cache,
+    block_tables,
+    page_table_offset,
+    page,
+    token,
+    off_kv_h,
+    NUM_PAGES,
+    LOAD_BLOCK_N,
+    BLOCK_D,
+    _PAGE_SIZE,
+):
+    """
+    Load data from paged cache via TMA.
+
+    For single page, issues one TMA load.
+    For multiple pages, issues N independent TMA loads and concatenates via ct.cat.
+    Each individual load still uses TMA, loading one page at a time.
+
+    Args:
+        cache: cache array [total_num_pages, PAGE_SIZE, N_KV_HEADS, BLOCK_D]
+        block_tables: flattened page table array
+        page_table_offset: offset into block_tables for current batch
+        page: starting page index in the page table
+        token: token offset within page
+        off_kv_h: KV head index
+        NUM_PAGES: number of pages to load (compile-time constant; any value)
+        LOAD_BLOCK_N: tokens per page load (== PAGE_SIZE)
+        BLOCK_D: feature dimension
+        _PAGE_SIZE: tokens per page (unused; LOAD_BLOCK_N is used instead)
+
+    Returns:
+        Loaded tensor of shape [NUM_PAGES * LOAD_BLOCK_N, BLOCK_D]
+    """
+    # Multi-page load path. On tileiras >= 13.3 (see _SUPPORTS_ADVANCED_INDEXING)
+    # use the single gather-TMA `ct.load_advanced_indexing`, which gathers all
+    # NUM_PAGES pages in one op and handles arbitrary NUM_PAGES (incl. page_size==1).
+    # On 13.2 fall back to _load_page_tree (a balanced ct.cat over per-page TMA
+    # loads) so decode still compiles. The two paths are numerically equivalent;
+    # advanced-indexing is used for generality (page_size==1). `_SUPPORTS_ADVANCED_INDEXING`
+    # is a module-level Python bool, so exactly one branch is traced at compile time.
+    if NUM_PAGES == 1:
+        page_id = ct.gather(
+            block_tables, (page_table_offset + page,), padding_value=0
+        ).item()
+        data = ct.reshape(
+            ct.load(
+                cache,
+                index=(page_id, token // LOAD_BLOCK_N, off_kv_h, 0),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+    elif _SUPPORTS_ADVANCED_INDEXING:
+        p_idx = ct.arange(NUM_PAGES, dtype=ct.int32)
+        page_ids = ct.gather(
+            block_tables, (page_table_offset + page + p_idx,), padding_value=0
+        )
+        data = ct.reshape(
+            ct.load_advanced_indexing(
+                cache,
+                (
+                    page_ids,
+                    ct.Slice(token, LOAD_BLOCK_N),
+                    ct.Slice(off_kv_h, 1),
+                    ct.Slice(0, BLOCK_D),
+                ),
+                padding_mode=ct.PaddingMode.ZERO,
+            ),
+            (NUM_PAGES * LOAD_BLOCK_N, BLOCK_D),
+        )
+    else:
+        data = _load_page_tree(
+            cache,
+            block_tables,
+            page_table_offset,
+            page,
+            token,
+            off_kv_h,
+            0,
+            NUM_PAGES,
+            LOAD_BLOCK_N,
+            BLOCK_D,
+        )
+    return data
+
+
+def _load_page_tree(
+    cache,
+    block_tables,
+    page_table_offset,
+    page,
+    token,
+    off_kv_h,
+    lo,
+    hi,
+    LOAD_BLOCK_N,
+    BLOCK_D,
+):
+    """Load pages [lo, hi) and return them concatenated along axis 0.
+
+    Balanced-tree recursion over the compile-time page range so the result is a
+    single nested ct.cat expression (never a reassigned variable). Page ``lo``
+    starts at the intra-page token offset; later pages start at row 0.
+    """
+    if hi - lo == 1:
+        page_id = ct.gather(
+            block_tables, (page_table_offset + page + lo,), padding_value=0
+        ).item()
+        row = token // LOAD_BLOCK_N if lo == 0 else 0
+        return ct.reshape(
+            ct.load(
+                cache,
+                index=(page_id, row, off_kv_h, 0),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+    mid = (lo + hi) // 2
+    left = _load_page_tree(
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        off_kv_h,
+        lo,
+        mid,
+        LOAD_BLOCK_N,
+        BLOCK_D,
+    )
+    right = _load_page_tree(
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        off_kv_h,
+        mid,
+        hi,
+        LOAD_BLOCK_N,
+        BLOCK_D,
+    )
+    return ct.cat((left, right), 0)
+
+
+def _load_page_wrapper(
+    curr_n,
+    cache,
+    block_tables,
+    page_table_offset,
+    off_kv_h,
+    PAGE_SIZE,
+    BLOCK_N,
+    BLOCK_D,
+    LOAD_BLOCK_N,
+):
+    """
+    Load cache data (K or V) for current position.
+
+    Computes page index and token offset from curr_n, then delegates to _load_page.
+    """
+    NUM_PAGES = BLOCK_N // LOAD_BLOCK_N
+    page = curr_n // PAGE_SIZE
+    token = curr_n % PAGE_SIZE
+
+    data = _load_page(
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        off_kv_h,
+        NUM_PAGES,
+        LOAD_BLOCK_N,
+        BLOCK_D,
+        PAGE_SIZE,
+    )
+    return data
+
+
+@ct.kernel
+def _decode_attention_kv_paged_kernel(
+    q,
+    k_cache,
+    v_cache,
+    actual_seq_lens,
+    block_tables,
+    output,
+    lse_out,
+    K_SCALE: ConstFloat,
+    V_SCALE: ConstFloat,
+    N_KV_HEADS: ConstInt,
+    PAGE_SIZE: ConstInt,
+    BLOCK_H: ConstInt,
+    BLOCK_N: ConstInt,
+    BLOCK_D: ConstInt,
+    QUERY_GROUP_SIZE: ConstInt,
+    NUM_KV_SPLITS: ConstInt,
+    KV_LEN_PER_SPLIT: ConstInt,
+    HAS_LSE_OUT: ConstBool,
+    stride_block_table,
+    NUM_HEAD_BLOCKS: ConstInt,
+    TRANS_QK: ConstBool,
+    LOAD_BLOCK_N: ConstInt,
+    NUM_PAGES_PER_BLOCK: ConstInt,
+):
+    batch_id = ct.bid(0)
+    head_block_id = ct.bid(1)
+    kv_split_id = ct.bid(2)
+
+    kv_head_id = head_block_id // NUM_HEAD_BLOCKS
+    hb = head_block_id % NUM_HEAD_BLOCKS
+
+    seq_len_tile = ct.gather(actual_seq_lens, (batch_id,), padding_value=0)
+    seq_len = seq_len_tile.item()
+
+    qk_scale = K_SCALE * INV_LOG_2
+    page_table_offset = batch_id * stride_block_table
+
+    if KV_LEN_PER_SPLIT > 0:
+        start_n = KV_LEN_PER_SPLIT * kv_split_id
+        end_n = min(start_n + KV_LEN_PER_SPLIT, seq_len)
+    else:
+        start_n = 0
+        end_n = seq_len
+
+    if start_n >= end_n:
+        return
+
+    num_iters = (end_n - start_n + BLOCK_N - 1) // BLOCK_N
+    offs_n_base = ct.arange(BLOCK_N, dtype=ct.int32)
+    tail_n = start_n + ((end_n - start_n) // BLOCK_N) * BLOCK_N
+
+    head_offset = kv_head_id * QUERY_GROUP_SIZE + hb * BLOCK_H
+    head_block_idx = head_offset // BLOCK_H
+
+    q_tile = ct.load(
+        q,
+        index=(batch_id, head_block_idx, 0),
+        shape=(1, BLOCK_H, BLOCK_D),
+        order=(0, 1, 2),
+        allow_tma=True,
+        latency=2,
+    )
+    q_tile = ct.reshape(q_tile, (BLOCK_H, BLOCK_D))
+
+    neg_inf_h = ct.full((BLOCK_H,), -math.inf, dtype=ct.float32)
+    ones_h = ct.full((BLOCK_H,), 1.0, dtype=ct.float32)
+
+    if TRANS_QK:
+        m_i = neg_inf_h
+        l_i = ct.full((BLOCK_N, BLOCK_H), 0.0, dtype=ct.float32)
+        acc = ct.full((BLOCK_D, BLOCK_H), 0.0, dtype=ct.float32)
+        qk_zeros = ct.full((BLOCK_N, BLOCK_H), 0.0, dtype=ct.float32)
+        mask_fill = ct.full((BLOCK_N, BLOCK_H), -1.0e6, dtype=ct.float32)
+
+        for iter_idx in range(num_iters):
+            curr_n = start_n + iter_idx * BLOCK_N
+
+            if NUM_PAGES_PER_BLOCK == 1:
+                # Single-page path: share page_id between K and V loads
+                page = curr_n // PAGE_SIZE
+                token = curr_n % PAGE_SIZE
+                page_id = ct.gather(
+                    block_tables, (page_table_offset + page,), padding_value=0
+                ).item()
+                token_idx = token // LOAD_BLOCK_N
+
+                k = ct.reshape(
+                    ct.load(
+                        k_cache,
+                        index=(page_id, token_idx, kv_head_id, 0),
+                        shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                        order=(0, 1, 2, 3),
+                        allow_tma=True,
+                        latency=2,
+                    ),
+                    (LOAD_BLOCK_N, BLOCK_D),
+                )
+            else:
+                k = _load_page_wrapper(
+                    curr_n,
+                    k_cache,
+                    block_tables,
+                    page_table_offset,
+                    kv_head_id,
+                    PAGE_SIZE,
+                    BLOCK_N,
+                    BLOCK_D,
+                    LOAD_BLOCK_N,
+                )
+
+            qk = ct.mma(k, ct.transpose(q_tile), acc=qk_zeros)
+
+            if curr_n >= tail_n:
+                offs_n = curr_n + offs_n_base
+                mask = ct.reshape((offs_n < end_n), (BLOCK_N, 1))
+                qk = ct.where(mask, qk, mask_fill)
+
+            qk_max = ct.max(qk, axis=0, keepdims=False)
+            m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+            p = ct.exp2(
+                qk * qk_scale - ct.reshape(m_ij, (1, BLOCK_H)), flush_to_zero=True
+            )
+
+            alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+            alpha_2d = ct.reshape(alpha, (1, BLOCK_H))
+            l_i = l_i * alpha_2d + p
+            acc = acc * alpha_2d
+
+            if NUM_PAGES_PER_BLOCK == 1:
+                # Reuse page_id from K load
+                v = ct.reshape(
+                    ct.load(
+                        v_cache,
+                        index=(page_id, token_idx, kv_head_id, 0),
+                        shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                        order=(0, 1, 2, 3),
+                        allow_tma=True,
+                        latency=2,
+                    ),
+                    (LOAD_BLOCK_N, BLOCK_D),
+                )
+            else:
+                v = _load_page_wrapper(
+                    curr_n,
+                    v_cache,
+                    block_tables,
+                    page_table_offset,
+                    kv_head_id,
+                    PAGE_SIZE,
+                    BLOCK_N,
+                    BLOCK_D,
+                    LOAD_BLOCK_N,
+                )
+
+            acc = ct.mma(ct.transpose(v), ct.astype(p, q.dtype), acc=acc)
+            m_i = m_ij
+
+        l_i_sum = ct.sum(l_i, axis=0, keepdims=False)
+        l_i_expanded = ct.reshape(l_i_sum, (1, BLOCK_H))
+        acc = ct.truediv(
+            (acc * V_SCALE), l_i_expanded, flush_to_zero=True, rounding_mode=RMd.APPROX
+        )
+        acc_out = ct.astype(ct.transpose(acc), output.dtype)
+    else:
+        m_i = neg_inf_h
+        l_i = ones_h
+        acc = ct.full((BLOCK_H, BLOCK_D), 0.0, dtype=ct.float32)
+        qk_zeros = ct.full((BLOCK_H, BLOCK_N), 0.0, dtype=ct.float32)
+        mask_fill = ct.full((BLOCK_H, BLOCK_N), -1.0e6, dtype=ct.float32)
+
+        for iter_idx in range(num_iters):
+            curr_n = start_n + iter_idx * BLOCK_N
+
+            if NUM_PAGES_PER_BLOCK == 1:
+                # Single-page path: share page_id between K and V loads
+                page = curr_n // PAGE_SIZE
+                token = curr_n % PAGE_SIZE
+                page_id = ct.gather(
+                    block_tables, (page_table_offset + page,), padding_value=0
+                ).item()
+                token_idx = token // LOAD_BLOCK_N
+
+                k = ct.reshape(
+                    ct.load(
+                        k_cache,
+                        index=(page_id, token_idx, kv_head_id, 0),
+                        shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                        order=(0, 1, 2, 3),
+                        allow_tma=True,
+                        latency=2,
+                    ),
+                    (LOAD_BLOCK_N, BLOCK_D),
+                )
+            else:
+                k = _load_page_wrapper(
+                    curr_n,
+                    k_cache,
+                    block_tables,
+                    page_table_offset,
+                    kv_head_id,
+                    PAGE_SIZE,
+                    BLOCK_N,
+                    BLOCK_D,
+                    LOAD_BLOCK_N,
+                )
+
+            qk = ct.mma(q_tile, ct.transpose(k), acc=qk_zeros)
+
+            if curr_n >= tail_n:
+                offs_n = curr_n + offs_n_base
+                mask = ct.reshape((offs_n < end_n), (1, BLOCK_N))
+                qk = ct.where(mask, qk, mask_fill)
+
+            qk_max = ct.max(qk, axis=1, keepdims=False)
+            m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+            p = ct.exp2(
+                qk * qk_scale - ct.reshape(m_ij, (BLOCK_H, 1)), flush_to_zero=True
+            )
+
+            alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+            l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+
+            if NUM_PAGES_PER_BLOCK == 1:
+                # Reuse page_id from K load
+                v = ct.reshape(
+                    ct.load(
+                        v_cache,
+                        index=(page_id, token_idx, kv_head_id, 0),
+                        shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                        order=(0, 1, 2, 3),
+                        allow_tma=True,
+                        latency=2,
+                    ),
+                    (LOAD_BLOCK_N, BLOCK_D),
+                )
+            else:
+                v = _load_page_wrapper(
+                    curr_n,
+                    v_cache,
+                    block_tables,
+                    page_table_offset,
+                    kv_head_id,
+                    PAGE_SIZE,
+                    BLOCK_N,
+                    BLOCK_D,
+                    LOAD_BLOCK_N,
+                )
+
+            acc = acc * ct.reshape(alpha, (BLOCK_H, 1))
+            acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
+            m_i = m_ij
+
+        l_i_expanded = ct.reshape(l_i, (BLOCK_H, 1))
+        acc = ct.truediv(
+            (acc * V_SCALE), l_i_expanded, flush_to_zero=True, rounding_mode=RMd.APPROX
+        )
+        acc_out = ct.astype(acc, output.dtype)
+
+    acc_4d = ct.reshape(acc_out, (1, 1, BLOCK_H, BLOCK_D))
+    ct.store(
+        output,
+        index=(kv_split_id, batch_id, head_block_idx, 0),
+        tile=acc_4d,
+        order=(0, 1, 2, 3),
+        allow_tma=True,
+        latency=2,
+    )
+
+    if HAS_LSE_OUT:
+        lse = m_i + ct.log2(
+            l_i if not TRANS_QK else ct.sum(l_i, axis=0, keepdims=False)
+        )
+        offs_h = ct.arange(BLOCK_H, dtype=ct.int32)
+        lse_indices = (batch_id, head_offset + offs_h, kv_split_id)
+        ct.scatter(lse_out, lse_indices, lse)
+
+
+def _load_page_mla_tree(
+    cache, block_tables, page_table_offset, page, token, lo, hi, LOAD_BLOCK_N, BLOCK_DIM
+):
+    """Load MLA pages [lo, hi) and return them concatenated along axis 0.
+
+    Balanced-tree recursion over the compile-time page range (mirrors
+    ``_load_page_tree`` for the 4D KV cache) so the result is a single nested
+    ct.cat expression -- never a reassigned variable, which the cuTile tracer
+    rejects. Page ``lo`` starts at the intra-page token offset; later pages
+    start at row 0.
+    """
+    if hi - lo == 1:
+        page_id = ct.gather(
+            block_tables, (page_table_offset + page + lo,), padding_value=0
+        ).item()
+        row = token // LOAD_BLOCK_N if lo == 0 else 0
+        return ct.reshape(
+            ct.load(
+                cache,
+                index=(page_id, row, 0),
+                shape=(1, LOAD_BLOCK_N, BLOCK_DIM),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_DIM),
+        )
+    mid = (lo + hi) // 2
+    left = _load_page_mla_tree(
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        lo,
+        mid,
+        LOAD_BLOCK_N,
+        BLOCK_DIM,
+    )
+    right = _load_page_mla_tree(
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        mid,
+        hi,
+        LOAD_BLOCK_N,
+        BLOCK_DIM,
+    )
+    return ct.cat((left, right), 0)
+
+
+def _load_page_mla(
+    cache,
+    block_tables,
+    page_table_offset,
+    page,
+    token,
+    NUM_PAGES,
+    LOAD_BLOCK_N,
+    BLOCK_DIM,
+    _PAGE_SIZE,
+):
+    """
+    Load data from paged MLA cache (3D: [total_num_pages, PAGE_SIZE, dim]) via TMA.
+
+    Issues one TMA load per page and concatenates via a balanced ct.cat tree,
+    supporting arbitrary NUM_PAGES. A small page_size yields NUM_PAGES up to 16
+    (BLOCK_N // page_size), so the loader must not be limited to a fixed set of
+    page counts -- the previous {1, 2, 4} branches fell through to an undefined
+    ``data`` for NUM_PAGES in {8, 16} and failed during tracing.
+
+    Args:
+        cache: cache array [total_num_pages, PAGE_SIZE, dim]
+        block_tables: flattened page table array
+        page_table_offset: offset into block_tables for current batch
+        page: starting page index in the page table
+        token: token offset within page
+        NUM_PAGES: number of pages to load (any positive compile-time integer)
+        LOAD_BLOCK_N: tokens per page load (== PAGE_SIZE)
+        BLOCK_DIM: feature dimension (BLOCK_D or BLOCK_R)
+        _PAGE_SIZE: tokens per page (unused; LOAD_BLOCK_N is used instead)
+
+    Returns:
+        Loaded tensor of shape [NUM_PAGES * LOAD_BLOCK_N, BLOCK_DIM]
+    """
+    return _load_page_mla_tree(
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        0,
+        NUM_PAGES,
+        LOAD_BLOCK_N,
+        BLOCK_DIM,
+    )
+
+
+def _load_page_mla_wrapper(
+    curr_n,
+    cache,
+    block_tables,
+    page_table_offset,
+    PAGE_SIZE,
+    BLOCK_N,
+    BLOCK_DIM,
+    LOAD_BLOCK_N,
+):
+    """
+    Load MLA cache data (K, V, or K_rope) for current position.
+
+    Computes page index and token offset from curr_n, then delegates to _load_page_mla.
+    """
+    NUM_PAGES = BLOCK_N // LOAD_BLOCK_N
+    page = curr_n // PAGE_SIZE
+    token = curr_n % PAGE_SIZE
+
+    data = _load_page_mla(
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        NUM_PAGES,
+        LOAD_BLOCK_N,
+        BLOCK_DIM,
+        PAGE_SIZE,
+    )
+    return data
+
+
+@ct.kernel
+def _decode_mla_kv_paged_kernel(
+    q_nope,
+    q_rope,
+    k_cache,
+    v_cache,
+    k_rope,
+    actual_seq_lens,
+    block_tables,
+    output,
+    lse_out,
+    K_SCALE: ConstFloat,
+    V_SCALE: ConstFloat,
+    PAGE_SIZE: ConstInt,
+    BLOCK_H: ConstInt,
+    BLOCK_N: ConstInt,
+    BLOCK_D: ConstInt,
+    BLOCK_R: ConstInt,
+    QUERY_GROUP_SIZE: ConstInt,
+    NUM_KV_SPLITS: ConstInt,
+    KV_LEN_PER_SPLIT: ConstInt,
+    HAS_LSE_OUT: ConstBool,
+    stride_block_table,
+    LOAD_BLOCK_N: ConstInt,
+    NUM_PAGES_PER_BLOCK: ConstInt,
+):
+    batch_id = ct.bid(0)
+    head_block_id = ct.bid(1)
+    kv_split_id = ct.bid(2)
+
+    seq_len_tile = ct.gather(actual_seq_lens, (batch_id,), padding_value=0)
+    seq_len = seq_len_tile.item()
+
+    qk_scale = K_SCALE * INV_LOG_2
+    page_table_offset = batch_id * stride_block_table
+
+    if KV_LEN_PER_SPLIT > 0:
+        start_n = KV_LEN_PER_SPLIT * kv_split_id
+        end_n = min(start_n + KV_LEN_PER_SPLIT, seq_len)
+    else:
+        start_n = 0
+        end_n = seq_len
+
+    if start_n >= end_n:
+        return
+
+    num_iters = (end_n - start_n + BLOCK_N - 1) // BLOCK_N
+    offs_n_base = ct.arange(BLOCK_N, dtype=ct.int32)
+    # tail_n = start position of last incomplete block (where masking is needed)
+    tail_n = start_n + ((end_n - start_n) // BLOCK_N) * BLOCK_N
+
+    head_block_idx = head_block_id
+    head_offset = head_block_id * BLOCK_H
+
+    q_nope_tile = ct.load(
+        q_nope,
+        index=(batch_id, head_block_idx, 0),
+        shape=(1, BLOCK_H, BLOCK_D),
+        order=(0, 1, 2),
+        allow_tma=True,
+        latency=2,
+    )
+    q_nope_tile = ct.reshape(q_nope_tile, (BLOCK_H, BLOCK_D))
+
+    q_rope_tile = ct.load(
+        q_rope,
+        index=(batch_id, head_block_idx, 0),
+        shape=(1, BLOCK_H, BLOCK_R),
+        order=(0, 1, 2),
+        allow_tma=True,
+        latency=2,
+    )
+    q_rope_tile = ct.reshape(q_rope_tile, (BLOCK_H, BLOCK_R))
+
+    m_i = ct.full((BLOCK_H,), -math.inf, dtype=ct.float32)
+    l_i = ct.full((BLOCK_H,), 1.0, dtype=ct.float32)
+    acc = ct.full((BLOCK_H, BLOCK_D), 0.0, dtype=ct.float32)
+
+    for iter_idx in range(num_iters):
+        curr_n = start_n + iter_idx * BLOCK_N
+
+        if NUM_PAGES_PER_BLOCK == 1:
+            # Single-page path: share page_id between K, K_rope, and V loads
+            page_idx = curr_n // PAGE_SIZE
+            token_block_idx = (curr_n % PAGE_SIZE) // BLOCK_N
+            page_id = ct.gather(
+                block_tables, (page_table_offset + page_idx,), padding_value=0
+            ).item()
+
+            k_tile = ct.reshape(
+                ct.load(
+                    k_cache,
+                    index=(page_id, token_block_idx, 0),
+                    shape=(1, BLOCK_N, BLOCK_D),
+                    order=(0, 1, 2),
+                    allow_tma=True,
+                    latency=2,
+                ),
+                (BLOCK_N, BLOCK_D),
+            )
+
+            k_rope_tile = ct.reshape(
+                ct.load(
+                    k_rope,
+                    index=(page_id, token_block_idx, 0),
+                    shape=(1, BLOCK_N, BLOCK_R),
+                    order=(0, 1, 2),
+                    allow_tma=True,
+                    latency=2,
+                ),
+                (BLOCK_N, BLOCK_R),
+            )
+        else:
+            # Multi-page path: load BLOCK_N tokens across multiple pages
+            k_tile = _load_page_mla_wrapper(
+                curr_n,
+                k_cache,
+                block_tables,
+                page_table_offset,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_D,
+                LOAD_BLOCK_N,
+            )
+            k_rope_tile = _load_page_mla_wrapper(
+                curr_n,
+                k_rope,
+                block_tables,
+                page_table_offset,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_R,
+                LOAD_BLOCK_N,
+            )
+
+        qk = ct.mma(
+            q_nope_tile,
+            ct.transpose(k_tile),
+            acc=ct.full((BLOCK_H, BLOCK_N), 0.0, dtype=ct.float32),
+        )
+        if BLOCK_R > 0:
+            qk = ct.mma(q_rope_tile, ct.transpose(k_rope_tile), acc=qk)
+
+        if curr_n >= tail_n:
+            offs_n = curr_n + offs_n_base
+            mask = ct.reshape((offs_n < end_n), (1, BLOCK_N))
+            qk = ct.where(
+                mask, qk, ct.full((BLOCK_H, BLOCK_N), -1.0e6, dtype=ct.float32)
+            )
+
+        qk_max = ct.max(qk, axis=1, keepdims=False)
+        m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+        p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_H, 1)), flush_to_zero=True)
+
+        alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+        l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+
+        if NUM_PAGES_PER_BLOCK == 1:
+            # Reuse page_id from K load
+            v_tile = ct.reshape(
+                ct.load(
+                    v_cache,
+                    index=(page_id, token_block_idx, 0),
+                    shape=(1, BLOCK_N, BLOCK_D),
+                    order=(0, 1, 2),
+                    allow_tma=True,
+                    latency=2,
+                ),
+                (BLOCK_N, BLOCK_D),
+            )
+        else:
+            v_tile = _load_page_mla_wrapper(
+                curr_n,
+                v_cache,
+                block_tables,
+                page_table_offset,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_D,
+                LOAD_BLOCK_N,
+            )
+
+        acc = acc * ct.reshape(alpha, (BLOCK_H, 1))
+        acc = ct.mma(ct.astype(p, q_nope.dtype), v_tile, acc=acc)
+        m_i = m_ij
+
+    l_i_expanded = ct.reshape(l_i, (BLOCK_H, 1))
+    acc = ct.truediv(
+        (acc * V_SCALE), l_i_expanded, flush_to_zero=True, rounding_mode=RMd.APPROX
+    )
+    acc_out = ct.astype(acc, output.dtype)
+
+    acc_4d = ct.reshape(acc_out, (1, 1, BLOCK_H, BLOCK_D))
+    ct.store(
+        output,
+        index=(kv_split_id, batch_id, head_block_idx, 0),
+        tile=acc_4d,
+        order=(0, 1, 2, 3),
+        allow_tma=True,
+        latency=2,
+    )
+
+    if HAS_LSE_OUT:
+        lse = m_i + ct.log2(l_i)
+        offs_h = ct.arange(BLOCK_H, dtype=ct.int32)
+        lse_indices = (batch_id, head_offset + offs_h, kv_split_id)
+        ct.scatter(lse_out, lse_indices, lse)
+
+
+_gqa_decode_autotune_cache = {}
+
+
+def _get_gqa_decode_autotune_configs(query_group_size: int, page_size: int = 128):
+    """Get autotune configurations for GQA decode kernel."""
+    cache_key = (query_group_size, page_size)
+    if cache_key not in _gqa_decode_autotune_cache:
+        configs = []
+        # Include small BLOCK_H (2, 4) so common GQA ratios (e.g. 32 qo / 8 kv
+        # heads => query_group_size=4, as in Llama-3) get a real autotune space
+        # instead of collapsing to the single BLOCK_N=page_size fallback below.
+        for BLOCK_H in [2, 4, 8, 16, 32, 64]:
+            if query_group_size >= BLOCK_H and query_group_size % BLOCK_H == 0:
+                # Allow BLOCK_N values that are multiples of page_size for multi-page loading
+                for BLOCK_N in [32, 64, 128]:
+                    if page_size > BLOCK_N:
+                        continue
+                    # BLOCK_N must be a multiple of page_size (or equal)
+                    if page_size < BLOCK_N and BLOCK_N % page_size != 0:
+                        continue
+                    # Cap the per-block page count: _load_page unrolls a balanced
+                    # ct.cat tree of NUM_PAGES per-page TMA loads, so a large
+                    # NUM_PAGES (e.g. page_size=1 + BLOCK_N=128 -> 128 pages)
+                    # compiles a huge kernel and blows up autotune time. 8 keeps
+                    # the useful multi-page configs (page_size>=16 fits fully;
+                    # page_size=1 falls back to the single-page config below).
+                    if BLOCK_N // page_size > _MAX_LOAD_PAGES:
+                        continue
+                    for occupancy in [1, 2]:
+                        configs.append(
+                            SimpleNamespace(
+                                BLOCK_H=BLOCK_H, BLOCK_N=BLOCK_N, occupancy=occupancy
+                            )
+                        )
+        if not configs:
+            # Reached only for odd query_group_size (any even ratio >= 2 gets
+            # BLOCK_H=2 from the loop above). BLOCK_H must DIVIDE query_group_size
+            # or the head-block grid over/under-covers query heads -- so pick the
+            # largest power-of-two divisor (n & -n), which always divides it and
+            # is >= 1. The old _next_power_of_2(n)//2 rounded to a non-divisor
+            # (e.g. ratio 3 -> 2, which splits 3 heads into a 2+2 grid).
+            BLOCK_H = (
+                (query_group_size & -query_group_size) if query_group_size > 0 else 1
+            )
+            configs.append(
+                SimpleNamespace(
+                    BLOCK_H=BLOCK_H, BLOCK_N=min(64, page_size), occupancy=1
+                )
+            )
+        _gqa_decode_autotune_cache[cache_key] = configs
+    return _gqa_decode_autotune_cache[cache_key]
+
+
+def _gqa_decode_autotune_base(
+    stream,
+    q,
+    k_cache,
+    v_cache,
+    actual_seq_lens_flat,
+    block_tables_flat,
+    Att_Out,
+    LSE_Out_arg,
+    num_batch,
+    num_qo_heads,
+    num_kv_heads,
+    total_num_pages,
+    k_scale,
+    v_scale,
+    page_size,
+    head_dim_qk,
+    QUERY_GROUP_SIZE,
+    NUM_KV_SPLITS,
+    kv_len_per_split,
+    HAS_LSE_OUT,
+    stride_block_table,
+    TRANS_QK,
+):
+    configs = _get_gqa_decode_autotune_configs(QUERY_GROUP_SIZE, page_size)
+
+    cache_key = (
+        num_batch,
+        num_qo_heads,
+        num_kv_heads,
+        page_size,
+        head_dim_qk,
+        QUERY_GROUP_SIZE,
+        NUM_KV_SPLITS,
+        kv_len_per_split,
+        HAS_LSE_OUT,
+        TRANS_QK,
+        q.dtype,
+        str(q.device),
+    )
+    if cache_key not in _decode_kv_paged_tune_cache:
+        if _AUTOTUNE_DISABLED:
+            # Respect FLASHINFER_CUTILE_AUTOTUNE_DISABLED: skip the exhaustive
+            # search and take the first (deterministic) config. configs is never
+            # empty -- _get_gqa_decode_autotune_configs always appends a fallback.
+            best_cfg = configs[0]
+        else:
+            result = exhaustive_search(
+                list(configs),
+                stream,
+                lambda cfg: (
+                    num_batch,
+                    num_kv_heads * max(QUERY_GROUP_SIZE // cfg.BLOCK_H, 1),
+                    NUM_KV_SPLITS,
+                ),
+                _decode_attention_kv_paged_kernel,
+                lambda cfg: (
+                    q,
+                    k_cache,
+                    v_cache,
+                    actual_seq_lens_flat,
+                    block_tables_flat,
+                    Att_Out,
+                    LSE_Out_arg,
+                    k_scale,
+                    v_scale,
+                    num_kv_heads,
+                    page_size,
+                    cfg.BLOCK_H,
+                    cfg.BLOCK_N,
+                    head_dim_qk,
+                    QUERY_GROUP_SIZE,
+                    NUM_KV_SPLITS,
+                    kv_len_per_split,
+                    HAS_LSE_OUT,
+                    stride_block_table,
+                    max(QUERY_GROUP_SIZE // cfg.BLOCK_H, 1),
+                    TRANS_QK,
+                    min(cfg.BLOCK_N, page_size),
+                    max(cfg.BLOCK_N // page_size, 1),
+                ),
+                lambda cfg: {"occupancy": cfg.occupancy},
+            )
+            best_cfg = result.best.config
+        _decode_kv_paged_tune_cache[cache_key] = (
+            best_cfg,
+            _decode_attention_kv_paged_kernel.replace_hints(
+                occupancy=best_cfg.occupancy
+            ),
+        )
+    best_cfg, tuned_kernel = _decode_kv_paged_tune_cache[cache_key]
+    ct.launch(
+        stream,
+        (
+            num_batch,
+            num_kv_heads * max(QUERY_GROUP_SIZE // best_cfg.BLOCK_H, 1),
+            NUM_KV_SPLITS,
+        ),
+        tuned_kernel,
+        (
+            q,
+            k_cache,
+            v_cache,
+            actual_seq_lens_flat,
+            block_tables_flat,
+            Att_Out,
+            LSE_Out_arg,
+            k_scale,
+            v_scale,
+            num_kv_heads,
+            page_size,
+            best_cfg.BLOCK_H,
+            best_cfg.BLOCK_N,
+            head_dim_qk,
+            QUERY_GROUP_SIZE,
+            NUM_KV_SPLITS,
+            kv_len_per_split,
+            HAS_LSE_OUT,
+            stride_block_table,
+            max(QUERY_GROUP_SIZE // best_cfg.BLOCK_H, 1),
+            TRANS_QK,
+            min(best_cfg.BLOCK_N, page_size),
+            max(best_cfg.BLOCK_N // page_size, 1),
+        ),
+    )
+    return Att_Out
+
+
+def fmha_decode_bsr_cutile(
+    q,
+    k_cache,
+    v_cache,
+    actual_seq_lens,
+    block_tables,
+    k_scale,
+    v_scale,
+    max_seq_len: int = -1,
+    outputs: Optional[torch.Tensor] = None,
+    force_split_kv: bool = False,
+    force_persistent: bool = False,
+):
+    num_batch = q.shape[0]
+    num_qo_heads = q.shape[1]
+    head_dim_qk = q.shape[-1]
+
+    total_num_pages = k_cache.shape[0]
+    page_size = k_cache.shape[1]
+    num_kv_heads = k_cache.shape[2]
+    head_dim_vo = v_cache.shape[-1]
+
+    if num_qo_heads % num_kv_heads != 0:
+        # QUERY_GROUP_SIZE below is a floor division; a non-integral GQA ratio
+        # would silently drop the trailing query heads.
+        raise ValueError(
+            "cuTile decode requires num_qo_heads % num_kv_heads == 0 "
+            f"(num_qo_heads={num_qo_heads}, num_kv_heads={num_kv_heads})."
+        )
+    if head_dim_qk != head_dim_vo:
+        # The kernel uses a single BLOCK_D (= head_dim_qk) for Q/K loads, the
+        # attention accumulator, V loads, and the output store; a different
+        # head_dim_vo would produce incorrect output.
+        raise NotImplementedError(
+            "cuTile decode requires head_dim_qk == head_dim_vo (got "
+            f"{head_dim_qk} vs {head_dim_vo})."
+        )
+
+    QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
+    TRANS_QK = QUERY_GROUP_SIZE < 64
+
+    if not (_is_power_of_2(head_dim_qk) and _is_power_of_2(head_dim_vo)):
+        raise NotImplementedError(
+            f"cuTile decode attention requires power-of-2 dimensions. Got head_dim_qk={head_dim_qk}, head_dim_vo={head_dim_vo}."
+        )
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    LSE_Out = None
+    kv_len_per_split = -1
+    NUM_KV_SPLITS = 1
+
+    if max_seq_len < 0:
+        max_pages_per_seq = (
+            block_tables.shape[1] if block_tables.dim() > 1 else block_tables.shape[0]
+        )
+        max_seq_len = max_pages_per_seq * page_size
+
+    persistent = num_batch * num_kv_heads > NUM_SMS
+    if force_split_kv:
+        should_use_split_kv = True
+    else:
+        # force_persistent (persistent scheduling) is mutually exclusive with
+        # split-KV; honor it here so the caller can actually disable split-KV.
+        should_use_split_kv = (
+            not force_persistent and not persistent and max_seq_len > 2048
+        )
+
+    if should_use_split_kv:
+        num_split_kv_estimated = max(NUM_SMS // num_batch, 1)
+        kv_len_per_split = 1 << (
+            (max_seq_len // num_split_kv_estimated - 1).bit_length()
+        )
+        kv_len_per_split = max(kv_len_per_split, 128)
+        NUM_KV_SPLITS = (max_seq_len + kv_len_per_split - 1) // kv_len_per_split
+
+        if num_batch <= 4:
+            NUM_KV_SPLITS = min(NUM_KV_SPLITS, 4)
+            kv_len_per_split = (max_seq_len + NUM_KV_SPLITS - 1) // NUM_KV_SPLITS
+            # Align kv_len_per_split to next power of 2 (ensure alignment with BLOCK_N)
+            kv_len_per_split = 1 << (kv_len_per_split - 1).bit_length()
+
+        # Initialize to 0 and -inf so empty splits (where start_n >= end_n) contribute nothing
+        Att_Out = torch.zeros(
+            (NUM_KV_SPLITS, num_batch, num_qo_heads, head_dim_vo),
+            device=q.device,
+            dtype=q.dtype,
+        )
+        LSE_Out = torch.full(
+            (num_batch, num_qo_heads, NUM_KV_SPLITS),
+            float("-inf"),
+            device=q.device,
+            dtype=torch.float32,
+        )
+    else:
+        outputs = (
+            torch.zeros(
+                (num_batch, num_qo_heads, head_dim_vo), device=q.device, dtype=q.dtype
+            )
+            if outputs is None
+            else outputs
+        )
+        Att_Out = outputs.reshape(NUM_KV_SPLITS, num_batch, num_qo_heads, head_dim_vo)
+
+    actual_seq_lens_flat = actual_seq_lens.reshape(-1).contiguous()
+    block_tables_flat = block_tables.reshape(-1).contiguous()
+    stride_block_table = block_tables.shape[1] if block_tables.dim() > 1 else 1
+
+    LSE_Out_arg = (
+        LSE_Out
+        if LSE_Out is not None
+        else torch.zeros(1, device=q.device, dtype=torch.float32)
+    )
+    HAS_LSE_OUT = LSE_Out is not None
+
+    _gqa_decode_autotune_base(
+        torch.cuda.current_stream(),
+        q,
+        k_cache,
+        v_cache,
+        actual_seq_lens_flat,
+        block_tables_flat,
+        Att_Out,
+        LSE_Out_arg,
+        num_batch,
+        num_qo_heads,
+        num_kv_heads,
+        total_num_pages,
+        k_scale,
+        v_scale,
+        page_size,
+        head_dim_qk,
+        QUERY_GROUP_SIZE,
+        NUM_KV_SPLITS,
+        kv_len_per_split,
+        HAS_LSE_OUT,
+        stride_block_table,
+        TRANS_QK,
+    )
+
+    if should_use_split_kv:
+        return _splitk_reduce_with_seq_len(
+            Att_Out, LSE_Out, actual_seq_lens_flat, kv_len_per_split, outputs
+        )
+    return outputs
+
+
+def _mla_decode_autotune_configs():
+    for bh in [16, 32]:
+        for bn in [16, 32, 64, 128]:
+            for occupancy in [1, 2]:
+                yield SimpleNamespace(BLOCK_H=bh, BLOCK_N=bn, occupancy=occupancy)
+
+
+def _mla_decode_autotune_base(
+    stream,
+    q,
+    q_rope,
+    kv_cache,
+    k_rope,
+    actual_seq_lens_flat,
+    block_tables_flat,
+    Att_Out,
+    LSE_Out_arg,
+    num_batch,
+    num_qo_heads,
+    total_num_pages,
+    k_scale,
+    v_scale,
+    page_size,
+    head_dim_qk,
+    head_dim_rope,
+    QUERY_GROUP_SIZE,
+    NUM_KV_SPLITS,
+    kv_len_per_split,
+    HAS_LSE_OUT,
+    stride_block_table,
+):
+    mla_cache_key = (
+        num_batch,
+        num_qo_heads,
+        page_size,
+        head_dim_qk,
+        head_dim_rope,
+        QUERY_GROUP_SIZE,
+        NUM_KV_SPLITS,
+        kv_len_per_split,
+        HAS_LSE_OUT,
+        q.dtype,
+        str(q.device),
+    )
+    if mla_cache_key not in _decode_mla_paged_tune_cache:
+        result = exhaustive_search(
+            list(_mla_decode_autotune_configs()),
+            stream,
+            lambda cfg: (
+                num_batch,
+                (num_qo_heads + cfg.BLOCK_H - 1) // cfg.BLOCK_H,
+                NUM_KV_SPLITS,
+            ),
+            _decode_mla_kv_paged_kernel,
+            lambda cfg: (
+                q,
+                q_rope,
+                kv_cache,
+                kv_cache,
+                k_rope,
+                actual_seq_lens_flat,
+                block_tables_flat,
+                Att_Out,
+                LSE_Out_arg,
+                k_scale,
+                v_scale,
+                page_size,
+                cfg.BLOCK_H,
+                min(cfg.BLOCK_N, page_size),
+                head_dim_qk,
+                head_dim_rope,
+                QUERY_GROUP_SIZE,
+                NUM_KV_SPLITS,
+                kv_len_per_split,
+                HAS_LSE_OUT,
+                stride_block_table,
+                min(cfg.BLOCK_N, page_size),
+                max(cfg.BLOCK_N // page_size, 1),
+            ),
+            lambda cfg: {"occupancy": cfg.occupancy},
+        )
+        best_cfg = result.best.config
+        _decode_mla_paged_tune_cache[mla_cache_key] = (
+            best_cfg,
+            _decode_mla_kv_paged_kernel.replace_hints(occupancy=best_cfg.occupancy),
+        )
+    best_cfg, tuned_kernel = _decode_mla_paged_tune_cache[mla_cache_key]
+    ct.launch(
+        stream,
+        (
+            num_batch,
+            (num_qo_heads + best_cfg.BLOCK_H - 1) // best_cfg.BLOCK_H,
+            NUM_KV_SPLITS,
+        ),
+        tuned_kernel,
+        (
+            q,
+            q_rope,
+            kv_cache,
+            kv_cache,
+            k_rope,
+            actual_seq_lens_flat,
+            block_tables_flat,
+            Att_Out,
+            LSE_Out_arg,
+            k_scale,
+            v_scale,
+            page_size,
+            best_cfg.BLOCK_H,
+            min(best_cfg.BLOCK_N, page_size),
+            head_dim_qk,
+            head_dim_rope,
+            QUERY_GROUP_SIZE,
+            NUM_KV_SPLITS,
+            kv_len_per_split,
+            HAS_LSE_OUT,
+            stride_block_table,
+            min(best_cfg.BLOCK_N, page_size),
+            max(best_cfg.BLOCK_N // page_size, 1),
+        ),
+    )
+    return Att_Out
+
+
+def decode_mla_kv_paged_cutile(
+    q,
+    q_rope,
+    kv_cache,
+    k_rope,
+    actual_seq_lens,
+    block_tables,
+    k_scale,
+    v_scale,
+    max_seq_len: int = -1,
+    outputs: Optional[torch.Tensor] = None,
+    force_split_kv: bool = False,
+    force_persistent: bool = False,
+):
+    num_qo_heads = q.shape[1]
+    head_dim_qk = q.shape[-1]
+    head_dim_rope = q_rope.shape[-1]
+    num_batch = q.shape[0]
+    total_num_pages = kv_cache.shape[0]
+    page_size = kv_cache.shape[1]
+
+    QUERY_GROUP_SIZE = num_qo_heads
+
+    use_autotune = not _AUTOTUNE_DISABLED
+    if use_autotune:
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        num_head_blocks = max(QUERY_GROUP_SIZE // 32, 1)
+        total_work = num_batch * num_head_blocks
+
+        if max_seq_len < 0:
+            max_pages_per_seq = (
+                block_tables.shape[1]
+                if block_tables.dim() > 1
+                else block_tables.shape[0]
+            )
+            estimated_seq_len = max_pages_per_seq * page_size
+        else:
+            estimated_seq_len = max_seq_len
+
+        # Split-KV heuristic: use split-KV when not persistent and seqlen > 256
+        # This parallelizes across the sequence dimension for better SM utilization
+        if force_split_kv or (
+            not force_persistent and estimated_seq_len > 256 and total_work < NUM_SMS
+        ):
+            should_use_split_kv = True
+            num_split_kv_estimated = max(NUM_SMS // num_batch, 1)
+            kv_len_per_split = estimated_seq_len // num_split_kv_estimated
+            kv_len_per_split = max(
+                1 << (kv_len_per_split - 1).bit_length()
+                if kv_len_per_split > 0
+                else 128,
+                128,
+            )
+            NUM_KV_SPLITS = (
+                estimated_seq_len + kv_len_per_split - 1
+            ) // kv_len_per_split
+            max_seq_len = estimated_seq_len
+        else:
+            should_use_split_kv = False
+            NUM_KV_SPLITS = 1
+            kv_len_per_split = -1
+
+        if should_use_split_kv:
+            # Initialize to 0 and -inf so empty splits contribute nothing
+            Att_Out = torch.zeros(
+                (NUM_KV_SPLITS, num_batch, num_qo_heads, head_dim_qk),
+                device=q.device,
+                dtype=q.dtype,
+            )
+            LSE_Out = torch.full(
+                (num_batch, num_qo_heads, NUM_KV_SPLITS),
+                float("-inf"),
+                device=q.device,
+                dtype=torch.float32,
+            )
+        else:
+            outputs = torch.zeros_like(q) if outputs is None else outputs
+            Att_Out = outputs.reshape(1, num_batch, num_qo_heads, head_dim_qk)
+            LSE_Out = torch.zeros(1, device=q.device, dtype=torch.float32)
+
+        actual_seq_lens_flat = actual_seq_lens.reshape(-1).contiguous()
+        block_tables_flat = block_tables.reshape(-1).contiguous()
+        stride_block_table = block_tables.shape[1] if block_tables.dim() > 1 else 1
+
+        HAS_LSE_OUT = should_use_split_kv
+        LSE_Out_arg = (
+            LSE_Out
+            if should_use_split_kv
+            else torch.zeros(1, device=q.device, dtype=torch.float32)
+        )
+
+        _mla_decode_autotune_base(
+            torch.cuda.current_stream(),
+            q,
+            q_rope,
+            kv_cache,
+            k_rope,
+            actual_seq_lens_flat,
+            block_tables_flat,
+            Att_Out,
+            LSE_Out_arg,
+            num_batch,
+            num_qo_heads,
+            total_num_pages,
+            k_scale,
+            v_scale,
+            page_size,
+            head_dim_qk,
+            head_dim_rope,
+            QUERY_GROUP_SIZE,
+            NUM_KV_SPLITS,
+            kv_len_per_split,
+            HAS_LSE_OUT,
+            stride_block_table,
+        )
+
+        if should_use_split_kv:
+            return _splitk_reduce_with_seq_len(
+                Att_Out, LSE_Out, actual_seq_lens_flat, kv_len_per_split, outputs
+            )
+        return outputs
+
+    use_large_block_h = num_batch >= 16
+
+    if use_large_block_h:
+        for bh in [128, 64, 32, 16, 8]:
+            if bh <= QUERY_GROUP_SIZE and QUERY_GROUP_SIZE % bh == 0:
+                BLOCK_H = bh
+                break
+        else:
+            BLOCK_H = max(QUERY_GROUP_SIZE, 1)
+    else:
+        for bh in [16, 8, 32]:
+            if bh <= QUERY_GROUP_SIZE and QUERY_GROUP_SIZE % bh == 0:
+                BLOCK_H = bh
+                break
+        else:
+            BLOCK_H = max(QUERY_GROUP_SIZE, 1)
+
+    while QUERY_GROUP_SIZE % BLOCK_H != 0 and BLOCK_H > 1:
+        BLOCK_H = BLOCK_H // 2
+
+    if not _is_power_of_2(BLOCK_H):
+        # The divisor from the loop above may be non-power-of-2 (e.g.
+        # QUERY_GROUP_SIZE=6 -> BLOCK_H=6). Rounding it (next_pow2//2) can break
+        # divisibility (6 -> 4) and drop query heads. The largest power-of-two
+        # divisor (n & -n) is both a power of two and divides QUERY_GROUP_SIZE.
+        BLOCK_H = QUERY_GROUP_SIZE & -QUERY_GROUP_SIZE
+
+    BLOCK_N = page_size if page_size >= 16 else 16
+    LOAD_BLOCK_N = min(BLOCK_N, page_size)
+    NUM_PAGES_PER_BLOCK = max(BLOCK_N // page_size, 1)
+    num_head_blocks = max(QUERY_GROUP_SIZE // BLOCK_H, 1)
+
+    if not (
+        _is_power_of_2(head_dim_qk)
+        and _is_power_of_2(head_dim_rope)
+        and _is_power_of_2(BLOCK_H)
+    ):
+        raise NotImplementedError(
+            f"cuTile MLA decode requires power-of-2 dimensions. Got head_dim_qk={head_dim_qk}, head_dim_rope={head_dim_rope}, BLOCK_H={BLOCK_H}."
+        )
+
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+    LSE_Out = None
+    kv_len_per_split = -1
+    NUM_KV_SPLITS = 1
+
+    if max_seq_len < 0:
+        max_pages_per_seq = (
+            block_tables.shape[1] if block_tables.dim() > 1 else block_tables.shape[0]
+        )
+        estimated_seq_len = max_pages_per_seq * page_size
+    else:
+        estimated_seq_len = max_seq_len
+
+    # force_split_kv must enter the split path unconditionally (matching the two
+    # paged-decode sites above); the degenerate NUM_KV_SPLITS==1 case below still
+    # resolves should_use_split_kv=False, so no >=1024 length gate is needed.
+    if force_split_kv or (
+        not force_persistent
+        and estimated_seq_len > 256
+        and num_batch * num_head_blocks < NUM_SMS
+    ):
+        num_split_kv_estimated = max(NUM_SMS // num_batch, 1)
+        kv_len_per_split = estimated_seq_len // num_split_kv_estimated
+        kv_len_per_split = max(_next_power_of_2(kv_len_per_split), 128)
+        NUM_KV_SPLITS = (estimated_seq_len + kv_len_per_split - 1) // kv_len_per_split
+        should_use_split_kv = NUM_KV_SPLITS > 1
+        max_seq_len = estimated_seq_len
+    else:
+        should_use_split_kv = False
+        kv_len_per_split = estimated_seq_len
+
+    if should_use_split_kv:
+        # Initialize to 0 and -inf so empty splits contribute nothing
+        Att_Out = torch.zeros(
+            (NUM_KV_SPLITS, num_batch, num_qo_heads, head_dim_qk),
+            device=q.device,
+            dtype=q.dtype,
+        )
+        LSE_Out = torch.full(
+            (num_batch, num_qo_heads, NUM_KV_SPLITS),
+            float("-inf"),
+            device=q.device,
+            dtype=torch.float32,
+        )
+        grid = (num_batch, num_head_blocks, NUM_KV_SPLITS)
+    else:
+        outputs = torch.zeros_like(q) if outputs is None else outputs
+        Att_Out = outputs.reshape(NUM_KV_SPLITS, num_batch, num_qo_heads, head_dim_qk)
+        grid = (num_batch, num_head_blocks, NUM_KV_SPLITS)
+
+    actual_seq_lens_flat = actual_seq_lens.reshape(-1).contiguous()
+    block_tables_flat = block_tables.reshape(-1).contiguous()
+    stride_block_table = block_tables.shape[1] if block_tables.dim() > 1 else 1
+
+    LSE_Out_arg = (
+        LSE_Out
+        if LSE_Out is not None
+        else torch.zeros(1, device=q.device, dtype=torch.float32)
+    )
+    HAS_LSE_OUT = LSE_Out is not None
+
+    num_ctas = 2 if (num_batch >= 16 and BLOCK_H >= 64) else None
+    kernel = (
+        _decode_mla_kv_paged_kernel.replace_hints(num_ctas=num_ctas)
+        if num_ctas
+        else _decode_mla_kv_paged_kernel
+    )
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        grid,
+        kernel,
+        (
+            q,
+            q_rope,
+            kv_cache,
+            kv_cache,
+            k_rope,
+            actual_seq_lens_flat,
+            block_tables_flat,
+            Att_Out,
+            LSE_Out_arg,
+            k_scale,
+            v_scale,
+            page_size,
+            BLOCK_H,
+            BLOCK_N,
+            head_dim_qk,
+            head_dim_rope,
+            QUERY_GROUP_SIZE,
+            NUM_KV_SPLITS,
+            kv_len_per_split,
+            HAS_LSE_OUT,
+            stride_block_table,
+            LOAD_BLOCK_N,
+            NUM_PAGES_PER_BLOCK,
+        ),
+    )
+
+    if should_use_split_kv:
+        return _splitk_reduce_with_seq_len(
+            Att_Out, LSE_Out, actual_seq_lens_flat, kv_len_per_split, outputs
+        )
+    return outputs

--- a/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
@@ -156,18 +156,11 @@ def _splitk_reduce_with_seq_len(
         attn_out.copy_(attn_splitk_out[0])
         return attn_out
 
-    if NUM_KV_SPLITS == 2:
-        lse_0, lse_1 = lse_splitk_out[:, :, 0], lse_splitk_out[:, :, 1]
-        lse_max = torch.maximum(lse_0, lse_1)
-        w0, w1 = torch.exp2(lse_0 - lse_max), torch.exp2(lse_1 - lse_max)
-        w_sum = w0 + w1
-        result = (
-            attn_splitk_out[0].float() * w0.unsqueeze(-1)
-            + attn_splitk_out[1].float() * w1.unsqueeze(-1)
-        ) / w_sum.unsqueeze(-1)
-        attn_out.copy_(result.to(attn_out.dtype))
-        return attn_out
-
+    # NUM_KV_SPLITS >= 2 all go through the cuTile _splitk_reduce_kernel below.
+    # (A former torch-pointwise fast path for exactly 2 splits used torch.exp2,
+    # which routes through PyTorch's nvrtc jiterator — a portability hazard on
+    # toolchains where jiterator can't compile for the running arch. 2 is
+    # already a power of two, so the kernel path handles it with no padding.)
     NUM_KV_SPLITS_POW2 = _next_power_of_2(NUM_KV_SPLITS)
     BLOCK_D = _next_power_of_2(head_dim)
 

--- a/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
@@ -20,10 +20,12 @@ _AUTOTUNE_DISABLED = os.getenv("FLASHINFER_CUTILE_AUTOTUNE_DISABLED", "0") != "0
 
 
 def _is_power_of_2(n: int) -> bool:
+    """True if `n` is a positive power of two."""
     return n > 0 and (n & (n - 1)) == 0
 
 
 def _next_power_of_2(n: int) -> int:
+    """Smallest power of two >= `n` (at least 1)."""
     if n <= 0:
         return 1
     return 1 << (n - 1).bit_length()
@@ -102,6 +104,7 @@ def _splitk_reduce_kernel(
     NUM_KV_SPLITS_POW2: ConstInt,
     BLOCK_D: ConstInt,
 ):
+    """cuTile kernel: combine the per-split partial attention outputs and LSEs into the final output."""
     batch_id = ct.bid(0)
     head_id = ct.bid(1)
     dtype = attn_out.dtype
@@ -159,6 +162,7 @@ def _splitk_reduce_with_seq_len(
     num_kv_len_per_split,
     attn_out=None,
 ):
+    """Host wrapper for the split-KV reduction; copies through when there is a single split."""
     NUM_KV_SPLITS, B, num_heads, head_dim = attn_splitk_out.shape
 
     if attn_out is None:
@@ -423,6 +427,7 @@ def _decode_attention_kv_paged_kernel(
     LOAD_BLOCK_N: ConstInt,
     NUM_PAGES_PER_BLOCK: ConstInt,
 ):
+    """cuTile kernel: paged GQA decode over a block-sparse (page-table) KV cache."""
     batch_id = ct.bid(0)
     head_block_id = ct.bid(1)
     kv_split_id = ct.bid(2)
@@ -836,6 +841,7 @@ def _decode_mla_kv_paged_kernel(
     NUM_PAGES_PER_BLOCK: ConstInt,
     TRANS_QK: ConstBool,
 ):
+    """cuTile kernel: paged DeepSeek-MLA decode over the compressed latent KV cache."""
     batch_id = ct.bid(0)
     head_block_id = ct.bid(1)
     kv_split_id = ct.bid(2)
@@ -1147,6 +1153,7 @@ def _gqa_decode_autotune_base(
     stride_block_table,
     TRANS_QK,
 ):
+    """Launch one GQA-decode autotune candidate and return its output tensor."""
     configs = _get_gqa_decode_autotune_configs(QUERY_GROUP_SIZE, page_size)
 
     cache_key = (
@@ -1264,6 +1271,7 @@ def fmha_decode_bsr_cutile(
     force_split_kv: bool = False,
     force_persistent: bool = False,
 ):
+    """Paged GQA decode entry point: autotune, launch, and reduce split-KV if used."""
     num_batch = q.shape[0]
     num_qo_heads = q.shape[1]
     head_dim_qk = q.shape[-1]
@@ -1398,6 +1406,7 @@ def fmha_decode_bsr_cutile(
 
 
 def _mla_decode_autotune_configs(trans_qk: bool = False):
+    """Yield the MLA-decode autotune candidates valid for this TRANS_QK setting."""
     for bh in [16, 32]:
         for bn in [16, 32, 64, 128]:
             if trans_qk and bn < 64:
@@ -1433,6 +1442,7 @@ def _mla_decode_autotune_base(
     stride_block_table,
     TRANS_QK,
 ):
+    """Launch one MLA-decode autotune candidate and return its output tensor."""
     mla_cache_key = (
         num_batch,
         num_qo_heads,
@@ -1543,6 +1553,7 @@ def decode_mla_kv_paged_cutile(
     force_split_kv: bool = False,
     force_persistent: bool = False,
 ):
+    """Paged MLA decode entry point: pick TRANS_QK, autotune, launch, and reduce split-KV if used."""
     num_qo_heads = q.shape[1]
     head_dim_qk = q.shape[-1]
     head_dim_rope = q_rope.shape[-1]

--- a/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
@@ -131,6 +131,13 @@ def _splitk_reduce_kernel(
         valid_mask, weights, ct.zeros((NUM_KV_SPLITS_POW2,), dtype=ct.float32)
     )
     weights_sum = ct.sum(weights)
+    # An empty sequence (seq_len == 0 -> actual_num_splits == 0) masks every
+    # split off, so weights_sum would be 0 and this division would write NaN to
+    # the output. Clamp the denominator: every weight is already 0, so the
+    # reduction below yields 0 (attention over no keys). For any nonempty
+    # sequence the max-lse split contributes exp2(0) == 1, so weights_sum >= 1
+    # and the clamp is inert.
+    weights_sum = ct.maximum(weights_sum, 1e-30)
     weights = weights / weights_sum
 
     # attn_splitk_out has NUM_KV_SPLITS (<= POW2) splits on axis 0; only lse is

--- a/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_decode_bsr_cutile.py
@@ -867,6 +867,18 @@ def _decode_mla_kv_paged_kernel(
         end_n = seq_len
 
     if start_n >= end_n:
+        # Split-KV scratch is zero-initialized by the host. A no-split launch,
+        # however, writes directly into a caller-owned (or empty-allocated)
+        # output, so an empty request must overwrite that row explicitly.
+        if not HAS_LSE_OUT:
+            ct.store(
+                output,
+                index=(kv_split_id, batch_id, head_block_id, 0),
+                tile=ct.zeros((1, 1, BLOCK_H, BLOCK_D), dtype=output.dtype),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            )
         return
 
     num_iters = (end_n - start_n + BLOCK_N - 1) // BLOCK_N

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -921,6 +921,17 @@ def _prefill_attention_ragged_body(
             k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
             qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
 
+        # Mask KV columns past the valid range. The final BLOCK_N tile is
+        # PAD_ZERO-loaded, so padded columns have qk == 0 and would otherwise add
+        # exp2(-m_ij) mass to the softmax denominator (their V rows are zero, so
+        # only the denominator is corrupted). No-op when off_band_hi is a multiple
+        # of BLOCK_N.
+        offs_n = curr_n + offs_n_base
+        boundary_mask = ct.reshape((offs_n < off_band_hi), (1, BLOCK_N))
+        qk = ct.where(
+            boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
+        )
+
         qk_max = ct.max(qk, axis=1, keepdims=False)
         m_ij = ct.maximum(m_i, (qk_max * qk_scale))
         p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True)
@@ -1190,6 +1201,13 @@ def prefill_attention_kv_paged_cutile(
     head_dim_qk = q.shape[-1]
     head_dim_vo = v_cache.shape[-1]
 
+    if num_qo_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"num_qo_heads ({num_qo_heads}) must be divisible by num_kv_heads "
+            f"({num_kv_heads}); a non-integral GQA ratio floor-divides and maps "
+            "trailing query heads to out-of-range KV heads."
+        )
+
     BLOCK_R = head_dim_qk - head_dim_vo
     QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
 
@@ -1458,6 +1476,13 @@ def prefill_attention_kv_ragged_cutile(
     num_qo_heads = q.shape[1]
     head_dim_qk = q.shape[-1]
     head_dim_vo = v_cache.shape[-1]
+
+    if num_qo_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"num_qo_heads ({num_qo_heads}) must be divisible by num_kv_heads "
+            f"({num_kv_heads}); a non-integral GQA ratio floor-divides and maps "
+            "trailing query heads to out-of-range KV heads."
+        )
 
     BLOCK_R = head_dim_qk - head_dim_vo
     QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -936,18 +936,20 @@ def _prefill_attention_ragged_body(
             k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
             qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
 
-        # Mask KV columns past the valid range. The final BLOCK_N tile is
-        # PAD_ZERO-loaded, so padded columns have qk == 0 and would otherwise add
-        # exp2(-m_ij) mass to the softmax denominator (their V rows are zero, so
-        # only the denominator is corrupted). No-op when off_band_hi is a multiple
-        # of BLOCK_N. (Kept unconditional: the ragged KV is PAD_ZERO-loaded, so
-        # this drops padded columns from the softmax denominator — a different
-        # mechanism from the paged page-0 case; gating it broke ragged tests.)
-        offs_n = curr_n + offs_n_base
-        boundary_mask = ct.reshape((offs_n < off_band_hi), (1, BLOCK_N))
-        qk = ct.where(
-            boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
-        )
+        # Mask KV columns past the valid range. Only the FINAL off-band block can
+        # straddle off_band_hi: for iter_idx < off_band_iters-1, curr_n+BLOCK_N =
+        # (iter_idx+1)*BLOCK_N <= (off_band_iters-1)*BLOCK_N < off_band_hi, so every
+        # column is in range and the mask is a proven no-op. Peeling it to the last
+        # iteration drops a where + a -1e6 tile materialization from the hot loop
+        # (the padded-column-in-denominator hazard only exists on that last tile).
+        if iter_idx == off_band_iters - 1:
+            offs_n = curr_n + offs_n_base
+            boundary_mask = ct.reshape((offs_n < off_band_hi), (1, BLOCK_N))
+            qk = ct.where(
+                boundary_mask,
+                qk,
+                ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32),
+            )
 
         qk_max = ct.max(qk, axis=1, keepdims=False)
         m_ij = ct.maximum(m_i, (qk_max * qk_scale))

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -1250,7 +1250,11 @@ def prefill_attention_kv_paged_cutile(
     # Flatten tensors for kernel
     actual_seq_lens_q_flat = actual_seq_lens_q.reshape(-1).contiguous()
     actual_seq_lens_kv_flat = actual_seq_lens_kv.reshape(-1).contiguous()
-    batch_offsets_flat = actual_seq_offset.reshape(-1).contiguous()
+    # int64: seq_start_index scales the axis-0 base-pointer offset of the q/o
+    # slices (seq_start * num_heads * head_dim). With int32 that product overflows
+    # once a tensor exceeds 2**31 elements (e.g. total_q>=131072 at 128x128),
+    # giving an illegal memory access on large prefills.
+    batch_offsets_flat = actual_seq_offset.reshape(-1).contiguous().to(torch.int64)
     block_tables_flat = block_tables.reshape(-1).contiguous()
     stride_block_table = block_tables.shape[1] if block_tables.dim() > 1 else 1
 
@@ -1528,7 +1532,9 @@ def prefill_attention_kv_ragged_cutile(
     # Flatten tensors for kernel
     actual_seq_lens_q_flat = actual_seq_lens_q.reshape(-1).contiguous()
     actual_seq_lens_kv_flat = actual_seq_lens_kv.reshape(-1).contiguous()
-    batch_offsets_flat = actual_seq_offset.reshape(-1).contiguous()
+    # int64: see paged entry — avoids int32 overflow of the axis-0 base-pointer
+    # offset (seq_start * num_heads * head_dim) on large ragged prefills.
+    batch_offsets_flat = actual_seq_offset.reshape(-1).contiguous().to(torch.int64)
 
     # Autotune key matching Triton's key for consistent caching across problem sizes
     autotune_key = (

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -1,0 +1,1668 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Paged / ragged prefill attention (block-sparse-row layout) using the public
+# cuda.tile API, with two-stage causal masking and boundary-masked multi-page loads.
+
+import math
+from types import SimpleNamespace
+from typing import Optional
+from typing import TypeAlias
+
+import cuda.tile as ct
+import torch
+from cuda.tile import RoundingMode as RMd
+from cuda.tile.tune import exhaustive_search
+
+# Module-level tune caches for prefill kernels
+_prefill_paged_lpt_tune_cache: dict = {}
+_prefill_paged_tune_cache: dict = {}
+_prefill_ragged_lpt_tune_cache: dict = {}
+_prefill_ragged_tune_cache: dict = {}
+
+INV_LOG_2 = 1.0 / math.log(2)
+
+ConstInt: TypeAlias = ct.Constant[int]
+ConstBool: TypeAlias = ct.Constant[bool]
+ConstFloat: TypeAlias = ct.Constant[float]
+
+# Max pages one BLOCK_N may span. _load_page_prefill unrolls a per-page TMA load
+# for NUM_PAGES in {1,2,4,8}; capping BLOCK_N // page_size at 8 keeps configs
+# inside that range and bounds the unrolled-kernel compile time.
+_MAX_LOAD_PAGES = 8
+
+
+def _get_prefill_autotune_configs(page_size=None):
+    configs = [
+        SimpleNamespace(BLOCK_M=128, BLOCK_N=32, occupancy=1, num_ctas=1),
+        SimpleNamespace(BLOCK_M=128, BLOCK_N=64, occupancy=1, num_ctas=1),
+        SimpleNamespace(BLOCK_M=128, BLOCK_N=128, occupancy=1, num_ctas=1),
+    ]
+
+    if torch.cuda.get_device_capability()[0] != 9:
+        configs.extend(
+            [
+                SimpleNamespace(BLOCK_M=256, BLOCK_N=128, occupancy=1, num_ctas=1),
+                SimpleNamespace(BLOCK_M=256, BLOCK_N=64, occupancy=1, num_ctas=1),
+                SimpleNamespace(BLOCK_M=128, BLOCK_N=16, occupancy=1, num_ctas=1),
+                SimpleNamespace(BLOCK_M=128, BLOCK_N=16, occupancy=2, num_ctas=1),
+                SimpleNamespace(BLOCK_M=128, BLOCK_N=32, occupancy=2, num_ctas=1),
+                SimpleNamespace(BLOCK_M=128, BLOCK_N=64, occupancy=2, num_ctas=1),
+                SimpleNamespace(BLOCK_M=128, BLOCK_N=128, occupancy=2, num_ctas=1),
+            ]
+        )
+
+    for cfg in configs:
+        if page_size is not None:
+            # Allow BLOCK_N to span multiple pages (BLOCK_N > page_size) as long as
+            # it is a whole number of pages, so the unrolled 2/4/8-page loader is
+            # actually reachable -- a real throughput win for block-sparse where
+            # page_size == C is small (e.g. 16). This is only correct because the
+            # kernel now boundary-masks the off-band (and on-band) tail; without
+            # that, a BLOCK_N spanning k>1 pages folds out-of-range KV into the
+            # softmax (verified: 94% mismatch). LOAD_BLOCK_N = min(BLOCK_N,
+            # page_size), so NUM_PAGES = BLOCK_N // page_size here; cap it at
+            # _MAX_LOAD_PAGES to stay within the loader's {1,2,4,8} range.
+            if page_size < cfg.BLOCK_N and cfg.BLOCK_N % page_size != 0:
+                continue
+            if cfg.BLOCK_N // page_size > _MAX_LOAD_PAGES:
+                continue
+        yield cfg
+
+
+def _load_page_prefill(
+    cache,
+    block_tables,
+    page_table_offset,
+    page,
+    token,
+    off_kv_h,
+    NUM_PAGES,
+    LOAD_BLOCK_N,
+    BLOCK_D,
+    _PAGE_SIZE,
+    dim3_offset=0,
+    LATENCY=3,
+):
+    """
+    Load data from paged cache via TMA for prefill attention.
+
+    For single page, issues one TMA load.
+    For multiple pages, issues N independent TMA loads and concatenates via ct.cat.
+    """
+    PAD_ZERO = ct.PaddingMode.ZERO
+    if NUM_PAGES == 1:
+        page_id = ct.gather(
+            block_tables, (page_table_offset + page,), padding_value=0
+        ).item()
+        data = ct.reshape(
+            ct.load(
+                cache,
+                index=(page_id, token // LOAD_BLOCK_N, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+    elif NUM_PAGES == 2:
+        pg0 = ct.gather(
+            block_tables, (page_table_offset + page,), padding_value=0
+        ).item()
+        d0 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg0, token // LOAD_BLOCK_N, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg1 = ct.gather(
+            block_tables, (page_table_offset + page + 1,), padding_value=0
+        ).item()
+        d1 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg1, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        data = ct.cat((d0, d1), 0)
+    elif NUM_PAGES == 4:
+        pg0 = ct.gather(
+            block_tables, (page_table_offset + page,), padding_value=0
+        ).item()
+        d0 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg0, token // LOAD_BLOCK_N, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg1 = ct.gather(
+            block_tables, (page_table_offset + page + 1,), padding_value=0
+        ).item()
+        d1 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg1, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg2 = ct.gather(
+            block_tables, (page_table_offset + page + 2,), padding_value=0
+        ).item()
+        d2 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg2, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg3 = ct.gather(
+            block_tables, (page_table_offset + page + 3,), padding_value=0
+        ).item()
+        d3 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg3, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        data = ct.cat((ct.cat((d0, d1), 0), ct.cat((d2, d3), 0)), 0)
+    elif NUM_PAGES == 8:
+        pg0 = ct.gather(
+            block_tables, (page_table_offset + page,), padding_value=0
+        ).item()
+        d0 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg0, token // LOAD_BLOCK_N, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg1 = ct.gather(
+            block_tables, (page_table_offset + page + 1,), padding_value=0
+        ).item()
+        d1 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg1, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg2 = ct.gather(
+            block_tables, (page_table_offset + page + 2,), padding_value=0
+        ).item()
+        d2 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg2, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg3 = ct.gather(
+            block_tables, (page_table_offset + page + 3,), padding_value=0
+        ).item()
+        d3 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg3, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg4 = ct.gather(
+            block_tables, (page_table_offset + page + 4,), padding_value=0
+        ).item()
+        d4 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg4, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg5 = ct.gather(
+            block_tables, (page_table_offset + page + 5,), padding_value=0
+        ).item()
+        d5 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg5, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg6 = ct.gather(
+            block_tables, (page_table_offset + page + 6,), padding_value=0
+        ).item()
+        d6 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg6, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg7 = ct.gather(
+            block_tables, (page_table_offset + page + 7,), padding_value=0
+        ).item()
+        d7 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg7, 0, off_kv_h, dim3_offset),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=LATENCY,
+                padding_mode=PAD_ZERO,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        data = ct.cat(
+            (
+                ct.cat((ct.cat((d0, d1), 0), ct.cat((d2, d3), 0)), 0),
+                ct.cat((ct.cat((d4, d5), 0), ct.cat((d6, d7), 0)), 0),
+            ),
+            0,
+        )
+    return data
+
+
+def _load_page_wrapper_prefill(
+    curr_n,
+    cache,
+    block_tables,
+    page_table_offset,
+    off_kv_h,
+    PAGE_SIZE,
+    BLOCK_N,
+    BLOCK_D,
+    LOAD_BLOCK_N,
+    dim3_offset=0,
+    LATENCY=3,
+):
+    NUM_PAGES = BLOCK_N // LOAD_BLOCK_N
+    page = curr_n // PAGE_SIZE
+    token = curr_n % PAGE_SIZE
+    return _load_page_prefill(
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        off_kv_h,
+        NUM_PAGES,
+        LOAD_BLOCK_N,
+        BLOCK_D,
+        PAGE_SIZE,
+        dim3_offset,
+        LATENCY,
+    )
+
+
+def _prefill_attention_paged_body(
+    batch_id,
+    head_id,
+    seq_block_id,
+    query,
+    key_cache,
+    value_cache,
+    actual_seq_lens_q,
+    actual_seq_lens_kv,
+    batch_offsets,
+    block_tables,
+    output,
+    lse_output,
+    k_scale: ConstFloat,
+    v_scale: ConstFloat,
+    N_KV_HEADS: ConstInt,
+    PAGE_SIZE: ConstInt,
+    BLOCK_M: ConstInt,
+    BLOCK_N: ConstInt,
+    BLOCK_D: ConstInt,
+    BLOCK_R: ConstInt,
+    QUERY_GROUP_SIZE: ConstInt,
+    stride_block_table,
+    IS_CAUSAL: ConstBool,
+    LOAD_BLOCK_N: ConstInt,
+):
+    # Load sequence info
+    seq_start_idx_tile = ct.gather(batch_offsets, (batch_id,), padding_value=0)
+    seq_start_index = seq_start_idx_tile.item()
+
+    seq_len_q_tile = ct.gather(actual_seq_lens_q, (batch_id,), padding_value=0)
+    seq_len_q = seq_len_q_tile.item()
+
+    seq_len_kv_tile = ct.gather(actual_seq_lens_kv, (batch_id,), padding_value=0)
+    seq_len_kv = seq_len_kv_tile.item()
+
+    start_m = BLOCK_M * seq_block_id
+
+    if start_m >= seq_len_q:
+        return
+
+    off_kv_h = head_id // QUERY_GROUP_SIZE
+    qk_scale = k_scale * INV_LOG_2
+    PAD_ZERO = ct.PaddingMode.ZERO
+
+    page_table_offset = batch_id * stride_block_table
+
+    q_seq = query.slice(axis=0, start=seq_start_index, stop=seq_start_index + seq_len_q)
+    o_seq = output.slice(
+        axis=0, start=seq_start_index, stop=seq_start_index + seq_len_q
+    )
+
+    q_tile = ct.load(
+        q_seq,
+        index=(seq_block_id, head_id, 0),
+        shape=(BLOCK_M, 1, BLOCK_D),
+        order=(0, 1, 2),
+        allow_tma=True,
+        latency=2,
+        padding_mode=PAD_ZERO,
+    )
+    q = ct.reshape(q_tile, (BLOCK_M, BLOCK_D))
+
+    q_pe = None
+    if BLOCK_R > 0:
+        q_pe_tile = ct.load(
+            q_seq,
+            index=(seq_block_id, head_id, BLOCK_D // BLOCK_R),
+            shape=(BLOCK_M, 1, BLOCK_R),
+            order=(0, 1, 2),
+            allow_tma=True,
+            latency=2,
+            padding_mode=PAD_ZERO,
+        )
+        q_pe = ct.reshape(q_pe_tile, (BLOCK_M, BLOCK_R))
+
+    # Initialize accumulators
+    m_i = ct.full((BLOCK_M,), -math.inf, dtype=ct.float32)
+    l_i = ct.full((BLOCK_M,), 1.0, dtype=ct.float32)
+    acc = ct.full((BLOCK_M, BLOCK_D), 0.0, dtype=ct.float32)
+
+    # Pre-allocate zero accumulator for QK (hoisted outside loop)
+    qk_zeros = ct.full((BLOCK_M, BLOCK_N), 0.0, dtype=ct.float32)
+
+    offs_n_base = ct.arange(BLOCK_N, dtype=ct.int32)
+    offs_m = start_m + ct.arange(BLOCK_M, dtype=ct.int32)
+
+    # Compute bounds for two-stage causal split
+    if IS_CAUSAL:
+        # Off-band: everything before the diagonal block (fully unmasked)
+        off_band_hi = ct.minimum(seq_len_kv, start_m)
+        # On-band: the diagonal block itself
+        on_band_lo = start_m
+        on_band_hi = ct.minimum(seq_len_kv, start_m + BLOCK_M)
+    else:
+        # Non-causal: process everything in off-band loop
+        off_band_hi = seq_len_kv
+        on_band_lo = 0
+        on_band_hi = 0
+
+    off_band_iters = (off_band_hi + BLOCK_N - 1) // BLOCK_N
+    for iter_idx in range(off_band_iters):
+        curr_n = iter_idx * BLOCK_N
+
+        k = _load_page_wrapper_prefill(
+            curr_n,
+            key_cache,
+            block_tables,
+            page_table_offset,
+            off_kv_h,
+            PAGE_SIZE,
+            BLOCK_N,
+            BLOCK_D,
+            LOAD_BLOCK_N,
+            0,
+            3,
+        )
+
+        qk = ct.mma(q, ct.transpose(k), acc=qk_zeros)
+
+        if BLOCK_R > 0:
+            k_pe = _load_page_wrapper_prefill(
+                curr_n,
+                key_cache,
+                block_tables,
+                page_table_offset,
+                off_kv_h,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_R,
+                LOAD_BLOCK_N,
+                BLOCK_D // BLOCK_R,
+                3,
+            )
+            qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
+
+        # Boundary mask: drop KV positions at/after off_band_hi. Required once a
+        # config lets BLOCK_N span multiple pages (BLOCK_N > page_size): off_band_hi
+        # is then no longer a multiple of BLOCK_N, so the final iteration would
+        # otherwise fold out-of-range KV (next block-row / padding-page 0, which is
+        # real data, not zeros) into the softmax. No-op when off_band_hi is a
+        # multiple of BLOCK_N (the single-page case), so single-page results are bit-identical.
+        offs_n = curr_n + offs_n_base
+        boundary_mask = ct.reshape((offs_n < off_band_hi), (1, BLOCK_N))
+        qk = ct.where(
+            boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
+        )
+
+        # Online softmax with flush_to_zero for IR parity with Triton
+        qk_max = ct.max(qk, axis=1, keepdims=False)
+        m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+        p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True)
+
+        alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+        l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+        acc = acc * ct.reshape(alpha, (BLOCK_M, 1))
+
+        v = _load_page_wrapper_prefill(
+            curr_n,
+            value_cache,
+            block_tables,
+            page_table_offset,
+            off_kv_h,
+            PAGE_SIZE,
+            BLOCK_N,
+            BLOCK_D,
+            LOAD_BLOCK_N,
+            0,
+            4,
+        )
+
+        acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
+        m_i = m_ij
+
+    if IS_CAUSAL:
+        on_band_iters = (on_band_hi - on_band_lo + BLOCK_N - 1) // BLOCK_N
+        for iter_idx in range(on_band_iters):
+            curr_n = on_band_lo + iter_idx * BLOCK_N
+
+            k = _load_page_wrapper_prefill(
+                curr_n,
+                key_cache,
+                block_tables,
+                page_table_offset,
+                off_kv_h,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_D,
+                LOAD_BLOCK_N,
+                0,
+                3,
+            )
+
+            qk = ct.mma(q, ct.transpose(k), acc=qk_zeros)
+
+            if BLOCK_R > 0:
+                k_pe = _load_page_wrapper_prefill(
+                    curr_n,
+                    key_cache,
+                    block_tables,
+                    page_table_offset,
+                    off_kv_h,
+                    PAGE_SIZE,
+                    BLOCK_N,
+                    BLOCK_R,
+                    LOAD_BLOCK_N,
+                    BLOCK_D // BLOCK_R,
+                    3,
+                )
+                qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
+
+            offs_n = curr_n + offs_n_base
+            causal_mask = ct.reshape(offs_m, (BLOCK_M, 1)) >= ct.reshape(
+                offs_n, (1, BLOCK_N)
+            )
+            qk = ct.where(
+                causal_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
+            )
+
+            # Boundary mask: when seq_len_kv < start_m + BLOCK_M, on_band_hi is
+            # clamped to seq_len_kv and the causal mask alone (offs_m >= offs_n)
+            # does not exclude past-seq_len_kv positions that a multi-page BLOCK_N
+            # can pull in. No-op when seq_len_kv is a multiple of BLOCK_N.
+            boundary_mask = ct.reshape((offs_n < seq_len_kv), (1, BLOCK_N))
+            qk = ct.where(
+                boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
+            )
+
+            qk_max = ct.max(qk, axis=1, keepdims=False)
+            m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+            p = ct.exp2(
+                qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True
+            )
+
+            alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+            l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+            acc = acc * ct.reshape(alpha, (BLOCK_M, 1))
+
+            v = _load_page_wrapper_prefill(
+                curr_n,
+                value_cache,
+                block_tables,
+                page_table_offset,
+                off_kv_h,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_D,
+                LOAD_BLOCK_N,
+                0,
+                4,
+            )
+
+            acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
+            m_i = m_ij
+
+    # Epilogue: normalize and store with RMd.APPROX
+    l_i_rcp = ct.truediv(v_scale, l_i, flush_to_zero=True, rounding_mode=RMd.APPROX)
+    acc = acc * ct.reshape(l_i_rcp, (BLOCK_M, 1))
+    lse = m_i + ct.log2(l_i)
+
+    # Store output using TMA
+    acc_out = ct.astype(acc, output.dtype)
+    acc_3d = ct.reshape(acc_out, (BLOCK_M, 1, BLOCK_D))
+    ct.store(
+        o_seq,
+        index=(seq_block_id, head_id, 0),
+        tile=acc_3d,
+        order=(0, 1, 2),
+        allow_tma=True,
+        latency=2,
+    )
+
+    # Store LSE - lse_output is 2D [total_tokens, num_heads]
+    lse_scaled = lse * (1.0 / INV_LOG_2)  # multiply by constant instead of dividing
+    offs_m_store = ct.arange(BLOCK_M, dtype=ct.int32)
+    token_indices = seq_start_index + start_m + offs_m_store
+    head_indices = ct.full((BLOCK_M,), head_id, dtype=ct.int32)
+    lse_mask = offs_m_store + start_m < seq_len_q
+    token_indices_masked = ct.where(
+        lse_mask, token_indices, ct.full((BLOCK_M,), -1, dtype=ct.int32)
+    )
+    lse_indices = (token_indices_masked, head_indices)
+    ct.scatter(lse_output, lse_indices, lse_scaled)
+
+
+@ct.kernel
+def _prefill_attention_paged_kernel(
+    query,
+    key_cache,
+    value_cache,
+    actual_seq_lens_q,
+    actual_seq_lens_kv,
+    batch_offsets,
+    block_tables,
+    output,
+    lse_output,
+    K_SCALE: ConstFloat,
+    V_SCALE: ConstFloat,
+    N_KV_HEADS: ConstInt,
+    PAGE_SIZE: ConstInt,
+    BLOCK_M: ConstInt,
+    BLOCK_N: ConstInt,
+    BLOCK_D: ConstInt,
+    BLOCK_R: ConstInt,
+    QUERY_GROUP_SIZE: ConstInt,
+    stride_block_table,
+    IS_CAUSAL: ConstBool,
+    LOAD_BLOCK_N: ConstInt,
+):
+    batch_id = ct.bid(0)
+    head_id = ct.bid(1)
+    seq_block_id = ct.bid(2)
+
+    _prefill_attention_paged_body(
+        batch_id,
+        head_id,
+        seq_block_id,
+        query,
+        key_cache,
+        value_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        batch_offsets,
+        block_tables,
+        output,
+        lse_output,
+        K_SCALE,
+        V_SCALE,
+        N_KV_HEADS,
+        PAGE_SIZE,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_D,
+        BLOCK_R,
+        QUERY_GROUP_SIZE,
+        stride_block_table,
+        IS_CAUSAL,
+        LOAD_BLOCK_N,
+    )
+
+
+@ct.kernel
+def _prefill_attention_paged_lpt_kernel(
+    query,
+    key_cache,
+    value_cache,
+    actual_seq_lens_q,
+    actual_seq_lens_kv,
+    batch_offsets,
+    block_tables,
+    output,
+    lse_output,
+    K_SCALE: ConstFloat,
+    V_SCALE: ConstFloat,
+    N_KV_HEADS: ConstInt,
+    PAGE_SIZE: ConstInt,
+    BLOCK_M: ConstInt,
+    BLOCK_N: ConstInt,
+    BLOCK_D: ConstInt,
+    BLOCK_R: ConstInt,
+    QUERY_GROUP_SIZE: ConstInt,
+    stride_block_table,
+    IS_CAUSAL: ConstBool,
+    LOAD_BLOCK_N: ConstInt,
+    NUM_HEADS: ConstInt,
+    NUM_BATCH: ConstInt,
+    MAX_SEQ_LEN: ConstInt,
+    SWIZZLE: ConstInt,
+    NUM_HB_QUOTIENT: ConstInt,
+    NUM_HB_REMAINDER: ConstInt,
+):
+    tile_idx = ct.bid(0)
+    NUM_BLOCKS = (MAX_SEQ_LEN + BLOCK_M - 1) // BLOCK_M
+    l2_major_blocks = SWIZZLE * NUM_BLOCKS
+    bidhb = tile_idx // l2_major_blocks
+    l2_mod = tile_idx % l2_major_blocks
+    if bidhb < NUM_HB_QUOTIENT:
+        block = l2_mod // SWIZZLE
+        bidhb_residual = l2_mod % SWIZZLE
+    else:
+        block = l2_mod // NUM_HB_REMAINDER
+        bidhb_residual = l2_mod % NUM_HB_REMAINDER
+    bidhb_actual = bidhb * SWIZZLE + bidhb_residual
+    batch_id = bidhb_actual // NUM_HEADS
+    head_id = bidhb_actual % NUM_HEADS
+    seq_block_id = NUM_BLOCKS - 1 - block
+
+    if (
+        tile_idx >= NUM_BLOCKS * NUM_HEADS * NUM_BATCH
+        or batch_id >= NUM_BATCH
+        or head_id >= NUM_HEADS
+    ):
+        return
+
+    _prefill_attention_paged_body(
+        batch_id,
+        head_id,
+        seq_block_id,
+        query,
+        key_cache,
+        value_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        batch_offsets,
+        block_tables,
+        output,
+        lse_output,
+        K_SCALE,
+        V_SCALE,
+        N_KV_HEADS,
+        PAGE_SIZE,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_D,
+        BLOCK_R,
+        QUERY_GROUP_SIZE,
+        stride_block_table,
+        IS_CAUSAL,
+        LOAD_BLOCK_N,
+    )
+
+
+def _prefill_attention_ragged_body(
+    batch_id,
+    head_id,
+    seq_block_id,
+    query,
+    key_cache,
+    value_cache,
+    actual_seq_lens_q,
+    actual_seq_lens_kv,
+    batch_offsets,
+    output,
+    lse_output,
+    k_scale: ConstFloat,
+    v_scale: ConstFloat,
+    N_KV_HEADS: ConstInt,
+    BLOCK_M: ConstInt,
+    BLOCK_N: ConstInt,
+    BLOCK_D: ConstInt,
+    BLOCK_R: ConstInt,
+    QUERY_GROUP_SIZE: ConstInt,
+    IS_CAUSAL: ConstBool,
+):
+    # Load sequence info
+    seq_start_idx_tile = ct.gather(batch_offsets, (batch_id,), padding_value=0)
+    seq_start_index = seq_start_idx_tile.item()
+
+    seq_len_q_tile = ct.gather(actual_seq_lens_q, (batch_id,), padding_value=0)
+    seq_len_q = seq_len_q_tile.item()
+
+    seq_len_kv_tile = ct.gather(actual_seq_lens_kv, (batch_id,), padding_value=0)
+    seq_len_kv = seq_len_kv_tile.item()
+
+    start_m = BLOCK_M * seq_block_id
+
+    if start_m >= seq_len_q:
+        return
+
+    off_kv_h = head_id // QUERY_GROUP_SIZE
+    qk_scale = k_scale * INV_LOG_2
+    PAD_ZERO = ct.PaddingMode.ZERO
+
+    # Create sliced views for ragged tensors - enables TMA with block indices
+    # Slice along axis 0 to offset base pointer by seq_start_index
+    q_seq = query.slice(axis=0, start=seq_start_index, stop=seq_start_index + seq_len_q)
+    k_seq = key_cache.slice(
+        axis=0, start=seq_start_index, stop=seq_start_index + seq_len_kv
+    )
+    v_seq = value_cache.slice(
+        axis=0, start=seq_start_index, stop=seq_start_index + seq_len_kv
+    )
+    o_seq = output.slice(
+        axis=0, start=seq_start_index, stop=seq_start_index + seq_len_q
+    )
+
+    # Load Q tile using TMA - use seq_block_id as block index
+    # q_seq shape: [seq_len_q, num_heads, head_dim_qk + head_dim_rope]
+    q_tile = ct.load(
+        q_seq,
+        index=(seq_block_id, head_id, 0),
+        shape=(BLOCK_M, 1, BLOCK_D),
+        order=(0, 1, 2),
+        allow_tma=True,
+        latency=2,
+        padding_mode=PAD_ZERO,
+    )
+    q = ct.reshape(q_tile, (BLOCK_M, BLOCK_D))
+
+    # Load Q_PE if needed
+    q_pe = None
+    if BLOCK_R > 0:
+        q_pe_tile = ct.load(
+            q_seq,
+            index=(seq_block_id, head_id, BLOCK_D // BLOCK_R),
+            shape=(BLOCK_M, 1, BLOCK_R),
+            order=(0, 1, 2),
+            allow_tma=True,
+            latency=2,
+            padding_mode=PAD_ZERO,
+        )
+        q_pe = ct.reshape(q_pe_tile, (BLOCK_M, BLOCK_R))
+
+    # Initialize accumulators
+    m_i = ct.full((BLOCK_M,), -math.inf, dtype=ct.float32)
+    l_i = ct.full((BLOCK_M,), 1.0, dtype=ct.float32)
+    acc = ct.full((BLOCK_M, BLOCK_D), 0.0, dtype=ct.float32)
+
+    # Pre-allocate zero accumulator for QK (hoisted outside loop)
+    qk_zeros = ct.full((BLOCK_M, BLOCK_N), 0.0, dtype=ct.float32)
+
+    offs_n_base = ct.arange(BLOCK_N, dtype=ct.int32)
+    offs_m = start_m + ct.arange(BLOCK_M, dtype=ct.int32)
+
+    # Compute bounds for two-stage causal split
+    if IS_CAUSAL:
+        # Off-band: everything before the diagonal block (fully unmasked)
+        off_band_hi = ct.minimum(seq_len_kv, start_m)
+        # On-band: the diagonal block itself
+        on_band_lo = start_m
+        on_band_hi = ct.minimum(seq_len_kv, start_m + BLOCK_M)
+    else:
+        # Non-causal: process everything in off-band loop
+        off_band_hi = seq_len_kv
+        on_band_lo = 0
+        on_band_hi = 0
+
+    off_band_iters = (off_band_hi + BLOCK_N - 1) // BLOCK_N
+    for iter_idx in range(off_band_iters):
+        curr_n = iter_idx * BLOCK_N
+
+        k_tile = ct.load(
+            k_seq,
+            index=(iter_idx, off_kv_h, 0),
+            shape=(BLOCK_N, 1, BLOCK_D),
+            order=(0, 1, 2),
+            allow_tma=True,
+            latency=2,
+            padding_mode=PAD_ZERO,
+        )
+        k = ct.reshape(k_tile, (BLOCK_N, BLOCK_D))
+
+        qk = ct.mma(q, ct.transpose(k), acc=qk_zeros)
+
+        if BLOCK_R > 0:
+            k_pe_tile = ct.load(
+                k_seq,
+                index=(iter_idx, off_kv_h, BLOCK_D // BLOCK_R),
+                shape=(BLOCK_N, 1, BLOCK_R),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+                padding_mode=PAD_ZERO,
+            )
+            k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
+            qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
+
+        qk_max = ct.max(qk, axis=1, keepdims=False)
+        m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+        p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True)
+
+        alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+        l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+        acc = acc * ct.reshape(alpha, (BLOCK_M, 1))
+
+        v_tile = ct.load(
+            v_seq,
+            index=(iter_idx, off_kv_h, 0),
+            shape=(BLOCK_N, 1, BLOCK_D),
+            order=(0, 1, 2),
+            allow_tma=True,
+            latency=2,
+            padding_mode=PAD_ZERO,
+        )
+        v = ct.reshape(v_tile, (BLOCK_N, BLOCK_D))
+
+        acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
+        m_i = m_ij
+
+    if IS_CAUSAL:
+        on_band_iters = (on_band_hi - on_band_lo + BLOCK_N - 1) // BLOCK_N
+        on_band_block_start = on_band_lo // BLOCK_N
+        for iter_idx in range(on_band_iters):
+            curr_n = on_band_lo + iter_idx * BLOCK_N
+            block_idx = on_band_block_start + iter_idx
+
+            k_tile = ct.load(
+                k_seq,
+                index=(block_idx, off_kv_h, 0),
+                shape=(BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+                padding_mode=PAD_ZERO,
+            )
+            k = ct.reshape(k_tile, (BLOCK_N, BLOCK_D))
+
+            qk = ct.mma(q, ct.transpose(k), acc=qk_zeros)
+
+            if BLOCK_R > 0:
+                k_pe_tile = ct.load(
+                    k_seq,
+                    index=(block_idx, off_kv_h, BLOCK_D // BLOCK_R),
+                    shape=(BLOCK_N, 1, BLOCK_R),
+                    order=(0, 1, 2),
+                    allow_tma=True,
+                    latency=2,
+                    padding_mode=PAD_ZERO,
+                )
+                k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
+                qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
+
+            offs_n = curr_n + offs_n_base
+            causal_mask = ct.reshape(offs_m, (BLOCK_M, 1)) >= ct.reshape(
+                offs_n, (1, BLOCK_N)
+            )
+            qk = ct.where(
+                causal_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
+            )
+
+            qk_max = ct.max(qk, axis=1, keepdims=False)
+            m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+            p = ct.exp2(
+                qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True
+            )
+
+            alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+            l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+            acc = acc * ct.reshape(alpha, (BLOCK_M, 1))
+
+            v_tile = ct.load(
+                v_seq,
+                index=(block_idx, off_kv_h, 0),
+                shape=(BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+                padding_mode=PAD_ZERO,
+            )
+            v = ct.reshape(v_tile, (BLOCK_N, BLOCK_D))
+
+            acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
+            m_i = m_ij
+
+    l_i_rcp = ct.truediv(v_scale, l_i, flush_to_zero=True, rounding_mode=RMd.APPROX)
+    acc = acc * ct.reshape(l_i_rcp, (BLOCK_M, 1))
+    lse = m_i + ct.log2(l_i)
+
+    acc_out = ct.astype(acc, output.dtype)
+    acc_3d = ct.reshape(acc_out, (BLOCK_M, 1, BLOCK_D))
+    ct.store(
+        o_seq,
+        index=(seq_block_id, head_id, 0),
+        tile=acc_3d,
+        order=(0, 1, 2),
+        allow_tma=True,
+        latency=2,
+    )
+
+    lse_scaled = lse * (1.0 / INV_LOG_2)
+    offs_m_store = ct.arange(BLOCK_M, dtype=ct.int32)
+    token_indices = seq_start_index + start_m + offs_m_store
+    head_indices = ct.full((BLOCK_M,), head_id, dtype=ct.int32)
+    lse_mask = offs_m_store + start_m < seq_len_q
+    token_indices_masked = ct.where(
+        lse_mask, token_indices, ct.full((BLOCK_M,), -1, dtype=ct.int32)
+    )
+    lse_indices = (token_indices_masked, head_indices)
+    ct.scatter(lse_output, lse_indices, lse_scaled)
+
+
+@ct.kernel
+def _prefill_attention_ragged_kernel(
+    query,
+    key_cache,
+    value_cache,
+    actual_seq_lens_q,
+    actual_seq_lens_kv,
+    batch_offsets,
+    output,
+    lse_output,
+    K_SCALE: ConstFloat,
+    V_SCALE: ConstFloat,
+    N_KV_HEADS: ConstInt,
+    BLOCK_M: ConstInt,
+    BLOCK_N: ConstInt,
+    BLOCK_D: ConstInt,
+    BLOCK_R: ConstInt,
+    QUERY_GROUP_SIZE: ConstInt,
+    IS_CAUSAL: ConstBool,
+):
+    """
+    Prefill attention kernel with ragged (contiguous) KV cache.
+    Optimized with two-stage causal loop split:
+    - Stage 1 (off-band): Fully unmasked region before diagonal - no causal mask needed
+    - Stage 2 (on-band): Diagonal block where causal mask matters
+    """
+    seq_block_id = ct.bid(0)
+    batch_id = ct.bid(1)
+    head_id = ct.bid(2)
+
+    _prefill_attention_ragged_body(
+        batch_id,
+        head_id,
+        seq_block_id,
+        query,
+        key_cache,
+        value_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        batch_offsets,
+        output,
+        lse_output,
+        K_SCALE,
+        V_SCALE,
+        N_KV_HEADS,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_D,
+        BLOCK_R,
+        QUERY_GROUP_SIZE,
+        IS_CAUSAL,
+    )
+
+
+@ct.kernel
+def _prefill_attention_ragged_lpt_kernel(
+    query,
+    key_cache,
+    value_cache,
+    actual_seq_lens_q,
+    actual_seq_lens_kv,
+    batch_offsets,
+    output,
+    lse_output,
+    K_SCALE: ConstFloat,
+    V_SCALE: ConstFloat,
+    N_KV_HEADS: ConstInt,
+    BLOCK_M: ConstInt,
+    BLOCK_N: ConstInt,
+    BLOCK_D: ConstInt,
+    BLOCK_R: ConstInt,
+    QUERY_GROUP_SIZE: ConstInt,
+    IS_CAUSAL: ConstBool,
+    NUM_HEADS: ConstInt,
+    NUM_BATCH: ConstInt,
+    MAX_SEQ_LEN: ConstInt,
+    SWIZZLE: ConstInt,
+    NUM_HB_QUOTIENT: ConstInt,
+    NUM_HB_REMAINDER: ConstInt,
+):
+    tile_idx = ct.bid(0)
+    NUM_BLOCKS = (MAX_SEQ_LEN + BLOCK_M - 1) // BLOCK_M
+    l2_major_blocks = SWIZZLE * NUM_BLOCKS
+    bidhb = tile_idx // l2_major_blocks
+    l2_mod = tile_idx % l2_major_blocks
+    if bidhb < NUM_HB_QUOTIENT:
+        block = l2_mod // SWIZZLE
+        bidhb_residual = l2_mod % SWIZZLE
+    else:
+        block = l2_mod // NUM_HB_REMAINDER
+        bidhb_residual = l2_mod % NUM_HB_REMAINDER
+    bidhb_actual = bidhb * SWIZZLE + bidhb_residual
+    batch_id = bidhb_actual // NUM_HEADS
+    head_id = bidhb_actual % NUM_HEADS
+    seq_block_id = NUM_BLOCKS - 1 - block  # LPT: reverse order
+
+    if (
+        tile_idx >= NUM_BLOCKS * NUM_HEADS * NUM_BATCH
+        or batch_id >= NUM_BATCH
+        or head_id >= NUM_HEADS
+    ):
+        return
+
+    _prefill_attention_ragged_body(
+        batch_id,
+        head_id,
+        seq_block_id,
+        query,
+        key_cache,
+        value_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        batch_offsets,
+        output,
+        lse_output,
+        K_SCALE,
+        V_SCALE,
+        N_KV_HEADS,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_D,
+        BLOCK_R,
+        QUERY_GROUP_SIZE,
+        IS_CAUSAL,
+    )
+
+
+def prefill_attention_kv_paged_cutile(
+    q,
+    k_cache,
+    v_cache,
+    actual_seq_lens_q,
+    actual_seq_lens_kv,
+    actual_seq_offset,
+    block_tables,
+    k_scale,
+    v_scale,
+    num_batch,
+    max_seq_len,
+    is_causal: bool = True,
+    outputs: Optional[torch.Tensor] = None,
+    out_lse: Optional[torch.Tensor] = None,
+    use_lpt_scheduler: bool = True,
+):
+    """
+    Prefill attention with paged KV cache (cuTile implementation).
+    """
+    # KV cache [num_pages, page_size, num_kv_heads, head_dim_qk]
+    total_num_pages = k_cache.shape[0]
+    page_size = k_cache.shape[1]
+    num_kv_heads = k_cache.shape[2]
+    num_qo_heads = q.shape[1]
+    head_dim_qk = q.shape[-1]
+    head_dim_vo = v_cache.shape[-1]
+
+    BLOCK_R = head_dim_qk - head_dim_vo
+    QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
+
+    outputs = (
+        torch.zeros(
+            [q.shape[0], num_qo_heads, head_dim_vo],
+            dtype=q.dtype,
+            device=q.device,
+        )
+        if outputs is None
+        else outputs
+    )
+    out_lse = (
+        torch.zeros([q.shape[0], num_qo_heads], dtype=torch.float32, device=q.device)
+        if out_lse is None
+        else out_lse
+    )
+
+    # Flatten tensors for kernel
+    actual_seq_lens_q_flat = actual_seq_lens_q.reshape(-1).contiguous()
+    actual_seq_lens_kv_flat = actual_seq_lens_kv.reshape(-1).contiguous()
+    batch_offsets_flat = actual_seq_offset.reshape(-1).contiguous()
+    block_tables_flat = block_tables.reshape(-1).contiguous()
+    stride_block_table = block_tables.shape[1] if block_tables.dim() > 1 else 1
+
+    if use_lpt_scheduler:
+        element_size = q.element_size()
+        size_one_kv_head = max_seq_len * (head_dim_qk + head_dim_vo) * element_size
+        size_l2 = 50 * 1024 * 1024  # 50 MB for K & V
+        if size_l2 < size_one_kv_head:
+            swizzle = 1
+        else:
+            log2_floor = (size_l2 // size_one_kv_head).bit_length() - 1
+            swizzle = 1 << log2_floor
+        num_hb_quotient = (num_qo_heads * num_batch) // swizzle
+        num_hb_remainder = (num_qo_heads * num_batch) % swizzle
+
+        paged_lpt_stream = torch.cuda.current_stream()
+        paged_lpt_cache_key = (
+            num_batch,
+            num_qo_heads,
+            num_kv_heads,
+            total_num_pages,
+            page_size,
+            head_dim_qk,
+            head_dim_vo,
+            BLOCK_R,
+            QUERY_GROUP_SIZE,
+            max_seq_len,
+            is_causal,
+            swizzle,
+            q.dtype,
+            str(q.device),
+        )
+        if paged_lpt_cache_key not in _prefill_paged_lpt_tune_cache:
+            result = exhaustive_search(
+                list(_get_prefill_autotune_configs(page_size)),
+                paged_lpt_stream,
+                lambda cfg: (
+                    (max_seq_len + cfg.BLOCK_M - 1)
+                    // cfg.BLOCK_M
+                    * num_qo_heads
+                    * num_batch,
+                    1,
+                    1,
+                ),
+                _prefill_attention_paged_lpt_kernel,
+                lambda cfg: (
+                    q,
+                    k_cache,
+                    v_cache,
+                    actual_seq_lens_q_flat,
+                    actual_seq_lens_kv_flat,
+                    batch_offsets_flat,
+                    block_tables_flat,
+                    outputs,
+                    out_lse,
+                    k_scale,
+                    v_scale,
+                    num_kv_heads,
+                    page_size,
+                    cfg.BLOCK_M,
+                    cfg.BLOCK_N,
+                    head_dim_vo,
+                    BLOCK_R,
+                    QUERY_GROUP_SIZE,
+                    stride_block_table,
+                    is_causal,
+                    min(cfg.BLOCK_N, page_size),
+                    num_qo_heads,
+                    num_batch,
+                    max_seq_len,
+                    swizzle,
+                    num_hb_quotient,
+                    max(num_hb_remainder, 1),
+                ),
+                lambda cfg: {"occupancy": cfg.occupancy},
+            )
+            best_cfg = result.best.config
+            _prefill_paged_lpt_tune_cache[paged_lpt_cache_key] = (
+                best_cfg,
+                _prefill_attention_paged_lpt_kernel.replace_hints(
+                    occupancy=best_cfg.occupancy
+                ),
+            )
+        best_cfg, tuned_kernel = _prefill_paged_lpt_tune_cache[paged_lpt_cache_key]
+        ct.launch(
+            paged_lpt_stream,
+            (
+                (max_seq_len + best_cfg.BLOCK_M - 1)
+                // best_cfg.BLOCK_M
+                * num_qo_heads
+                * num_batch,
+                1,
+                1,
+            ),
+            tuned_kernel,
+            (
+                q,
+                k_cache,
+                v_cache,
+                actual_seq_lens_q_flat,
+                actual_seq_lens_kv_flat,
+                batch_offsets_flat,
+                block_tables_flat,
+                outputs,
+                out_lse,
+                k_scale,
+                v_scale,
+                num_kv_heads,
+                page_size,
+                best_cfg.BLOCK_M,
+                best_cfg.BLOCK_N,
+                head_dim_vo,
+                BLOCK_R,
+                QUERY_GROUP_SIZE,
+                stride_block_table,
+                is_causal,
+                min(best_cfg.BLOCK_N, page_size),
+                num_qo_heads,
+                num_batch,
+                max_seq_len,
+                swizzle,
+                num_hb_quotient,
+                max(num_hb_remainder, 1),
+            ),
+        )
+    else:
+        paged_stream = torch.cuda.current_stream()
+        paged_cache_key = (
+            num_batch,
+            num_qo_heads,
+            num_kv_heads,
+            total_num_pages,
+            page_size,
+            head_dim_qk,
+            head_dim_vo,
+            BLOCK_R,
+            QUERY_GROUP_SIZE,
+            max_seq_len,
+            is_causal,
+            q.dtype,
+            str(q.device),
+        )
+        if paged_cache_key not in _prefill_paged_tune_cache:
+            result = exhaustive_search(
+                list(_get_prefill_autotune_configs(page_size)),
+                paged_stream,
+                lambda cfg: (
+                    num_batch,
+                    num_qo_heads,
+                    (max_seq_len + cfg.BLOCK_M - 1) // cfg.BLOCK_M,
+                ),
+                _prefill_attention_paged_kernel,
+                lambda cfg: (
+                    q,
+                    k_cache,
+                    v_cache,
+                    actual_seq_lens_q_flat,
+                    actual_seq_lens_kv_flat,
+                    batch_offsets_flat,
+                    block_tables_flat,
+                    outputs,
+                    out_lse,
+                    k_scale,
+                    v_scale,
+                    num_kv_heads,
+                    page_size,
+                    cfg.BLOCK_M,
+                    cfg.BLOCK_N,
+                    head_dim_vo,
+                    BLOCK_R,
+                    QUERY_GROUP_SIZE,
+                    stride_block_table,
+                    is_causal,
+                    min(cfg.BLOCK_N, page_size),
+                ),
+                lambda cfg: {"occupancy": cfg.occupancy},
+            )
+            best_cfg = result.best.config
+            _prefill_paged_tune_cache[paged_cache_key] = (
+                best_cfg,
+                _prefill_attention_paged_kernel.replace_hints(
+                    occupancy=best_cfg.occupancy
+                ),
+            )
+        best_cfg, tuned_kernel = _prefill_paged_tune_cache[paged_cache_key]
+        ct.launch(
+            paged_stream,
+            (
+                num_batch,
+                num_qo_heads,
+                (max_seq_len + best_cfg.BLOCK_M - 1) // best_cfg.BLOCK_M,
+            ),
+            tuned_kernel,
+            (
+                q,
+                k_cache,
+                v_cache,
+                actual_seq_lens_q_flat,
+                actual_seq_lens_kv_flat,
+                batch_offsets_flat,
+                block_tables_flat,
+                outputs,
+                out_lse,
+                k_scale,
+                v_scale,
+                num_kv_heads,
+                page_size,
+                best_cfg.BLOCK_M,
+                best_cfg.BLOCK_N,
+                head_dim_vo,
+                BLOCK_R,
+                QUERY_GROUP_SIZE,
+                stride_block_table,
+                is_causal,
+                min(best_cfg.BLOCK_N, page_size),
+            ),
+        )
+
+    return outputs, out_lse
+
+
+def prefill_attention_kv_ragged_cutile(
+    q,
+    k_cache,
+    v_cache,
+    actual_seq_lens_q,
+    actual_seq_lens_kv,
+    actual_seq_offset,
+    block_tables,
+    k_scale,
+    v_scale,
+    num_batch,
+    max_seq_len,
+    is_causal: bool = True,
+    outputs: Optional[torch.Tensor] = None,
+    out_lse: Optional[torch.Tensor] = None,
+    use_lpt_scheduler: bool = True,
+):
+    """
+    Prefill attention with ragged KV cache (cuTile implementation).
+    """
+    # KV cache [total_num_tokens, num_kv_heads, head_dim_qk]
+    num_kv_heads = k_cache.shape[1]
+    num_qo_heads = q.shape[1]
+    head_dim_qk = q.shape[-1]
+    head_dim_vo = v_cache.shape[-1]
+
+    BLOCK_R = head_dim_qk - head_dim_vo
+    QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
+
+    outputs = (
+        torch.zeros(
+            [q.shape[0], num_qo_heads, head_dim_vo],
+            device=q.device,
+            dtype=q.dtype,
+        )
+        if outputs is None
+        else outputs
+    )
+    out_lse = (
+        torch.zeros([q.shape[0], num_qo_heads], dtype=torch.float32, device=q.device)
+        if out_lse is None
+        else out_lse
+    )
+
+    # Flatten tensors for kernel
+    actual_seq_lens_q_flat = actual_seq_lens_q.reshape(-1).contiguous()
+    actual_seq_lens_kv_flat = actual_seq_lens_kv.reshape(-1).contiguous()
+    batch_offsets_flat = actual_seq_offset.reshape(-1).contiguous()
+
+    # Autotune key matching Triton's key for consistent caching across problem sizes
+    autotune_key = (
+        QUERY_GROUP_SIZE,
+        num_kv_heads,
+        BLOCK_R,
+        head_dim_vo,
+        k_scale,
+        v_scale,
+        max_seq_len,
+        num_batch,
+        3 if is_causal else 1,  # STAGE
+    )
+
+    if use_lpt_scheduler:
+        element_size = q.element_size()
+        size_one_kv_head = max_seq_len * (head_dim_qk + head_dim_vo) * element_size
+        size_l2 = 50 * 1024 * 1024  # 50 MB for K & V
+        if size_l2 < size_one_kv_head:
+            swizzle = 1
+        else:
+            log2_floor = (size_l2 // size_one_kv_head).bit_length() - 1
+            swizzle = 1 << log2_floor
+        num_hb_quotient = (num_qo_heads * num_batch) // swizzle
+        num_hb_remainder = (num_qo_heads * num_batch) % swizzle
+
+        ragged_lpt_stream = torch.cuda.current_stream()
+        ragged_lpt_cache_key = (autotune_key, swizzle, str(q.device))
+        if ragged_lpt_cache_key not in _prefill_ragged_lpt_tune_cache:
+            result = exhaustive_search(
+                list(_get_prefill_autotune_configs(None)),
+                ragged_lpt_stream,
+                lambda cfg: (
+                    (max_seq_len + cfg.BLOCK_M - 1)
+                    // cfg.BLOCK_M
+                    * num_qo_heads
+                    * num_batch,
+                    1,
+                    1,
+                ),
+                _prefill_attention_ragged_lpt_kernel,
+                lambda cfg: (
+                    q,
+                    k_cache,
+                    v_cache,
+                    actual_seq_lens_q_flat,
+                    actual_seq_lens_kv_flat,
+                    batch_offsets_flat,
+                    outputs,
+                    out_lse,
+                    k_scale,
+                    v_scale,
+                    num_kv_heads,
+                    cfg.BLOCK_M,
+                    cfg.BLOCK_N,
+                    head_dim_vo,
+                    BLOCK_R,
+                    QUERY_GROUP_SIZE,
+                    is_causal,
+                    num_qo_heads,
+                    num_batch,
+                    max_seq_len,
+                    swizzle,
+                    num_hb_quotient,
+                    max(num_hb_remainder, 1),
+                ),
+                lambda cfg: {"occupancy": cfg.occupancy},
+            )
+            best_cfg = result.best.config
+            _prefill_ragged_lpt_tune_cache[ragged_lpt_cache_key] = (
+                best_cfg,
+                _prefill_attention_ragged_lpt_kernel.replace_hints(
+                    occupancy=best_cfg.occupancy
+                ),
+            )
+        best_cfg, tuned_kernel = _prefill_ragged_lpt_tune_cache[ragged_lpt_cache_key]
+        ct.launch(
+            ragged_lpt_stream,
+            (
+                (max_seq_len + best_cfg.BLOCK_M - 1)
+                // best_cfg.BLOCK_M
+                * num_qo_heads
+                * num_batch,
+                1,
+                1,
+            ),
+            tuned_kernel,
+            (
+                q,
+                k_cache,
+                v_cache,
+                actual_seq_lens_q_flat,
+                actual_seq_lens_kv_flat,
+                batch_offsets_flat,
+                outputs,
+                out_lse,
+                k_scale,
+                v_scale,
+                num_kv_heads,
+                best_cfg.BLOCK_M,
+                best_cfg.BLOCK_N,
+                head_dim_vo,
+                BLOCK_R,
+                QUERY_GROUP_SIZE,
+                is_causal,
+                num_qo_heads,
+                num_batch,
+                max_seq_len,
+                swizzle,
+                num_hb_quotient,
+                max(num_hb_remainder, 1),
+            ),
+        )
+    else:
+        ragged_stream = torch.cuda.current_stream()
+        ragged_cache_key = (autotune_key, str(q.device))
+        if ragged_cache_key not in _prefill_ragged_tune_cache:
+            result = exhaustive_search(
+                list(_get_prefill_autotune_configs(None)),
+                ragged_stream,
+                lambda cfg: (
+                    (max_seq_len + cfg.BLOCK_M - 1) // cfg.BLOCK_M,
+                    num_batch,
+                    num_qo_heads,
+                ),
+                _prefill_attention_ragged_kernel,
+                lambda cfg: (
+                    q,
+                    k_cache,
+                    v_cache,
+                    actual_seq_lens_q_flat,
+                    actual_seq_lens_kv_flat,
+                    batch_offsets_flat,
+                    outputs,
+                    out_lse,
+                    k_scale,
+                    v_scale,
+                    num_kv_heads,
+                    cfg.BLOCK_M,
+                    cfg.BLOCK_N,
+                    head_dim_vo,
+                    BLOCK_R,
+                    QUERY_GROUP_SIZE,
+                    is_causal,
+                ),
+                lambda cfg: {"occupancy": cfg.occupancy},
+            )
+            best_cfg = result.best.config
+            _prefill_ragged_tune_cache[ragged_cache_key] = (
+                best_cfg,
+                _prefill_attention_ragged_kernel.replace_hints(
+                    occupancy=best_cfg.occupancy
+                ),
+            )
+        best_cfg, tuned_kernel = _prefill_ragged_tune_cache[ragged_cache_key]
+        ct.launch(
+            ragged_stream,
+            (
+                (max_seq_len + best_cfg.BLOCK_M - 1) // best_cfg.BLOCK_M,
+                num_batch,
+                num_qo_heads,
+            ),
+            tuned_kernel,
+            (
+                q,
+                k_cache,
+                v_cache,
+                actual_seq_lens_q_flat,
+                actual_seq_lens_kv_flat,
+                batch_offsets_flat,
+                outputs,
+                out_lse,
+                k_scale,
+                v_scale,
+                num_kv_heads,
+                best_cfg.BLOCK_M,
+                best_cfg.BLOCK_N,
+                head_dim_vo,
+                BLOCK_R,
+                QUERY_GROUP_SIZE,
+                is_causal,
+            ),
+        )
+
+    return outputs, out_lse

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -636,8 +636,12 @@ def _prefill_attention_paged_body(
         latency=2,
     )
 
-    # Store LSE - lse_output is 2D [total_tokens, num_heads]
-    lse_scaled = lse * (1.0 / INV_LOG_2)  # multiply by constant instead of dividing
+    # Store LSE - lse_output is 2D [total_tokens, num_heads].
+    # `lse` (= m_i + log2(l_i)) is already log2(sum exp(S)) = logsumexp_natural *
+    # log2(e), which is FlashInfer's base-2 LSE convention (see fa2 / cutlass /
+    # test_blackwell_fmha reference: lse_ref * math.log2(math.e)). Store it as-is;
+    # rescaling by ln2 here would emit natural-log LSE and break merge/cascade.
+    lse_scaled = lse
     offs_m_store = ct.arange(BLOCK_M, dtype=ct.int32)
     token_indices = seq_start_index + start_m + offs_m_store
     head_indices = ct.full((BLOCK_M,), head_id, dtype=ct.int32)
@@ -1034,7 +1038,8 @@ def _prefill_attention_ragged_body(
         latency=2,
     )
 
-    lse_scaled = lse * (1.0 / INV_LOG_2)
+    # Base-2 LSE = FlashInfer convention (see ragged body above); store as-is.
+    lse_scaled = lse
     offs_m_store = ct.arange(BLOCK_M, dtype=ct.int32)
     token_indices = seq_start_index + start_m + offs_m_store
     head_indices = ct.full((BLOCK_M,), head_id, dtype=ct.int32)

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -1217,7 +1217,10 @@ def prefill_attention_kv_paged_cutile(
     QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
 
     outputs = (
-        torch.zeros(
+        # torch.empty (not zeros): the kernel masked-scatters every valid query
+        # row, so pre-zeroing the output is wasted bandwidth. Matches the Ocean
+        # tilegym source; the zeros here was a migration perf regression.
+        torch.empty(
             [q.shape[0], num_qo_heads, head_dim_vo],
             dtype=q.dtype,
             device=q.device,
@@ -1493,7 +1496,9 @@ def prefill_attention_kv_ragged_cutile(
     QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
 
     outputs = (
-        torch.zeros(
+        # torch.empty (not zeros): masked-scatter writes every valid query row;
+        # pre-zeroing is wasted bandwidth. Matches Ocean tilegym source.
+        torch.empty(
             [q.shape[0], num_qo_heads, head_dim_vo],
             device=q.device,
             dtype=q.dtype,

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -507,10 +507,16 @@ def _prefill_attention_paged_body(
         # real data, not zeros) into the softmax. No-op when off_band_hi is a
         # multiple of BLOCK_N (the single-page case), so single-page results are bit-identical.
         offs_n = curr_n + offs_n_base
-        boundary_mask = ct.reshape((offs_n < off_band_hi), (1, BLOCK_N))
-        qk = ct.where(
-            boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
-        )
+        # Skip only when single-page (BLOCK_N == LOAD_BLOCK_N) AND causal:
+        # off_band_hi == start_m is then BLOCK_N-aligned (no overshoot) and no
+        # multi-page load can pull real page-0 data, so the mask is a no-op.
+        # Multi-page or non-causal still need it. Verified vs torch ref incl.
+        # non-BLOCK_N-aligned seq lens.
+        if BLOCK_N > LOAD_BLOCK_N or not IS_CAUSAL:
+            boundary_mask = ct.reshape((offs_n < off_band_hi), (1, BLOCK_N))
+            qk = ct.where(
+                boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
+            )
 
         # Online softmax with flush_to_zero for IR parity with Triton
         qk_max = ct.max(qk, axis=1, keepdims=False)
@@ -587,10 +593,15 @@ def _prefill_attention_paged_body(
             # clamped to seq_len_kv and the causal mask alone (offs_m >= offs_n)
             # does not exclude past-seq_len_kv positions that a multi-page BLOCK_N
             # can pull in. No-op when seq_len_kv is a multiple of BLOCK_N.
-            boundary_mask = ct.reshape((offs_n < seq_len_kv), (1, BLOCK_N))
-            qk = ct.where(
-                boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
-            )
+            # On-band loop runs only when causal. Single-page: the seq_len_kv tail
+            # is already excluded by the causal mask (garbage offs_n >= seq_len_kv
+            # > offs_m for every stored query row), so skip. Multi-page can pull
+            # page-0 data past the band -> keep.
+            if BLOCK_N > LOAD_BLOCK_N:
+                boundary_mask = ct.reshape((offs_n < seq_len_kv), (1, BLOCK_N))
+                qk = ct.where(
+                    boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
+                )
 
             qk_max = ct.max(qk, axis=1, keepdims=False)
             m_ij = ct.maximum(m_i, (qk_max * qk_scale))
@@ -929,7 +940,9 @@ def _prefill_attention_ragged_body(
         # PAD_ZERO-loaded, so padded columns have qk == 0 and would otherwise add
         # exp2(-m_ij) mass to the softmax denominator (their V rows are zero, so
         # only the denominator is corrupted). No-op when off_band_hi is a multiple
-        # of BLOCK_N.
+        # of BLOCK_N. (Kept unconditional: the ragged KV is PAD_ZERO-loaded, so
+        # this drops padded columns from the softmax denominator — a different
+        # mechanism from the paged page-0 case; gating it broke ragged tests.)
         offs_n = curr_n + offs_n_base
         boundary_mask = ct.reshape((offs_n < off_band_hi), (1, BLOCK_N))
         qk = ct.where(

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -33,6 +33,7 @@ _MAX_LOAD_PAGES = 8
 
 
 def _get_prefill_autotune_configs(page_size=None):
+    """Return the prefill autotune candidates valid for this arch and page size."""
     configs = [
         SimpleNamespace(BLOCK_M=128, BLOCK_N=32, occupancy=1, num_ctas=1),
         SimpleNamespace(BLOCK_M=128, BLOCK_N=64, occupancy=1, num_ctas=1),
@@ -345,6 +346,7 @@ def _load_page_wrapper_prefill(
     dim3_offset=0,
     LATENCY=3,
 ):
+    """Load one BLOCK_N tile of a paged cache, translating `curr_n` into (page, token)."""
     NUM_PAGES = BLOCK_N // LOAD_BLOCK_N
     page = curr_n // PAGE_SIZE
     token = curr_n % PAGE_SIZE
@@ -391,6 +393,7 @@ def _prefill_attention_paged_body(
     LOAD_BLOCK_N: ConstInt,
 ):
     # Load sequence info
+    """Shared per-tile paged-prefill body (online softmax over the KV blocks of one query tile)."""
     seq_start_idx_tile = ct.gather(batch_offsets, (batch_id,), padding_value=0)
     seq_start_index = seq_start_idx_tile.item()
 
@@ -690,6 +693,7 @@ def _prefill_attention_paged_kernel(
     IS_CAUSAL: ConstBool,
     LOAD_BLOCK_N: ConstInt,
 ):
+    """cuTile kernel: paged prefill, one CTA per (batch, head, query-block)."""
     batch_id = ct.bid(0)
     head_id = ct.bid(1)
     seq_block_id = ct.bid(2)
@@ -752,6 +756,7 @@ def _prefill_attention_paged_lpt_kernel(
     NUM_HB_QUOTIENT: ConstInt,
     NUM_HB_REMAINDER: ConstInt,
 ):
+    """cuTile kernel: paged prefill with longest-processing-time scheduling over a persistent grid."""
     tile_idx = ct.bid(0)
     NUM_BLOCKS = (MAX_SEQ_LEN + BLOCK_M - 1) // BLOCK_M
     l2_major_blocks = SWIZZLE * NUM_BLOCKS
@@ -826,6 +831,7 @@ def _prefill_attention_ragged_body(
     IS_CAUSAL: ConstBool,
 ):
     # Load sequence info
+    """Shared per-tile ragged-prefill body (online softmax over the KV blocks of one query tile)."""
     seq_start_idx_tile = ct.gather(batch_offsets, (batch_id,), padding_value=0)
     seq_start_index = seq_start_idx_tile.item()
 
@@ -1148,6 +1154,7 @@ def _prefill_attention_ragged_lpt_kernel(
     NUM_HB_QUOTIENT: ConstInt,
     NUM_HB_REMAINDER: ConstInt,
 ):
+    """cuTile kernel: ragged prefill with longest-processing-time scheduling over a persistent grid."""
     tile_idx = ct.bid(0)
     NUM_BLOCKS = (MAX_SEQ_LEN + BLOCK_M - 1) // BLOCK_M
     l2_major_blocks = SWIZZLE * NUM_BLOCKS

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -5,6 +5,7 @@
 # cuda.tile API, with two-stage causal masking and boundary-masked multi-page loads.
 
 import math
+import os
 from types import SimpleNamespace
 from typing import Optional
 from typing import TypeAlias
@@ -13,6 +14,9 @@ import cuda.tile as ct
 import torch
 from cuda.tile import RoundingMode as RMd
 from cuda.tile.tune import exhaustive_search
+
+# Set FLASHINFER_CUTILE_AUTOTUNE_DISABLED=1 to skip exhaustive search
+_AUTOTUNE_DISABLED = os.getenv("FLASHINFER_CUTILE_AUTOTUNE_DISABLED", "0") != "0"
 
 # Module-level tune caches for prefill kernels
 _prefill_paged_lpt_tune_cache: dict = {}
@@ -69,6 +73,13 @@ def _get_prefill_autotune_configs(page_size=None):
             if cfg.BLOCK_N // page_size > _MAX_LOAD_PAGES:
                 continue
         yield cfg
+        if _AUTOTUNE_DISABLED:
+            # Honor FLASHINFER_CUTILE_AUTOTUNE_DISABLED (as the decode kernels
+            # already do): emit only the first page-compatible candidate so the
+            # exhaustive search below degenerates to a single launch instead of
+            # a full sweep. Filtering stays identical, so the chosen config is
+            # always valid for this page_size.
+            return
 
 
 def _load_page_prefill(

--- a/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
+++ b/flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py
@@ -600,7 +600,9 @@ def _prefill_attention_paged_body(
             if BLOCK_N > LOAD_BLOCK_N:
                 boundary_mask = ct.reshape((offs_n < seq_len_kv), (1, BLOCK_N))
                 qk = ct.where(
-                    boundary_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32)
+                    boundary_mask,
+                    qk,
+                    ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32),
                 )
 
             qk_max = ct.max(qk, axis=1, keepdims=False)

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1549,6 +1549,70 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     f"request with kv_len={min_kv_len}: its earlier rows "
                     "would attend to an empty KV range."
                 )
+        if self._backend == "cutile":
+            # Pure cuda.tile Python kernel: no C++ module to JIT. Stash the
+            # per-sequence KV lengths and page size, and materialize the dense
+            # block table now (at plan time) so run() is CUDA-graph-capturable --
+            # reconstructing it in run() would require host .item() syncs.
+            if logits_soft_cap is not None and logits_soft_cap > 0:
+                raise NotImplementedError(
+                    "cuTile decode backend does not support logits_soft_cap."
+                )
+            if window_left >= 0:
+                # The kernel receives no window_left; a sliding window would be
+                # silently ignored and run as full attention.
+                raise NotImplementedError(
+                    "cuTile decode backend does not support sliding window "
+                    f"(window_left={window_left})."
+                )
+            if pos_encoding_mode != "NONE":
+                # The kernel applies no positional encoding; anything other than
+                # "NONE" would be silently dropped.
+                raise NotImplementedError(
+                    "cuTile decode backend does not apply position encoding "
+                    f"(pos_encoding_mode must be 'NONE'); got {pos_encoding_mode!r}."
+                )
+            self._page_size = page_size
+            self._kv_lens_arr_host = kv_lens_arr_host
+            # Device copy of the per-seq KV lengths, staged once at plan time.
+            # run() must not copy it H2D itself: a CPU->CUDA copy from unpinned
+            # host memory is illegal during CUDA graph capture.
+            self._kv_lens_device = kv_lens_arr_host.to(
+                device=self.device, dtype=torch.int32
+            )
+            if self._block_tables is None:
+                # Build a dense [batch, max_pages] block table from the CSR
+                # (indptr/indices) plan state. Done here, once, outside any CUDA
+                # graph capture, so run() pays no per-call host sync (mirrors the
+                # trtllm-gen plan-time reconstruction below).
+                blocks_per_seq = [
+                    (int(seq_len) + page_size - 1) // page_size
+                    for seq_len in kv_lens_arr_host
+                ]
+                max_num_blocks_per_seq = max(blocks_per_seq)
+                self._block_tables = torch.zeros(
+                    (batch_size, max_num_blocks_per_seq),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                block_id = int(indptr_host[0].item())
+                for i in range(batch_size):
+                    num_blocks_needed = blocks_per_seq[i]
+                    self._block_tables[i, :num_blocks_needed] = (
+                        self._paged_kv_indices_buf[
+                            block_id : block_id + num_blocks_needed
+                        ]
+                    )
+                    block_id += num_blocks_needed
+            self._plan_info = None
+            # run() reads these; normally set after the module-build branches below.
+            self._pos_encoding_mode = pos_encoding_mode
+            self._window_left = window_left
+            self._logits_soft_cap = logits_soft_cap
+            self._sm_scale = sm_scale
+            self._rope_scale = rope_scale
+            self._rope_theta = rope_theta
+            return
         if self._backend == "cute-dsl":
             if logits_soft_cap is not None and logits_soft_cap > 0:
                 raise NotImplementedError(
@@ -2047,6 +2111,50 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 check_shape_dtype_device(
                     lse, (q.size(0), q.size(1)), torch.float32, q.device, "lse"
                 )
+
+        if self._backend == "cutile":
+            if return_lse:
+                raise NotImplementedError(
+                    "cuTile decode backend does not support return_lse."
+                )
+            if sinks is not None:
+                raise NotImplementedError(
+                    "cuTile decode backend does not support attention sinks."
+                )
+            if kv_cache_sf is not None:
+                raise NotImplementedError(
+                    "cuTile decode backend does not support NVFP4 KV cache."
+                )
+            if self._kv_layout != "NHD":
+                raise NotImplementedError(
+                    "cuTile decode backend requires kv_layout='NHD'."
+                )
+            if q.shape[0] != actual_batch_size:
+                raise NotImplementedError(
+                    "cuTile decode backend requires q_len_per_req == 1 "
+                    f"(got q.shape[0]={q.shape[0]}, batch_size={actual_batch_size})."
+                )
+            from .attention.kernels.cutile.fmha_decode_bsr_cutile import (
+                fmha_decode_bsr_cutile,
+            )
+
+            # Both the block table and the device KV-lengths are materialized at
+            # plan() time (see the cuTile plan branch), so run() does only
+            # device->device ops (no host .item() sync, no CPU->CUDA copy) and is
+            # safe to capture in a CUDA graph.
+            actual_seq_lens = self._kv_lens_device.to(device=q.device)
+            block_tables = self._block_tables.to(device=q.device, dtype=torch.int32)
+
+            return fmha_decode_bsr_cutile(
+                q=q,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                actual_seq_lens=actual_seq_lens,
+                block_tables=block_tables,
+                k_scale=sm_scale,
+                v_scale=1.0 if v_scale is None else v_scale,
+                outputs=out,
+            )
 
         if self._backend == "cute-dsl" and out is None:
             out = None  # Let cute-dsl wrapper handle the alloc

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1425,6 +1425,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         disable_split_kv: bool = False,
         q_len_per_req: int = 1,
     ) -> None:
+        """Shared plan() implementation for the paged-decode wrapper across backends."""
         _check_workspace_buffer_alignment(
             self._float_workspace_buffer, "float_workspace_buffer"
         )

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2139,6 +2139,22 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 fmha_decode_bsr_cutile,
             )
 
+            # This branch returns before the shared out / out_dtype handling
+            # below, so honor the planned o_data_type here as well: allocate with
+            # it when the caller passed no out, and otherwise validate the buffer
+            # we were handed rather than letting the kernel write a tensor whose
+            # dtype disagrees with plan().
+            cutile_out_dtype = getattr(self, "_cached_o_data_type", None) or q.dtype
+            cutile_out_shape = q.shape[:-1] + (v_cache.shape[-1],)
+            if out is None:
+                out = torch.empty(
+                    cutile_out_shape, dtype=cutile_out_dtype, device=q.device
+                )
+            else:
+                check_shape_dtype_device(
+                    out, cutile_out_shape, cutile_out_dtype, q.device, "out"
+                )
+
             # Both the block table and the device KV-lengths are materialized at
             # plan() time (see the cuTile plan branch), so run() does only
             # device->device ops (no host .item() sync, no CPU->CUDA copy) and is

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1473,6 +1473,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         q_len_per_req: int = 1,
         is_causal: Optional[bool] = None,
     ) -> None:
+        """Shared plan() implementation for the paged-decode wrapper across backends."""
         _check_workspace_buffer_alignment(
             self._float_workspace_buffer, "float_workspace_buffer"
         )

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -2240,6 +2240,22 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 fmha_decode_bsr_cutile,
             )
 
+            # This branch returns before the shared out / out_dtype handling
+            # below, so honor the planned o_data_type here as well: allocate with
+            # it when the caller passed no out, and otherwise validate the buffer
+            # we were handed rather than letting the kernel write a tensor whose
+            # dtype disagrees with plan().
+            cutile_out_dtype = getattr(self, "_cached_o_data_type", None) or q.dtype
+            cutile_out_shape = q.shape[:-1] + (v_cache.shape[-1],)
+            if out is None:
+                out = torch.empty(
+                    cutile_out_shape, dtype=cutile_out_dtype, device=q.device
+                )
+            else:
+                check_shape_dtype_device(
+                    out, cutile_out_shape, cutile_out_dtype, q.device, "out"
+                )
+
             # Both the block table and the device KV-lengths are materialized at
             # plan() time (see the cuTile plan branch), so run() does only
             # device->device ops (no host .item() sync, no CPU->CUDA copy) and is

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1602,6 +1602,70 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     f"request with kv_len={min_kv_len}: its earlier rows "
                     "would attend to an empty KV range."
                 )
+        if self._backend == "cutile":
+            # Pure cuda.tile Python kernel: no C++ module to JIT. Stash the
+            # per-sequence KV lengths and page size, and materialize the dense
+            # block table now (at plan time) so run() is CUDA-graph-capturable --
+            # reconstructing it in run() would require host .item() syncs.
+            if logits_soft_cap is not None and logits_soft_cap > 0:
+                raise NotImplementedError(
+                    "cuTile decode backend does not support logits_soft_cap."
+                )
+            if window_left >= 0:
+                # The kernel receives no window_left; a sliding window would be
+                # silently ignored and run as full attention.
+                raise NotImplementedError(
+                    "cuTile decode backend does not support sliding window "
+                    f"(window_left={window_left})."
+                )
+            if pos_encoding_mode != "NONE":
+                # The kernel applies no positional encoding; anything other than
+                # "NONE" would be silently dropped.
+                raise NotImplementedError(
+                    "cuTile decode backend does not apply position encoding "
+                    f"(pos_encoding_mode must be 'NONE'); got {pos_encoding_mode!r}."
+                )
+            self._page_size = page_size
+            self._kv_lens_arr_host = kv_lens_arr_host
+            # Device copy of the per-seq KV lengths, staged once at plan time.
+            # run() must not copy it H2D itself: a CPU->CUDA copy from unpinned
+            # host memory is illegal during CUDA graph capture.
+            self._kv_lens_device = kv_lens_arr_host.to(
+                device=self.device, dtype=torch.int32
+            )
+            if self._block_tables is None:
+                # Build a dense [batch, max_pages] block table from the CSR
+                # (indptr/indices) plan state. Done here, once, outside any CUDA
+                # graph capture, so run() pays no per-call host sync (mirrors the
+                # trtllm-gen plan-time reconstruction below).
+                blocks_per_seq = [
+                    (int(seq_len) + page_size - 1) // page_size
+                    for seq_len in kv_lens_arr_host
+                ]
+                max_num_blocks_per_seq = max(blocks_per_seq)
+                self._block_tables = torch.zeros(
+                    (batch_size, max_num_blocks_per_seq),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                block_id = int(indptr_host[0].item())
+                for i in range(batch_size):
+                    num_blocks_needed = blocks_per_seq[i]
+                    self._block_tables[i, :num_blocks_needed] = (
+                        self._paged_kv_indices_buf[
+                            block_id : block_id + num_blocks_needed
+                        ]
+                    )
+                    block_id += num_blocks_needed
+            self._plan_info = None
+            # run() reads these; normally set after the module-build branches below.
+            self._pos_encoding_mode = pos_encoding_mode
+            self._window_left = window_left
+            self._logits_soft_cap = logits_soft_cap
+            self._sm_scale = sm_scale
+            self._rope_scale = rope_scale
+            self._rope_theta = rope_theta
+            return
         if self._backend == "cute-dsl":
             if logits_soft_cap is not None and logits_soft_cap > 0:
                 raise NotImplementedError(
@@ -2148,6 +2212,50 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 check_shape_dtype_device(
                     lse, (q.size(0), q.size(1)), torch.float32, q.device, "lse"
                 )
+
+        if self._backend == "cutile":
+            if return_lse:
+                raise NotImplementedError(
+                    "cuTile decode backend does not support return_lse."
+                )
+            if sinks is not None:
+                raise NotImplementedError(
+                    "cuTile decode backend does not support attention sinks."
+                )
+            if kv_cache_sf is not None:
+                raise NotImplementedError(
+                    "cuTile decode backend does not support NVFP4 KV cache."
+                )
+            if self._kv_layout != "NHD":
+                raise NotImplementedError(
+                    "cuTile decode backend requires kv_layout='NHD'."
+                )
+            if q.shape[0] != actual_batch_size:
+                raise NotImplementedError(
+                    "cuTile decode backend requires q_len_per_req == 1 "
+                    f"(got q.shape[0]={q.shape[0]}, batch_size={actual_batch_size})."
+                )
+            from .attention.kernels.cutile.fmha_decode_bsr_cutile import (
+                fmha_decode_bsr_cutile,
+            )
+
+            # Both the block table and the device KV-lengths are materialized at
+            # plan() time (see the cuTile plan branch), so run() does only
+            # device->device ops (no host .item() sync, no CPU->CUDA copy) and is
+            # safe to capture in a CUDA graph.
+            actual_seq_lens = self._kv_lens_device.to(device=q.device)
+            block_tables = self._block_tables.to(device=q.device, dtype=torch.int32)
+
+            return fmha_decode_bsr_cutile(
+                q=q,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                actual_seq_lens=actual_seq_lens,
+                block_tables=block_tables,
+                k_scale=sm_scale,
+                v_scale=1.0 if v_scale is None else v_scale,
+                outputs=out,
+            )
 
         if self._backend == "cute-dsl" and out is None:
             out = None  # Let cute-dsl wrapper handle the alloc

--- a/flashinfer/mla/_batch_mla/_backends/cutile_backend.py
+++ b/flashinfer/mla/_batch_mla/_backends/cutile_backend.py
@@ -1,0 +1,488 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+"""
+
+import functools
+import math
+from typing import ClassVar, Optional, cast
+
+import torch
+
+from ....attention.prims_ts._tensor_aliasing import (
+    _validate_out_does_not_overlap_inputs,
+)
+from ....utils import get_compute_capability
+from .._contracts import _are_adjacent_last_dim_views
+from .._planning import _MLAPlanArguments
+from ._capabilities import MLAPlanCapabilities, plan_capability_rejection_reason
+
+
+_CUTILE_SUPPORTED_COMPUTE_CAPABILITIES = frozenset({(10, 0), (10, 3), (12, 0), (12, 1)})
+
+
+def _get_compute_capability(device: torch.device):
+    if device.type != "cuda":
+        raise ValueError(
+            f"cutile backend requires a CUDA workspace device, got {device}."
+        )
+    return get_compute_capability(device)
+
+
+@functools.cache
+def get_cutile_mla_decode():
+    """Load the cuda.tile kernel only after the cuTile plan is validated."""
+
+    from ....attention.kernels.cutile.fmha_decode_bsr_cutile import (
+        decode_mla_kv_paged_cutile,
+    )
+
+    return decode_mla_kv_paged_cutile
+
+
+def _validate_cutile_page_size(page_size: int) -> None:
+    if (
+        not isinstance(page_size, int)
+        or isinstance(page_size, bool)
+        or page_size < 2
+        or page_size > 128
+        or page_size & (page_size - 1)
+    ):
+        raise ValueError(
+            "cutile backend requires a power-of-two integer page_size in "
+            f"[2, 128], got {page_size!r}."
+        )
+
+
+def _validate_cutile_num_heads(num_heads: int) -> None:
+    if (
+        not isinstance(num_heads, int)
+        or isinstance(num_heads, bool)
+        or num_heads < 8
+        or num_heads > 128
+        or num_heads % 8 != 0
+    ):
+        raise ValueError(
+            "cutile backend requires num_heads to be a multiple of 8 in [8, 128], "
+            f"got {num_heads!r}."
+        )
+
+
+def _validate_compact_split_pair(
+    left: torch.Tensor,
+    right: torch.Tensor,
+    *,
+    name: str,
+) -> None:
+    if left.is_contiguous() and right.is_contiguous():
+        return
+    if _are_adjacent_last_dim_views(left, right):
+        return
+    raise ValueError(
+        f"cutile {name} tensors must be contiguous independent tensors or "
+        "adjacent views of one contiguous packed tensor."
+    )
+
+
+def _unpack_split_pair(
+    value: object,
+    *,
+    name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if type(value) is not tuple:
+        raise TypeError(f"cutile backend requires split {name} tensors.")
+    if len(value) != 2:
+        raise ValueError(f"cutile split {name} must contain exactly two tensors.")
+    left, right = value
+    if not isinstance(left, torch.Tensor) or not isinstance(right, torch.Tensor):
+        raise TypeError(f"cutile split {name} leaves must be torch.Tensor.")
+    return left, right
+
+
+def _validate_launch_tensor(
+    tensor: object,
+    *,
+    name: str,
+    device: torch.device,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+) -> None:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"cutile launch tensor {name} must be a torch.Tensor.")
+    if tensor.layout != torch.strided:
+        raise ValueError(f"cutile launch tensor {name} must have strided layout.")
+    if tuple(tensor.shape) != shape:
+        raise ValueError(
+            f"cutile launch tensor {name} must have shape {shape}, got "
+            f"{tuple(tensor.shape)}."
+        )
+    if tensor.dtype != dtype:
+        raise ValueError(
+            f"cutile launch tensor {name} must have dtype {dtype}, got {tensor.dtype}."
+        )
+    if tensor.device != device:
+        raise ValueError(
+            f"cutile launch tensor {name} must be on workspace device {device}, "
+            f"got {tensor.device}."
+        )
+
+
+def _validate_runtime_metadata(
+    tensor: object,
+    *,
+    name: str,
+    device: torch.device,
+    shape: tuple[int, ...],
+) -> None:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor.")
+    if tensor.layout != torch.strided:
+        raise ValueError(f"{name} must have strided layout.")
+    if tuple(tensor.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}, got {tuple(tensor.shape)}.")
+    if tensor.dtype != torch.int32:
+        raise ValueError(f"{name} must have dtype torch.int32.")
+    if tensor.device != device:
+        raise ValueError(
+            f"{name} must be on workspace device {device}, got {tensor.device}."
+        )
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous.")
+
+
+class _BatchMLAPagedAttentionCutileBackend:
+    _plan_capabilities: ClassVar[MLAPlanCapabilities] = MLAPlanCapabilities(
+        backend_name="cutile",
+        lse_modes=frozenset({"none"}),
+        kv_layouts=frozenset({"combined", "independent-split"}),
+        output_scales=frozenset({"none"}),
+        scale_modes=frozenset({"default"}),
+        requires_packed_query=False,
+        requires_packed_kv_cache=False,
+    )
+
+    def __init__(self, float_workspace_buffer: torch.Tensor) -> None:
+        self._backend = "cutile"
+        self._float_workspace_buffer = float_workspace_buffer
+        self.device = float_workspace_buffer.device
+
+    @classmethod
+    def plan_from_wrapper(
+        cls, args: _MLAPlanArguments
+    ) -> "_BatchMLAPagedAttentionCutileBackend":
+        if reason := plan_capability_rejection_reason(args, cls._plan_capabilities):
+            raise ValueError(reason)
+        dense = args.native_dense()
+        backend = cls(args._float_workspace_buffer)
+        backend.plan(
+            num_heads=args.num_heads,
+            head_dim_ckv=args.head_dim_ckv,
+            head_dim_kpe=args.head_dim_kpe,
+            page_size=args.page_size,
+            causal=args.causal,
+            sm_scale=args.sm_scale,
+            q_data_type=args.q_data_type,
+            kv_data_type=args.kv_data_type,
+            output_dtype=args.output_dtype,
+            output_scale=args.output_scale,
+            use_profiler=args.use_profiler,
+            use_cuda_graph=args._use_cuda_graph,
+            cum_seq_lens_q=dense.cum_seq_lens_q,
+            max_q_len=dense.max_q_len,
+            kv_len=dense.seq_lens,
+            page_table=dense.block_tables,
+        )
+        return backend
+
+    def plan(
+        self,
+        *,
+        num_heads: int,
+        head_dim_ckv: int,
+        head_dim_kpe: int,
+        page_size: int,
+        causal: bool,
+        sm_scale: float,
+        q_data_type: torch.dtype,
+        kv_data_type: torch.dtype,
+        output_dtype: torch.dtype,
+        output_scale: str,
+        use_profiler: bool,
+        use_cuda_graph: bool,
+        cum_seq_lens_q: torch.Tensor,
+        max_q_len: int,
+        kv_len: torch.Tensor,
+        page_table: torch.Tensor,
+    ) -> None:
+        # -----------------------------------------------------------------------
+        # Validate the cuTile plan contract before importing cuda.tile
+        # -----------------------------------------------------------------------
+        if use_profiler:
+            raise ValueError("use_profiler is not supported by the cutile backend.")
+        if causal:
+            raise ValueError("causal=True is not supported by the cutile backend.")
+        _validate_cutile_num_heads(num_heads)
+        if head_dim_ckv != 512 or head_dim_kpe != 64:
+            raise ValueError(
+                "cutile backend expects head_dim_ckv=512 and head_dim_kpe=64, "
+                f"got {head_dim_ckv=} and {head_dim_kpe=}."
+            )
+        if q_data_type not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                "cutile backend expects q_data_type to be torch.float16 or "
+                f"torch.bfloat16, got {q_data_type}."
+            )
+        if kv_data_type != q_data_type:
+            raise ValueError(
+                "cutile backend expects kv_data_type to match q_data_type, "
+                f"got {kv_data_type=} and {q_data_type=}."
+            )
+        if output_dtype != q_data_type:
+            raise ValueError(
+                "cutile backend expects output_dtype to match q_data_type, "
+                f"got {output_dtype=} and {q_data_type=}."
+            )
+        if output_scale != "none":
+            raise ValueError(
+                f"cutile backend does not support output_scale={output_scale!r}."
+            )
+        if not isinstance(sm_scale, (int, float)) or isinstance(sm_scale, bool):
+            raise ValueError(
+                f"sm_scale must be a finite positive number, got {sm_scale!r}."
+            )
+        resolved_sm_scale = float(sm_scale)
+        if not math.isfinite(resolved_sm_scale) or resolved_sm_scale <= 0.0:
+            raise ValueError(
+                f"sm_scale must be a finite positive number, got {sm_scale!r}."
+            )
+        _validate_cutile_page_size(page_size)
+        major, minor = _get_compute_capability(self.device)
+        if (major, minor) not in _CUTILE_SUPPORTED_COMPUTE_CAPABILITIES:
+            raise ValueError(
+                "cutile backend supports only the validated Blackwell targets "
+                f"SM100, SM103, SM120, and SM121, got SM{major}{minor}."
+            )
+
+        batch_size = cum_seq_lens_q.numel() - 1
+        if batch_size <= 0:
+            raise ValueError("cutile backend requires a positive batch size.")
+        if max_q_len != 1:
+            raise ValueError(
+                "cutile backend supports decode plans with one query per request, "
+                f"got max_q_len={max_q_len}."
+            )
+        expected_cum_seq_lens_q = torch.arange(
+            batch_size + 1,
+            dtype=torch.int32,
+            device=cum_seq_lens_q.device,
+        )
+        if not torch.equal(cum_seq_lens_q, expected_cum_seq_lens_q):
+            raise ValueError(
+                "cutile backend requires cum_seq_lens_q=[0, 1, ..., batch_size]."
+            )
+        if tuple(kv_len.shape) != (batch_size,):
+            raise ValueError(
+                f"cutile kv_len must have shape {(batch_size,)}, got "
+                f"{tuple(kv_len.shape)}."
+            )
+        if page_table.ndim != 2 or page_table.shape[0] != batch_size:
+            raise ValueError(
+                "cutile page_table must be rank 2 with one row per request, got "
+                f"shape {tuple(page_table.shape)}."
+            )
+        if page_table.shape[1] <= 0:
+            raise ValueError("cutile page_table must have positive width.")
+
+        # Stage canonical metadata during planning. Device inputs retain their
+        # identity, which lets callers mutate values in place before graph replay.
+        planned_kv_len = kv_len.to(device=self.device, non_blocking=True)
+        planned_page_table = page_table.to(device=self.device, non_blocking=True)
+        decode_mla_kv_paged_cutile = get_cutile_mla_decode()
+
+        # -----------------------------------------------------------------------
+        # Publish only fully validated plan state
+        # -----------------------------------------------------------------------
+        self._batch_size = batch_size
+        self._num_heads = num_heads
+        self._page_size = page_size
+        self._page_table_width = page_table.shape[1]
+        self._head_dim_ckv = head_dim_ckv
+        self._head_dim_kpe = head_dim_kpe
+        self._sm_scale = resolved_sm_scale
+        self._q_data_type = q_data_type
+        self._kv_data_type = kv_data_type
+        self._output_dtype = output_dtype
+        self._use_cuda_graph = use_cuda_graph
+        self._kv_len = planned_kv_len
+        self._page_table = planned_page_table
+        self._decode_mla_kv_paged_cutile = decode_mla_kv_paged_cutile
+
+    def run_from_wrapper(
+        self,
+        *,
+        query: object,
+        kv_cache: object,
+        out: Optional[torch.Tensor],
+        lse: Optional[torch.Tensor],
+        return_lse: bool,
+        profiler_buffer: Optional[torch.Tensor],
+        kv_len: Optional[torch.Tensor],
+        page_table: Optional[torch.Tensor],
+        return_lse_base_on_e: bool,
+        o_scale: Optional[float],
+        ckv_scale: Optional[float],
+        ckv_scale_arr: Optional[torch.Tensor],
+        kpe_scale: Optional[float],
+    ) -> torch.Tensor:
+        # -----------------------------------------------------------------------
+        # Validate the run contract and resolve planned metadata
+        # -----------------------------------------------------------------------
+        if return_lse:
+            raise ValueError("return_lse is not supported with cutile backend.")
+        if lse is not None:
+            raise ValueError("lse is not supported with cutile backend.")
+        if profiler_buffer is not None:
+            raise ValueError("profiler_buffer is not supported with cutile backend.")
+        if return_lse_base_on_e:
+            raise ValueError(
+                "return_lse_base_on_e is not supported with cutile backend."
+            )
+        if o_scale is not None:
+            raise ValueError("o_scale is not supported with cutile backend.")
+        if ckv_scale is not None or ckv_scale_arr is not None or kpe_scale is not None:
+            raise ValueError(
+                "ckv_scale / ckv_scale_arr / kpe_scale are not supported with "
+                "cutile backend."
+            )
+        if (kv_len is None) != (page_table is None):
+            raise ValueError(
+                "run-time kv_len and page_table must both be omitted or both be provided."
+            )
+        kv_len = self._kv_len if kv_len is None else kv_len
+        page_table = self._page_table if page_table is None else page_table
+        _validate_runtime_metadata(
+            kv_len,
+            name="kv_len",
+            device=self.device,
+            shape=(self._batch_size,),
+        )
+        _validate_runtime_metadata(
+            page_table,
+            name="page_table",
+            device=self.device,
+            shape=(self._batch_size, self._page_table_width),
+        )
+
+        q_nope, q_pe = _unpack_split_pair(query, name="query")
+        ckv_cache, kpe_cache = _unpack_split_pair(kv_cache, name="KV cache")
+        query_prefix = (self._batch_size, self._num_heads)
+        _validate_launch_tensor(
+            q_nope,
+            name="q_nope",
+            device=self.device,
+            dtype=self._q_data_type,
+            shape=(*query_prefix, self._head_dim_ckv),
+        )
+        _validate_launch_tensor(
+            q_pe,
+            name="q_pe",
+            device=self.device,
+            dtype=self._q_data_type,
+            shape=(*query_prefix, self._head_dim_kpe),
+        )
+        if ckv_cache.ndim != 3:
+            raise ValueError(
+                f"cutile launch tensor ckv_cache must have rank 3, got "
+                f"{ckv_cache.ndim}."
+            )
+        if ckv_cache.shape[0] <= 0:
+            raise ValueError("cutile KV cache must contain at least one page.")
+        kv_prefix = (ckv_cache.shape[0], self._page_size)
+        _validate_launch_tensor(
+            ckv_cache,
+            name="ckv_cache",
+            device=self.device,
+            dtype=self._kv_data_type,
+            shape=(*kv_prefix, self._head_dim_ckv),
+        )
+        _validate_launch_tensor(
+            kpe_cache,
+            name="kpe_cache",
+            device=self.device,
+            dtype=self._kv_data_type,
+            shape=(*kv_prefix, self._head_dim_kpe),
+        )
+        _validate_compact_split_pair(q_nope, q_pe, name="query")
+        _validate_compact_split_pair(ckv_cache, kpe_cache, name="KV-cache")
+
+        # -----------------------------------------------------------------------
+        # Prepare and validate the output without converting launch inputs
+        # -----------------------------------------------------------------------
+        output_shape = (*query_prefix, self._head_dim_ckv)
+        if out is None:
+            out = torch.empty(
+                output_shape,
+                dtype=self._output_dtype,
+                device=self.device,
+            )
+        else:
+            _validate_launch_tensor(
+                out,
+                name="out",
+                device=self.device,
+                dtype=self._output_dtype,
+                shape=output_shape,
+            )
+            if not out.is_contiguous():
+                raise ValueError("cutile launch tensor out must be contiguous.")
+        _validate_out_does_not_overlap_inputs(
+            out,
+            ("q_nope", q_nope),
+            ("q_pe", q_pe),
+            ("ckv_cache", ckv_cache),
+            ("kpe_cache", kpe_cache),
+            ("kv_len", kv_len),
+            ("page_table", page_table),
+            ("float_workspace_buffer", self._float_workspace_buffer),
+        )
+
+        # -----------------------------------------------------------------------
+        # Launch the lazily loaded cuTile backend
+        # -----------------------------------------------------------------------
+        launch_args = (
+            q_nope,
+            q_pe,
+            ckv_cache,
+            kpe_cache,
+            kv_len,
+            page_table,
+            self._sm_scale,
+            1.0,
+        )
+        if self.device.type == "cuda":
+            with torch.cuda.device(self.device):
+                self._decode_mla_kv_paged_cutile(
+                    *launch_args,
+                    max_seq_len=-1,
+                    outputs=out,
+                )
+        else:
+            # This path is reachable only by tests that replace the architecture
+            # probe and kernel loader with CPU fakes.
+            self._decode_mla_kv_paged_cutile(
+                *launch_args,
+                max_seq_len=-1,
+                outputs=out,
+            )
+        return cast(torch.Tensor, out)
+
+
+__all__ = [
+    "_BatchMLAPagedAttentionCutileBackend",
+    "_get_compute_capability",
+    "_validate_cutile_num_heads",
+    "_validate_cutile_page_size",
+    "get_cutile_mla_decode",
+]

--- a/flashinfer/mla/_batch_mla/_wrapper.py
+++ b/flashinfer/mla/_batch_mla/_wrapper.py
@@ -19,6 +19,10 @@ from ...trace.templates.attention import mla_paged_decode_trace
 from ...utils import determine_mla_backend, get_compute_capability
 from ._backends._capabilities import MLAPlanCapabilities
 from ._backends.cutlass_backend import _BatchMLAPagedAttentionCutlassBackend
+from ._backends.cutile_backend import (
+    _CUTILE_SUPPORTED_COMPUTE_CAPABILITIES,
+    _BatchMLAPagedAttentionCutileBackend,
+)
 from ._backends.fa2_backend import _BatchMLAPagedAttentionFa2Backend
 from ._backends.fa3_backend import _BatchMLAPagedAttentionFa3Backend
 from ._contracts import (
@@ -65,6 +69,7 @@ _BACKEND_TYPES: dict[str, type[_WrapperBackendType]] = {
     "fa2": _BatchMLAPagedAttentionFa2Backend,
     "fa3": _BatchMLAPagedAttentionFa3Backend,
     "cutlass": _BatchMLAPagedAttentionCutlassBackend,
+    "cutile": _BatchMLAPagedAttentionCutileBackend,
 }
 
 _MIRRORED_BACKEND_ATTRS = (
@@ -109,10 +114,10 @@ class BatchMLAPagedAttentionWrapper:
     projections are absorbed before attention. For the non-absorbed MLA
     prefill path, use the appropriate prefill wrapper instead.
 
-    The planned-wrapper surface owns FA2, FA3, and CUTLASS planning and
-    execution. Call :meth:`plan` once with canonical metadata before invoking
-    :meth:`run`; the plan captures the supported input/output contract and the
-    concrete backend's metadata representation.
+    The planned-wrapper surface owns FA2, FA3, CUTLASS, and cuTile planning
+    and execution. Call :meth:`plan` once with canonical metadata before
+    invoking :meth:`run`; the plan captures the supported input/output contract
+    and the concrete backend's metadata representation.
 
     See :ref:`MLA Page Layout <mla-page-layout>` for the paged KV-cache layout
     and the `FlashInfer MLA blog post
@@ -133,14 +138,21 @@ class BatchMLAPagedAttentionWrapper:
         if major < 10:
             return
         cls._blackwell_auto_fallback_warned = True
+        if (major, minor) in _CUTILE_SUPPORTED_COMPUTE_CAPABILITIES:
+            in_wrapper_alternative = (
+                "backend='cutile' is the native in-wrapper cuda.tile alternative."
+            )
+        else:
+            in_wrapper_alternative = (
+                "backend='cutlass' is the closest in-wrapper alternative but may be "
+                "slower than this fallback for decode shapes."
+            )
         warnings.warn(
             f"BatchMLAPagedAttentionWrapper: backend='auto' selected "
             f"'{selected_backend}' on SM{major}{minor}, which is not Blackwell-native "
             f"and gives poor MLA decode performance. For decode, use "
             f"flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla "
-            f"(Blackwell-native trtllm-gen); backend='cutlass' is the closest "
-            f"in-wrapper alternative but may be slower than this fallback for "
-            f"decode shapes.",
+            f"(Blackwell-native trtllm-gen); {in_wrapper_alternative}",
             UserWarning,
             stacklevel=3,
         )
@@ -238,11 +250,14 @@ class BatchMLAPagedAttentionWrapper:
         kv_len_arr : Optional[torch.Tensor]
             Caller-reserved ``int32`` buffer of shape ``[batch_size]`` for CSR
             KV lengths. Used only with CUDA graphs.
-        backend : {"auto", "fa2", "fa3", "cutlass"}
+        backend : {"auto", "fa2", "fa3", "cutlass", "cutile"}
             Requested concrete backend. ``"auto"`` selects the architecture
             default exposed by :func:`flashinfer.utils.determine_mla_backend`.
             Explicit CUTLASS callers should plan with canonical dense metadata;
             its historical planless ``run`` path remains deprecated.
+            Explicit cuTile callers should plan packed or split FP16/BF16
+            DeepSeek MLA decode inputs with canonical dense or CSR metadata.
+            cuTile is not selected automatically.
         """
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
@@ -259,7 +274,8 @@ class BatchMLAPagedAttentionWrapper:
             self._backend = backend
         else:
             raise ValueError(
-                "backend must be one of 'auto', 'fa2', 'fa3', or 'cutlass', "
+                "backend must be one of 'auto', 'fa2', 'fa3', 'cutlass', or "
+                "'cutile', "
                 f"got {backend!r}."
             )
         self._planned_backend: Optional[_PlannedBackend] = None
@@ -324,7 +340,7 @@ class BatchMLAPagedAttentionWrapper:
     ) -> None: ...
 
     # Legacy flat-metadata compatibility: canonical dense page-table metadata,
-    # native for CUTLASS. This keyword-only form is deprecated.
+    # native for CUTLASS and cuTile. This keyword-only form is deprecated.
     @overload
     def plan(
         self,
@@ -389,7 +405,8 @@ class BatchMLAPagedAttentionWrapper:
         ``MLAPlanMetadata.dual(...)`` may be used when both representations
         already exist; the planner verifies that they describe the same
         requests and page mapping before publishing the plan. FA2 and FA3
-        consume CSR metadata natively, while CUTLASS consumes dense metadata.
+        consume CSR metadata natively, while CUTLASS and cuTile consume dense
+        metadata.
 
         Metadata tensors may be on CPU or the wrapper device. They are
         normalized to the device required by the selected backend; tensors on
@@ -594,13 +611,20 @@ class BatchMLAPagedAttentionWrapper:
         # ---------------------------------------------------------------------------
         # Enforce CUDA graph replanning constraints
         # ---------------------------------------------------------------------------
+        planned_backend_name = getattr(
+            getattr(self, "_planned_backend", None), "_backend", None
+        )
         if (
             self._use_cuda_graph
             and getattr(self, "_planned_backend", None) is not None
-            and getattr(self._planned_backend, "_backend", None) == "cutlass"
+            and planned_backend_name in ("cutlass", "cutile")
         ):
+            graph_backend_name = (
+                "CUTLASS" if planned_backend_name == "cutlass" else "cuTile"
+            )
             raise RuntimeError(
-                "CUDA graph CUTLASS plans cannot replan because dense metadata "
+                f"CUDA graph {graph_backend_name} plans cannot replan because "
+                "dense metadata "
                 "pointers must remain stable."
             )
 
@@ -826,8 +850,13 @@ class BatchMLAPagedAttentionWrapper:
         profiler_buffer : Optional[torch.Tensor]
             Backend profiler output buffer.
         kv_len, page_table : Optional[torch.Tensor]
-            CUTLASS metadata aliases. A planned CUTLASS request may omit them;
-            the deprecated unplanned CUTLASS path requires both.
+            CUTLASS/cuTile metadata aliases. A planned request may omit them;
+            the deprecated unplanned CUTLASS path requires both. Runtime
+            metadata is a trusted hot-path input: every length must be
+            nonnegative and fit within its page-table row, every live page ID
+            must index ``kv_cache``, and callers must not mutate either tensor
+            while a launch is in flight. These values are not synchronized to
+            the host for validation so that CUDA-graph capture remains valid.
         return_lse_base_on_e : bool
             Return natural-log rather than base-2 LSE values.
         o_scale : Optional[float]

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2089,7 +2089,8 @@ class BatchMLAPagedAttentionWrapper:
             User-reserved buffer to back the ``kv_len_arr`` array, shape ``[batch_size]``,
             dtype ``int32``.  Only consulted when ``use_cuda_graph=True``.
         backend : str
-            One of ``"auto"``, ``"fa2"``, ``"fa3"``, ``"cutlass"``. Default ``"auto"``.
+            One of ``"auto"``, ``"fa2"``, ``"fa3"``, ``"cutlass"``, ``"cutile"``.
+            Default ``"auto"``.
 
             ``"auto"`` picks ``"fa3"`` on SM90a, else ``"fa2"``. On SM>=100 neither
             is Blackwell-native; for MLA decode prefer
@@ -2106,6 +2107,13 @@ class BatchMLAPagedAttentionWrapper:
         self.device = float_workspace_buffer.device
 
         if backend == "cutlass":
+            self._backend = backend
+            return
+
+        if backend == "cutile":
+            # cuda.tile MLA decode: like cutlass, it needs no JIT module, no int
+            # workspace, and no plan-info. run() consumes block_tables + kv_len
+            # directly. Skip the fa2/fa3 workspace setup below.
             self._backend = backend
             return
 
@@ -2216,6 +2224,29 @@ class BatchMLAPagedAttentionWrapper:
                     "head_dim_ckv=512 and head_dim_kpe=64 (DeepSeek MLA), got "
                     f"head_dim_ckv={head_dim_ckv}, head_dim_kpe={head_dim_kpe}."
                 )
+
+        if self._backend == "cutile":
+            # cuda.tile MLA decode needs no JIT module or workspace plan; it
+            # takes block_tables + kv_len at run() time. Stash only the metadata
+            # run() consumes, then return.
+            if kv_data_type not in (torch.float16, torch.bfloat16):
+                raise ValueError(
+                    "cutile MLA backend supports only fp16/bf16 kv_data_type, "
+                    f"got {kv_data_type}."
+                )
+            if head_dim_ckv != 512 or head_dim_kpe != 64:
+                raise ValueError(
+                    "cutile MLA backend supports only head_dim_ckv=512 and "
+                    f"head_dim_kpe=64 (DeepSeek MLA), got "
+                    f"head_dim_ckv={head_dim_ckv}, head_dim_kpe={head_dim_kpe}."
+                )
+            self._causal = causal
+            self._page_size = page_size
+            self._sm_scale = sm_scale
+            self._q_data_type = q_data_type
+            self._kv_data_type = kv_data_type
+            self._use_profiler = use_profiler
+            return
 
         self._cached_module = get_batch_mla_module(
             self._backend,
@@ -2346,9 +2377,9 @@ class BatchMLAPagedAttentionWrapper:
         profiler_buffer : Optional[torch.Tensor]
             The buffer to store the profiler data.
         kv_len : Optional[torch.Tensor]
-            The query length of each request, shape: ``[batch_size]``. Required when ``backend`` is ``cutlass``.
+            The query length of each request, shape: ``[batch_size]``. Required when ``backend`` is ``cutlass`` or ``cutile``.
         page_table : Optional[torch.Tensor]
-            The page table of the paged kv-cache, shape: ``[batch_size, num_pages]``. Required when ``backend`` is ``cutlass``.
+            The page table of the paged kv-cache, shape: ``[batch_size, num_pages]``. Required when ``backend`` is ``cutlass`` or ``cutile``.
         return_lse_base_on_e : bool, optional
             Controls the base of the returned LSE values when ``return_lse=True``.
             If ``False`` (default), the LSE is returned in base-2
@@ -2370,6 +2401,55 @@ class BatchMLAPagedAttentionWrapper:
             ``kv_data_type`` is FP8 (``real = quantized * kpe_scale``). Same
             usage rules as ``ckv_scale``.
         """
+        if self._backend == "cutile":
+            if return_lse:
+                raise ValueError(
+                    "return_lse is not supported by the cutile MLA backend."
+                )
+            if profiler_buffer is not None:
+                raise ValueError(
+                    "profiler_buffer is not supported by the cutile MLA backend."
+                )
+            if o_scale is not None or ckv_scale is not None or kpe_scale is not None:
+                raise ValueError(
+                    "o_scale / ckv_scale / kpe_scale (FP8 paths) are not supported "
+                    "by the cutile MLA backend."
+                )
+            if kv_len is None or page_table is None:
+                raise ValueError(
+                    "cutile MLA backend requires kv_len and page_table at run() "
+                    "(like the cutlass backend)."
+                )
+            if out is None:
+                out = torch.empty_like(q_nope)
+            else:
+                check_shape_dtype_device(
+                    out, q_nope.shape, q_nope.dtype, q_nope.device, "out"
+                )
+            # Lazy import keeps cuda.tile an optional dependency.
+            from ..attention.kernels.cutile.fmha_decode_bsr_cutile import (
+                decode_mla_kv_paged_cutile,
+            )
+
+            # K and V share the single compressed-latent cache (ckv_cache); the
+            # kernel reads it for both. k_scale carries the full softmax scale
+            # (sm_scale), v_scale=1.0 (no output dequant). max_seq_len=-1 lets the
+            # kernel infer the bound from block_tables (no host sync -> CUDA-graph
+            # safe).
+            decode_mla_kv_paged_cutile(
+                q_nope,
+                q_pe,
+                ckv_cache,
+                kpe_cache,
+                kv_len.to(torch.int32),
+                page_table.to(torch.int32),
+                self._sm_scale,
+                1.0,
+                max_seq_len=-1,
+                outputs=out,
+            )
+            return out
+
         if self._backend == "cutlass":
             if return_lse:
                 raise ValueError("return_lse does not support cutlass backend for now.")

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3301,11 +3301,13 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         backend : str
             The implementation backend, could be ``auto``/``fa2``/``fa3``/``cudnn``/``cutlass``
-            or ``cute-dsl``.
+            /``cute-dsl`` or ``cutile``.
             Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
             The ``cute-dsl`` backend uses the CuTe DSL attention kernel for Blackwell (SM100+).
+            The ``cutile`` backend uses the pure cuda.tile Python prefill kernel (Blackwell,
+            opt-in); it requires ``qo_indptr == kv_indptr`` (equal-length prefill).
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
@@ -3763,6 +3765,57 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     window_left=window_left,
                     variant=variant,
                 )
+        elif self._backend == "cutile":
+            # cuTile ragged prefill: no C++ module to build. Materialize the
+            # per-request length/offset arrays the kernel needs from
+            # qo_indptr/kv_indptr here (plan() may host-sync; run() must not).
+            if custom_mask is not None or packed_custom_mask is not None:
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support custom_mask."
+                )
+            if pos_encoding_mode != "NONE":
+                raise NotImplementedError(
+                    "cuTile ragged prefill only supports pos_encoding_mode='NONE'. "
+                    "Apply RoPE to Q/K before calling the kernel."
+                )
+            if logits_soft_cap is not None and logits_soft_cap > 0:
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support logits_soft_cap."
+                )
+            if window_left >= 0:
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support sliding window."
+                )
+            # The kernel slices Q and KV with a single shared per-request offset,
+            # so it only supports qo_indptr == kv_indptr (equal-length prefill /
+            # self-attention, no cached prefix). Append/chunked prefill with
+            # kv_len != q_len must use another backend.
+            if not torch.equal(qo_indptr_host, kv_indptr_host):
+                raise NotImplementedError(
+                    "cuTile ragged prefill requires qo_indptr == kv_indptr "
+                    "(equal-length prefill). For append/chunked prefill with "
+                    "kv_len != q_len, use backend='fa2'."
+                )
+            seq_lens_q_host = (qo_indptr_host[1:] - qo_indptr_host[:-1]).to(
+                torch.int32
+            )
+            kv_len_arr_i32 = kv_len_arr.to(torch.int32)
+            self._cutile_num_batch = batch_size
+            self._cutile_seq_lens_q = seq_lens_q_host.to(
+                self.device, non_blocking=non_blocking
+            )
+            self._cutile_seq_lens_kv = kv_len_arr_i32.to(
+                self.device, non_blocking=non_blocking
+            )
+            # Shared exclusive-prefix-sum offset (== qo_indptr[:-1] == kv_indptr[:-1]).
+            self._cutile_seq_offset = self._qo_indptr_buf[:-1].to(torch.int32)
+            self._cutile_max_seq_len = (
+                int(kv_len_arr_i32.max().item()) if batch_size > 0 else 0
+            )
+            # block_tables is accepted but unused by the ragged kernel.
+            self._cutile_block_tables = torch.zeros(
+                batch_size, 1, dtype=torch.int32, device=self.device
+            )
         elif self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
@@ -3857,7 +3910,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         elif self._backend == "fmha_v2":
             # fmha_v2 handles planning internally — no JIT module plan needed
             pass
-        elif self._backend not in ("cudnn", "cute-dsl"):
+        elif self._backend not in ("cudnn", "cute-dsl", "cutile"):
             assert self._cached_module is not None, "cached module is not initialized"
             args = [
                 self._float_workspace_buffer,
@@ -4268,6 +4321,39 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             )
 
             return (out, lse) if return_lse else out
+        elif self._backend == "cutile":
+            if any(s is not None for s in (q_scale, k_scale, v_scale, o_scale)):
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support FP8 scale parameters."
+                )
+            if kv_cache_sf is not None:
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support NVFP4 KV scaling."
+                )
+            from .attention.kernels.cutile.fmha_prefill_bsr_cutile import (  # noqa: PLC0415
+                prefill_attention_kv_ragged_cutile,
+            )
+
+            # k/v are ragged [total_kv, num_kv_heads, head_dim]. The kernel folds
+            # the softmax scale into k_scale (qk_scale = k_scale * INV_LOG_2),
+            # matching single_prefill_with_kv_cache's default.
+            out_ragged, lse_ragged = prefill_attention_kv_ragged_cutile(
+                q=q,
+                k_cache=k,
+                v_cache=v,
+                actual_seq_lens_q=self._cutile_seq_lens_q,
+                actual_seq_lens_kv=self._cutile_seq_lens_kv,
+                actual_seq_offset=self._cutile_seq_offset,
+                block_tables=self._cutile_block_tables,
+                k_scale=sm_scale,
+                v_scale=1.0,
+                num_batch=self._cutile_num_batch,
+                max_seq_len=self._cutile_max_seq_len,
+                is_causal=self._causal,
+                outputs=out,
+                out_lse=lse if return_lse else None,
+            )
+            return (out_ragged, lse_ragged) if return_lse else out_ragged
 
         # Skip FP8->FP16 conversion for FA3 backend with FP8 support
         # The JIT module will handle FP8 natively

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3796,9 +3796,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     "(equal-length prefill). For append/chunked prefill with "
                     "kv_len != q_len, use backend='fa2'."
                 )
-            seq_lens_q_host = (qo_indptr_host[1:] - qo_indptr_host[:-1]).to(
-                torch.int32
-            )
+            seq_lens_q_host = (qo_indptr_host[1:] - qo_indptr_host[:-1]).to(torch.int32)
             kv_len_arr_i32 = kv_len_arr.to(torch.int32)
             self._cutile_num_batch = batch_size
             self._cutile_seq_lens_q = seq_lens_q_host.to(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4123,9 +4123,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     "(equal-length prefill). For append/chunked prefill with "
                     "kv_len != q_len, use backend='fa2'."
                 )
-            seq_lens_q_host = (qo_indptr_host[1:] - qo_indptr_host[:-1]).to(
-                torch.int32
-            )
+            seq_lens_q_host = (qo_indptr_host[1:] - qo_indptr_host[:-1]).to(torch.int32)
             kv_len_arr_i32 = kv_len_arr.to(torch.int32)
             self._cutile_num_batch = batch_size
             self._cutile_seq_lens_q = seq_lens_q_host.to(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3529,12 +3529,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         backend : str
             The implementation backend, could be ``auto``/``fa2``/``fa3``/``cudnn``/``cutlass``
-            or ``cute-dsl``/``cute-dsl-prims``.
+            or ``cute-dsl``/``cute-dsl-prims``/``cutile``.
             Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
             The ``cute-dsl`` backend uses the CuTe DSL attention kernel for Blackwell (SM100+).
             ``cute-dsl-prims`` is an explicit SM120-only packed FP8 prefill backend.
+            The ``cutile`` backend uses the pure cuda.tile Python prefill kernel (Blackwell,
+            opt-in); it requires ``qo_indptr == kv_indptr`` (equal-length prefill).
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
@@ -4090,6 +4092,57 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     window_left=window_left,
                     variant=variant,
                 )
+        elif self._backend == "cutile":
+            # cuTile ragged prefill: no C++ module to build. Materialize the
+            # per-request length/offset arrays the kernel needs from
+            # qo_indptr/kv_indptr here (plan() may host-sync; run() must not).
+            if custom_mask is not None or packed_custom_mask is not None:
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support custom_mask."
+                )
+            if pos_encoding_mode != "NONE":
+                raise NotImplementedError(
+                    "cuTile ragged prefill only supports pos_encoding_mode='NONE'. "
+                    "Apply RoPE to Q/K before calling the kernel."
+                )
+            if logits_soft_cap is not None and logits_soft_cap > 0:
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support logits_soft_cap."
+                )
+            if window_left >= 0:
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support sliding window."
+                )
+            # The kernel slices Q and KV with a single shared per-request offset,
+            # so it only supports qo_indptr == kv_indptr (equal-length prefill /
+            # self-attention, no cached prefix). Append/chunked prefill with
+            # kv_len != q_len must use another backend.
+            if not torch.equal(qo_indptr_host, kv_indptr_host):
+                raise NotImplementedError(
+                    "cuTile ragged prefill requires qo_indptr == kv_indptr "
+                    "(equal-length prefill). For append/chunked prefill with "
+                    "kv_len != q_len, use backend='fa2'."
+                )
+            seq_lens_q_host = (qo_indptr_host[1:] - qo_indptr_host[:-1]).to(
+                torch.int32
+            )
+            kv_len_arr_i32 = kv_len_arr.to(torch.int32)
+            self._cutile_num_batch = batch_size
+            self._cutile_seq_lens_q = seq_lens_q_host.to(
+                self.device, non_blocking=non_blocking
+            )
+            self._cutile_seq_lens_kv = kv_len_arr_i32.to(
+                self.device, non_blocking=non_blocking
+            )
+            # Shared exclusive-prefix-sum offset (== qo_indptr[:-1] == kv_indptr[:-1]).
+            self._cutile_seq_offset = self._qo_indptr_buf[:-1].to(torch.int32)
+            self._cutile_max_seq_len = (
+                int(kv_len_arr_i32.max().item()) if batch_size > 0 else 0
+            )
+            # block_tables is accepted but unused by the ragged kernel.
+            self._cutile_block_tables = torch.zeros(
+                batch_size, 1, dtype=torch.int32, device=self.device
+            )
         elif self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
@@ -4184,7 +4237,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         elif self._backend == "fmha_v2":
             # fmha_v2 handles planning internally — no JIT module plan needed
             pass
-        elif self._backend not in ("cudnn", "cute-dsl", "cute-dsl-prims"):
+        elif self._backend not in (
+            "cudnn",
+            "cute-dsl",
+            "cute-dsl-prims",
+            "cutile",
+        ):
             assert self._cached_module is not None, "cached module is not initialized"
             args = [
                 self._float_workspace_buffer,
@@ -4647,6 +4705,39 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             )
 
             return (out, lse) if return_lse else out
+        elif self._backend == "cutile":
+            if any(s is not None for s in (q_scale, k_scale, v_scale, o_scale)):
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support FP8 scale parameters."
+                )
+            if kv_cache_sf is not None:
+                raise NotImplementedError(
+                    "cuTile ragged prefill does not support NVFP4 KV scaling."
+                )
+            from .attention.kernels.cutile.fmha_prefill_bsr_cutile import (  # noqa: PLC0415
+                prefill_attention_kv_ragged_cutile,
+            )
+
+            # k/v are ragged [total_kv, num_kv_heads, head_dim]. The kernel folds
+            # the softmax scale into k_scale (qk_scale = k_scale * INV_LOG_2),
+            # matching single_prefill_with_kv_cache's default.
+            out_ragged, lse_ragged = prefill_attention_kv_ragged_cutile(
+                q=q,
+                k_cache=k,
+                v_cache=v,
+                actual_seq_lens_q=self._cutile_seq_lens_q,
+                actual_seq_lens_kv=self._cutile_seq_lens_kv,
+                actual_seq_offset=self._cutile_seq_offset,
+                block_tables=self._cutile_block_tables,
+                k_scale=sm_scale,
+                v_scale=1.0,
+                num_batch=self._cutile_num_batch,
+                max_seq_len=self._cutile_max_seq_len,
+                is_causal=self._causal,
+                outputs=out,
+                out_lse=lse if return_lse else None,
+            )
+            return (out_ragged, lse_ragged) if return_lse else out_ragged
 
         # Skip FP8->FP16 conversion for FA3 backend with FP8 support
         # The JIT module will handle FP8 natively

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -434,6 +434,90 @@ class BlockSparseAttentionWrapper:
         kv_data_type = canonicalize_torch_dtype(kv_data_type)
         self._o_dtype = canonicalize_torch_dtype(o_data_type)
 
+        # ---- cuTile backend (pure cuda.tile Python kernel) ------------------------
+        # No C++ module to JIT: just stash the BSR plan state. run() reconstructs a
+        # dense block table from (indptr/indices) and treats each block-row as one
+        # variable-length prefill "batch" with page_size == C.
+        if self._backend == "cutile":
+            if indptr is None or indices is None:
+                raise ValueError(
+                    "cuTile block-sparse backend requires indptr and indices."
+                )
+            if N % C != 0:
+                raise ValueError(
+                    f"cuTile block-sparse backend requires N % C == 0 (N={N}, C={C})."
+                )
+            if mask is not None or packed_mask is not None:
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not support per-element "
+                    "intra-block masks (mask/packed_mask)."
+                )
+            if logits_soft_cap is not None and logits_soft_cap > 0:
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not support logits_soft_cap."
+                )
+            if pos_encoding_mode != "NONE":
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not apply position encoding "
+                    "(pos_encoding_mode must be 'NONE')."
+                )
+            if M % R != 0:
+                # run() forces each block-row batch to exactly R query rows; a
+                # non-multiple M would slice past the query buffer -> OOB.
+                raise ValueError(
+                    f"cuTile block-sparse backend requires M % R == 0 (M={M}, R={R})."
+                )
+            if C < 16:
+                # Prefill autotune's minimum BLOCK_N is 16 (32 on SM90); a smaller
+                # C yields an empty search space -> opaque exhaustive_search error.
+                raise ValueError(
+                    "cuTile block-sparse backend requires C >= 16 (the minimum "
+                    f"prefill BLOCK_N); got C={C}."
+                )
+            if causal:
+                # The BSR->paged mapping gathers arbitrary column-blocks, so the
+                # kernel's packed (gathered-block) position mask does NOT equal
+                # global row/column causality. (The standalone prefill kernel
+                # supports causal for contiguous paged/ragged inputs; only this
+                # block-sparse mapping cannot express it correctly.)
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not support causal masking "
+                    "under the block-sparse (gathered-block) mapping."
+                )
+            if num_qo_heads % num_kv_heads != 0:
+                # run() maps each (block-row, kv-head) onto QUERY_GROUP_SIZE =
+                # num_qo_heads // num_kv_heads query heads; a non-multiple would
+                # silently drop the remainder heads.
+                raise ValueError(
+                    "cuTile block-sparse backend requires num_qo_heads % "
+                    f"num_kv_heads == 0 (num_qo_heads={num_qo_heads}, "
+                    f"num_kv_heads={num_kv_heads})."
+                )
+            num_col_blocks = N // C
+            if indices.numel() > 0:
+                # Each index selects a column-block gathered as a page; an
+                # out-of-range value would issue an invalid page load.
+                idx_min = int(indices.min().item())
+                idx_max = int(indices.max().item())
+                if idx_min < 0 or idx_max >= num_col_blocks:
+                    raise ValueError(
+                        "cuTile block-sparse backend requires all indices in "
+                        f"[0, N // C) = [0, {num_col_blocks}); got "
+                        f"[{idx_min}, {idx_max}]."
+                    )
+            self._R = R
+            self._C = C
+            self._M = M
+            self._N = N
+            self._num_qo_heads = num_qo_heads
+            self._num_kv_heads = num_kv_heads
+            self._head_dim = head_dim
+            self._causal = causal
+            self._sm_scale = sm_scale
+            self._sparse_indptr = indptr.to(self.device, non_blocking=non_blocking)
+            self._sparse_indices = indices.to(self.device, non_blocking=non_blocking)
+            return
+
         # ---- VSA Blackwell backend (BSA blk128 kernel) ----------------------------
         if self._backend == "vsa_blackwell":
             cc = get_compute_capability(self.device)
@@ -881,6 +965,72 @@ class BlockSparseAttentionWrapper:
         """
         if enable_pdl is None:
             enable_pdl = device_support_pdl(q.device)
+
+        # ---- cuTile backend (pure cuda.tile Python kernel) ------------------------
+        # Map the BSR plan onto a paged prefill: each block-row (R query rows) is one
+        # variable-length batch whose KV pages are the selected column-blocks (width C).
+        if self._backend == "cutile":
+            if return_lse:
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not support return_lse."
+                )
+            from .attention.kernels.cutile.fmha_prefill_bsr_cutile import (  # noqa: PLC0415
+                prefill_attention_kv_paged_cutile,
+            )
+
+            R, C = self._R, self._C
+            indptr = self._sparse_indptr
+            indices = self._sparse_indices
+            num_block_rows = indptr.numel() - 1
+
+            # KV as page_size==C paged cache: [N, H_kv, D] -> [N // C, C, H_kv, D].
+            k_cache = k.reshape(self._N // C, C, self._num_kv_heads, self._head_dim)
+            v_cache = v.reshape(self._N // C, C, self._num_kv_heads, v.shape[-1])
+
+            nnz_per_row = (indptr[1:] - indptr[:-1]).to(torch.int32)
+            actual_seq_lens_q = torch.full(
+                (num_block_rows,), R, dtype=torch.int32, device=q.device
+            )
+            actual_seq_lens_kv = (nnz_per_row * C).to(torch.int32)
+            max_pages = int(nnz_per_row.max().item())
+            block_tables = torch.zeros(
+                (num_block_rows, max_pages), dtype=torch.int32, device=q.device
+            )
+            col = torch.arange(max_pages, device=q.device)
+            valid = col[None, :] < nnz_per_row[:, None]
+            block_tables[valid] = indices.to(torch.int32)
+            actual_seq_offset = torch.nn.functional.pad(
+                actual_seq_lens_q.cumsum(0), (1, 0)
+            ).to(torch.int32)
+
+            # The kernel folds the softmax scale into k_scale (qk_scale =
+            # k_scale * INV_LOG_2), so k_scale must carry the 1/sqrt(head_dim)
+            # softmax scale, matching single_prefill_with_kv_cache's default.
+            sm_scale = self._sm_scale
+            if sm_scale is None:
+                sm_scale = 1.0 / math.sqrt(self._head_dim)
+
+            out, _ = prefill_attention_kv_paged_cutile(
+                q=q,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                actual_seq_lens_q=actual_seq_lens_q,
+                actual_seq_lens_kv=actual_seq_lens_kv,
+                actual_seq_offset=actual_seq_offset,
+                block_tables=block_tables,
+                k_scale=sm_scale,
+                v_scale=1.0,
+                num_batch=num_block_rows,
+                # Each block-row is one variable-length batch of exactly R query
+                # rows, so the per-batch max query length is R (not the global M).
+                # Passing R sizes the grid / LPT tile count to exactly ceil(R/
+                # BLOCK_M) tiles instead of ceil(M/BLOCK_M), avoiding the ~M/R x
+                # over-launch of CTAs that would otherwise early-return.
+                max_seq_len=R,
+                is_causal=self._causal,
+                outputs=out,
+            )
+            return out
 
         # ---- VSA Blackwell backend (BSA blk128 kernel) ----------------------------
         if self._backend == "vsa_blackwell":

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -514,8 +514,39 @@ class BlockSparseAttentionWrapper:
             self._head_dim = head_dim
             self._causal = causal
             self._sm_scale = sm_scale
-            self._sparse_indptr = indptr.to(self.device, non_blocking=non_blocking)
-            self._sparse_indices = indices.to(self.device, non_blocking=non_blocking)
+            indptr = indptr.to(self.device, non_blocking=non_blocking)
+            indices = indices.to(self.device, non_blocking=non_blocking)
+            self._sparse_indptr = indptr
+            self._sparse_indices = indices
+
+            # Materialize the dense block table and the per-batch length/offset
+            # arrays now (at plan time) so run() is CUDA-graph-capturable:
+            # everything here derives only from (indptr, indices, R, C), which
+            # are fixed at plan time. Reconstructing it in run() -- as an earlier
+            # version did -- forced a host `.item()` sync on max_pages plus ~6
+            # tensor allocations on every call, breaking graph capture (mirrors
+            # the plan-time block-table build in decode.py's cuTile backend).
+            num_block_rows = indptr.numel() - 1
+            nnz_per_row = (indptr[1:] - indptr[:-1]).to(torch.int32)
+            actual_seq_lens_q = torch.full(
+                (num_block_rows,), R, dtype=torch.int32, device=self.device
+            )
+            max_pages = int(nnz_per_row.max().item()) if num_block_rows > 0 else 0
+            block_tables = torch.zeros(
+                (num_block_rows, max_pages), dtype=torch.int32, device=self.device
+            )
+            col = torch.arange(max_pages, device=self.device)
+            valid = col[None, :] < nnz_per_row[:, None]
+            block_tables[valid] = indices.to(torch.int32)
+            actual_seq_offset = torch.nn.functional.pad(
+                actual_seq_lens_q.cumsum(0), (1, 0)
+            ).to(torch.int32)
+
+            self._sparse_num_block_rows = num_block_rows
+            self._sparse_actual_seq_lens_q = actual_seq_lens_q
+            self._sparse_actual_seq_lens_kv = (nnz_per_row * C).to(torch.int32)
+            self._sparse_block_tables = block_tables
+            self._sparse_actual_seq_offset = actual_seq_offset
             return
 
         # ---- VSA Blackwell backend (BSA blk128 kernel) ----------------------------
@@ -979,29 +1010,19 @@ class BlockSparseAttentionWrapper:
             )
 
             R, C = self._R, self._C
-            indptr = self._sparse_indptr
-            indices = self._sparse_indices
-            num_block_rows = indptr.numel() - 1
+            num_block_rows = self._sparse_num_block_rows
 
             # KV as page_size==C paged cache: [N, H_kv, D] -> [N // C, C, H_kv, D].
             k_cache = k.reshape(self._N // C, C, self._num_kv_heads, self._head_dim)
             v_cache = v.reshape(self._N // C, C, self._num_kv_heads, v.shape[-1])
 
-            nnz_per_row = (indptr[1:] - indptr[:-1]).to(torch.int32)
-            actual_seq_lens_q = torch.full(
-                (num_block_rows,), R, dtype=torch.int32, device=q.device
-            )
-            actual_seq_lens_kv = (nnz_per_row * C).to(torch.int32)
-            max_pages = int(nnz_per_row.max().item())
-            block_tables = torch.zeros(
-                (num_block_rows, max_pages), dtype=torch.int32, device=q.device
-            )
-            col = torch.arange(max_pages, device=q.device)
-            valid = col[None, :] < nnz_per_row[:, None]
-            block_tables[valid] = indices.to(torch.int32)
-            actual_seq_offset = torch.nn.functional.pad(
-                actual_seq_lens_q.cumsum(0), (1, 0)
-            ).to(torch.int32)
+            # Block table + per-batch length/offset arrays were materialized at
+            # plan() time (they derive only from indptr/indices/R/C), so run()
+            # does no host sync or allocation here and stays graph-capturable.
+            actual_seq_lens_q = self._sparse_actual_seq_lens_q
+            actual_seq_lens_kv = self._sparse_actual_seq_lens_kv
+            block_tables = self._sparse_block_tables
+            actual_seq_offset = self._sparse_actual_seq_offset
 
             # The kernel folds the softmax scale into k_scale (qk_scale =
             # k_scale * INV_LOG_2), so k_scale must carry the 1/sqrt(head_dim)

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -1147,7 +1147,7 @@ class BlockSparseAttentionWrapper:
         qo_indptr_host = R * torch.arange(num_blocks_row + 1, dtype=torch.int32)
         qo_indptr_host[-1] = M
         qo_indptr = qo_indptr_host.to(indptr.device, non_blocking=non_blocking)
-        if indices.max().item() * C > N:
+        if indices.numel() > 0 and indices.max().item() * C > N:
             raise ValueError("indices out of bound")
         last_block_len = torch.full(
             (num_blocks_row,), C, dtype=torch.int32, device=indptr.device

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -724,6 +724,90 @@ class BlockSparseAttentionWrapper:
             self._sm_scale = sm_scale
             return
 
+        # ---- cuTile backend (pure cuda.tile Python kernel) ------------------------
+        # No C++ module to JIT: just stash the BSR plan state. run() reconstructs a
+        # dense block table from (indptr/indices) and treats each block-row as one
+        # variable-length prefill "batch" with page_size == C.
+        if self._backend == "cutile":
+            if indptr is None or indices is None:
+                raise ValueError(
+                    "cuTile block-sparse backend requires indptr and indices."
+                )
+            if N % C != 0:
+                raise ValueError(
+                    f"cuTile block-sparse backend requires N % C == 0 (N={N}, C={C})."
+                )
+            if mask is not None or packed_mask is not None:
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not support per-element "
+                    "intra-block masks (mask/packed_mask)."
+                )
+            if logits_soft_cap is not None and logits_soft_cap > 0:
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not support logits_soft_cap."
+                )
+            if pos_encoding_mode != "NONE":
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not apply position encoding "
+                    "(pos_encoding_mode must be 'NONE')."
+                )
+            if M % R != 0:
+                # run() forces each block-row batch to exactly R query rows; a
+                # non-multiple M would slice past the query buffer -> OOB.
+                raise ValueError(
+                    f"cuTile block-sparse backend requires M % R == 0 (M={M}, R={R})."
+                )
+            if C < 16:
+                # Prefill autotune's minimum BLOCK_N is 16 (32 on SM90); a smaller
+                # C yields an empty search space -> opaque exhaustive_search error.
+                raise ValueError(
+                    "cuTile block-sparse backend requires C >= 16 (the minimum "
+                    f"prefill BLOCK_N); got C={C}."
+                )
+            if causal:
+                # The BSR->paged mapping gathers arbitrary column-blocks, so the
+                # kernel's packed (gathered-block) position mask does NOT equal
+                # global row/column causality. (The standalone prefill kernel
+                # supports causal for contiguous paged/ragged inputs; only this
+                # block-sparse mapping cannot express it correctly.)
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not support causal masking "
+                    "under the block-sparse (gathered-block) mapping."
+                )
+            if num_qo_heads % num_kv_heads != 0:
+                # run() maps each (block-row, kv-head) onto QUERY_GROUP_SIZE =
+                # num_qo_heads // num_kv_heads query heads; a non-multiple would
+                # silently drop the remainder heads.
+                raise ValueError(
+                    "cuTile block-sparse backend requires num_qo_heads % "
+                    f"num_kv_heads == 0 (num_qo_heads={num_qo_heads}, "
+                    f"num_kv_heads={num_kv_heads})."
+                )
+            num_col_blocks = N // C
+            if indices.numel() > 0:
+                # Each index selects a column-block gathered as a page; an
+                # out-of-range value would issue an invalid page load.
+                idx_min = int(indices.min().item())
+                idx_max = int(indices.max().item())
+                if idx_min < 0 or idx_max >= num_col_blocks:
+                    raise ValueError(
+                        "cuTile block-sparse backend requires all indices in "
+                        f"[0, N // C) = [0, {num_col_blocks}); got "
+                        f"[{idx_min}, {idx_max}]."
+                    )
+            self._R = R
+            self._C = C
+            self._M = M
+            self._N = N
+            self._num_qo_heads = num_qo_heads
+            self._num_kv_heads = num_kv_heads
+            self._head_dim = head_dim
+            self._causal = causal
+            self._sm_scale = sm_scale
+            self._sparse_indptr = indptr.to(self.device, non_blocking=non_blocking)
+            self._sparse_indices = indices.to(self.device, non_blocking=non_blocking)
+            return
+
         # ---- VSA blk128 backend (BSA CuTe-DSL kernel, SM100/SM103) ---------------
         if self._backend == "vsa_sm100_blk128":
             cc = get_compute_capability(self.device)
@@ -1293,6 +1377,72 @@ class BlockSparseAttentionWrapper:
                 return_lse=return_lse,
                 backend="cake",
             )
+
+        # ---- cuTile backend (pure cuda.tile Python kernel) ------------------------
+        # Map the BSR plan onto a paged prefill: each block-row (R query rows) is one
+        # variable-length batch whose KV pages are the selected column-blocks (width C).
+        if self._backend == "cutile":
+            if return_lse:
+                raise NotImplementedError(
+                    "cuTile block-sparse backend does not support return_lse."
+                )
+            from .attention.kernels.cutile.fmha_prefill_bsr_cutile import (  # noqa: PLC0415
+                prefill_attention_kv_paged_cutile,
+            )
+
+            R, C = self._R, self._C
+            indptr = self._sparse_indptr
+            indices = self._sparse_indices
+            num_block_rows = indptr.numel() - 1
+
+            # KV as page_size==C paged cache: [N, H_kv, D] -> [N // C, C, H_kv, D].
+            k_cache = k.reshape(self._N // C, C, self._num_kv_heads, self._head_dim)
+            v_cache = v.reshape(self._N // C, C, self._num_kv_heads, v.shape[-1])
+
+            nnz_per_row = (indptr[1:] - indptr[:-1]).to(torch.int32)
+            actual_seq_lens_q = torch.full(
+                (num_block_rows,), R, dtype=torch.int32, device=q.device
+            )
+            actual_seq_lens_kv = (nnz_per_row * C).to(torch.int32)
+            max_pages = int(nnz_per_row.max().item())
+            block_tables = torch.zeros(
+                (num_block_rows, max_pages), dtype=torch.int32, device=q.device
+            )
+            col = torch.arange(max_pages, device=q.device)
+            valid = col[None, :] < nnz_per_row[:, None]
+            block_tables[valid] = indices.to(torch.int32)
+            actual_seq_offset = torch.nn.functional.pad(
+                actual_seq_lens_q.cumsum(0), (1, 0)
+            ).to(torch.int32)
+
+            # The kernel folds the softmax scale into k_scale (qk_scale =
+            # k_scale * INV_LOG_2), so k_scale must carry the 1/sqrt(head_dim)
+            # softmax scale, matching single_prefill_with_kv_cache's default.
+            sm_scale = self._sm_scale
+            if sm_scale is None:
+                sm_scale = 1.0 / math.sqrt(self._head_dim)
+
+            out, _ = prefill_attention_kv_paged_cutile(
+                q=q,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                actual_seq_lens_q=actual_seq_lens_q,
+                actual_seq_lens_kv=actual_seq_lens_kv,
+                actual_seq_offset=actual_seq_offset,
+                block_tables=block_tables,
+                k_scale=sm_scale,
+                v_scale=1.0,
+                num_batch=num_block_rows,
+                # Each block-row is one variable-length batch of exactly R query
+                # rows, so the per-batch max query length is R (not the global M).
+                # Passing R sizes the grid / LPT tile count to exactly ceil(R/
+                # BLOCK_M) tiles instead of ceil(M/BLOCK_M), avoiding the ~M/R x
+                # over-launch of CTAs that would otherwise early-return.
+                max_seq_len=R,
+                is_causal=self._causal,
+                outputs=out,
+            )
+            return out
 
         # ---- VSA blk128 backend (BSA CuTe-DSL kernel, SM100/SM103) ---------------
         if self._backend == "vsa_sm100_blk128":

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -804,8 +804,39 @@ class BlockSparseAttentionWrapper:
             self._head_dim = head_dim
             self._causal = causal
             self._sm_scale = sm_scale
-            self._sparse_indptr = indptr.to(self.device, non_blocking=non_blocking)
-            self._sparse_indices = indices.to(self.device, non_blocking=non_blocking)
+            indptr = indptr.to(self.device, non_blocking=non_blocking)
+            indices = indices.to(self.device, non_blocking=non_blocking)
+            self._sparse_indptr = indptr
+            self._sparse_indices = indices
+
+            # Materialize the dense block table and the per-batch length/offset
+            # arrays now (at plan time) so run() is CUDA-graph-capturable:
+            # everything here derives only from (indptr, indices, R, C), which
+            # are fixed at plan time. Reconstructing it in run() -- as an earlier
+            # version did -- forced a host `.item()` sync on max_pages plus ~6
+            # tensor allocations on every call, breaking graph capture (mirrors
+            # the plan-time block-table build in decode.py's cuTile backend).
+            num_block_rows = indptr.numel() - 1
+            nnz_per_row = (indptr[1:] - indptr[:-1]).to(torch.int32)
+            actual_seq_lens_q = torch.full(
+                (num_block_rows,), R, dtype=torch.int32, device=self.device
+            )
+            max_pages = int(nnz_per_row.max().item()) if num_block_rows > 0 else 0
+            block_tables = torch.zeros(
+                (num_block_rows, max_pages), dtype=torch.int32, device=self.device
+            )
+            col = torch.arange(max_pages, device=self.device)
+            valid = col[None, :] < nnz_per_row[:, None]
+            block_tables[valid] = indices.to(torch.int32)
+            actual_seq_offset = torch.nn.functional.pad(
+                actual_seq_lens_q.cumsum(0), (1, 0)
+            ).to(torch.int32)
+
+            self._sparse_num_block_rows = num_block_rows
+            self._sparse_actual_seq_lens_q = actual_seq_lens_q
+            self._sparse_actual_seq_lens_kv = (nnz_per_row * C).to(torch.int32)
+            self._sparse_block_tables = block_tables
+            self._sparse_actual_seq_offset = actual_seq_offset
             return
 
         # ---- VSA blk128 backend (BSA CuTe-DSL kernel, SM100/SM103) ---------------
@@ -1391,29 +1422,19 @@ class BlockSparseAttentionWrapper:
             )
 
             R, C = self._R, self._C
-            indptr = self._sparse_indptr
-            indices = self._sparse_indices
-            num_block_rows = indptr.numel() - 1
+            num_block_rows = self._sparse_num_block_rows
 
             # KV as page_size==C paged cache: [N, H_kv, D] -> [N // C, C, H_kv, D].
             k_cache = k.reshape(self._N // C, C, self._num_kv_heads, self._head_dim)
             v_cache = v.reshape(self._N // C, C, self._num_kv_heads, v.shape[-1])
 
-            nnz_per_row = (indptr[1:] - indptr[:-1]).to(torch.int32)
-            actual_seq_lens_q = torch.full(
-                (num_block_rows,), R, dtype=torch.int32, device=q.device
-            )
-            actual_seq_lens_kv = (nnz_per_row * C).to(torch.int32)
-            max_pages = int(nnz_per_row.max().item())
-            block_tables = torch.zeros(
-                (num_block_rows, max_pages), dtype=torch.int32, device=q.device
-            )
-            col = torch.arange(max_pages, device=q.device)
-            valid = col[None, :] < nnz_per_row[:, None]
-            block_tables[valid] = indices.to(torch.int32)
-            actual_seq_offset = torch.nn.functional.pad(
-                actual_seq_lens_q.cumsum(0), (1, 0)
-            ).to(torch.int32)
+            # Block table + per-batch length/offset arrays were materialized at
+            # plan() time (they derive only from indptr/indices/R/C), so run()
+            # does no host sync or allocation here and stays graph-capturable.
+            actual_seq_lens_q = self._sparse_actual_seq_lens_q
+            actual_seq_lens_kv = self._sparse_actual_seq_lens_kv
+            block_tables = self._sparse_block_tables
+            actual_seq_offset = self._sparse_actual_seq_offset
 
             # The kernel folds the softmax scale into k_scale (qk_scale =
             # k_scale * INV_LOG_2), so k_scale must carry the 1/sqrt(head_dim)

--- a/tests/attention/test_batch_decode_cutile.py
+++ b/tests/attention/test_batch_decode_cutile.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cuTile paged-decode coverage kept outside the generic backend matrix."""
+
+import pytest
+import torch
+
+from flashinfer.cutile.cutile_common import is_cuda_tile_available
+from tests.attention.test_batch_decode_kernels import (
+    _run_batch_decode_with_paged_kv_cache_case,
+)
+
+if not is_cuda_tile_available():
+    pytest.skip("cuda.tile not available", allow_module_level=True)
+
+pytestmark = pytest.mark.solo
+
+
+@pytest.mark.parametrize("batch_size", [12, 17, 128])
+@pytest.mark.parametrize("kv_len", [54, 97, 512, 2048, 16384])
+@pytest.mark.parametrize("page_size", [1, 8, 16])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("head_dim", [128, 256])
+def test_batch_decode_cutile(batch_size, kv_len, page_size, num_qo_heads, head_dim):
+    """cuTile paged decode must match the single-decode reference."""
+    _run_batch_decode_with_paged_kv_cache_case(
+        "cutile",
+        batch_size,
+        kv_len,
+        page_size,
+        4,
+        num_qo_heads,
+        head_dim,
+        "NHD",
+        "NONE",
+        0.0,
+        True,
+        torch.float16,
+        torch.float16,
+        True,
+    )

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -126,6 +126,7 @@ def test_batch_decode_with_paged_kv_cache(
 ):
     # cuTile decode backend capability bounds (mirror the NotImplemented guards
     # in BatchDecodeWithPagedKVCacheWrapper.run for backend=="cutile").
+    """Paged decode must match the reference across backends, layouts and dtypes."""
     if backend == "cutile":
         if kv_layout != "NHD":
             pytest.skip("cuTile decode requires kv_layout='NHD'.")

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -94,6 +94,7 @@ def warmup_jit():
     yield
 
 
+@pytest.mark.parametrize("backend", ["fa2", "cutile"])
 @pytest.mark.parametrize("batch_size", [12, 17, 128])
 @pytest.mark.parametrize("kv_len", [54, 97, 512, 2048, 16384])
 @pytest.mark.parametrize("page_size", [1, 8, 16])
@@ -108,6 +109,7 @@ def warmup_jit():
 @pytest.mark.parametrize("kv_dtype", [torch.float16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("contiguous_kv", [True])
 def test_batch_decode_with_paged_kv_cache(
+    backend,
     batch_size,
     kv_len,
     page_size,
@@ -122,6 +124,19 @@ def test_batch_decode_with_paged_kv_cache(
     kv_dtype,
     contiguous_kv,
 ):
+    # cuTile decode backend capability bounds (mirror the NotImplemented guards
+    # in BatchDecodeWithPagedKVCacheWrapper.run for backend=="cutile").
+    if backend == "cutile":
+        if kv_layout != "NHD":
+            pytest.skip("cuTile decode requires kv_layout='NHD'.")
+        if pos_encoding_mode != "NONE":
+            pytest.skip(
+                "cuTile decode does not apply RoPE (pos_encoding_mode must be NONE)."
+            )
+        if kv_dtype == torch.float8_e4m3fn:
+            pytest.skip("cuTile decode fp8 KV not covered yet.")
+        if head_dim > 256:
+            pytest.skip("cuTile decode head_dim>256 not covered yet.")
     skip_if_head_dim_dtype_unsupported(head_dim, kv_dtype)
     q = torch.randn(batch_size, num_qo_heads, head_dim, device="cuda:0", dtype=q_dtype)
     num_pages_per_seq = (kv_len + page_size - 1) // page_size
@@ -159,7 +174,7 @@ def test_batch_decode_with_paged_kv_cache(
 
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
     wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout
+        workspace_buffer, kv_layout, backend=backend
     )
     wrapper.plan(
         kv_indptr,
@@ -174,7 +189,10 @@ def test_batch_decode_with_paged_kv_cache(
         data_type=kv_dtype,
         q_data_type=q_dtype,
     )
-    if return_lse:
+    # cuTile decode backend does not support return_lse; the reference
+    # comparison below only checks `o`, so drop the LSE request for it.
+    want_lse = return_lse and backend != "cutile"
+    if want_lse:
         o, _ = wrapper.run(q, kv_data, return_lse=True)
     else:
         o = wrapper.run(q, kv_data)

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -128,6 +128,7 @@ def test_batch_decode_with_paged_kv_cache(
 ):
     # cuTile decode backend capability bounds (mirror the NotImplemented guards
     # in BatchDecodeWithPagedKVCacheWrapper.run for backend=="cutile").
+    """Paged decode must match the reference across backends, layouts and dtypes."""
     if backend == "cutile":
         if kv_layout != "NHD":
             pytest.skip("cuTile decode requires kv_layout='NHD'.")

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -96,6 +96,7 @@ def warmup_jit():
     yield
 
 
+@pytest.mark.parametrize("backend", ["fa2", "cutile"])
 @pytest.mark.parametrize("batch_size", [12, 17, 128])
 @pytest.mark.parametrize("kv_len", [54, 97, 512, 2048, 16384])
 @pytest.mark.parametrize("page_size", [1, 8, 16])
@@ -110,6 +111,7 @@ def warmup_jit():
 @pytest.mark.parametrize("kv_dtype", [torch.float16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("contiguous_kv", [True])
 def test_batch_decode_with_paged_kv_cache(
+    backend,
     batch_size,
     kv_len,
     page_size,
@@ -124,6 +126,19 @@ def test_batch_decode_with_paged_kv_cache(
     kv_dtype,
     contiguous_kv,
 ):
+    # cuTile decode backend capability bounds (mirror the NotImplemented guards
+    # in BatchDecodeWithPagedKVCacheWrapper.run for backend=="cutile").
+    if backend == "cutile":
+        if kv_layout != "NHD":
+            pytest.skip("cuTile decode requires kv_layout='NHD'.")
+        if pos_encoding_mode != "NONE":
+            pytest.skip(
+                "cuTile decode does not apply RoPE (pos_encoding_mode must be NONE)."
+            )
+        if kv_dtype == torch.float8_e4m3fn:
+            pytest.skip("cuTile decode fp8 KV not covered yet.")
+        if head_dim > 256:
+            pytest.skip("cuTile decode head_dim>256 not covered yet.")
     skip_if_head_dim_dtype_unsupported(head_dim, kv_dtype)
     q = torch.randn(batch_size, num_qo_heads, head_dim, device="cuda:0", dtype=q_dtype)
     num_pages_per_seq = (kv_len + page_size - 1) // page_size
@@ -161,7 +176,7 @@ def test_batch_decode_with_paged_kv_cache(
 
     workspace_buffer = torch.empty(32 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
     wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout
+        workspace_buffer, kv_layout, backend=backend
     )
     wrapper.plan(
         kv_indptr,
@@ -176,7 +191,10 @@ def test_batch_decode_with_paged_kv_cache(
         data_type=kv_dtype,
         q_data_type=q_dtype,
     )
-    if return_lse:
+    # cuTile decode backend does not support return_lse; the reference
+    # comparison below only checks `o`, so drop the LSE request for it.
+    want_lse = return_lse and backend != "cutile"
+    if want_lse:
         o, _ = wrapper.run(q, kv_data, return_lse=True)
     else:
         o = wrapper.run(q, kv_data)

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -25,6 +25,7 @@ from tests.test_helpers.jit_utils import (
 from tests.test_helpers.utils_fp4 import create_nvfp4_kv, nvfp4_to_float
 from functools import partial
 import flashinfer
+from flashinfer.cutile.cutile_common import is_cuda_tile_available
 from flashinfer.utils import get_compute_capability, has_flashinfer_jit_cache
 
 
@@ -96,21 +97,8 @@ def warmup_jit():
     yield
 
 
-@pytest.mark.parametrize("backend", ["fa2", "cutile"])
-@pytest.mark.parametrize("batch_size", [12, 17, 128])
-@pytest.mark.parametrize("kv_len", [54, 97, 512, 2048, 16384])
-@pytest.mark.parametrize("page_size", [1, 8, 16])
-@pytest.mark.parametrize("num_kv_heads", [4])
-@pytest.mark.parametrize("num_qo_heads", [4, 32])
-@pytest.mark.parametrize("head_dim", [128, 256, 512])
-@pytest.mark.parametrize("kv_layout", ["NHD"])
-@pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA"])
-@pytest.mark.parametrize("logits_soft_cap", [0.0])
-@pytest.mark.parametrize("return_lse", [True])
-@pytest.mark.parametrize("q_dtype", [torch.float16])
-@pytest.mark.parametrize("kv_dtype", [torch.float16, torch.float8_e4m3fn])
-@pytest.mark.parametrize("contiguous_kv", [True])
-def test_batch_decode_with_paged_kv_cache(
+# Shared with test_batch_decode_cutile.py so both backends use the same oracle.
+def _run_batch_decode_with_paged_kv_cache_case(
     backend,
     batch_size,
     kv_len,
@@ -126,10 +114,12 @@ def test_batch_decode_with_paged_kv_cache(
     kv_dtype,
     contiguous_kv,
 ):
+    """Run one paged-decode backend case against the single-decode reference."""
     # cuTile decode backend capability bounds (mirror the NotImplemented guards
     # in BatchDecodeWithPagedKVCacheWrapper.run for backend=="cutile").
-    """Paged decode must match the reference across backends, layouts and dtypes."""
     if backend == "cutile":
+        if not is_cuda_tile_available():
+            pytest.skip("cuda-tile / tileiras compiler not available")
         if kv_layout != "NHD":
             pytest.skip("cuTile decode requires kv_layout='NHD'.")
         if pos_encoding_mode != "NONE":
@@ -247,6 +237,53 @@ def test_batch_decode_with_paged_kv_cache(
     o_buffer = torch.empty_like(o)
     wrapper.run(q, kv_data, out=o_buffer)
     torch.testing.assert_close(o, o_buffer, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [12, 17, 128])
+@pytest.mark.parametrize("kv_len", [54, 97, 512, 2048, 16384])
+@pytest.mark.parametrize("page_size", [1, 8, 16])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("head_dim", [128, 256, 512])
+@pytest.mark.parametrize("kv_layout", ["NHD"])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA"])
+@pytest.mark.parametrize("logits_soft_cap", [0.0])
+@pytest.mark.parametrize("return_lse", [True])
+@pytest.mark.parametrize("q_dtype", [torch.float16])
+@pytest.mark.parametrize("kv_dtype", [torch.float16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("contiguous_kv", [True])
+def test_batch_decode_with_paged_kv_cache(
+    batch_size,
+    kv_len,
+    page_size,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    kv_layout,
+    pos_encoding_mode,
+    logits_soft_cap,
+    return_lse,
+    q_dtype,
+    kv_dtype,
+    contiguous_kv,
+):
+    """Paged FA2 decode must match the single-decode reference."""
+    _run_batch_decode_with_paged_kv_cache_case(
+        "fa2",
+        batch_size,
+        kv_len,
+        page_size,
+        num_kv_heads,
+        num_qo_heads,
+        head_dim,
+        kv_layout,
+        pos_encoding_mode,
+        logits_soft_cap,
+        return_lse,
+        q_dtype,
+        kv_dtype,
+        contiguous_kv,
+    )
 
 
 global_override_indptr_cpu = None

--- a/tests/attention/test_block_sparse.py
+++ b/tests/attention/test_block_sparse.py
@@ -16,15 +16,23 @@ limitations under the License.
 
 import numpy as np
 import pytest
-import scipy as sp
 import torch
+
+try:
+    import scipy as sp
+
+    HAVE_SCIPY = True
+except ImportError:
+    sp = None
+    HAVE_SCIPY = False
+
 from tests.test_helpers.jit_utils import (
     gen_decode_attention_modules,
     gen_prefill_attention_modules,
 )
 
 import flashinfer
-from flashinfer.utils import has_flashinfer_jit_cache
+from flashinfer.utils import has_flashinfer_jit_cache, is_sm100a_supported
 
 
 @pytest.fixture(
@@ -65,11 +73,14 @@ def bsr_attention_ref(
 ):
     M = q.shape[0]
     N = k.shape[0]
-    bsr = sp.sparse.bsr_matrix(
-        (mask_data.cpu().numpy(), indices.cpu().numpy(), indptr.cpu().numpy()),
-        shape=(M, N),
-    )
-    dense_mask = torch.tensor(bsr.toarray(), dtype=bool, device=q.device)
+    if HAVE_SCIPY:
+        bsr = sp.sparse.bsr_matrix(
+            (mask_data.cpu().numpy(), indices.cpu().numpy(), indptr.cpu().numpy()),
+            shape=(M, N),
+        )
+        dense_mask = torch.tensor(bsr.toarray(), dtype=bool, device=q.device)
+    else:
+        dense_mask = _bsr_to_dense_torch(indptr, indices, mask_data, M, N).to(q.device)
     o = flashinfer.prefill.single_prefill_with_kv_cache(q, k, v, custom_mask=dense_mask)
     return o
 
@@ -80,8 +91,29 @@ def set_seed(seed: int = 42):
     np.random.seed(seed)
 
 
-@pytest.mark.parametrize("R", [1, 4, 16])
-@pytest.mark.parametrize("C", [1, 4, 16])
+def _bsr_to_dense_torch(
+    indptr: "torch.Tensor",
+    indices: "torch.Tensor",
+    mask_data: "torch.Tensor",
+    M: int,
+    N: int,
+) -> "torch.Tensor":
+    """Convert BSR format to dense boolean mask without scipy."""
+    R = mask_data.shape[1]
+    C = mask_data.shape[2]
+    device = mask_data.device
+    dense = torch.zeros(M, N, dtype=torch.bool, device=device)
+    n_block_rows = indptr.numel() - 1
+    for br in range(n_block_rows):
+        for ki in range(indptr[br].item(), indptr[br + 1].item()):
+            bc = indices[ki].item()
+            dense[br * R : (br + 1) * R, bc * C : (bc + 1) * C] = mask_data[ki]
+    return dense
+
+
+@pytest.mark.parametrize("backend", ["auto", "vsa_blackwell", "cutile"])
+@pytest.mark.parametrize("R", [1, 4, 16, 128])
+@pytest.mark.parametrize("C", [1, 4, 16, 128])
 @pytest.mark.parametrize("M", [64, 128, 256])
 @pytest.mark.parametrize("N", [64, 128, 256])
 @pytest.mark.parametrize("num_qo_heads", [1, 4, 16])
@@ -89,20 +121,63 @@ def set_seed(seed: int = 42):
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("mask_inside_block", [True, False])
 def test_block_sparse_attention(
-    R, C, M, N, num_qo_heads, num_kv_heads, head_dim, mask_inside_block
+    backend, R, C, M, N, num_qo_heads, num_kv_heads, head_dim, mask_inside_block
 ):
     if num_qo_heads % num_kv_heads != 0:
         pytest.skip("num_qo_heads must be divisible by num_kv_heads")
+
+    if backend == "vsa_blackwell":
+        if not is_sm100a_supported(torch.device(0)):
+            pytest.skip("vsa_blackwell requires sm100a (Blackwell GPU)")
+        if R != 128 or C != 128:
+            pytest.skip("vsa_blackwell requires R == C == 128")
+        if M % 128 != 0 or N % 128 != 0:
+            pytest.skip("vsa_blackwell requires M and N divisible by 128")
+        if head_dim not in (64, 96, 128):
+            pytest.skip("vsa_blackwell requires head_dim in {64, 96, 128}")
+        if mask_inside_block:
+            pytest.skip(
+                "vsa_blackwell does not support per-element block masks (mask_inside_block=True)"
+            )
+
+    if backend == "cutile":
+        # cuTile block-sparse maps each block-row onto a paged prefill batch with
+        # page_size == C; it expresses sparsity at block granularity only.
+        if mask_inside_block:
+            pytest.skip(
+                "cuTile block-sparse does not support per-element intra-block masks."
+            )
+        if M % R != 0 or N % C != 0:
+            pytest.skip("cuTile block-sparse requires M % R == 0 and N % C == 0.")
+        if C < 16:
+            # The BSR column-block size C maps to the paged-KV page_size; the
+            # prefill autotune (_get_prefill_autotune_configs) only yields configs
+            # with BLOCK_N <= page_size, and the smallest BLOCK_N is 16, so C < 16
+            # leaves an empty search space.
+            pytest.skip("cuTile block-sparse requires C >= 16 (min prefill BLOCK_N).")
 
     set_seed(33)
     rng = np.random.default_rng()
 
     MB = M // R
     NB = N // C
-    S = sp.sparse.random(MB, NB, density=0.25, random_state=rng).tocsr()
-    indptr = torch.from_numpy(S.indptr).to(0)
-    indices = torch.from_numpy(S.indices).to(0)
-    nnz = S.nnz
+    if HAVE_SCIPY:
+        S = sp.sparse.random(MB, NB, density=0.25, random_state=rng).tocsr()
+        indptr = torch.from_numpy(S.indptr).to(0)
+        indices = torch.from_numpy(S.indices).to(0)
+        nnz = S.nnz
+    else:
+        # Generate random sparse CSR pattern without scipy
+        sp_mask = torch.rand(MB, NB) < 0.25
+        indptr_list = [0]
+        indices_list = []
+        for br in range(MB):
+            cols = sp_mask[br].nonzero(as_tuple=True)[0].tolist()
+            indices_list.extend(cols)
+            indptr_list.append(len(indices_list))
+        indptr = torch.tensor(indptr_list, dtype=torch.int32, device=0)
+        indices = torch.tensor(indices_list, dtype=torch.int32, device=0)
+        nnz = len(indices_list)
     if mask_inside_block:
         data_mask = (torch.rand((nnz, R, C)) > 0.5).to(0)
     else:
@@ -114,7 +189,7 @@ def test_block_sparse_attention(
     o_ref = bsr_attention_ref(q, k, v, indptr, indices, data_mask)
     workspace_buffer = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=0)
     sparse_attention_wrapper = flashinfer.sparse.BlockSparseAttentionWrapper(
-        workspace_buffer
+        workspace_buffer, backend=backend
     )
 
     sparse_attention_wrapper.plan(

--- a/tests/attention/test_block_sparse.py
+++ b/tests/attention/test_block_sparse.py
@@ -71,6 +71,7 @@ def bsr_attention_ref(
     indices,
     mask_data,
 ):
+    """Dense reference for block-sparse attention, built from the BSR mask."""
     M = q.shape[0]
     N = k.shape[0]
     if HAVE_SCIPY:
@@ -123,6 +124,7 @@ def _bsr_to_dense_torch(
 def test_block_sparse_attention(
     backend, R, C, M, N, num_qo_heads, num_kv_heads, head_dim, mask_inside_block
 ):
+    """Block-sparse attention must match the dense reference for each backend."""
     if num_qo_heads % num_kv_heads != 0:
         pytest.skip("num_qo_heads must be divisible by num_kv_heads")
 

--- a/tests/attention/test_block_sparse.py
+++ b/tests/attention/test_block_sparse.py
@@ -32,6 +32,7 @@ from tests.test_helpers.jit_utils import (
 )
 
 import flashinfer
+from flashinfer.cutile.cutile_common import is_cuda_tile_available
 from flashinfer.utils import has_flashinfer_jit_cache, is_sm100a_supported
 
 
@@ -112,21 +113,15 @@ def _bsr_to_dense_torch(
     return dense
 
 
-@pytest.mark.parametrize("backend", ["auto", "vsa_blackwell", "cutile"])
-@pytest.mark.parametrize("R", [1, 4, 16, 128])
-@pytest.mark.parametrize("C", [1, 4, 16, 128])
-@pytest.mark.parametrize("M", [64, 128, 256])
-@pytest.mark.parametrize("N", [64, 128, 256])
-@pytest.mark.parametrize("num_qo_heads", [1, 4, 16])
-@pytest.mark.parametrize("num_kv_heads", [1, 4, 16])
-@pytest.mark.parametrize("head_dim", [128, 256])
-@pytest.mark.parametrize("mask_inside_block", [True, False])
-def test_block_sparse_attention(
+# Shared with test_block_sparse_cutile.py so both matrices use the same oracle.
+def _run_block_sparse_attention_case(
     backend, R, C, M, N, num_qo_heads, num_kv_heads, head_dim, mask_inside_block
 ):
-    """Block-sparse attention must match the dense reference for each backend."""
+    """Run one block-sparse backend case against the dense reference."""
     if num_qo_heads % num_kv_heads != 0:
         pytest.skip("num_qo_heads must be divisible by num_kv_heads")
+    if M % R != 0 or N % C != 0:
+        pytest.skip("BSR test dimensions require M % R == 0 and N % C == 0")
 
     if backend == "vsa_blackwell":
         if not is_sm100a_supported(torch.device(0)):
@@ -143,14 +138,14 @@ def test_block_sparse_attention(
             )
 
     if backend == "cutile":
+        if not is_cuda_tile_available():
+            pytest.skip("cuda-tile / tileiras compiler not available")
         # cuTile block-sparse maps each block-row onto a paged prefill batch with
         # page_size == C; it expresses sparsity at block granularity only.
         if mask_inside_block:
             pytest.skip(
                 "cuTile block-sparse does not support per-element intra-block masks."
             )
-        if M % R != 0 or N % C != 0:
-            pytest.skip("cuTile block-sparse requires M % R == 0 and N % C == 0.")
         if C < 16:
             # The BSR column-block size C maps to the paged-KV page_size; the
             # prefill autotune (_get_prefill_autotune_configs) only yields configs
@@ -159,7 +154,7 @@ def test_block_sparse_attention(
             pytest.skip("cuTile block-sparse requires C >= 16 (min prefill BLOCK_N).")
 
     set_seed(33)
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(33)
 
     MB = M // R
     NB = N // C
@@ -214,6 +209,32 @@ def test_block_sparse_attention(
     o_buffer = torch.empty_like(o)
     sparse_attention_wrapper.run(q, k, v, out=o_buffer)
     torch.testing.assert_close(o_ref, o_buffer, atol=1e-2, rtol=1e-3)
+
+
+@pytest.mark.parametrize("backend", ["auto", "vsa_blackwell"])
+@pytest.mark.parametrize("R", [1, 4, 16, 128])
+@pytest.mark.parametrize("C", [1, 4, 16, 128])
+@pytest.mark.parametrize("M", [64, 128, 256])
+@pytest.mark.parametrize("N", [64, 128, 256])
+@pytest.mark.parametrize("num_qo_heads", [1, 4, 16])
+@pytest.mark.parametrize("num_kv_heads", [1, 4, 16])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("mask_inside_block", [True, False])
+def test_block_sparse_attention(
+    backend, R, C, M, N, num_qo_heads, num_kv_heads, head_dim, mask_inside_block
+):
+    """Block-sparse attention must match the dense reference for each backend."""
+    _run_block_sparse_attention_case(
+        backend,
+        R,
+        C,
+        M,
+        N,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        mask_inside_block,
+    )
 
 
 def _ref_attention(

--- a/tests/attention/test_block_sparse_cutile.py
+++ b/tests/attention/test_block_sparse_cutile.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cuTile block-sparse coverage kept outside the generic backend matrix."""
+
+import pytest
+
+from flashinfer.cutile.cutile_common import is_cuda_tile_available
+from tests.attention.test_block_sparse import _run_block_sparse_attention_case
+
+if not is_cuda_tile_available():
+    pytest.skip("cuda.tile not available", allow_module_level=True)
+
+pytestmark = pytest.mark.solo
+
+_CUTILE_CASES = [
+    (R, C, M, N, num_qo_heads, num_kv_heads, head_dim)
+    for R in (1, 4, 16, 128)
+    for C in (16, 128)
+    for M in (64, 128, 256)
+    for N in (64, 128, 256)
+    for num_qo_heads in (1, 4, 16)
+    for num_kv_heads in (1, 4, 16)
+    for head_dim in (128, 256)
+    if num_qo_heads % num_kv_heads == 0 and M % R == 0 and N % C == 0
+]
+
+
+@pytest.mark.parametrize("R,C,M,N,num_qo_heads,num_kv_heads,head_dim", _CUTILE_CASES)
+def test_block_sparse_cutile(R, C, M, N, num_qo_heads, num_kv_heads, head_dim):
+    """cuTile block-sparse attention must match the dense reference."""
+    _run_block_sparse_attention_case(
+        "cutile",
+        R,
+        C,
+        M,
+        N,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        False,
+    )

--- a/tests/attention/test_fmha_prefill_bsr_cutile.py
+++ b/tests/attention/test_fmha_prefill_bsr_cutile.py
@@ -1,0 +1,405 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for the cuTile prefill attention kernels.
+# Loads kernels directly via importlib to bypass flashinfer/__init__.py
+# (which requires a newer cutlass than some test images provide).
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+import torch
+
+# ---------------------------------------------------------------------------
+# Direct kernel loading (bypass flashinfer.__init__.py import chain)
+# ---------------------------------------------------------------------------
+_REPO = pathlib.Path(__file__).resolve().parent.parent.parent
+
+
+def _load_module(name, rel_path):
+    path = _REPO / rel_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+_common = _load_module(
+    "cutile_common",
+    "flashinfer/cutile/cutile_common.py",
+)
+is_cuda_tile_available = _common.is_cuda_tile_available
+
+if not is_cuda_tile_available():
+    pytest.skip("cuda.tile not available", allow_module_level=True)
+
+_prefill_mod = _load_module(
+    "fmha_prefill_bsr_cutile",
+    "flashinfer/attention/kernels/cutile/fmha_prefill_bsr_cutile.py",
+)
+prefill_attention_kv_paged_cutile = _prefill_mod.prefill_attention_kv_paged_cutile
+prefill_attention_kv_ragged_cutile = _prefill_mod.prefill_attention_kv_ragged_cutile
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_paged_kvcache(
+    batch_seq_lens_kv, page_size, num_kv_heads, head_dim, dtype, device
+):
+    """
+    Allocate paged KV cache and build block_tables.
+    Returns (k_cache, v_cache, block_tables).
+    k_cache/v_cache: [total_pages, page_size, num_kv_heads, head_dim]
+    block_tables: [batch, max_pages_per_seq]
+    """
+    pages_per_seq = [(s + page_size - 1) // page_size for s in batch_seq_lens_kv]
+    max_pages_per_seq = max(pages_per_seq)
+    total_pages = sum(pages_per_seq)
+
+    k_cache = torch.randn(
+        total_pages, page_size, num_kv_heads, head_dim, dtype=dtype, device=device
+    )
+    v_cache = torch.randn(
+        total_pages, page_size, num_kv_heads, head_dim, dtype=dtype, device=device
+    )
+
+    # block_tables: [batch, max_pages_per_seq], unused slots set to 0
+    block_tables = torch.zeros(
+        len(batch_seq_lens_kv), max_pages_per_seq, dtype=torch.int32, device=device
+    )
+    page_idx = 0
+    for b, n_pages in enumerate(pages_per_seq):
+        for p in range(n_pages):
+            block_tables[b, p] = page_idx
+            page_idx += 1
+
+    return k_cache, v_cache, block_tables
+
+
+def _make_seq_offsets(seq_lens):
+    """Exclusive prefix sum (starting offset for each request in ragged tensor)."""
+    offsets = [0]
+    for l in seq_lens[:-1]:
+        offsets.append(offsets[-1] + l)
+    return offsets
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Paged prefill smoke test (causal, GQA)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_lpt", [True, False])
+def test_prefill_paged_smoke(use_lpt):
+    """
+    Smoke test: paged prefill runs and produces valid output shape with no NaN/Inf.
+    GQA 4:1 (8 qo heads, 2 kv heads), head_dim=128, page_size=64.
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+    num_qo_heads = 8
+    num_kv_heads = 2
+    head_dim = 128
+    page_size = 64
+
+    batch_seq_lens_q = [128, 128]
+    batch_seq_lens_kv = [128, 64]
+    num_batch = len(batch_seq_lens_q)
+    total_q = sum(batch_seq_lens_q)
+    max_seq_len = max(batch_seq_lens_kv)
+
+    # Ragged Q: all sequences concatenated along dim 0
+    q = torch.randn(total_q, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    k_cache, v_cache, block_tables = _make_paged_kvcache(
+        batch_seq_lens_kv, page_size, num_kv_heads, head_dim, dtype, device
+    )
+
+    actual_seq_lens_q = torch.tensor(batch_seq_lens_q, dtype=torch.int32, device=device)
+    actual_seq_lens_kv = torch.tensor(
+        batch_seq_lens_kv, dtype=torch.int32, device=device
+    )
+    actual_seq_offset = torch.tensor(
+        _make_seq_offsets(batch_seq_lens_q), dtype=torch.int32, device=device
+    )
+
+    out, out_lse = prefill_attention_kv_paged_cutile(
+        q,
+        k_cache,
+        v_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        actual_seq_offset,
+        block_tables,
+        k_scale=1.0,
+        v_scale=1.0,
+        num_batch=num_batch,
+        max_seq_len=max_seq_len,
+        is_causal=True,
+        use_lpt_scheduler=use_lpt,
+    )
+
+    assert out.shape == (total_q, num_qo_heads, head_dim), (
+        f"output shape mismatch: {out.shape}"
+    )
+    assert out_lse.shape == (total_q, num_qo_heads), (
+        f"lse shape mismatch: {out_lse.shape}"
+    )
+    assert not torch.isnan(out).any(), "output contains NaN"
+    assert not torch.isinf(out).any(), "output contains Inf"
+    assert not torch.isnan(out_lse).any(), "lse contains NaN"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Paged prefill non-causal
+# ---------------------------------------------------------------------------
+
+
+def test_prefill_paged_noncausal():
+    """Non-causal paged prefill: output should differ from causal."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    num_qo_heads = 4
+    num_kv_heads = 1
+    head_dim = 64
+    page_size = 64
+    seq_len = 128
+    num_batch = 1
+
+    torch.manual_seed(0)
+    q = torch.randn(seq_len, num_qo_heads, head_dim, dtype=dtype, device=device)
+    k_cache, v_cache, block_tables = _make_paged_kvcache(
+        [seq_len], page_size, num_kv_heads, head_dim, dtype, device
+    )
+    actual_seq_lens_q = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    actual_seq_lens_kv = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    actual_seq_offset = torch.tensor([0], dtype=torch.int32, device=device)
+
+    out_causal, _ = prefill_attention_kv_paged_cutile(
+        q,
+        k_cache,
+        v_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        actual_seq_offset,
+        block_tables,
+        k_scale=1.0,
+        v_scale=1.0,
+        num_batch=num_batch,
+        max_seq_len=seq_len,
+        is_causal=True,
+    )
+    out_noncausal, _ = prefill_attention_kv_paged_cutile(
+        q,
+        k_cache,
+        v_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        actual_seq_offset,
+        block_tables,
+        k_scale=1.0,
+        v_scale=1.0,
+        num_batch=num_batch,
+        max_seq_len=seq_len,
+        is_causal=False,
+    )
+
+    assert out_noncausal.shape == (seq_len, num_qo_heads, head_dim)
+    assert not torch.isnan(out_noncausal).any()
+    # Non-causal sees future tokens → outputs differ
+    assert not torch.allclose(out_causal, out_noncausal, atol=1e-2), (
+        "causal and non-causal outputs unexpectedly identical"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Ragged prefill smoke test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_lpt", [True, False])
+def test_prefill_ragged_smoke(use_lpt):
+    """
+    Smoke test: ragged prefill runs with correct output shape and no NaN/Inf.
+    MHA (equal qo/kv heads), head_dim=128.
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+    num_qo_heads = 4
+    num_kv_heads = 4
+    head_dim = 128
+
+    batch_seq_lens_q = [128, 128]
+    batch_seq_lens_kv = [128, 128]
+    num_batch = 2
+    total_q = sum(batch_seq_lens_q)
+    total_kv = sum(batch_seq_lens_kv)
+    max_seq_len = max(batch_seq_lens_kv)
+
+    q = torch.randn(total_q, num_qo_heads, head_dim, dtype=dtype, device=device)
+    # Ragged KV: [total_kv_tokens, num_kv_heads, head_dim]
+    k_cache = torch.randn(total_kv, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v_cache = torch.randn(total_kv, num_kv_heads, head_dim, dtype=dtype, device=device)
+
+    actual_seq_lens_q = torch.tensor(batch_seq_lens_q, dtype=torch.int32, device=device)
+    actual_seq_lens_kv = torch.tensor(
+        batch_seq_lens_kv, dtype=torch.int32, device=device
+    )
+    actual_seq_offset = torch.tensor(
+        _make_seq_offsets(batch_seq_lens_q), dtype=torch.int32, device=device
+    )
+    # block_tables accepted but unused by ragged kernel
+    block_tables = torch.zeros(num_batch, 1, dtype=torch.int32, device=device)
+
+    out, out_lse = prefill_attention_kv_ragged_cutile(
+        q,
+        k_cache,
+        v_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        actual_seq_offset,
+        block_tables,
+        k_scale=1.0,
+        v_scale=1.0,
+        num_batch=num_batch,
+        max_seq_len=max_seq_len,
+        is_causal=True,
+        use_lpt_scheduler=use_lpt,
+    )
+
+    assert out.shape == (total_q, num_qo_heads, head_dim), (
+        f"output shape mismatch: {out.shape}"
+    )
+    assert out_lse.shape == (total_q, num_qo_heads), (
+        f"lse shape mismatch: {out_lse.shape}"
+    )
+    assert not torch.isnan(out).any(), "output contains NaN"
+    assert not torch.isinf(out).any(), "output contains Inf"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Ragged prefill GQA
+# ---------------------------------------------------------------------------
+
+
+def test_prefill_ragged_gqa():
+    """Ragged prefill with GQA (8 qo heads, 2 kv heads)."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    num_qo_heads = 8
+    num_kv_heads = 2
+    head_dim = 128
+    seq_len = 128
+    num_batch = 1
+
+    q = torch.randn(seq_len, num_qo_heads, head_dim, dtype=dtype, device=device)
+    k_cache = torch.randn(seq_len, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v_cache = torch.randn(seq_len, num_kv_heads, head_dim, dtype=dtype, device=device)
+
+    actual_seq_lens_q = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    actual_seq_lens_kv = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    actual_seq_offset = torch.tensor([0], dtype=torch.int32, device=device)
+    block_tables = torch.zeros(num_batch, 1, dtype=torch.int32, device=device)
+
+    out, out_lse = prefill_attention_kv_ragged_cutile(
+        q,
+        k_cache,
+        v_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        actual_seq_offset,
+        block_tables,
+        k_scale=1.0,
+        v_scale=1.0,
+        num_batch=num_batch,
+        max_seq_len=seq_len,
+        is_causal=True,
+    )
+
+    assert out.shape == (seq_len, num_qo_heads, head_dim)
+    assert not torch.isnan(out).any()
+    assert not torch.isinf(out).any()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Paged vs ragged correctness
+# ---------------------------------------------------------------------------
+
+
+def test_prefill_paged_vs_ragged_correctness():
+    """
+    Paged and ragged prefill should produce numerically equivalent output
+    for a single sequence where paged KV stores the same data as ragged KV.
+    page_size=64, seq_len=128 → 2 contiguous pages.
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+    num_qo_heads = 4
+    num_kv_heads = 1
+    head_dim = 64
+    page_size = 64
+    seq_len = 128
+    num_batch = 1
+
+    torch.manual_seed(42)
+    q = torch.randn(seq_len, num_qo_heads, head_dim, dtype=dtype, device=device)
+
+    # Ragged KV: [seq_len, num_kv_heads, head_dim]
+    k_flat = torch.randn(seq_len, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v_flat = torch.randn(seq_len, num_kv_heads, head_dim, dtype=dtype, device=device)
+
+    # Paged KV: reshape ragged → [num_pages, page_size, num_kv_heads, head_dim]
+    num_pages = seq_len // page_size  # = 2
+    k_cache = k_flat.reshape(num_pages, page_size, num_kv_heads, head_dim).clone()
+    v_cache = v_flat.reshape(num_pages, page_size, num_kv_heads, head_dim).clone()
+    block_tables_paged = torch.arange(
+        num_pages, dtype=torch.int32, device=device
+    ).unsqueeze(0)
+
+    actual_seq_lens_q = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    actual_seq_lens_kv = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    actual_seq_offset = torch.tensor([0], dtype=torch.int32, device=device)
+    block_tables_ragged = torch.zeros(num_batch, 1, dtype=torch.int32, device=device)
+
+    out_paged, _ = prefill_attention_kv_paged_cutile(
+        q,
+        k_cache,
+        v_cache,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        actual_seq_offset,
+        block_tables_paged,
+        k_scale=1.0,
+        v_scale=1.0,
+        num_batch=num_batch,
+        max_seq_len=seq_len,
+        is_causal=True,
+    )
+    out_ragged, _ = prefill_attention_kv_ragged_cutile(
+        q,
+        k_flat,
+        v_flat,
+        actual_seq_lens_q,
+        actual_seq_lens_kv,
+        actual_seq_offset,
+        block_tables_ragged,
+        k_scale=1.0,
+        v_scale=1.0,
+        num_batch=num_batch,
+        max_seq_len=seq_len,
+        is_causal=True,
+    )
+
+    assert out_paged.shape == out_ragged.shape
+    assert not torch.isnan(out_paged).any()
+    assert not torch.isnan(out_ragged).any()
+
+    # Same computation, different cache layout → should match within bf16 tolerance
+    max_diff = (out_paged.float() - out_ragged.float()).abs().max().item()
+    assert max_diff < 0.05, f"paged vs ragged prefill diverged: max_diff={max_diff:.4f}"

--- a/tests/attention/test_fmha_prefill_bsr_cutile.py
+++ b/tests/attention/test_fmha_prefill_bsr_cutile.py
@@ -19,6 +19,7 @@ _REPO = pathlib.Path(__file__).resolve().parent.parent.parent
 
 
 def _load_module(name, rel_path):
+    """Import a module directly from its path in the repo checkout."""
     path = _REPO / rel_path
     spec = importlib.util.spec_from_file_location(name, path)
     m = importlib.util.module_from_spec(spec)

--- a/tests/attention/test_mla_auto_backend_warning.py
+++ b/tests/attention/test_mla_auto_backend_warning.py
@@ -60,3 +60,30 @@ def test_explicit_backend_does_not_warn(_cc, buf):
 )
 def test_no_warn_on_hopper(_cc, buf):
     assert _make(buf, "auto") == []
+
+
+@pytest.mark.parametrize(
+    ("capability", "expected_backend", "unexpected_backend"),
+    [
+        ((10, 0), "backend='cutile'", "backend='cutlass'"),
+        ((11, 0), "backend='cutlass'", "backend='cutile'"),
+    ],
+)
+def test_auto_warning_recommends_an_architecture_supported_backend(
+    monkeypatch, capability, expected_backend, unexpected_backend
+):
+    """The fallback warning must not recommend a backend that rejects the GPU."""
+    monkeypatch.setattr(
+        "flashinfer.mla._batch_mla._wrapper._get_compute_capability",
+        lambda _device: capability,
+    )
+    _fresh_state()
+
+    with pytest.warns(UserWarning, match=WARN_TAG) as caught:
+        BatchMLAPagedAttentionWrapper._maybe_warn_blackwell_auto_fallback(
+            torch.device("cuda"), "fa2"
+        )
+
+    message = str(caught[0].message)
+    assert expected_backend in message
+    assert unexpected_backend not in message

--- a/tests/attention/test_mla_cutile_backend.py
+++ b/tests/attention/test_mla_cutile_backend.py
@@ -1,0 +1,496 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU contract tests for the planned cuTile MLA backend."""
+
+import math
+
+import pytest
+import torch
+
+
+class _FakeCutileKernel:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(
+        self,
+        q_nope,
+        q_pe,
+        ckv_cache,
+        kpe_cache,
+        seq_lens,
+        block_tables,
+        k_scale,
+        v_scale,
+        max_seq_len=-1,
+        outputs=None,
+        **kwargs,
+    ):
+        self.calls.append(
+            {
+                "q_nope": q_nope,
+                "q_pe": q_pe,
+                "ckv_cache": ckv_cache,
+                "kpe_cache": kpe_cache,
+                "seq_lens": seq_lens,
+                "block_tables": block_tables,
+                "k_scale": k_scale,
+                "v_scale": v_scale,
+                "max_seq_len": max_seq_len,
+                "outputs": outputs,
+                "kwargs": kwargs,
+            }
+        )
+        if outputs is None:
+            outputs = torch.empty_like(q_nope)
+        outputs.copy_(q_nope)
+        return outputs
+
+
+def _patch_cutile_runtime(monkeypatch, kernel):
+    from flashinfer.mla._batch_mla._backends import cutile_backend
+
+    monkeypatch.setattr(
+        cutile_backend, "_get_compute_capability", lambda device: (10, 0)
+    )
+    monkeypatch.setattr(cutile_backend, "get_cutile_mla_decode", lambda: kernel)
+
+
+def _metadata():
+    from flashinfer.mla import MLAPlanMetadata
+
+    return MLAPlanMetadata.dense(
+        cum_seq_lens_q=torch.tensor([0, 1, 2], dtype=torch.int32),
+        block_tables=torch.tensor([[1, 0], [0, 1]], dtype=torch.int32),
+        seq_lens=torch.tensor([3, 2], dtype=torch.int32),
+    )
+
+
+def _plan_kwargs(metadata=None, **overrides):
+    kwargs = {
+        "metadata": _metadata() if metadata is None else metadata,
+        "num_heads": 16,
+        "head_dim_ckv": 512,
+        "head_dim_kpe": 64,
+        "page_size": 2,
+        "causal": False,
+        "sm_scale": 1.0 / math.sqrt(576),
+        "q_data_type": torch.bfloat16,
+        "kv_data_type": torch.bfloat16,
+        "query_layout": "split",
+        "kv_cache_layout": "split",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _inputs(*, num_heads=16, page_size=2, dtype=torch.bfloat16):
+    return (
+        (
+            torch.empty(2, num_heads, 512, dtype=dtype),
+            torch.empty(2, num_heads, 64, dtype=dtype),
+        ),
+        (
+            torch.empty(2, page_size, 512, dtype=dtype),
+            torch.empty(2, page_size, 64, dtype=dtype),
+        ),
+    )
+
+
+def _planned_wrapper(monkeypatch, *, use_cuda_graph=False, metadata=None):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+
+    kernel = _FakeCutileKernel()
+    _patch_cutile_runtime(monkeypatch, kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8),
+        use_cuda_graph=use_cuda_graph,
+        backend="cutile",
+    )
+    wrapper.plan(**_plan_kwargs(metadata))
+    return wrapper, kernel
+
+
+def test_cutile_backend_is_explicitly_registered_with_split_lowering():
+    from flashinfer.mla._batch_mla._backends.cutile_backend import (
+        _BatchMLAPagedAttentionCutileBackend,
+    )
+    from flashinfer.mla._batch_mla._wrapper import _BACKEND_TYPES
+
+    assert _BACKEND_TYPES["cutile"] is _BatchMLAPagedAttentionCutileBackend
+    capabilities = _BatchMLAPagedAttentionCutileBackend._plan_capabilities
+    assert capabilities.backend_name == "cutile"
+    assert capabilities.lse_modes == frozenset({"none"})
+    assert capabilities.output_scales == frozenset({"none"})
+    assert capabilities.scale_modes == frozenset({"default"})
+    assert {"combined", "independent-split"} <= capabilities.kv_layouts
+    assert capabilities.requires_packed_query is False
+    assert capabilities.requires_packed_kv_cache is False
+
+
+def test_cutile_lazy_kernel_lookup_and_retained_dense_metadata(monkeypatch):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+
+    metadata = _metadata()
+    kernel = _FakeCutileKernel()
+    getter_calls = []
+    from flashinfer.mla._batch_mla._backends import cutile_backend
+
+    monkeypatch.setattr(
+        cutile_backend, "_get_compute_capability", lambda device: (10, 0)
+    )
+
+    def get_kernel():
+        getter_calls.append(None)
+        return kernel
+
+    monkeypatch.setattr(cutile_backend, "get_cutile_mla_decode", get_kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8), backend="cutile"
+    )
+    with pytest.raises(ValueError, match="causal"):
+        wrapper.plan(**_plan_kwargs(metadata, causal=True))
+    assert getter_calls == []
+
+    wrapper.plan(**_plan_kwargs(metadata))
+    assert getter_calls == [None]
+
+    query, kv_cache = _inputs()
+    out = torch.empty_like(query[0])
+    actual = wrapper.run(query=query, kv_cache=kv_cache, out=out)
+
+    assert actual is out
+    assert getter_calls == [None]
+    assert len(kernel.calls) == 1
+    call = kernel.calls[0]
+    assert call["q_nope"] is query[0]
+    assert call["q_pe"] is query[1]
+    assert call["ckv_cache"] is kv_cache[0]
+    assert call["kpe_cache"] is kv_cache[1]
+    assert call["seq_lens"] is metadata.seq_lens
+    assert call["block_tables"] is metadata.block_tables
+    assert call["outputs"] is out
+
+
+def test_cutile_packed_contract_is_lowered_to_zero_copy_split_views(monkeypatch):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+
+    kernel = _FakeCutileKernel()
+    _patch_cutile_runtime(monkeypatch, kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8), backend="cutile"
+    )
+    wrapper.plan(**_plan_kwargs(query_layout="packed", kv_cache_layout="packed"))
+    query = torch.empty(2, 16, 576, dtype=torch.bfloat16)
+    kv_cache = torch.empty(2, 2, 576, dtype=torch.bfloat16)
+    wrapper.run(query=query, kv_cache=kv_cache)
+
+    call = kernel.calls[0]
+    assert (
+        call["q_nope"].untyped_storage().data_ptr()
+        == query.untyped_storage().data_ptr()
+    )
+    assert (
+        call["q_pe"].untyped_storage().data_ptr() == query.untyped_storage().data_ptr()
+    )
+    assert (
+        call["ckv_cache"].untyped_storage().data_ptr()
+        == kv_cache.untyped_storage().data_ptr()
+    )
+    assert (
+        call["kpe_cache"].untyped_storage().data_ptr()
+        == kv_cache.untyped_storage().data_ptr()
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_cutile_supported_float_dtypes_dispatch(monkeypatch, dtype):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+
+    kernel = _FakeCutileKernel()
+    _patch_cutile_runtime(monkeypatch, kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8), backend="cutile"
+    )
+    wrapper.plan(**_plan_kwargs(q_data_type=dtype, kv_data_type=dtype))
+    query = (
+        torch.empty(2, 16, 512, dtype=dtype),
+        torch.empty(2, 16, 64, dtype=dtype),
+    )
+    kv_cache = (
+        torch.empty(2, 2, 512, dtype=dtype),
+        torch.empty(2, 2, 64, dtype=dtype),
+    )
+
+    actual = wrapper.run(query=query, kv_cache=kv_cache)
+
+    assert actual.dtype == dtype
+    assert len(kernel.calls) == 1
+
+
+def test_cutile_runtime_metadata_override_is_paired_and_zero_copy(monkeypatch):
+    wrapper, kernel = _planned_wrapper(monkeypatch)
+    query, kv_cache = _inputs()
+    seq_lens = torch.tensor([2, 3], dtype=torch.int32)
+    block_tables = torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="both be omitted or both be provided"):
+        wrapper.run(query=query, kv_cache=kv_cache, kv_len=seq_lens)
+    with pytest.raises(ValueError, match="both be omitted or both be provided"):
+        wrapper.run(query=query, kv_cache=kv_cache, page_table=block_tables)
+
+    wrapper.run(
+        query=query,
+        kv_cache=kv_cache,
+        kv_len=seq_lens,
+        page_table=block_tables,
+    )
+    call = kernel.calls[-1]
+    assert call["seq_lens"] is seq_lens
+    assert call["block_tables"] is block_tables
+
+
+@pytest.mark.parametrize(
+    ("kv_len", "page_table", "match"),
+    [
+        (
+            torch.tensor([2, 3], dtype=torch.int64),
+            torch.tensor([[0, 1], [1, 0]], dtype=torch.int32),
+            "torch.int32",
+        ),
+        (
+            torch.tensor([2, 3], dtype=torch.int32),
+            torch.tensor([[0, 1], [1, 0]], dtype=torch.int64),
+            "torch.int32",
+        ),
+        (
+            torch.empty(4, dtype=torch.int32)[::2],
+            torch.tensor([[0, 1], [1, 0]], dtype=torch.int32),
+            "contiguous",
+        ),
+        (
+            torch.tensor([2], dtype=torch.int32),
+            torch.tensor([[0, 1], [1, 0]], dtype=torch.int32),
+            "shape",
+        ),
+        (
+            torch.tensor([2, 3], dtype=torch.int32),
+            torch.tensor([[0, 1]], dtype=torch.int32),
+            "shape",
+        ),
+        (
+            torch.empty(2, dtype=torch.int32, device="meta"),
+            torch.tensor([[0, 1], [1, 0]], dtype=torch.int32),
+            "workspace device",
+        ),
+        (
+            torch.tensor([2, 3], dtype=torch.int32),
+            torch.empty((2, 2), dtype=torch.int32, device="meta"),
+            "workspace device",
+        ),
+    ],
+)
+def test_cutile_runtime_metadata_override_rejects_unsafe_tensors(
+    monkeypatch, kv_len, page_table, match
+):
+    wrapper, kernel = _planned_wrapper(monkeypatch)
+    query, kv_cache = _inputs()
+
+    with pytest.raises(ValueError, match=match):
+        wrapper.run(
+            query=query,
+            kv_cache=kv_cache,
+            kv_len=kv_len,
+            page_table=page_table,
+        )
+    assert kernel.calls == []
+
+
+@pytest.mark.parametrize(
+    "plan_overrides",
+    [
+        {"lse_mode": "base2"},
+        {"output_dtype": torch.float8_e4m3fn, "output_scale": "per-tensor"},
+        {"scale_mode": "kv-per-tensor"},
+        {"skip_softmax": True},
+        {"causal": True},
+        {"head_dim_ckv": 256},
+        {"q_data_type": torch.float32, "kv_data_type": torch.float32},
+    ],
+)
+def test_cutile_plan_rejects_unsupported_contracts(monkeypatch, plan_overrides):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+
+    kernel = _FakeCutileKernel()
+    _patch_cutile_runtime(monkeypatch, kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8), backend="cutile"
+    )
+
+    with pytest.raises(ValueError):
+        wrapper.plan(**_plan_kwargs(**plan_overrides))
+    assert kernel.calls == []
+
+
+@pytest.mark.parametrize("page_size", [2, 128])
+def test_cutile_plan_accepts_supported_page_sizes(monkeypatch, page_size):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+
+    kernel = _FakeCutileKernel()
+    _patch_cutile_runtime(monkeypatch, kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8), backend="cutile"
+    )
+
+    wrapper.plan(**_plan_kwargs(page_size=page_size))
+    assert kernel.calls == []
+
+
+@pytest.mark.parametrize("page_size", [True, 1, 3, 129])
+def test_cutile_rejects_unsupported_page_sizes(page_size):
+    from flashinfer.mla._batch_mla._backends.cutile_backend import (
+        _validate_cutile_page_size,
+    )
+
+    with pytest.raises(ValueError, match=r"\[2, 128\]"):
+        _validate_cutile_page_size(page_size)
+
+
+@pytest.mark.parametrize("num_heads", [16, 128])
+def test_cutile_plan_accepts_supported_head_counts(monkeypatch, num_heads):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+
+    kernel = _FakeCutileKernel()
+    _patch_cutile_runtime(monkeypatch, kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8), backend="cutile"
+    )
+
+    wrapper.plan(**_plan_kwargs(num_heads=num_heads))
+    query, kv_cache = _inputs(num_heads=num_heads)
+    wrapper.run(query=query, kv_cache=kv_cache)
+    assert len(kernel.calls) == 1
+
+
+@pytest.mark.parametrize("num_heads", [True, 7, 9, 129])
+def test_cutile_rejects_unsupported_head_counts(num_heads):
+    from flashinfer.mla._batch_mla._backends.cutile_backend import (
+        _validate_cutile_num_heads,
+    )
+
+    with pytest.raises(ValueError, match=r"multiple of 8.*\[8, 128\]"):
+        _validate_cutile_num_heads(num_heads)
+
+
+@pytest.mark.parametrize("capability", [(10, 0), (10, 3), (12, 0), (12, 1)])
+def test_cutile_plan_accepts_supported_blackwell_architectures(monkeypatch, capability):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+    from flashinfer.mla._batch_mla._backends import cutile_backend
+
+    kernel = _FakeCutileKernel()
+    monkeypatch.setattr(
+        cutile_backend, "_get_compute_capability", lambda device: capability
+    )
+    monkeypatch.setattr(cutile_backend, "get_cutile_mla_decode", lambda: kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8), backend="cutile"
+    )
+
+    wrapper.plan(**_plan_kwargs())
+    query, kv_cache = _inputs()
+    wrapper.run(query=query, kv_cache=kv_cache)
+    assert len(kernel.calls) == 1
+
+
+@pytest.mark.parametrize("capability", [(9, 0), (12, 2)])
+def test_cutile_plan_rejects_undemonstrated_architectures(monkeypatch, capability):
+    from flashinfer.mla import BatchMLAPagedAttentionWrapper
+    from flashinfer.mla._batch_mla._backends import cutile_backend
+
+    kernel = _FakeCutileKernel()
+    monkeypatch.setattr(
+        cutile_backend, "_get_compute_capability", lambda device: capability
+    )
+    monkeypatch.setattr(cutile_backend, "get_cutile_mla_decode", lambda: kernel)
+    wrapper = BatchMLAPagedAttentionWrapper(
+        torch.empty(1024, dtype=torch.uint8), backend="cutile"
+    )
+
+    with pytest.raises(ValueError, match="SM100, SM103, SM120, and SM121"):
+        wrapper.plan(**_plan_kwargs())
+    assert kernel.calls == []
+
+
+@pytest.mark.parametrize(
+    ("run_overrides", "match"),
+    [
+        ({"return_lse": True}, "LSE mode"),
+        ({"lse": torch.empty(2, 16)}, "LSE mode"),
+        ({"o_scale": 0.5}, "o_scale"),
+        ({"ckv_scale": 1.0, "kpe_scale": 1.0}, "only valid"),
+        ({"profiler_buffer": torch.empty(1)}, "profiler"),
+    ],
+)
+def test_cutile_run_rejects_unsupported_options_before_dispatch(
+    monkeypatch, run_overrides, match
+):
+    wrapper, kernel = _planned_wrapper(monkeypatch)
+    query, kv_cache = _inputs()
+
+    with pytest.raises(ValueError, match=match):
+        wrapper.run(query=query, kv_cache=kv_cache, **run_overrides)
+    assert kernel.calls == []
+
+
+@pytest.mark.parametrize("case", ["shape", "overlap"])
+def test_cutile_rejects_unsafe_output_before_dispatch(monkeypatch, case):
+    wrapper, kernel = _planned_wrapper(monkeypatch)
+    query, kv_cache = _inputs()
+    if case == "shape":
+        out = torch.empty(2, 16, 511, dtype=torch.bfloat16)
+    else:
+        out = query[0]
+
+    with pytest.raises(ValueError):
+        wrapper.run(query=query, kv_cache=kv_cache, out=out)
+    assert kernel.calls == []
+
+
+@pytest.mark.parametrize("case", ["shape", "dtype"])
+def test_cutile_rejects_unsafe_launch_input_before_dispatch(monkeypatch, case):
+    wrapper, kernel = _planned_wrapper(monkeypatch)
+    query, kv_cache = _inputs()
+    q_nope, q_pe = query
+    if case == "shape":
+        q_nope = torch.empty(2, 16, 511, dtype=torch.bfloat16)
+    elif case == "dtype":
+        q_nope = torch.empty(2, 16, 512, dtype=torch.float16)
+    with pytest.raises(ValueError):
+        wrapper.run(query=(q_nope, q_pe), kv_cache=kv_cache)
+    assert kernel.calls == []
+
+
+def test_cutile_failed_replan_is_transactional(monkeypatch):
+    wrapper, _ = _planned_wrapper(monkeypatch)
+    prior_backend = wrapper._planned_backend
+    prior_contract = wrapper._input_contract
+
+    with pytest.raises(ValueError, match="causal"):
+        wrapper.plan(**_plan_kwargs(causal=True))
+
+    assert wrapper._planned_backend is prior_backend
+    assert wrapper._input_contract is prior_contract
+
+
+def test_cutile_cuda_graph_plan_retains_metadata_and_rejects_replan(monkeypatch):
+    metadata = _metadata()
+    wrapper, kernel = _planned_wrapper(
+        monkeypatch, use_cuda_graph=True, metadata=metadata
+    )
+    query, kv_cache = _inputs()
+    wrapper.run(query=query, kv_cache=kv_cache)
+
+    assert kernel.calls[-1]["seq_lens"] is metadata.seq_lens
+    assert kernel.calls[-1]["block_tables"] is metadata.block_tables
+    with pytest.raises(RuntimeError, match=r"CUDA graph.*replan"):
+        wrapper.plan(**_plan_kwargs(metadata))

--- a/tests/attention/test_mla_decode_cutile.py
+++ b/tests/attention/test_mla_decode_cutile.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the cuTile MLA paged decode backend of BatchMLAPagedAttentionWrapper."""
+
+import math
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.cutile.cutile_common import is_cuda_tile_available
+from flashinfer.utils import get_compute_capability
+
+if not is_cuda_tile_available():
+    pytest.skip("cuda.tile not available", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def _require_blackwell():
+    major, _ = get_compute_capability(torch.device("cuda"))
+    if major < 10:
+        pytest.skip("cuTile MLA decode requires SM100+ (Blackwell)")
+
+
+def _torch_mla_decode_ref(
+    q_nope, q_pe, ckv_cache, kpe_cache, kv_lens, page_table, page_size, sm_scale
+):
+    """Naive per-request paged MLA decode reference (fp32 math).
+
+    scores = (q_nope . ckv + q_pe . kpe) * sm_scale over valid kv positions;
+    out = softmax(scores) @ ckv  (V shares the compressed latent, head_dim_vo=512).
+    """
+    batch_size, num_heads, head_dim_ckv = q_nope.shape
+    out = torch.empty(
+        batch_size, num_heads, head_dim_ckv, dtype=torch.float32, device=q_nope.device
+    )
+    for b in range(batch_size):
+        seq_len = int(kv_lens[b].item())
+        n_pages = math.ceil(seq_len / page_size)
+        pages = page_table[b, :n_pages]
+        # gather [seq_len, dim] from the paged cache
+        ckv = ckv_cache[pages].reshape(-1, head_dim_ckv)[:seq_len].float()
+        kpe = kpe_cache[pages].reshape(-1, kpe_cache.shape[-1])[:seq_len].float()
+        qn = q_nope[b].float()  # [H, 512]
+        qp = q_pe[b].float()  # [H, 64]
+        # [H, seq_len]
+        scores = (qn @ ckv.t() + qp @ kpe.t()) * sm_scale
+        probs = torch.softmax(scores, dim=-1)
+        out[b] = probs @ ckv  # [H, 512]
+    return out
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("max_seq_len", [256, 1024])
+@pytest.mark.parametrize("page_size", [16, 64])
+@pytest.mark.parametrize("num_heads", [16, 32])
+def test_mla_decode_cutile_vs_torch(batch_size, max_seq_len, page_size, num_heads):
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+    dtype = torch.bfloat16
+    head_dim_ckv = 512
+    head_dim_kpe = 64
+    total_page_num = 512
+    sm_scale = 1.0 / math.sqrt(head_dim_ckv + head_dim_kpe)
+
+    q_nope = torch.randn(
+        batch_size, num_heads, head_dim_ckv, dtype=dtype, device=device
+    )
+    q_pe = torch.randn(batch_size, num_heads, head_dim_kpe, dtype=dtype, device=device)
+    ckv_cache = torch.randn(
+        total_page_num, page_size, head_dim_ckv, dtype=dtype, device=device
+    )
+    kpe_cache = torch.randn(
+        total_page_num, page_size, head_dim_kpe, dtype=dtype, device=device
+    )
+    # random but valid seq lengths (at least 1 token)
+    kv_lens = torch.randint(
+        1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    kv_lens[0] = max_seq_len  # ensure the long case is covered
+    pages_per_batch = math.ceil(max_seq_len / page_size)
+    page_table = torch.randint(
+        0,
+        total_page_num,
+        (batch_size, pages_per_batch),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
+
+    # plan() only needs to stash sm_scale/page_size/dtypes for cutile; the
+    # indptr args are unused by the cutile path but required by the signature.
+    qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indices = torch.zeros(1, dtype=torch.int32, device=device)
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_lens,
+        num_heads,
+        head_dim_ckv,
+        head_dim_kpe,
+        page_size,
+        False,  # causal (ignored for single-token decode)
+        sm_scale,
+        dtype,
+        dtype,
+    )
+
+    out = wrapper.run(
+        q_nope,
+        q_pe,
+        ckv_cache,
+        kpe_cache,
+        kv_len=kv_lens,
+        page_table=page_table,
+    )
+
+    ref = _torch_mla_decode_ref(
+        q_nope, q_pe, ckv_cache, kpe_cache, kv_lens, page_table, page_size, sm_scale
+    )
+
+    assert out.shape == (batch_size, num_heads, head_dim_ckv)
+    assert not out.isnan().any()
+    torch.testing.assert_close(out.float(), ref, rtol=2e-1, atol=1e-2)
+
+
+def test_mla_decode_cutile_preallocated_out():
+    """Passing a preallocated out tensor must match the auto-allocated path."""
+    device = torch.device("cuda")
+    torch.manual_seed(7)
+    dtype = torch.bfloat16
+    batch_size, num_heads, page_size, max_seq_len = 2, 32, 64, 512
+    head_dim_ckv, head_dim_kpe = 512, 64
+    total_page_num = 256
+    sm_scale = 1.0 / math.sqrt(head_dim_ckv + head_dim_kpe)
+
+    q_nope = torch.randn(
+        batch_size, num_heads, head_dim_ckv, dtype=dtype, device=device
+    )
+    q_pe = torch.randn(batch_size, num_heads, head_dim_kpe, dtype=dtype, device=device)
+    ckv_cache = torch.randn(
+        total_page_num, page_size, head_dim_ckv, dtype=dtype, device=device
+    )
+    kpe_cache = torch.randn(
+        total_page_num, page_size, head_dim_kpe, dtype=dtype, device=device
+    )
+    kv_lens = torch.full((batch_size,), max_seq_len, dtype=torch.int32, device=device)
+    pages_per_batch = math.ceil(max_seq_len / page_size)
+    page_table = torch.randint(
+        0,
+        total_page_num,
+        (batch_size, pages_per_batch),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
+    qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indices = torch.zeros(1, dtype=torch.int32, device=device)
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_lens,
+        num_heads,
+        head_dim_ckv,
+        head_dim_kpe,
+        page_size,
+        False,
+        sm_scale,
+        dtype,
+        dtype,
+    )
+
+    o_auto = wrapper.run(
+        q_nope, q_pe, ckv_cache, kpe_cache, kv_len=kv_lens, page_table=page_table
+    )
+    o_pre = torch.empty_like(o_auto)
+    wrapper.run(
+        q_nope,
+        q_pe,
+        ckv_cache,
+        kpe_cache,
+        out=o_pre,
+        kv_len=kv_lens,
+        page_table=page_table,
+    )
+    torch.testing.assert_close(o_auto, o_pre)
+
+
+def test_mla_decode_cutile_rejects_unsupported():
+    """cutile MLA backend must reject kv_len/page_table omission and fp8 scales."""
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
+    wrapper._backend = "cutile"
+    wrapper._sm_scale = 1.0 / math.sqrt(576)
+
+    q_nope = torch.randn(1, 32, 512, dtype=dtype, device=device)
+    q_pe = torch.randn(1, 32, 64, dtype=dtype, device=device)
+    ckv = torch.randn(8, 64, 512, dtype=dtype, device=device)
+    kpe = torch.randn(8, 64, 64, dtype=dtype, device=device)
+
+    with pytest.raises(ValueError, match="requires kv_len and page_table"):
+        wrapper.run(q_nope, q_pe, ckv, kpe)
+
+    kv_lens = torch.full((1,), 128, dtype=torch.int32, device=device)
+    page_table = torch.zeros(1, 2, dtype=torch.int32, device=device)
+    with pytest.raises(ValueError, match="not supported"):
+        wrapper.run(
+            q_nope, q_pe, ckv, kpe, kv_len=kv_lens, page_table=page_table, o_scale=0.1
+        )
+
+
+if __name__ == "__main__":
+    test_mla_decode_cutile_vs_torch(4, 1024, 64, 32)
+    test_mla_decode_cutile_preallocated_out()
+    test_mla_decode_cutile_rejects_unsupported()

--- a/tests/attention/test_mla_decode_cutile.py
+++ b/tests/attention/test_mla_decode_cutile.py
@@ -17,6 +17,7 @@ if not is_cuda_tile_available():
 
 @pytest.fixture(autouse=True)
 def _require_blackwell():
+    """Skip the test unless running on datacenter Blackwell (sm100+)."""
     major, _ = get_compute_capability(torch.device("cuda"))
     if major < 10:
         pytest.skip("cuTile MLA decode requires SM100+ (Blackwell)")
@@ -55,6 +56,7 @@ def _torch_mla_decode_ref(
 @pytest.mark.parametrize("page_size", [16, 64])
 @pytest.mark.parametrize("num_heads", [16, 32])
 def test_mla_decode_cutile_vs_torch(batch_size, max_seq_len, page_size, num_heads):
+    """cuTile paged MLA decode must match the torch reference across the shape sweep."""
     device = torch.device("cuda")
     torch.manual_seed(42)
     dtype = torch.bfloat16

--- a/tests/attention/test_mla_decode_cutile.py
+++ b/tests/attention/test_mla_decode_cutile.py
@@ -3,6 +3,7 @@
 """Tests for the cuTile MLA paged decode backend of BatchMLAPagedAttentionWrapper."""
 
 import math
+import warnings
 
 import pytest
 import torch
@@ -17,10 +18,10 @@ if not is_cuda_tile_available():
 
 @pytest.fixture(autouse=True)
 def _require_blackwell():
-    """Skip the test unless running on datacenter Blackwell (sm100+)."""
-    major, _ = get_compute_capability(torch.device("cuda"))
-    if major < 10:
-        pytest.skip("cuTile MLA decode requires SM100+ (Blackwell)")
+    """Skip unless this is a cuTile MLA-validated Blackwell target."""
+    capability = get_compute_capability(torch.device("cuda"))
+    if capability not in {(10, 0), (10, 3), (12, 0), (12, 1)}:
+        pytest.skip("cuTile MLA decode requires SM100, SM103, SM120, or SM121")
 
 
 def _torch_mla_decode_ref(
@@ -51,15 +52,18 @@ def _torch_mla_decode_ref(
     return out
 
 
-@pytest.mark.parametrize("batch_size", [1, 4])
-@pytest.mark.parametrize("max_seq_len", [256, 1024])
-@pytest.mark.parametrize("page_size", [16, 64])
-@pytest.mark.parametrize("num_heads", [16, 32])
-def test_mla_decode_cutile_vs_torch(batch_size, max_seq_len, page_size, num_heads):
-    """cuTile paged MLA decode must match the torch reference across the shape sweep."""
+def _run_mla_decode_case(
+    *,
+    batch_size,
+    max_seq_len,
+    page_size,
+    num_heads,
+    dtype=torch.bfloat16,
+    packed=False,
+    legacy_api=False,
+):
     device = torch.device("cuda")
-    torch.manual_seed(42)
-    dtype = torch.bfloat16
+    torch.manual_seed(42 + page_size + num_heads)
     head_dim_ckv = 512
     head_dim_kpe = 64
     total_page_num = 512
@@ -80,46 +84,75 @@ def test_mla_decode_cutile_vs_torch(batch_size, max_seq_len, page_size, num_head
         1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device
     )
     kv_lens[0] = max_seq_len  # ensure the long case is covered
+    if batch_size > 1:
+        kv_lens[1] = max_seq_len - 1  # guarantee a non-page-aligned tail
     pages_per_batch = math.ceil(max_seq_len / page_size)
-    page_table = torch.randint(
-        0,
-        total_page_num,
-        (batch_size, pages_per_batch),
-        dtype=torch.int32,
-        device=device,
-    )
+    page_table = torch.randperm(total_page_num, dtype=torch.int32, device=device)[
+        : batch_size * pages_per_batch
+    ].reshape(batch_size, pages_per_batch)
+    identity_pages = torch.arange(
+        batch_size * pages_per_batch, dtype=torch.int32, device=device
+    ).reshape_as(page_table)
+    assert not torch.equal(page_table, identity_pages)
 
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
     wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
 
-    # plan() only needs to stash sm_scale/page_size/dtypes for cutile; the
-    # indptr args are unused by the cutile path but required by the signature.
-    qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
-    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
-    kv_indices = torch.zeros(1, dtype=torch.int32, device=device)
-    wrapper.plan(
-        qo_indptr,
-        kv_indptr,
-        kv_indices,
-        kv_lens,
-        num_heads,
-        head_dim_ckv,
-        head_dim_kpe,
-        page_size,
-        False,  # causal (ignored for single-token decode)
-        sm_scale,
-        dtype,
-        dtype,
-    )
-
-    out = wrapper.run(
-        q_nope,
-        q_pe,
-        ckv_cache,
-        kpe_cache,
-        kv_len=kv_lens,
-        page_table=page_table,
-    )
+    if legacy_api:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            wrapper.plan(
+                torch.arange(batch_size + 1, dtype=torch.int32, device=device),
+                torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+                * pages_per_batch,
+                page_table.reshape(-1),
+                kv_lens,
+                num_heads,
+                head_dim_ckv,
+                head_dim_kpe,
+                page_size,
+                False,
+                sm_scale,
+                dtype,
+                dtype,
+            )
+            out = wrapper.run(
+                q_nope,
+                q_pe,
+                ckv_cache,
+                kpe_cache,
+                kv_len=kv_lens,
+                page_table=page_table,
+            )
+    else:
+        metadata = flashinfer.mla.MLAPlanMetadata.dense(
+            cum_seq_lens_q=torch.arange(
+                batch_size + 1, dtype=torch.int32, device=device
+            ),
+            block_tables=page_table,
+            seq_lens=kv_lens,
+        )
+        layout = "packed" if packed else "split"
+        wrapper.plan(
+            metadata=metadata,
+            num_heads=num_heads,
+            head_dim_ckv=head_dim_ckv,
+            head_dim_kpe=head_dim_kpe,
+            page_size=page_size,
+            causal=False,
+            sm_scale=sm_scale,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            query_layout=layout,
+            kv_cache_layout=layout,
+        )
+        query = torch.cat((q_nope, q_pe), dim=-1) if packed else (q_nope, q_pe)
+        kv_cache = (
+            torch.cat((ckv_cache, kpe_cache), dim=-1)
+            if packed
+            else (ckv_cache, kpe_cache)
+        )
+        out = wrapper.run(query=query, kv_cache=kv_cache)
 
     ref = _torch_mla_decode_ref(
         q_nope, q_pe, ckv_cache, kpe_cache, kv_lens, page_table, page_size, sm_scale
@@ -128,6 +161,141 @@ def test_mla_decode_cutile_vs_torch(batch_size, max_seq_len, page_size, num_head
     assert out.shape == (batch_size, num_heads, head_dim_ckv)
     assert not out.isnan().any()
     torch.testing.assert_close(out.float(), ref, rtol=2e-1, atol=1e-2)
+
+
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("max_seq_len", [256, 1024])
+@pytest.mark.parametrize("page_size", [16, 32, 64])
+@pytest.mark.parametrize("num_heads", [16, 32])
+def test_mla_decode_cutile_vs_torch(batch_size, max_seq_len, page_size, num_heads):
+    """cuTile paged MLA decode must match the torch reference across the shape sweep."""
+    _run_mla_decode_case(
+        batch_size=batch_size,
+        max_seq_len=max_seq_len,
+        page_size=page_size,
+        num_heads=num_heads,
+    )
+
+
+@pytest.mark.parametrize(
+    ("dtype", "num_heads"),
+    [
+        (torch.float16, 32),
+        (torch.bfloat16, 8),
+        (torch.bfloat16, 48),
+        (torch.bfloat16, 64),
+        (torch.bfloat16, 96),
+        (torch.bfloat16, 128),
+    ],
+)
+def test_mla_decode_cutile_supported_dtype_and_head_contract(dtype, num_heads):
+    """Persistent coverage for the restored dtype and head-count support."""
+    _run_mla_decode_case(
+        batch_size=1,
+        max_seq_len=127,
+        page_size=64,
+        num_heads=num_heads,
+        dtype=dtype,
+    )
+
+
+def test_mla_decode_cutile_packed_inputs():
+    """Packed canonical inputs must lower to the unchanged split kernel."""
+    _run_mla_decode_case(
+        batch_size=2,
+        max_seq_len=255,
+        page_size=16,
+        num_heads=32,
+        packed=True,
+    )
+
+
+def test_mla_decode_cutile_legacy_flat_api():
+    """The original flat-plan and positional-run compatibility path still works."""
+    _run_mla_decode_case(
+        batch_size=2,
+        max_seq_len=127,
+        page_size=64,
+        num_heads=32,
+        legacy_api=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "pages_per_batch",
+    [2, 8],
+    ids=["no_split", "split_kv"],
+)
+def test_mla_decode_cutile_zero_length_rows(pages_per_batch):
+    """Empty KV rows must be zero for auto- and caller-allocated outputs."""
+    device = torch.device("cuda")
+    torch.manual_seed(73 + pages_per_batch)
+    dtype = torch.bfloat16
+    batch_size, num_heads, page_size = 2, 16, 64
+    head_dim_ckv, head_dim_kpe = 512, 64
+    max_seq_len = pages_per_batch * page_size
+    total_page_num = batch_size * pages_per_batch
+    sm_scale = 1.0 / math.sqrt(head_dim_ckv + head_dim_kpe)
+
+    q_nope = torch.randn(
+        batch_size, num_heads, head_dim_ckv, dtype=dtype, device=device
+    )
+    q_pe = torch.randn(batch_size, num_heads, head_dim_kpe, dtype=dtype, device=device)
+    ckv_cache = torch.randn(
+        total_page_num, page_size, head_dim_ckv, dtype=dtype, device=device
+    )
+    kpe_cache = torch.randn(
+        total_page_num, page_size, head_dim_kpe, dtype=dtype, device=device
+    )
+    kv_lens = torch.tensor([0, max_seq_len - 1], dtype=torch.int32, device=device)
+    page_table = torch.arange(total_page_num, dtype=torch.int32, device=device).reshape(
+        batch_size, pages_per_batch
+    )
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
+    wrapper.plan(
+        metadata=flashinfer.mla.MLAPlanMetadata.dense(
+            cum_seq_lens_q=torch.arange(
+                batch_size + 1, dtype=torch.int32, device=device
+            ),
+            block_tables=page_table,
+            seq_lens=kv_lens,
+        ),
+        num_heads=num_heads,
+        head_dim_ckv=head_dim_ckv,
+        head_dim_kpe=head_dim_kpe,
+        page_size=page_size,
+        causal=False,
+        sm_scale=sm_scale,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        query_layout="split",
+        kv_cache_layout="split",
+    )
+
+    query = (q_nope, q_pe)
+    kv_cache = (ckv_cache, kpe_cache)
+    auto_out = wrapper.run(query=query, kv_cache=kv_cache)
+    caller_out = torch.full_like(auto_out, 7.0)
+    actual = wrapper.run(query=query, kv_cache=kv_cache, out=caller_out)
+
+    assert actual is caller_out
+    expected_empty = torch.zeros_like(auto_out[0])
+    torch.testing.assert_close(auto_out[0], expected_empty, rtol=0, atol=0)
+    torch.testing.assert_close(caller_out[0], expected_empty, rtol=0, atol=0)
+    ref = _torch_mla_decode_ref(
+        q_nope,
+        q_pe,
+        ckv_cache,
+        kpe_cache,
+        kv_lens,
+        page_table,
+        page_size,
+        sm_scale,
+    )
+    torch.testing.assert_close(auto_out.float(), ref, rtol=2e-1, atol=1e-2)
+    torch.testing.assert_close(caller_out.float(), ref, rtol=2e-1, atol=1e-2)
 
 
 def test_mla_decode_cutile_preallocated_out():
@@ -162,66 +330,126 @@ def test_mla_decode_cutile_preallocated_out():
 
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
     wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
-    qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
-    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
-    kv_indices = torch.zeros(1, dtype=torch.int32, device=device)
+    metadata = flashinfer.mla.MLAPlanMetadata.dense(
+        cum_seq_lens_q=torch.arange(batch_size + 1, dtype=torch.int32, device=device),
+        block_tables=page_table,
+        seq_lens=kv_lens,
+    )
     wrapper.plan(
-        qo_indptr,
-        kv_indptr,
-        kv_indices,
-        kv_lens,
-        num_heads,
-        head_dim_ckv,
-        head_dim_kpe,
-        page_size,
-        False,
-        sm_scale,
-        dtype,
-        dtype,
+        metadata=metadata,
+        num_heads=num_heads,
+        head_dim_ckv=head_dim_ckv,
+        head_dim_kpe=head_dim_kpe,
+        page_size=page_size,
+        causal=False,
+        sm_scale=sm_scale,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        query_layout="split",
+        kv_cache_layout="split",
     )
 
-    o_auto = wrapper.run(
-        q_nope, q_pe, ckv_cache, kpe_cache, kv_len=kv_lens, page_table=page_table
-    )
+    o_auto = wrapper.run(query=(q_nope, q_pe), kv_cache=(ckv_cache, kpe_cache))
     o_pre = torch.empty_like(o_auto)
-    wrapper.run(
+    actual = wrapper.run(
+        query=(q_nope, q_pe),
+        kv_cache=(ckv_cache, kpe_cache),
+        out=o_pre,
+    )
+    assert actual is o_pre
+    torch.testing.assert_close(o_auto, o_pre)
+
+
+def test_mla_decode_cutile_cuda_graph_replays_mutated_plan_metadata():
+    """Captured runs must read updated values through stable metadata pointers."""
+    device = torch.device("cuda")
+    torch.manual_seed(11)
+    dtype = torch.bfloat16
+    batch_size, num_heads, page_size = 2, 16, 64
+    head_dim_ckv, head_dim_kpe = 512, 64
+    total_page_num = 8
+    sm_scale = 1.0 / math.sqrt(head_dim_ckv + head_dim_kpe)
+
+    q_nope = torch.randn(
+        batch_size, num_heads, head_dim_ckv, dtype=dtype, device=device
+    )
+    q_pe = torch.randn(batch_size, num_heads, head_dim_kpe, dtype=dtype, device=device)
+    ckv_cache = torch.randn(
+        total_page_num, page_size, head_dim_ckv, dtype=dtype, device=device
+    )
+    kpe_cache = torch.randn(
+        total_page_num, page_size, head_dim_kpe, dtype=dtype, device=device
+    )
+    kv_lens = torch.tensor([96, 64], dtype=torch.int32, device=device)
+    page_table = torch.tensor([[3, 1], [6, 2]], dtype=torch.int32, device=device)
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    out = torch.empty(batch_size, num_heads, head_dim_ckv, dtype=dtype, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(
+        workspace,
+        use_cuda_graph=True,
+        backend="cutile",
+    )
+    wrapper.plan(
+        metadata=flashinfer.mla.MLAPlanMetadata.dense(
+            cum_seq_lens_q=torch.arange(
+                batch_size + 1, dtype=torch.int32, device=device
+            ),
+            block_tables=page_table,
+            seq_lens=kv_lens,
+        ),
+        num_heads=num_heads,
+        head_dim_ckv=head_dim_ckv,
+        head_dim_kpe=head_dim_kpe,
+        page_size=page_size,
+        causal=False,
+        sm_scale=sm_scale,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        query_layout="split",
+        kv_cache_layout="split",
+    )
+
+    # Compile and warm the exact launch before capture.
+    assert (
+        wrapper.run(query=(q_nope, q_pe), kv_cache=(ckv_cache, kpe_cache), out=out)
+        is out
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_out = wrapper.run(
+            query=(q_nope, q_pe), kv_cache=(ckv_cache, kpe_cache), out=out
+        )
+    assert captured_out is out
+    graph.replay()
+    torch.cuda.synchronize()
+    initial = out.clone()
+
+    updated_kv_lens = torch.tensor([0, 95], dtype=torch.int32, device=device)
+    updated_page_table = torch.tensor(
+        [[0, 5], [4, 7]], dtype=torch.int32, device=device
+    )
+    kv_lens.copy_(updated_kv_lens)
+    page_table.copy_(updated_page_table)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref = _torch_mla_decode_ref(
         q_nope,
         q_pe,
         ckv_cache,
         kpe_cache,
-        out=o_pre,
-        kv_len=kv_lens,
-        page_table=page_table,
+        updated_kv_lens,
+        updated_page_table,
+        page_size,
+        sm_scale,
     )
-    torch.testing.assert_close(o_auto, o_pre)
-
-
-def test_mla_decode_cutile_rejects_unsupported():
-    """cutile MLA backend must reject kv_len/page_table omission and fp8 scales."""
-    device = torch.device("cuda")
-    dtype = torch.bfloat16
-    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
-    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace, backend="cutile")
-    wrapper._backend = "cutile"
-    wrapper._sm_scale = 1.0 / math.sqrt(576)
-
-    q_nope = torch.randn(1, 32, 512, dtype=dtype, device=device)
-    q_pe = torch.randn(1, 32, 64, dtype=dtype, device=device)
-    ckv = torch.randn(8, 64, 512, dtype=dtype, device=device)
-    kpe = torch.randn(8, 64, 64, dtype=dtype, device=device)
-
-    with pytest.raises(ValueError, match="requires kv_len and page_table"):
-        wrapper.run(q_nope, q_pe, ckv, kpe)
-
-    kv_lens = torch.full((1,), 128, dtype=torch.int32, device=device)
-    page_table = torch.zeros(1, 2, dtype=torch.int32, device=device)
-    with pytest.raises(ValueError, match="not supported"):
-        wrapper.run(
-            q_nope, q_pe, ckv, kpe, kv_len=kv_lens, page_table=page_table, o_scale=0.1
-        )
+    assert not torch.equal(initial, out)
+    torch.testing.assert_close(out[0], torch.zeros_like(out[0]), rtol=0, atol=0)
+    torch.testing.assert_close(out.float(), ref, rtol=2e-1, atol=1e-2)
 
 
 if __name__ == "__main__":
     test_mla_decode_cutile_vs_torch(4, 1024, 64, 32)
     test_mla_decode_cutile_preallocated_out()
-    test_mla_decode_cutile_rejects_unsupported()

--- a/tests/attention/test_ragged_prefill_cutile_wrapper.py
+++ b/tests/attention/test_ragged_prefill_cutile_wrapper.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Wrapper-level tests for the cuTile ragged-prefill backend
+# (BatchPrefillWithRaggedKVCacheWrapper(backend="cutile")), checked against fa2.
+# Unlike test_fmha_prefill_bsr_cutile.py (which loads the kernel directly), these
+# exercise the full plan()/run() wiring in flashinfer/prefill.py.
+
+import math
+
+import pytest
+import torch
+
+flashinfer = pytest.importorskip("flashinfer")
+
+
+def _cutile_available():
+    try:
+        from flashinfer.cutile.cutile_common import is_cuda_tile_available
+
+        return is_cuda_tile_available()
+    except Exception:
+        return False
+
+
+def _is_blackwell():
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major >= 10
+
+
+pytestmark = pytest.mark.skipif(
+    not (_cutile_available() and _is_blackwell()),
+    reason="cuTile ragged prefill requires cuda.tile and a Blackwell (SM100+) GPU",
+)
+
+
+def _run(backend, qo_indptr, kv_indptr, q, k, v, nqo, nkv, hd, causal):
+    ws = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=q.device)
+    w = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(ws, backend=backend)
+    w.plan(qo_indptr, kv_indptr, nqo, nkv, hd, causal=causal, q_data_type=q.dtype)
+    return w.run(q, k, v, return_lse=True)
+
+
+@pytest.mark.parametrize(
+    "seq_lens,nqo,nkv",
+    [
+        ([128, 128], 4, 4),  # MHA, multi-batch
+        ([256], 8, 2),  # GQA 4:1
+        ([128, 256, 384], 4, 4),  # variable length
+        ([512, 512], 16, 1),  # GQA 16:1
+    ],
+)
+@pytest.mark.parametrize("causal", [True, False])
+def test_ragged_prefill_cutile_matches_fa2(seq_lens, nqo, nkv, causal):
+    dev, dt, hd = "cuda", torch.bfloat16, 128
+    torch.manual_seed(0)
+    qo_indptr = torch.tensor(
+        [0] + list(torch.tensor(seq_lens).cumsum(0)), dtype=torch.int32, device=dev
+    )
+    kv_indptr = qo_indptr.clone()  # cuTile ragged requires qo_indptr == kv_indptr
+    total = int(qo_indptr[-1])
+    q = torch.randn(total, nqo, hd, dtype=dt, device=dev)
+    k = torch.randn(total, nkv, hd, dtype=dt, device=dev)
+    v = torch.randn(total, nkv, hd, dtype=dt, device=dev)
+
+    o_ct, lse_ct = _run("cutile", qo_indptr, kv_indptr, q, k, v, nqo, nkv, hd, causal)
+    o_fa, lse_fa = _run("fa2", qo_indptr, kv_indptr, q, k, v, nqo, nkv, hd, causal)
+
+    assert o_ct.shape == (total, nqo, hd)
+    assert not torch.isnan(o_ct).any()
+    rel = (o_ct.float() - o_fa.float()).abs().max() / (o_fa.float().abs().max() + 1e-6)
+    assert rel < 2e-2, f"output rel error {rel:.4f} too large"
+    # cuTile and fa2 must agree on FlashInfer's base-2 LSE convention.
+    lse_diff = (lse_ct.float() - lse_fa.float()).abs().max()
+    assert lse_diff < 5e-2, f"lse diff {lse_diff:.4f} too large (base convention?)"
+
+
+def test_ragged_prefill_cutile_rejects_unequal_indptr():
+    """qo_indptr != kv_indptr (append/chunked prefill) must raise, not miscompute."""
+    dev, dt, hd = "cuda", torch.bfloat16, 128
+    qo_indptr = torch.tensor([0, 64], dtype=torch.int32, device=dev)
+    kv_indptr = torch.tensor([0, 128], dtype=torch.int32, device=dev)
+    ws = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=dev)
+    w = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(ws, backend="cutile")
+    with pytest.raises(NotImplementedError):
+        w.plan(qo_indptr, kv_indptr, 4, 4, hd, causal=True, q_data_type=dt)

--- a/tests/attention/test_ragged_prefill_cutile_wrapper.py
+++ b/tests/attention/test_ragged_prefill_cutile_wrapper.py
@@ -6,8 +6,6 @@
 # Unlike test_fmha_prefill_bsr_cutile.py (which loads the kernel directly), these
 # exercise the full plan()/run() wiring in flashinfer/prefill.py.
 
-import math
-
 import pytest
 import torch
 

--- a/tests/attention/test_ragged_prefill_cutile_wrapper.py
+++ b/tests/attention/test_ragged_prefill_cutile_wrapper.py
@@ -13,6 +13,7 @@ flashinfer = pytest.importorskip("flashinfer")
 
 
 def _cutile_available():
+    """True if the cuTile toolchain is importable in this environment."""
     try:
         from flashinfer.cutile.cutile_common import is_cuda_tile_available
 
@@ -22,6 +23,7 @@ def _cutile_available():
 
 
 def _is_blackwell():
+    """True if the current GPU is Blackwell (sm100+)."""
     if not torch.cuda.is_available():
         return False
     major, _ = torch.cuda.get_device_capability()
@@ -35,6 +37,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def _run(backend, qo_indptr, kv_indptr, q, k, v, nqo, nkv, hd, causal):
+    """Plan and run the ragged-prefill wrapper on `backend` and return its output."""
     ws = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=q.device)
     w = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(ws, backend=backend)
     w.plan(qo_indptr, kv_indptr, nqo, nkv, hd, causal=causal, q_data_type=q.dtype)
@@ -52,6 +55,7 @@ def _run(backend, qo_indptr, kv_indptr, q, k, v, nqo, nkv, hd, causal):
 )
 @pytest.mark.parametrize("causal", [True, False])
 def test_ragged_prefill_cutile_matches_fa2(seq_lens, nqo, nkv, causal):
+    """cuTile ragged prefill through the wrapper must match the fa2 backend."""
     dev, dt, hd = "cuda", torch.bfloat16, 128
     torch.manual_seed(0)
     qo_indptr = torch.tensor(

--- a/tests/attention/test_ragged_prefill_cutile_wrapper.py
+++ b/tests/attention/test_ragged_prefill_cutile_wrapper.py
@@ -10,16 +10,10 @@ import pytest
 import torch
 
 flashinfer = pytest.importorskip("flashinfer")
+cutile_common = pytest.importorskip("flashinfer.cutile.cutile_common")
 
-
-def _cutile_available():
-    """True if the cuTile toolchain is importable in this environment."""
-    try:
-        from flashinfer.cutile.cutile_common import is_cuda_tile_available
-
-        return is_cuda_tile_available()
-    except Exception:
-        return False
+if not cutile_common.is_cuda_tile_available():
+    pytest.skip("cuda.tile not available", allow_module_level=True)
 
 
 def _is_blackwell():
@@ -31,8 +25,8 @@ def _is_blackwell():
 
 
 pytestmark = pytest.mark.skipif(
-    not (_cutile_available() and _is_blackwell()),
-    reason="cuTile ragged prefill requires cuda.tile and a Blackwell (SM100+) GPU",
+    not _is_blackwell(),
+    reason="cuTile ragged prefill requires a Blackwell (SM100+) GPU",
 )
 
 


### PR DESCRIPTION
## 📌 Description

Adds cuTile-authored attention kernels (public `cuda.tile` Python API) as an **opt-in `backend="cutile"`** on existing FlashInfer wrappers — defaults unchanged.

**Why FlashInfer wants this:** written in the high-level `cuda.tile` Python API instead of CUDA/CUTLASS templates, giving contributors a maintainable path to author and tune Blackwell (SM100/SM103) attention. Registered on existing wrappers so they validate against FlashInfer's own references, at parity on standard shapes.

**Added**
- `fmha_decode_bsr_cutile` — **paged GQA decode** (split-KV reduction, persistent scheduling, CUDA-graph-capturable `run()`) → `BatchDecodeWithPagedKVCacheWrapper(backend="cutile")`; and **DeepSeek MLA paged decode** (head_dim_ckv=512 + head_dim_kpe=64, compressed latent KV) → `BatchMLAPagedAttentionWrapper(backend="cutile")`.
- `fmha_prefill_bsr_cutile` — paged / ragged prefill, two-stage causal masking → `BlockSparseAttentionWrapper(backend="cutile")` and `BatchPrefillWithRaggedKVCacheWrapper(backend="cutile")`.

### Decode perf — B300 / sm103, bf16, GQA group 8 (heads 64/8, head_dim 128)

| batch · s_kv | cuTile ÷ trtllm-gen (SOTA) | cuTile vs fa2_tc |
|---|---|---|
| 1 · 1024 | 0.63× | — |
| 16 · 2048 | 0.98× | +32% |
| 200 · 8192 | 0.97× | +5% |

Decode is GQA-group-sensitive; small groups (e.g. GQA-4) currently run ~0.3× — a kernel-formulation follow-up, not a default regression.

### MLA decode perf — B200 / sm100, bf16, DeepSeek MLA (ckv=512 + kpe=64, page=64), num_heads=32

This PR adds an **arch-gated `TRANS_QK`** operand-swap that makes the QK-GEMM M-dim = BLOCK_N (128) to fill the Blackwell WGMMA tile (small query-groups otherwise leave it 3/4 empty):

| batch · s_kv | pre-TRANS_QK | **this PR** | speedup | trtllm-gen (SOTA) |
|---|---|---|---|---|
| 16 · 2048 | 0.040 ms | **0.023 ms** | 1.7× | 0.018 ms |
| 200 · 8192 | 1.386 ms | **0.497 ms** | **2.8×** | 0.543 ms |

`TRANS_QK` is gated to datacenter Blackwell (sm100/sm103) via `_supports_trans_qk`; sm120 / A100 keep the byte-identical original path (the transposed [512, BLOCK_H] accumulator would spill on their smaller SMs). Correctness unchanged (MLA 18/18). cuTile MLA decode now essentially matches trtllm-gen at large batch.

### Prefill perf — B300 / sm103, dense paged, vs fa2

| shape | cuTile ÷ fa2 |
|---|---|
| bs4 · s2048 · g4 · causal | 0.93× |
| bs1 · s4096 | 1.11× |

### Backend-comparison benchmarks

`benchmarks/bench_{ragged_prefill,paged_prefill,mla_decode,gqa_decode}_backend_comparison.py` (canonical `--providers`/`--csv`, inline correctness verify, `bench_gpu_time` kernel self-time, speedup-vs-trtllm table + heatmap). Two-flashinfer: cuTile from this checkout vs the trtllm-gen SOTA from an installed flashinfer, measured in separate processes and merged.

Full ocean-workload sweeps on **B200 (sm100)**, median kernel time, cuTile ÷ trtllm-gen (>1 = cuTile faster):

| op | sweep | geomean | range |
|---|---|---|---|
| **ragged prefill** (hd_qk=192, DeepSeek) | batch{1,16} × s_kv{1k…8k} | **0.60×** | 0.53–0.67× |
| **paged prefill** | page{16,64} × batch{1,16} × s_kv{1k…8k} | 0.60× | **page64 0.79–1.13×** · page16 0.33–0.48× |
| **MLA decode** (num_heads=32) | page{32,64} × batch{1…256} × s_kv{1k…8k} | 0.85× | **page64 batch≥128: 1.17–1.28×** · page32 0.57–0.85× |
| **GQA decode** | page{32,64} × batch{1…256} × s_kv{1k…8k} | 0.85× | **batch≥64: 0.88–0.97×** · batch≤16 0.56–0.89× |

Reading: cuTile **beats** trtllm-gen on MLA decode in the throughput regime (page64, batch ≥128) and on small-batch paged prefill with page64; it **converges to ~0.96–0.97×** on GQA decode at serving scale. It lags on **small pages** (page16 prefill, page32 MLA) and on **ragged prefill hd192**, both of which are cuTile-compiler scheduling effects under active work upstream — neither is on a default path here, since the backend is opt-in.

## 🔍 Related Issues

Part of a 3-way split of the cuTile migration (attention / quantization / GEMM), replacing #3959. Sibling PRs: #4019 (quantization), #4020 (GEMM).

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Measured on B300 / sm103:
- decode native test: 180 passed / 900 skipped
- block-sparse prefill (narrow slice): 12 passed
- standalone prefill: 7 passed
- decode `run()` CUDA-graph capture: replay bit-exact vs eager
- MLA paged decode (`BatchMLAPagedAttentionWrapper(backend="cutile")`) vs torch reference: 18 passed (batch×seq×page_size×heads sweep + preallocated-out)
- ragged prefill wrapper (`BatchPrefillWithRaggedKVCacheWrapper(backend="cutile")`) wired + tested

## Reviewer Notes

The backend is opt-in on every wrapper — no default path changes. The perf table above is the standing on the public toolchain over the full ocean workload sweep, including the regimes where cuTile currently lags (small pages, ragged hd192); those are tracked as kernel/compiler follow-ups rather than blockers for landing an opt-in backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cuTile-backed attention for paged and ragged KV prefill.
  * Added cuTile paged decode support for standard and MLA KV cache layouts, including split-KV reduction.
  * Introduced a new cuTile backend option for batch decode and block-sparse attention with backend-specific runtime limitations.

* **Bug Fixes**
  * Improved block-sparse test coverage to work when SciPy is unavailable.

* **Tests**
  * Added CUDA-only cuTile prefill tests and GPU-only cuTile MLA decode tests.
  * Expanded decode and block-sparse tests to run across the cuTile backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
