### PR TITLE
fix(moe): restore legacy fused_moe.core imports for interleave helpers

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -79,6 +79,12 @@ from ..utils import (
     register_custom_op,
     register_fake_op,
 )
+
+# These helpers moved to prepare.py; keep aliases here for backward compatibility.
+from .prepare import (
+    interleave_moe_scales_for_sm90_mixed_gemm as interleave_moe_scales_for_sm90_mixed_gemm,
+    interleave_moe_weights_for_sm90_mixed_gemm as interleave_moe_weights_for_sm90_mixed_gemm,
+)
 from .utils import (
     get_hybrid_num_tokens_buckets,
     make_hybrid_bucket_mapper,


### PR DESCRIPTION
## 📌 Description

PR #3738 moved the following helper APIs from `flashinfer.fused_moe.core` to
`flashinfer.fused_moe.prepare`:

- `interleave_moe_scales_for_sm90_mixed_gemm`
- `interleave_moe_weights_for_sm90_mixed_gemm`

That module-path change breaks downstream users that still import these public
helpers directly from `flashinfer.fused_moe.core`.

This PR restores backward compatibility by re-exporting both helpers from
`flashinfer.fused_moe.core`, while keeping their implementations and canonical
definitions in `flashinfer.fused_moe.prepare`. It does not change their runtime
or CUDA behavior.

## 🔍 Related Issues

Fixes #4022.

Follow-up to #3738.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request,
please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used
  my preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed
  any reported issues.

> If you are unsure about how to set up `pre-commit`, see the
> [pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] `pre-commit run --all-files`
- [ ] Verify the legacy imports on H20:

  ```python
  from flashinfer.fused_moe.core import (
      interleave_moe_scales_for_sm90_mixed_gemm,
      interleave_moe_weights_for_sm90_mixed_gemm,
  )
  ```

- [ ] Run a representative Hopper mixed-input MoE correctness test on H20.

## Reviewer Notes

- The explicit same-name aliases are intentional: they expose the imported
  symbols as public module attributes and satisfy static linting.
- `prepare.py` remains the canonical implementation location; this PR only
  restores the previous import path for compatibility.
- `prepare.py` does not import `core.py` during module initialization, so these
  re-exports do not introduce an import-time circular dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Kept backward compatibility for existing callers of mixture-of-experts weight and scale utilities.
  * Consolidated where these utilities are sourced so they remain available under the same public names and behave the same for current users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->