### PR TITLE
feat(moe): add unified block-scale FP8 support

### DIFF
--- a/flashinfer/fused_moe/__init__.py
+++ b/flashinfer/fused_moe/__init__.py
@@ -35,7 +35,11 @@ from .api import (  # noqa: F401
     TrtllmMxInt4Config,
 )
 from .layer import MoELayer  # noqa: F401
-from .runners import CuteDslNvfp4Runner, TrtllmFp4RoutedRunner  # noqa: F401
+from .runners import (  # noqa: F401
+    CuteDslNvfp4Runner,
+    TrtllmFp4RoutedRunner,
+    TrtllmFp8BlockRunner,
+)
 
 # Legacy flat-argument APIs (unchanged, not deprecated)
 from .core import (
@@ -62,6 +66,8 @@ from .core import (
 from .prepare import (
     interleave_moe_scales_for_sm90_mixed_gemm,
     interleave_moe_weights_for_sm90_mixed_gemm,
+    prepare_trtllm_fp8_block_activations,
+    prepare_trtllm_fp8_block_weights,
     preprocess_moe_weights_for_sm90_mixed_gemm_humming,
 )
 
@@ -127,6 +133,7 @@ __all__ = [
     "MoELayer",
     "MoEWeightPack",
     "TrtllmFp4RoutedRunner",
+    "TrtllmFp8BlockRunner",
     "QuantConfig",
     "QuantVariant",
     "RoutingConfig",
@@ -144,6 +151,8 @@ __all__ = [
     "cutlass_fused_moe",
     "interleave_moe_scales_for_sm90_mixed_gemm",
     "interleave_moe_weights_for_sm90_mixed_gemm",
+    "prepare_trtllm_fp8_block_activations",
+    "prepare_trtllm_fp8_block_weights",
     "preprocess_moe_weights_for_sm90_mixed_gemm_humming",
     "gen_cutlass_fused_moe_sm120_module",
     "gen_cutlass_fused_moe_sm103_module",

--- a/flashinfer/fused_moe/__init__.py
+++ b/flashinfer/fused_moe/__init__.py
@@ -66,8 +66,6 @@ from .core import (
 from .prepare import (
     interleave_moe_scales_for_sm90_mixed_gemm,
     interleave_moe_weights_for_sm90_mixed_gemm,
-    prepare_trtllm_fp8_block_activations,
-    prepare_trtllm_fp8_block_weights,
     preprocess_moe_weights_for_sm90_mixed_gemm_humming,
 )
 
@@ -151,8 +149,6 @@ __all__ = [
     "cutlass_fused_moe",
     "interleave_moe_scales_for_sm90_mixed_gemm",
     "interleave_moe_weights_for_sm90_mixed_gemm",
-    "prepare_trtllm_fp8_block_activations",
-    "prepare_trtllm_fp8_block_weights",
     "preprocess_moe_weights_for_sm90_mixed_gemm_humming",
     "gen_cutlass_fused_moe_sm120_module",
     "gen_cutlass_fused_moe_sm103_module",

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -273,9 +273,9 @@ class TrtllmFp8BlockConfig:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        # This adapter delegates to get_trtllm_moe_sm100_module(), whose
-        # trtllm-gen kernels require Blackwell SM100+.
-        return arch >= 100
+        # The JIT and C++ launcher support only SM major 10 and 12. Keep this
+        # explicit so SM110 is rejected before JIT compilation.
+        return arch in (100, 103, 120, 121)
 
     @staticmethod
     def prepare_weights(

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -566,7 +566,17 @@ class MoEConfig:
 
 @dataclass
 class MoEActivationPack:
-    """Per-call transient data — pre-quantized NVFP4 activations plus routing inputs.
+    """Per-call backend-native activations plus routing inputs.
+
+    Activation encoding depends on ``QuantConfig.variant``:
+
+    * NVFP4: packed ``uint8 [M, H/2]`` values with
+      ``float8_e4m3fn [M, H/16]`` block scales.
+    * BF16: raw ``bfloat16 [M, H]`` values with no scale tensor.
+    * DeepSeek FP8: ``float8_e4m3fn [M, H]`` values with transposed
+      ``float32 [H/128, M]`` block scales.
+    * MXFP8: ``float8_e4m3fn [M, H]`` values with token-major
+      ``uint8 [M, H/32]`` UE8M0 scales.
 
     ``routing_input_mode`` selects how routing reaches the kernel (the runner reads it directly):
 
@@ -578,9 +588,9 @@ class MoEActivationPack:
       methods like DeepSeekV3/MiniMax2, ``routing_bias``); the kernel computes the top-k selection
       itself per ``RoutingConfig.method``.  ``topk_ids`` / ``topk_weights`` stay ``None`` — the
       runner allocates internal kernel-filled buffers, and the routing result is not surfaced
-      back through the pack (routing replay is a separate, future capability).  Currently only
-      the TRTLLM FP4 runner supports this mode; ``MoELayer`` dispatches a logits pack only to
-      capable backends (see each runner's ``supported_routing_modes``).
+      back through the pack (routing replay is a separate, future capability). TRTLLM FP4 and
+      block-FP8 runners support this mode; ``MoELayer`` dispatches a logits pack only to capable
+      backends (see each runner's ``supported_routing_modes``).
 
     ``topk_ids`` / ``topk_weights`` follow the routed-MoE naming convention (gh #2425); they
     keep the field positions of the former ``selected_experts`` / ``final_scales``, so
@@ -588,10 +598,10 @@ class MoEActivationPack:
     are keyword-only.
     """
 
-    hidden_states_q: Tensor  # [M, H//2] uint8 (packed NVFP4) or [M, H] bf16
-    hidden_states_scale: Optional[
-        Tensor
-    ]  # [M, H//16] float8_e4m3fn block scales; None for BF16
+    # Backend-native activation payload; layouts documented above.
+    hidden_states_q: Tensor
+    # Variant-specific scales documented above; None for BF16.
+    hidden_states_scale: Optional[Tensor]
     # Pre-routed top-k selection (Packed/Unpacked modes); None under FromLogits.
     topk_ids: Optional[Tensor] = None  # [M, top_k] int32 (expert indices)
     topk_weights: Optional[Tensor] = None  # [M, top_k] float32 (routing weights)

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -273,7 +273,45 @@ class TrtllmFp8BlockConfig:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        return arch >= 80
+        # This adapter delegates to get_trtllm_moe_sm100_module(), whose
+        # trtllm-gen kernels require Blackwell SM100+.
+        return arch >= 100
+
+    @staticmethod
+    def prepare_weights(
+        w1_bf16,
+        w2_bf16,
+        *,
+        variant: QuantVariant,
+        num_local_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        device=None,
+    ):
+        """Build the ``trtllm_fp8_block`` weight view from canonical BF16.
+
+        ``variant`` must be :attr:`QuantVariant.DeepSeekFp8` or
+        :attr:`QuantVariant.MxFp8`; their scale formats are intentionally
+        prepared by separate paths.
+        """
+        from .prepare import prepare_trtllm_fp8_block_weights
+
+        return prepare_trtllm_fp8_block_weights(
+            w1_bf16,
+            w2_bf16,
+            variant=variant,
+            num_local_experts=num_local_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            device=device,
+        )
+
+    @staticmethod
+    def prepare_activations(hidden_states_bf16, *, variant: QuantVariant):
+        """Quantize BF16 activations for the selected block-FP8 convention."""
+        from .prepare import prepare_trtllm_fp8_block_activations
+
+        return prepare_trtllm_fp8_block_activations(hidden_states_bf16, variant=variant)
 
     def __repr__(self) -> str:
         return "TrtllmFp8BlockConfig()"

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -273,9 +273,10 @@ class TrtllmFp8BlockConfig:
 
     @classmethod
     def supported(cls, arch: int) -> bool:
-        # The JIT and C++ launcher support only SM major 10 and 12. Keep this
-        # explicit so SM110 is rejected before JIT compilation.
-        return arch in (100, 103, 120, 121)
+        # The available TRTLLM block-FP8 BMM cubins are validated only on the
+        # SM100 family. The outer JIT can compile for major 12, but its FP8
+        # kernels currently fail at runtime on SM120/121.
+        return arch in (100, 103)
 
     @staticmethod
     def prepare_weights(

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1363,6 +1363,10 @@ def get_trtllm_moe_sm100_module():
             expert_weights = moe_inputs.expert_weights
             topk_weights = expert_weights
             hidden_states = moe_inputs.hidden_states
+            # The generic helper identifies TRTLLM dtypes whose ABI normally
+            # consumes an auxiliary scale tensor (FP4 and MX formats). Plain
+            # E4m3 returns false, but DeepSeek block-FP8 is an exception: it
+            # requires the real per-1x128-block scales from the activation pack.
             hidden_states_scale = (
                 moe_inputs.hidden_states_scale
                 if (

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1359,7 +1359,10 @@ def get_trtllm_moe_sm100_module():
             hidden_states = moe_inputs.hidden_states
             hidden_states_scale = (
                 moe_inputs.hidden_states_scale
-                if trtllm_gen_dtype_has_scale(self.dtype_act)
+                if (
+                    trtllm_gen_dtype_has_scale(self.dtype_act)
+                    or self.fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8
+                )
                 else None
             )
 
@@ -1446,30 +1449,13 @@ def get_trtllm_moe_sm100_module():
                     or self.fp8_quantization_type == Fp8QuantizationType.MxFp8
                 ):
                     # FP8 block scale
-                    current_num_tokens = hidden_states.shape[0]
-                    current_hidden_size = hidden_states.shape[1]
-                    if self.fp8_quantization_type == Fp8QuantizationType.DeepSeekFp8:
-                        current_hidden_states_scale = torch.full(
-                            (current_hidden_size // 128, current_num_tokens),
-                            2.0,
-                            dtype=torch.float,
-                            device=hidden_states.device,
-                        )
-                    elif self.fp8_quantization_type == Fp8QuantizationType.MxFp8:
-                        current_hidden_states_scale = hidden_states_scale
-
-                    else:
-                        raise ValueError(
-                            f"Unsupported FP8 quantization type: {self.fp8_quantization_type}"
-                        )
-
                     moe_op.trtllm_fp8_block_scale_moe(
                         routing_logits,
                         topk_ids,
                         topk_weights,
                         kwargs["routing_bias"],
                         hidden_states,
-                        current_hidden_states_scale,
+                        hidden_states_scale,
                         kwargs["gemm1_weights"],
                         kwargs["gemm1_weights_scale"],
                         moe_inputs.gemm1_lora_delta,

--- a/flashinfer/fused_moe/layer.py
+++ b/flashinfer/fused_moe/layer.py
@@ -38,11 +38,13 @@ from .api import (
     QuantVariant,
     TrtllmBf16Config,
     TrtllmFp4Config,
+    TrtllmFp8BlockConfig,
 )
 from .runners import (
     CuteDslNvfp4Runner,
     TrtllmBf16RoutedRunner,
     TrtllmFp4RoutedRunner,
+    TrtllmFp8BlockRunner,
 )
 from .utils import map_to_hybrid_bucket
 
@@ -50,13 +52,19 @@ from .utils import map_to_hybrid_bucket
 # Union of the concrete runners the layer dispatches to.  All share
 # backend_key / tuning_config / pack_inputs as attributes or class members;
 # typing the list with this Union gives mypy the visibility it needs.
-_RunnerT = Union[CuteDslNvfp4Runner, TrtllmFp4RoutedRunner, TrtllmBf16RoutedRunner]
+_RunnerT = Union[
+    CuteDslNvfp4Runner,
+    TrtllmFp4RoutedRunner,
+    TrtllmBf16RoutedRunner,
+    TrtllmFp8BlockRunner,
+]
 
 # Map backend-config class -> runner class
 _BACKEND_RUNNERS: Dict[type, Type[_RunnerT]] = {
     CuteDslConfig: CuteDslNvfp4Runner,
     TrtllmFp4Config: TrtllmFp4RoutedRunner,
     TrtllmBf16Config: TrtllmBf16RoutedRunner,
+    TrtllmFp8BlockConfig: TrtllmFp8BlockRunner,
 }
 
 # Quant variants each runner can execute.  Used by _validate_mvp_scope to accept
@@ -65,6 +73,7 @@ _RUNNER_QUANTS: Dict[type, Tuple[QuantVariant, ...]] = {
     CuteDslConfig: (QuantVariant.NVFP4,),
     TrtllmFp4Config: (QuantVariant.NVFP4,),
     TrtllmBf16Config: (QuantVariant.BF16,),
+    TrtllmFp8BlockConfig: (QuantVariant.DeepSeekFp8, QuantVariant.MxFp8),
 }
 
 
@@ -113,7 +122,7 @@ class MoELayer:
             raise RuntimeError(
                 f"MoELayer: none of the configured backends "
                 f"{[type(c).__name__ for c in config.backend]} are usable on "
-                f"arch sm{arch}. The MVP supports only NVFP4 via [{mvp}]."
+                f"arch sm{arch}. Registered unified runners: [{mvp}]."
             )
 
         # Cross-backend winner cache, keyed by (num_tokens tuning bucket,
@@ -133,8 +142,8 @@ class MoELayer:
         Surfacing this at construction time turns a deep C++ crash or silent
         backend skip into a clear, actionable Python error.  NVFP4 (CuteDSL /
         TRTLLM-FP4) and BF16 (TRTLLM-BF16, the EP grouped-GEMM path) are
-        supported; FP8 / MXFP4 / MxInt4 remain post-MVP.  Only the Swiglu
-        activation is supported.
+        supported, as are DeepSeek FP8 / MXFP8 through TRTLLM block-scale.
+        MXFP4 / MxInt4 remain post-MVP. Only the Swiglu activation is supported.
         """
         variant = config.quant.variant
         supported = {
@@ -145,7 +154,7 @@ class MoELayer:
                 f"MoELayer: QuantVariant.{variant.name} is not executable by any "
                 f"configured backend (supported here: "
                 f"{sorted(q.name for q in supported) or 'none'}). "
-                "FP8 / MXFP4 / MxInt4 paths are tracked as post-MVP follow-ups."
+                "MXFP4 / MxInt4 paths are tracked as post-MVP follow-ups."
             )
         act = config.activation.type
         if act is not ActivationType.Swiglu:

--- a/flashinfer/fused_moe/prepare.py
+++ b/flashinfer/fused_moe/prepare.py
@@ -47,6 +47,7 @@ from ..utils import get_compute_capability
 # Module-level permute-index cache.  Permute indices depend only on weight
 # dims, so the cache is safe to reuse across shapes and calls.
 _TRTLLM_PERMUTE_CACHE: dict = {}
+_TRTLLM_FP8_PERMUTE_CACHE: dict = {}
 
 
 # The E8M0 range clamp and residual-scale factorization are adapted from
@@ -536,6 +537,196 @@ def prepare_trtllm_fp4_weights(
         "output1_scale_gate_scalar": ones,
         "output2_scale_scalar": ones,
     }
+
+
+def _deepseek_fp8_quantize_activations(
+    x: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize ``[M, K]`` BF16 per 1x128 block.
+
+    TRTLLM's DeepSeek path consumes scales transposed as ``[K // 128, M]``.
+    """
+    block = 128
+    m, k = x.shape
+    blocks = x.float().reshape(m, k // block, block)
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    scales = (blocks.abs().amax(dim=-1, keepdim=True) / fp8_max).clamp(min=1e-12)
+    quantized = (blocks / scales).clamp(-fp8_max, fp8_max)
+    return (
+        quantized.reshape(m, k).to(torch.float8_e4m3fn),
+        scales.squeeze(-1).transpose(0, 1).contiguous(),
+    )
+
+
+def _deepseek_fp8_quantize_weights(
+    weights: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize ``[E, N, K]`` BF16 per 128x128 block."""
+    block = 128
+    e, n, k = weights.shape
+    blocks = (
+        weights.float()
+        .reshape(e, n // block, block, k // block, block)
+        .permute(0, 1, 3, 2, 4)
+    )
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    scales = (blocks.abs().amax(dim=(-1, -2), keepdim=True) / fp8_max).clamp(min=1e-12)
+    quantized = (blocks / scales).clamp(-fp8_max, fp8_max)
+    quantized = quantized.permute(0, 1, 3, 2, 4).reshape(e, n, k)
+    return quantized.to(torch.float8_e4m3fn), scales[..., 0, 0].contiguous()
+
+
+def _validate_trtllm_fp8_block_inputs(
+    w1_bf16: torch.Tensor,
+    w2_bf16: torch.Tensor,
+    *,
+    num_local_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+) -> None:
+    if w1_bf16.dtype != torch.bfloat16 or w2_bf16.dtype != torch.bfloat16:
+        raise ValueError(
+            "prepare_trtllm_fp8_block_weights expects BF16 weights, got "
+            f"w1={w1_bf16.dtype}, w2={w2_bf16.dtype}."
+        )
+    expected_w1 = (num_local_experts, 2 * intermediate_size, hidden_size)
+    expected_w2 = (num_local_experts, hidden_size, intermediate_size)
+    if tuple(w1_bf16.shape) != expected_w1 or tuple(w2_bf16.shape) != expected_w2:
+        raise ValueError(
+            f"weight shapes {tuple(w1_bf16.shape)}/{tuple(w2_bf16.shape)} != "
+            f"expected {expected_w1}/{expected_w2}."
+        )
+
+
+def prepare_trtllm_fp8_block_weights(
+    w1_bf16: torch.Tensor,
+    w2_bf16: torch.Tensor,
+    *,
+    variant,
+    num_local_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    device: Optional[torch.device] = None,
+) -> Dict[str, torch.Tensor]:
+    """Prepare canonical BF16 expert weights for TRTLLM block-FP8 MoE.
+
+    DeepSeek FP8 uses E4M3 payloads with FP32 128x128 block scales. MXFP8
+    uses E4M3 payloads with linear UE8M0 scales over 32-element K blocks.
+    Both native views remain in ``MajorK`` layout; the unified runner records
+    the exact variant and passes the corresponding kernel enum.
+    """
+    from .api import QuantVariant
+
+    if variant not in (QuantVariant.DeepSeekFp8, QuantVariant.MxFp8):
+        raise ValueError(
+            "variant must be QuantVariant.DeepSeekFp8 or QuantVariant.MxFp8, "
+            f"got {variant!r}."
+        )
+    _validate_trtllm_fp8_block_inputs(
+        w1_bf16,
+        w2_bf16,
+        num_local_experts=num_local_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    if device is None:
+        device = w1_bf16.device
+    w1_bf16 = w1_bf16.to(device).contiguous()
+    w2_bf16 = w2_bf16.to(device).contiguous()
+
+    if variant is QuantVariant.DeepSeekFp8:
+        for name, dim in (
+            ("hidden_size", hidden_size),
+            ("intermediate_size", intermediate_size),
+            ("2 * intermediate_size", 2 * intermediate_size),
+        ):
+            if dim % 128 != 0:
+                raise ValueError(f"DeepSeek FP8 requires {name} divisible by 128.")
+        w1_q, w1_sf = _deepseek_fp8_quantize_weights(w1_bf16)
+        w2_q, w2_sf = _deepseek_fp8_quantize_weights(w2_bf16)
+    else:
+        if hidden_size % 32 != 0 or intermediate_size % 32 != 0:
+            raise ValueError(
+                "MXFP8 requires hidden_size and intermediate_size divisible by 32."
+            )
+        from ..quantization.fp8_quantization import mxfp8_quantize
+        from .core import (
+            _maybe_get_cached_w3_w1_permute_indices,
+            get_w2_permute_indices_with_cache,
+        )
+
+        w1_q, w1_sf, w2_q, w2_sf = [], [], [], []
+        for expert in range(num_local_experts):
+            q, sf = mxfp8_quantize(w1_bf16[expert], is_sf_swizzled_layout=False)
+            sf = sf.view(torch.uint8).reshape(2 * intermediate_size, hidden_size // 32)
+            permute = _maybe_get_cached_w3_w1_permute_indices(
+                _TRTLLM_FP8_PERMUTE_CACHE,
+                q.view(torch.uint8),
+                128,
+                is_gated_act_gemm=True,
+            )
+            permute_sf = _maybe_get_cached_w3_w1_permute_indices(
+                _TRTLLM_FP8_PERMUTE_CACHE,
+                sf,
+                128,
+                num_elts_per_sf=32,
+                is_gated_act_gemm=True,
+            )
+            w1_q.append(q.view(torch.uint8)[permute.to(device)].view(q.dtype))
+            w1_sf.append(sf[permute_sf.to(device)])
+
+            q, sf = mxfp8_quantize(w2_bf16[expert], is_sf_swizzled_layout=False)
+            sf = sf.view(torch.uint8).reshape(hidden_size, intermediate_size // 32)
+            permute = get_w2_permute_indices_with_cache(
+                _TRTLLM_FP8_PERMUTE_CACHE, q.view(torch.uint8), 128
+            )
+            permute_sf = get_w2_permute_indices_with_cache(
+                _TRTLLM_FP8_PERMUTE_CACHE,
+                sf,
+                128,
+                num_elts_per_sf=32,
+            )
+            w2_q.append(q.view(torch.uint8)[permute.to(device)].view(q.dtype))
+            w2_sf.append(sf[permute_sf.to(device)])
+        w1_q, w1_sf = torch.stack(w1_q), torch.stack(w1_sf)
+        w2_q, w2_sf = torch.stack(w2_q), torch.stack(w2_sf)
+
+    return {
+        "gemm1_weights": w1_q,
+        "gemm1_weights_scale": w1_sf,
+        "gemm2_weights": w2_q,
+        "gemm2_weights_scale": w2_sf,
+    }
+
+
+def prepare_trtllm_fp8_block_activations(
+    hidden_states_bf16: torch.Tensor,
+    *,
+    variant,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize ``[M, H]`` BF16 activations for TRTLLM block-FP8 MoE."""
+    from .api import QuantVariant
+
+    if hidden_states_bf16.dtype != torch.bfloat16 or hidden_states_bf16.dim() != 2:
+        raise ValueError(
+            "prepare_trtllm_fp8_block_activations expects a 2D BF16 tensor, "
+            f"got shape={tuple(hidden_states_bf16.shape)}, "
+            f"dtype={hidden_states_bf16.dtype}."
+        )
+    hidden_states_bf16 = hidden_states_bf16.contiguous()
+    if variant is QuantVariant.DeepSeekFp8:
+        if hidden_states_bf16.shape[1] % 128 != 0:
+            raise ValueError("DeepSeek FP8 hidden_size must be divisible by 128.")
+        return _deepseek_fp8_quantize_activations(hidden_states_bf16)
+    if variant is QuantVariant.MxFp8:
+        from ..quantization.fp8_quantization import mxfp8_quantize
+
+        q, sf = mxfp8_quantize(hidden_states_bf16, is_sf_swizzled_layout=False)
+        return q, sf.view(torch.uint8).reshape(hidden_states_bf16.shape[0], -1)
+    raise ValueError(
+        "variant must be QuantVariant.DeepSeekFp8 or QuantVariant.MxFp8, "
+        f"got {variant!r}."
+    )
 
 
 def prepare_trtllm_bf16_weights(

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -397,6 +397,8 @@ class TrtllmFp4RoutedRunner(TunableRunner):
         routing_input_mode = act.routing_input_mode
         if routing_input_mode == RoutingInputMode.FromLogits:
             # In-kernel routing: topk_ids/expert_weights are OUTPUT buffers the kernel fills.
+            # Unlike the FP8 launcher, FP4 receives routing_input_mode explicitly;
+            # non-empty output buffers therefore do not select precomputed routing.
             # We allocate them here (mirroring trtllm_fp4_block_scale_moe_op, core.py ~2268)
             # because MoERunner.forward calls the raw op directly, bypassing the buffer-allocating
             # wrapper. Weight dtype mirrors logits dtype (core.py:2253).
@@ -717,12 +719,12 @@ class TrtllmFp8BlockRunner(TunableRunner):
             )
             routing_logits = act.routing_logits
             routing_bias = act.routing_bias
-            topk_ids = act.hidden_states_q.new_empty(
-                (num_tokens, routing.top_k), dtype=torch.int32
-            )
-            expert_weights = routing_logits.new_empty(
-                (num_tokens, routing.top_k), dtype=torch.bfloat16
-            )
+            # FP8 infers the routing mode from the expert-index tensor: a
+            # non-empty 2D tensor means PackedPrecomputed and suppresses
+            # routing_logits. Empty placeholders select FromLogits, matching
+            # the canonical trtllm_fp8_block_scale_moe wrapper.
+            topk_ids = act.hidden_states_q.new_empty((0,), dtype=torch.int32)
+            expert_weights = act.hidden_states_q.new_empty((0,), dtype=torch.bfloat16)
         elif routing_input_mode == RoutingInputMode.PackedPrecomputed:
             _validate_prerouted_inputs(
                 act, num_tokens, routing.top_k, "TrtllmFp8BlockRunner"

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -773,6 +773,8 @@ class TrtllmFp8BlockRunner(TunableRunner):
             weight_layout=int(WeightLayout.MajorK),
             do_finalize=True,
             enable_pdl=self._enable_pdl,
+            # Matches the legacy block-FP8 FromLogits wrapper. Pre-routed
+            # execution ignores this flag because weights are already final.
             norm_topk_prob=True,
             routing_replay_out=None,
         )

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -504,6 +504,293 @@ class TrtllmFp4RoutedRunner(TunableRunner):
 
 
 # ---------------------------------------------------------------------------
+# TRTLLM block-FP8 runner — DeepSeek FP8 and MXFP8
+# ---------------------------------------------------------------------------
+
+
+class TrtllmFp8BlockRunner(TunableRunner):
+    """Block-FP8 adapter over the canonical trtllm-gen ``MoERunner``.
+
+    DeepSeek FP8 and MXFP8 share the kernel family but not scale contracts:
+    DeepSeek uses FP32 128-element/128x128 block scales, while MXFP8 uses
+    linear UE8M0 scales over 32-element K blocks.
+    """
+
+    backend_key = "trtllm_fp8_block"
+    supported_routing_modes = (
+        RoutingInputMode.PackedPrecomputed,
+        RoutingInputMode.FromLogits,
+    )
+
+    def __init__(self, config: MoEConfig, device: torch.device):
+        from ..tllm_enums import DtypeTrtllmGen, Fp8QuantizationType
+        from ..utils import device_support_pdl
+        from .api import QuantVariant
+        from .core import get_trtllm_moe_sm100_module
+
+        if config.quant.variant is QuantVariant.DeepSeekFp8:
+            dtype = DtypeTrtllmGen.E4m3
+            fp8_type = Fp8QuantizationType.DeepSeekFp8
+        elif config.quant.variant is QuantVariant.MxFp8:
+            dtype = DtypeTrtllmGen.MxE4m3
+            fp8_type = Fp8QuantizationType.MxFp8
+        else:
+            raise NotImplementedError(
+                "TrtllmFp8BlockRunner supports only DeepSeekFp8 and MxFp8, "
+                f"got {config.quant.variant!r}."
+            )
+        if not config.execution.do_finalize:
+            raise NotImplementedError(
+                "TrtllmFp8BlockRunner initially supports only do_finalize=True."
+            )
+
+        self.config = config
+        self.device = device
+        self._module = get_trtllm_moe_sm100_module()
+        self._variant = config.quant.variant
+        self._dtype_act = dtype
+        self._dtype_weights = dtype
+        self._fp8_quantization_type = fp8_type
+        self._use_shuffled_weight = config.quant.variant is QuantVariant.MxFp8
+
+        routing = config.routing
+        experts = config.experts
+        execution = config.execution
+        self._num_local_experts = experts.local_num_experts or routing.num_experts
+        self._local_expert_offset = experts.local_expert_offset
+        self._intermediate_size = experts.intermediate_size
+        self._activation_type = int(config.activation.type)
+        self._tune_max_num_tokens = execution.tune_max_num_tokens
+
+        enable_pdl = execution.enable_pdl
+        if enable_pdl is None:
+            enable_pdl = device_support_pdl(device)
+        self._enable_pdl = enable_pdl
+
+        self._inner: Any = None
+        self._static_kwargs: dict = {}
+        self.tuning_config: Any = None
+
+    def _ensure_inner(self, hidden_size: int) -> None:
+        if self._inner is not None:
+            return
+        from ..tllm_enums import WeightLayout
+
+        self._inner = self._module.MoERunner(
+            top_k=self.config.routing.top_k,
+            num_local_experts=self._num_local_experts,
+            dtype_act=self._dtype_act,
+            dtype_weights=self._dtype_weights,
+            fp8_quantization_type=self._fp8_quantization_type,
+            hidden_size=hidden_size,
+            intermediate_size=self._intermediate_size,
+            activation_type=self._activation_type,
+            use_shuffled_weight=self._use_shuffled_weight,
+            weight_layout=int(WeightLayout.MajorK),
+            use_per_token_scaling=False,
+            num_experts=self.config.routing.num_experts,
+        )
+
+    def get_valid_tactics(  # type: ignore[override]
+        self, inputs: List[torch.Tensor], profile: Any
+    ) -> List[Any]:
+        return self._inner.get_valid_tactics(inputs, profile)
+
+    def forward(
+        self,
+        inputs: List[torch.Tensor],
+        tactic: Any = -1,
+        do_preparation: bool = False,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        self._inner.forward(
+            inputs,
+            tactic=tactic,
+            do_preparation=do_preparation,
+            **self._static_kwargs,
+        )
+        return inputs[0]
+
+    def _validate_fp8_tensors(
+        self,
+        act: MoEActivationPack,
+        view: dict,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        from .api import QuantVariant
+
+        if act.hidden_states_q.dtype != torch.float8_e4m3fn:
+            raise TypeError(
+                "TrtllmFp8BlockRunner requires float8_e4m3fn hidden_states_q, "
+                f"got {act.hidden_states_q.dtype}."
+            )
+        scale = act.hidden_states_scale
+        if scale is None:
+            raise ValueError("TrtllmFp8BlockRunner requires hidden_states_scale.")
+        num_tokens = act.hidden_states_q.shape[0]
+        if self._variant is QuantVariant.DeepSeekFp8:
+            expected_scale = (hidden_size // 128, num_tokens)
+            if scale.dtype != torch.float32 or tuple(scale.shape) != expected_scale:
+                raise ValueError(
+                    "DeepSeekFp8 hidden_states_scale must be float32 with shape "
+                    f"{expected_scale}, got {scale.dtype} {tuple(scale.shape)}."
+                )
+            expected_w1_scale = (
+                self._num_local_experts,
+                2 * self._intermediate_size // 128,
+                hidden_size // 128,
+            )
+            expected_w2_scale = (
+                self._num_local_experts,
+                hidden_size // 128,
+                self._intermediate_size // 128,
+            )
+            scale_dtype = torch.float32
+        else:
+            expected_scale = (num_tokens, hidden_size // 32)
+            if scale.dtype != torch.uint8 or tuple(scale.shape) != expected_scale:
+                raise ValueError(
+                    "MxFp8 hidden_states_scale must be uint8 UE8M0 with shape "
+                    f"{expected_scale}, got {scale.dtype} {tuple(scale.shape)}."
+                )
+            expected_w1_scale = (
+                self._num_local_experts,
+                2 * self._intermediate_size,
+                hidden_size // 32,
+            )
+            expected_w2_scale = (
+                self._num_local_experts,
+                hidden_size,
+                self._intermediate_size // 32,
+            )
+            scale_dtype = torch.uint8
+
+        expected_weights = {
+            "gemm1_weights": (
+                self._num_local_experts,
+                2 * self._intermediate_size,
+                hidden_size,
+            ),
+            "gemm2_weights": (
+                self._num_local_experts,
+                hidden_size,
+                self._intermediate_size,
+            ),
+        }
+        for name, expected in expected_weights.items():
+            tensor = view[name]
+            if tensor.dtype != torch.float8_e4m3fn or tuple(tensor.shape) != expected:
+                raise ValueError(
+                    f"{name} must be float8_e4m3fn with shape {expected}, got "
+                    f"{tensor.dtype} {tuple(tensor.shape)}."
+                )
+        for name, expected in (
+            ("gemm1_weights_scale", expected_w1_scale),
+            ("gemm2_weights_scale", expected_w2_scale),
+        ):
+            tensor = view[name]
+            if tensor.dtype != scale_dtype or tuple(tensor.shape) != expected:
+                raise ValueError(
+                    f"{name} must be {scale_dtype} with shape {expected}, got "
+                    f"{tensor.dtype} {tuple(tensor.shape)}."
+                )
+        return scale
+
+    def pack_inputs(
+        self, act: MoEActivationPack, weights: MoEWeightPack
+    ) -> List[torch.Tensor]:
+        from ..tllm_enums import WeightLayout
+        from .core import MoeRunnerInputs, RoutingInputMode
+
+        view = weights.get_view(self.backend_key)
+        routing = self.config.routing
+        num_tokens, hidden_size = act.hidden_states_q.shape
+        hidden_states_scale = self._validate_fp8_tensors(act, view, hidden_size)
+
+        output = act.hidden_states_q.new_empty(
+            (num_tokens, hidden_size), dtype=torch.bfloat16
+        )
+        routing_input_mode = act.routing_input_mode
+        if routing_input_mode == RoutingInputMode.FromLogits:
+            _validate_logits_inputs(
+                act, num_tokens, routing.num_experts, "TrtllmFp8BlockRunner"
+            )
+            routing_logits = act.routing_logits
+            routing_bias = act.routing_bias
+            topk_ids = act.hidden_states_q.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.int32
+            )
+            expert_weights = routing_logits.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.bfloat16
+            )
+        elif routing_input_mode == RoutingInputMode.PackedPrecomputed:
+            _validate_prerouted_inputs(
+                act, num_tokens, routing.top_k, "TrtllmFp8BlockRunner"
+            )
+            routing_logits = None
+            routing_bias = None
+            weight_bits = (
+                act.topk_weights.to(torch.bfloat16).view(torch.int16).to(torch.int32)
+            )
+            topk_ids = (act.topk_ids << 16) | (weight_bits & 0xFFFF)
+            expert_weights = act.topk_weights.new_empty(
+                (num_tokens, routing.top_k), dtype=torch.bfloat16
+            )
+        else:
+            raise NotImplementedError(
+                "TrtllmFp8BlockRunner supports only FromLogits and "
+                "PackedPrecomputed routing."
+            )
+
+        moe_inputs = MoeRunnerInputs(
+            output=output,
+            routing_logits=routing_logits,
+            topk_ids=topk_ids,
+            expert_weights=expert_weights,
+            hidden_states=act.hidden_states_q,
+            hidden_states_scale=hidden_states_scale,
+            gemm1_lora_delta=None,
+            per_token_scale=None,
+        )
+        self._static_kwargs = dict(
+            routing_input_mode=routing_input_mode,
+            routing_bias=routing_bias,
+            gemm1_weights=view["gemm1_weights"],
+            gemm1_weights_scale=view["gemm1_weights_scale"],
+            gemm1_alpha=None,
+            gemm1_beta=None,
+            gemm1_clamp_limit=None,
+            gemm2_weights=view["gemm2_weights"],
+            gemm2_weights_scale=view["gemm2_weights_scale"],
+            num_experts=routing.num_experts,
+            num_fused_shared_experts=0,
+            n_group=routing.n_group,
+            topk_group=routing.topk_group,
+            local_expert_offset=self._local_expert_offset,
+            routed_scaling_factor=routing.routed_scaling_factor,
+            routing_method_type=int(routing.method),
+            use_shuffled_weight=self._use_shuffled_weight,
+            weight_layout=int(WeightLayout.MajorK),
+            do_finalize=True,
+            enable_pdl=self._enable_pdl,
+            norm_topk_prob=True,
+            routing_replay_out=None,
+        )
+
+        self._ensure_inner(hidden_size)
+        self.tuning_config = self._inner._make_tuning_config(
+            moe_inputs,
+            tune_max_num_tokens=self._tune_max_num_tokens,
+            use_cuda_graph=True,
+            use_cold_l2_cache=True,
+        )
+        return moe_inputs.to_list()
+
+    def __hash__(self):
+        return hash(("trtllm_fp8_block", self._variant))
+
+
+# ---------------------------------------------------------------------------
 # TRTLLM BF16 routed runner — canonical trtllm-gen MoERunner, bf16 dtypes
 # ---------------------------------------------------------------------------
 

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -266,6 +266,8 @@ class TestBackendOptions:
         )
         valid = opts.valid_for(100)
         assert len(valid) == 3
+        assert not TrtllmFp8BlockConfig.supported(110)
+        assert TrtllmFp8BlockConfig.supported(120)
 
     def test_iteration(self):
         opts = BackendOptions(candidates=(TrtllmFp4Config(), CutlassConfig()))

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -255,11 +255,10 @@ class TestBackendOptions:
         opts = BackendOptions(
             candidates=(TrtllmBf16Config(), TrtllmFp8BlockConfig(), CutlassConfig())
         )
-        # sm80: BF16 requires 100+, FP8Block requires 80+, Cutlass is universal
+        # TRTLLM-gen BF16 and block-FP8 require SM100+; Cutlass is universal.
         valid = opts.valid_for(80)
-        assert len(valid) == 2
-        assert isinstance(valid[0], TrtllmFp8BlockConfig)
-        assert isinstance(valid[1], CutlassConfig)
+        assert len(valid) == 1
+        assert isinstance(valid[0], CutlassConfig)
 
     def test_valid_for_blackwell(self):
         opts = BackendOptions(
@@ -586,15 +585,24 @@ class TestMoELayerMVPValidation:
 
     @pytest.mark.parametrize(
         "variant",
-        # NVFP4 (CuteDSL/TRTLLM-FP4) and BF16 (TRTLLM-BF16, the EP grouped-GEMM
-        # path) are both MVP-supported now; everything else is still rejected.
-        [v for v in QuantVariant if v not in (QuantVariant.NVFP4, QuantVariant.BF16)],
+        # NVFP4, BF16, DeepSeek FP8, and MXFP8 have unified runners.
+        [
+            v
+            for v in QuantVariant
+            if v
+            not in (
+                QuantVariant.NVFP4,
+                QuantVariant.BF16,
+                QuantVariant.DeepSeekFp8,
+                QuantVariant.MxFp8,
+            )
+        ],
     )
     def test_non_nvfp4_quant_rejected(self, variant):
         from flashinfer.fused_moe import MoELayer
 
         cfg = self._nvfp4_swiglu(quant=QuantConfig(variant=variant))
-        with pytest.raises(NotImplementedError, match="NVFP4"):
+        with pytest.raises(NotImplementedError, match="not executable"):
             MoELayer(cfg)
 
     @pytest.mark.parametrize(

--- a/tests/moe/test_unified_moe.py
+++ b/tests/moe/test_unified_moe.py
@@ -267,7 +267,7 @@ class TestBackendOptions:
         valid = opts.valid_for(100)
         assert len(valid) == 3
         assert not TrtllmFp8BlockConfig.supported(110)
-        assert TrtllmFp8BlockConfig.supported(120)
+        assert not TrtllmFp8BlockConfig.supported(120)
 
     def test_iteration(self):
         opts = BackendOptions(candidates=(TrtllmFp4Config(), CutlassConfig()))

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -21,7 +21,10 @@ from flashinfer.fused_moe import (
     RoutingInputMode,
     TrtllmFp8BlockConfig,
 )
-from flashinfer.quantization.fp8_quantization import mxfp8_dequantize_host
+from flashinfer.quantization.fp8_quantization import (
+    mxfp8_dequantize_host,
+    mxfp8_quantize,
+)
 from flashinfer.utils import get_compute_capability
 from tests.moe.trtllm_gen_fused_moe_utils import check_accuracy
 
@@ -60,6 +63,12 @@ def _mxfp8_dequant_matrix(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
     ).to(q.device)
 
 
+def _mxfp8_quant_matrix(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize one logical matrix without applying the MoE weight shuffle."""
+    q, scale = mxfp8_quantize(x, is_sf_swizzled_layout=False)
+    return q, scale.view(torch.uint8).reshape(x.shape[0], x.shape[1] // 32)
+
+
 def _dequant_view(variant, x_q, x_scale, view, canonical_w1, canonical_w2):
     if variant is QuantVariant.DeepSeekFp8:
         x = _deepseek_dequant_activations(x_q, x_scale)
@@ -73,17 +82,13 @@ def _dequant_view(variant, x_q, x_scale, view, canonical_w1, canonical_w2):
         x = _mxfp8_dequant_matrix(x_q, x_scale)
         w1 = torch.stack(
             [
-                _mxfp8_dequant_matrix(
-                    *TrtllmFp8BlockConfig.prepare_activations(expert, variant=variant)
-                )
+                _mxfp8_dequant_matrix(*_mxfp8_quant_matrix(expert))
                 for expert in canonical_w1
             ]
         )
         w2 = torch.stack(
             [
-                _mxfp8_dequant_matrix(
-                    *TrtllmFp8BlockConfig.prepare_activations(expert, variant=variant)
-                )
+                _mxfp8_dequant_matrix(*_mxfp8_quant_matrix(expert))
                 for expert in canonical_w2
             ]
         )
@@ -91,11 +96,12 @@ def _dequant_view(variant, x_q, x_scale, view, canonical_w1, canonical_w2):
 
 
 def _requant_intermediate(inter: torch.Tensor, variant) -> torch.Tensor:
-    q, sf = TrtllmFp8BlockConfig.prepare_activations(
-        inter.to(torch.bfloat16), variant=variant
-    )
     if variant is QuantVariant.DeepSeekFp8:
+        q, sf = TrtllmFp8BlockConfig.prepare_activations(
+            inter.to(torch.bfloat16), variant=variant
+        )
         return _deepseek_dequant_activations(q, sf)
+    q, sf = _mxfp8_quant_matrix(inter.to(torch.bfloat16))
     return _mxfp8_dequant_matrix(q, sf)
 
 
@@ -115,7 +121,9 @@ def _reference(x, w1, w2, ids, weights, variant, expert_offset=0):
 
 
 def _assert_fp8_close(actual, expected):
-    check_accuracy(expected.float(), actual.float(), atol=0.1, rtol=0.85, percent=0.79)
+    # Calibrated on the deterministic SM100 cases below: DeepSeek FP8 reached
+    # 100% and MXFP8 99.68% within this bound. Recalibrate when shapes expand.
+    check_accuracy(expected.float(), actual.float(), atol=0.05, rtol=0.3, percent=0.99)
 
 
 def _make_case(variant, *, expert_offset=0, local_experts=NUM_EXPERTS):
@@ -207,6 +215,67 @@ def test_block_fp8_layer_and_direct_runner_match_reference(variant):
     direct = runner.forward(runner.pack_inputs(pack, weights), tactic=-1)
     _assert_fp8_close(direct, reference)
     _assert_fp8_close(layer(pack, weights), reference)
+
+
+def test_mxfp8_prepared_weight_layout_matches_expected_permutation():
+    from flashinfer.fused_moe.core import (
+        _maybe_get_cached_w3_w1_permute_indices,
+        get_w2_permute_indices_with_cache,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(20260718)
+    w1 = torch.randn(
+        1,
+        2 * INTERMEDIATE,
+        HIDDEN,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    w2 = torch.randn(
+        1,
+        HIDDEN,
+        INTERMEDIATE,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    view = TrtllmFp8BlockConfig.prepare_weights(
+        w1,
+        w2,
+        variant=QuantVariant.MxFp8,
+        num_local_experts=1,
+        hidden_size=HIDDEN,
+        intermediate_size=INTERMEDIATE,
+        device=torch.device("cuda"),
+    )
+
+    cache = {}
+    w1_q, w1_sf = _mxfp8_quant_matrix(w1[0])
+    w1_perm = _maybe_get_cached_w3_w1_permute_indices(
+        cache, w1_q.view(torch.uint8), 128, is_gated_act_gemm=True
+    )
+    w1_sf_perm = _maybe_get_cached_w3_w1_permute_indices(
+        cache,
+        w1_sf,
+        128,
+        num_elts_per_sf=32,
+        is_gated_act_gemm=True,
+    )
+    torch.testing.assert_close(view["gemm1_weights"][0], w1_q[w1_perm], rtol=0, atol=0)
+    torch.testing.assert_close(
+        view["gemm1_weights_scale"][0], w1_sf[w1_sf_perm], rtol=0, atol=0
+    )
+
+    w2_q, w2_sf = _mxfp8_quant_matrix(w2[0])
+    w2_perm = get_w2_permute_indices_with_cache(cache, w2_q.view(torch.uint8), 128)
+    w2_sf_perm = get_w2_permute_indices_with_cache(
+        cache, w2_sf, 128, num_elts_per_sf=32
+    )
+    torch.testing.assert_close(view["gemm2_weights"][0], w2_q[w2_perm], rtol=0, atol=0)
+    torch.testing.assert_close(
+        view["gemm2_weights_scale"][0], w2_sf[w2_sf_perm], rtol=0, atol=0
+    )
 
 
 @pytest.mark.parametrize("variant", [QuantVariant.DeepSeekFp8, QuantVariant.MxFp8])

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -1,0 +1,271 @@
+"""Unified TRTLLM block-FP8 conformance tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.fused_moe import (
+    ActivationConfig,
+    BackendOptions,
+    ExecutionConfig,
+    ExpertConfig,
+    MoEActivationPack,
+    MoEConfig,
+    MoELayer,
+    MoEWeightPack,
+    QuantConfig,
+    QuantVariant,
+    RoutingConfig,
+    RoutingInputMode,
+    TrtllmFp8BlockConfig,
+)
+from flashinfer.quantization.fp8_quantization import mxfp8_dequantize_host
+from flashinfer.utils import get_compute_capability
+from tests.moe.trtllm_gen_fused_moe_utils import check_accuracy
+
+
+def _is_sm100_plus() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = get_compute_capability(torch.device("cuda"))
+    return major >= 10
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_sm100_plus(), reason="TRTLLM block-FP8 MoE requires SM100+"
+)
+
+HIDDEN = 256
+INTERMEDIATE = 256
+NUM_EXPERTS = 8
+TOP_K = 2
+TOKENS = 64
+
+
+def _deepseek_dequant_activations(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return q.float() * scale.transpose(0, 1).repeat_interleave(128, dim=1)
+
+
+def _deepseek_dequant_weights(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return q.float() * scale.repeat_interleave(128, dim=1).repeat_interleave(128, dim=2)
+
+
+def _mxfp8_dequant_matrix(q: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return mxfp8_dequantize_host(
+        q.detach().cpu().view(torch.uint8),
+        scale.detach().cpu().view(torch.uint8).reshape(-1),
+        False,
+    ).to(q.device)
+
+
+def _dequant_view(variant, x_q, x_scale, view, canonical_w1, canonical_w2):
+    if variant is QuantVariant.DeepSeekFp8:
+        x = _deepseek_dequant_activations(x_q, x_scale)
+        w1 = _deepseek_dequant_weights(
+            view["gemm1_weights"], view["gemm1_weights_scale"]
+        )
+        w2 = _deepseek_dequant_weights(
+            view["gemm2_weights"], view["gemm2_weights_scale"]
+        )
+    else:
+        x = _mxfp8_dequant_matrix(x_q, x_scale)
+        w1 = torch.stack(
+            [
+                _mxfp8_dequant_matrix(
+                    *TrtllmFp8BlockConfig.prepare_activations(expert, variant=variant)
+                )
+                for expert in canonical_w1
+            ]
+        )
+        w2 = torch.stack(
+            [
+                _mxfp8_dequant_matrix(
+                    *TrtllmFp8BlockConfig.prepare_activations(expert, variant=variant)
+                )
+                for expert in canonical_w2
+            ]
+        )
+    return x.float(), w1.float(), w2.float()
+
+
+def _requant_intermediate(inter: torch.Tensor, variant) -> torch.Tensor:
+    q, sf = TrtllmFp8BlockConfig.prepare_activations(
+        inter.to(torch.bfloat16), variant=variant
+    )
+    if variant is QuantVariant.DeepSeekFp8:
+        return _deepseek_dequant_activations(q, sf)
+    return _mxfp8_dequant_matrix(q, sf)
+
+
+def _reference(x, w1, w2, ids, weights, variant, expert_offset=0):
+    weights = weights.to(torch.bfloat16).float()
+    out = torch.zeros(x.shape[0], x.shape[1], device=x.device, dtype=torch.float32)
+    for local_expert in range(w1.shape[0]):
+        token, slot = torch.where(ids == local_expert + expert_offset)
+        if token.numel() == 0:
+            continue
+        up = x[token] @ w1[local_expert, :INTERMEDIATE].t()
+        gate = x[token] @ w1[local_expert, INTERMEDIATE:].t()
+        inter = _requant_intermediate(F.silu(gate) * up, variant)
+        expert_out = inter @ w2[local_expert].t()
+        out[token] += weights[token, slot, None] * expert_out
+    return out
+
+
+def _assert_fp8_close(actual, expected):
+    check_accuracy(expected.float(), actual.float(), atol=0.1, rtol=0.85, percent=0.79)
+
+
+def _make_case(variant, *, expert_offset=0, local_experts=NUM_EXPERTS):
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(20260717)
+    x = torch.randn(
+        TOKENS, HIDDEN, device=device, dtype=torch.bfloat16, generator=generator
+    )
+    w1 = (
+        torch.randn(
+            local_experts,
+            2 * INTERMEDIATE,
+            HIDDEN,
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.02
+    )
+    w2 = (
+        torch.randn(
+            local_experts,
+            HIDDEN,
+            INTERMEDIATE,
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.02
+    )
+    ids = torch.randint(
+        expert_offset,
+        expert_offset + local_experts,
+        (TOKENS, TOP_K),
+        device=device,
+        dtype=torch.int32,
+        generator=generator,
+    )
+    route_weights = torch.softmax(
+        torch.randn(
+            TOKENS, TOP_K, device=device, dtype=torch.float32, generator=generator
+        ),
+        dim=-1,
+    )
+
+    x_q, x_scale = TrtllmFp8BlockConfig.prepare_activations(x, variant=variant)
+    view = TrtllmFp8BlockConfig.prepare_weights(
+        w1,
+        w2,
+        variant=variant,
+        num_local_experts=local_experts,
+        hidden_size=HIDDEN,
+        intermediate_size=INTERMEDIATE,
+        device=device,
+    )
+    weight_pack = MoEWeightPack()
+    weight_pack.prepare_for("trtllm_fp8_block", view)
+    config = MoEConfig(
+        routing=RoutingConfig(
+            num_experts=expert_offset + local_experts,
+            top_k=TOP_K,
+        ),
+        quant=QuantConfig(variant=variant),
+        experts=ExpertConfig(
+            intermediate_size=INTERMEDIATE,
+            local_expert_offset=expert_offset,
+            local_num_experts=local_experts,
+        ),
+        activation=ActivationConfig.swiglu,
+        backend=BackendOptions(candidates=(TrtllmFp8BlockConfig(),)),
+        execution=ExecutionConfig(tune_max_num_tokens=TOKENS),
+    )
+    pack = MoEActivationPack(
+        hidden_states_q=x_q,
+        hidden_states_scale=x_scale,
+        topk_ids=ids,
+        topk_weights=route_weights,
+    )
+    dequant = _dequant_view(variant, x_q, x_scale, view, w1, w2)
+    return pack, weight_pack, config, dequant
+
+
+@pytest.mark.parametrize("variant", [QuantVariant.DeepSeekFp8, QuantVariant.MxFp8])
+def test_block_fp8_layer_and_direct_runner_match_reference(variant):
+    pack, weights, config, (x, w1, w2) = _make_case(variant)
+    reference = _reference(x, w1, w2, pack.topk_ids, pack.topk_weights, variant)
+    layer = MoELayer(config)
+    runner = layer.runners[0]
+    direct = runner.forward(runner.pack_inputs(pack, weights), tactic=-1)
+    _assert_fp8_close(direct, reference)
+    _assert_fp8_close(layer(pack, weights), reference)
+
+
+@pytest.mark.parametrize("variant", [QuantVariant.DeepSeekFp8, QuantVariant.MxFp8])
+def test_block_fp8_from_logits_matches_prerouted(variant):
+    pack, weights, config, _ = _make_case(variant)
+    logits = torch.randn(TOKENS, NUM_EXPERTS, device="cuda", dtype=torch.float32)
+    probabilities = torch.softmax(logits, dim=-1)
+    topk_weights, topk_ids = torch.topk(probabilities, TOP_K, dim=-1)
+    prerouted = MoEActivationPack(
+        hidden_states_q=pack.hidden_states_q,
+        hidden_states_scale=pack.hidden_states_scale,
+        topk_ids=topk_ids.to(torch.int32),
+        topk_weights=topk_weights,
+    )
+    from_logits = MoEActivationPack(
+        hidden_states_q=pack.hidden_states_q,
+        hidden_states_scale=pack.hidden_states_scale,
+        routing_input_mode=RoutingInputMode.FromLogits,
+        routing_logits=logits,
+    )
+    layer = MoELayer(config)
+    expected = layer(prerouted, weights).clone()
+    actual = layer(from_logits, weights)
+    _assert_fp8_close(actual, expected)
+
+
+@pytest.mark.parametrize("variant", [QuantVariant.DeepSeekFp8, QuantVariant.MxFp8])
+def test_block_fp8_nonzero_expert_offset(variant):
+    offset = 8
+    pack, weights, config, (x, w1, w2) = _make_case(
+        variant, expert_offset=offset, local_experts=8
+    )
+    layer = MoELayer(config)
+    actual = layer.runners[0].forward(
+        layer.runners[0].pack_inputs(pack, weights), tactic=-1
+    )
+    expected = _reference(
+        x,
+        w1,
+        w2,
+        pack.topk_ids,
+        pack.topk_weights,
+        variant,
+        expert_offset=offset,
+    )
+    assert actual.float().abs().max().item() > 0
+    _assert_fp8_close(actual, expected)
+
+
+@pytest.mark.parametrize("variant", [QuantVariant.DeepSeekFp8, QuantVariant.MxFp8])
+def test_block_fp8_prerouted_cuda_graph(variant):
+    pack, weights, config, _ = _make_case(variant)
+    layer = MoELayer(config)
+    for _ in range(3):
+        layer(pack, weights)
+    eager = layer(pack, weights).clone()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = layer(pack, weights)
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_fp8_close(captured, eager)

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -19,6 +21,7 @@ from flashinfer.fused_moe import (
     QuantVariant,
     RoutingConfig,
     RoutingInputMode,
+    RoutingMethodType,
     TrtllmFp8BlockConfig,
 )
 from flashinfer.quantization.fp8_quantization import (
@@ -29,15 +32,15 @@ from flashinfer.utils import get_compute_capability
 from tests.moe.trtllm_gen_fused_moe_utils import check_accuracy
 
 
-def _is_sm100_plus() -> bool:
+def _is_trtllm_fp8_arch() -> bool:
     if not torch.cuda.is_available():
         return False
-    major, _ = get_compute_capability(torch.device("cuda"))
-    return major >= 10
+    major, minor = get_compute_capability(torch.device("cuda"))
+    return major * 10 + minor in (100, 103, 120, 121)
 
 
 pytestmark = pytest.mark.skipif(
-    not _is_sm100_plus(), reason="TRTLLM block-FP8 MoE requires SM100+"
+    not _is_trtllm_fp8_arch(), reason="TRTLLM block-FP8 MoE requires SM100/103/120/121"
 )
 
 HIDDEN = 256
@@ -278,6 +281,22 @@ def test_mxfp8_prepared_weight_layout_matches_expected_permutation():
     )
 
 
+def _run_from_logits_with_replay(layer, act_pack, weights, expected_ids):
+    """Run in-kernel routing and assert its selected expert set exactly."""
+    runner = layer.runners[0]
+    inputs = runner.pack_inputs(act_pack, weights)
+    routing_replay = torch.empty_like(expected_ids, dtype=torch.int16)
+    runner._static_kwargs["routing_replay_out"] = routing_replay
+    actual = runner.forward(inputs, tactic=-1)
+    torch.testing.assert_close(
+        torch.sort(routing_replay.to(torch.int32), dim=-1).values,
+        torch.sort(expected_ids.to(torch.int32), dim=-1).values,
+        rtol=0,
+        atol=0,
+    )
+    return actual
+
+
 @pytest.mark.parametrize("variant", [QuantVariant.DeepSeekFp8, QuantVariant.MxFp8])
 def test_block_fp8_from_logits_matches_prerouted(variant):
     pack, weights, config, _ = _make_case(variant)
@@ -298,7 +317,86 @@ def test_block_fp8_from_logits_matches_prerouted(variant):
     )
     layer = MoELayer(config)
     expected = layer(prerouted, weights).clone()
-    actual = layer(from_logits, weights)
+    actual = _run_from_logits_with_replay(layer, from_logits, weights, topk_ids)
+    _assert_fp8_close(actual, expected)
+
+
+def _deepseek_v3_route(logits, bias, *, top_k, n_group, topk_group, scale):
+    scores = torch.sigmoid(logits.float())
+    selection_scores = scores + bias.float()
+    grouped = selection_scores.view(logits.shape[0], n_group, -1)
+    group_scores = torch.topk(grouped, k=2, dim=-1).values.sum(dim=-1)
+    selected_groups = torch.topk(group_scores, k=topk_group, dim=-1).indices
+    group_mask = torch.zeros_like(group_scores, dtype=torch.bool).scatter_(
+        -1, selected_groups, True
+    )
+    expert_mask = (
+        group_mask.unsqueeze(-1).expand_as(grouped).reshape_as(selection_scores)
+    )
+    selected = torch.topk(
+        selection_scores.masked_fill(~expert_mask, float("-inf")),
+        k=top_k,
+        dim=-1,
+    ).indices
+    weights = torch.gather(scores, -1, selected)
+    weights = weights / weights.sum(dim=-1, keepdim=True) * scale
+    return selected.to(torch.int32), weights
+
+
+@pytest.mark.parametrize("variant", [QuantVariant.DeepSeekFp8, QuantVariant.MxFp8])
+def test_block_fp8_deepseek_v3_from_logits_matches_prerouted(variant):
+    num_experts = 64
+    pack, weights, config, _ = _make_case(variant, local_experts=num_experts)
+    generator = torch.Generator(device="cuda").manual_seed(20260719)
+    logits = torch.randn(
+        TOKENS,
+        num_experts,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    bias = torch.randn(
+        num_experts,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    n_group, topk_group, routed_scale = 8, 4, 2.5
+    topk_ids, topk_weights = _deepseek_v3_route(
+        logits,
+        bias,
+        top_k=TOP_K,
+        n_group=n_group,
+        topk_group=topk_group,
+        scale=routed_scale,
+    )
+    config = dataclasses.replace(
+        config,
+        routing=RoutingConfig(
+            num_experts=num_experts,
+            top_k=TOP_K,
+            method=RoutingMethodType.DeepSeekV3,
+            n_group=n_group,
+            topk_group=topk_group,
+            routed_scaling_factor=routed_scale,
+        ),
+    )
+    prerouted = MoEActivationPack(
+        hidden_states_q=pack.hidden_states_q,
+        hidden_states_scale=pack.hidden_states_scale,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+    )
+    from_logits = MoEActivationPack(
+        hidden_states_q=pack.hidden_states_q,
+        hidden_states_scale=pack.hidden_states_scale,
+        routing_input_mode=RoutingInputMode.FromLogits,
+        routing_logits=logits,
+        routing_bias=bias,
+    )
+    layer = MoELayer(config)
+    expected = layer(prerouted, weights).clone()
+    actual = _run_from_logits_with_replay(layer, from_logits, weights, topk_ids)
     _assert_fp8_close(actual, expected)
 
 

--- a/tests/moe/test_unified_moe_fp8.py
+++ b/tests/moe/test_unified_moe_fp8.py
@@ -28,19 +28,16 @@ from flashinfer.quantization.fp8_quantization import (
     mxfp8_dequantize_host,
     mxfp8_quantize,
 )
-from flashinfer.utils import get_compute_capability
+from flashinfer.utils import is_sm100a_supported
 from tests.moe.trtllm_gen_fused_moe_utils import check_accuracy
 
 
 def _is_trtllm_fp8_arch() -> bool:
-    if not torch.cuda.is_available():
-        return False
-    major, minor = get_compute_capability(torch.device("cuda"))
-    return major * 10 + minor in (100, 103, 120, 121)
+    return torch.cuda.is_available() and is_sm100a_supported(torch.device("cuda"))
 
 
 pytestmark = pytest.mark.skipif(
-    not _is_trtllm_fp8_arch(), reason="TRTLLM block-FP8 MoE requires SM100/103/120/121"
+    not _is_trtllm_fp8_arch(), reason="TRTLLM block-FP8 MoE requires SM100/103"
 )
 
 HIDDEN = 256

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -239,16 +239,7 @@ _DETERMINISTIC = {
 # "unexpectedly passed -> remove this entry" signal. A crash is never tolerated (only wrong answers).
 _KNOWN_FAILURES = [
     # Entries: (backend_key, predicate(cfg), "reason; gh #NNNN").
-    # This routing stage is shared by DeepSeekFp8 and MxFp8; the all-zero
-    # output reproduces with both variants, so the predicate is intentionally
-    # backend-wide rather than variant-specific.
-    (
-        "trtllm_fp8_block",
-        lambda cfg: cfg.is_fromlogits
-        and cfg.routing_method == RoutingMethodType.DeepSeekV3,
-        "block-FP8 DeepSeekV3 FromLogits can emit all-zero output; "
-        "tracked as a follow-up to gh #4026",
-    ),
+    # Empty since the gh #3547 EP-offset double-subtraction fix.
 ]
 
 

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -466,17 +466,17 @@ def _block_fp8_reference(
         x_q, x_sf = TrtllmFp8BlockConfig.prepare_activations(x, variant=variant)
     else:
         x_q, x_sf = _mxfp8_quant_matrix(x)
-    view = TrtllmFp8BlockConfig.prepare_weights(
-        w1,
-        w2,
-        variant=variant,
-        num_local_experts=w1.shape[0],
-        hidden_size=x.shape[1],
-        intermediate_size=intermediate_size,
-        device=x.device,
-    )
     x32 = _block_fp8_dequant(x_q, x_sf, variant)
     if variant is QuantVariant.DeepSeekFp8:
+        view = TrtllmFp8BlockConfig.prepare_weights(
+            w1,
+            w2,
+            variant=variant,
+            num_local_experts=w1.shape[0],
+            hidden_size=x.shape[1],
+            intermediate_size=intermediate_size,
+            device=x.device,
+        )
         w1_32 = _block_fp8_dequant(
             view["gemm1_weights"], view["gemm1_weights_scale"], variant
         )

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -190,6 +190,7 @@ from flashinfer.fused_moe.api import (
     RoutingConfig,
     TrtllmBf16Config,
     TrtllmFp4Config,
+    TrtllmFp8BlockConfig,
 )
 from flashinfer.fused_moe.layer import _BACKEND_RUNNERS
 from flashinfer.quantization import e2m1_and_ufp8sf_scale_to_float
@@ -228,6 +229,7 @@ _DETERMINISTIC = {
     "trtllm_fp4_routed": True,  # bitwise-stable across reruns in calibration
     "cute_dsl_nvfp4": False,  # atomic scatter-add finalize -> non-bit-exact by design
     "trtllm_bf16_routed": True,  # same trtllm-gen finalize path as fp4_routed; bitwise-stable in calibration
+    "trtllm_fp8_block": True,
 }
 
 # Known-bug ledger: (backend_key, predicate(cfg)) -> reason. A matching (backend, config) is run but
@@ -401,6 +403,113 @@ def _bf16_reference(
     return out
 
 
+def _block_fp8_dequant(x_q, scale, variant):
+    if variant is QuantVariant.DeepSeekFp8:
+        if x_q.dim() == 2:
+            expanded = scale.transpose(0, 1).repeat_interleave(128, dim=-1)
+        else:
+            expanded = scale.repeat_interleave(128, dim=-2).repeat_interleave(
+                128, dim=-1
+            )
+        return x_q.float() * expanded
+    scale_f32 = torch.pow(2.0, scale.to(torch.uint8).float() - 127.0)
+    return x_q.float() * scale_f32.repeat_interleave(32, dim=-1)
+
+
+def _block_fp8_act_pack(x, selected_experts, final_scales, *, variant):
+    q, sf = TrtllmFp8BlockConfig.prepare_activations(x, variant=variant)
+    return MoEActivationPack(
+        hidden_states_q=q,
+        hidden_states_scale=sf,
+        routing_input_mode=RoutingInputMode.PackedPrecomputed,
+        topk_ids=selected_experts,
+        topk_weights=final_scales,
+    )
+
+
+def _block_fp8_snap(t: torch.Tensor) -> torch.Tensor:
+    """Keep FP8 fuzz inputs in a realistic MoE numerical range."""
+    scale = 0.02 if t.dim() == 3 else 0.25
+    return (t * scale).to(torch.bfloat16)
+
+
+def _block_fp8_act_pack_logits(x, routing_logits, routing_bias, *, variant):
+    q, sf = TrtllmFp8BlockConfig.prepare_activations(x, variant=variant)
+    return MoEActivationPack(
+        hidden_states_q=q,
+        hidden_states_scale=sf,
+        routing_input_mode=RoutingInputMode.FromLogits,
+        routing_logits=routing_logits,
+        routing_bias=routing_bias,
+    )
+
+
+def _block_fp8_reference(
+    x,
+    w1,
+    w2,
+    selected_experts,
+    final_scales,
+    intermediate_size,
+    expert_offset=0,
+    *,
+    variant,
+):
+    x_q, x_sf = TrtllmFp8BlockConfig.prepare_activations(x, variant=variant)
+    view = TrtllmFp8BlockConfig.prepare_weights(
+        w1,
+        w2,
+        variant=variant,
+        num_local_experts=w1.shape[0],
+        hidden_size=x.shape[1],
+        intermediate_size=intermediate_size,
+        device=x.device,
+    )
+    x32 = _block_fp8_dequant(x_q, x_sf, variant)
+    if variant is QuantVariant.DeepSeekFp8:
+        w1_32 = _block_fp8_dequant(
+            view["gemm1_weights"], view["gemm1_weights_scale"], variant
+        )
+        w2_32 = _block_fp8_dequant(
+            view["gemm2_weights"], view["gemm2_weights_scale"], variant
+        )
+    else:
+        w1_32 = torch.stack(
+            [
+                _block_fp8_dequant(q, sf, variant)
+                for q, sf in (
+                    TrtllmFp8BlockConfig.prepare_activations(expert, variant=variant)
+                    for expert in w1
+                )
+            ]
+        )
+        w2_32 = torch.stack(
+            [
+                _block_fp8_dequant(q, sf, variant)
+                for q, sf in (
+                    TrtllmFp8BlockConfig.prepare_activations(expert, variant=variant)
+                    for expert in w2
+                )
+            ]
+        )
+    final_scales = final_scales.to(torch.bfloat16).float()
+    out = torch.zeros_like(x32)
+    for local_e in range(w1.shape[0]):
+        token, slot = torch.where(selected_experts == local_e + expert_offset)
+        if token.numel() == 0:
+            continue
+        up = x32[token] @ w1_32[local_e, :intermediate_size].t()
+        gate = x32[token] @ w1_32[local_e, intermediate_size:].t()
+        inter = F.silu(gate) * up
+        inter_q, inter_sf = TrtllmFp8BlockConfig.prepare_activations(
+            inter.to(torch.bfloat16), variant=variant
+        )
+        inter = _block_fp8_dequant(inter_q, inter_sf, variant)
+        expert_out = inter @ w2_32[local_e].t()
+        out[token] += final_scales[token, slot, None] * expert_out
+    return out
+
+
 _DTYPE = {
     QuantVariant.NVFP4: DTypeHandler(
         variant=QuantVariant.NVFP4,
@@ -426,15 +535,55 @@ _DTYPE = {
         atol_frac=0.05,  # initial; calibrate on SM100 (bf16 rounding floor)
         rtol=0.05,
     ),
-    # FP8 / MXFP4 / MXINT4 add one entry each as their runners are wired upstream.
+    QuantVariant.DeepSeekFp8: DTypeHandler(
+        variant=QuantVariant.DeepSeekFp8,
+        candidate_configs=(TrtllmFp8BlockConfig,),
+        snap=_block_fp8_snap,
+        make_act_pack=lambda x, ids, weights: _block_fp8_act_pack(
+            x, ids, weights, variant=QuantVariant.DeepSeekFp8
+        ),
+        make_act_pack_logits=lambda x, logits, bias: _block_fp8_act_pack_logits(
+            x, logits, bias, variant=QuantVariant.DeepSeekFp8
+        ),
+        reference=lambda *args: _block_fp8_reference(
+            *args, variant=QuantVariant.DeepSeekFp8
+        ),
+        poison=_poison_bf16_out,
+        out_dtype=torch.bfloat16,
+        atol_frac=0.15,
+        rtol=0.85,
+    ),
+    QuantVariant.MxFp8: DTypeHandler(
+        variant=QuantVariant.MxFp8,
+        candidate_configs=(TrtllmFp8BlockConfig,),
+        snap=_block_fp8_snap,
+        make_act_pack=lambda x, ids, weights: _block_fp8_act_pack(
+            x, ids, weights, variant=QuantVariant.MxFp8
+        ),
+        make_act_pack_logits=lambda x, logits, bias: _block_fp8_act_pack_logits(
+            x, logits, bias, variant=QuantVariant.MxFp8
+        ),
+        reference=lambda *args: _block_fp8_reference(*args, variant=QuantVariant.MxFp8),
+        poison=_poison_bf16_out,
+        out_dtype=torch.bfloat16,
+        atol_frac=0.15,
+        rtol=0.85,
+    ),
+    # MXFP4 / MXINT4 add one entry each as their runners are wired upstream.
 }
 
 # Cfg.variant string <-> handler lookup (labels stay lowercase enum names).
 _VARIANT_IDS = tuple(v.name.lower() for v in _DTYPE)
+_HANDLER_BY_ID = {variant.name.lower(): handler for variant, handler in _DTYPE.items()}
+_FROMLOGITS_VARIANT_IDS = tuple(
+    variant.name.lower()
+    for variant, handler in _DTYPE.items()
+    if handler.make_act_pack_logits is not None
+)
 
 
 def _handler_for(cfg):
-    return _DTYPE[QuantVariant[cfg.variant.upper()]]
+    return _HANDLER_BY_ID[cfg.variant]
 
 
 # ---------------------------------------------------------------------------
@@ -616,9 +765,10 @@ def _gen(seed):
         intermediate=i,
         num_experts=ne,
         top_k=top_k,
-        # BF16 is pre-routed-only today; FromLogits currently requires the
-        # TRTLLM FP4 runner.
-        variant="nvfp4" if fromlogits else rng.choice(_VARIANT_IDS),
+        # FromLogits can use only variants with an in-kernel-routing runner.
+        variant=rng.choice(_FROMLOGITS_VARIANT_IDS)
+        if fromlogits
+        else rng.choice(_VARIANT_IDS),
         route=rng.choice(_ROUTE),
         seed=seed,
         local_experts=local,
@@ -711,6 +861,43 @@ _CURATED = [
     Cfg(
         2048, 1024, 1024, 128, 6, "bf16", "imbalanced", 900_010
     ),  # bf16 mid size + empty-expert load
+    Cfg(
+        16,
+        7168,
+        2048,
+        256,
+        2,
+        "deepseekfp8",
+        "uniform",
+        900_011,
+        local_experts=2,
+    ),  # DeepSeek-V3 dimensions with a two-expert local shard
+    Cfg(
+        256,
+        1024,
+        512,
+        32,
+        4,
+        "deepseekfp8",
+        "uniform",
+        900_012,
+        routing_method=RoutingMethodType.Default,
+        routing_input_mode="fromlogits",
+        logits_dtype="fp32",
+    ),
+    Cfg(256, 2048, 1024, 16, 4, "mxfp8", "imbalanced", 900_013),
+    Cfg(
+        256,
+        1024,
+        512,
+        32,
+        4,
+        "mxfp8",
+        "uniform",
+        900_014,
+        routing_method=RoutingMethodType.Default,
+        routing_input_mode="fromlogits",
+    ),
 ]
 if _ONLY_SEEDS:  # perfect-repro: run only the named seed(s)
     _curated_by_seed = {c.seed: c for c in _CURATED}
@@ -993,15 +1180,20 @@ def test_unified_moe_fuzz(cfg):
         act_pack = handler.make_act_pack(x, selected_experts, final_scales)
     weight_pack = MoEWeightPack()
     for BackendCfg in wired_backends:
+        prepare_kwargs = dict(
+            num_local_experts=cfg.n_local,
+            hidden_size=cfg.hidden,
+            intermediate_size=cfg.intermediate,
+            device=dev,
+        )
+        if BackendCfg is TrtllmFp8BlockConfig:
+            prepare_kwargs["variant"] = handler.variant
         weight_pack.prepare_for(
             _BACKEND_RUNNERS[BackendCfg].backend_key,
             BackendCfg.prepare_weights(
                 w1,
                 w2,
-                num_local_experts=cfg.n_local,
-                hidden_size=cfg.hidden,
-                intermediate_size=cfg.intermediate,
-                device=dev,
+                **prepare_kwargs,
             ),
         )
 
@@ -1202,9 +1394,15 @@ _CACHE_TOKEN_SEQ = [
     256,
     16,
 ]  # buckets + boundaries + cache-hit re-runs
+_CACHE_VARIANTS = (
+    QuantVariant.NVFP4,
+    QuantVariant.BF16,
+)  # The 21-tactic block-FP8 runners make this multi-bucket stress sweep prohibitive.
 
 
-@pytest.mark.parametrize("variant", list(_DTYPE), ids=[v.name.lower() for v in _DTYPE])
+@pytest.mark.parametrize(
+    "variant", _CACHE_VARIANTS, ids=[v.name.lower() for v in _CACHE_VARIANTS]
+)
 @pytest.mark.parametrize(
     "base", _CACHE_BASES, ids=[f"e{e}h{h}i{i}" for e, h, i in _CACHE_BASES]
 )
@@ -1245,15 +1443,20 @@ def test_autotune_cache_coherence(base, variant):
     w1, w2 = sparse(E, 2 * I, H), sparse(E, H, I)
     weight_pack = MoEWeightPack()
     for B in wired:
+        prepare_kwargs = dict(
+            num_local_experts=E,
+            hidden_size=H,
+            intermediate_size=I,
+            device=dev,
+        )
+        if B is TrtllmFp8BlockConfig:
+            prepare_kwargs["variant"] = variant
         weight_pack.prepare_for(
             _BACKEND_RUNNERS[B].backend_key,
             B.prepare_weights(
                 w1,
                 w2,
-                num_local_experts=E,
-                hidden_size=H,
-                intermediate_size=I,
-                device=dev,
+                **prepare_kwargs,
             ),
         )
     layer = MoELayer(

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -910,10 +910,10 @@ _CURATED = [
         4,
         "mxfp8",
         "uniform",
-        900_014,
+        900_016,
         routing_method=RoutingMethodType.Default,
         routing_input_mode="fromlogits",
-    ),
+    ),  # seed % 4 == 0 deliberately exercises production autotuning for MXFP8
 ]
 if _ONLY_SEEDS:  # perfect-repro: run only the named seed(s)
     _curated_by_seed = {c.seed: c for c in _CURATED}
@@ -1202,6 +1202,8 @@ def test_unified_moe_fuzz(cfg):
             intermediate_size=cfg.intermediate,
             device=dev,
         )
+        # TrtllmFp8BlockConfig is shared by DeepSeekFp8 and MxFp8, so pass the
+        # handler's variant explicitly to select the native scale/layout format.
         if BackendCfg is TrtllmFp8BlockConfig:
             prepare_kwargs["variant"] = handler.variant
         weight_pack.prepare_for(
@@ -1465,6 +1467,8 @@ def test_autotune_cache_coherence(base, variant):
             intermediate_size=I,
             device=dev,
         )
+        # TrtllmFp8BlockConfig is shared by DeepSeekFp8 and MxFp8, so pass the
+        # handler's variant explicitly to select the native scale/layout format.
         if B is TrtllmFp8BlockConfig:
             prepare_kwargs["variant"] = variant
         weight_pack.prepare_for(

--- a/tests/moe/test_unified_moe_fuzz.py
+++ b/tests/moe/test_unified_moe_fuzz.py
@@ -194,6 +194,7 @@ from flashinfer.fused_moe.api import (
 )
 from flashinfer.fused_moe.layer import _BACKEND_RUNNERS
 from flashinfer.quantization import e2m1_and_ufp8sf_scale_to_float
+from flashinfer.quantization.fp8_quantization import mxfp8_quantize
 from flashinfer.tllm_enums import RoutingMethodType
 from flashinfer.utils import get_compute_capability
 
@@ -238,7 +239,16 @@ _DETERMINISTIC = {
 # "unexpectedly passed -> remove this entry" signal. A crash is never tolerated (only wrong answers).
 _KNOWN_FAILURES = [
     # Entries: (backend_key, predicate(cfg), "reason; gh #NNNN").
-    # Empty since the gh #3547 EP-offset double-subtraction fix.
+    # This routing stage is shared by DeepSeekFp8 and MxFp8; the all-zero
+    # output reproduces with both variants, so the predicate is intentionally
+    # backend-wide rather than variant-specific.
+    (
+        "trtllm_fp8_block",
+        lambda cfg: cfg.is_fromlogits
+        and cfg.routing_method == RoutingMethodType.DeepSeekV3,
+        "block-FP8 DeepSeekV3 FromLogits can emit all-zero output; "
+        "tracked as a follow-up to gh #4026",
+    ),
 ]
 
 
@@ -416,6 +426,12 @@ def _block_fp8_dequant(x_q, scale, variant):
     return x_q.float() * scale_f32.repeat_interleave(32, dim=-1)
 
 
+def _mxfp8_quant_matrix(x):
+    """Quantize a logical matrix without applying the MoE weight shuffle."""
+    q, scale = mxfp8_quantize(x, is_sf_swizzled_layout=False)
+    return q, scale.view(torch.uint8).reshape(x.shape[0], x.shape[1] // 32)
+
+
 def _block_fp8_act_pack(x, selected_experts, final_scales, *, variant):
     q, sf = TrtllmFp8BlockConfig.prepare_activations(x, variant=variant)
     return MoEActivationPack(
@@ -455,7 +471,10 @@ def _block_fp8_reference(
     *,
     variant,
 ):
-    x_q, x_sf = TrtllmFp8BlockConfig.prepare_activations(x, variant=variant)
+    if variant is QuantVariant.DeepSeekFp8:
+        x_q, x_sf = TrtllmFp8BlockConfig.prepare_activations(x, variant=variant)
+    else:
+        x_q, x_sf = _mxfp8_quant_matrix(x)
     view = TrtllmFp8BlockConfig.prepare_weights(
         w1,
         w2,
@@ -477,19 +496,13 @@ def _block_fp8_reference(
         w1_32 = torch.stack(
             [
                 _block_fp8_dequant(q, sf, variant)
-                for q, sf in (
-                    TrtllmFp8BlockConfig.prepare_activations(expert, variant=variant)
-                    for expert in w1
-                )
+                for q, sf in (_mxfp8_quant_matrix(expert) for expert in w1)
             ]
         )
         w2_32 = torch.stack(
             [
                 _block_fp8_dequant(q, sf, variant)
-                for q, sf in (
-                    TrtllmFp8BlockConfig.prepare_activations(expert, variant=variant)
-                    for expert in w2
-                )
+                for q, sf in (_mxfp8_quant_matrix(expert) for expert in w2)
             ]
         )
     final_scales = final_scales.to(torch.bfloat16).float()
@@ -501,9 +514,12 @@ def _block_fp8_reference(
         up = x32[token] @ w1_32[local_e, :intermediate_size].t()
         gate = x32[token] @ w1_32[local_e, intermediate_size:].t()
         inter = F.silu(gate) * up
-        inter_q, inter_sf = TrtllmFp8BlockConfig.prepare_activations(
-            inter.to(torch.bfloat16), variant=variant
-        )
+        if variant is QuantVariant.DeepSeekFp8:
+            inter_q, inter_sf = TrtllmFp8BlockConfig.prepare_activations(
+                inter.to(torch.bfloat16), variant=variant
+            )
+        else:
+            inter_q, inter_sf = _mxfp8_quant_matrix(inter.to(torch.bfloat16))
         inter = _block_fp8_dequant(inter_q, inter_sf, variant)
         expert_out = inter @ w2_32[local_e].t()
         out[token] += final_scales[token, slot, None] * expert_out
@@ -550,8 +566,8 @@ _DTYPE = {
         ),
         poison=_poison_bf16_out,
         out_dtype=torch.bfloat16,
-        atol_frac=0.15,
-        rtol=0.85,
+        atol_frac=0.15,  # provisional; recalibrate over the expanded SM100 sweep
+        rtol=0.85,  # legacy-aligned initial bound, not a settled regression bar
     ),
     QuantVariant.MxFp8: DTypeHandler(
         variant=QuantVariant.MxFp8,
@@ -566,8 +582,8 @@ _DTYPE = {
         reference=lambda *args: _block_fp8_reference(*args, variant=QuantVariant.MxFp8),
         poison=_poison_bf16_out,
         out_dtype=torch.bfloat16,
-        atol_frac=0.15,
-        rtol=0.85,
+        atol_frac=0.15,  # provisional; recalibrate over the expanded SM100 sweep
+        rtol=0.85,  # legacy-aligned initial bound, not a settled regression bar
     ),
     # MXFP4 / MXINT4 add one entry each as their runners are wired upstream.
 }

--- a/tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py
+++ b/tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py
@@ -173,8 +173,8 @@ def test_split_bf16_kernel_matches_torch_reference():
     act = MoEActivationPack(
         hidden_states_q=x,
         hidden_states_scale=torch.empty(0, device=x.device),
-        selected_experts=topk_ids.to(torch.int32),
-        final_scales=topk_weights.to(torch.float32),
+        topk_ids=topk_ids.to(torch.int32),
+        topk_weights=topk_weights.to(torch.float32),
     )
     y_kernel = MoELayer(cfg)(act, wp)
     torch.cuda.synchronize()
@@ -227,8 +227,8 @@ def test_split_nvfp4_kernel_matches_torch_reference():
     act = MoEActivationPack(
         hidden_states_q=x_q,
         hidden_states_scale=x_sf,
-        selected_experts=topk_ids.to(torch.int32),
-        final_scales=topk_weights.to(torch.float32),
+        topk_ids=topk_ids.to(torch.int32),
+        topk_weights=topk_weights.to(torch.float32),
     )
     y_kernel = MoELayer(cfg)(act, wp)
     torch.cuda.synchronize()


### PR DESCRIPTION
## 📌 Description

Adds first-class DeepSeek FP8 and MXFP8 block-scale execution through the unified `MoELayer` API. These formats previously existed in the configuration schema and legacy flat APIs, but were not executable through `MoELayer`.

Fixed one issue in `tests/moe_ep/test_split_fused_moe_kernel_vs_reference.py`.

### What changed

- Added `TrtllmFp8BlockRunner` to the unified `MoELayer` API with:
  - DeepSeek FP8 and MXFP8 block-scale execution
  - Precomputed and in-kernel routing
  - Local expert offsets, autotuning, and CUDA graphs
- Added format-aware weight and activation preparation:
  - DeepSeek FP8: FP32 128-element/128x128 block scales
  - MXFP8: UE8M0 32-element scales with shuffled MajorK weights
- Fixed DeepSeek FP8 to preserve caller-provided activation scales.
- Restricted unified block-FP8 support to the validated SM100 family (SM100 and SM103).
- Added independent-reference, routing-replay, CUDA graph, and unified-fuzzer coverage.

## 🔍 Scope and follow-up

Unified FP8 support is split into two PRs because block-scale and per-tensor FP8 have distinct scaling and execution contracts. This PR covers block-scale FP8.

### Follow-up work for per-tensor FP8

- Add `TrtllmFp8PerTensorRunner`
- Add per-tensor weight and scalar-scale preparation
- Register `QuantVariant.FP8PerTensor` with `MoELayer`
- Initially support `FromLogits`, matching the legacy API
- Add independent conformance, CUDA-graph, tactic, fuzzer, and model-profile coverage

### Additional future work

- FP8 expert-parallel integration
- `do_finalize=False`
- Routing replay
- LoRA and fused shared experts
- OA parameters
- Non-SwiGLU activations

Existing legacy tests remain under the Mirror → Bridge → Prune policy. The legacy flat APIs are unchanged. The unified runner delegates to the existing TRTLLM `MoERunner` and kernel entry points.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

Validated on SM100:
- `11 passed` — unified block-FP8 conformance suite
- `19 passed` — unified API validation subset
- `2 passed` — curated DeepSeek FP8 and MXFP8 fuzzer cases with production autotuning
- `1 passed` — existing FP4 `FromLogits` fuzzer confirmation on SM100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified TRT-LLM block-FP8 MoE support for **DeepSeek FP8** and **MXFP8**.
  * Added variant-aware block-FP8 weight/activation preparation and a new public **block-FP8 runner**.
  * Enabled both pre-routed and **logits-based** routing (including expert offsets), with CUDA graph capture/replay support.
* **Bug Fixes**
  * Tightened block-FP8 backend SM support to explicitly allowed targets.
  * Corrected FP8 block activation/scale handling for accurate kernel dispatch.
* **Tests**
  * Expanded block-FP8 conformance and fuzz coverage; updated backend support/validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->