### PR TITLE
fix(docs): mock optional quack dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,9 @@ autodoc_mock_imports = [
     "triton",
     "flashinfer._build_meta",
     "cuda",
+    # CuTe-DSL imports its CUDA/CUTLASS stack eagerly, but API docs only need
+    # the public function signatures.
+    "cutlass",
     "numpy",
     "einops",
     "mpi4py",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,14 +1,6 @@
-import sys
 from typing import Any, List
 
 import flashinfer  # noqa: F401
-
-# Importing ``flashinfer`` can transitively load the real CuTe-DSL stack.  The
-# Sphinx mock importer only intercepts future imports, so remove those cached
-# modules before autosummary loads the block-sparse API package.
-for _module_name in tuple(sys.modules):
-    if _module_name == "cutlass" or _module_name.startswith("cutlass."):
-        del sys.modules[_module_name]
 
 # import tlcpack_sphinx_addon
 # Configuration file for the Sphinx documentation builder.
@@ -25,9 +17,9 @@ autodoc_mock_imports = [
     "triton",
     "flashinfer._build_meta",
     "cuda",
-    # CuTe-DSL imports its CUDA/CUTLASS stack eagerly, but API docs only need
-    # the public function signatures.
-    "cutlass",
+    # Optional VSA CuTe-DSL dependency; API documentation needs signatures
+    # but must not require the package from its separate source repository.
+    "quack",
     "numpy",
     "einops",
     "mpi4py",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,6 @@ autodoc_mock_imports = [
     "triton",
     "flashinfer._build_meta",
     "cuda",
-    # Optional VSA CuTe-DSL dependency; API documentation needs signatures
-    # but must not require the package from its separate source repository.
     "quack",
     "numpy",
     "einops",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,14 @@
+import sys
 from typing import Any, List
 
 import flashinfer  # noqa: F401
+
+# Importing ``flashinfer`` can transitively load the real CuTe-DSL stack.  The
+# Sphinx mock importer only intercepts future imports, so remove those cached
+# modules before autosummary loads the block-sparse API package.
+for _module_name in tuple(sys.modules):
+    if _module_name == "cutlass" or _module_name.startswith("cutlass."):
+        del sys.modules[_module_name]
 
 # import tlcpack_sphinx_addon
 # Configuration file for the Sphinx documentation builder.


### PR DESCRIPTION
## Summary
- Mock the optional `quack` dependency during Sphinx autosummary generation.

## Why
Adding the block-sparse API entries made Sphinx import `flashinfer.cute_dsl.sparse`. Its blk128 VSA backend imports `quack`, which is intentionally optional and absent from the Docs CI environment. Mocking it lets Sphinx inspect the public API signatures without requiring the runtime-only dependency.

## Validation
- Docs CI: https://github.com/flashinfer-ai/flashinfer/actions/runs/29560730971
- pre-commit hooks (including Ruff)
- `python3 -m py_compile docs/conf.py`
- verified that the blk128 package loads when Sphinx mocks `quack`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation build reliability by mocking an additional optional dependency so it doesn’t need to be imported during API autosummary.
  * Updated the documentation configuration to clarify that docs only require public API signatures, not full optional dependency availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->