### PR TITLE
feat(quantization): cuTile per-token-group 8bit quant + fused RoPE-FP8

### DIFF
--- a/benchmarks/bench_per_token_group_quant_8bit.py
+++ b/benchmarks/bench_per_token_group_quant_8bit.py
@@ -1,34 +1,70 @@
 """
-Benchmark: per-token-group 8-bit quantization — cuTile backend vs SOTA.
+Copyright (c) 2025 by FlashInfer team.
 
-Compares FlashInfer's migrated ``backend="cutile"`` kernel (PR #4019) against
-the SGLang ``sgl_kernel`` reference (the SOTA baseline used by ocean-eval's
-dashboard for this op) and a PyTorch-native reference.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Workloads mirror ocean-eval's ``Test_Per_Token_Group_Quant_8bit`` perf suite:
-num_tokens in {128,256,384,512,768}, hidden in {2048,4096,7168}, group_size=128,
-bf16 -> fp8_e4m3, row-major scales.
+  http://www.apache.org/licenses/LICENSE-2.0
 
-Provider availability is graceful: ``cutile`` needs ``cuda.tile`` (run in the
-cuTile toolchain image); ``sgl`` needs ``sgl_kernel`` (run in an sglang image).
-Whichever provider's backend is absent returns NaN so the other still plots.
-Run the same script in each image and merge the rows for the full comparison.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Benchmark: Per-Token-Group 8-bit Quantization Backend Comparison
+
+Compares FlashInfer's ``per_token_group_quant_8bit`` cuTile backend against
+external references across a (num_tokens, hidden_dim) sweep:
+
+  - ``cutile`` : FlashInfer ``per_token_group_quant_8bit(backend="cutile")``
+  - ``sgl``    : SGLang ``sgl_kernel.sgl_per_token_group_quant_8bit`` (SOTA
+                 baseline used by ocean-eval's dashboard for this op)
+  - ``triton`` : SGLang Triton ``per_token_group_quant_fp8`` reference
+  - ``torch``  : PyTorch-native reference
+
+Providers whose backend is unavailable are skipped (NaN), so ``cutile`` (needs
+the cuda.tile toolchain image) and ``sgl``/``triton`` (need an sglang image)
+can be measured separately and their result CSVs merged. Emits a per-provider
+latency table, a speedup summary vs the SOTA baseline, and a heatmap.
+
+Usage:
+    python bench_per_token_group_quant_8bit.py
+    python bench_per_token_group_quant_8bit.py --providers cutile,torch
+    python bench_per_token_group_quant_8bit.py --dst-dtype int8 --csv out.csv
+
+Requirements:
+    - cuda.tile toolchain (cutile provider); sgl_kernel / sglang (sgl, triton)
+    - matplotlib for the heatmap
 """
 
+import argparse
+import csv as _csv
 import numpy as np
 import torch
-import triton
+from typing import Callable, Dict, List, Optional, Tuple
 
-import flashinfer  # noqa: F401
-from flashinfer.quantization import per_token_group_quant_8bit
-from flashinfer.testing.utils import bench_gpu_time_with_cudagraph
+from flashinfer.testing.utils import bench_gpu_time
 
-GROUP_SIZE = 128
+GROUP_SIZE_DEFAULT = 128
 EPS = 1e-10
-DST_DTYPE = torch.float8_e4m3fn
 
 
-def _sgl_available() -> bool:
+# --------------------------------------------------------------------------- #
+# Provider availability
+# --------------------------------------------------------------------------- #
+def _has_cutile() -> bool:
+    try:
+        import cuda.tile  # noqa: F401
+        from flashinfer.quantization import per_token_group_quant_8bit  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _has_sgl() -> bool:
     try:
         from sgl_kernel import sgl_per_token_group_quant_8bit  # noqa: F401
 
@@ -37,99 +73,345 @@ def _sgl_available() -> bool:
         return False
 
 
-def _cutile_available() -> bool:
+def _has_triton() -> bool:
     try:
-        import cuda.tile  # noqa: F401
+        from sglang.srt.layers.quantization.fp8_kernel import (  # noqa: F401
+            per_token_group_quant_8bit as _sgl_triton_quant,
+        )
 
         return True
     except Exception:
         return False
 
 
-def _torch_reference(x, group_size, dst_dtype, eps):
-    finfo = torch.finfo(dst_dtype)
-    x_ = x.reshape(x.numel() // group_size, group_size)
-    amax = x_.abs().max(dim=-1, keepdim=True)[0].clamp(min=eps).to(torch.float32)
-    x_s = amax / finfo.max
-    x_q = (x_ / x_s).clamp(min=finfo.min, max=finfo.max).to(dst_dtype).reshape(x.shape)
+ALL_PROVIDERS = ["cutile", "sgl", "triton", "torch"]
+_AVAIL = {
+    "cutile": _has_cutile,
+    "sgl": _has_sgl,
+    "triton": _has_triton,
+    "torch": lambda: True,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Reference + per-provider callables
+# --------------------------------------------------------------------------- #
+def _torch_reference(
+    x: torch.Tensor, group_size: int, dst_dtype: torch.dtype, eps: float
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if dst_dtype == torch.int8:
+        qmin, qmax = -128.0, 127.0
+    else:
+        finfo = torch.finfo(dst_dtype)
+        qmin, qmax = finfo.min, finfo.max
+    x_ = x.reshape(x.numel() // group_size, group_size).to(torch.float32)
+    amax = x_.abs().amax(dim=-1, keepdim=True).clamp(min=eps)
+    x_s = amax / qmax
+    x_q = (x_ / x_s).clamp(qmin, qmax)
+    x_q = (x_q.round() if dst_dtype == torch.int8 else x_q).to(dst_dtype).reshape(x.shape)
     x_s = x_s.reshape(x.shape[:-1] + (x.shape[-1] // group_size,))
     return x_q, x_s
 
 
-def benchmark_config(num_tokens, hidden_dim, provider):
-    device = "cuda"
-    torch.manual_seed(0)
-    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device)
-
+def _make_execute(
+    provider: str,
+    x: torch.Tensor,
+    group_size: int,
+    dst_dtype: torch.dtype,
+    eps: float,
+) -> Callable[[], Tuple[torch.Tensor, torch.Tensor]]:
     if provider == "cutile":
-        if not _cutile_available():
-            return float("nan"), float("nan"), float("nan")
+        from flashinfer.quantization import per_token_group_quant_8bit
 
-        def execute():
-            per_token_group_quant_8bit(
-                x, GROUP_SIZE, eps=EPS, dst_dtype=DST_DTYPE, backend="cutile"
+        def run():
+            return per_token_group_quant_8bit(
+                x, group_size, eps=eps, dst_dtype=dst_dtype, backend="cutile"
             )
 
     elif provider == "sgl":
-        if not _sgl_available():
-            return float("nan"), float("nan"), float("nan")
         from sgl_kernel import sgl_per_token_group_quant_8bit
 
-        finfo = torch.finfo(DST_DTYPE)
-        x_q = torch.empty_like(x, dtype=DST_DTYPE)
+        if dst_dtype == torch.int8:
+            qmin, qmax = -128.0, 127.0
+        else:
+            finfo = torch.finfo(dst_dtype)
+            qmin, qmax = finfo.min, finfo.max
+        x_q = torch.empty_like(x, dtype=dst_dtype)
         x_s = torch.empty(
-            x.shape[:-1] + (x.shape[-1] // GROUP_SIZE,),
-            device=device,
+            x.shape[:-1] + (x.shape[-1] // group_size,),
+            device=x.device,
             dtype=torch.float32,
         )
 
-        def execute():
+        def run():
             sgl_per_token_group_quant_8bit(
-                x, x_q, x_s, GROUP_SIZE, EPS, finfo.min, finfo.max, False, enable_v2=False
+                x, x_q, x_s, group_size, eps, qmin, qmax, False, enable_v2=False
             )
+            return x_q, x_s
+
+    elif provider == "triton":
+        from sglang.srt.layers.quantization.fp8_kernel import (
+            per_token_group_quant_8bit as sgl_triton_quant,
+        )
+
+        def run():
+            return sgl_triton_quant(x, group_size, dst_dtype, eps=eps)
 
     elif provider == "torch":
 
-        def execute():
-            _torch_reference(x, GROUP_SIZE, DST_DTYPE, EPS)
+        def run():
+            return _torch_reference(x, group_size, dst_dtype, eps)
 
     else:
         raise ValueError(f"Unknown provider: {provider}")
 
-    measurements = bench_gpu_time_with_cudagraph(execute)
-    ms = np.median(measurements)
-    return ms, np.percentile(measurements, 20), np.percentile(measurements, 80)
+    return run
 
 
-def _make_report(hidden_dim, plot_color):
-    @triton.testing.perf_report(
-        triton.testing.Benchmark(
-            x_names=["num_tokens"],
-            x_vals=[128, 256, 384, 512, 768],
-            line_arg="provider",
-            line_vals=["cutile", "sgl", "torch"],
-            line_names=["cuTile", "SGLang (SOTA)", "PyTorch"],
-            styles=[("orange", "-"), ("blue", "-"), ("green", "--")],
-            ylabel="Latency (ms)",
-            plot_name=f"per-token-group-quant-8bit-hidden{hidden_dim}",
-            args={"hidden_dim": hidden_dim},
+# --------------------------------------------------------------------------- #
+# Correctness + timing
+# --------------------------------------------------------------------------- #
+def verify_correctness(
+    num_tokens: int,
+    hidden_dim: int,
+    group_size: int,
+    dst_dtype: torch.dtype,
+    provider: str,
+) -> Tuple[bool, float]:
+    """Return (ok, cosine_similarity) of provider quant output vs torch reference."""
+    torch.manual_seed(42)
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+    try:
+        q, _ = _make_execute(provider, x, group_size, dst_dtype, EPS)()
+        ref_q, _ = _torch_reference(x, group_size, dst_dtype, EPS)
+        a = q.to(torch.float32).reshape(1, -1)
+        b = ref_q.to(torch.float32).reshape(1, -1)
+        cos = torch.nn.functional.cosine_similarity(a, b).item()
+        return cos > 0.99, cos
+    except Exception:
+        return False, 0.0
+
+
+def bench_one(
+    num_tokens: int,
+    hidden_dim: int,
+    group_size: int,
+    dst_dtype: torch.dtype,
+    provider: str,
+) -> float:
+    """Median latency (ms) for one (shape, provider); NaN if unavailable/failed."""
+    if not _AVAIL[provider]():
+        return float("nan")
+    torch.manual_seed(0)
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+    try:
+        run = _make_execute(provider, x, group_size, dst_dtype, EPS)
+        run()  # warmup / compile
+        times = bench_gpu_time(
+            fn=run,
+            enable_cupti=True,
+            dry_run_iters=5,
+            repeat_iters=30,
+            cold_l2_cache=True,
+            use_cuda_graph=False,
         )
+        return float(np.median(times))
+    except Exception:
+        return float("nan")
+
+
+# --------------------------------------------------------------------------- #
+# Sweep
+# --------------------------------------------------------------------------- #
+def run_benchmark_sweep(
+    num_tokens_values: List[int],
+    hidden_values: List[int],
+    group_size: int,
+    dst_dtype: torch.dtype,
+    providers: List[str],
+) -> Dict[str, Dict[Tuple[int, int], float]]:
+    """Return {provider: {(num_tokens, hidden): median_ms}}."""
+    results: Dict[str, Dict[Tuple[int, int], float]] = {p: {} for p in providers}
+    total = len(num_tokens_values) * len(hidden_values)
+    current = 0
+
+    print(f"\nBenchmarking per_token_group_quant_8bit  gs={group_size}  bf16->{dst_dtype}")
+    print("=" * (30 + 12 * len(providers)))
+    header = f"{'ntok':>6} {'hidden':>7} |"
+    for p in providers:
+        header += f" {p:>10}"
+    print(header)
+    print("-" * (30 + 12 * len(providers)))
+
+    for ntok in num_tokens_values:
+        for hidden in hidden_values:
+            current += 1
+            row = f"{ntok:>6} {hidden:>7} |"
+            for p in providers:
+                ms = bench_one(ntok, hidden, group_size, dst_dtype, p)
+                results[p][(ntok, hidden)] = ms
+                row += f" {ms:>10.5f}" if ms == ms else f" {'--':>10}"
+            print(f"[{current:3d}/{total}] " + row)
+
+    return results
+
+
+def print_summary_table(
+    num_tokens_values: List[int],
+    hidden_values: List[int],
+    results: Dict[str, Dict[Tuple[int, int], float]],
+    providers: List[str],
+    baseline: str,
+):
+    """Speedup of each provider vs the baseline (>1 = provider faster)."""
+    if baseline not in results:
+        return
+    for p in providers:
+        if p == baseline:
+            continue
+        print(f"\n{'=' * 72}")
+        print(f"Speedup: {p} vs {baseline} (baseline_ms / {p}_ms;  >1 = {p} faster)")
+        print(f"{'=' * 72}")
+        header = "ntok\\hidden".ljust(12)
+        for h in hidden_values:
+            header += f"{h:>10}"
+        print(header)
+        print("-" * (12 + 10 * len(hidden_values)))
+        ratios = []
+        for ntok in num_tokens_values:
+            row = f"{ntok:<12}"
+            for h in hidden_values:
+                bt = results[baseline].get((ntok, h), float("nan"))
+                pt = results[p].get((ntok, h), float("nan"))
+                if pt == pt and bt == bt and pt > 0:
+                    r = bt / pt
+                    ratios.append(r)
+                    row += f"{r:>10.2f}"
+                else:
+                    row += f"{'N/A':>10}"
+            print(row)
+        if ratios:
+            print(
+                f"\n  geomean {np.exp(np.mean(np.log(ratios))):.2f}x  "
+                f"min {min(ratios):.2f}x  max {max(ratios):.2f}x  "
+                f"({sum(1 for r in ratios if r > 1)}/{len(ratios)} shapes {p} faster)"
+            )
+
+
+def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int], float]]):
+    with open(path, "w", newline="") as f:
+        w = _csv.writer(f)
+        w.writerow(["provider", "num_tokens", "hidden_dim", "median_ms"])
+        for provider, d in results.items():
+            for (ntok, hidden), ms in sorted(d.items()):
+                w.writerow([provider, ntok, hidden, f"{ms:.6f}"])
+    print(f"\nWrote {path}")
+
+
+def create_heatmap(
+    num_tokens_values: List[int],
+    hidden_values: List[int],
+    results: Dict[str, Dict[Tuple[int, int], float]],
+    provider: str,
+    baseline: str,
+    output_file: str,
+):
+    """Heatmap of `provider` speedup vs `baseline` over (num_tokens x hidden)."""
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as mcolors
+    except ImportError:
+        print("matplotlib not installed, skipping heatmap")
+        return
+    if provider not in results or baseline not in results:
+        return
+    mat = np.full((len(num_tokens_values), len(hidden_values)), np.nan)
+    for i, ntok in enumerate(num_tokens_values):
+        for j, h in enumerate(hidden_values):
+            bt = results[baseline].get((ntok, h), float("nan"))
+            pt = results[provider].get((ntok, h), float("nan"))
+            if pt == pt and bt == bt and pt > 0:
+                mat[i, j] = bt / pt
+    if np.all(np.isnan(mat)):
+        return
+    fig, ax = plt.subplots(figsize=(max(6, 1.5 * len(hidden_values)), max(5, 0.5 * len(num_tokens_values))))
+    norm = mcolors.TwoSlopeNorm(
+        vmin=min(0.5, np.nanmin(mat)), vcenter=1.0, vmax=max(1.5, np.nanmax(mat))
     )
-    def _bench(num_tokens, hidden_dim, provider):
-        return benchmark_config(num_tokens, hidden_dim, provider)
+    im = ax.imshow(mat, cmap="RdYlGn", norm=norm, aspect="auto")
+    cbar = ax.figure.colorbar(im, ax=ax, shrink=0.8)
+    cbar.ax.set_ylabel(f"{baseline}_ms / {provider}_ms", rotation=-90, va="bottom")
+    ax.set_xticks(np.arange(len(hidden_values)))
+    ax.set_yticks(np.arange(len(num_tokens_values)))
+    ax.set_xticklabels([str(h) for h in hidden_values])
+    ax.set_yticklabels([str(n) for n in num_tokens_values])
+    for i in range(len(num_tokens_values)):
+        for j in range(len(hidden_values)):
+            if not np.isnan(mat[i, j]):
+                ax.text(j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                        color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black")
+    ax.set_xlabel("hidden_dim")
+    ax.set_ylabel("num_tokens")
+    ax.set_title(f"per_token_group_quant_8bit: {provider} speedup vs {baseline}\n(>1.0 = {provider} faster)")
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    print(f"Saved heatmap to {output_file}")
+    plt.close()
 
-    return _bench
 
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark per_token_group_quant_8bit backends"
+    )
+    parser.add_argument("--dst-dtype", choices=["fp8_e4m3", "int8"], default="fp8_e4m3")
+    parser.add_argument("--group-size", type=int, default=GROUP_SIZE_DEFAULT)
+    parser.add_argument(
+        "--providers",
+        type=str,
+        default=",".join(ALL_PROVIDERS),
+        help=f"Comma-separated subset of {ALL_PROVIDERS}",
+    )
+    parser.add_argument("--baseline", type=str, default="sgl", help="Speedup baseline provider")
+    parser.add_argument("--output-prefix", type=str, default="per_token_group_quant_8bit")
+    parser.add_argument("--csv", type=str, default=None, help="Write raw medians to CSV")
+    args = parser.parse_args()
 
-benchmark_h2048 = _make_report(2048, "orange")
-benchmark_h4096 = _make_report(4096, "orange")
-benchmark_h7168 = _make_report(7168, "orange")
+    dst_dtype = torch.float8_e4m3fn if args.dst_dtype == "fp8_e4m3" else torch.int8
+    requested = [p.strip() for p in args.providers.split(",") if p.strip()]
+    providers = [p for p in requested if p in ALL_PROVIDERS]
+    available = [p for p in providers if _AVAIL[p]()]
+    print(f"Requested providers: {providers}")
+    print(f"Available here:      {available}  (unavailable are skipped as N/A)")
+
+    num_tokens_values = [1, 16, 64, 128, 256, 384, 512, 768, 1024, 2048, 4096]
+    hidden_values = [2048, 4096, 7168]
+
+    # Inline correctness check (once per available provider at a mid shape)
+    print("\nCorrectness (cosine-sim of quant vs torch ref, at 512x4096):")
+    for p in available:
+        ok, cos = verify_correctness(512, 4096, args.group_size, dst_dtype, p)
+        print(f"  {p:>8}: {'OK ' if ok else 'FAIL'} cos={cos:.4f}")
+
+    results = run_benchmark_sweep(
+        num_tokens_values, hidden_values, args.group_size, dst_dtype, providers
+    )
+    baseline = args.baseline if args.baseline in providers else providers[0]
+    print_summary_table(num_tokens_values, hidden_values, results, providers, baseline)
+
+    if args.csv:
+        write_csv(args.csv, results)
+
+    for p in providers:
+        if p != baseline:
+            create_heatmap(
+                num_tokens_values, hidden_values, results, p, baseline,
+                f"{args.output_prefix}_{p}_vs_{baseline}_{args.dst_dtype}.png",
+            )
+
+    print("\n" + "=" * 72)
+    print("BENCHMARK COMPLETE")
+    print("=" * 72)
 
 
 if __name__ == "__main__":
-    print(
-        f"per_token_group_quant_8bit  gs={GROUP_SIZE} bf16->fp8_e4m3  "
-        f"(cutile={_cutile_available()} sgl={_sgl_available()})"
-    )
-    for bench in (benchmark_h2048, benchmark_h4096, benchmark_h7168):
-        bench.run(print_data=True)
+    main()

--- a/benchmarks/bench_per_token_group_quant_8bit.py
+++ b/benchmarks/bench_per_token_group_quant_8bit.py
@@ -21,7 +21,7 @@ external references across a (num_tokens, hidden_dim) sweep:
   - ``cutile`` : FlashInfer ``per_token_group_quant_8bit(backend="cutile")``
   - ``sgl``    : SGLang ``sgl_kernel.sgl_per_token_group_quant_8bit`` (SOTA
                  baseline used by ocean-eval's dashboard for this op)
-  - ``triton`` : SGLang Triton ``per_token_group_quant_fp8`` reference
+  - ``triton`` : SGLang Triton ``per_token_group_quant_8bit`` reference
   - ``torch``  : PyTorch-native reference
 
 Providers whose backend is unavailable are skipped (NaN), so ``cutile`` (needs

--- a/benchmarks/bench_per_token_group_quant_8bit.py
+++ b/benchmarks/bench_per_token_group_quant_8bit.py
@@ -1,0 +1,135 @@
+"""
+Benchmark: per-token-group 8-bit quantization — cuTile backend vs SOTA.
+
+Compares FlashInfer's migrated ``backend="cutile"`` kernel (PR #4019) against
+the SGLang ``sgl_kernel`` reference (the SOTA baseline used by ocean-eval's
+dashboard for this op) and a PyTorch-native reference.
+
+Workloads mirror ocean-eval's ``Test_Per_Token_Group_Quant_8bit`` perf suite:
+num_tokens in {128,256,384,512,768}, hidden in {2048,4096,7168}, group_size=128,
+bf16 -> fp8_e4m3, row-major scales.
+
+Provider availability is graceful: ``cutile`` needs ``cuda.tile`` (run in the
+cuTile toolchain image); ``sgl`` needs ``sgl_kernel`` (run in an sglang image).
+Whichever provider's backend is absent returns NaN so the other still plots.
+Run the same script in each image and merge the rows for the full comparison.
+"""
+
+import numpy as np
+import torch
+import triton
+
+import flashinfer  # noqa: F401
+from flashinfer.quantization import per_token_group_quant_8bit
+from flashinfer.testing.utils import bench_gpu_time_with_cudagraph
+
+GROUP_SIZE = 128
+EPS = 1e-10
+DST_DTYPE = torch.float8_e4m3fn
+
+
+def _sgl_available() -> bool:
+    try:
+        from sgl_kernel import sgl_per_token_group_quant_8bit  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _cutile_available() -> bool:
+    try:
+        import cuda.tile  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _torch_reference(x, group_size, dst_dtype, eps):
+    finfo = torch.finfo(dst_dtype)
+    x_ = x.reshape(x.numel() // group_size, group_size)
+    amax = x_.abs().max(dim=-1, keepdim=True)[0].clamp(min=eps).to(torch.float32)
+    x_s = amax / finfo.max
+    x_q = (x_ / x_s).clamp(min=finfo.min, max=finfo.max).to(dst_dtype).reshape(x.shape)
+    x_s = x_s.reshape(x.shape[:-1] + (x.shape[-1] // group_size,))
+    return x_q, x_s
+
+
+def benchmark_config(num_tokens, hidden_dim, provider):
+    device = "cuda"
+    torch.manual_seed(0)
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device)
+
+    if provider == "cutile":
+        if not _cutile_available():
+            return float("nan"), float("nan"), float("nan")
+
+        def execute():
+            per_token_group_quant_8bit(
+                x, GROUP_SIZE, eps=EPS, dst_dtype=DST_DTYPE, backend="cutile"
+            )
+
+    elif provider == "sgl":
+        if not _sgl_available():
+            return float("nan"), float("nan"), float("nan")
+        from sgl_kernel import sgl_per_token_group_quant_8bit
+
+        finfo = torch.finfo(DST_DTYPE)
+        x_q = torch.empty_like(x, dtype=DST_DTYPE)
+        x_s = torch.empty(
+            x.shape[:-1] + (x.shape[-1] // GROUP_SIZE,),
+            device=device,
+            dtype=torch.float32,
+        )
+
+        def execute():
+            sgl_per_token_group_quant_8bit(
+                x, x_q, x_s, GROUP_SIZE, EPS, finfo.min, finfo.max, False, enable_v2=False
+            )
+
+    elif provider == "torch":
+
+        def execute():
+            _torch_reference(x, GROUP_SIZE, DST_DTYPE, EPS)
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    measurements = bench_gpu_time_with_cudagraph(execute)
+    ms = np.median(measurements)
+    return ms, np.percentile(measurements, 20), np.percentile(measurements, 80)
+
+
+def _make_report(hidden_dim, plot_color):
+    @triton.testing.perf_report(
+        triton.testing.Benchmark(
+            x_names=["num_tokens"],
+            x_vals=[128, 256, 384, 512, 768],
+            line_arg="provider",
+            line_vals=["cutile", "sgl", "torch"],
+            line_names=["cuTile", "SGLang (SOTA)", "PyTorch"],
+            styles=[("orange", "-"), ("blue", "-"), ("green", "--")],
+            ylabel="Latency (ms)",
+            plot_name=f"per-token-group-quant-8bit-hidden{hidden_dim}",
+            args={"hidden_dim": hidden_dim},
+        )
+    )
+    def _bench(num_tokens, hidden_dim, provider):
+        return benchmark_config(num_tokens, hidden_dim, provider)
+
+    return _bench
+
+
+benchmark_h2048 = _make_report(2048, "orange")
+benchmark_h4096 = _make_report(4096, "orange")
+benchmark_h7168 = _make_report(7168, "orange")
+
+
+if __name__ == "__main__":
+    print(
+        f"per_token_group_quant_8bit  gs={GROUP_SIZE} bf16->fp8_e4m3  "
+        f"(cutile={_cutile_available()} sgl={_sgl_available()})"
+    )
+    for bench in (benchmark_h2048, benchmark_h4096, benchmark_h7168):
+        bench.run(print_data=True)

--- a/benchmarks/bench_per_token_group_quant_8bit.py
+++ b/benchmarks/bench_per_token_group_quant_8bit.py
@@ -55,6 +55,7 @@ EPS = 1e-10
 # Provider availability
 # --------------------------------------------------------------------------- #
 def _has_cutile() -> bool:
+    """True if this checkout can run the cuTile quantization backend."""
     try:
         import cuda.tile  # noqa: F401
         from flashinfer.quantization import per_token_group_quant_8bit  # noqa: F401
@@ -65,6 +66,7 @@ def _has_cutile() -> bool:
 
 
 def _has_sgl() -> bool:
+    """True if SGLang's sgl_kernel quantizer is importable."""
     try:
         from sgl_kernel import sgl_per_token_group_quant_8bit  # noqa: F401
 
@@ -74,6 +76,7 @@ def _has_sgl() -> bool:
 
 
 def _has_triton() -> bool:
+    """True if SGLang's Triton quantizer is importable."""
     try:
         from sglang.srt.layers.quantization.fp8_kernel import (  # noqa: F401
             per_token_group_quant_8bit as _sgl_triton_quant,
@@ -99,6 +102,7 @@ _AVAIL = {
 def _torch_reference(
     x: torch.Tensor, group_size: int, dst_dtype: torch.dtype, eps: float
 ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch per-token-group quantization; the correctness reference."""
     if dst_dtype == torch.int8:
         qmin, qmax = -128.0, 127.0
     else:
@@ -122,10 +126,12 @@ def _make_execute(
     dst_dtype: torch.dtype,
     eps: float,
 ) -> Callable[[], Tuple[torch.Tensor, torch.Tensor]]:
+    """Return a zero-arg callable running `provider`'s quantizer on `x`."""
     if provider == "cutile":
         from flashinfer.quantization import per_token_group_quant_8bit
 
         def run():
+            """Run the cuTile per-token-group quantizer."""
             return per_token_group_quant_8bit(
                 x, group_size, eps=eps, dst_dtype=dst_dtype, backend="cutile"
             )
@@ -146,6 +152,7 @@ def _make_execute(
         )
 
         def run():
+            """Run sgl_kernel's per-token-group quantizer into preallocated outputs."""
             sgl_per_token_group_quant_8bit(
                 x, x_q, x_s, group_size, eps, qmin, qmax, False, enable_v2=False
             )
@@ -157,11 +164,13 @@ def _make_execute(
         )
 
         def run():
+            """Run SGLang's Triton per-token-group quantizer."""
             return sgl_triton_quant(x, group_size, dst_dtype, eps=eps)
 
     elif provider == "torch":
 
         def run():
+            """Run the pure-PyTorch reference quantizer."""
             return _torch_reference(x, group_size, dst_dtype, eps)
 
     else:
@@ -303,6 +312,7 @@ def print_summary_table(
 
 
 def write_csv(path: str, results: Dict[str, Dict[Tuple[int, int], float]]):
+    """Write the raw per-provider medians to `path` as CSV."""
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(["provider", "num_tokens", "hidden_dim", "median_ms"])
@@ -375,6 +385,7 @@ def create_heatmap(
 
 
 def main():
+    """Parse args, sweep the shapes, and emit table / CSV / heatmap."""
     parser = argparse.ArgumentParser(
         description="Benchmark per_token_group_quant_8bit backends"
     )

--- a/benchmarks/bench_per_token_group_quant_8bit.py
+++ b/benchmarks/bench_per_token_group_quant_8bit.py
@@ -43,7 +43,7 @@ import argparse
 import csv as _csv
 import numpy as np
 import torch
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Tuple
 
 from flashinfer.testing.utils import bench_gpu_time
 
@@ -108,7 +108,9 @@ def _torch_reference(
     amax = x_.abs().amax(dim=-1, keepdim=True).clamp(min=eps)
     x_s = amax / qmax
     x_q = (x_ / x_s).clamp(qmin, qmax)
-    x_q = (x_q.round() if dst_dtype == torch.int8 else x_q).to(dst_dtype).reshape(x.shape)
+    x_q = (
+        (x_q.round() if dst_dtype == torch.int8 else x_q).to(dst_dtype).reshape(x.shape)
+    )
     x_s = x_s.reshape(x.shape[:-1] + (x.shape[-1] // group_size,))
     return x_q, x_s
 
@@ -235,7 +237,9 @@ def run_benchmark_sweep(
     total = len(num_tokens_values) * len(hidden_values)
     current = 0
 
-    print(f"\nBenchmarking per_token_group_quant_8bit  gs={group_size}  bf16->{dst_dtype}")
+    print(
+        f"\nBenchmarking per_token_group_quant_8bit  gs={group_size}  bf16->{dst_dtype}"
+    )
     print("=" * (30 + 12 * len(providers)))
     header = f"{'ntok':>6} {'hidden':>7} |"
     for p in providers:
@@ -334,7 +338,9 @@ def create_heatmap(
                 mat[i, j] = bt / pt
     if np.all(np.isnan(mat)):
         return
-    fig, ax = plt.subplots(figsize=(max(6, 1.5 * len(hidden_values)), max(5, 0.5 * len(num_tokens_values))))
+    fig, ax = plt.subplots(
+        figsize=(max(6, 1.5 * len(hidden_values)), max(5, 0.5 * len(num_tokens_values)))
+    )
     norm = mcolors.TwoSlopeNorm(
         vmin=min(0.5, np.nanmin(mat)), vcenter=1.0, vmax=max(1.5, np.nanmax(mat))
     )
@@ -348,11 +354,20 @@ def create_heatmap(
     for i in range(len(num_tokens_values)):
         for j in range(len(hidden_values)):
             if not np.isnan(mat[i, j]):
-                ax.text(j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
-                        color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black")
+                ax.text(
+                    j,
+                    i,
+                    f"{mat[i, j]:.2f}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
+                    color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
+                )
     ax.set_xlabel("hidden_dim")
     ax.set_ylabel("num_tokens")
-    ax.set_title(f"per_token_group_quant_8bit: {provider} speedup vs {baseline}\n(>1.0 = {provider} faster)")
+    ax.set_title(
+        f"per_token_group_quant_8bit: {provider} speedup vs {baseline}\n(>1.0 = {provider} faster)"
+    )
     plt.tight_layout()
     plt.savefig(output_file, dpi=150, bbox_inches="tight")
     print(f"Saved heatmap to {output_file}")
@@ -371,9 +386,15 @@ def main():
         default=",".join(ALL_PROVIDERS),
         help=f"Comma-separated subset of {ALL_PROVIDERS}",
     )
-    parser.add_argument("--baseline", type=str, default="sgl", help="Speedup baseline provider")
-    parser.add_argument("--output-prefix", type=str, default="per_token_group_quant_8bit")
-    parser.add_argument("--csv", type=str, default=None, help="Write raw medians to CSV")
+    parser.add_argument(
+        "--baseline", type=str, default="sgl", help="Speedup baseline provider"
+    )
+    parser.add_argument(
+        "--output-prefix", type=str, default="per_token_group_quant_8bit"
+    )
+    parser.add_argument(
+        "--csv", type=str, default=None, help="Write raw medians to CSV"
+    )
     args = parser.parse_args()
 
     dst_dtype = torch.float8_e4m3fn if args.dst_dtype == "fp8_e4m3" else torch.int8
@@ -404,7 +425,11 @@ def main():
     for p in providers:
         if p != baseline:
             create_heatmap(
-                num_tokens_values, hidden_values, results, p, baseline,
+                num_tokens_values,
+                hidden_values,
+                results,
+                p,
+                baseline,
                 f"{args.output_prefix}_{p}_vs_{baseline}_{args.dst_dtype}.png",
             )
 

--- a/benchmarks/bench_rope_quantize_fp8.py
+++ b/benchmarks/bench_rope_quantize_fp8.py
@@ -183,6 +183,46 @@ def benchmark_config(config_name, num_tokens, provider, enable_pdl=False):
             if mode_ncu and run_idx == 20:
                 torch.cuda.cudart().cudaProfilerStop()
 
+    elif provider == "cutile":
+        # Migrated cuTile backend (PR #4019). cuTile rope_quantize_fp8 supports
+        # only MLA-style 2D key + is_neox=False; GQA/MHA raise NotImplementedError.
+        q_rope = q_in[..., :rope_dim]
+        q_nope = q_in[..., rope_dim:]
+        k_rope = k_in[..., :rope_dim]
+        k_nope = k_in[..., rope_dim:]
+
+        q_rope_out = torch.empty_like(q_rope, dtype=quant_dtype)
+        q_nope_out = torch.empty_like(q_nope, dtype=quant_dtype)
+        k_rope_out = torch.empty_like(k_rope, dtype=quant_dtype)
+        k_nope_out = torch.empty_like(k_nope, dtype=quant_dtype)
+
+        def execute():
+            nonlocal run_idx
+            run_idx += 1
+
+            if mode_ncu and run_idx == 20:
+                torch.cuda.cudart().cudaProfilerStart()
+
+            flashinfer.rope.rope_quantize_fp8(
+                q_rope=q_rope,
+                k_rope=k_rope,
+                q_nope=q_nope,
+                k_nope=k_nope,
+                cos_sin_cache=rope_ref.cos_sin_cache,
+                pos_ids=pos_ids,
+                is_neox=False,
+                q_rope_out=q_rope_out,
+                k_rope_out=k_rope_out,
+                q_nope_out=q_nope_out,
+                k_nope_out=k_nope_out,
+                quant_scale_q=1.0,
+                quant_scale_kv=1.0,
+                backend="cutile",
+            )
+
+            if mode_ncu and run_idx == 20:
+                torch.cuda.cudart().cudaProfilerStop()
+
     elif provider == "torch":
         # Create compiled version for better performance
         @torch.compile
@@ -233,9 +273,9 @@ def benchmark_config(config_name, num_tokens, provider, enable_pdl=False):
         x_names=["num_tokens"],
         x_vals=[768] if mode_ncu else [1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 768],
         line_arg="provider",
-        line_vals=["flashinfer", "torch"],
-        line_names=["FlashInfer", "PyTorch Compiled"],
-        styles=[("blue", "-"), ("blue", "--")],
+        line_vals=["flashinfer", "cutile", "torch"],
+        line_names=["FlashInfer (native CUDA)", "cuTile", "PyTorch Compiled"],
+        styles=[("blue", "-"), ("orange", "-"), ("blue", "--")],
         ylabel="Latency (ms)",
         plot_name="mla-rope-benchmark",
         args={},

--- a/benchmarks/bench_rope_quantize_fp8.py
+++ b/benchmarks/bench_rope_quantize_fp8.py
@@ -197,6 +197,7 @@ def benchmark_config(config_name, num_tokens, provider, enable_pdl=False):
         k_nope_out = torch.empty_like(k_nope, dtype=quant_dtype)
 
         def execute():
+            """Run one fused RoPE+fp8-quant call, starting the CUDA profiler on the ncu warmup iteration."""
             nonlocal run_idx
             run_idx += 1
 

--- a/benchmarks/bench_rope_quantize_fp8_backend_comparison.py
+++ b/benchmarks/bench_rope_quantize_fp8_backend_comparison.py
@@ -1,0 +1,520 @@
+"""
+Copyright (c) 2025 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Benchmark: Fused MLA RoPE + FP8-Quantize Backend Comparison
+
+Compares FlashInfer's fused ``rope.rope_quantize_fp8`` op (RoPE + per-tensor
+fp8_e4m3 quantization applied together) across backends over a ``num_tokens``
+sweep:
+
+  - ``cutile``     : FlashInfer ``rope_quantize_fp8(backend="cutile")`` (the
+                     migrated cuTile backend, PR #4019)
+  - ``flashinfer`` : FlashInfer native fused CUDA kernel (the SOTA baseline)
+  - ``torch``      : PyTorch-native reference (``torch.compile`` RoPE + fp8 cast)
+
+Providers whose backend is unavailable degrade to N/A (NaN) via try/except, so
+``cutile`` (needs the cuda.tile toolchain image) can be measured separately from
+the native kernel and the result CSVs merged. Emits a per-provider latency
+table, a speedup summary vs the baseline, and a heatmap.
+
+The op is modeled on the ``mla`` configuration used for regression/perf testing:
+128 Q heads, 1 (shared 2D) K head, head_size 576 = rope_dim 64 + no_rope_dim 512,
+bf16 in -> fp8_e4m3 out. ``gqa``/``mha`` configs are also selectable via
+``--config``. Only ``backend="cutile"`` is limited to the MLA-style 2D key with
+``is_neox=False``, so it raises and degrades to N/A on ``gqa``/``mha``; the
+native ``flashinfer`` CUDA kernel and the ``torch`` provider support GQA/MHA
+(3D key) and run on those configs too.
+
+Usage:
+    python bench_rope_quantize_fp8_backend_comparison.py
+    python bench_rope_quantize_fp8_backend_comparison.py --providers cutile --csv out.csv
+    python bench_rope_quantize_fp8_backend_comparison.py --config mla --baseline flashinfer
+
+Requirements:
+    - flashinfer (flashinfer / native kernel providers)
+    - cuda.tile toolchain (cutile provider)
+    - matplotlib for the heatmap
+"""
+
+import argparse
+import csv as _csv
+import os
+import sys
+from typing import Callable, Dict, List, Tuple
+
+import numpy as np
+import torch
+
+from flashinfer.testing.utils import bench_gpu_time
+
+# Add the project root to Python path to import test helpers (same as the
+# source bench_rope_quantize_fp8.py).
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from tests.test_helpers.rope_reference import RotaryEmbedding  # noqa: E402
+
+INPUT_DTYPE = torch.bfloat16
+QUANT_DTYPE = torch.float8_e4m3fn
+
+
+# --------------------------------------------------------------------------- #
+# Provider availability
+# --------------------------------------------------------------------------- #
+def _has_flashinfer() -> bool:
+    try:
+        import flashinfer  # noqa: F401
+        from flashinfer.rope import rope_quantize_fp8  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _has_cutile() -> bool:
+    try:
+        import cuda.tile  # noqa: F401
+        from flashinfer.rope import rope_quantize_fp8  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+ALL_PROVIDERS = ["cutile", "flashinfer", "torch"]
+_AVAIL = {
+    "cutile": _has_cutile,
+    "flashinfer": _has_flashinfer,
+    "torch": lambda: True,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Config + input construction (mirrors bench_rope_quantize_fp8.benchmark_config)
+# --------------------------------------------------------------------------- #
+def _config_params(config_name: str) -> Tuple[int, int, int, int]:
+    """Return (num_qo_heads, num_kv_heads, rope_dim, no_rope_dim)."""
+    if config_name == "mla":
+        # MLA: shipped/perf configuration, 2D (shared) K tensor.
+        return 128, 1, 64, 512
+    elif config_name == "gqa":
+        return 32, 8, 64, 64
+    elif config_name == "mha":
+        return 32, 32, 64, 64
+    else:
+        raise ValueError(f"Unknown config: {config_name}")
+
+
+class _Inputs:
+    """Container for one (config, num_tokens) input set."""
+
+    def __init__(self, config_name: str, num_tokens: int, device: str, seed: int):
+        torch.manual_seed(seed)
+        num_qo_heads, num_kv_heads, rope_dim, no_rope_dim = _config_params(config_name)
+        total_dim = rope_dim + no_rope_dim
+
+        self.config_name = config_name
+        self.num_tokens = num_tokens
+        self.rope_dim = rope_dim
+        self.no_rope_dim = no_rope_dim
+        self.total_dim = total_dim
+
+        self.q_in = torch.randn(
+            num_tokens, num_qo_heads, total_dim, dtype=INPUT_DTYPE, device=device
+        )
+        if config_name == "mla":
+            # MLA: 2D K tensor (shared across heads)
+            self.k_in = torch.randn(
+                num_tokens, total_dim, dtype=INPUT_DTYPE, device=device
+            )
+        else:
+            self.k_in = torch.randn(
+                num_tokens, num_kv_heads, total_dim, dtype=INPUT_DTYPE, device=device
+            )
+
+        self.pos_ids = torch.arange(num_tokens, device=device)
+
+        self.rope_ref = RotaryEmbedding(
+            head_size=total_dim,
+            rotary_dim=rope_dim,
+            max_position_embeddings=4096,
+            base=10000,
+            is_neox_style=False,
+            dtype=INPUT_DTYPE,
+            device=device,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Reference + per-provider callables
+# --------------------------------------------------------------------------- #
+def _torch_reference(inp: _Inputs) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Eager PyTorch-native RoPE + fp8 cast; used as the correctness reference."""
+    q_out_f16, k_out_f16 = inp.rope_ref.forward_native(
+        inp.pos_ids, inp.q_in, inp.k_in
+    )
+    return q_out_f16.to(QUANT_DTYPE), k_out_f16.to(QUANT_DTYPE)
+
+
+def _make_execute(provider: str, inp: _Inputs) -> Callable[[], Tuple[torch.Tensor, ...]]:
+    """Return a zero-arg callable that runs `provider`'s op and returns its outputs.
+
+    For the fused kernels the returned tuple is
+    ``(q_rope_out, q_nope_out, k_rope_out, k_nope_out)``; for torch it is
+    ``(q_out_f8, k_out_f8)``.  ``_to_full_qk`` normalizes either into full q/k.
+    """
+    rope_dim = inp.rope_dim
+
+    if provider in ("flashinfer", "cutile"):
+        import flashinfer
+
+        # Split tensors for the fused kernel (rope / no-rope halves).
+        q_rope = inp.q_in[..., :rope_dim]
+        q_nope = inp.q_in[..., rope_dim:]
+        k_rope = inp.k_in[..., :rope_dim]
+        k_nope = inp.k_in[..., rope_dim:]
+
+        q_rope_out = torch.empty_like(q_rope, dtype=QUANT_DTYPE)
+        q_nope_out = torch.empty_like(q_nope, dtype=QUANT_DTYPE)
+        k_rope_out = torch.empty_like(k_rope, dtype=QUANT_DTYPE)
+        k_nope_out = torch.empty_like(k_nope, dtype=QUANT_DTYPE)
+
+        cos_sin_cache = inp.rope_ref.cos_sin_cache
+        pos_ids = inp.pos_ids
+
+        if provider == "flashinfer":
+
+            def run():
+                flashinfer.rope.rope_quantize_fp8(
+                    q_rope=q_rope,
+                    k_rope=k_rope,
+                    q_nope=q_nope,
+                    k_nope=k_nope,
+                    cos_sin_cache=cos_sin_cache,
+                    pos_ids=pos_ids,
+                    is_neox=False,
+                    q_rope_out=q_rope_out,
+                    k_rope_out=k_rope_out,
+                    q_nope_out=q_nope_out,
+                    k_nope_out=k_nope_out,
+                    quant_scale_q=1.0,
+                    quant_scale_kv=1.0,
+                    enable_pdl=False,
+                )
+                return q_rope_out, q_nope_out, k_rope_out, k_nope_out
+
+        else:  # cutile
+
+            def run():
+                flashinfer.rope.rope_quantize_fp8(
+                    q_rope=q_rope,
+                    k_rope=k_rope,
+                    q_nope=q_nope,
+                    k_nope=k_nope,
+                    cos_sin_cache=cos_sin_cache,
+                    pos_ids=pos_ids,
+                    is_neox=False,
+                    q_rope_out=q_rope_out,
+                    k_rope_out=k_rope_out,
+                    q_nope_out=q_nope_out,
+                    k_nope_out=k_nope_out,
+                    quant_scale_q=1.0,
+                    quant_scale_kv=1.0,
+                    backend="cutile",
+                )
+                return q_rope_out, q_nope_out, k_rope_out, k_nope_out
+
+    elif provider == "torch":
+        q_in = inp.q_in
+        k_in = inp.k_in
+        pos_ids = inp.pos_ids
+        rope_ref = inp.rope_ref
+
+        @torch.compile
+        def torch_rope_quantize(q_in, k_in, pos_ids):
+            q_out_f16, k_out_f16 = rope_ref.forward_native(pos_ids, q_in, k_in)
+            return q_out_f16.to(QUANT_DTYPE), k_out_f16.to(QUANT_DTYPE)
+
+        def run():
+            return torch_rope_quantize(q_in, k_in, pos_ids)
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+    return run
+
+
+def _to_full_qk(
+    provider: str, out: Tuple[torch.Tensor, ...], rope_dim: int
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Normalize a provider's raw output tuple into full (q, k) fp8 tensors."""
+    if provider in ("flashinfer", "cutile"):
+        q_rope_out, q_nope_out, k_rope_out, k_nope_out = out
+        q_full = torch.cat([q_rope_out, q_nope_out], dim=-1)
+        k_full = torch.cat([k_rope_out, k_nope_out], dim=-1)
+        return q_full, k_full
+    else:  # torch
+        return out[0], out[1]
+
+
+# --------------------------------------------------------------------------- #
+# Correctness + timing
+# --------------------------------------------------------------------------- #
+def verify_correctness(
+    config_name: str, num_tokens: int, provider: str
+) -> Tuple[bool, float]:
+    """Return (ok, cosine_similarity) of provider output vs torch reference."""
+    try:
+        inp = _Inputs(config_name, num_tokens, device="cuda", seed=42)
+        out = _make_execute(provider, inp)()
+        q, k = _to_full_qk(provider, out, inp.rope_dim)
+        ref_q, ref_k = _torch_reference(inp)
+        a = torch.cat(
+            [q.to(torch.float32).reshape(-1), k.to(torch.float32).reshape(-1)]
+        ).reshape(1, -1)
+        b = torch.cat(
+            [ref_q.to(torch.float32).reshape(-1), ref_k.to(torch.float32).reshape(-1)]
+        ).reshape(1, -1)
+        cos = torch.nn.functional.cosine_similarity(a, b).item()
+        return cos > 0.99, cos
+    except Exception:
+        return False, 0.0
+
+
+def bench_one(config_name: str, num_tokens: int, provider: str) -> float:
+    """Median latency (ms) for one (config, num_tokens, provider); NaN if failed."""
+    if not _AVAIL[provider]():
+        return float("nan")
+    try:
+        inp = _Inputs(config_name, num_tokens, device="cuda", seed=0)
+        run = _make_execute(provider, inp)
+        run()  # warmup / compile
+        times = bench_gpu_time(
+            fn=run,
+            enable_cupti=True,
+            dry_run_iters=5,
+            repeat_iters=30,
+            cold_l2_cache=True,
+            use_cuda_graph=False,
+        )
+        return float(np.median(times))
+    except Exception:
+        return float("nan")
+
+
+# --------------------------------------------------------------------------- #
+# Sweep
+# --------------------------------------------------------------------------- #
+def run_benchmark_sweep(
+    config_name: str,
+    num_tokens_values: List[int],
+    providers: List[str],
+) -> Dict[str, Dict[int, float]]:
+    """Return {provider: {num_tokens: median_ms}}."""
+    results: Dict[str, Dict[int, float]] = {p: {} for p in providers}
+    total = len(num_tokens_values)
+    current = 0
+
+    print(f"\nBenchmarking rope_quantize_fp8  config={config_name}  bf16->fp8_e4m3")
+    print("=" * (20 + 12 * len(providers)))
+    header = f"{'ntok':>6} |"
+    for p in providers:
+        header += f" {p:>12}"
+    print(header)
+    print("-" * (20 + 12 * len(providers)))
+
+    for ntok in num_tokens_values:
+        current += 1
+        row = f"{ntok:>6} |"
+        for p in providers:
+            ms = bench_one(config_name, ntok, p)
+            results[p][ntok] = ms
+            row += f" {ms:>12.5f}" if ms == ms else f" {'--':>12}"
+        print(f"[{current:3d}/{total}] " + row)
+
+    return results
+
+
+def print_summary_table(
+    num_tokens_values: List[int],
+    results: Dict[str, Dict[int, float]],
+    providers: List[str],
+    baseline: str,
+):
+    """Speedup of each provider vs the baseline (>1 = provider faster)."""
+    if baseline not in results:
+        return
+    for p in providers:
+        if p == baseline:
+            continue
+        print(f"\n{'=' * 60}")
+        print(f"Speedup: {p} vs {baseline} (baseline_ms / {p}_ms;  >1 = {p} faster)")
+        print(f"{'=' * 60}")
+        header = "num_tokens".ljust(12) + f"{'speedup':>12}"
+        print(header)
+        print("-" * 24)
+        ratios = []
+        for ntok in num_tokens_values:
+            bt = results[baseline].get(ntok, float("nan"))
+            pt = results[p].get(ntok, float("nan"))
+            if pt == pt and bt == bt and pt > 0:
+                r = bt / pt
+                ratios.append(r)
+                print(f"{ntok:<12}{r:>12.2f}")
+            else:
+                print(f"{ntok:<12}{'N/A':>12}")
+        if ratios:
+            print(
+                f"\n  geomean {np.exp(np.mean(np.log(ratios))):.2f}x  "
+                f"min {min(ratios):.2f}x  max {max(ratios):.2f}x  "
+                f"({sum(1 for r in ratios if r > 1)}/{len(ratios)} shapes {p} faster)"
+            )
+
+
+def write_csv(path: str, config_name: str, results: Dict[str, Dict[int, float]]):
+    with open(path, "w", newline="") as f:
+        w = _csv.writer(f)
+        w.writerow(["provider", "config", "num_tokens", "median_ms"])
+        for provider, d in results.items():
+            for ntok, ms in sorted(d.items()):
+                w.writerow([provider, config_name, ntok, f"{ms:.6f}"])
+    print(f"\nWrote {path}")
+
+
+def create_heatmap(
+    config_name: str,
+    num_tokens_values: List[int],
+    results: Dict[str, Dict[int, float]],
+    providers: List[str],
+    baseline: str,
+    output_file: str,
+):
+    """Heatmap of speedup vs `baseline` over (provider x num_tokens)."""
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.colors as mcolors
+    except ImportError:
+        print("matplotlib not installed, skipping heatmap")
+        return
+    if baseline not in results:
+        return
+    others = [p for p in providers if p != baseline]
+    if not others:
+        return
+    mat = np.full((len(others), len(num_tokens_values)), np.nan)
+    for i, p in enumerate(others):
+        for j, ntok in enumerate(num_tokens_values):
+            bt = results[baseline].get(ntok, float("nan"))
+            pt = results[p].get(ntok, float("nan"))
+            if pt == pt and bt == bt and pt > 0:
+                mat[i, j] = bt / pt
+    if np.all(np.isnan(mat)):
+        return
+    fig, ax = plt.subplots(
+        figsize=(max(6, 1.0 * len(num_tokens_values)), max(2.5, 1.0 * len(others)))
+    )
+    norm = mcolors.TwoSlopeNorm(
+        vmin=min(0.5, np.nanmin(mat)), vcenter=1.0, vmax=max(1.5, np.nanmax(mat))
+    )
+    im = ax.imshow(mat, cmap="RdYlGn", norm=norm, aspect="auto")
+    cbar = ax.figure.colorbar(im, ax=ax, shrink=0.8)
+    cbar.ax.set_ylabel(f"{baseline}_ms / provider_ms", rotation=-90, va="bottom")
+    ax.set_xticks(np.arange(len(num_tokens_values)))
+    ax.set_yticks(np.arange(len(others)))
+    ax.set_xticklabels([str(n) for n in num_tokens_values])
+    ax.set_yticklabels(others)
+    for i in range(len(others)):
+        for j in range(len(num_tokens_values)):
+            if not np.isnan(mat[i, j]):
+                ax.text(
+                    j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                    color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
+                )
+    ax.set_xlabel("num_tokens")
+    ax.set_ylabel("provider")
+    ax.set_title(
+        f"rope_quantize_fp8 ({config_name}): speedup vs {baseline}\n"
+        f"(>1.0 = provider faster)"
+    )
+    plt.tight_layout()
+    plt.savefig(output_file, dpi=150, bbox_inches="tight")
+    print(f"Saved heatmap to {output_file}")
+    plt.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark fused rope_quantize_fp8 backends"
+    )
+    parser.add_argument(
+        "--config",
+        choices=["mla", "gqa", "mha"],
+        default="mla",
+        help="Attention configuration (default mla, the shipped/perf one)",
+    )
+    parser.add_argument(
+        "--providers",
+        type=str,
+        default=",".join(ALL_PROVIDERS),
+        help=f"Comma-separated subset of {ALL_PROVIDERS}",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=str,
+        default="flashinfer",
+        help="Speedup baseline provider (default flashinfer, the SOTA kernel)",
+    )
+    parser.add_argument(
+        "--output-prefix", type=str, default="rope_quantize_fp8_backend_comparison"
+    )
+    parser.add_argument("--csv", type=str, default=None, help="Write raw medians to CSV")
+    args = parser.parse_args()
+
+    requested = [p.strip() for p in args.providers.split(",") if p.strip()]
+    providers = [p for p in requested if p in ALL_PROVIDERS]
+    available = [p for p in providers if _AVAIL[p]()]
+    print(f"Config:              {args.config}")
+    print(f"Requested providers: {providers}")
+    print(f"Available here:      {available}  (unavailable are skipped as N/A)")
+
+    num_tokens_values = [1, 4, 16, 32, 64, 128, 256, 384, 512, 768, 1024, 2048, 4096]
+
+    # Inline correctness check (once per available provider at a mid shape).
+    print("\nCorrectness (cosine-sim of q/k output vs torch ref, at 512 tokens):")
+    for p in available:
+        ok, cos = verify_correctness(args.config, 512, p)
+        print(f"  {p:>10}: {'OK ' if ok else 'FAIL'} cos={cos:.4f}")
+
+    results = run_benchmark_sweep(args.config, num_tokens_values, providers)
+    baseline = args.baseline if args.baseline in providers else providers[0]
+    print_summary_table(num_tokens_values, results, providers, baseline)
+
+    if args.csv:
+        write_csv(args.csv, args.config, results)
+
+    create_heatmap(
+        args.config,
+        num_tokens_values,
+        results,
+        providers,
+        baseline,
+        f"{args.output_prefix}_{args.config}_vs_{baseline}.png",
+    )
+
+    print("\n" + "=" * 60)
+    print("BENCHMARK COMPLETE")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_rope_quantize_fp8_backend_comparison.py
+++ b/benchmarks/bench_rope_quantize_fp8_backend_comparison.py
@@ -72,6 +72,7 @@ QUANT_DTYPE = torch.float8_e4m3fn
 # Provider availability
 # --------------------------------------------------------------------------- #
 def _has_flashinfer() -> bool:
+    """True if flashinfer's native fused RoPE+fp8 kernel is importable."""
     try:
         import flashinfer  # noqa: F401
         from flashinfer.rope import rope_quantize_fp8  # noqa: F401
@@ -82,6 +83,7 @@ def _has_flashinfer() -> bool:
 
 
 def _has_cutile() -> bool:
+    """True if this checkout can run the cuTile fused RoPE+fp8 backend."""
     try:
         import cuda.tile  # noqa: F401
         from flashinfer.rope import rope_quantize_fp8  # noqa: F401
@@ -119,6 +121,7 @@ class _Inputs:
     """Container for one (config, num_tokens) input set."""
 
     def __init__(self, config_name: str, num_tokens: int, device: str, seed: int):
+        """Build the q/k tensors, position ids and RoPE cache for one (config, num_tokens) case."""
         torch.manual_seed(seed)
         num_qo_heads, num_kv_heads, rope_dim, no_rope_dim = _config_params(config_name)
         total_dim = rope_dim + no_rope_dim
@@ -195,6 +198,7 @@ def _make_execute(
         if provider == "flashinfer":
 
             def run():
+                """Run the native fused CUDA RoPE+fp8 kernel."""
                 flashinfer.rope.rope_quantize_fp8(
                     q_rope=q_rope,
                     k_rope=k_rope,
@@ -216,6 +220,7 @@ def _make_execute(
         else:  # cutile
 
             def run():
+                """Run the cuTile fused RoPE+fp8 kernel."""
                 flashinfer.rope.rope_quantize_fp8(
                     q_rope=q_rope,
                     k_rope=k_rope,
@@ -242,10 +247,12 @@ def _make_execute(
 
         @torch.compile
         def torch_rope_quantize(q_in, k_in, pos_ids):
+            """Compiled PyTorch reference: RoPE followed by an fp8 cast."""
             q_out_f16, k_out_f16 = rope_ref.forward_native(pos_ids, q_in, k_in)
             return q_out_f16.to(QUANT_DTYPE), k_out_f16.to(QUANT_DTYPE)
 
         def run():
+            """Run the compiled PyTorch RoPE+fp8 reference."""
             return torch_rope_quantize(q_in, k_in, pos_ids)
 
     else:
@@ -380,6 +387,7 @@ def print_summary_table(
 
 
 def write_csv(path: str, config_name: str, results: Dict[str, Dict[int, float]]):
+    """Write the raw per-provider medians to `path` as CSV."""
     with open(path, "w", newline="") as f:
         w = _csv.writer(f)
         w.writerow(["provider", "config", "num_tokens", "median_ms"])
@@ -456,6 +464,7 @@ def create_heatmap(
 
 
 def main():
+    """Parse args, sweep num_tokens, and emit table / CSV / heatmap."""
     parser = argparse.ArgumentParser(
         description="Benchmark fused rope_quantize_fp8 backends"
     )

--- a/benchmarks/bench_rope_quantize_fp8_backend_comparison.py
+++ b/benchmarks/bench_rope_quantize_fp8_backend_comparison.py
@@ -160,13 +160,13 @@ class _Inputs:
 # --------------------------------------------------------------------------- #
 def _torch_reference(inp: _Inputs) -> Tuple[torch.Tensor, torch.Tensor]:
     """Eager PyTorch-native RoPE + fp8 cast; used as the correctness reference."""
-    q_out_f16, k_out_f16 = inp.rope_ref.forward_native(
-        inp.pos_ids, inp.q_in, inp.k_in
-    )
+    q_out_f16, k_out_f16 = inp.rope_ref.forward_native(inp.pos_ids, inp.q_in, inp.k_in)
     return q_out_f16.to(QUANT_DTYPE), k_out_f16.to(QUANT_DTYPE)
 
 
-def _make_execute(provider: str, inp: _Inputs) -> Callable[[], Tuple[torch.Tensor, ...]]:
+def _make_execute(
+    provider: str, inp: _Inputs
+) -> Callable[[], Tuple[torch.Tensor, ...]]:
     """Return a zero-arg callable that runs `provider`'s op and returns its outputs.
 
     For the fused kernels the returned tuple is
@@ -323,7 +323,6 @@ def run_benchmark_sweep(
     """Return {provider: {num_tokens: median_ms}}."""
     results: Dict[str, Dict[int, float]] = {p: {} for p in providers}
     total = len(num_tokens_values)
-    current = 0
 
     print(f"\nBenchmarking rope_quantize_fp8  config={config_name}  bf16->fp8_e4m3")
     print("=" * (20 + 12 * len(providers)))
@@ -333,8 +332,7 @@ def run_benchmark_sweep(
     print(header)
     print("-" * (20 + 12 * len(providers)))
 
-    for ntok in num_tokens_values:
-        current += 1
+    for current, ntok in enumerate(num_tokens_values, start=1):
         row = f"{ntok:>6} |"
         for p in providers:
             ms = bench_one(config_name, ntok, p)
@@ -437,7 +435,12 @@ def create_heatmap(
         for j in range(len(num_tokens_values)):
             if not np.isnan(mat[i, j]):
                 ax.text(
-                    j, i, f"{mat[i, j]:.2f}", ha="center", va="center", fontsize=8,
+                    j,
+                    i,
+                    f"{mat[i, j]:.2f}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
                     color="white" if mat[i, j] < 0.7 or mat[i, j] > 1.5 else "black",
                 )
     ax.set_xlabel("num_tokens")
@@ -477,7 +480,9 @@ def main():
     parser.add_argument(
         "--output-prefix", type=str, default="rope_quantize_fp8_backend_comparison"
     )
-    parser.add_argument("--csv", type=str, default=None, help="Write raw medians to CSV")
+    parser.add_argument(
+        "--csv", type=str, default=None, help="Write raw medians to CSV"
+    )
     args = parser.parse_args()
 
     requested = [p.strip() for p in args.providers.split(",") if p.strip()]

--- a/flashinfer/cutile/cutile_common.py
+++ b/flashinfer/cutile/cutile_common.py
@@ -18,6 +18,41 @@ import importlib.util
 import os
 import shutil
 import subprocess
+from collections import OrderedDict
+
+# ---------------------------------------------------------------------------
+# Hinted-kernel cache (ported from tilegym.ops.cutile.utils.cached_replace_hints)
+# ---------------------------------------------------------------------------
+# cuTile's per-shape JIT compile cache lives *on the hinted-kernel object*
+# returned by ``kernel.replace_hints(...)``. Calling ``replace_hints`` afresh on
+# every launch (as a naive migration does) builds a new object each time and
+# discards that compile cache -> a full recompile per launch on the non-autotune
+# / single-config paths. Memoizing the hinted kernel keeps the compile cache
+# alive across launches, matching the TileGym source behavior.
+#
+# Deliberately no ``cuda.tile`` import here so this module stays importable on
+# environments without the cuTile compile chain (see module docstring).
+_HINTED_KERNEL_CACHE: "OrderedDict[tuple, tuple]" = OrderedDict()
+_HINTED_KERNEL_CACHE_MAX = 256
+
+
+def cached_replace_hints(kernel, **hints):
+    """Return a memoized ``kernel.replace_hints(**hints)``.
+
+    Keyed on ``(id(kernel), sorted(hints))``. The source kernel is stored
+    alongside the hinted kernel so its ``id()`` cannot be recycled while the
+    entry is live. Bounded LRU (cap ``_HINTED_KERNEL_CACHE_MAX``).
+    """
+    key = (id(kernel), tuple(sorted(hints.items())))
+    entry = _HINTED_KERNEL_CACHE.get(key)
+    if entry is not None:
+        _HINTED_KERNEL_CACHE.move_to_end(key)
+        return entry[0]
+    hinted = kernel.replace_hints(**hints)
+    _HINTED_KERNEL_CACHE[key] = (hinted, kernel)  # keep owner alive
+    if len(_HINTED_KERNEL_CACHE) > _HINTED_KERNEL_CACHE_MAX:
+        _HINTED_KERNEL_CACHE.popitem(last=False)
+    return hinted
 
 
 def _find_tileiras_binary() -> str | None:

--- a/flashinfer/quantization/__init__.py
+++ b/flashinfer/quantization/__init__.py
@@ -22,6 +22,7 @@ from .fp8_quantization import (
     mxfp8_quantize,
     mxfp8_grouped_quantize,
     mxfp8_dequantize_host,
+    per_token_group_quant_8bit,
 )
 
 # Re-export FP4 quantization (all public symbols)
@@ -76,6 +77,7 @@ __all__ = [
     "mxfp8_quantize",
     "mxfp8_grouped_quantize",
     "mxfp8_dequantize_host",
+    "per_token_group_quant_8bit",
     # FP4
     "SfLayout",
     "block_scale_interleave",

--- a/flashinfer/quantization/fp8_quantization.py
+++ b/flashinfer/quantization/fp8_quantization.py
@@ -489,3 +489,68 @@ def mxfp8_dequantize_host(
         scale_tensor,
         sf_swizzle_layout,
     )
+
+
+@flashinfer_api
+def per_token_group_quant_8bit(
+    x: torch.Tensor,
+    group_size: int,
+    eps: float = 1e-10,
+    dst_dtype: Optional[torch.dtype] = None,
+    column_major_scales: bool = False,
+    scale_tma_aligned: bool = False,
+    scale_ue8m0: bool = False,
+    backend: Literal["cutile"] = "cutile",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    r"""Per-token group 8-bit quantization (FP8 or INT8).
+
+    Quantizes ``x`` along its last dimension in contiguous groups of
+    ``group_size`` elements, producing a quantized tensor and a per-group scale
+    tensor. This is the per-token-group quantization used by block-scaled FP8 /
+    INT8 GEMM paths (e.g. DeepGEMM-style grouped quantization).
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor to quantize; the last dimension must be a multiple of
+        ``group_size``.
+    group_size : int
+        Number of elements per quantization group (along the last dimension).
+    eps : float
+        Epsilon for numerical stability when computing per-group scales.
+    dst_dtype : Optional[torch.dtype]
+        Quantized output dtype (``torch.float8_e4m3fn`` or ``torch.int8``).
+        Defaults to ``torch.float8_e4m3fn``.
+    column_major_scales : bool
+        If ``True``, return the scale tensor in column-major (Fortran) memory
+        layout. The logical shape is unchanged.
+    scale_tma_aligned : bool
+        If ``True``, pad the scale tensor's leading dimension for TMA alignment.
+    scale_ue8m0 : bool
+        If ``True``, encode scales in the UE8M0 format (Blackwell / sm100+).
+    backend : str
+        Implementation backend. Currently only ``"cutile"`` (the cuda.tile
+        Python backend) is supported.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        ``(x_q, x_s)``: the quantized tensor (same shape as ``x``) and the
+        per-group scale tensor of shape ``(*x.shape[:-1], x.shape[-1] // group_size)``.
+    """
+    if backend == "cutile":
+        from .kernels.cutile.per_token_group_quant_8bit_cutile import (
+            per_token_group_quant_8bit_cutile,
+        )
+
+        return per_token_group_quant_8bit_cutile(
+            x,
+            group_size,
+            eps=eps,
+            dst_dtype=dst_dtype,
+            column_major_scales=column_major_scales,
+            scale_tma_aligned=scale_tma_aligned,
+            scale_ue8m0=scale_ue8m0,
+        )
+
+    raise ValueError(f"Unsupported backend for per_token_group_quant_8bit: {backend!r}")

--- a/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
@@ -69,6 +69,13 @@ def _per_token_group_quant_8bit_kernel(
 
     # Quantize: clamp(y * y_s_inv, bit8_min, bit8_max)
     y_q = ct.minimum(ct.maximum(y * y_s_inv, bit8_min), bit8_max)
+    # ct.astype float->int truncates toward zero, but the INT8 reference rounds
+    # to nearest -- truncation would leave a systematic ~0.5-LSB bias. cuda.tile
+    # exposes no round op, so round-half-up via floor(x + 0.5) on the (already
+    # clamped, so in-range) value. FP8 casts round in hardware, so only the
+    # integer path needs this.
+    if y_quantized.dtype == ct.int8:
+        y_q = ct.floor(y_q + 0.5)
     y_q = ct.astype(y_q, y_quantized.dtype)
 
     # Store quantized values with mask (use OOB offsets for invalid positions)
@@ -145,6 +152,10 @@ def _per_token_group_quant_8bit_colmajor_kernel(
 
     # Quantize: clamp(y / y_s, bit8_min, bit8_max)
     y_q = ct.minimum(ct.maximum(y / y_s, bit8_min), bit8_max)
+    # ct.astype float->int truncates toward zero; round-half-up for INT8 to
+    # match the rounding reference (see row-major kernel). FP8 rounds in HW.
+    if y_quantized.dtype == ct.int8:
+        y_q = ct.floor(y_q + 0.5)
     y_q = ct.astype(y_q, y_quantized.dtype)
 
     # Store quantized values with mask

--- a/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
@@ -203,8 +203,7 @@ def per_token_group_quant_8bit_cutile(
         dst_dtype = torch.float8_e4m3fn
     if dst_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2, torch.int8):
         raise ValueError(
-            "dst_dtype must be float8_e4m3fn, float8_e5m2, or int8; "
-            f"got {dst_dtype}"
+            f"dst_dtype must be float8_e4m3fn, float8_e5m2, or int8; got {dst_dtype}"
         )
     assert x.shape[-1] % group_size == 0, (
         f"the last dimension of `x` {x.shape[-1]} must be divisible by `group_size` {group_size}"

--- a/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
@@ -311,7 +311,14 @@ def per_token_group_quant_8bit_cutile(
             ),
         )
         if scale_tma_aligned:
-            x_s = x_s_raw[:, :num_tokens].t().contiguous()
+            # Return a transposed VIEW, not a contiguous copy: x_s_raw is
+            # (num_groups, aligned_size) row-major, so .t() yields a
+            # (num_tokens, num_groups) column-major tensor whose token dim is
+            # unit-stride and whose group stride keeps the aligned_size (16B)
+            # TMA padding. .contiguous() here would repack to a tight row-major
+            # layout, destroying both the column-major property and the TMA
+            # alignment this branch exists to produce.
+            x_s = x_s_raw[:, :num_tokens].t()
     else:
         assert not scale_ue8m0
 

--- a/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Per-token-group FP8 / INT8 quantization using the public cuda.tile API,
+# with row-major or column-major scale output.
+
+from typing import Optional
+from typing import Tuple
+from typing import TypeAlias
+
+import cuda.tile as ct
+import torch
+
+ConstInt: TypeAlias = ct.Constant[int]
+
+
+def _next_power_of_2(n):
+    """Return the smallest power of 2 greater than or equal to n."""
+    if n <= 0:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+@ct.kernel
+def _per_token_group_quant_8bit_kernel(
+    y_input,
+    y_quantized,
+    y_scale,
+    y_stride,
+    n,
+    eps,
+    bit8_min,
+    bit8_max,
+    BLOCK: ConstInt,
+    y_array_size,
+    y_q_array_size,
+    y_s_array_size,
+):
+    """Per-token-group quantization kernel (row-major scales)."""
+    g_id = ct.bid(0)
+
+    # Compute base offsets for this group
+    y_base = g_id * y_stride
+    y_q_base = g_id * y_stride
+
+    # Create column offsets and mask
+    cols = ct.arange(BLOCK, dtype=ct.int32)
+    mask = cols < n
+
+    # Load input values with gather (element-level access with mask)
+    y_indices = y_base + cols
+    y = ct.gather(y_input, (y_indices,), check_bounds=True, padding_value=0.0)
+    y = ct.astype(y, ct.float32)
+
+    # Compute absmax
+    abs_y = ct.abs(y)
+    _absmax = ct.max(abs_y, axis=0)
+    _absmax = ct.maximum(_absmax, eps)
+
+    # Compute scale and inverse scale
+    y_s = _absmax / bit8_max
+    y_s_inv = 1.0 / y_s
+
+    # Quantize: clamp(y * y_s_inv, bit8_min, bit8_max)
+    y_q = ct.minimum(ct.maximum(y * y_s_inv, bit8_min), bit8_max)
+    y_q = ct.astype(y_q, y_quantized.dtype)
+
+    # Store quantized values with mask (use OOB offsets for invalid positions)
+    oob_offset = ct.full((BLOCK,), y_q_array_size, dtype=ct.int32)
+    y_q_indices = y_q_base + cols
+    y_q_indices_masked = ct.where(mask, y_q_indices, oob_offset)
+    ct.scatter(y_quantized, (y_q_indices_masked,), y_q, check_bounds=True)
+
+    # Store scale (single scalar per group)
+    y_s_idx = g_id
+    oob_scalar = ct.full((), y_s_array_size, dtype=ct.int32)
+    s_idx_masked = ct.where(y_s_idx < y_s_array_size, y_s_idx, oob_scalar)
+    ct.scatter(y_scale, (s_idx_masked,), y_s)
+
+
+@ct.kernel
+def _per_token_group_quant_8bit_colmajor_kernel(
+    y_input,
+    y_quantized,
+    y_scale,
+    group_size,
+    y_num_columns,
+    y_row_stride,
+    y_s_col_stride,
+    eps,
+    bit8_min,
+    bit8_max,
+    scale_ue8m0,
+    BLOCK: ConstInt,
+    y_array_size,
+    y_q_array_size,
+    y_s_array_size,
+):
+    """Per-token-group quantization kernel (column-major scales)."""
+    groups_per_row = y_num_columns // group_size
+
+    g_id = ct.bid(0)
+    row = g_id // groups_per_row
+    group_id = g_id % groups_per_row
+
+    # Compute base offsets
+    y_base = row * y_row_stride + group_id * group_size
+    y_q_base = g_id * group_size
+    y_s_offset = group_id * y_s_col_stride + row
+
+    # Create column offsets and mask
+    cols = ct.arange(BLOCK, dtype=ct.int32)
+    mask = cols < group_size
+
+    # Load input values
+    y_indices = y_base + cols
+    y = ct.gather(y_input, (y_indices,), check_bounds=True, padding_value=0.0)
+    y = ct.astype(y, ct.float32)
+
+    # Compute absmax
+    abs_y = ct.abs(y)
+    _absmax = ct.max(abs_y, axis=0)
+    _absmax = ct.maximum(_absmax, eps)
+
+    # Compute scale
+    y_s = _absmax / bit8_max
+
+    # Optional: round scale to power of 2 (UE8M0)
+    if scale_ue8m0:
+        abs_y_s = ct.abs(y_s)
+        safe_y_s = ct.maximum(abs_y_s, 1e-10)
+        y_s = ct.exp2(ct.ceil(ct.log2(safe_y_s)))
+
+    # Quantize: clamp(y / y_s, bit8_min, bit8_max)
+    y_q = ct.minimum(ct.maximum(y / y_s, bit8_min), bit8_max)
+    y_q = ct.astype(y_q, y_quantized.dtype)
+
+    # Store quantized values with mask
+    oob_offset = ct.full((BLOCK,), y_q_array_size, dtype=ct.int32)
+    y_q_indices = y_q_base + cols
+    y_q_indices_masked = ct.where(mask, y_q_indices, oob_offset)
+    ct.scatter(y_quantized, (y_q_indices_masked,), y_q, check_bounds=True)
+
+    # Store scale (single scalar)
+    oob_scalar = ct.full((), y_s_array_size, dtype=ct.int32)
+    s_idx_masked = ct.where(y_s_offset < y_s_array_size, y_s_offset, oob_scalar)
+    ct.scatter(y_scale, (s_idx_masked,), y_s)
+
+
+def _ceil_align(x: int, align: int) -> int:
+    return (x + align - 1) // align * align
+
+
+def per_token_group_quant_8bit_cutile(
+    x: torch.Tensor,
+    group_size: int,
+    eps: float = 1e-10,
+    dst_dtype: Optional[torch.dtype] = None,
+    column_major_scales: bool = False,
+    scale_tma_aligned: bool = False,
+    scale_ue8m0: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-token group 8-bit quantization (FP8 or INT8) — cuTile backend.
+
+    Implemented with the public cuda.tile API.
+
+    Args:
+        x: Input tensor to quantize.
+        group_size: Number of elements per quantization group (last dimension).
+        eps: Epsilon for numerical stability in scale computation.
+        dst_dtype: Output dtype (default: torch.float8_e4m3fn).
+        column_major_scales: Store scales in column-major layout (for TMA compatibility).
+        scale_tma_aligned: Align scale storage to 4-element (16B) boundaries.
+        scale_ue8m0: Round scales to UE8M0 (power-of-2) format.
+
+    Returns:
+        (x_q, x_s): Quantized tensor and scale tensor.
+    """
+    if dst_dtype is None:
+        dst_dtype = torch.float8_e4m3fn
+    assert x.shape[-1] % group_size == 0, (
+        f"the last dimension of `x` {x.shape[-1]} must be divisible by `group_size` {group_size}"
+    )
+    assert x.is_contiguous(), "`x` must be contiguous"
+    if scale_tma_aligned or scale_ue8m0:
+        assert column_major_scales, (
+            "scale_tma_aligned or scale_ue8m0 requires column_major_scales=True"
+        )
+
+    if dst_dtype == torch.int8:
+        info = torch.iinfo(dst_dtype)
+        bit8_min = float(info.min)
+        bit8_max = float(info.max)
+    else:
+        info = torch.finfo(dst_dtype)
+        bit8_min = info.min
+        bit8_max = info.max
+
+    # Pre-zero output buffers to avoid NaN from beta=0 epilogue (PR #3426 pattern)
+    x_q = torch.zeros_like(x, device=x.device, dtype=dst_dtype)
+    M = x.numel() // group_size
+    N = group_size
+
+    if column_major_scales:
+        num_groups = x.shape[-1] // group_size
+        num_tokens = x.shape[-2] if x.dim() >= 2 else x.shape[0]
+        if scale_tma_aligned:
+            # TMA-friendly layout: (num_groups, aligned_num_tokens), align to 4 floats (16B)
+            aligned_size = _ceil_align(num_tokens, 4)
+            x_s_raw = torch.zeros(
+                (num_groups, aligned_size),
+                device=x.device,
+                dtype=torch.float32,
+            )
+            x_s_col_stride = aligned_size
+        else:
+            shape = (num_groups,) + x.shape[:-1]
+            x_s_raw = torch.zeros(shape, device=x.device, dtype=torch.float32).permute(
+                -1, -2
+            )
+            x_s_col_stride = x_s_raw.stride(1)
+        x_s = x_s_raw
+    else:
+        shape = x.shape[:-1] + (x.shape[-1] // group_size,)
+        x_s = torch.zeros(shape, device=x.device, dtype=torch.float32)
+
+    BLOCK = _next_power_of_2(N)
+
+    stream = torch.cuda.current_stream()
+    grid = (M, 1, 1)
+
+    # Flatten tensors for gather/scatter access
+    x_flat = x.contiguous().view(-1)
+    x_q_flat = x_q.view(-1)
+    x_s_flat = x_s.contiguous().view(-1) if not column_major_scales else x_s
+
+    if column_major_scales:
+        # Use a contiguous flat view of x_s for scatter
+        # x_s may be non-contiguous (permuted), so we use as_strided to get the raw storage
+        x_s_for_kernel = (
+            x_s_raw.view(-1)
+            if x_s_raw.is_contiguous()
+            else torch.as_strided(
+                x_s_raw,
+                (x_s_raw.numel(),),
+                (1,),
+                storage_offset=x_s_raw.storage_offset(),
+            )
+        )
+
+        ct.launch(
+            stream,
+            grid,
+            _per_token_group_quant_8bit_colmajor_kernel,
+            (
+                x_flat,
+                x_q_flat,
+                x_s_for_kernel,
+                group_size,
+                x.shape[-1],
+                x.stride(-2) if x.dim() >= 2 else x.shape[-1],
+                x_s_col_stride,
+                eps,
+                bit8_min,
+                bit8_max,
+                1 if scale_ue8m0 else 0,
+                BLOCK,
+                x_flat.numel(),
+                x_q_flat.numel(),
+                x_s_for_kernel.numel(),
+            ),
+        )
+        if scale_tma_aligned:
+            x_s = x_s_raw[:, :num_tokens].t().contiguous()
+    else:
+        assert not scale_ue8m0
+
+        ct.launch(
+            stream,
+            grid,
+            _per_token_group_quant_8bit_kernel,
+            (
+                x_flat,
+                x_q_flat,
+                x_s_flat,
+                group_size,
+                N,
+                eps,
+                bit8_min,
+                bit8_max,
+                BLOCK,
+                x_flat.numel(),
+                x_q_flat.numel(),
+                x_s_flat.numel(),
+            ),
+        )
+
+    return x_q, x_s

--- a/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
@@ -52,6 +52,12 @@ def _per_token_group_quant_8bit_kernel(
     y = ct.gather(y_input, (y_indices,), check_bounds=True, padding_value=0.0)
     y = ct.astype(y, ct.float32)
 
+    # Zero the padded lanes (BLOCK = next_pow2(group_size) > group_size when
+    # group_size is not a power of two). Those lanes gather in-bounds data from
+    # the *next* group (gather's padding_value only fires on true OOB), so
+    # without this they would corrupt the absmax reduction below.
+    y = ct.where(mask, y, 0.0)
+
     # Compute absmax
     abs_y = ct.abs(y)
     _absmax = ct.max(abs_y, axis=0)
@@ -117,6 +123,12 @@ def _per_token_group_quant_8bit_colmajor_kernel(
     y = ct.gather(y_input, (y_indices,), check_bounds=True, padding_value=0.0)
     y = ct.astype(y, ct.float32)
 
+    # Zero the padded lanes (BLOCK = next_pow2(group_size) > group_size when
+    # group_size is not a power of two). Those lanes gather in-bounds data from
+    # the *next* group (gather's padding_value only fires on true OOB), so
+    # without this they would corrupt the absmax reduction below.
+    y = ct.where(mask, y, 0.0)
+
     # Compute absmax
     abs_y = ct.abs(y)
     _absmax = ct.max(abs_y, axis=0)
@@ -178,6 +190,11 @@ def per_token_group_quant_8bit_cutile(
     """
     if dst_dtype is None:
         dst_dtype = torch.float8_e4m3fn
+    if dst_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2, torch.int8):
+        raise ValueError(
+            "dst_dtype must be float8_e4m3fn, float8_e5m2, or int8; "
+            f"got {dst_dtype}"
+        )
     assert x.shape[-1] % group_size == 0, (
         f"the last dimension of `x` {x.shape[-1]} must be divisible by `group_size` {group_size}"
     )
@@ -202,6 +219,11 @@ def per_token_group_quant_8bit_cutile(
     N = group_size
 
     if column_major_scales:
+        if x.dim() != 2:
+            raise ValueError(
+                "column_major_scales is only supported for 2D inputs; "
+                f"got a {x.dim()}D input"
+            )
         num_groups = x.shape[-1] // group_size
         num_tokens = x.shape[-2] if x.dim() >= 2 else x.shape[0]
         if scale_tma_aligned:

--- a/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
@@ -213,8 +213,12 @@ def per_token_group_quant_8bit_cutile(
         bit8_min = info.min
         bit8_max = info.max
 
-    # Pre-zero output buffers to avoid NaN from beta=0 epilogue (PR #3426 pattern)
-    x_q = torch.zeros_like(x, device=x.device, dtype=dst_dtype)
+    # These kernels are pure element-wise scatters: every group writes its full
+    # [g*group_size, g*group_size+group_size) span of x_q, so the union over all
+    # groups covers the whole output — no pre-zeroing needed (unlike the beta=0
+    # GEMM epilogue). Using empty_like avoids a redundant full-tensor memset on a
+    # bandwidth-bound path.
+    x_q = torch.empty_like(x, device=x.device, dtype=dst_dtype)
     M = x.numel() // group_size
     N = group_size
 
@@ -229,7 +233,10 @@ def per_token_group_quant_8bit_cutile(
         if scale_tma_aligned:
             # TMA-friendly layout: (num_groups, aligned_num_tokens), align to 4 floats (16B)
             aligned_size = _ceil_align(num_tokens, 4)
-            x_s_raw = torch.zeros(
+            # Every (group, token) slot is written by the kernel; the only
+            # uninitialized region is the [num_tokens:aligned_size] alignment
+            # pad, which is sliced off below before returning, so empty is safe.
+            x_s_raw = torch.empty(
                 (num_groups, aligned_size),
                 device=x.device,
                 dtype=torch.float32,
@@ -237,14 +244,14 @@ def per_token_group_quant_8bit_cutile(
             x_s_col_stride = aligned_size
         else:
             shape = (num_groups,) + x.shape[:-1]
-            x_s_raw = torch.zeros(shape, device=x.device, dtype=torch.float32).permute(
+            x_s_raw = torch.empty(shape, device=x.device, dtype=torch.float32).permute(
                 -1, -2
             )
             x_s_col_stride = x_s_raw.stride(1)
         x_s = x_s_raw
     else:
         shape = x.shape[:-1] + (x.shape[-1] // group_size,)
-        x_s = torch.zeros(shape, device=x.device, dtype=torch.float32)
+        x_s = torch.empty(shape, device=x.device, dtype=torch.float32)
 
     BLOCK = _next_power_of_2(N)
 

--- a/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/per_token_group_quant_8bit_cutile.py
@@ -171,6 +171,7 @@ def _per_token_group_quant_8bit_colmajor_kernel(
 
 
 def _ceil_align(x: int, align: int) -> int:
+    """Round `x` up to the next multiple of `align`."""
     return (x + align - 1) // align * align
 
 

--- a/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fused RoPE + FP8 quantization (MLA latent key/value) using the public
+# cuda.tile API.
+
+import math
+import os
+from types import SimpleNamespace
+from typing import Optional
+from typing import Tuple
+from typing import TypeAlias
+
+import cuda.tile as ct
+import torch
+from cuda.tile.tune import exhaustive_search
+
+from ....cutile.cutile_common import cached_replace_hints
+
+ConstInt: TypeAlias = ct.Constant[int]
+PAD_ZERO = ct.PaddingMode.ZERO
+
+# Set FLASHINFER_CUTILE_AUTOTUNE_DISABLED=1 to skip exhaustive search (faster but suboptimal)
+_AUTOTUNE_DISABLED = os.getenv("FLASHINFER_CUTILE_AUTOTUNE_DISABLED", "0") != "0"
+
+# Module-level tune cache: (num_tokens, num_qo_heads, num_kv_heads, rope_dim, no_rope_dim, q_dtype, out_dtype, device) -> (best_cfg, tuned_kernel)
+_rope_quantize_fp8_tune_cache: dict = {}
+
+
+def _default_tokens_per_block(num_tokens: int) -> int:
+    if num_tokens <= 4:
+        return 1
+    if num_tokens <= 32:
+        return 4
+    if num_tokens <= 128:
+        return 8
+    return 32
+
+
+def _rope_quantize_fp8_cutile_configs(num_tokens: int):
+    candidates = [tpb for tpb in (1, 4, 8, 16, 32) if tpb <= max(32, num_tokens)]
+    if _AUTOTUNE_DISABLED:
+        default_tpb = _default_tokens_per_block(num_tokens)
+        return [SimpleNamespace(TOKENS_PER_BLOCK=default_tpb, occupancy=4)]
+
+    return [
+        SimpleNamespace(TOKENS_PER_BLOCK=tokens_per_block, occupancy=occupancy)
+        for tokens_per_block in candidates
+        for occupancy in (1, 2, 4)
+    ]
+
+
+def _cutile_autotune_rope_quantize_fp8(
+    stream,
+    q_rope,
+    k_rope,
+    q_nope,
+    k_nope,
+    cos_sin_cache,
+    pos_ids,
+    q_rope_out,
+    k_rope_out,
+    q_nope_out,
+    k_nope_out,
+    quant_scale_q,
+    quant_scale_kv,
+    num_tokens,
+    num_qo_heads,
+    num_kv_heads,
+    rope_dim,
+    no_rope_dim,
+    total_blocks_y,
+):
+    cache_key = (
+        num_tokens,
+        num_qo_heads,
+        num_kv_heads,
+        rope_dim,
+        no_rope_dim,
+        q_rope.dtype,
+        q_rope_out.dtype,
+        str(q_rope.device),
+    )
+    if cache_key not in _rope_quantize_fp8_tune_cache:
+        result = exhaustive_search(
+            list(_rope_quantize_fp8_cutile_configs(num_tokens)),
+            stream,
+            lambda cfg: (
+                math.ceil(num_tokens / cfg.TOKENS_PER_BLOCK),
+                total_blocks_y,
+                1,
+            ),
+            _rope_quantize_fp8_kernel,
+            lambda cfg: (
+                q_rope,
+                k_rope,
+                q_nope,
+                k_nope,
+                cos_sin_cache,
+                pos_ids,
+                q_rope_out,
+                k_rope_out,
+                q_nope_out,
+                k_nope_out,
+                quant_scale_q,
+                quant_scale_kv,
+                num_tokens,
+                num_qo_heads,
+                num_kv_heads,
+                rope_dim,
+                no_rope_dim,
+                cfg.TOKENS_PER_BLOCK,
+            ),
+            lambda cfg: {"occupancy": cfg.occupancy},
+        )
+        best_cfg = result.best.config
+        _rope_quantize_fp8_tune_cache[cache_key] = (
+            best_cfg,
+            _rope_quantize_fp8_kernel.replace_hints(occupancy=best_cfg.occupancy),
+        )
+    best_cfg, tuned_kernel = _rope_quantize_fp8_tune_cache[cache_key]
+    ct.launch(
+        stream,
+        (math.ceil(num_tokens / best_cfg.TOKENS_PER_BLOCK), total_blocks_y, 1),
+        tuned_kernel,
+        (
+            q_rope,
+            k_rope,
+            q_nope,
+            k_nope,
+            cos_sin_cache,
+            pos_ids,
+            q_rope_out,
+            k_rope_out,
+            q_nope_out,
+            k_nope_out,
+            quant_scale_q,
+            quant_scale_kv,
+            num_tokens,
+            num_qo_heads,
+            num_kv_heads,
+            rope_dim,
+            no_rope_dim,
+            best_cfg.TOKENS_PER_BLOCK,
+        ),
+    )
+
+
+def _load_rope_factors(pos_ids, cos_sin_cache, token_block, TOKENS_PER_BLOCK, HALF_DIM):
+    pos_tile = ct.load(
+        pos_ids, index=token_block, shape=TOKENS_PER_BLOCK, padding_mode=PAD_ZERO
+    )
+    pos_rows = ct.reshape(pos_tile, (TOKENS_PER_BLOCK, 1))
+    half_cols = ct.reshape(ct.arange(HALF_DIM, dtype=ct.int32), (1, HALF_DIM))
+    cos = ct.gather(cos_sin_cache, (pos_rows, half_cols), check_bounds=False)
+    sin = ct.gather(cos_sin_cache, (pos_rows, half_cols + HALF_DIM), check_bounds=False)
+    return cos, sin
+
+
+def _apply_rope_interleave_batched(
+    x_tile, cos, sin, out_dtype, quant_scale, TOKENS_PER_BLOCK, HALF_DIM
+):
+    x_3d = ct.reshape(ct.astype(x_tile, ct.float32), (TOKENS_PER_BLOCK, HALF_DIM, 2))
+    x_even = ct.reshape(
+        ct.extract(x_3d, index=(0, 0, 0), shape=(TOKENS_PER_BLOCK, HALF_DIM, 1)),
+        (TOKENS_PER_BLOCK, HALF_DIM),
+    )
+    x_odd = ct.reshape(
+        ct.extract(x_3d, index=(0, 0, 1), shape=(TOKENS_PER_BLOCK, HALF_DIM, 1)),
+        (TOKENS_PER_BLOCK, HALF_DIM),
+    )
+
+    out_even = (x_even * cos - x_odd * sin) * quant_scale
+    out_odd = (x_odd * cos + x_even * sin) * quant_scale
+
+    return ct.cat(
+        (
+            ct.reshape(ct.astype(out_even, out_dtype), (TOKENS_PER_BLOCK, HALF_DIM, 1)),
+            ct.reshape(ct.astype(out_odd, out_dtype), (TOKENS_PER_BLOCK, HALF_DIM, 1)),
+        ),
+        2,
+    )
+
+
+def _quantize_batched_tile(x_tile, out_dtype, quant_scale):
+    return ct.astype(ct.astype(x_tile, ct.float32) * quant_scale, out_dtype)
+
+
+@ct.kernel
+def _rope_quantize_fp8_kernel(
+    q_rope,
+    k_rope,
+    q_nope,
+    k_nope,
+    cos_sin_cache,
+    pos_ids,
+    q_rope_out,
+    k_rope_out,
+    q_nope_out,
+    k_nope_out,
+    quant_scale_q,
+    quant_scale_kv,
+    NUM_TOKENS: ConstInt,
+    NUM_QO_HEADS: ConstInt,
+    NUM_KV_HEADS: ConstInt,
+    ROPE_DIM: ConstInt,
+    NO_ROPE_DIM: ConstInt,
+    TOKENS_PER_BLOCK: ConstInt,
+):
+    pid_x = ct.bid(0)
+    pid_y = ct.bid(1)
+
+    HALF_DIM: ConstInt = ROPE_DIM // 2
+    no_rope_chunks: ConstInt = (NO_ROPE_DIM + ROPE_DIM - 1) // ROPE_DIM
+
+    q_rope_end = NUM_QO_HEADS
+    k_rope_end = q_rope_end + NUM_KV_HEADS
+    k_nope_end = k_rope_end + NUM_KV_HEADS * no_rope_chunks
+
+    if pid_y < q_rope_end:
+        cos, sin = _load_rope_factors(
+            pos_ids, cos_sin_cache, pid_x, TOKENS_PER_BLOCK, HALF_DIM
+        )
+        head_idx = pid_y
+        q_tile = ct.load(
+            q_rope,
+            index=(pid_x, head_idx, 0),
+            shape=(TOKENS_PER_BLOCK, 1, ROPE_DIM),
+            padding_mode=PAD_ZERO,
+        )
+        q_rot = _apply_rope_interleave_batched(
+            q_tile,
+            cos,
+            sin,
+            q_rope_out.dtype,
+            quant_scale_q,
+            TOKENS_PER_BLOCK,
+            HALF_DIM,
+        )
+        ct.store(
+            q_rope_out,
+            index=(pid_x, head_idx, 0),
+            tile=ct.reshape(q_rot, (TOKENS_PER_BLOCK, 1, ROPE_DIM)),
+        )
+    elif pid_y < k_rope_end:
+        cos, sin = _load_rope_factors(
+            pos_ids, cos_sin_cache, pid_x, TOKENS_PER_BLOCK, HALF_DIM
+        )
+        k_tile = ct.load(
+            k_rope,
+            index=(pid_x, 0),
+            shape=(TOKENS_PER_BLOCK, ROPE_DIM),
+            padding_mode=PAD_ZERO,
+        )
+        k_rot = _apply_rope_interleave_batched(
+            k_tile,
+            cos,
+            sin,
+            k_rope_out.dtype,
+            quant_scale_kv,
+            TOKENS_PER_BLOCK,
+            HALF_DIM,
+        )
+        ct.store(
+            k_rope_out,
+            index=(pid_x, 0),
+            tile=ct.reshape(k_rot, (TOKENS_PER_BLOCK, ROPE_DIM)),
+        )
+    elif pid_y < k_nope_end:
+        chunk_idx = pid_y - k_rope_end
+        k_tile = ct.load(
+            k_nope,
+            index=(pid_x, chunk_idx),
+            shape=(TOKENS_PER_BLOCK, ROPE_DIM),
+            padding_mode=PAD_ZERO,
+        )
+        ct.store(
+            k_nope_out,
+            index=(pid_x, chunk_idx),
+            tile=_quantize_batched_tile(k_tile, k_nope_out.dtype, quant_scale_kv),
+        )
+    else:
+        task_idx = pid_y - k_nope_end
+        head_idx = task_idx // no_rope_chunks
+        chunk_idx = task_idx % no_rope_chunks
+        q_tile = ct.load(
+            q_nope,
+            index=(pid_x, head_idx, chunk_idx),
+            shape=(TOKENS_PER_BLOCK, 1, ROPE_DIM),
+            padding_mode=PAD_ZERO,
+        )
+        ct.store(
+            q_nope_out,
+            index=(pid_x, head_idx, chunk_idx),
+            tile=_quantize_batched_tile(q_tile, q_nope_out.dtype, quant_scale_q),
+        )
+
+
+def rope_quantize_fp8_cutile(
+    q_rope: torch.Tensor,
+    k_rope: torch.Tensor,
+    q_nope: Optional[torch.Tensor],
+    k_nope: Optional[torch.Tensor],
+    cos_sin_cache: torch.Tensor,
+    pos_ids: torch.Tensor,
+    is_neox: bool = True,
+    quantize_dtype: Optional[torch.dtype] = None,
+    quant_scale_q: float = 1.0,
+    quant_scale_kv: float = 1.0,
+    q_rope_out: Optional[torch.Tensor] = None,
+    k_rope_out: Optional[torch.Tensor] = None,
+    q_nope_out: Optional[torch.Tensor] = None,
+    k_nope_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """RoPE + FP8 quantization — cuTile backend.
+
+    Applies Rotary Position Embedding and quantizes q/k tensors to FP8 in a single
+    fused pass, using the public cuda.tile API.
+
+    Args:
+        q_rope: Query RoPE portion [num_tokens, num_qo_heads, rope_dim].
+        k_rope: Key RoPE portion [num_tokens, rope_dim] (MLA) or [num_tokens, num_kv_heads, rope_dim].
+        q_nope: Query non-RoPE portion [num_tokens, num_qo_heads, no_rope_dim] or None.
+        k_nope: Key non-RoPE portion, shape depends on MLA vs MHA.
+        cos_sin_cache: Float32 [max_seq_len, rope_dim] cosine/sine cache.
+        pos_ids: Int32 position IDs [num_tokens].
+        is_neox: Must be False (interleaved layout only).
+        quantize_dtype: Output dtype (default: torch.float8_e4m3fn).
+        quant_scale_q: Quantization scale for Q.
+        quant_scale_kv: Quantization scale for KV.
+        q_rope_out / k_rope_out / q_nope_out / k_nope_out: Optional pre-allocated outputs.
+
+    Returns:
+        (q_rope_out, k_rope_out, q_nope_out, k_nope_out)
+    """
+    if cos_sin_cache.dtype != torch.float32:
+        raise ValueError("cos_sin_cache should be float32")
+    if k_rope.ndim != 2:
+        # The kernel loads k_rope as a 2D [tokens, rope_dim] latent (the MLA
+        # single-shared-K-head case). A 3D GQA/MHA key would compile to an
+        # opaque TileTypeError, so reject it up front.
+        raise NotImplementedError(
+            "rope_quantize_fp8_cutile supports MLA-style 2D key tensors "
+            f"(single shared K head) only; got {k_rope.ndim}D key."
+        )
+
+    nnz = q_rope.shape[0]
+    num_qo_heads = q_rope.shape[1]
+    is_mla = k_rope.ndim == 2
+    num_kv_heads = 1 if is_mla else k_rope.shape[1]
+
+    if q_nope is None:
+        q_nope = torch.empty(
+            nnz, num_qo_heads, 0, dtype=q_rope.dtype, device=q_rope.device
+        )
+    if k_nope is None:
+        if is_mla:
+            k_nope = torch.empty(nnz, 0, dtype=k_rope.dtype, device=k_rope.device)
+        else:
+            k_nope = torch.empty(
+                nnz, num_kv_heads, 0, dtype=k_rope.dtype, device=k_rope.device
+            )
+
+    if quantize_dtype is None:
+        for out in (q_rope_out, k_rope_out, q_nope_out, k_nope_out):
+            if out is not None:
+                quantize_dtype = out.dtype
+                break
+        else:
+            quantize_dtype = torch.float8_e4m3fn
+
+    # Pre-zero output buffers to avoid NaN from beta=0 epilogue (PR #3426 pattern)
+    q_rope_out = (
+        q_rope_out
+        if q_rope_out is not None
+        else torch.zeros_like(q_rope, dtype=quantize_dtype)
+    )
+    k_rope_out = (
+        k_rope_out
+        if k_rope_out is not None
+        else torch.zeros_like(k_rope, dtype=quantize_dtype)
+    )
+    q_nope_out = (
+        q_nope_out
+        if q_nope_out is not None
+        else torch.zeros_like(q_nope, dtype=quantize_dtype)
+    )
+    k_nope_out = (
+        k_nope_out
+        if k_nope_out is not None
+        else torch.zeros_like(k_nope, dtype=quantize_dtype)
+    )
+
+    num_tokens = q_rope.shape[0]
+    rope_dim = q_rope.shape[2]
+    num_kv_heads = 1 if k_rope.ndim == 2 else k_rope.shape[1]
+    no_rope_dim = q_nope.shape[2] if q_nope is not None else 0
+
+    no_rope_chunks = (no_rope_dim + rope_dim - 1) // rope_dim
+    total_blocks_y = (
+        num_qo_heads
+        + num_kv_heads
+        + num_kv_heads * no_rope_chunks
+        + num_qo_heads * no_rope_chunks
+    )
+
+    if is_neox:
+        raise ValueError(
+            "rope_quantize_fp8_cutile supports is_neox=False (interleaved) only."
+        )
+
+    stream = torch.cuda.current_stream()
+    configs = _rope_quantize_fp8_cutile_configs(num_tokens)
+    if len(configs) == 1:
+        cfg = configs[0]
+        grid = (math.ceil(num_tokens / cfg.TOKENS_PER_BLOCK), total_blocks_y, 1)
+        # Memoize the hinted kernel so cuTile's per-shape JIT compile cache
+        # survives across launches on this single-config (non-autotune) path.
+        kernel = cached_replace_hints(
+            _rope_quantize_fp8_kernel, occupancy=cfg.occupancy
+        )
+        args = (
+            q_rope,
+            k_rope,
+            q_nope,
+            k_nope,
+            cos_sin_cache,
+            pos_ids,
+            q_rope_out,
+            k_rope_out,
+            q_nope_out,
+            k_nope_out,
+            quant_scale_q,
+            quant_scale_kv,
+            num_tokens,
+            num_qo_heads,
+            num_kv_heads,
+            rope_dim,
+            no_rope_dim,
+            cfg.TOKENS_PER_BLOCK,
+        )
+        ct.launch(stream, grid, kernel, args)
+    else:
+        _cutile_autotune_rope_quantize_fp8(
+            stream,
+            q_rope,
+            k_rope,
+            q_nope,
+            k_nope,
+            cos_sin_cache,
+            pos_ids,
+            q_rope_out,
+            k_rope_out,
+            q_nope_out,
+            k_nope_out,
+            quant_scale_q,
+            quant_scale_kv,
+            num_tokens,
+            num_qo_heads,
+            num_kv_heads,
+            rope_dim,
+            no_rope_dim,
+            total_blocks_y,
+        )
+    return q_rope_out, k_rope_out, q_nope_out, k_nope_out

--- a/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
@@ -371,8 +371,7 @@ def rope_quantize_fp8_cutile(
 
     if quantize_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
         raise ValueError(
-            "quantize_dtype must be float8_e4m3fn or float8_e5m2; "
-            f"got {quantize_dtype}"
+            f"quantize_dtype must be float8_e4m3fn or float8_e5m2; got {quantize_dtype}"
         )
 
     # The kernel tiles the full (token, head, rope/nope-chunk) space and writes

--- a/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
@@ -375,26 +375,30 @@ def rope_quantize_fp8_cutile(
             f"got {quantize_dtype}"
         )
 
-    # Pre-zero output buffers to avoid NaN from beta=0 epilogue (PR #3426 pattern)
+    # The kernel tiles the full (token, head, rope/nope-chunk) space and writes
+    # every in-bounds output element (tail token-blocks are bounds-clipped on
+    # store, mirroring the mm_bf16 idiom); empty nope buffers are 0-byte. So the
+    # outputs need no pre-zeroing — empty_like avoids a redundant memset on this
+    # fused hot path (unlike the beta=0 GEMM epilogue the #3426 pattern guards).
     q_rope_out = (
         q_rope_out
         if q_rope_out is not None
-        else torch.zeros_like(q_rope, dtype=quantize_dtype)
+        else torch.empty_like(q_rope, dtype=quantize_dtype)
     )
     k_rope_out = (
         k_rope_out
         if k_rope_out is not None
-        else torch.zeros_like(k_rope, dtype=quantize_dtype)
+        else torch.empty_like(k_rope, dtype=quantize_dtype)
     )
     q_nope_out = (
         q_nope_out
         if q_nope_out is not None
-        else torch.zeros_like(q_nope, dtype=quantize_dtype)
+        else torch.empty_like(q_nope, dtype=quantize_dtype)
     )
     k_nope_out = (
         k_nope_out
         if k_nope_out is not None
-        else torch.zeros_like(k_nope, dtype=quantize_dtype)
+        else torch.empty_like(k_nope, dtype=quantize_dtype)
     )
 
     num_tokens = q_rope.shape[0]

--- a/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
@@ -369,6 +369,12 @@ def rope_quantize_fp8_cutile(
         else:
             quantize_dtype = torch.float8_e4m3fn
 
+    if quantize_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+        raise ValueError(
+            "quantize_dtype must be float8_e4m3fn or float8_e5m2; "
+            f"got {quantize_dtype}"
+        )
+
     # Pre-zero output buffers to avoid NaN from beta=0 epilogue (PR #3426 pattern)
     q_rope_out = (
         q_rope_out

--- a/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
@@ -28,6 +28,7 @@ _rope_quantize_fp8_tune_cache: dict = {}
 
 
 def _default_tokens_per_block(num_tokens: int) -> int:
+    """Heuristic tokens-per-block used when autotuning is disabled."""
     if num_tokens <= 4:
         return 1
     if num_tokens <= 32:
@@ -38,6 +39,7 @@ def _default_tokens_per_block(num_tokens: int) -> int:
 
 
 def _rope_quantize_fp8_cutile_configs(num_tokens: int):
+    """Return the autotune candidates for this token count (one default config if autotune is off)."""
     candidates = [tpb for tpb in (1, 4, 8, 16, 32) if tpb <= max(32, num_tokens)]
     if _AUTOTUNE_DISABLED:
         default_tpb = _default_tokens_per_block(num_tokens)
@@ -71,6 +73,7 @@ def _cutile_autotune_rope_quantize_fp8(
     no_rope_dim,
     total_blocks_y,
 ):
+    """Launch one fused RoPE+fp8 autotune candidate."""
     cache_key = (
         num_tokens,
         num_qo_heads,
@@ -147,6 +150,7 @@ def _cutile_autotune_rope_quantize_fp8(
 
 
 def _load_rope_factors(pos_ids, cos_sin_cache, token_block, TOKENS_PER_BLOCK, HALF_DIM):
+    """Gather the cos/sin RoPE factors for one token block from the cache."""
     pos_tile = ct.load(
         pos_ids, index=token_block, shape=TOKENS_PER_BLOCK, padding_mode=PAD_ZERO
     )
@@ -160,6 +164,7 @@ def _load_rope_factors(pos_ids, cos_sin_cache, token_block, TOKENS_PER_BLOCK, HA
 def _apply_rope_interleave_batched(
     x_tile, cos, sin, out_dtype, quant_scale, TOKENS_PER_BLOCK, HALF_DIM
 ):
+    """Apply interleaved RoPE to a token tile and scale it into the output dtype."""
     x_3d = ct.reshape(ct.astype(x_tile, ct.float32), (TOKENS_PER_BLOCK, HALF_DIM, 2))
     x_even = ct.reshape(
         ct.extract(x_3d, index=(0, 0, 0), shape=(TOKENS_PER_BLOCK, HALF_DIM, 1)),
@@ -183,6 +188,7 @@ def _apply_rope_interleave_batched(
 
 
 def _quantize_batched_tile(x_tile, out_dtype, quant_scale):
+    """Scale and cast a tile that needs no rotation (the no-RoPE half)."""
     return ct.astype(ct.astype(x_tile, ct.float32) * quant_scale, out_dtype)
 
 
@@ -207,6 +213,7 @@ def _rope_quantize_fp8_kernel(
     NO_ROPE_DIM: ConstInt,
     TOKENS_PER_BLOCK: ConstInt,
 ):
+    """cuTile kernel: fused RoPE + fp8 quantization over one block of tokens."""
     pid_x = ct.bid(0)
     pid_y = ct.bid(1)
 

--- a/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
+++ b/flashinfer/quantization/kernels/cutile/rope_quantize_fp8_cutile.py
@@ -6,6 +6,7 @@
 
 import math
 import os
+from collections import OrderedDict
 from types import SimpleNamespace
 from typing import Optional
 from typing import Tuple
@@ -24,7 +25,11 @@ PAD_ZERO = ct.PaddingMode.ZERO
 _AUTOTUNE_DISABLED = os.getenv("FLASHINFER_CUTILE_AUTOTUNE_DISABLED", "0") != "0"
 
 # Module-level tune cache: (num_tokens, num_qo_heads, num_kv_heads, rope_dim, no_rope_dim, q_dtype, out_dtype, device) -> (best_cfg, tuned_kernel)
-_rope_quantize_fp8_tune_cache: dict = {}
+# Bounded LRU, like the hinted-kernel cache in cutile_common: num_tokens is part
+# of the key, so a server sweeping many token counts would otherwise grow this
+# dict (and the tuned kernels it pins) without limit.
+_ROPE_QUANTIZE_FP8_TUNE_CACHE_MAX = 128
+_rope_quantize_fp8_tune_cache: "OrderedDict[tuple, tuple]" = OrderedDict()
 
 
 def _default_tokens_per_block(num_tokens: int) -> int:
@@ -121,6 +126,10 @@ def _cutile_autotune_rope_quantize_fp8(
             best_cfg,
             _rope_quantize_fp8_kernel.replace_hints(occupancy=best_cfg.occupancy),
         )
+        if len(_rope_quantize_fp8_tune_cache) > _ROPE_QUANTIZE_FP8_TUNE_CACHE_MAX:
+            _rope_quantize_fp8_tune_cache.popitem(last=False)
+    else:
+        _rope_quantize_fp8_tune_cache.move_to_end(cache_key)
     best_cfg, tuned_kernel = _rope_quantize_fp8_tune_cache[cache_key]
     ct.launch(
         stream,

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -1377,6 +1377,7 @@ def rope_quantize_fp8(
     q_nope_out: Optional[torch.Tensor] = None,
     k_nope_out: Optional[torch.Tensor] = None,
     enable_pdl: bool = False,
+    backend: str = "cuda",
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     r"""Apply RoPE (Rotary Positional Embeddings) and quantize to FP8 format.
 
@@ -1423,12 +1424,56 @@ def rope_quantize_fp8(
         Pre-allocated output tensor for quantized key (non-rotary). If ``None``, allocated automatically.
     enable_pdl : bool
         Whether to enable PDL (Programmatic Dependent Launch). Default: ``False``.
+    backend : str
+        Implementation backend. ``"cuda"`` (default) uses the fused CUDA kernel;
+        ``"cutile"`` uses the cuda.tile Python kernel.
 
     Returns
     -------
     Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         Quantized tensors: (q_rope_out, k_rope_out, q_nope_out, k_nope_out).
     """
+    if backend == "cutile":
+        if is_neox:
+            # The cuTile kernel implements only the interleaved (GPT-J) rotary
+            # layout. is_neox defaults to True, so surface a clear error instead
+            # of the kernel's bare AssertionError (which -O would also strip).
+            raise NotImplementedError(
+                "backend='cutile' supports is_neox=False (interleaved/GPT-J "
+                "rotary) only; got is_neox=True."
+            )
+        if k_rope.ndim != 2:
+            # The kernel addresses the key as 2D [tokens, rope_dim] (single
+            # shared latent K head, the MLA use case). A 3D GQA/MHA key would
+            # fail deep in autotune with an opaque TileTypeError.
+            raise NotImplementedError(
+                "backend='cutile' rope_quantize_fp8 supports MLA-style 2D key "
+                f"tensors (single shared K head) only; got {k_rope.ndim}D key "
+                "(GQA/MHA multi-head K is not supported)."
+            )
+        if cos_sin_cache.dtype != torch.float32:
+            raise ValueError("cos_sin_cache should be float32")
+        from .quantization.kernels.cutile.rope_quantize_fp8_cutile import (
+            rope_quantize_fp8_cutile,
+        )
+
+        return rope_quantize_fp8_cutile(
+            q_rope,
+            k_rope,
+            q_nope,
+            k_nope,
+            cos_sin_cache,
+            pos_ids,
+            is_neox=is_neox,
+            quantize_dtype=quantize_dtype,
+            quant_scale_q=quant_scale_q,
+            quant_scale_kv=quant_scale_kv,
+            q_rope_out=q_rope_out,
+            k_rope_out=k_rope_out,
+            q_nope_out=q_nope_out,
+            k_nope_out=k_nope_out,
+        )
+
     if cos_sin_cache.dtype != torch.float32:
         raise ValueError("cos_sin_cache should be float32")
 

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -1433,6 +1433,11 @@ def rope_quantize_fp8(
     Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
         Quantized tensors: (q_rope_out, k_rope_out, q_nope_out, k_nope_out).
     """
+    if backend not in ("cuda", "cutile"):
+        raise ValueError(
+            f"Unsupported backend for rope_quantize_fp8: {backend!r}; "
+            "expected 'cuda' or 'cutile'."
+        )
     if backend == "cutile":
         if is_neox:
             # The cuTile kernel implements only the interleaved (GPT-J) rotary

--- a/tests/attention/test_rope.py
+++ b/tests/attention/test_rope.py
@@ -385,6 +385,7 @@ def test_rope_cos_sin_cache(
 @pytest.mark.parametrize("input_dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("quant_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 @pytest.mark.parametrize("enable_pdl", [True, False])
+@pytest.mark.parametrize("backend", ["cuda", "cutile"])
 def test_generalized_rope_quantize(
     attention_type,
     num_qo_heads,
@@ -395,8 +396,31 @@ def test_generalized_rope_quantize(
     input_dtype,
     quant_dtype,
     enable_pdl,
+    backend,
 ):
     """Test generalized rope + quantization for MLA, GQA, and MHA architectures."""
+    if backend == "cutile":
+        from flashinfer.cutile.cutile_common import is_cuda_tile_available
+
+        if not is_cuda_tile_available():
+            pytest.skip("cuda.tile not available")
+        # The cuTile fused rope+quant kernel is MLA-scoped: it addresses the key
+        # tensor as 2D [tokens, rope_dim] (single shared latent K head), matching
+        # the DeepSeek/MLA use case it targets. GQA/MHA pass a 3D
+        # [tokens, kv_heads, rope_dim] key, which the kernel cannot index.
+        if attention_type != "mla":
+            pytest.skip(
+                "cuTile rope_quantize supports MLA-style 2D key tensors only "
+                "(single shared K head); GQA/MHA multi-head K is not supported."
+            )
+        # cuTile backend currently validates only e4m3fn output and ignores PDL;
+        # gate to its supported subset to avoid redundant / unsupported cases.
+        if quant_dtype != torch.float8_e4m3fn:
+            pytest.skip("cuTile rope_quantize backend supports float8_e4m3fn only.")
+        if enable_pdl:
+            pytest.skip(
+                "cuTile rope_quantize backend ignores PDL; covered with enable_pdl=False."
+            )
     device = "cuda:0"
     # Fixed seed for reproducibility across tests
     torch.manual_seed(0)
@@ -470,6 +494,7 @@ def test_generalized_rope_quantize(
         quant_scale_q=1.0,
         quant_scale_kv=1.0,
         enable_pdl=enable_pdl,
+        backend=backend,
     )
 
     # Verify results

--- a/tests/attention/test_rope.py
+++ b/tests/attention/test_rope.py
@@ -1730,6 +1730,56 @@ def test_mla_rope_quantize(
     )
 
 
+@pytest.mark.parametrize("unsupported", ["neox", "multi_head_key", "bad_backend"])
+def test_rope_quantize_fp8_cutile_rejects_unsupported(unsupported):
+    """The cuTile dispatch guards must raise, not fall through to CUDA or the kernel.
+
+    The parametrized test above only *skips* NeoX / GQA / MHA for the cuTile
+    backend, so without this the documented contract is never exercised.
+    """
+    from flashinfer.cutile.cutile_common import is_cuda_tile_available
+
+    if not is_cuda_tile_available():
+        pytest.skip("cuda.tile not available")
+
+    device, dt = "cuda:0", torch.bfloat16
+    num_tokens, rope_dim, no_rope_dim, num_qo_heads = 4, 64, 512, 8
+    kv_heads = 2
+
+    q_rope = torch.randn(num_tokens, num_qo_heads, rope_dim, dtype=dt, device=device)
+    q_nope = torch.randn(num_tokens, num_qo_heads, no_rope_dim, dtype=dt, device=device)
+    # 2D key = the supported MLA layout; 3D key = the rejected GQA/MHA layout.
+    k_rope_2d = torch.randn(num_tokens, rope_dim, dtype=dt, device=device)
+    k_nope_2d = torch.randn(num_tokens, no_rope_dim, dtype=dt, device=device)
+    k_rope_3d = torch.randn(num_tokens, kv_heads, rope_dim, dtype=dt, device=device)
+    k_nope_3d = torch.randn(num_tokens, kv_heads, no_rope_dim, dtype=dt, device=device)
+    cos_sin_cache = torch.randn(
+        num_tokens, rope_dim, dtype=torch.float32, device=device
+    )
+    pos_ids = torch.arange(num_tokens, dtype=torch.int32, device=device)
+
+    k_rope = k_rope_3d if unsupported == "multi_head_key" else k_rope_2d
+    k_nope = k_nope_3d if unsupported == "multi_head_key" else k_nope_2d
+
+    kwargs = dict(
+        q_rope=q_rope,
+        k_rope=k_rope,
+        q_nope=q_nope,
+        k_nope=k_nope,
+        cos_sin_cache=cos_sin_cache,
+        pos_ids=pos_ids,
+        quant_scale_q=1.0,
+        quant_scale_kv=1.0,
+        is_neox=(unsupported == "neox"),
+        backend="cuitle" if unsupported == "bad_backend" else "cutile",
+    )
+    # A misspelled backend must be rejected outright rather than silently
+    # running the CUDA path.
+    expected = ValueError if unsupported == "bad_backend" else NotImplementedError
+    with pytest.raises(expected):
+        flashinfer.rope.rope_quantize_fp8(**kwargs)
+
+
 if __name__ == "__main__":
     # test_rope(2, 1, 8, 8, 1, 128, "llama", 1.0, False)
     # test_rope_pos_ids(2, 1, 8, 8, 1, 128, "llama31", 1.0, False)

--- a/tests/quantization/test_per_token_group_quant_8bit_cutile.py
+++ b/tests/quantization/test_per_token_group_quant_8bit_cutile.py
@@ -101,7 +101,9 @@ def test_column_major_scales(num_tokens, hidden_dim, group_size, dst_dtype, back
     assert not x_s.isnan().any()
     # Column-major (Fortran order): the token dim is the contiguous one, so its
     # stride is 1 — this is what makes the scales TMA-loadable per group.
-    assert x_s.stride(0) == 1, f"expected column-major scales, got strides {x_s.stride()}"
+    assert x_s.stride(0) == 1, (
+        f"expected column-major scales, got strides {x_s.stride()}"
+    )
 
 
 @pytest.mark.parametrize("num_tokens", [128, 130])  # 130 -> aligned to 132

--- a/tests/quantization/test_per_token_group_quant_8bit_cutile.py
+++ b/tests/quantization/test_per_token_group_quant_8bit_cutile.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for per_token_group_quant_8bit_cutile kernel."""
+
+import pytest
+import torch
+
+from flashinfer.cutile.cutile_common import is_cuda_tile_available
+from flashinfer.quantization import per_token_group_quant_8bit
+
+if not is_cuda_tile_available():
+    pytest.skip("cuda.tile not available", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def require_sm90():
+    cc = torch.cuda.get_device_capability()
+    if cc[0] * 10 + cc[1] < 90:
+        pytest.skip(f"requires sm90+, got sm{cc[0] * 10 + cc[1]}")
+
+
+def _ref_quant(x, group_size, dst_dtype):
+    """Pure-PyTorch reference: per-token-group quantization."""
+    orig = x.shape
+    K = orig[-1]
+    n_groups = K // group_size
+    xf = x.reshape(-1, n_groups, group_size).float()
+    max_val = 127.0 if dst_dtype == torch.int8 else 448.0
+    abs_max = xf.abs().amax(dim=-1, keepdim=True).clamp(min=1e-12)
+    scales = (abs_max / max_val).squeeze(-1)
+    x_scaled = (xf / abs_max * max_val).clamp(-max_val, max_val)
+    x_q = (
+        x_scaled.round().to(dst_dtype)
+        if dst_dtype == torch.int8
+        else x_scaled.to(dst_dtype)
+    )
+    return x_q.reshape(orig), scales.reshape(*orig[:-1], n_groups).to(torch.float32)
+
+
+@pytest.mark.parametrize("num_tokens,hidden_dim", [(128, 2048), (256, 4096)])
+@pytest.mark.parametrize("group_size", [64, 128])
+@pytest.mark.parametrize("dst_dtype", [torch.int8, torch.float8_e4m3fn])
+@pytest.mark.parametrize("backend", ["cutile"])
+def test_basic(num_tokens, hidden_dim, group_size, dst_dtype, backend):
+    """Basic correctness: scale accuracy + dequant match."""
+    torch.manual_seed(42)
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+
+    x_q, x_s = per_token_group_quant_8bit(
+        x,
+        group_size=group_size,
+        dst_dtype=dst_dtype,
+        column_major_scales=False,
+        backend=backend,
+    )
+    ref_q, ref_s = _ref_quant(x, group_size, dst_dtype)
+
+    assert x_q.shape == x.shape
+    assert x_q.dtype == dst_dtype
+    assert x_s.shape == (num_tokens, hidden_dim // group_size)
+
+    torch.testing.assert_close(x_s.float(), ref_s.float(), rtol=1e-3, atol=1e-3)
+
+    n_groups = hidden_dim // group_size
+    out_dq = x_q.float().reshape(num_tokens, n_groups, group_size) * x_s.reshape(
+        num_tokens, n_groups, 1
+    )
+    ref_dq = ref_q.float().reshape(num_tokens, n_groups, group_size) * ref_s.reshape(
+        num_tokens, n_groups, 1
+    )
+    # INT8 quantization has coarser resolution (1/127 of max) than FP8 (1/448),
+    # so dequant comparison needs a wider absolute tolerance for INT8.
+    dq_atol = 5e-2 if dst_dtype == torch.int8 else 1e-2
+    torch.testing.assert_close(out_dq, ref_dq, rtol=2e-1, atol=dq_atol)
+
+
+@pytest.mark.parametrize("num_tokens,hidden_dim", [(128, 2048), (512, 4096)])
+@pytest.mark.parametrize("group_size", [64, 128])
+@pytest.mark.parametrize("dst_dtype", [torch.int8, torch.float8_e4m3fn])
+@pytest.mark.parametrize("backend", ["cutile"])
+def test_column_major_scales(num_tokens, hidden_dim, group_size, dst_dtype, backend):
+    """Column-major scale layout."""
+    torch.manual_seed(7)
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+
+    x_q, x_s = per_token_group_quant_8bit(
+        x,
+        group_size=group_size,
+        dst_dtype=dst_dtype,
+        column_major_scales=True,
+        backend=backend,
+    )
+
+    n_groups = hidden_dim // group_size
+    # Kernel always returns shape (num_tokens, n_groups) — "column_major" controls the
+    # memory layout/strides (Fortran order vs C order), not the logical shape.
+    assert x_s.shape == (num_tokens, n_groups), (
+        f"expected ({num_tokens},{n_groups}) got {x_s.shape}"
+    )
+    assert not x_s.isnan().any()
+
+
+@pytest.mark.parametrize(
+    "num_tokens,hidden_dim,group_size", [(128, 2048, 64), (256, 4096, 128)]
+)
+@pytest.mark.parametrize("backend", ["cutile"])
+def test_scale_ue8m0(num_tokens, hidden_dim, group_size, backend):
+    """UE8M0 scale format (Blackwell only)."""
+    cc = torch.cuda.get_device_capability()
+    if cc[0] < 10:
+        pytest.skip("scale_ue8m0 requires sm100+ (Blackwell)")
+    torch.manual_seed(99)
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+    x_q, x_s = per_token_group_quant_8bit(
+        x,
+        group_size=group_size,
+        dst_dtype=torch.float8_e4m3fn,
+        column_major_scales=True,
+        scale_ue8m0=True,
+        backend=backend,
+    )
+    assert x_q.shape == x.shape
+    assert not x_s.isnan().any()

--- a/tests/quantization/test_per_token_group_quant_8bit_cutile.py
+++ b/tests/quantization/test_per_token_group_quant_8bit_cutile.py
@@ -7,6 +7,7 @@ import torch
 
 from flashinfer.cutile.cutile_common import is_cuda_tile_available
 from flashinfer.quantization import per_token_group_quant_8bit
+from flashinfer.utils import get_compute_capability
 
 if not is_cuda_tile_available():
     pytest.skip("cuda.tile not available", allow_module_level=True)
@@ -14,9 +15,9 @@ if not is_cuda_tile_available():
 
 @pytest.fixture(autouse=True)
 def require_sm90():
-    cc = torch.cuda.get_device_capability()
-    if cc[0] * 10 + cc[1] < 90:
-        pytest.skip(f"requires sm90+, got sm{cc[0] * 10 + cc[1]}")
+    major, minor = get_compute_capability(torch.device("cuda"))
+    if major * 10 + minor < 90:
+        pytest.skip(f"requires sm90+, got sm{major * 10 + minor}")
 
 
 def _ref_quant(x, group_size, dst_dtype):
@@ -98,6 +99,9 @@ def test_column_major_scales(num_tokens, hidden_dim, group_size, dst_dtype, back
         f"expected ({num_tokens},{n_groups}) got {x_s.shape}"
     )
     assert not x_s.isnan().any()
+    # Column-major (Fortran order): the token dim is the contiguous one, so its
+    # stride is 1 — this is what makes the scales TMA-loadable per group.
+    assert x_s.stride(0) == 1, f"expected column-major scales, got strides {x_s.stride()}"
 
 
 @pytest.mark.parametrize(
@@ -106,8 +110,8 @@ def test_column_major_scales(num_tokens, hidden_dim, group_size, dst_dtype, back
 @pytest.mark.parametrize("backend", ["cutile"])
 def test_scale_ue8m0(num_tokens, hidden_dim, group_size, backend):
     """UE8M0 scale format (Blackwell only)."""
-    cc = torch.cuda.get_device_capability()
-    if cc[0] < 10:
+    major, _ = get_compute_capability(torch.device("cuda"))
+    if major < 10:
         pytest.skip("scale_ue8m0 requires sm100+ (Blackwell)")
     torch.manual_seed(99)
     x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
@@ -121,3 +125,32 @@ def test_scale_ue8m0(num_tokens, hidden_dim, group_size, backend):
     )
     assert x_q.shape == x.shape
     assert not x_s.isnan().any()
+    # UE8M0 = 8-bit exponent, no mantissa, so every nonzero scale is an exact
+    # power of two. frexp of 2**k is (0.5, k+1), i.e. mantissa == 0.5.
+    nz = x_s[x_s != 0]
+    mant, _ = torch.frexp(nz)
+    assert torch.all(mant == 0.5), "UE8M0 scales must be exact powers of two"
+
+
+@pytest.mark.parametrize("num_tokens", [128, 257])
+@pytest.mark.parametrize("group_size", [96, 48])
+@pytest.mark.parametrize("dst_dtype", [torch.int8, torch.float8_e4m3fn])
+def test_non_pow2_group_size(num_tokens, group_size, dst_dtype):
+    """Regression: non-power-of-2 group_size. BLOCK = next_pow2(group_size) >
+    group_size, so the padded lanes gather in-bounds data from the next group;
+    without masking them out they corrupt the per-group absmax → wrong scales."""
+    torch.manual_seed(123)
+    hidden_dim = group_size * 12
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+
+    x_q, x_s = per_token_group_quant_8bit(
+        x,
+        group_size=group_size,
+        dst_dtype=dst_dtype,
+        column_major_scales=False,
+        backend="cutile",
+    )
+    ref_q, ref_s = _ref_quant(x, group_size, dst_dtype)
+
+    assert x_s.shape == (num_tokens, hidden_dim // group_size)
+    torch.testing.assert_close(x_s.float(), ref_s.float(), rtol=1e-3, atol=1e-3)

--- a/tests/quantization/test_per_token_group_quant_8bit_cutile.py
+++ b/tests/quantization/test_per_token_group_quant_8bit_cutile.py
@@ -104,6 +104,50 @@ def test_column_major_scales(num_tokens, hidden_dim, group_size, dst_dtype, back
     assert x_s.stride(0) == 1, f"expected column-major scales, got strides {x_s.stride()}"
 
 
+@pytest.mark.parametrize("num_tokens", [128, 130])  # 130 -> aligned to 132
+@pytest.mark.parametrize("hidden_dim", [2048])
+@pytest.mark.parametrize("group_size", [128])
+@pytest.mark.parametrize("dst_dtype", [torch.float8_e4m3fn])
+@pytest.mark.parametrize("backend", ["cutile"])
+def test_tma_aligned_scales(num_tokens, hidden_dim, group_size, dst_dtype, backend):
+    """scale_tma_aligned must return a padded column-major VIEW (no contiguous copy).
+
+    Regression for a `.contiguous()` that repacked the scales to a tight
+    row-major layout, silently destroying the column-major property and the
+    16B TMA leading-dim padding this path exists to produce.
+    """
+    torch.manual_seed(11)
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device="cuda")
+
+    x_q, x_s = per_token_group_quant_8bit(
+        x,
+        group_size=group_size,
+        dst_dtype=dst_dtype,
+        column_major_scales=True,
+        scale_tma_aligned=True,
+        backend=backend,
+    )
+
+    n_groups = hidden_dim // group_size
+    aligned_tokens = ((num_tokens + 3) // 4) * 4  # ceil-align to 4 floats (16B)
+
+    assert x_s.shape == (num_tokens, n_groups), (
+        f"expected ({num_tokens},{n_groups}) got {x_s.shape}"
+    )
+    # Column-major: token dim unit-stride.
+    assert x_s.stride(0) == 1, f"expected column-major, got strides {x_s.stride()}"
+    # TMA padding preserved: group stride is the ALIGNED token count, not the
+    # tight num_tokens a .contiguous() copy would give.
+    assert x_s.stride(1) == aligned_tokens, (
+        f"expected group stride {aligned_tokens} (TMA-padded), got {x_s.stride(1)}"
+    )
+    assert not x_s.isnan().any()
+
+    # Values still correct through the padded view.
+    ref_q, ref_s = _ref_quant(x, group_size, dst_dtype)
+    torch.testing.assert_close(x_s.float(), ref_s, rtol=2e-1, atol=1e-2)
+
+
 @pytest.mark.parametrize(
     "num_tokens,hidden_dim,group_size", [(128, 2048, 64), (256, 4096, 128)]
 )

--- a/tests/quantization/test_per_token_group_quant_8bit_cutile.py
+++ b/tests/quantization/test_per_token_group_quant_8bit_cutile.py
@@ -15,6 +15,7 @@ if not is_cuda_tile_available():
 
 @pytest.fixture(autouse=True)
 def require_sm90():
+    """Skip the module unless running on sm90 or newer."""
     major, minor = get_compute_capability(torch.device("cuda"))
     if major * 10 + minor < 90:
         pytest.skip(f"requires sm90+, got sm{major * 10 + minor}")


### PR DESCRIPTION
## 📌 Description

Adds two cuTile quantization kernels (public `cuda.tile` API), opt-in `backend="cutile"`.

**Why FlashInfer wants this:** `rope_quantize_fp8` fuses RoPE + FP8 quantization into one pass for the MLA / DeepSeek paged-KV append path (replaces separate rope + quant launches); `per_token_group_quant_8bit` provides the block-scaled FP8/INT8 quantizer feeding the groupwise FP8 GEMM path.

**Added**
- `per_token_group_quant_8bit_cutile` — FP8 / INT8 per-token-group quant, row/col-major scale.
- `rope_quantize_fp8_cutile` — fused RoPE + FP8 quant (MLA 2D latent key) → `rope_quantize_fp8(..., backend="cutile")`.

### Benchmarks

Canonical `benchmarks/bench_*_backend_comparison.py` (argparse `--providers`/`--csv`, inline correctness verify, `bench_gpu_time` kernel self-time, speedup-vs-SOTA table + heatmap):
- `bench_per_token_group_quant_8bit.py` — cuTile vs **sgl_kernel** (SOTA) / SGLang triton / torch, over a (num_tokens × hidden_dim) sweep.
- `bench_rope_quantize_fp8_backend_comparison.py` — fused MLA RoPE+fp8 cuTile vs the **native fused CUDA** kernel (SOTA) / torch, over a num_tokens sweep.

Measured on **B200 (sm100)**, median kernel time, speedup = SOTA ÷ cuTile (>1 = cuTile faster).

**`per_token_group_quant_8bit`** vs sgl_kernel — sweep num_tokens{1…4096} × hidden{2048,4096,7168}, **geomean 0.72×**. cuTile is at parity while the op is launch-bound and falls behind once it becomes bandwidth-bound:

| num_tokens | hidden 2048 | 4096 | 7168 |
|---|---|---|---|
| 1–64 | 1.00× | 1.00× | 1.00× |
| 128 | 0.99× | 1.00× | 0.79× |
| 256 | 1.00× | 0.80× | 0.71× |
| 512 | 0.80× | 0.71× | 0.57× |
| 1024 | 0.71× | 0.58× | 0.50× |
| 4096 | 0.45× | 0.42× | 0.39× |

SGLang's triton kernel tracks cuTile closely (0.9–1.0× across the sweep); torch is 3–6× slower than both. So cuTile is competitive with sgl_kernel at small token counts and ~2–2.5× behind at serving-scale batches — a per-token-group memory-access follow-up, not a default-path regression (the backend is opt-in).

**`rope_quantize_fp8` (MLA, 128 heads, head_size 576)** vs the native fused CUDA kernel — sweep num_tokens{1…4096}, **geomean 0.87×**: cuTile **wins at ntok ≤ 16** (1.00–1.10×), ~0.90–0.94× at 32–128, settling at 0.75–0.83× for ntok ≥ 256. Both are ~3× faster than the torch reference.

## 🔍 Related Issues

Part of a 3-way split of the cuTile migration (attention / quantization / GEMM), replacing #3959. Sibling PRs: #4018 (attention), #4020 (GEMM).

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Measured on B300 / sm103:
- rope MLA + per-token-quant: 66 passed
- GQA/MHA rope correctly gated (`NotImplementedError`, not a crash)
- new coverage: non-power-of-two `group_size`, column-major scale strides, TMA scale padding, UE8M0 power-of-two scales

## Reviewer Notes

Carries the shared `cached_replace_hints` helper in `flashinfer/cutile/cutile_common.py` (also in the GEMM PR, #4020) — whichever merges second drops the duplicate hunk on rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public per-token-group 8-bit quantization API with FP8/INT8 outputs, row/column-major scales, TMA-aligned scales, and UE8M0 encoding.
  * Added a selectable `cutile` backend for fused FP8 RoPE quantization.
  * Re-exported an additional FP8 quantization utility in the public quantization API.
* **Performance**
  * Reduced repeated cuTile compilation overhead via cached hinted-kernel launches.
* **Tests**
  * Extended RoPE and per-token-group 8-bit quantization tests to validate both CUDA and cuTile paths and scale layout/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
