### PR TITLE
gemm: avoid unsafe TinyGEMM shapes on SM103

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -118,6 +118,30 @@ from ..utils import (
 )
 
 DEFAULT_WORKSPACE_SIZE = 32 * 1024 * 1024
+_SM103_TINYGEMM_MAX_PROJECTION_ELEMENTS = 32 * 1024 * 1024
+
+
+def _is_sm103_tinygemm_unsafe_shape(
+    compute_capability: Tuple[int, int], n: int, k: int
+) -> bool:
+    """Return whether TinyGEMM is unsafe for an SM103 projection shape.
+
+    TinyGEMM can hang indefinitely on B300A/SM103 for large BF16 projection
+    shapes. Keep the workaround scoped to the affected architecture and
+    disable it only once the N*K projection size reaches the smallest
+    reported failure threshold. See flashinfer-ai/flashinfer#3848.
+    """
+    return (
+        compute_capability == (10, 3)
+        and n * k >= _SM103_TINYGEMM_MAX_PROJECTION_ELEMENTS
+    )
+
+
+def _is_sm103_tinygemm_unsafe(a: torch.Tensor, b: torch.Tensor) -> bool:
+    return _is_sm103_tinygemm_unsafe_shape(
+        get_compute_capability(a.device), b.shape[1], a.shape[1]
+    )
+
 
 # sizeof(cublasLtMatmulAlgo_t) = uint64_t[8] = 64 bytes.
 # Shared by cuBLAS FP8, cuBLASLt BF16, and any other cuBLASLt-based runners.
@@ -445,6 +469,11 @@ def _tinygemm_mm_bf16_requirement(
         raise ValueError("The TinyGEMM backend requires a contiguous output tensor.")
     if bias is not None and not bias.is_contiguous():
         raise ValueError("The TinyGEMM backend requires a contiguous bias tensor.")
+    if _is_sm103_tinygemm_unsafe(a, b):
+        raise ValueError(
+            "The TinyGEMM backend is disabled for this large BF16 projection on SM103 "
+            "to avoid a known kernel hang; see flashinfer-ai/flashinfer#3848."
+        )
     return True
 
 
@@ -519,7 +548,11 @@ def _heuristic_func_mm_bf16(
         if "cublaslt" in suitable_backends:
             heuristic_backends.append("cublaslt")
 
-    if "tinygemm" in suitable_backends and out_dtype == torch.bfloat16:
+    if (
+        "tinygemm" in suitable_backends
+        and out_dtype == torch.bfloat16
+        and not _is_sm103_tinygemm_unsafe(a, b)
+    ):
         heuristic_backends.append("tinygemm")
 
     return heuristic_backends

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -60,13 +60,14 @@ from .kernels.utils import (
     _select_sm100_mm_fp4_cute_dsl_tactic,
 )
 from ..utils import (
+    LibraryError,
+    backend_requirement,
     get_device_sm_count,
     get_native_fp4_dtype,
     is_sm100a_supported,
     is_sm100f_supported,
+    is_sm103_tinygemm_unsafe,
     is_sm12x_supported,
-    LibraryError,
-    backend_requirement,
     supported_compute_capability,
 )
 from ..jit.gemm import gen_gemm_sm90_module
@@ -118,29 +119,6 @@ from ..utils import (
 )
 
 DEFAULT_WORKSPACE_SIZE = 32 * 1024 * 1024
-_SM103_TINYGEMM_MAX_PROJECTION_ELEMENTS = 32 * 1024 * 1024
-
-
-def _is_sm103_tinygemm_unsafe_shape(
-    compute_capability: Tuple[int, int], n: int, k: int
-) -> bool:
-    """Return whether TinyGEMM is unsafe for an SM103 projection shape.
-
-    TinyGEMM can hang indefinitely on B300A/SM103 for large BF16 projection
-    shapes. Keep the workaround scoped to the affected architecture and
-    disable it only once the N*K projection size reaches the smallest
-    reported failure threshold. See flashinfer-ai/flashinfer#3848.
-    """
-    return (
-        compute_capability == (10, 3)
-        and n * k >= _SM103_TINYGEMM_MAX_PROJECTION_ELEMENTS
-    )
-
-
-def _is_sm103_tinygemm_unsafe(a: torch.Tensor, b: torch.Tensor) -> bool:
-    return _is_sm103_tinygemm_unsafe_shape(
-        get_compute_capability(a.device), b.shape[1], a.shape[1]
-    )
 
 
 # sizeof(cublasLtMatmulAlgo_t) = uint64_t[8] = 64 bytes.
@@ -448,6 +426,7 @@ def _tinygemm_mm_bf16_requirement(
     pdl: bool = False,
     backend: Literal["cudnn", "cutlass", "tgv", "tinygemm", "auto"] = "cudnn",
 ):
+    """Validate BF16 TinyGEMM layout, dtype, and SM103 safety requirements."""
     if out_dtype != torch.bfloat16:
         raise ValueError("The TinyGEMM backend only supports bfloat16 output.")
     if a.dim() != 2:
@@ -469,7 +448,7 @@ def _tinygemm_mm_bf16_requirement(
         raise ValueError("The TinyGEMM backend requires a contiguous output tensor.")
     if bias is not None and not bias.is_contiguous():
         raise ValueError("The TinyGEMM backend requires a contiguous bias tensor.")
-    if _is_sm103_tinygemm_unsafe(a, b):
+    if is_sm103_tinygemm_unsafe(a, b):
         raise ValueError(
             "The TinyGEMM backend is disabled for this large BF16 projection on SM103 "
             "to avoid a known kernel hang; see flashinfer-ai/flashinfer#3848."
@@ -531,6 +510,7 @@ def _heuristic_func_mm_bf16(
         "cudnn", "cutlass", "tgv", "cublaslt", "tinygemm", "auto"
     ] = "cudnn",
 ):
+    """Order valid BF16 GEMM backends for automatic selection."""
     heuristic_backends = []
     if bias is not None or pdl:
         # CUTLASS and cuBLASLt doesn't support bias/pdl, only TGV and cuDNN do
@@ -548,11 +528,7 @@ def _heuristic_func_mm_bf16(
         if "cublaslt" in suitable_backends:
             heuristic_backends.append("cublaslt")
 
-    if (
-        "tinygemm" in suitable_backends
-        and out_dtype == torch.bfloat16
-        and not _is_sm103_tinygemm_unsafe(a, b)
-    ):
+    if "tinygemm" in suitable_backends and out_dtype == torch.bfloat16:
         heuristic_backends.append("tinygemm")
 
     return heuristic_backends

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -10,9 +10,11 @@ from types import SimpleNamespace
 from typing import Optional
 import torch
 from flashinfer.utils import (
+    backend_requirement,
+    get_compute_capability,
+    is_sm103_tinygemm_unsafe_shape,
     register_custom_op,
     supported_compute_capability,
-    backend_requirement,
 )
 
 
@@ -310,6 +312,7 @@ def mm_M1_16_K6144_N256(
 
 @supported_compute_capability([90, 100, 103, 110, 120, 121])
 def _tinygemm_bf16_shape_checks(input, weight, out, bias, use_pdl):
+    """Validate public TinyGEMM tensor layout, dtype, and SM103 safety."""
     if input.dim() != 2:
         raise ValueError("input must be a 2D tensor")
     if weight.dim() != 2:
@@ -337,6 +340,13 @@ def _tinygemm_bf16_shape_checks(input, weight, out, bias, use_pdl):
             f"out.shape[1] ({out.shape[1]}) must equal weight.shape[0] ({weight.shape[0]})"
         )
     output_features = weight.shape[0]
+    if is_sm103_tinygemm_unsafe_shape(
+        get_compute_capability(input.device), output_features, weight.shape[1]
+    ):
+        raise ValueError(
+            "The TinyGEMM backend is disabled for this large BF16 projection on SM103 "
+            "to avoid a known kernel hang; see flashinfer-ai/flashinfer#3848."
+        )
 
     if output_features % 16 != 0:
         raise ValueError(

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -73,6 +73,32 @@ class BackendSupportedError(Exception):
     pass
 
 
+_SM103_TINYGEMM_MAX_PROJECTION_ELEMENTS = 32 * 1024 * 1024
+
+
+def is_sm103_tinygemm_unsafe_shape(
+    compute_capability: Tuple[int, int], n: int, k: int
+) -> bool:
+    """Return whether TinyGEMM is unsafe for an SM103 projection shape.
+
+    TinyGEMM can hang indefinitely on B300A/SM103 for large BF16 projection
+    shapes. Keep the workaround scoped to the affected architecture and
+    disable it only once the N*K projection size reaches the smallest
+    reported failure threshold. See flashinfer-ai/flashinfer#3848.
+    """
+    return (
+        compute_capability == (10, 3)
+        and n * k >= _SM103_TINYGEMM_MAX_PROJECTION_ELEMENTS
+    )
+
+
+def is_sm103_tinygemm_unsafe(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Return whether a GEMM's BF16 TinyGEMM projection is unsafe on SM103."""
+    return is_sm103_tinygemm_unsafe_shape(
+        get_compute_capability(a.device), b.shape[1], a.shape[1]
+    )
+
+
 def _expand_5d(x: torch.Tensor, kv_layout: str) -> torch.Tensor:
     if x.ndim not in [4, 5]:
         raise ValueError("x must be 4D or 5D")

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -3,8 +3,8 @@ import torch
 import torch.nn.functional as F
 
 from flashinfer import autotune, mm_bf16
-from flashinfer.gemm.gemm_base import CUDNN_AVAILABLE
 from flashinfer.gemm import is_cuda_tile_available
+from flashinfer.gemm.gemm_base import CUDNN_AVAILABLE, _is_sm103_tinygemm_unsafe_shape
 from flashinfer.utils import get_compute_capability
 
 
@@ -98,6 +98,28 @@ def test_mm_bf16(
 
     cos_sim = F.cosine_similarity(reference.reshape(-1), out.reshape(-1), dim=0)
     assert cos_sim > 0.99
+
+
+@pytest.mark.parametrize(
+    ("compute_capability", "n", "k", "expected"),
+    [
+        ((10, 3), 7168, 5120, True),
+        ((10, 3), 55296, 5120, True),
+        ((10, 3), 5120, 27648, True),
+        ((10, 3), 4096, 8191, False),
+        ((10, 0), 55296, 5120, False),
+    ],
+)
+def test_sm103_tinygemm_large_projection_guard(
+    compute_capability: tuple[int, int], n: int, k: int, expected: bool
+):
+    assert _is_sm103_tinygemm_unsafe_shape(compute_capability, n, k) is expected
+
+
+def test_sm103_tinygemm_guard_boundary():
+    threshold = 32 * 1024 * 1024
+    assert _is_sm103_tinygemm_unsafe_shape((10, 3), threshold // 5120, 5120) is False
+    assert _is_sm103_tinygemm_unsafe_shape((10, 3), threshold // 5120 + 1, 5120) is True
 
 
 def test_mm_bf16_cutile_rejects_bias_and_pdl():

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -4,8 +4,11 @@ import torch.nn.functional as F
 
 from flashinfer import autotune, mm_bf16
 from flashinfer.gemm import is_cuda_tile_available
-from flashinfer.gemm.gemm_base import CUDNN_AVAILABLE, _is_sm103_tinygemm_unsafe_shape
-from flashinfer.utils import get_compute_capability
+from flashinfer.gemm.gemm_base import CUDNN_AVAILABLE
+from flashinfer.utils import (
+    get_compute_capability,
+    is_sm103_tinygemm_unsafe_shape,
+)
 
 
 @pytest.mark.parametrize("m", [1, 8, 16, 32, 64])
@@ -113,13 +116,15 @@ def test_mm_bf16(
 def test_sm103_tinygemm_large_projection_guard(
     compute_capability: tuple[int, int], n: int, k: int, expected: bool
 ):
-    assert _is_sm103_tinygemm_unsafe_shape(compute_capability, n, k) is expected
+    """Cover reported SM103 hangs and unaffected architectures."""
+    assert is_sm103_tinygemm_unsafe_shape(compute_capability, n, k) is expected
 
 
 def test_sm103_tinygemm_guard_boundary():
+    """Verify the guard changes behavior exactly at its projection threshold."""
     threshold = 32 * 1024 * 1024
-    assert _is_sm103_tinygemm_unsafe_shape((10, 3), threshold // 5120, 5120) is False
-    assert _is_sm103_tinygemm_unsafe_shape((10, 3), threshold // 5120 + 1, 5120) is True
+    assert is_sm103_tinygemm_unsafe_shape((10, 3), threshold // 5120, 5120) is False
+    assert is_sm103_tinygemm_unsafe_shape((10, 3), threshold // 5120 + 1, 5120) is True
 
 
 def test_mm_bf16_cutile_rejects_bias_and_pdl():


### PR DESCRIPTION
## Summary

- guard BF16 TinyGEMM against the large SM103 projection shapes reported in #3848
- reject unsafe explicit `backend="tinygemm"` calls before launching a wedging kernel
- exclude the same shapes from `backend="auto"` candidate selection
- add regression coverage for reported shapes and the threshold boundary

## Testing

- `python3 -m py_compile flashinfer/gemm/gemm_base.py tests/gemm/test_mm_bf16.py`
- `ruff check flashinfer/gemm/gemm_base.py tests/gemm/test_mm_bf16.py`
- `git diff --check`
- pure guard behavior checks passed
- CUDA pytest could not run in this checkout because the sparse worktree omits the JIT package and no CUDA device is available

Closes #3848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an SM103-specific safety guard to prevent selecting the TinyGEMM backend for unsafe BF16 projection shapes.
  * Now raises a clear error to avoid a known hang when the BF16 projection is too large.

* **Tests**
  * Added SM103 TinyGEMM guard tests, including expected-boolean cases and a boundary check around the projection-size threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->