### PR TITLE
fix(cute-dsl): handle maximum UE8M0 inverse scale

### DIFF
--- a/flashinfer/quantization/quantization_cute_dsl_utils.py
+++ b/flashinfer/quantization/quantization_cute_dsl_utils.py
@@ -208,8 +208,9 @@ def ue8m0_to_inv_scale_fast(ue8m0_val: Uint32, *, loc=None, ip=None) -> Float32:
     """
     Convert UE8M0 to inverse scale using integer bit construction.
 
-    Constructs a float32 with exponent = (254 - ue8m0) and zero mantissa,
-    which is exactly 2^(127 - ue8m0). No SFU dependency.
+    For nonzero ue8m0 in [1, 254], constructs the exact float32
+    representation of 2^(127 - ue8m0). The ue8m0 == 254 case is the
+    subnormal 2^-127 (bits 0x00400000). No SFU dependency.
     Returns 0 for ue8m0 == 0.
     """
     return Float32(
@@ -220,12 +221,14 @@ def ue8m0_to_inv_scale_fast(ue8m0_val: Uint32, *, loc=None, ip=None) -> Float32:
             {
                 .reg .s32 new_exp;
                 .reg .b32 float_bits;
-                .reg .pred p_zero;
+                .reg .pred p_zero, p_subnormal;
 
                 setp.eq.u32 p_zero, $1, 0;
+                setp.eq.u32 p_subnormal, $1, 254;
                 sub.s32 new_exp, 254, $1;
                 max.s32 new_exp, new_exp, 0;
                 shl.b32 float_bits, new_exp, 23;
+                @p_subnormal mov.b32 float_bits, 0x00400000;
                 mov.b32 $0, float_bits;
                 @p_zero mov.b32 $0, 0;
             }

--- a/tests/utils/test_fp8_quantize.py
+++ b/tests/utils/test_fp8_quantize.py
@@ -825,7 +825,8 @@ def test_mxfp8_quantize_extreme_scale_inputs(dtype, is_sf_swizzled_layout, backe
         pytest.skip("CuTe-DSL is not available")
 
     a = torch.zeros((2, 128), dtype=dtype, device="cuda")
-    a[:, 32:64] = float("inf")
+    a[0, 32:64] = float("inf")
+    a[1, 32:64] = -float("inf")
     a[:, 64:96] = 448.0
     a[:, 96:128] = -448.0
 

--- a/tests/utils_fp8.py
+++ b/tests/utils_fp8.py
@@ -110,6 +110,12 @@ def mxfp8_quantize_reference(
     )
     inv_scale.masked_fill_(scales == 0, 0)
     quantized = (blocks * inv_scale.unsqueeze(-1)).to(torch.float8_e4m3fn)
+    # Model cvt.rn.satfinite.e4m3x2.f32 explicitly for Inf because PyTorch
+    # float8 conversion behavior differs across toolkit versions.
+    extreme_inf = (scales == 254).unsqueeze(-1) & torch.isinf(blocks)
+    quantized_bits = quantized.view(torch.uint8)
+    quantized_bits.masked_fill_(extreme_inf & (blocks > 0), 0x7E)
+    quantized_bits.masked_fill_(extreme_inf & (blocks < 0), 0xFE)
     return quantized.reshape(*a.shape[:-1], padded_k), _swizzle_mxfp8_scales(
         scales,
         sf_swizzle_layout,


### PR DESCRIPTION
## 📌 Description

Fix CuTe-DSL quantization for blocks whose UE8M0 scale encoding saturates at 254, such as blocks containing `Inf`.

The fast inverse-scale helper encoded `2^(127 - 254) = 2^-127` by shifting a biased FP32 exponent of zero. This produced `0.0` instead of the required FP32 subnormal (`0x00400000`). MXFP8 quantization therefore evaluated `Inf * 0` as `NaN` and emitted E4M3FN NaN (`0x7f`) instead of the satfinite values `+448`/`-448` (`0x7e`/`0xfe`).

This change:

- constructs `2^-127` explicitly for UE8M0 encoding 254;
- makes the reference model the PTX satfinite result for both signs of infinity; and
- extends the extreme-scale test to cover positive and negative infinity.

The zero-block behavior and UE8M0 encodings 1 through 253 are unchanged. The inverse-scale helper is shared by the CuTe-DSL MXFP8 and MXFP4 quantizers.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Installed `pre-commit` and its hook in an isolated remote validation checkout.
- [x] Ran `pre-commit run --all-files`; all hooks passed.

## 🧪 Tests

- [x] Tests have been updated to cover both positive and negative infinity.
- [x] Relevant tests pass on GB200; the full repository GPU matrix is left to CI.

Tested with public `nvidia-cutlass-dsl==4.6.1`:

- CUDA 12.9 / PyTorch 2.12.1+cu129: focused extreme-scale cases, `4 passed`
- CUDA 13.0 / PyTorch 2.12.1+cu130: focused extreme-scale cases, `4 passed`
- CUDA 12.9 CuTe-DSL MXFP8 subset: `236 passed, 60 skipped, 447 deselected`
- CUDA 13.0 CuTe-DSL MXFP8 subset: `236 passed, 60 skipped, 447 deselected`
- Direct CuTe-DSL MXFP4 quantization smoke: passed on CUDA 12 and CUDA 13
- `pre-commit run --all-files`: passed

## Reviewer Notes

With public CUTLASS DSL 4.6.1, CUDA 13 reproduced the original bitwise mismatch: 64/256 elements differed, with `NaN` (`0x7f`) instead of `448` (`0x7e`). CUDA 12 could mask the production bug because its PyTorch reference path also flushed the inverse scale or converted infinity differently. The reference update explicitly models the kernel's PTX satfinite semantics only for infinity blocks using UE8M0 encoding 254.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected FP8 scale conversion for subnormal and zero values.
  * Improved handling of positive and negative infinity during MXFP8 quantization.
  * Ensured extreme scale inputs produce the correct signed FP8 bit patterns.
* **Tests**
  * Updated coverage for mixed positive and negative infinity inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->