### PR TITLE
perf(msa): chunked top-k and in-kernel causal offsets for the SM12x indexer

### DIFF
--- a/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
@@ -644,6 +644,7 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         paged: bool = False,
         qhead_per_kv: int = _QHEAD_PER_KV,
         pack_q_len: int = _PACK_Q_LEN,
+        qoff_default: bool = False,
     ):
         super().__init__(head_dim=head_dim, is_causal=is_causal, paged=paged)
         if qhead_per_kv * pack_q_len != self._M:
@@ -655,6 +656,10 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         # gather/epilogue, so each factorization compiles to its own kernel.
         self._QHEAD_PER_KV = qhead_per_kv
         self._PACK_Q_LEN = pack_q_len
+        # Right-aligned decode (q_offset=None): the causal offset is
+        # seqlen_k - seqlen_q, computed in-kernel so the wrapper does not
+        # launch tensor-arithmetic kernels to build an offset tensor.
+        self._qoff_default = qoff_default
 
     @cute.jit
     def __call__(
@@ -911,13 +916,15 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
                 thr_vmnk = tiled_mma.thr_layout_vmnk.get_flat_coord(tidx)
                 nwarp = thr_vmnk[2]
                 self.cta_sync_barrier.arrive_and_wait()
+                if cutlass.const_expr(self._qoff_default):
+                    q_off = seqlen_k - seqlen_q
+                else:
+                    q_off = mQOffset[batch_idx]
                 for r in cutlass.range_constexpr(n_rows):
                     row = tScS_mn[r, 0][0]
                     token = row % self._PACK_Q_LEN
                     if cutlass.const_expr(self._is_causal):
-                        col_limit = cutlass.min(
-                            token + mQOffset[batch_idx] + 1, seqlen_k
-                        )
+                        col_limit = cutlass.min(token + q_off + 1, seqlen_k)
                     else:
                         col_limit = seqlen_k
                     for c in cutlass.range_constexpr(cute.size(acc_mn.shape[1])):

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
@@ -656,9 +656,8 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         # gather/epilogue, so each factorization compiles to its own kernel.
         self._QHEAD_PER_KV = qhead_per_kv
         self._PACK_Q_LEN = pack_q_len
-        # Right-aligned decode (q_offset=None): the causal offset is
-        # seqlen_k - seqlen_q, computed in-kernel so the wrapper does not
-        # launch tensor-arithmetic kernels to build an offset tensor.
+        # True: right-aligned decode; the causal offset (seqlen_k - seqlen_q)
+        # is computed in-kernel instead of read from mQOffset.
         self._qoff_default = qoff_default
 
     @cute.jit
@@ -733,6 +732,12 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._N)
         num_qo_heads = mQ.shape[1]
+        q_off = cutlass.Int32(0)
+        if cutlass.const_expr(self._is_causal):
+            if cutlass.const_expr(self._qoff_default):
+                q_off = seqlen_k - seqlen_q
+            else:
+                q_off = mQOffset[batch_idx]
 
         tiled_mma, mma_atom, sfa_layout, sfb_layout = self._build_mma()
         sA_layout = self._ab_layout(self._M)
@@ -916,10 +921,6 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
                 thr_vmnk = tiled_mma.thr_layout_vmnk.get_flat_coord(tidx)
                 nwarp = thr_vmnk[2]
                 self.cta_sync_barrier.arrive_and_wait()
-                if cutlass.const_expr(self._qoff_default):
-                    q_off = seqlen_k - seqlen_q
-                else:
-                    q_off = mQOffset[batch_idx]
                 for r in cutlass.range_constexpr(n_rows):
                     row = tScS_mn[r, 0][0]
                     token = row % self._PACK_Q_LEN

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
@@ -656,8 +656,7 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         # gather/epilogue, so each factorization compiles to its own kernel.
         self._QHEAD_PER_KV = qhead_per_kv
         self._PACK_Q_LEN = pack_q_len
-        # True: right-aligned decode; the causal offset (seqlen_k - seqlen_q)
-        # is computed in-kernel instead of read from mQOffset.
+        # True: right-aligned decode; the causal offset is computed in-kernel.
         self._qoff_default = qoff_default
 
     @cute.jit

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
@@ -663,9 +663,8 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         # gather/epilogue, so each factorization compiles to its own kernel.
         self._QHEAD_PER_KV = qhead_per_kv
         self._PACK_Q_LEN = pack_q_len
-        # Right-aligned decode (q_offset=None): the causal offset is
-        # seqlen_k - seqlen_q, computed in-kernel so the wrapper does not
-        # launch tensor-arithmetic kernels to build an offset tensor.
+        # True: right-aligned decode; the causal offset (seqlen_k - seqlen_q)
+        # is computed in-kernel instead of read from mQOffset.
         self._qoff_default = qoff_default
 
     @cute.jit
@@ -747,6 +746,12 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
             seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._N)
         num_qo_heads = mQ.shape[1]
+        q_off = cutlass.Int32(0)
+        if cutlass.const_expr(self._is_causal):
+            if cutlass.const_expr(self._qoff_default):
+                q_off = seqlen_k - seqlen_q
+            else:
+                q_off = mQOffset[batch_idx]
 
         tiled_mma, mma_atom, sfa_layout, sfb_layout = self._build_mma()
         sA_layout = self._ab_layout(self._M)
@@ -930,10 +935,6 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
                 thr_vmnk = tiled_mma.thr_layout_vmnk.get_flat_coord(tidx)
                 nwarp = thr_vmnk[2]
                 self.cta_sync_barrier.arrive_and_wait()
-                if cutlass.const_expr(self._qoff_default):
-                    q_off = seqlen_k - seqlen_q
-                else:
-                    q_off = mQOffset[batch_idx]
                 for r in cutlass.range_constexpr(n_rows):
                     row = tScS_mn[r, 0][0]
                     token = row % self._PACK_Q_LEN

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
@@ -651,6 +651,7 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         paged: bool = False,
         qhead_per_kv: int = _QHEAD_PER_KV,
         pack_q_len: int = _PACK_Q_LEN,
+        qoff_default: bool = False,
     ):
         super().__init__(head_dim=head_dim, is_causal=is_causal, paged=paged)
         if qhead_per_kv * pack_q_len != self._M:
@@ -662,6 +663,10 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         # gather/epilogue, so each factorization compiles to its own kernel.
         self._QHEAD_PER_KV = qhead_per_kv
         self._PACK_Q_LEN = pack_q_len
+        # Right-aligned decode (q_offset=None): the causal offset is
+        # seqlen_k - seqlen_q, computed in-kernel so the wrapper does not
+        # launch tensor-arithmetic kernels to build an offset tensor.
+        self._qoff_default = qoff_default
 
     @cute.jit
     def __call__(
@@ -925,13 +930,15 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
                 thr_vmnk = tiled_mma.thr_layout_vmnk.get_flat_coord(tidx)
                 nwarp = thr_vmnk[2]
                 self.cta_sync_barrier.arrive_and_wait()
+                if cutlass.const_expr(self._qoff_default):
+                    q_off = seqlen_k - seqlen_q
+                else:
+                    q_off = mQOffset[batch_idx]
                 for r in cutlass.range_constexpr(n_rows):
                     row = tScS_mn[r, 0][0]
                     token = row % self._PACK_Q_LEN
                     if cutlass.const_expr(self._is_causal):
-                        col_limit = cutlass.min(
-                            token + mQOffset[batch_idx] + 1, seqlen_k
-                        )
+                        col_limit = cutlass.min(token + q_off + 1, seqlen_k)
                     else:
                         col_limit = seqlen_k
                     for c in cutlass.range_constexpr(cute.size(acc_mn.shape[1])):

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_fp4_sm12x.py
@@ -663,8 +663,7 @@ class MsaProxyScoreFp4MmaDecodePackedSm12x(MsaProxyScoreFp4MmaSm12x):
         # gather/epilogue, so each factorization compiles to its own kernel.
         self._QHEAD_PER_KV = qhead_per_kv
         self._PACK_Q_LEN = pack_q_len
-        # True: right-aligned decode; the causal offset (seqlen_k - seqlen_q)
-        # is computed in-kernel instead of read from mQOffset.
+        # True: right-aligned decode; the causal offset is computed in-kernel.
         self._qoff_default = qoff_default
 
     @cute.jit

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -474,9 +474,8 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         # factorization compiles to its own kernel.
         self._qhead_per_kv = qhead_per_kv
         self._pack_q_len = pack_q_len
-        # Right-aligned decode (q_offset=None): the causal offset is
-        # seqlen_k - seqlen_q, computed in-kernel so the wrapper does not
-        # launch tensor-arithmetic kernels to build an offset tensor.
+        # True: right-aligned decode; the causal offset (seqlen_k - seqlen_q)
+        # is computed in-kernel instead of read from mQOffset.
         self._qoff_default = qoff_default
 
     @cute.jit
@@ -549,6 +548,12 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         k_start = mCuK[batch_idx]
         seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._n_block_size)
+        q_off = cutlass.Int32(0)
+        if cutlass.const_expr(self._is_causal):
+            if cutlass.const_expr(self._qoff_default):
+                q_off = seqlen_k - seqlen_q
+            else:
+                q_off = mQOffset[batch_idx]
 
         sQ_layout = self._make_sq_layout()
         sK_layout = self._make_sk_layout()
@@ -738,10 +743,6 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
 
                 # A packed row maps to (local_head, token); a packed query's causal
                 # position is its token index (the decode q within this step).
-                if cutlass.const_expr(self._qoff_default):
-                    q_off = seqlen_k - seqlen_q
-                else:
-                    q_off = mQOffset[batch_idx]
                 for r in cutlass.range_constexpr(n_rows):
                     row = tScS_mn[r, 0][0]
                     token = row % self._pack_q_len

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -474,8 +474,7 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         # factorization compiles to its own kernel.
         self._qhead_per_kv = qhead_per_kv
         self._pack_q_len = pack_q_len
-        # True: right-aligned decode; the causal offset (seqlen_k - seqlen_q)
-        # is computed in-kernel instead of read from mQOffset.
+        # True: right-aligned decode; the causal offset is computed in-kernel.
         self._qoff_default = qoff_default
 
     @cute.jit

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -454,6 +454,7 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         kv_fp8: bool = False,
         qhead_per_kv: int = 4,
         pack_q_len: int = 16,
+        qoff_default: bool = False,
     ):
         super().__init__(
             head_dim=head_dim,
@@ -473,6 +474,10 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         # factorization compiles to its own kernel.
         self._qhead_per_kv = qhead_per_kv
         self._pack_q_len = pack_q_len
+        # Right-aligned decode (q_offset=None): the causal offset is
+        # seqlen_k - seqlen_q, computed in-kernel so the wrapper does not
+        # launch tensor-arithmetic kernels to build an offset tensor.
+        self._qoff_default = qoff_default
 
     @cute.jit
     def __call__(
@@ -733,13 +738,15 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
 
                 # A packed row maps to (local_head, token); a packed query's causal
                 # position is its token index (the decode q within this step).
+                if cutlass.const_expr(self._qoff_default):
+                    q_off = seqlen_k - seqlen_q
+                else:
+                    q_off = mQOffset[batch_idx]
                 for r in cutlass.range_constexpr(n_rows):
                     row = tScS_mn[r, 0][0]
                     token = row % self._pack_q_len
                     if cutlass.const_expr(self._is_causal):
-                        col_limit = cutlass.min(
-                            token + mQOffset[batch_idx] + 1, seqlen_k
-                        )
+                        col_limit = cutlass.min(token + q_off + 1, seqlen_k)
                     else:
                         col_limit = seqlen_k
                     for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -531,6 +531,7 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         kv_fp8: bool = False,
         qhead_per_kv: int = 4,
         pack_q_len: int = 16,
+        qoff_default: bool = False,
     ):
         super().__init__(
             head_dim=head_dim,
@@ -550,6 +551,10 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         # factorization compiles to its own kernel.
         self._qhead_per_kv = qhead_per_kv
         self._pack_q_len = pack_q_len
+        # Right-aligned decode (q_offset=None): the causal offset is
+        # seqlen_k - seqlen_q, computed in-kernel so the wrapper does not
+        # launch tensor-arithmetic kernels to build an offset tensor.
+        self._qoff_default = qoff_default
 
     @cute.jit
     def __call__(
@@ -780,13 +785,15 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
 
                 # A packed row maps to (local_head, token); a packed query's causal
                 # position is its token index (the decode q within this step).
+                if cutlass.const_expr(self._qoff_default):
+                    q_off = seqlen_k - seqlen_q
+                else:
+                    q_off = mQOffset[batch_idx]
                 for r in cutlass.range_constexpr(n_rows):
                     row = tScS_mn[r, 0][0]
                     token = row % self._pack_q_len
                     if cutlass.const_expr(self._is_causal):
-                        col_limit = cutlass.min(
-                            token + mQOffset[batch_idx] + 1, seqlen_k
-                        )
+                        col_limit = cutlass.min(token + q_off + 1, seqlen_k)
                     else:
                         col_limit = seqlen_k
                     for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):
@@ -890,6 +897,12 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
             k_start = mCuK[batch_idx]
             seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._n_block_size)
+        q_off = cutlass.Int32(0)
+        if cutlass.const_expr(self._is_causal):
+            if cutlass.const_expr(self._qoff_default):
+                q_off = seqlen_k - seqlen_q
+            else:
+                q_off = mQOffset[batch_idx]
 
         sQ_layout = self._make_sq_layout()
         sK_layout = self._make_sk8_layout()
@@ -1090,9 +1103,7 @@ class MsaProxyScoreDecodePackedFp8Sm12x(MsaProxyScoreDecodePackedSm12x):
                     row = tScS_mn[r, 0][0]
                     token = row % self._pack_q_len
                     if cutlass.const_expr(self._is_causal):
-                        col_limit = cutlass.min(
-                            token + mQOffset[batch_idx] + 1, seqlen_k
-                        )
+                        col_limit = cutlass.min(token + q_off + 1, seqlen_k)
                     else:
                         col_limit = seqlen_k
                     for c in cutlass.range_constexpr(cute.size(tScS_mn.shape[1])):

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -551,8 +551,7 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         # factorization compiles to its own kernel.
         self._qhead_per_kv = qhead_per_kv
         self._pack_q_len = pack_q_len
-        # True: right-aligned decode; the causal offset (seqlen_k - seqlen_q)
-        # is computed in-kernel instead of read from mQOffset.
+        # True: right-aligned decode; the causal offset is computed in-kernel.
         self._qoff_default = qoff_default
 
     @cute.jit

--- a/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/proxy_score_sm12x.py
@@ -551,9 +551,8 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
         # factorization compiles to its own kernel.
         self._qhead_per_kv = qhead_per_kv
         self._pack_q_len = pack_q_len
-        # Right-aligned decode (q_offset=None): the causal offset is
-        # seqlen_k - seqlen_q, computed in-kernel so the wrapper does not
-        # launch tensor-arithmetic kernels to build an offset tensor.
+        # True: right-aligned decode; the causal offset (seqlen_k - seqlen_q)
+        # is computed in-kernel instead of read from mQOffset.
         self._qoff_default = qoff_default
 
     @cute.jit
@@ -633,6 +632,12 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
             k_start = mCuK[batch_idx]
             seqlen_k = mCuK[batch_idx + 1] - k_start
         num_kv_blocks = cute.ceil_div(seqlen_k, self._n_block_size)
+        q_off = cutlass.Int32(0)
+        if cutlass.const_expr(self._is_causal):
+            if cutlass.const_expr(self._qoff_default):
+                q_off = seqlen_k - seqlen_q
+            else:
+                q_off = mQOffset[batch_idx]
 
         sQ_layout = self._make_sq_layout()
         sK_layout = self._make_sk_layout()
@@ -785,10 +790,6 @@ class MsaProxyScoreDecodePackedSm12x(MsaProxyScoreSm12x):
 
                 # A packed row maps to (local_head, token); a packed query's causal
                 # position is its token index (the decode q within this step).
-                if cutlass.const_expr(self._qoff_default):
-                    q_off = seqlen_k - seqlen_q
-                else:
-                    q_off = mQOffset[batch_idx]
                 for r in cutlass.range_constexpr(n_rows):
                     row = tScS_mn[r, 0][0]
                     token = row % self._pack_q_len

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -30,9 +30,9 @@ _MAX_CHUNK_BLOCKS = 128
 # Merge capacity is _MAX_CHUNKS * topk candidate slots; together with the chunk
 # cap this bounds the middle region the chunked path can cover.
 _MAX_CHUNKS = 16
-# Target blocks per chunk. Small enough to spread one row's scan across many
-# CTAs, large enough that the merge's candidate count (topk per chunk) stays
-# low — measured crossover: halving the chunk count beats halving the scan.
+# Target blocks per chunk: small enough to spread one row's scan across many
+# CTAs, large enough to keep the merge's candidate count (topk per chunk) low.
+# The crossover was measured empirically.
 _CHUNK_BLOCKS = 64
 # Below two chunks the split is pure overhead over the single-CTA count-rank.
 _MIN_CHUNKS = 2
@@ -160,11 +160,11 @@ class TopKSelectChunkedSm12x:
 
         # rank = count of strictly-better blocks within the chunk (lower key =
         # higher score, ties broken toward the lower index). Every block in the
-        # global top-target ranks < target inside its own chunk too, so the
+        # global top-target ranks below target inside its own chunk too, so the
         # per-chunk survivors are a superset of the final selection. Ranks are
-        # distinct, so a survivor's rank IS its candidate slot — no atomics.
-        # The scan is 4-way unrolled: the serial chain of dependent SMEM loads
-        # is what a near-empty grid can't hide, so shortening it is the win.
+        # distinct, so a survivor's rank is its candidate slot — no atomics.
+        # The scan is 4-way unrolled because at these grid sizes there are too
+        # few warps to hide the serial chain of dependent SMEM loads.
         l = cutlass.Int32(tid)
         while l < n_local:
             kb = score[l]
@@ -255,11 +255,10 @@ class TopKSelectChunkedSm12x:
         cute.arch.barrier()
 
         # Global rank over the union of chunk survivors, by the same (key,
-        # block index) order the chunks used; empty slots never rank or count
-        # (their key/tie-break can never win, so no guard is needed on them).
-        # Distinct ranks double as emit slots; the scan is 4-way unrolled
-        # (n_cand is a multiple of topk) to shorten the serial SMEM chain a
-        # near-empty grid can't hide.
+        # block index) order the chunks used — rank-as-slot emit and unrolled
+        # scan as in the partial kernel (n_cand is a multiple of the unroll
+        # width). Empty slots need no guard as rankers: their sentinel key and
+        # index can never beat a real candidate.
         i = cutlass.Int32(tid)
         while i < n_cand:
             ib = idx[i]

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -13,46 +13,40 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Chunked count-rank MSA top-K KV-block selection for SM120/SM121: candidate
-blocks are split into chunks ranked by independent CTAs, and a second kernel
-merges the per-chunk survivors. Recovers parallelism when the (query, head)
-grid alone leaves the GPU idle — the single-CTA-per-row kernels serialize the
-whole candidate scan on a handful of SMs there.
+Chunked count-rank MSA top-K KV-block selection for SM120/SM121: independent
+CTAs rank chunks of candidate blocks, then a second kernel merges the
+survivors. Exists for grids too small to fill the GPU, where the
+single-CTA-per-row kernels serialize each row's whole scan.
 """
 
 import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 
-# Per-chunk staging cap: matches the count-rank kernel's SMEM score cap, so a
-# chunk is never bigger than what the single-kernel path already handles well.
+# Per-chunk SMEM staging cap (same as the count-rank kernel's score cap).
 _MAX_CHUNK_BLOCKS = 128
-# Merge capacity is _MAX_CHUNKS * topk candidate slots; together with the chunk
-# cap this bounds the middle region the chunked path can cover.
+# The merge stages _MAX_CHUNKS * topk candidate slots in SMEM.
 _MAX_CHUNKS = 16
-# Target blocks per chunk: small enough to spread one row's scan across many
-# CTAs, large enough to keep the merge's candidate count (topk per chunk) low.
-# The crossover was measured empirically.
+# Target blocks per chunk: balances CTA parallelism against the merge's
+# candidate count. The crossover was measured empirically.
 _CHUNK_BLOCKS = 64
 # Below two chunks the split is pure overhead over the single-CTA count-rank.
 _MIN_CHUNKS = 2
-# Dispatch floor: under this many middle blocks the single-CTA count-rank's
-# scan is short enough that the second launch never pays for itself.
+# Dispatch floor: under this many middle blocks the second launch never pays
+# for itself.
 _MIN_BLOCKS = 32
 _NTHREADS_PARTIAL = 128
 _NTHREADS_MERGE = 256
 _SENTINEL = 0x7FFFFFFF  # INT32_MAX: empty slots sort to the tail, unlike -1
-# Empty candidate slots also carry the worst possible key; detection uses the
-# index (a real NaN score can legitimately produce key 0xFFFFFFFF).
+# Empty-slot key. Detection must use the index: a NaN score can legitimately
+# produce this key.
 _SENTINEL_KEY = 0xFFFFFFFF
 
 
 class TopKSelectChunkedSm12x:
     """Two-phase (per-chunk rank + merge) top-K selection for small grids.
-
-    Ranks by the same (radix bit-key, block index) total order as the
-    single-kernel count-rank path, so the two produce identical selections.
-    """
+    Uses the count-rank kernel's (bit-key, block index) order, so the two
+    produce identical selections."""
 
     def __init__(self, topk: int):
         if topk != 16:
@@ -127,28 +121,25 @@ class TopKSelectChunkedSm12x:
         n_forced = force_begin + force_end
         target = cutlass.Int32(self._topk) - n_forced
 
-        # This chunk's slice of the middle region (tail chunk may be short or,
-        # past the end, empty; the sentinel fill below still runs for those).
+        # Tail chunks may be short or empty; their sentinel fill still runs.
         c_lo = force_begin + c * chunk_len
         c_hi = c_lo + chunk_len
         if c_hi > mid_hi:
             c_hi = mid_hi
         n_local = c_hi - c_lo
-        # Padding the staged keys to the unroll width keeps the rank loop
-        # branch-free; padded entries sit at local indices >= any real block,
-        # so neither the key compare nor the lower-index tie-break counts them.
+        # Pad to the unroll width; padded keys sit at indices above every real
+        # block, so neither the compare nor the tie-break can count them.
         n_pad = (n_local + 3) & ~cutlass.Int32(3)
         cand_base = c * cutlass.Int32(self._topk)
 
-        # Sentinel-fill this chunk's candidate slots; survivors overwrite after
-        # the barrier below, so unfilled slots read as empty in the merge.
+        # Sentinel-fill the candidate slots; survivors overwrite them after
+        # the barrier below.
         if tid < self._topk:
             mKey[q, h, cand_base + tid] = cutlass.Uint32(_SENTINEL_KEY)
             mIdx[q, h, cand_base + tid] = cutlass.Int32(_SENTINEL)
 
-        # Stage the chunk's radix keys in SMEM: the rank loop rereads each one
-        # n_local times, and the bit key preserves the exact radix-kernel order,
-        # with deterministic NaN placement.
+        # The bit keys preserve the radix-kernel order, with deterministic NaN
+        # placement.
         l = cutlass.Int32(tid)
         while l < n_pad:
             k = cutlass.Uint32(_SENTINEL_KEY)
@@ -158,13 +149,11 @@ class TopKSelectChunkedSm12x:
             l += _NTHREADS_PARTIAL
         cute.arch.barrier()
 
-        # rank = count of strictly-better blocks within the chunk (lower key =
-        # higher score, ties broken toward the lower index). Every block in the
-        # global top-target ranks below target inside its own chunk too, so the
-        # per-chunk survivors are a superset of the final selection. Ranks are
-        # distinct, so a survivor's rank is its candidate slot — no atomics.
-        # The scan is 4-way unrolled because at these grid sizes there are too
-        # few warps to hide the serial chain of dependent SMEM loads.
+        # A block in the global top-target also ranks below target within its
+        # chunk, so the per-chunk survivors are a superset of the final
+        # selection. Ranks are distinct, so a survivor's rank is its slot (no
+        # atomics). The 4-way unroll shortens the dependent-SMEM-load chain,
+        # which these small grids have too few warps to hide.
         l = cutlass.Int32(tid)
         while l < n_local:
             kb = score[l]
@@ -254,11 +243,10 @@ class TopKSelectChunkedSm12x:
             i += _NTHREADS_MERGE
         cute.arch.barrier()
 
-        # Global rank over the union of chunk survivors, by the same (key,
-        # block index) order the chunks used — rank-as-slot emit and unrolled
-        # scan as in the partial kernel (n_cand is a multiple of the unroll
-        # width). Empty slots need no guard as rankers: their sentinel key and
-        # index can never beat a real candidate.
+        # Rank-as-slot emit and unrolled scan as in the partial kernel, over
+        # the union of survivors (n_cand is a multiple of the unroll width).
+        # Empty slots need no ranker guard: a sentinel key and index can never
+        # beat a real candidate.
         i = cutlass.Int32(tid)
         while i < n_cand:
             ib = idx[i]

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -1,0 +1,301 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Chunked count-rank MSA top-K KV-block selection for SM120/SM121: candidate
+blocks are split into chunks ranked by independent CTAs, and a second kernel
+merges the per-chunk survivors. Recovers parallelism when the (query, head)
+grid alone leaves the GPU idle — the single-CTA-per-row kernels serialize the
+whole candidate scan on a handful of SMs there.
+"""
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+
+# Per-chunk staging cap: matches the count-rank kernel's SMEM score cap, so a
+# chunk is never bigger than what the single-kernel path already handles well.
+_MAX_CHUNK_BLOCKS = 128
+# Merge capacity is _MAX_CHUNKS * topk candidate slots; together with the chunk
+# cap this bounds the middle region the chunked path can cover.
+_MAX_CHUNKS = 16
+# Target blocks per chunk. Small enough to spread one row's scan across many
+# CTAs, large enough that the merge's candidate count (topk per chunk) stays
+# low — measured crossover: halving the chunk count beats halving the scan.
+_CHUNK_BLOCKS = 64
+# Below two chunks the split is pure overhead over the single-CTA count-rank.
+_MIN_CHUNKS = 2
+# Dispatch floor: under this many middle blocks the single-CTA count-rank's
+# scan is short enough that the second launch never pays for itself.
+_MIN_BLOCKS = 32
+_NTHREADS_PARTIAL = 128
+_NTHREADS_MERGE = 256
+_SENTINEL = 0x7FFFFFFF  # INT32_MAX: empty slots sort to the tail, unlike -1
+# Empty candidate slots also carry the worst possible key; detection uses the
+# index (a real NaN score can legitimately produce key 0xFFFFFFFF).
+_SENTINEL_KEY = 0xFFFFFFFF
+
+
+class TopKSelectChunkedSm12x:
+    """Two-phase (per-chunk rank + merge) top-K selection for small grids.
+
+    Ranks by the same (radix bit-key, block index) total order as the
+    single-kernel count-rank path, so the two produce identical selections.
+    """
+
+    def __init__(self, topk: int):
+        if topk != 16:
+            raise ValueError(f"topk must be 16, got {topk}")
+        self._topk = topk
+
+    @cute.jit
+    def __call__(
+        self,
+        mMaxScore: cute.Tensor,  # (H, P, S) f32  (P = max_k_tiles)
+        mCandKey: cute.Tensor,  # (S, H, C*topk) int32 scratch, recast to u32
+        mCandIdx: cute.Tensor,  # (S, H, C*topk) int32 scratch
+        mOut: cute.Tensor,  # (S, H, topk) int32
+        num_valid_pages: cutlass.Int32,
+        force_begin: cutlass.Int32,
+        force_end: cutlass.Int32,
+        num_chunks: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        total_qo_len: cutlass.Int32,
+        num_qo_heads: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        mBits = cute.recast_tensor(mMaxScore, cutlass.Uint32)
+        mKey = cute.recast_tensor(mCandKey, cutlass.Uint32)
+        self.kernel_partial(
+            mBits, mKey, mCandIdx, num_valid_pages, force_begin, force_end, chunk_len
+        ).launch(
+            grid=(total_qo_len, num_qo_heads, num_chunks),
+            block=(_NTHREADS_PARTIAL, 1, 1),
+            stream=stream,
+        )
+        self.kernel_merge(
+            mKey, mCandIdx, mOut, num_valid_pages, force_begin, force_end, num_chunks
+        ).launch(
+            grid=(total_qo_len, num_qo_heads, 1),
+            block=(_NTHREADS_MERGE, 1, 1),
+            stream=stream,
+            use_pdl=True,
+        )
+
+    @cute.jit
+    def _radix_key(self, bits):
+        """Order-preserving transform: ascending key == descending float score."""
+        key = (~bits) & cutlass.Uint32(0x7FFFFFFF)
+        if (bits & cutlass.Uint32(0x80000000)) != cutlass.Uint32(0):
+            key = bits
+        return key
+
+    @cute.kernel
+    def kernel_partial(
+        self,
+        mBits: cute.Tensor,  # (H, P, S) uint32, raw bits of max_score
+        mKey: cute.Tensor,  # (S, H, C*topk) uint32 candidate keys
+        mIdx: cute.Tensor,  # (S, H, C*topk) int32 candidate block indices
+        num_valid_pages: cutlass.Int32,
+        force_begin: cutlass.Int32,
+        force_end: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        q, h, c = cute.arch.block_idx()
+
+        @cute.struct
+        class SharedStorage:
+            score: cute.struct.MemRange[cutlass.Uint32, _MAX_CHUNK_BLOCKS]
+
+        smem = cutlass.utils.SmemAllocator()
+        st = smem.allocate(SharedStorage)
+        score = st.score.get_tensor(cute.make_layout(_MAX_CHUNK_BLOCKS))
+
+        mid_hi = num_valid_pages - force_end
+        n_forced = force_begin + force_end
+        target = cutlass.Int32(self._topk) - n_forced
+
+        # This chunk's slice of the middle region (tail chunk may be short or,
+        # past the end, empty; the sentinel fill below still runs for those).
+        c_lo = force_begin + c * chunk_len
+        c_hi = c_lo + chunk_len
+        if c_hi > mid_hi:
+            c_hi = mid_hi
+        n_local = c_hi - c_lo
+        # Padding the staged keys to the unroll width keeps the rank loop
+        # branch-free; padded entries sit at local indices >= any real block,
+        # so neither the key compare nor the lower-index tie-break counts them.
+        n_pad = (n_local + 3) & ~cutlass.Int32(3)
+        cand_base = c * cutlass.Int32(self._topk)
+
+        # Sentinel-fill this chunk's candidate slots; survivors overwrite after
+        # the barrier below, so unfilled slots read as empty in the merge.
+        if tid < self._topk:
+            mKey[q, h, cand_base + tid] = cutlass.Uint32(_SENTINEL_KEY)
+            mIdx[q, h, cand_base + tid] = cutlass.Int32(_SENTINEL)
+
+        # Stage the chunk's radix keys in SMEM: the rank loop rereads each one
+        # n_local times, and the bit key preserves the exact radix-kernel order,
+        # with deterministic NaN placement.
+        l = cutlass.Int32(tid)
+        while l < n_pad:
+            k = cutlass.Uint32(_SENTINEL_KEY)
+            if l < n_local:
+                k = self._radix_key(mBits[h, c_lo + l, q])
+            score[l] = k
+            l += _NTHREADS_PARTIAL
+        cute.arch.barrier()
+
+        # rank = count of strictly-better blocks within the chunk (lower key =
+        # higher score, ties broken toward the lower index). Every block in the
+        # global top-target ranks < target inside its own chunk too, so the
+        # per-chunk survivors are a superset of the final selection. Ranks are
+        # distinct, so a survivor's rank IS its candidate slot — no atomics.
+        # The scan is 4-way unrolled: the serial chain of dependent SMEM loads
+        # is what a near-empty grid can't hide, so shortening it is the win.
+        l = cutlass.Int32(tid)
+        while l < n_local:
+            kb = score[l]
+            rank = cutlass.Int32(0)
+            j = cutlass.Int32(0)
+            while j < n_pad:
+                k0 = score[j]
+                k1 = score[j + 1]
+                k2 = score[j + 2]
+                k3 = score[j + 3]
+                if (k0 < kb) or ((k0 == kb) and (j < l)):
+                    rank += 1
+                if (k1 < kb) or ((k1 == kb) and (j + 1 < l)):
+                    rank += 1
+                if (k2 < kb) or ((k2 == kb) and (j + 2 < l)):
+                    rank += 1
+                if (k3 < kb) or ((k3 == kb) and (j + 3 < l)):
+                    rank += 1
+                j += 4
+            if rank < target:
+                mKey[q, h, cand_base + rank] = kb
+                mIdx[q, h, cand_base + rank] = c_lo + l
+            l += _NTHREADS_PARTIAL
+
+        # PDL: let the merge grid start its preamble now; its griddepcontrol
+        # wait holds off the candidate reads until these stores land.
+        cute.arch.griddepcontrol_launch_dependents()
+
+    @cute.kernel
+    def kernel_merge(
+        self,
+        mKey: cute.Tensor,  # (S, H, C*topk) uint32 candidate keys
+        mIdx: cute.Tensor,  # (S, H, C*topk) int32 candidate block indices
+        mOut: cute.Tensor,  # (S, H, topk) int32
+        num_valid_pages: cutlass.Int32,
+        force_begin: cutlass.Int32,
+        force_end: cutlass.Int32,
+        num_chunks: cutlass.Int32,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        q, h, _ = cute.arch.block_idx()
+
+        @cute.struct
+        class SharedStorage:
+            key: cute.struct.MemRange[cutlass.Uint32, _MAX_CHUNKS * 16]
+            idx: cute.struct.MemRange[cutlass.Int32, _MAX_CHUNKS * 16]
+            sel: cute.struct.MemRange[cutlass.Int32, 16]
+
+        smem = cutlass.utils.SmemAllocator()
+        st = smem.allocate(SharedStorage)
+        key = st.key.get_tensor(cute.make_layout(_MAX_CHUNKS * 16))
+        idx = st.idx.get_tensor(cute.make_layout(_MAX_CHUNKS * 16))
+        sel = st.sel.get_tensor(cute.make_layout(16))
+
+        nvp = num_valid_pages
+        n_forced = force_begin + force_end
+        target = cutlass.Int32(self._topk) - n_forced
+        n_cand = num_chunks * cutlass.Int32(self._topk)
+
+        # Forced sink/window blocks bypass ranking; emit slots start after
+        # them. SMEM-only, so it runs in the PDL preamble before the wait.
+        if tid == 0:
+            w = cutlass.Int32(0)
+            fi = cutlass.Int32(0)
+            while fi < force_begin:
+                sel[w] = fi
+                w += 1
+                fi += 1
+            fj = cutlass.Int32(0)
+            while fj < force_end:
+                sel[w] = (nvp - force_end) + fj
+                w += 1
+                fj += 1
+            k = w
+            while k < self._topk:
+                sel[k] = cutlass.Int32(_SENTINEL)
+                k += 1
+
+        # PDL: this kernel launches while the partial ranker is still running;
+        # wait for its candidate stores before reading them.
+        cute.arch.griddepcontrol_wait()
+
+        i = cutlass.Int32(tid)
+        while i < n_cand:
+            key[i] = mKey[q, h, i]
+            idx[i] = mIdx[q, h, i]
+            i += _NTHREADS_MERGE
+        cute.arch.barrier()
+
+        # Global rank over the union of chunk survivors, by the same (key,
+        # block index) order the chunks used; empty slots never rank or count
+        # (their key/tie-break can never win, so no guard is needed on them).
+        # Distinct ranks double as emit slots; the scan is 4-way unrolled
+        # (n_cand is a multiple of topk) to shorten the serial SMEM chain a
+        # near-empty grid can't hide.
+        i = cutlass.Int32(tid)
+        while i < n_cand:
+            ib = idx[i]
+            kb = key[i]
+            rank = cutlass.Int32(0)
+            j = cutlass.Int32(0)
+            while j < n_cand:
+                k0 = key[j]
+                k1 = key[j + 1]
+                k2 = key[j + 2]
+                k3 = key[j + 3]
+                if (k0 < kb) or ((k0 == kb) and (idx[j] < ib)):
+                    rank += 1
+                if (k1 < kb) or ((k1 == kb) and (idx[j + 1] < ib)):
+                    rank += 1
+                if (k2 < kb) or ((k2 == kb) and (idx[j + 2] < ib)):
+                    rank += 1
+                if (k3 < kb) or ((k3 == kb) and (idx[j + 3] < ib)):
+                    rank += 1
+                j += 4
+            if (ib != cutlass.Int32(_SENTINEL)) and (rank < target):
+                sel[n_forced + rank] = ib
+            i += _NTHREADS_MERGE
+        cute.arch.barrier()
+
+        # Parallel rank-order write: each of topk threads places one selected
+        # index (sentinels tie on value, broken by slot, and become -1).
+        if tid < self._topk:
+            v = sel[tid]
+            pos = cutlass.Int32(0)
+            jj = cutlass.Int32(0)
+            while jj < self._topk:
+                u = sel[jj]
+                if (u < v) or ((u == v) and (jj < tid)):
+                    pos += 1
+                jj += 1
+            if v == cutlass.Int32(_SENTINEL):
+                v = cutlass.Int32(-1)
+            mOut[q, h, pos] = v

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -23,6 +23,8 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 
+from .topk_select_radix_sm12x import _radix_key
+
 # Per-chunk SMEM staging cap (same as the count-rank kernel's score cap).
 _MAX_CHUNK_BLOCKS = 128
 # The merge stages _MAX_CHUNKS * topk candidate slots in SMEM.
@@ -35,6 +37,9 @@ _MIN_CHUNKS = 2
 # Dispatch floor: under this many middle blocks the second launch never pays
 # for itself.
 _MIN_BLOCKS = 32
+# Dispatch row cap: covers saturated decode batches while bounding the
+# per-call candidate scratch (rows * _MAX_CHUNKS * topk * 8 bytes).
+_MAX_CHUNKED_ROWS = 2048
 _NTHREADS_PARTIAL = 128
 _NTHREADS_MERGE = 256
 _SENTINEL = 0x7FFFFFFF  # INT32_MAX: empty slots sort to the tail, unlike -1
@@ -87,14 +92,6 @@ class TopKSelectChunkedSm12x:
             use_pdl=True,
         )
 
-    @cute.jit
-    def _radix_key(self, bits):
-        """Order-preserving transform: ascending key == descending float score."""
-        key = (~bits) & cutlass.Uint32(0x7FFFFFFF)
-        if (bits & cutlass.Uint32(0x80000000)) != cutlass.Uint32(0):
-            key = bits
-        return key
-
     @cute.kernel
     def kernel_partial(
         self,
@@ -144,7 +141,7 @@ class TopKSelectChunkedSm12x:
         while l < n_pad:
             k = cutlass.Uint32(_SENTINEL_KEY)
             if l < n_local:
-                k = self._radix_key(mBits[h, c_lo + l, q])
+                k = _radix_key(mBits[h, c_lo + l, q])
             score[l] = k
             l += _NTHREADS_PARTIAL
         cute.arch.barrier()

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -43,9 +43,12 @@ _MIN_BLOCKS = 32
 # row-per-CTA fan-out to fill the GPU; above it the q-tiled partial takes
 # over for coalesced score reads.
 _MAX_CHUNKED_ROWS = 2048
-# Candidate-scratch ceiling (rows * num_chunks * topk * 8 bytes per call);
-# grids that would exceed it fall back to the single-kernel paths.
-_MAX_CHUNKED_SCRATCH_BYTES = 512 << 20
+# Candidate-scratch ceiling (rows * num_chunks * topk * 8 bytes per call).
+# Sized to cover the benchmarked range (32k-token prefill needs ~67MB) with
+# margin; larger grids keep the allocation-free single-kernel paths so a
+# memory-tight serving setup never sees a surprise multi-hundred-MB
+# allocation from a top-k call.
+_MAX_CHUNKED_SCRATCH_BYTES = 128 << 20
 _NTHREADS_PARTIAL = 128
 _NTHREADS_MERGE = 256
 # Queries per CTA in the full-grid partial kernel: one warp lane per query

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -15,10 +15,9 @@ limitations under the License.
 
 Chunked count-rank MSA top-K KV-block selection for SM120/SM121: independent
 CTAs rank chunks of candidate blocks, then a second kernel merges the
-survivors. Serves grids too small to fill the GPU, where the
-single-CTA-per-row kernels serialize each row's whole scan, and full grids,
-where reading the scores exactly once beats the radix kernel's pass per
-stage and shortens the count-rank kernel's per-candidate scan.
+survivors. Serves grids too small to fill the GPU with one CTA per row, and
+full grids, where reading the scores once beats the radix kernel's pass per
+stage.
 """
 
 import cuda.bindings.driver as cuda
@@ -27,37 +26,27 @@ import cutlass.cute as cute
 
 from .topk_select_radix_sm12x import _radix_key
 
-# Per-chunk SMEM staging cap (same as the count-rank kernel's score cap).
+# Per-chunk SMEM staging cap.
 _MAX_CHUNK_BLOCKS = 128
 # The merge stages _MAX_CHUNKS * topk candidate slots in SMEM.
 _MAX_CHUNKS = 16
-# Target blocks per chunk: balances CTA parallelism against the merge's
-# candidate count. The crossover was measured empirically.
+# Target blocks per chunk: balances CTA parallelism against merge size.
 _CHUNK_BLOCKS = 64
 # Below two chunks the split is pure overhead over the single-CTA count-rank.
 _MIN_CHUNKS = 2
-# Dispatch floor: under this many middle blocks the second launch never pays
-# for itself.
+# Dispatch floor: fewer middle blocks never repay the second launch.
 _MIN_BLOCKS = 32
-# Partial-kernel boundary: at or below this many queries the grid needs
-# row-per-CTA fan-out to fill the GPU; above it the q-tiled partial takes
-# over for coalesced score reads.
+# Above this many queries the q-tiled partial replaces row-per-CTA fan-out.
 _TILED_MIN_QUERIES = 2048
 # Candidate-scratch ceiling (rows * num_chunks * topk * 8 bytes per call).
-# Sized to cover the benchmarked range (32k-token prefill needs ~67MB) with
-# margin; larger grids keep the allocation-free single-kernel paths so a
-# memory-tight serving setup never sees a surprise multi-hundred-MB
-# allocation from a top-k call.
 _MAX_CHUNKED_SCRATCH_BYTES = 128 << 20
 _NTHREADS_PARTIAL = 128
 _NTHREADS_MERGE = 256
-# Queries per CTA in the full-grid partial kernel: one warp lane per query
-# turns the (H, P, S) score reads coalesced (S is the contiguous axis, so a
-# single row's block scores are S floats apart).
+# Queries per CTA in the q-tiled partial: one lane per query makes score
+# reads coalesced.
 _QTILE = 32
 _SENTINEL = 0x7FFFFFFF  # INT32_MAX: empty slots sort to the tail, unlike -1
-# Empty-slot key. Detection must use the index: a NaN score can legitimately
-# produce this key.
+# Empty-slot key; NaN scores can also produce it, so detect empties by index.
 _SENTINEL_KEY = 0xFFFFFFFF
 
 
@@ -70,9 +59,6 @@ class TopKSelectChunkedSm12x:
         if topk != 16:
             raise ValueError(f"topk must be 16, got {topk}")
         self._topk = topk
-        # Tiled = full-grid variant: the partial kernel covers _QTILE queries
-        # per CTA for coalesced score reads. The row-per-CTA variant stays for
-        # small grids, where those extra CTAs are the needed parallelism.
         self._tiled = tiled
 
     @cute.jit
@@ -161,25 +147,21 @@ class TopKSelectChunkedSm12x:
         n_forced = force_begin + force_end
         target = cutlass.Int32(self._topk) - n_forced
 
-        # Tail chunks may be short or empty; their sentinel fill still runs.
+        # Tail chunks may be short or empty.
         c_lo = force_begin + c * chunk_len
         c_hi = c_lo + chunk_len
         if c_hi > mid_hi:
             c_hi = mid_hi
         n_local = c_hi - c_lo
-        # Pad to the unroll width; padded keys sit at indices above every real
-        # block, so neither the compare nor the tie-break can count them.
+        # Pad to the unroll width; padded sentinel keys cannot affect any rank.
         n_pad = (n_local + 3) & ~cutlass.Int32(3)
         cand_base = c * cutlass.Int32(self._topk)
 
-        # Sentinel-fill the candidate slots; survivors overwrite them after
-        # the barrier below.
+        # Sentinel-fill the candidate slots; the merge reads every slot.
         if tid < self._topk:
             mKey[q, h, cand_base + tid] = cutlass.Uint32(_SENTINEL_KEY)
             mIdx[q, h, cand_base + tid] = cutlass.Int32(_SENTINEL)
 
-        # The bit keys preserve the radix-kernel order, with deterministic NaN
-        # placement.
         l = cutlass.Int32(tid)
         while l < n_pad:
             k = cutlass.Uint32(_SENTINEL_KEY)
@@ -189,11 +171,9 @@ class TopKSelectChunkedSm12x:
             l += _NTHREADS_PARTIAL
         cute.arch.barrier()
 
-        # A block in the global top-target also ranks below target within its
-        # chunk, so the per-chunk survivors are a superset of the final
-        # selection. Ranks are distinct, so a survivor's rank is its slot (no
-        # atomics). The 4-way unroll shortens the dependent-SMEM-load chain,
-        # which these small grids have too few warps to hide.
+        # Chunk survivors are a superset of the final selection: a globally
+        # top-target block also ranks below target within its chunk. A
+        # survivor's rank is its emit slot.
         l = cutlass.Int32(tid)
         while l < n_local:
             kb = score[l]
@@ -218,8 +198,6 @@ class TopKSelectChunkedSm12x:
                 mIdx[q, h, cand_base + rank] = c_lo + l
             l += _NTHREADS_PARTIAL
 
-        # PDL: let the merge grid start its preamble now; its griddepcontrol
-        # wait holds off the candidate reads until these stores land.
         cute.arch.griddepcontrol_launch_dependents()
 
     @cute.kernel
@@ -237,9 +215,8 @@ class TopKSelectChunkedSm12x:
         tid, _, _ = cute.arch.thread_idx()
         qb, h, c = cute.arch.block_idx()
 
-        # Row-major (block, query) staging: a warp stages one block for 32
-        # consecutive queries in a single coalesced line, and the rank scan
-        # walks blocks down a bank-aligned column.
+        # (block, query) staging: a warp stages one block for 32 consecutive
+        # queries in one coalesced line; rank scans walk a bank-aligned column.
         @cute.struct
         class SharedStorage:
             score: cute.struct.MemRange[cutlass.Uint32, _MAX_CHUNK_BLOCKS * _QTILE]
@@ -267,8 +244,6 @@ class TopKSelectChunkedSm12x:
         n_pad = (n_local + 3) & ~cutlass.Int32(3)
         cand_base = c * cutlass.Int32(self._topk)
 
-        # Sentinel-fill every covered row's candidate slots; the barrier below
-        # orders the fill before any thread's survivor stores.
         i = cutlass.Int32(tid)
         while i < cutlass.Int32(_QTILE * self._topk):
             qq = q0 + i // self._topk
@@ -277,7 +252,6 @@ class TopKSelectChunkedSm12x:
                 mIdx[qq, h, cand_base + i % self._topk] = cutlass.Int32(_SENTINEL)
             i += _NTHREADS_PARTIAL
 
-        # Out-of-range queries stage sentinels so no lane reads out of bounds.
         l = cutlass.Int32(grp)
         while l < n_pad:
             k = cutlass.Uint32(_SENTINEL_KEY)
@@ -287,7 +261,7 @@ class TopKSelectChunkedSm12x:
             l += n_grp
         cute.arch.barrier()
 
-        # Same rank-as-slot emit as the row-per-CTA kernel, per lane's query.
+        # Same rank-as-slot emit as kernel_partial, applied to each lane's query.
         l = cutlass.Int32(grp)
         while l < n_local:
             kb = score[l * _QTILE + lane]
@@ -345,8 +319,7 @@ class TopKSelectChunkedSm12x:
         target = cutlass.Int32(self._topk) - n_forced
         n_cand = num_chunks * cutlass.Int32(self._topk)
 
-        # Forced sink/window blocks bypass ranking; emit slots start after
-        # them. SMEM-only, so it runs in the PDL preamble before the wait.
+        # Forced blocks bypass ranking; SMEM-only work may precede the PDL wait.
         if tid == 0:
             w = cutlass.Int32(0)
             fi = cutlass.Int32(0)
@@ -364,8 +337,6 @@ class TopKSelectChunkedSm12x:
                 sel[k] = cutlass.Int32(_SENTINEL)
                 k += 1
 
-        # PDL: this kernel launches while the partial ranker is still running;
-        # wait for its candidate stores before reading them.
         cute.arch.griddepcontrol_wait()
 
         i = cutlass.Int32(tid)
@@ -375,10 +346,8 @@ class TopKSelectChunkedSm12x:
             i += _NTHREADS_MERGE
         cute.arch.barrier()
 
-        # Rank-as-slot emit and unrolled scan as in the partial kernel, over
-        # the union of survivors (n_cand is a multiple of the unroll width).
-        # Empty slots need no ranker guard: a sentinel key and index can never
-        # beat a real candidate.
+        # Rank-as-slot emit over the union of survivors; sentinel slots can
+        # never beat a real candidate.
         i = cutlass.Int32(tid)
         while i < n_cand:
             ib = idx[i]
@@ -404,8 +373,8 @@ class TopKSelectChunkedSm12x:
             i += _NTHREADS_MERGE
         cute.arch.barrier()
 
-        # Parallel rank-order write: each of topk threads places one selected
-        # index (sentinels tie on value, broken by slot, and become -1).
+        # Rank-order write: sentinels tie on value, are broken by slot, and
+        # come out as -1.
         if tid < self._topk:
             v = sel[tid]
             pos = cutlass.Int32(0)

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -39,10 +39,10 @@ _MIN_CHUNKS = 2
 # Dispatch floor: under this many middle blocks the second launch never pays
 # for itself.
 _MIN_BLOCKS = 32
-# Partial-kernel boundary: at or below this many rows the grid needs
+# Partial-kernel boundary: at or below this many queries the grid needs
 # row-per-CTA fan-out to fill the GPU; above it the q-tiled partial takes
 # over for coalesced score reads.
-_MAX_CHUNKED_ROWS = 2048
+_TILED_MIN_QUERIES = 2048
 # Candidate-scratch ceiling (rows * num_chunks * topk * 8 bytes per call).
 # Sized to cover the benchmarked range (32k-token prefill needs ~67MB) with
 # margin; larger grids keep the allocation-free single-kernel paths so a

--- a/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_chunked_sm12x.py
@@ -15,8 +15,10 @@ limitations under the License.
 
 Chunked count-rank MSA top-K KV-block selection for SM120/SM121: independent
 CTAs rank chunks of candidate blocks, then a second kernel merges the
-survivors. Exists for grids too small to fill the GPU, where the
-single-CTA-per-row kernels serialize each row's whole scan.
+survivors. Serves grids too small to fill the GPU, where the
+single-CTA-per-row kernels serialize each row's whole scan, and full grids,
+where reading the scores exactly once beats the radix kernel's pass per
+stage and shortens the count-rank kernel's per-candidate scan.
 """
 
 import cuda.bindings.driver as cuda
@@ -37,11 +39,19 @@ _MIN_CHUNKS = 2
 # Dispatch floor: under this many middle blocks the second launch never pays
 # for itself.
 _MIN_BLOCKS = 32
-# Dispatch row cap: covers saturated decode batches while bounding the
-# per-call candidate scratch (rows * _MAX_CHUNKS * topk * 8 bytes).
+# Partial-kernel boundary: at or below this many rows the grid needs
+# row-per-CTA fan-out to fill the GPU; above it the q-tiled partial takes
+# over for coalesced score reads.
 _MAX_CHUNKED_ROWS = 2048
+# Candidate-scratch ceiling (rows * num_chunks * topk * 8 bytes per call);
+# grids that would exceed it fall back to the single-kernel paths.
+_MAX_CHUNKED_SCRATCH_BYTES = 512 << 20
 _NTHREADS_PARTIAL = 128
 _NTHREADS_MERGE = 256
+# Queries per CTA in the full-grid partial kernel: one warp lane per query
+# turns the (H, P, S) score reads coalesced (S is the contiguous axis, so a
+# single row's block scores are S floats apart).
+_QTILE = 32
 _SENTINEL = 0x7FFFFFFF  # INT32_MAX: empty slots sort to the tail, unlike -1
 # Empty-slot key. Detection must use the index: a NaN score can legitimately
 # produce this key.
@@ -53,10 +63,14 @@ class TopKSelectChunkedSm12x:
     Uses the count-rank kernel's (bit-key, block index) order, so the two
     produce identical selections."""
 
-    def __init__(self, topk: int):
+    def __init__(self, topk: int, tiled: bool = False):
         if topk != 16:
             raise ValueError(f"topk must be 16, got {topk}")
         self._topk = topk
+        # Tiled = full-grid variant: the partial kernel covers _QTILE queries
+        # per CTA for coalesced score reads. The row-per-CTA variant stays for
+        # small grids, where those extra CTAs are the needed parallelism.
+        self._tiled = tiled
 
     @cute.jit
     def __call__(
@@ -76,13 +90,39 @@ class TopKSelectChunkedSm12x:
     ):
         mBits = cute.recast_tensor(mMaxScore, cutlass.Uint32)
         mKey = cute.recast_tensor(mCandKey, cutlass.Uint32)
-        self.kernel_partial(
-            mBits, mKey, mCandIdx, num_valid_pages, force_begin, force_end, chunk_len
-        ).launch(
-            grid=(total_qo_len, num_qo_heads, num_chunks),
-            block=(_NTHREADS_PARTIAL, 1, 1),
-            stream=stream,
-        )
+        if cutlass.const_expr(self._tiled):
+            self.kernel_partial_tiled(
+                mBits,
+                mKey,
+                mCandIdx,
+                num_valid_pages,
+                force_begin,
+                force_end,
+                chunk_len,
+                total_qo_len,
+            ).launch(
+                grid=(
+                    (total_qo_len + _QTILE - 1) // _QTILE,
+                    num_qo_heads,
+                    num_chunks,
+                ),
+                block=(_NTHREADS_PARTIAL, 1, 1),
+                stream=stream,
+            )
+        else:
+            self.kernel_partial(
+                mBits,
+                mKey,
+                mCandIdx,
+                num_valid_pages,
+                force_begin,
+                force_end,
+                chunk_len,
+            ).launch(
+                grid=(total_qo_len, num_qo_heads, num_chunks),
+                block=(_NTHREADS_PARTIAL, 1, 1),
+                stream=stream,
+            )
         self.kernel_merge(
             mKey, mCandIdx, mOut, num_valid_pages, force_begin, force_end, num_chunks
         ).launch(
@@ -177,6 +217,98 @@ class TopKSelectChunkedSm12x:
 
         # PDL: let the merge grid start its preamble now; its griddepcontrol
         # wait holds off the candidate reads until these stores land.
+        cute.arch.griddepcontrol_launch_dependents()
+
+    @cute.kernel
+    def kernel_partial_tiled(
+        self,
+        mBits: cute.Tensor,  # (H, P, S) uint32, raw bits of max_score
+        mKey: cute.Tensor,  # (S, H, C*topk) uint32 candidate keys
+        mIdx: cute.Tensor,  # (S, H, C*topk) int32 candidate block indices
+        num_valid_pages: cutlass.Int32,
+        force_begin: cutlass.Int32,
+        force_end: cutlass.Int32,
+        chunk_len: cutlass.Int32,
+        total_qo_len: cutlass.Int32,
+    ):
+        tid, _, _ = cute.arch.thread_idx()
+        qb, h, c = cute.arch.block_idx()
+
+        # Row-major (block, query) staging: a warp stages one block for 32
+        # consecutive queries in a single coalesced line, and the rank scan
+        # walks blocks down a bank-aligned column.
+        @cute.struct
+        class SharedStorage:
+            score: cute.struct.MemRange[cutlass.Uint32, _MAX_CHUNK_BLOCKS * _QTILE]
+
+        smem = cutlass.utils.SmemAllocator()
+        st = smem.allocate(SharedStorage)
+        score = st.score.get_tensor(cute.make_layout(_MAX_CHUNK_BLOCKS * _QTILE))
+
+        q0 = qb * _QTILE
+        lane = tid % _QTILE
+        grp = tid // _QTILE
+        n_grp = _NTHREADS_PARTIAL // _QTILE
+        q = q0 + lane
+        q_ok = q < total_qo_len
+
+        mid_hi = num_valid_pages - force_end
+        n_forced = force_begin + force_end
+        target = cutlass.Int32(self._topk) - n_forced
+
+        c_lo = force_begin + c * chunk_len
+        c_hi = c_lo + chunk_len
+        if c_hi > mid_hi:
+            c_hi = mid_hi
+        n_local = c_hi - c_lo
+        n_pad = (n_local + 3) & ~cutlass.Int32(3)
+        cand_base = c * cutlass.Int32(self._topk)
+
+        # Sentinel-fill every covered row's candidate slots; the barrier below
+        # orders the fill before any thread's survivor stores.
+        i = cutlass.Int32(tid)
+        while i < cutlass.Int32(_QTILE * self._topk):
+            qq = q0 + i // self._topk
+            if qq < total_qo_len:
+                mKey[qq, h, cand_base + i % self._topk] = cutlass.Uint32(_SENTINEL_KEY)
+                mIdx[qq, h, cand_base + i % self._topk] = cutlass.Int32(_SENTINEL)
+            i += _NTHREADS_PARTIAL
+
+        # Out-of-range queries stage sentinels so no lane reads out of bounds.
+        l = cutlass.Int32(grp)
+        while l < n_pad:
+            k = cutlass.Uint32(_SENTINEL_KEY)
+            if (l < n_local) and q_ok:
+                k = _radix_key(mBits[h, c_lo + l, q])
+            score[l * _QTILE + lane] = k
+            l += n_grp
+        cute.arch.barrier()
+
+        # Same rank-as-slot emit as the row-per-CTA kernel, per lane's query.
+        l = cutlass.Int32(grp)
+        while l < n_local:
+            kb = score[l * _QTILE + lane]
+            rank = cutlass.Int32(0)
+            j = cutlass.Int32(0)
+            while j < n_pad:
+                k0 = score[j * _QTILE + lane]
+                k1 = score[(j + 1) * _QTILE + lane]
+                k2 = score[(j + 2) * _QTILE + lane]
+                k3 = score[(j + 3) * _QTILE + lane]
+                if (k0 < kb) or ((k0 == kb) and (j < l)):
+                    rank += 1
+                if (k1 < kb) or ((k1 == kb) and (j + 1 < l)):
+                    rank += 1
+                if (k2 < kb) or ((k2 == kb) and (j + 2 < l)):
+                    rank += 1
+                if (k3 < kb) or ((k3 == kb) and (j + 3 < l)):
+                    rank += 1
+                j += 4
+            if q_ok and (rank < target):
+                mKey[q, h, cand_base + rank] = kb
+                mIdx[q, h, cand_base + rank] = c_lo + l
+            l += n_grp
+
         cute.arch.griddepcontrol_launch_dependents()
 
     @cute.kernel

--- a/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
@@ -21,7 +21,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 
-from .topk_select_radix_sm12x import _atomic_add_i32
+from .topk_select_radix_sm12x import _atomic_add_i32, _radix_key
 
 # SMEM-resident score cap and dispatch threshold. Below this many candidate blocks
 # (128 blocks = 16k context) the O(N^2) rank count beats the radix kernel's fixed
@@ -59,14 +59,6 @@ class TopKSelectCountRankSm12x:
             stream=stream,
         )
 
-    @cute.jit
-    def _radix_key(self, bits):
-        """Order-preserving transform: ascending key == descending float score."""
-        key = (~bits) & cutlass.Uint32(0x7FFFFFFF)
-        if (bits & cutlass.Uint32(0x80000000)) != cutlass.Uint32(0):
-            key = bits
-        return key
-
     @cute.kernel
     def kernel(
         self,
@@ -102,7 +94,7 @@ class TopKSelectCountRankSm12x:
         # with deterministic NaN placement.
         b = mid_lo + tid
         while b < mid_hi:
-            score[b] = self._radix_key(mScore[h, b, q])
+            score[b] = _radix_key(mScore[h, b, q])
             b += _NTHREADS
 
         # Forced sink/window blocks bypass ranking; emit slots start after them

--- a/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_countrank_sm12x.py
@@ -21,7 +21,7 @@ import cuda.bindings.driver as cuda
 import cutlass
 import cutlass.cute as cute
 
-from .topk_select_radix_sm12x import _atomic_add_i32
+from .topk_select_radix_sm12x import _atomic_add_i32, _radix_key
 
 # SMEM-resident score cap and dispatch threshold. Below this many candidate blocks
 # (128 blocks = 16k context) the O(N^2) rank count beats the radix kernel's fixed
@@ -65,14 +65,6 @@ class TopKSelectCountRankSm12x:
             block=(_NTHREADS, 1, 1),
             stream=stream,
         )
-
-    @cute.jit
-    def _radix_key(self, bits):
-        """Order-preserving transform: ascending key == descending float score."""
-        key = (~bits) & cutlass.Uint32(0x7FFFFFFF)
-        if (bits & cutlass.Uint32(0x80000000)) != cutlass.Uint32(0):
-            key = bits
-        return key
 
     @cute.kernel
     def kernel(
@@ -131,7 +123,7 @@ class TopKSelectCountRankSm12x:
         # with deterministic NaN placement.
         b = mid_lo + tid
         while b < mid_hi:
-            score[b] = self._radix_key(mScore[h, b, q])
+            score[b] = _radix_key(mScore[h, b, q])
             b += _NTHREADS
 
         # Forced sink/window blocks bypass ranking; emit slots start after them

--- a/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
@@ -50,6 +50,19 @@ def _atomic_add_i32(a, ptr: cute.Pointer) -> cutlass.Int32:
     return nvvm.atomicrmw(op=nvvm.AtomicOpKind.ADD, ptr=ptr.llvm_ptr, a=av)
 
 
+@cute.jit
+def _radix_key(bits):
+    """Order-preserving transform: ascending key == descending float score.
+
+    Shared by every top-k kernel; the cross-kernel identical-selection
+    invariant depends on all of them ranking on this exact key.
+    """
+    key = (~bits) & cutlass.Uint32(0x7FFFFFFF)
+    if (bits & cutlass.Uint32(0x80000000)) != cutlass.Uint32(0):
+        key = bits
+    return key
+
+
 class TopKSelectRadixSm12x:
     """Multi-stage MSD radix top-K selection over per-block proxy scores."""
 
@@ -76,14 +89,6 @@ class TopKSelectRadixSm12x:
             block=(_KTHREADS, 1, 1),
             stream=stream,
         )
-
-    @cute.jit
-    def _radix_key(self, bits):
-        """Order-preserving transform: ascending key == descending float score."""
-        key = (~bits) & cutlass.Uint32(0x7FFFFFFF)
-        if (bits & cutlass.Uint32(0x80000000)) != cutlass.Uint32(0):
-            key = bits
-        return key
 
     @cute.kernel
     def kernel(
@@ -191,7 +196,7 @@ class TopKSelectRadixSm12x:
             if dn == cutlass.Int32(0):
                 b = mid_lo + tid
                 while b < mid_hi:
-                    okey = self._radix_key(mBits[h, b, q])
+                    okey = _radix_key(mBits[h, b, q])
                     binv = cutlass.Int32((okey >> shift) & cutlass.Uint32(0x3FF))
                     if cutlass.const_expr(step == 1):
                         _atomic_add_i32(1, hist.iterator + binv)
@@ -280,7 +285,7 @@ class TopKSelectRadixSm12x:
                 fits = fbs <= cutlass.Int32(_STAGE_CAP)
                 b = mid_lo + tid
                 while b < mid_hi:
-                    okey = self._radix_key(mBits[h, b, q])
+                    okey = _radix_key(mBits[h, b, q])
                     # `proceed` is always a dynamic (uniform-true for stage 1)
                     # bool so the body below traces once, not per static branch.
                     if cutlass.const_expr(step == 1):

--- a/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/topk_select_radix_sm12x.py
@@ -50,6 +50,19 @@ def _atomic_add_i32(a, ptr: cute.Pointer) -> cutlass.Int32:
     return nvvm.atomicrmw(op=nvvm.AtomicOpKind.ADD, ptr=ptr.llvm_ptr, a=av)
 
 
+@cute.jit
+def _radix_key(bits):
+    """Order-preserving transform: ascending key == descending float score.
+
+    Shared by every top-k kernel; the cross-kernel identical-selection
+    invariant depends on all of them ranking on this exact key.
+    """
+    key = (~bits) & cutlass.Uint32(0x7FFFFFFF)
+    if (bits & cutlass.Uint32(0x80000000)) != cutlass.Uint32(0):
+        key = bits
+    return key
+
+
 class TopKSelectRadixSm12x:
     """Multi-stage MSD radix top-K selection over per-block proxy scores."""
 
@@ -81,14 +94,6 @@ class TopKSelectRadixSm12x:
             block=(_KTHREADS, 1, 1),
             stream=stream,
         )
-
-    @cute.jit
-    def _radix_key(self, bits):
-        """Order-preserving transform: ascending key == descending float score."""
-        key = (~bits) & cutlass.Uint32(0x7FFFFFFF)
-        if (bits & cutlass.Uint32(0x80000000)) != cutlass.Uint32(0):
-            key = bits
-        return key
 
     @cute.kernel
     def kernel(
@@ -213,7 +218,7 @@ class TopKSelectRadixSm12x:
             if dn == cutlass.Int32(0):
                 b = mid_lo + tid
                 while b < mid_hi:
-                    okey = self._radix_key(mBits[h, b, q])
+                    okey = _radix_key(mBits[h, b, q])
                     binv = cutlass.Int32((okey >> shift) & cutlass.Uint32(0x3FF))
                     if cutlass.const_expr(step == 1):
                         _atomic_add_i32(1, hist.iterator + binv)
@@ -302,7 +307,7 @@ class TopKSelectRadixSm12x:
                 fits = fbs <= cutlass.Int32(_STAGE_CAP)
                 b = mid_lo + tid
                 while b < mid_hi:
-                    okey = self._radix_key(mBits[h, b, q])
+                    okey = _radix_key(mBits[h, b, q])
                     # `proceed` is always a dynamic (uniform-true for stage 1)
                     # bool so the body below traces once, not per static branch.
                     if cutlass.const_expr(step == 1):

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -409,14 +409,6 @@ def msa_proxy_score(
     use_stream = (
         not kv_fp8 and max_seqlen_q == 1 and total_q == batch_size and group_size <= 8
     )
-    # Right-aligned decode on the stream path computes the causal limit
-    # in-kernel, so no offset tensor (and its build kernels) is needed.
-    qoff_default = q_offset is None
-    if use_stream and qoff_default:
-        qoff_dev = _proxy_dummies(dev.index)[1]
-    else:
-        qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev)
-
     # Head-fused decode path: pack group_size heads x pack_q_len q-tokens into one
     # 64-row MMA tile so index-K is read once per (batch, kv_head). Outside the regime
     # (prefill, fp8 K, group_size not dividing 64) use the general schedule.
@@ -430,6 +422,14 @@ def msa_proxy_score(
     )
     pack_q_len = _PACK_ROWS // group_size if use_packed else 0
 
+    # Right-aligned decode on the stream and packed paths computes the causal
+    # limit in-kernel, so no offset tensor (and its build kernels) is needed.
+    qoff_default = q_offset is None
+    if (use_stream or use_packed) and qoff_default:
+        qoff_dev = _proxy_dummies(dev.index)[1]
+    else:
+        qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev)
+
     # group_size keys the packed/stream schedules: it is constexpr-baked into
     # the gather/epilogue, so each factorization is its own kernel.
     key = (
@@ -441,7 +441,7 @@ def msa_proxy_score(
         use_stream,
         use_packed,
         group_size if use_stream else pack_q_len,
-        qoff_default if use_stream else None,
+        qoff_default if (use_stream or use_packed) else None,
     )
     compiled = _compile_cache.get(key)
     if compiled is None:
@@ -474,6 +474,7 @@ def msa_proxy_score(
                 kv_fp8=kv_fp8,
                 qhead_per_kv=group_size,
                 pack_q_len=pack_q_len,
+                qoff_default=qoff_default,
             )
         else:
             kernel_obj = MsaProxyScoreSm12x(
@@ -701,7 +702,6 @@ def msa_proxy_score_fp4(
         batch_size = cu_k.numel() - 1
 
     cu_q_dev = cu_seqlens_q.to(dev)
-    qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev)
     max_seqlen_q, max_k_tiles = _resolve_proxy_dims(
         cu_seqlens_q, cu_k, max_seqlen_q, max_k_tiles, output
     )
@@ -729,13 +729,28 @@ def msa_proxy_score_fp4(
     )
     pack_q_len = _PACK_ROWS // group_size if use_packed else 0
 
+    # Right-aligned decode on the packed path computes the causal limit
+    # in-kernel, so no offset tensor (and its build kernels) is needed.
+    qoff_default = q_offset is None
+    if use_packed and qoff_default:
+        qoff_dev = _proxy_dummies(dev.index)[1]
+    else:
+        qoff_dev = _q_offset_tensor(q_offset, cu_q_dev, cu_k, dev)
+
     # Base grid CTAs (feeds split-K) and cache key, as in msa_proxy_score.
     if use_packed:
         base_ctas = batch_size * num_kv_heads
     else:
         base_ctas = ((max_seqlen_q + 127) // 128) * batch_size * num_qo_heads
 
-    key = ("proxy_fp4", causal, paged, use_packed, pack_q_len)
+    key = (
+        "proxy_fp4",
+        causal,
+        paged,
+        use_packed,
+        pack_q_len,
+        qoff_default if use_packed else None,
+    )
     compiled = _compile_cache.get(key)
     if compiled is None:
         u8 = _cutlass_dtype(torch.uint8)
@@ -767,6 +782,7 @@ def msa_proxy_score_fp4(
                 paged=paged,
                 qhead_per_kv=group_size,
                 pack_q_len=pack_q_len,
+                qoff_default=qoff_default,
             )
         else:
             kernel_obj = MsaProxyScoreFp4MmaSm12x(

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -698,7 +698,7 @@ def msa_proxy_score_fp4(
         if k_fp4.ndim != 3:
             raise ValueError("flat k_fp4 must be (total_k, num_kv_heads, 64)")
         cu_k = cu_seqlens_k.to(dev)
-        pt_dev = torch.zeros((1, 1), dtype=torch.int32, device=dev)
+        pt_dev = _proxy_dummies(dev.index)[0]
         batch_size = cu_k.numel() - 1
 
     cu_q_dev = cu_seqlens_q.to(dev)

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -814,7 +814,7 @@ def msa_proxy_score_fp4(
         if k_fp4.ndim != 3:
             raise ValueError("flat k_fp4 must be (total_k, num_kv_heads, 64)")
         k_len_or_cu = cu_seqlens_k.to(dev)
-        pt_dev = torch.zeros((1, 1), dtype=torch.int32, device=dev)
+        pt_dev = _proxy_dummies(dev.index)[0]
         batch_size = k_len_or_cu.numel() - 1
 
     cu_q_dev = cu_seqlens_q.to(dev)

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -477,10 +477,10 @@ def msa_proxy_score(
         q = q.to(torch.bfloat16)
         q_fp8 = False
 
-    # Right-aligned decode on the stream and key-major paths computes the
-    # causal limit in-kernel, so no offset tensor (and its build kernels,
-    # which dominate at batch 1) is needed.
-    if (use_stream or use_keymajor) and qoff_default:
+    # Right-aligned decode on the stream and packed paths computes the causal
+    # limit in-kernel, so no offset tensor (and its build kernels, which
+    # dominate at batch 1) is needed.
+    if (use_stream or use_packed) and qoff_default:
         qoff_dev = _proxy_dummies(dev.index)[1]
     else:
         qoff_dev = _q_offset_tensor(
@@ -501,7 +501,7 @@ def msa_proxy_score(
         use_keymajor,
         group_size,
         pack_q_len,
-        qoff_default if (use_stream or use_keymajor) else None,
+        qoff_default if (use_stream or use_packed) else None,
     )
     # The packed fp8 schedules take e4m3 operands as 16-bit torch views (half
     # the last dim): the kernel moves raw bytes and upconverts in registers,
@@ -571,6 +571,7 @@ def msa_proxy_score(
                 kv_fp8=kv_fp8,
                 qhead_per_kv=group_size,
                 pack_q_len=pack_q_len,
+                qoff_default=qoff_default,
             )
         else:
             kernel_obj = MsaProxyScoreSm12x(
@@ -817,9 +818,6 @@ def msa_proxy_score_fp4(
         batch_size = k_len_or_cu.numel() - 1
 
     cu_q_dev = cu_seqlens_q.to(dev)
-    qoff_dev = _q_offset_tensor(
-        q_offset, cu_q_dev, k_len_or_cu, dev, k_is_lengths=paged
-    )
     max_seqlen_q, max_k_tiles = _resolve_proxy_dims(
         cu_seqlens_q, k_len_or_cu, max_seqlen_q, max_k_tiles, output, k_is_lengths=paged
     )
@@ -847,13 +845,30 @@ def msa_proxy_score_fp4(
     )
     pack_q_len = _PACK_ROWS // group_size if use_packed else 0
 
+    # Right-aligned decode on the packed path computes the causal limit
+    # in-kernel, so no offset tensor (and its build kernels) is needed.
+    qoff_default = q_offset is None
+    if use_packed and qoff_default:
+        qoff_dev = _proxy_dummies(dev.index)[1]
+    else:
+        qoff_dev = _q_offset_tensor(
+            q_offset, cu_q_dev, k_len_or_cu, dev, k_is_lengths=paged
+        )
+
     # Base grid CTAs (feeds split-K) and cache key, as in msa_proxy_score.
     if use_packed:
         base_ctas = batch_size * num_kv_heads
     else:
         base_ctas = ((max_seqlen_q + 127) // 128) * batch_size * num_qo_heads
 
-    key = ("proxy_fp4", causal, paged, use_packed, pack_q_len)
+    key = (
+        "proxy_fp4",
+        causal,
+        paged,
+        use_packed,
+        pack_q_len,
+        qoff_default if use_packed else None,
+    )
     compiled = _compile_cache.get(key)
     if compiled is None:
         u8 = _cutlass_dtype(torch.uint8)
@@ -888,6 +903,7 @@ def msa_proxy_score_fp4(
                 paged=paged,
                 qhead_per_kv=group_size,
                 pack_q_len=pack_q_len,
+                qoff_default=qoff_default,
             )
         else:
             kernel_obj = MsaProxyScoreFp4MmaSm12x(

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -209,17 +209,19 @@ def msa_topk_select(
 
     # Dispatch on the runtime valid-page count: the kernels only ever touch
     # blocks below num_valid_pages. The chunked path serves every grid with
-    # enough middle blocks to amortize its second launch: small grids because
-    # the single-CTA-per-row kernels cannot fill the GPU, full grids because
-    # it reads the scores exactly once where the radix kernel makes a pass
-    # per stage. ``tiled`` swaps in the coalesced q-tile partial kernel once
-    # the grid is large enough to fill the GPU without row-per-CTA fan-out.
-    # Everything here is shape-constant, so the choice is CUDA-graph safe.
+    # enough middle blocks to amortize its second launch (why it wins on both
+    # small and full grids is explained in topk_select_chunked_sm12x);
+    # ``tiled`` swaps in the coalesced q-tile partial kernel once the grid
+    # fills the GPU without row-per-CTA fan-out. Everything here is
+    # shape-constant, so the choice is CUDA-graph safe.
     small = int(num_valid_pages) <= _MAX_BLOCKS
     rows = total_qo_len * num_qo_heads
     n_mid = int(num_valid_pages) - force_begin_blocks - force_end_blocks
     chunked = _MIN_BLOCKS < n_mid <= _MAX_CHUNKS * _MAX_CHUNK_BLOCKS
-    tiled = rows > _MAX_CHUNKED_ROWS
+    # Keyed on queries, not rows: the tiled kernel's lanes parallelize over
+    # queries only, so a head-heavy grid with few queries would run it with
+    # mostly idle lanes even though rows is large.
+    tiled = total_qo_len > _MAX_CHUNKED_ROWS
     if chunked:
         num_chunks = max(_MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS)))
         if rows * num_chunks * topk * 8 > _MAX_CHUNKED_SCRATCH_BYTES:

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -133,10 +133,11 @@ def msa_topk_select(
 
     Notes
     -----
-    The kernel is chosen by problem size. All kernels select the same blocks
-    when scores are distinct; among near-tied scores (equal in the top 30
-    score bits) the chosen representatives may differ between kernels and
-    releases.
+    Several kernels implement this selection, chosen by problem size. They
+    return identical indices unless two blocks have nearly identical scores
+    competing for the last slots; either block may then be selected, so exact
+    output indices are only reproducible for a fixed problem size and library
+    version. The selected score values match in every case.
     """
     if not is_sm12x_supported(max_score.device):
         raise RuntimeError(

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -231,13 +231,11 @@ def msa_topk_select(
     from .cute_dsl.topk_select_countrank_sm12x import _MAX_BLOCKS
 
     # Dispatch on the runtime valid-page count: the kernels only ever touch
-    # blocks below num_valid_pages, regardless of the allocated score
-    # dimension. The chunked path covers grids that underfill the GPU, where
-    # the single-CTA kernels serialize each row's scan, and it also reads the
-    # scores once where the radix kernel makes a pass per stage; prefill-sized
-    # grids fill the GPU on their own and keep the single-kernel paths. All
-    # quantities are shape- or capture-constant, so the choice is CUDA-graph
-    # safe.
+    # blocks below num_valid_pages. The chunked path serves grids too small to
+    # fill the GPU, and still wins at full ones by reading the scores once
+    # where the radix kernel makes a pass per stage; prefill-sized grids keep
+    # the single-kernel paths. Everything here is shape-constant, so the
+    # choice is CUDA-graph safe.
     small = int(num_valid_pages) <= _MAX_BLOCKS
     n_mid = int(num_valid_pages) - force_begin_blocks - force_end_blocks
     chunked = (

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -199,7 +199,7 @@ def msa_topk_select(
     from .cute_dsl.topk_select_chunked_sm12x import (
         _CHUNK_BLOCKS,
         _MAX_CHUNK_BLOCKS,
-        _MAX_CHUNKED_ROWS,
+        _TILED_MIN_QUERIES,
         _MAX_CHUNKED_SCRATCH_BYTES,
         _MAX_CHUNKS,
         _MIN_BLOCKS,
@@ -221,13 +221,15 @@ def msa_topk_select(
     # Keyed on queries, not rows: the tiled kernel's lanes parallelize over
     # queries only, so a head-heavy grid with few queries would run it with
     # mostly idle lanes even though rows is large.
-    tiled = total_qo_len > _MAX_CHUNKED_ROWS
+    tiled = total_qo_len > _TILED_MIN_QUERIES
     if chunked:
         num_chunks = max(_MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS)))
         if rows * num_chunks * topk * 8 > _MAX_CHUNKED_SCRATCH_BYTES:
             chunked = False
     if chunked:
         chunk_len = -(-n_mid // num_chunks)
+        # The partial kernels' SMEM staging has no in-kernel clamp.
+        assert chunk_len <= _MAX_CHUNK_BLOCKS
         # One allocation for both candidate buffers keeps this hot path at a
         # single allocator call.
         cand = torch.empty(

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -69,10 +69,12 @@ def _get_compiled_topk(topk: int, small: bool):
     return compiled
 
 
-def _get_compiled_topk_chunked(topk: int):
+def _get_compiled_topk_chunked(topk: int, tiled: bool):
     """Two-kernel (per-chunk rank + merge) variant; selections match the
-    count-rank kernel exactly (same bit-key and tie order)."""
-    key = (topk, "chunked")
+    count-rank kernel exactly (same bit-key and tie order). ``tiled`` picks
+    the full-grid partial kernel (coalesced q-tile staging) over the
+    row-per-CTA one."""
+    key = (topk, "chunked", tiled)
     compiled = _topk_compile_cache.get(key)
     if compiled is not None:
         return compiled
@@ -81,7 +83,7 @@ def _get_compiled_topk_chunked(topk: int):
 
     # Tensors: max_score, candidate keys, candidate indices, out. Scalars: nvp,
     # force_begin/end, num_chunks, chunk_len, total_q, heads.
-    compiled = _compile_topk(TopKSelectChunkedSm12x(topk=topk), 4, 7)
+    compiled = _compile_topk(TopKSelectChunkedSm12x(topk=topk, tiled=tiled), 4, 7)
     _topk_compile_cache[key] = compiled
     return compiled
 
@@ -198,6 +200,7 @@ def msa_topk_select(
         _CHUNK_BLOCKS,
         _MAX_CHUNK_BLOCKS,
         _MAX_CHUNKED_ROWS,
+        _MAX_CHUNKED_SCRATCH_BYTES,
         _MAX_CHUNKS,
         _MIN_BLOCKS,
         _MIN_CHUNKS,
@@ -205,19 +208,23 @@ def msa_topk_select(
     from .cute_dsl.topk_select_countrank_sm12x import _MAX_BLOCKS
 
     # Dispatch on the runtime valid-page count: the kernels only ever touch
-    # blocks below num_valid_pages. The chunked path serves grids too small to
-    # fill the GPU, and still wins at full ones by reading the scores once
-    # where the radix kernel makes a pass per stage; prefill-sized grids keep
-    # the single-kernel paths. Everything here is shape-constant, so the
-    # choice is CUDA-graph safe.
+    # blocks below num_valid_pages. The chunked path serves every grid with
+    # enough middle blocks to amortize its second launch: small grids because
+    # the single-CTA-per-row kernels cannot fill the GPU, full grids because
+    # it reads the scores exactly once where the radix kernel makes a pass
+    # per stage. ``tiled`` swaps in the coalesced q-tile partial kernel once
+    # the grid is large enough to fill the GPU without row-per-CTA fan-out.
+    # Everything here is shape-constant, so the choice is CUDA-graph safe.
     small = int(num_valid_pages) <= _MAX_BLOCKS
+    rows = total_qo_len * num_qo_heads
     n_mid = int(num_valid_pages) - force_begin_blocks - force_end_blocks
-    chunked = (
-        total_qo_len * num_qo_heads <= _MAX_CHUNKED_ROWS
-        and _MIN_BLOCKS < n_mid <= _MAX_CHUNKS * _MAX_CHUNK_BLOCKS
-    )
+    chunked = _MIN_BLOCKS < n_mid <= _MAX_CHUNKS * _MAX_CHUNK_BLOCKS
+    tiled = rows > _MAX_CHUNKED_ROWS
     if chunked:
         num_chunks = max(_MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS)))
+        if rows * num_chunks * topk * 8 > _MAX_CHUNKED_SCRATCH_BYTES:
+            chunked = False
+    if chunked:
         chunk_len = -(-n_mid // num_chunks)
         # One allocation for both candidate buffers keeps this hot path at a
         # single allocator call.
@@ -227,7 +234,7 @@ def msa_topk_select(
             device=max_score.device,
         )
         cand_key, cand_idx = cand[0], cand[1]
-        _get_compiled_topk_chunked(topk)(
+        _get_compiled_topk_chunked(topk, tiled)(
             max_score,
             cand_key,
             cand_idx,

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -24,17 +24,32 @@ from ..utils import is_sm12x_supported
 
 _topk_compile_cache: dict = {}
 
-# Row cap for the chunked kernel: covers saturated decode batches while keeping
-# the per-call candidate scratch bounded (rows * _MAX_CHUNKS * topk * 8 bytes).
-_MAX_CHUNKED_ROWS = 2048
+
+def _compile_topk(kernel_obj, num_score_tensors: int, num_scalars: int):
+    """Shared compile plumbing so every top-k variant builds with identical
+    fake-tensor setup and options. All tensor arguments are 3D and the scalar
+    values are placeholders (the compiled kernels take them dynamically)."""
+    import cutlass
+    import cutlass.cute as cute
+
+    def fk(dtype):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype,
+            tuple(cute.sym_int() for _ in range(3)),
+            stride_order=(2, 1, 0),
+            assumed_align=4,
+        )
+
+    args = [fk(cutlass.Float32)]  # max_score (H, P, S)
+    args += [fk(cutlass.Int32) for _ in range(num_score_tensors - 1)]
+    args += [cutlass.Int32(1)] * num_scalars
+    args.append(cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True))
+    return cute.compile(kernel_obj, *args, options="--enable-tvm-ffi")
 
 
 def _get_compiled_topk(topk: int, small: bool):
     """``small`` picks the O(N^2) count-rank kernel, else the radix kernel; the
     two give identical selections only on distinct-score inputs (ties may differ)."""
-    import cutlass
-    import cutlass.cute as cute
-
     key = (topk, small)
     compiled = _topk_compile_cache.get(key)
     if compiled is not None:
@@ -48,29 +63,8 @@ def _get_compiled_topk(topk: int, small: bool):
         from .cute_dsl.topk_select_radix_sm12x import (  # type: ignore[assignment,no-redef]
             TopKSelectRadixSm12x as _TopKKernel,
         )
-    kernel_obj = _TopKKernel(topk=topk)
-
-    def fk(dtype, ndim, align):
-        return cute.runtime.make_fake_compact_tensor(
-            dtype,
-            tuple(cute.sym_int() for _ in range(ndim)),
-            stride_order=tuple(reversed(range(ndim))),
-            assumed_align=align,
-        )
-
-    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
-    compiled = cute.compile(
-        kernel_obj,
-        fk(cutlass.Float32, 3, 4),  # max_score (H, P, S)
-        fk(cutlass.Int32, 3, 4),  # out (S, H, topk)
-        cutlass.Int32(1),  # num_valid_pages
-        cutlass.Int32(0),  # force_begin
-        cutlass.Int32(0),  # force_end
-        cutlass.Int32(1),  # total_qo_len
-        cutlass.Int32(1),  # num_qo_heads
-        stream_fake,
-        options="--enable-tvm-ffi",
-    )
+    # Tensors: max_score, out. Scalars: nvp, force_begin/end, total_q, heads.
+    compiled = _compile_topk(_TopKKernel(topk=topk), 2, 5)
     _topk_compile_cache[key] = compiled
     return compiled
 
@@ -78,9 +72,6 @@ def _get_compiled_topk(topk: int, small: bool):
 def _get_compiled_topk_chunked(topk: int):
     """Two-kernel (per-chunk rank + merge) variant; selections match the
     count-rank kernel exactly (same bit-key and tie order)."""
-    import cutlass
-    import cutlass.cute as cute
-
     key = (topk, "chunked")
     compiled = _topk_compile_cache.get(key)
     if compiled is not None:
@@ -88,33 +79,9 @@ def _get_compiled_topk_chunked(topk: int):
 
     from .cute_dsl.topk_select_chunked_sm12x import TopKSelectChunkedSm12x
 
-    kernel_obj = TopKSelectChunkedSm12x(topk=topk)
-
-    def fk(dtype, ndim, align):
-        return cute.runtime.make_fake_compact_tensor(
-            dtype,
-            tuple(cute.sym_int() for _ in range(ndim)),
-            stride_order=tuple(reversed(range(ndim))),
-            assumed_align=align,
-        )
-
-    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
-    compiled = cute.compile(
-        kernel_obj,
-        fk(cutlass.Float32, 3, 4),  # max_score (H, P, S)
-        fk(cutlass.Int32, 3, 4),  # candidate keys (S, H, C*topk)
-        fk(cutlass.Int32, 3, 4),  # candidate block indices (S, H, C*topk)
-        fk(cutlass.Int32, 3, 4),  # out (S, H, topk)
-        cutlass.Int32(1),  # num_valid_pages
-        cutlass.Int32(0),  # force_begin
-        cutlass.Int32(0),  # force_end
-        cutlass.Int32(1),  # num_chunks
-        cutlass.Int32(1),  # chunk_len
-        cutlass.Int32(1),  # total_qo_len
-        cutlass.Int32(1),  # num_qo_heads
-        stream_fake,
-        options="--enable-tvm-ffi",
-    )
+    # Tensors: max_score, candidate keys, candidate indices, out. Scalars: nvp,
+    # force_begin/end, num_chunks, chunk_len, total_q, heads.
+    compiled = _compile_topk(TopKSelectChunkedSm12x(topk=topk), 4, 7)
     _topk_compile_cache[key] = compiled
     return compiled
 
@@ -163,6 +130,13 @@ def msa_topk_select(
         Shape ``(total_qo_len, num_qo_heads, topk)``, dtype int32.
         Ascending KV-block indices; ``-1`` entries are tail-padded invalid
         slots.
+
+    Notes
+    -----
+    The kernel is chosen by problem size. All kernels select the same blocks
+    when scores are distinct; among near-tied scores (equal in the top 30
+    score bits) the chosen representatives may differ between kernels and
+    releases.
     """
     if not is_sm12x_supported(max_score.device):
         raise RuntimeError(
@@ -224,6 +198,7 @@ def msa_topk_select(
     from .cute_dsl.topk_select_chunked_sm12x import (
         _CHUNK_BLOCKS,
         _MAX_CHUNK_BLOCKS,
+        _MAX_CHUNKED_ROWS,
         _MAX_CHUNKS,
         _MIN_BLOCKS,
         _MIN_CHUNKS,
@@ -245,12 +220,14 @@ def msa_topk_select(
     if chunked:
         num_chunks = max(_MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS)))
         chunk_len = -(-n_mid // num_chunks)
-        cand_key = torch.empty(
-            (total_qo_len, num_qo_heads, num_chunks * topk),
+        # One allocation for both candidate buffers keeps this hot path at a
+        # single allocator call.
+        cand = torch.empty(
+            (2, total_qo_len, num_qo_heads, num_chunks * topk),
             dtype=torch.int32,
             device=max_score.device,
         )
-        cand_idx = torch.empty_like(cand_key)
+        cand_key, cand_idx = cand[0], cand[1]
         _get_compiled_topk_chunked(topk)(
             max_score,
             cand_key,

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -24,6 +24,10 @@ from ..utils import is_sm12x_supported
 
 _topk_compile_cache: dict = {}
 
+# Row cap for the chunked kernel: covers saturated decode batches while keeping
+# the per-call candidate scratch bounded (rows * _MAX_CHUNKS * topk * 8 bytes).
+_MAX_CHUNKED_ROWS = 2048
+
 
 def _get_compiled_topk(topk: int, small: bool):
     """``small`` picks the O(N^2) count-rank kernel, else the radix kernel; the
@@ -62,6 +66,50 @@ def _get_compiled_topk(topk: int, small: bool):
         cutlass.Int32(1),  # num_valid_pages
         cutlass.Int32(0),  # force_begin
         cutlass.Int32(0),  # force_end
+        cutlass.Int32(1),  # total_qo_len
+        cutlass.Int32(1),  # num_qo_heads
+        stream_fake,
+        options="--enable-tvm-ffi",
+    )
+    _topk_compile_cache[key] = compiled
+    return compiled
+
+
+def _get_compiled_topk_chunked(topk: int):
+    """Two-kernel (per-chunk rank + merge) variant; selections match the
+    count-rank kernel exactly (same bit-key and tie order)."""
+    import cutlass
+    import cutlass.cute as cute
+
+    key = (topk, "chunked")
+    compiled = _topk_compile_cache.get(key)
+    if compiled is not None:
+        return compiled
+
+    from .cute_dsl.topk_select_chunked_sm12x import TopKSelectChunkedSm12x
+
+    kernel_obj = TopKSelectChunkedSm12x(topk=topk)
+
+    def fk(dtype, ndim, align):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype,
+            tuple(cute.sym_int() for _ in range(ndim)),
+            stride_order=tuple(reversed(range(ndim))),
+            assumed_align=align,
+        )
+
+    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+    compiled = cute.compile(
+        kernel_obj,
+        fk(cutlass.Float32, 3, 4),  # max_score (H, P, S)
+        fk(cutlass.Int32, 3, 4),  # candidate keys (S, H, C*topk)
+        fk(cutlass.Int32, 3, 4),  # candidate block indices (S, H, C*topk)
+        fk(cutlass.Int32, 3, 4),  # out (S, H, topk)
+        cutlass.Int32(1),  # num_valid_pages
+        cutlass.Int32(0),  # force_begin
+        cutlass.Int32(0),  # force_end
+        cutlass.Int32(1),  # num_chunks
+        cutlass.Int32(1),  # chunk_len
         cutlass.Int32(1),  # total_qo_len
         cutlass.Int32(1),  # num_qo_heads
         stream_fake,
@@ -173,12 +221,54 @@ def msa_topk_select(
         if output.dtype != torch.int32:
             raise ValueError(f"output must be int32, got {output.dtype}")
 
+    from .cute_dsl.topk_select_chunked_sm12x import (
+        _CHUNK_BLOCKS,
+        _MAX_CHUNK_BLOCKS,
+        _MAX_CHUNKS,
+        _MIN_BLOCKS,
+        _MIN_CHUNKS,
+    )
     from .cute_dsl.topk_select_countrank_sm12x import _MAX_BLOCKS
 
-    # Dispatch on the runtime valid-page count: the count-rank kernel only ever
-    # touches blocks below num_valid_pages, regardless of the allocated score
-    # dimension.
+    # Dispatch on the runtime valid-page count: the kernels only ever touch
+    # blocks below num_valid_pages, regardless of the allocated score
+    # dimension. The chunked variant splits each row's candidate scan across
+    # CTAs and merges the survivors: decode-sized (query, head) grids stop
+    # serializing on a few SMs, and the scores are read once instead of the
+    # radix kernel's pass-per-stage. The row cap keeps its candidate scratch
+    # small and leaves prefill-sized grids — which fill the GPU on their own —
+    # to the single-kernel paths. All quantities are shape- or capture-
+    # constant, so the choice is CUDA-graph safe.
     small = int(num_valid_pages) <= _MAX_BLOCKS
+    n_mid = int(num_valid_pages) - force_begin_blocks - force_end_blocks
+    chunked = (
+        total_qo_len * num_qo_heads <= _MAX_CHUNKED_ROWS
+        and _MIN_BLOCKS < n_mid <= _MAX_CHUNKS * _MAX_CHUNK_BLOCKS
+    )
+    if chunked:
+        num_chunks = max(_MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS)))
+        chunk_len = -(-n_mid // num_chunks)
+        cand_key = torch.empty(
+            (total_qo_len, num_qo_heads, num_chunks * topk),
+            dtype=torch.int32,
+            device=max_score.device,
+        )
+        cand_idx = torch.empty_like(cand_key)
+        _get_compiled_topk_chunked(topk)(
+            max_score,
+            cand_key,
+            cand_idx,
+            output,
+            int(num_valid_pages),
+            int(force_begin_blocks),
+            int(force_end_blocks),
+            num_chunks,
+            chunk_len,
+            int(total_qo_len),
+            int(num_qo_heads),
+        )
+        return output
+
     _get_compiled_topk(topk, small)(
         max_score,
         output,

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -63,7 +63,6 @@ def _get_compiled_topk(topk: int, small: bool):
         from .cute_dsl.topk_select_radix_sm12x import (  # type: ignore[assignment,no-redef]
             TopKSelectRadixSm12x as _TopKKernel,
         )
-    # Tensors: max_score, out. Scalars: nvp, force_begin/end, total_q, heads.
     compiled = _compile_topk(_TopKKernel(topk=topk), 2, 5)
     _topk_compile_cache[key] = compiled
     return compiled
@@ -81,8 +80,6 @@ def _get_compiled_topk_chunked(topk: int, tiled: bool):
 
     from .cute_dsl.topk_select_chunked_sm12x import TopKSelectChunkedSm12x
 
-    # Tensors: max_score, candidate keys, candidate indices, out. Scalars: nvp,
-    # force_begin/end, num_chunks, chunk_len, total_q, heads.
     compiled = _compile_topk(TopKSelectChunkedSm12x(topk=topk, tiled=tiled), 4, 7)
     _topk_compile_cache[key] = compiled
     return compiled
@@ -207,13 +204,9 @@ def msa_topk_select(
     )
     from .cute_dsl.topk_select_countrank_sm12x import _MAX_BLOCKS
 
-    # Dispatch on the runtime valid-page count: the kernels only ever touch
-    # blocks below num_valid_pages. The chunked path serves every grid with
-    # enough middle blocks to amortize its second launch (why it wins on both
-    # small and full grids is explained in topk_select_chunked_sm12x);
-    # ``tiled`` swaps in the coalesced q-tile partial kernel once the grid
-    # fills the GPU without row-per-CTA fan-out. Everything here is
-    # shape-constant, so the choice is CUDA-graph safe.
+    # Dispatch on num_valid_pages (the kernels never touch blocks above it);
+    # topk_select_chunked_sm12x explains why chunked wins on both small and
+    # full grids. Everything here is shape-constant, so CUDA-graph safe.
     small = int(num_valid_pages) <= _MAX_BLOCKS
     rows = total_qo_len * num_qo_heads
     n_mid = int(num_valid_pages) - force_begin_blocks - force_end_blocks

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -133,11 +133,9 @@ def msa_topk_select(
 
     Notes
     -----
-    Several kernels implement this selection, chosen by problem size. They
-    return identical indices unless two blocks have nearly identical scores
-    competing for the last slots; either block may then be selected, so exact
-    output indices are only reproducible for a fixed problem size and library
-    version. The selected score values match in every case.
+    When near-tied scores compete for the last slots, either block may be
+    selected; exact indices may vary across problem sizes and releases, but
+    the selected score values always match.
     """
     if not is_sm12x_supported(max_score.device):
         raise RuntimeError(

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -232,13 +232,12 @@ def msa_topk_select(
 
     # Dispatch on the runtime valid-page count: the kernels only ever touch
     # blocks below num_valid_pages, regardless of the allocated score
-    # dimension. The chunked variant splits each row's candidate scan across
-    # CTAs and merges the survivors: decode-sized (query, head) grids stop
-    # serializing on a few SMs, and the scores are read once instead of the
-    # radix kernel's pass-per-stage. The row cap keeps its candidate scratch
-    # small and leaves prefill-sized grids — which fill the GPU on their own —
-    # to the single-kernel paths. All quantities are shape- or capture-
-    # constant, so the choice is CUDA-graph safe.
+    # dimension. The chunked path covers grids that underfill the GPU, where
+    # the single-CTA kernels serialize each row's scan, and it also reads the
+    # scores once where the radix kernel makes a pass per stage; prefill-sized
+    # grids fill the GPU on their own and keep the single-kernel paths. All
+    # quantities are shape- or capture-constant, so the choice is CUDA-graph
+    # safe.
     small = int(num_valid_pages) <= _MAX_BLOCKS
     n_mid = int(num_valid_pages) - force_begin_blocks - force_end_blocks
     chunked = (

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -283,13 +283,12 @@ def msa_topk_select(
         _MIN_CHUNKS,
     )
 
-    # The chunked path covers grids that underfill the GPU, where the
-    # single-CTA kernels serialize each row's scan, and it also reads the
-    # scores once where the radix kernel makes a pass per stage; prefill-sized
-    # grids fill the GPU on their own and keep the single-kernel paths.
+    # The chunked path serves grids too small to fill the GPU, and still wins
+    # at full ones by reading the scores once where the radix kernel makes a
+    # pass per stage; prefill-sized grids keep the single-kernel paths.
     # Per-token extents stay on the single-kernel paths: the chunk geometry is
-    # host-derived from the scalar count. All quantities are shape- or
-    # capture-constant, so the choice is CUDA-graph safe.
+    # host-derived from the scalar count. Everything here is shape-constant,
+    # so the choice is CUDA-graph safe.
     if not per_token_nvp:
         n_mid = nvp_scalar - force_begin_blocks - force_end_blocks
         chunked = (

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -271,7 +271,7 @@ def msa_topk_select(
     from .cute_dsl.topk_select_chunked_sm12x import (
         _CHUNK_BLOCKS,
         _MAX_CHUNK_BLOCKS,
-        _MAX_CHUNKED_ROWS,
+        _TILED_MIN_QUERIES,
         _MAX_CHUNKED_SCRATCH_BYTES,
         _MAX_CHUNKS,
         _MIN_BLOCKS,
@@ -292,13 +292,15 @@ def msa_topk_select(
         # Keyed on queries, not rows: the tiled kernel's lanes parallelize
         # over queries only, so a head-heavy grid with few queries would run
         # it with mostly idle lanes even though rows is large.
-        tiled = total_qo_len > _MAX_CHUNKED_ROWS
+        tiled = total_qo_len > _TILED_MIN_QUERIES
         if chunked:
             num_chunks = max(_MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS)))
             if rows * num_chunks * topk * 8 > _MAX_CHUNKED_SCRATCH_BYTES:
                 chunked = False
         if chunked:
             chunk_len = -(-n_mid // num_chunks)
+            # The partial kernels' SMEM staging has no in-kernel clamp.
+            assert chunk_len <= _MAX_CHUNK_BLOCKS
             # One allocation for both candidate buffers keeps this hot path at
             # a single allocator call.
             cand = torch.empty(

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -20,6 +20,7 @@ from typing import Optional, Union
 import torch
 
 from ..api_logging import flashinfer_api
+from ..trace.templates.msa import msa_topk_select_trace
 from ..utils import is_sm12x_supported
 
 
@@ -108,7 +109,7 @@ def _get_compiled_topk_chunked(topk: int, tiled: bool):
     return _compile_topk(TopKSelectChunkedSm12x(topk=topk, tiled=tiled), 4, 7)
 
 
-@flashinfer_api
+@flashinfer_api(trace=msa_topk_select_trace)
 def msa_topk_select(
     max_score: torch.Tensor,
     topk: int,

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -279,19 +279,20 @@ def msa_topk_select(
     )
 
     # The chunked path serves every grid with enough middle blocks to
-    # amortize its second launch: small grids because the single-CTA-per-row
-    # kernels cannot fill the GPU, full grids because it reads the scores
-    # exactly once where the radix kernel makes a pass per stage. ``tiled``
-    # swaps in the coalesced q-tile partial kernel once the grid is large
-    # enough to fill the GPU without row-per-CTA fan-out. Per-token extents
-    # stay on the single-kernel paths: the chunk geometry is host-derived from
-    # the scalar count. Everything here is shape-constant, so the choice is
-    # CUDA-graph safe.
+    # amortize its second launch (why it wins on both small and full grids is
+    # explained in topk_select_chunked_sm12x); ``tiled`` swaps in the
+    # coalesced q-tile partial kernel once the grid fills the GPU without
+    # row-per-CTA fan-out. Per-token extents stay on the single-kernel paths:
+    # the chunk geometry is host-derived from the scalar count. Everything
+    # here is shape-constant, so the choice is CUDA-graph safe.
     if not per_token_nvp:
         rows = total_qo_len * num_qo_heads
         n_mid = nvp_scalar - force_begin_blocks - force_end_blocks
         chunked = _MIN_BLOCKS < n_mid <= _MAX_CHUNKS * _MAX_CHUNK_BLOCKS
-        tiled = rows > _MAX_CHUNKED_ROWS
+        # Keyed on queries, not rows: the tiled kernel's lanes parallelize
+        # over queries only, so a head-heavy grid with few queries would run
+        # it with mostly idle lanes even though rows is large.
+        tiled = total_qo_len > _MAX_CHUNKED_ROWS
         if chunked:
             num_chunks = max(_MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS)))
             if rows * num_chunks * topk * 8 > _MAX_CHUNKED_SCRATCH_BYTES:

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -98,14 +98,16 @@ def _get_compiled_topk(topk: int, small: bool, per_token_nvp: bool):
 
 
 @functools.cache
-def _get_compiled_topk_chunked(topk: int):
+def _get_compiled_topk_chunked(topk: int, tiled: bool):
     """Two-kernel (per-chunk rank + merge) variant; selections match the
-    count-rank kernel exactly (same bit-key and tie order)."""
+    count-rank kernel exactly (same bit-key and tie order). ``tiled`` picks
+    the full-grid partial kernel (coalesced q-tile staging) over the
+    row-per-CTA one."""
     from .cute_dsl.topk_select_chunked_sm12x import TopKSelectChunkedSm12x
 
     # Tensors: max_score, candidate keys, candidate indices, out. Scalars: nvp,
     # force_begin/end, num_chunks, chunk_len, total_q, heads.
-    return _compile_topk(TopKSelectChunkedSm12x(topk=topk), 4, 7)
+    return _compile_topk(TopKSelectChunkedSm12x(topk=topk, tiled=tiled), 4, 7)
 
 
 @flashinfer_api
@@ -270,27 +272,31 @@ def msa_topk_select(
         _CHUNK_BLOCKS,
         _MAX_CHUNK_BLOCKS,
         _MAX_CHUNKED_ROWS,
+        _MAX_CHUNKED_SCRATCH_BYTES,
         _MAX_CHUNKS,
         _MIN_BLOCKS,
         _MIN_CHUNKS,
     )
 
-    # The chunked path serves grids too small to fill the GPU, and still wins
-    # at full ones by reading the scores once where the radix kernel makes a
-    # pass per stage; prefill-sized grids keep the single-kernel paths.
-    # Per-token extents stay on the single-kernel paths: the chunk geometry is
-    # host-derived from the scalar count. Everything here is shape-constant,
-    # so the choice is CUDA-graph safe.
+    # The chunked path serves every grid with enough middle blocks to
+    # amortize its second launch: small grids because the single-CTA-per-row
+    # kernels cannot fill the GPU, full grids because it reads the scores
+    # exactly once where the radix kernel makes a pass per stage. ``tiled``
+    # swaps in the coalesced q-tile partial kernel once the grid is large
+    # enough to fill the GPU without row-per-CTA fan-out. Per-token extents
+    # stay on the single-kernel paths: the chunk geometry is host-derived from
+    # the scalar count. Everything here is shape-constant, so the choice is
+    # CUDA-graph safe.
     if not per_token_nvp:
+        rows = total_qo_len * num_qo_heads
         n_mid = nvp_scalar - force_begin_blocks - force_end_blocks
-        chunked = (
-            total_qo_len * num_qo_heads <= _MAX_CHUNKED_ROWS
-            and _MIN_BLOCKS < n_mid <= _MAX_CHUNKS * _MAX_CHUNK_BLOCKS
-        )
+        chunked = _MIN_BLOCKS < n_mid <= _MAX_CHUNKS * _MAX_CHUNK_BLOCKS
+        tiled = rows > _MAX_CHUNKED_ROWS
         if chunked:
-            num_chunks = max(
-                _MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS))
-            )
+            num_chunks = max(_MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS)))
+            if rows * num_chunks * topk * 8 > _MAX_CHUNKED_SCRATCH_BYTES:
+                chunked = False
+        if chunked:
             chunk_len = -(-n_mid // num_chunks)
             # One allocation for both candidate buffers keeps this hot path at
             # a single allocator call.
@@ -300,7 +306,7 @@ def msa_topk_select(
                 device=max_score.device,
             )
             cand_key, cand_idx = cand[0], cand[1]
-            _get_compiled_topk_chunked(topk)(
+            _get_compiled_topk_chunked(topk, tiled)(
                 max_score,
                 cand_key,
                 cand_idx,

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -29,6 +29,10 @@ def _dummy_nvp(device_index: int) -> torch.Tensor:
     reads it; cached so repeat calls do not launch a fill kernel."""
     return torch.zeros(1, dtype=torch.int32, device=torch.device("cuda", device_index))
 
+# Row cap for the chunked kernel: covers saturated decode batches while keeping
+# the per-call candidate scratch bounded (rows * _MAX_CHUNKS * topk * 8 bytes).
+_MAX_CHUNKED_ROWS = 2048
+
 
 @functools.cache
 def _get_compiled_topk(topk: int, small: bool, per_token_nvp: bool):
@@ -72,6 +76,50 @@ def _get_compiled_topk(topk: int, small: bool, per_token_nvp: bool):
         stream_fake,
         options="--enable-tvm-ffi",
     )
+    return compiled
+
+
+def _get_compiled_topk_chunked(topk: int):
+    """Two-kernel (per-chunk rank + merge) variant; selections match the
+    count-rank kernel exactly (same bit-key and tie order)."""
+    import cutlass
+    import cutlass.cute as cute
+
+    key = (topk, "chunked")
+    compiled = _topk_compile_cache.get(key)
+    if compiled is not None:
+        return compiled
+
+    from .cute_dsl.topk_select_chunked_sm12x import TopKSelectChunkedSm12x
+
+    kernel_obj = TopKSelectChunkedSm12x(topk=topk)
+
+    def fk(dtype, ndim, align):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype,
+            tuple(cute.sym_int() for _ in range(ndim)),
+            stride_order=tuple(reversed(range(ndim))),
+            assumed_align=align,
+        )
+
+    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+    compiled = cute.compile(
+        kernel_obj,
+        fk(cutlass.Float32, 3, 4),  # max_score (H, P, S)
+        fk(cutlass.Int32, 3, 4),  # candidate keys (S, H, C*topk)
+        fk(cutlass.Int32, 3, 4),  # candidate block indices (S, H, C*topk)
+        fk(cutlass.Int32, 3, 4),  # out (S, H, topk)
+        cutlass.Int32(1),  # num_valid_pages
+        cutlass.Int32(0),  # force_begin
+        cutlass.Int32(0),  # force_end
+        cutlass.Int32(1),  # num_chunks
+        cutlass.Int32(1),  # chunk_len
+        cutlass.Int32(1),  # total_qo_len
+        cutlass.Int32(1),  # num_qo_heads
+        stream_fake,
+        options="--enable-tvm-ffi",
+    )
+    _topk_compile_cache[key] = compiled
     return compiled
 
 
@@ -226,6 +274,54 @@ def msa_topk_select(
             )
         if output.dtype != torch.int32:
             raise ValueError(f"output must be int32, got {output.dtype}")
+
+    from .cute_dsl.topk_select_chunked_sm12x import (
+        _CHUNK_BLOCKS,
+        _MAX_CHUNK_BLOCKS,
+        _MAX_CHUNKS,
+        _MIN_BLOCKS,
+        _MIN_CHUNKS,
+    )
+
+    # The chunked variant splits each row's candidate scan across CTAs and
+    # merges the survivors: decode-sized (query, head) grids stop serializing
+    # on a few SMs, and the scores are read once instead of the radix kernel's
+    # pass-per-stage. The row cap keeps its candidate scratch small and leaves
+    # prefill-sized grids — which fill the GPU on their own — to the
+    # single-kernel paths. Per-token extents stay on the single-kernel paths:
+    # the chunk geometry is host-derived from the scalar count. All quantities
+    # are shape- or capture-constant, so the choice is CUDA-graph safe.
+    if not per_token_nvp:
+        n_mid = nvp_scalar - force_begin_blocks - force_end_blocks
+        chunked = (
+            total_qo_len * num_qo_heads <= _MAX_CHUNKED_ROWS
+            and _MIN_BLOCKS < n_mid <= _MAX_CHUNKS * _MAX_CHUNK_BLOCKS
+        )
+        if chunked:
+            num_chunks = max(
+                _MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS))
+            )
+            chunk_len = -(-n_mid // num_chunks)
+            cand_key = torch.empty(
+                (total_qo_len, num_qo_heads, num_chunks * topk),
+                dtype=torch.int32,
+                device=max_score.device,
+            )
+            cand_idx = torch.empty_like(cand_key)
+            _get_compiled_topk_chunked(topk)(
+                max_score,
+                cand_key,
+                cand_idx,
+                output,
+                nvp_scalar,
+                int(force_begin_blocks),
+                int(force_end_blocks),
+                num_chunks,
+                chunk_len,
+                int(total_qo_len),
+                int(num_qo_heads),
+            )
+            return output
 
     _get_compiled_topk(topk, small, per_token_nvp)(
         max_score,

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -29,9 +29,27 @@ def _dummy_nvp(device_index: int) -> torch.Tensor:
     reads it; cached so repeat calls do not launch a fill kernel."""
     return torch.zeros(1, dtype=torch.int32, device=torch.device("cuda", device_index))
 
-# Row cap for the chunked kernel: covers saturated decode batches while keeping
-# the per-call candidate scratch bounded (rows * _MAX_CHUNKS * topk * 8 bytes).
-_MAX_CHUNKED_ROWS = 2048
+
+def _compile_topk(kernel_obj, num_score_tensors: int, num_scalars: int):
+    """Compile plumbing shared by the chunked top-k variants. All tensor
+    arguments are 3D and the scalar values are placeholders (the compiled
+    kernels take them dynamically)."""
+    import cutlass
+    import cutlass.cute as cute
+
+    def fk(dtype):
+        return cute.runtime.make_fake_compact_tensor(
+            dtype,
+            tuple(cute.sym_int() for _ in range(3)),
+            stride_order=(2, 1, 0),
+            assumed_align=4,
+        )
+
+    args = [fk(cutlass.Float32)]  # max_score (H, P, S)
+    args += [fk(cutlass.Int32) for _ in range(num_score_tensors - 1)]
+    args += [cutlass.Int32(1)] * num_scalars
+    args.append(cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True))
+    return cute.compile(kernel_obj, *args, options="--enable-tvm-ffi")
 
 
 @functools.cache
@@ -79,48 +97,15 @@ def _get_compiled_topk(topk: int, small: bool, per_token_nvp: bool):
     return compiled
 
 
+@functools.cache
 def _get_compiled_topk_chunked(topk: int):
     """Two-kernel (per-chunk rank + merge) variant; selections match the
     count-rank kernel exactly (same bit-key and tie order)."""
-    import cutlass
-    import cutlass.cute as cute
-
-    key = (topk, "chunked")
-    compiled = _topk_compile_cache.get(key)
-    if compiled is not None:
-        return compiled
-
     from .cute_dsl.topk_select_chunked_sm12x import TopKSelectChunkedSm12x
 
-    kernel_obj = TopKSelectChunkedSm12x(topk=topk)
-
-    def fk(dtype, ndim, align):
-        return cute.runtime.make_fake_compact_tensor(
-            dtype,
-            tuple(cute.sym_int() for _ in range(ndim)),
-            stride_order=tuple(reversed(range(ndim))),
-            assumed_align=align,
-        )
-
-    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
-    compiled = cute.compile(
-        kernel_obj,
-        fk(cutlass.Float32, 3, 4),  # max_score (H, P, S)
-        fk(cutlass.Int32, 3, 4),  # candidate keys (S, H, C*topk)
-        fk(cutlass.Int32, 3, 4),  # candidate block indices (S, H, C*topk)
-        fk(cutlass.Int32, 3, 4),  # out (S, H, topk)
-        cutlass.Int32(1),  # num_valid_pages
-        cutlass.Int32(0),  # force_begin
-        cutlass.Int32(0),  # force_end
-        cutlass.Int32(1),  # num_chunks
-        cutlass.Int32(1),  # chunk_len
-        cutlass.Int32(1),  # total_qo_len
-        cutlass.Int32(1),  # num_qo_heads
-        stream_fake,
-        options="--enable-tvm-ffi",
-    )
-    _topk_compile_cache[key] = compiled
-    return compiled
+    # Tensors: max_score, candidate keys, candidate indices, out. Scalars: nvp,
+    # force_begin/end, num_chunks, chunk_len, total_q, heads.
+    return _compile_topk(TopKSelectChunkedSm12x(topk=topk), 4, 7)
 
 
 @flashinfer_api
@@ -179,6 +164,13 @@ def msa_topk_select(
         Shape ``(total_qo_len, num_qo_heads, topk)``, dtype int32.
         Ascending KV-block indices; ``-1`` entries are tail-padded invalid
         slots.
+
+    Notes
+    -----
+    The kernel is chosen by problem size. All kernels select the same blocks
+    when scores are distinct; among near-tied scores (equal in the top 30
+    score bits) the chosen representatives may differ between kernels and
+    releases.
     """
     if not is_sm12x_supported(max_score.device):
         raise RuntimeError(
@@ -278,6 +270,7 @@ def msa_topk_select(
     from .cute_dsl.topk_select_chunked_sm12x import (
         _CHUNK_BLOCKS,
         _MAX_CHUNK_BLOCKS,
+        _MAX_CHUNKED_ROWS,
         _MAX_CHUNKS,
         _MIN_BLOCKS,
         _MIN_CHUNKS,
@@ -300,12 +293,14 @@ def msa_topk_select(
                 _MIN_CHUNKS, min(_MAX_CHUNKS, -(-n_mid // _CHUNK_BLOCKS))
             )
             chunk_len = -(-n_mid // num_chunks)
-            cand_key = torch.empty(
-                (total_qo_len, num_qo_heads, num_chunks * topk),
+            # One allocation for both candidate buffers keeps this hot path at
+            # a single allocator call.
+            cand = torch.empty(
+                (2, total_qo_len, num_qo_heads, num_chunks * topk),
                 dtype=torch.int32,
                 device=max_score.device,
             )
-            cand_idx = torch.empty_like(cand_key)
+            cand_key, cand_idx = cand[0], cand[1]
             _get_compiled_topk_chunked(topk)(
                 max_score,
                 cand_key,

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -105,8 +105,6 @@ def _get_compiled_topk_chunked(topk: int, tiled: bool):
     row-per-CTA one."""
     from .cute_dsl.topk_select_chunked_sm12x import TopKSelectChunkedSm12x
 
-    # Tensors: max_score, candidate keys, candidate indices, out. Scalars: nvp,
-    # force_begin/end, num_chunks, chunk_len, total_q, heads.
     return _compile_topk(TopKSelectChunkedSm12x(topk=topk, tiled=tiled), 4, 7)
 
 
@@ -278,13 +276,9 @@ def msa_topk_select(
         _MIN_CHUNKS,
     )
 
-    # The chunked path serves every grid with enough middle blocks to
-    # amortize its second launch (why it wins on both small and full grids is
-    # explained in topk_select_chunked_sm12x); ``tiled`` swaps in the
-    # coalesced q-tile partial kernel once the grid fills the GPU without
-    # row-per-CTA fan-out. Per-token extents stay on the single-kernel paths:
-    # the chunk geometry is host-derived from the scalar count. Everything
-    # here is shape-constant, so the choice is CUDA-graph safe.
+    # topk_select_chunked_sm12x explains why chunked wins on both small and
+    # full grids; per-token extents stay on the single-kernel paths.
+    # Everything here is shape-constant, so CUDA-graph safe.
     if not per_token_nvp:
         rows = total_qo_len * num_qo_heads
         n_mid = nvp_scalar - force_begin_blocks - force_end_blocks

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -167,11 +167,9 @@ def msa_topk_select(
 
     Notes
     -----
-    Several kernels implement this selection, chosen by problem size. They
-    return identical indices unless two blocks have nearly identical scores
-    competing for the last slots; either block may then be selected, so exact
-    output indices are only reproducible for a fixed problem size and library
-    version. The selected score values match in every case.
+    When near-tied scores compete for the last slots, either block may be
+    selected; exact indices may vary across problem sizes and releases, but
+    the selected score values always match.
     """
     if not is_sm12x_supported(max_score.device):
         raise RuntimeError(

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -283,14 +283,13 @@ def msa_topk_select(
         _MIN_CHUNKS,
     )
 
-    # The chunked variant splits each row's candidate scan across CTAs and
-    # merges the survivors: decode-sized (query, head) grids stop serializing
-    # on a few SMs, and the scores are read once instead of the radix kernel's
-    # pass-per-stage. The row cap keeps its candidate scratch small and leaves
-    # prefill-sized grids — which fill the GPU on their own — to the
-    # single-kernel paths. Per-token extents stay on the single-kernel paths:
-    # the chunk geometry is host-derived from the scalar count. All quantities
-    # are shape- or capture-constant, so the choice is CUDA-graph safe.
+    # The chunked path covers grids that underfill the GPU, where the
+    # single-CTA kernels serialize each row's scan, and it also reads the
+    # scores once where the radix kernel makes a pass per stage; prefill-sized
+    # grids fill the GPU on their own and keep the single-kernel paths.
+    # Per-token extents stay on the single-kernel paths: the chunk geometry is
+    # host-derived from the scalar count. All quantities are shape- or
+    # capture-constant, so the choice is CUDA-graph safe.
     if not per_token_nvp:
         n_mid = nvp_scalar - force_begin_blocks - force_end_blocks
         chunked = (

--- a/flashinfer/msa_ops/sparse_topk_select.py
+++ b/flashinfer/msa_ops/sparse_topk_select.py
@@ -167,10 +167,11 @@ def msa_topk_select(
 
     Notes
     -----
-    The kernel is chosen by problem size. All kernels select the same blocks
-    when scores are distinct; among near-tied scores (equal in the top 30
-    score bits) the chosen representatives may differ between kernels and
-    releases.
+    Several kernels implement this selection, chosen by problem size. They
+    return identical indices unless two blocks have nearly identical scores
+    competing for the last slots; either block may then be selected, so exact
+    output indices are only reproducible for a fixed problem size and library
+    version. The selected score values match in every case.
     """
     if not is_sm12x_supported(max_score.device):
         raise RuntimeError(

--- a/flashinfer/trace/templates/msa.py
+++ b/flashinfer/trace/templates/msa.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TraceTemplates for the numeric MSA ops; references mirror the torch oracles
-in ``tests/msa_ops/``. Metadata ops (topk select, union builders) produce
-indices, not numeric tensors, so they are not traced."""
+"""TraceTemplates for the MSA ops; references mirror the torch oracles in
+``tests/msa_ops/``. Internal metadata helpers (union builders) are not
+traced."""
 
 import torch
 
@@ -379,6 +379,180 @@ msa_proxy_score_fp4_trace = TraceTemplate(
     reference=_msa_proxy_score_fp4_reference,
     check=_msa_score_check,
     init=_msa_proxy_score_fp4_init,
+)
+
+# ── msa_topk_select (block selection) ─────────────────────────────────────────
+
+
+@torch.no_grad()
+def _msa_topk_select_reference(
+    max_score, topk, num_valid_pages=None, force_begin_blocks=0, force_end_blocks=0
+):
+    """Top-k KV blocks per (query, head): forced begin/end blocks always kept,
+    the rest by score rank within [0, num_valid_pages); ascending, -1 padded."""
+    H, P, S = max_score.shape
+    if num_valid_pages is None:
+        nvps = torch.full((S,), P, dtype=torch.long)
+    elif isinstance(num_valid_pages, torch.Tensor):
+        nvps = num_valid_pages.long().clamp(0, P).cpu()
+    else:
+        nvps = torch.full((S,), max(0, min(int(num_valid_pages), P)), dtype=torch.long)
+    scores = max_score.float().cpu()
+    out = torch.full((S, H, topk), -1, dtype=torch.int32)
+    for q in range(S):
+        nvp = int(nvps[q])
+        mid_end = max(nvp - force_end_blocks, force_begin_blocks)
+        forced = set(range(min(force_begin_blocks, nvp))) | set(range(mid_end, nvp))
+        free = topk - len(forced)
+        for h in range(H):
+            mid = scores[h, force_begin_blocks:mid_end, q]
+            k = min(free, mid.numel())
+            picked = (torch.topk(mid, k).indices + force_begin_blocks).tolist()
+            sel = sorted(forced | set(picked))
+            out[q, h, : len(sel)] = torch.tensor(sel, dtype=torch.int32)
+    return out.to(max_score.device)
+
+
+def _msa_topk_select_check(
+    reference_outputs,
+    actual_outputs,
+    max_score=None,
+    num_valid_pages=None,
+    force_begin_blocks=0,
+    force_end_blocks=0,
+    **_unused,
+):
+    """Near-tied scores make the selected index set ambiguous (see the
+    msa_topk_select docstring), so with ``max_score`` rows are compared by
+    their selected score multisets against the reference, plus forced-block
+    membership (a tied block must not displace a forced one). Without
+    ``max_score``, exact equality."""
+
+    # Nested: the JSON-embedded source must be self-contained.
+    def unwrap(x):
+        if isinstance(x, dict):
+            x = next(iter(x.values()))
+        if isinstance(x, (list, tuple)):
+            x = x[0]
+        return x
+
+    ref = unwrap(reference_outputs)
+    act = unwrap(actual_outputs)
+    if not (isinstance(ref, torch.Tensor) and isinstance(act, torch.Tensor)):
+        return False
+    if ref.shape != act.shape:
+        return False
+    ref, act = ref.cpu(), act.cpu()
+    scores = None if max_score is None else max_score.float().cpu()
+    S, H, _ = act.shape
+    nvps = None
+    if scores is not None:
+        P = scores.shape[1]
+        if num_valid_pages is None:
+            nvps = torch.full((S,), P, dtype=torch.long)
+        elif isinstance(num_valid_pages, torch.Tensor):
+            nvps = num_valid_pages.long().clamp(0, P).cpu()
+        else:
+            nvps = torch.full(
+                (S,), max(0, min(int(num_valid_pages), P)), dtype=torch.long
+            )
+    for q in range(S):
+        for h in range(H):
+            r, a = ref[q, h], act[q, h]
+            av = a[a >= 0]
+            # Valid entries must form a strictly ascending prefix, -1 tail only.
+            if (
+                (a[: av.numel()] != av).any()
+                or (a[av.numel() :] != -1).any()
+                or (av.diff() <= 0).any()
+            ):
+                return False
+            rv = r[r >= 0]
+            if av.numel() != rv.numel():
+                return False
+            if scores is None:
+                if not torch.equal(av, rv):
+                    return False
+                continue
+            nvp = int(nvps[q])
+            if (av >= nvp).any():
+                return False
+            mid_end = max(nvp - force_end_blocks, force_begin_blocks)
+            forced = set(range(min(force_begin_blocks, nvp))) | set(range(mid_end, nvp))
+            if not forced <= set(av.tolist()):
+                return False
+            got = scores[h, av.long(), q].sort(descending=True).values
+            exp = scores[h, rv.long(), q].sort(descending=True).values
+            # rtol absorbs the radix kernel's dropped low key bits (<= 3 ulp).
+            if not torch.allclose(got, exp, rtol=1e-5, atol=0.0, equal_nan=True):
+                return False
+    return True
+
+
+def _msa_topk_select_init(
+    *,
+    total_q: int,
+    max_k_tiles: int = 256,
+    num_qo_heads: int = 4,
+    topk: int = 16,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Random proxy scores; defaults follow MiniMax-M3 (4 index heads) at a
+    32k-token context (256 KV blocks of 128)."""
+    torch.manual_seed(seed)
+    max_score = torch.randn(
+        num_qo_heads, max_k_tiles, total_q, dtype=torch.float32, device=device
+    )
+    return {"max_score": max_score, "topk": topk}
+
+
+msa_topk_select_trace = TraceTemplate(
+    op_type="msa_topk",
+    name_prefix="msa_topk_select",
+    description=(
+        "MSA block selection: per-(query token, head) top-k KV blocks by proxy "
+        "score, ascending indices with -1 tail padding; consumes msa_proxy_score "
+        "output and feeds msa_sparse_attention."
+    ),
+    axes={
+        "num_qo_heads": Const(abbrev="h"),
+        "max_k_tiles": Var(description="Number of candidate KV-block columns."),
+        "total_q": Var(description="Total query tokens across the batch."),
+        "topk": Const(abbrev="topk"),
+    },
+    inputs={
+        "max_score": Tensor(
+            ["num_qo_heads", "max_k_tiles", "total_q"],
+            description="Per-(head, KV-block, query) proxy scores; invalid tiles -inf.",
+        ),
+        "topk": Scalar("int32", description="KV blocks selected per (token, head)."),
+        "num_valid_pages": Tensor(
+            ["total_q"],
+            dtype="int32",
+            optional=True,
+            description="Per-token valid KV pages; a scalar int is also "
+            "accepted batch-wide.",
+        ),
+        "force_begin_blocks": Scalar("int32", optional=True),
+        "force_end_blocks": Scalar("int32", optional=True),
+    },
+    outputs={
+        "block_indices": Tensor(
+            ["total_q", "num_qo_heads", "topk"],
+            dtype="int32",
+            description="Ascending selected KV-block ids; -1 tail padding.",
+        ),
+    },
+    constraints=[
+        "max_score.shape[0] == num_qo_heads",
+        "max_score.shape[1] == max_k_tiles",
+        "max_score.shape[2] == total_q",
+    ],
+    tags=["status:verified", "stage:indexer", "sparse:topk"],
+    reference=_msa_topk_select_reference,
+    check=_msa_topk_select_check,
+    init=_msa_topk_select_init,
 )
 
 # ── msa_sparse_attention (prefill) ─────────────────────────────────────────────

--- a/tests/msa_ops/test_cuda_graph.py
+++ b/tests/msa_ops/test_cuda_graph.py
@@ -95,10 +95,13 @@ def _build_decode_pipeline(B, ctx):
     return run
 
 
-def test_msa_decode_pipeline_cuda_graph():
+# ctx=4096 (32 blocks) runs the count-rank top-k, ctx=16384 (128 blocks) the
+# chunked one, whose candidate scratch must allocate cleanly under capture.
+@pytest.mark.parametrize("ctx", [4096, 16384])
+def test_msa_decode_pipeline_cuda_graph(ctx):
     """Graph replay of the captured pipeline must be bit-identical to eager."""
     _skip()
-    run = _build_decode_pipeline(B=64, ctx=4096)
+    run = _build_decode_pipeline(B=64, ctx=ctx)
 
     for _ in range(3):  # JIT compile / warm caches before capture
         eager = run()

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -883,10 +883,11 @@ def test_sparse_decode_nvfp4_scale_size_guard():
 # ---------------------------------------------------------------------------
 
 
-# nvp = P - 56 lands each case on a different kernel: P=88 count-rank with a
-# tiny middle region, P=128 count-rank with a multi-pass scan (the S=1200 grid
-# is past the chunked row cap), P=256 chunked, P=2560 radix (past the chunked
-# block coverage).
+# nvp = P - 56 lands each case on a different dispatch: P=88 count-rank with
+# a tiny middle region, P=128 with S=1200 chunked on a full grid (rows past
+# the chunking-policy boundary, longest-chunk regime), P=256 chunked on a
+# small grid (short-chunk regime), P=2560 radix (past the chunked block
+# coverage).
 @pytest.mark.parametrize("P,S", [(88, 64), (128, 1200), (256, 64), (2560, 64)])
 def test_msa_topk_select_forced_and_clamped(P, S):
     """Forced begin/end blocks are always selected within the topk budget;
@@ -1664,11 +1665,12 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
     chunk_len = (P + num_chunks - 1) // num_chunks
     cand_key = torch.empty(S, H, num_chunks * topk, dtype=torch.int32, device=dev)
     cand_idx = torch.empty_like(cand_key)
-    for _ in range(2):
+    for tiled in (False, False, True):
         out = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
-        _get_compiled_topk_chunked(topk)(
+        _get_compiled_topk_chunked(topk, tiled)(
             score, cand_key, cand_idx, out, P, 0, 0, num_chunks, chunk_len, S, H
         )
         outs.append(out.cpu())
     assert torch.equal(outs[3], outs[4]), "chunked nondeterministic on NaN"
     assert torch.equal(outs[0], outs[3]), "chunked != count-rank on NaN scores"
+    assert torch.equal(outs[0], outs[5]), "tiled chunked != count-rank on NaN scores"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -883,8 +883,9 @@ def test_sparse_decode_nvfp4_scale_size_guard():
 # ---------------------------------------------------------------------------
 
 
-# P=128 exercises the count-rank kernel, P=256 the radix kernel (crossover at 128).
-@pytest.mark.parametrize("P", [128, 256])
+# nvp = P - 56 lands each P on a different kernel: P=88 count-rank (<= 32
+# middle blocks), P=256 chunked, P=2560 radix (past the chunked coverage).
+@pytest.mark.parametrize("P", [88, 256, 2560])
 def test_msa_topk_select_forced_and_clamped(P):
     """Forced begin/end blocks are always selected within the topk budget;
     num_valid_pages clamps the candidate range."""
@@ -1634,10 +1635,13 @@ def test_fp8_q_decode():
 
 
 def test_msa_topk_select_countrank_matches_radix_on_nan():
-    """Both kernels must produce the same, deterministic selection even when the
-    proxy emits NaN scores (count-rank ranks on the radix bit-key)."""
+    """All three kernels must produce the same, deterministic selection even
+    when the proxy emits NaN scores (all rank on the radix bit-key)."""
     _skip_if_unsupported()
-    from flashinfer.msa_ops.sparse_topk_select import _get_compiled_topk
+    from flashinfer.msa_ops.sparse_topk_select import (
+        _get_compiled_topk,
+        _get_compiled_topk_chunked,
+    )
 
     dev = "cuda"
     H, P, S, topk = 2, 100, 64, 16
@@ -1652,3 +1656,16 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
         outs.append(out.cpu())
     assert torch.equal(outs[0], outs[2]), "count-rank nondeterministic on NaN"
     assert torch.equal(outs[0], outs[1]), "count-rank != radix on NaN scores"
+
+    num_chunks = 2
+    chunk_len = (P + num_chunks - 1) // num_chunks
+    cand_key = torch.empty(S, H, num_chunks * topk, dtype=torch.int32, device=dev)
+    cand_idx = torch.empty_like(cand_key)
+    for _ in range(2):
+        out = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
+        _get_compiled_topk_chunked(topk)(
+            score, cand_key, cand_idx, out, P, 0, 0, num_chunks, chunk_len, S, H
+        )
+        outs.append(out.cpu())
+    assert torch.equal(outs[3], outs[4]), "chunked nondeterministic on NaN"
+    assert torch.equal(outs[0], outs[3]), "chunked != count-rank on NaN scores"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -883,10 +883,9 @@ def test_sparse_decode_nvfp4_scale_size_guard():
 # ---------------------------------------------------------------------------
 
 
-# nvp = P - 56 lands each case on a different dispatch: P=88 count-rank with
-# a tiny middle region, P=128 with S=2400 the q-tiled chunked kernel (queries
-# past the tiled boundary, with a ragged 32-query tail), P=256 chunked on a
-# small grid (row-per-CTA), P=2560 radix (past the chunked block coverage).
+# nvp = P - 56 lands each case on a different dispatch: P=88 count-rank,
+# P=128 with S=2400 q-tiled chunked (S covers the ragged 32-query tail),
+# P=256 row-per-CTA chunked, P=2560 radix.
 @pytest.mark.parametrize("P,S", [(88, 64), (128, 2400), (256, 64), (2560, 64)])
 def test_msa_topk_select_forced_and_clamped(P, S):
     """Forced begin/end blocks are always selected within the topk budget;

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -884,11 +884,10 @@ def test_sparse_decode_nvfp4_scale_size_guard():
 
 
 # nvp = P - 56 lands each case on a different dispatch: P=88 count-rank with
-# a tiny middle region, P=128 with S=1200 chunked on a full grid (rows past
-# the chunking-policy boundary, longest-chunk regime), P=256 chunked on a
-# small grid (short-chunk regime), P=2560 radix (past the chunked block
-# coverage).
-@pytest.mark.parametrize("P,S", [(88, 64), (128, 1200), (256, 64), (2560, 64)])
+# a tiny middle region, P=128 with S=2400 the q-tiled chunked kernel (queries
+# past the tiled boundary, with a ragged 32-query tail), P=256 chunked on a
+# small grid (row-per-CTA), P=2560 radix (past the chunked block coverage).
+@pytest.mark.parametrize("P,S", [(88, 64), (128, 2400), (256, 64), (2560, 64)])
 def test_msa_topk_select_forced_and_clamped(P, S):
     """Forced begin/end blocks are always selected within the topk budget;
     num_valid_pages clamps the candidate range."""
@@ -1186,15 +1185,18 @@ def test_msa_proxy_score(B, Hq, Hkv, seqs_q, seqs_k, causal):
 
 
 @pytest.mark.parametrize(
-    "B,Hq,Hkv,seqlen_q,seqlen_k,causal",
+    "B,Hq,Hkv,seqlen_q,seqlen_k,causal,explicit_qoff",
     [
-        (4, 4, 1, 1, 8192, True),  # group 4, q_len 1 -> packed (4 x 16 tile)
-        (2, 4, 1, 16, 4096, True),  # group 4, q_len at the gate edge (16)
-        (3, 8, 2, 8, 2048, True),  # group 4 (Hq/Hkv), q_len 8
-        (2, 4, 1, 16, 4096, False),  # non-causal packed
+        (4, 4, 1, 1, 8192, True, False),  # group 4, q_len 1 -> packed (4 x 16 tile)
+        (2, 4, 1, 16, 4096, True, False),  # group 4, q_len at the gate edge (16)
+        (3, 8, 2, 8, 2048, True, False),  # group 4 (Hq/Hkv), q_len 8
+        (2, 4, 1, 16, 4096, False, False),  # non-causal packed
+        (2, 4, 1, 8, 4096, True, True),  # explicit q_offset masks mid-sequence
     ],
 )
-def test_msa_proxy_score_decode_packed(B, Hq, Hkv, seqlen_q, seqlen_k, causal):
+def test_msa_proxy_score_decode_packed(
+    B, Hq, Hkv, seqlen_q, seqlen_k, causal, explicit_qoff
+):
     """Short-q decode dispatches the head-fused packed bf16 kernel; group 4 with
     q_len <= 16 is the MiniMax-M3 indexer shape."""
     _skip_if_unsupported()
@@ -1208,11 +1210,36 @@ def test_msa_proxy_score_decode_packed(B, Hq, Hkv, seqlen_q, seqlen_k, causal):
     total_q, total_k = int(cu_q[-1]), int(cu_k[-1])
     q = torch.randn(total_q, Hq, 128, dtype=torch.bfloat16, device=dev) / 3
     k = torch.randn(total_k, Hkv, 128, dtype=torch.bfloat16, device=dev) / 3
-    out = msa_proxy_score(q, k, cu_q, cu_k, causal=causal)
+    qoff = None
+    if explicit_qoff:
+        # Positions strictly inside each sequence so the causal limit bites.
+        qoff = torch.tensor(
+            [seqlen_k // 2 + 37 * b for b in range(B)], dtype=torch.int32, device=dev
+        )
+    out = msa_proxy_score(q, k, cu_q, cu_k, causal=causal, q_offset=qoff)
     torch.cuda.synchronize()
-    ref = _ref_proxy_score(
-        q.cpu(), k.cpu(), cu_q.cpu(), cu_k.cpu(), causal, out.shape[1]
-    )
+    if explicit_qoff:
+        # Same reference, with the causal diagonal moved to the given offset:
+        # query token t of batch b may see kv positions <= t + qoff[b].
+        mkt = out.shape[1]
+        G = Hq // Hkv
+        ref = torch.full((Hq, mkt, total_q), float("-inf"), dtype=torch.float32)
+        for b in range(B):
+            qlo = b * seqlen_q
+            for h in range(Hq):
+                kb = k[b * seqlen_k : (b + 1) * seqlen_k, h // G].float().cpu()
+                s = q[qlo : qlo + seqlen_q, h].float().cpu() @ kb.T
+                qi = torch.arange(seqlen_q).unsqueeze(1) + int(qoff[b])
+                ki = torch.arange(seqlen_k).unsqueeze(0)
+                s = s.masked_fill(ki > qi, float("-inf"))
+                for t in range(-(-seqlen_k // BLK_KV)):
+                    ref[h, t, qlo : qlo + seqlen_q] = s[
+                        :, t * BLK_KV : (t + 1) * BLK_KV
+                    ].amax(dim=1)
+    else:
+        ref = _ref_proxy_score(
+            q.cpu(), k.cpu(), cu_q.cpu(), cu_k.cpu(), causal, out.shape[1]
+        )
     got = out.cpu()
     assert ((got == float("-inf")) == (ref == float("-inf"))).all(), "-inf pattern"
     fin = ref != float("-inf")
@@ -1665,7 +1692,7 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
     chunk_len = (P + num_chunks - 1) // num_chunks
     cand_key = torch.empty(S, H, num_chunks * topk, dtype=torch.int32, device=dev)
     cand_idx = torch.empty_like(cand_key)
-    for tiled in (False, False, True):
+    for tiled in (False, False, True, True):
         out = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
         _get_compiled_topk_chunked(topk, tiled)(
             score, cand_key, cand_idx, out, P, 0, 0, num_chunks, chunk_len, S, H
@@ -1673,4 +1700,32 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
         outs.append(out.cpu())
     assert torch.equal(outs[3], outs[4]), "chunked nondeterministic on NaN"
     assert torch.equal(outs[0], outs[3]), "chunked != count-rank on NaN scores"
+    assert torch.equal(outs[5], outs[6]), "tiled chunked nondeterministic on NaN"
     assert torch.equal(outs[0], outs[5]), "tiled chunked != count-rank on NaN scores"
+
+
+def test_msa_topk_select_countrank_near_block_cap():
+    """Count-rank near its 128-block ceiling with forced blocks is only reachable
+    through the dispatcher via the scratch-cap fallback (multi-million-row grids),
+    so pin the kernel directly and check it still matches the chunked selection."""
+    _skip_if_unsupported()
+    from flashinfer.msa_ops import msa_topk_select
+    from flashinfer.msa_ops.sparse_topk_select import _get_compiled_topk
+
+    dev = "cuda"
+    H, S, topk = 2, 96, 16
+    nvp, fb, fe = 120, 3, 2
+    torch.manual_seed(11)
+    score = torch.randn(H, 128, S, device=dev, dtype=torch.float32)
+    score[:, nvp:, :] = float("-inf")
+    api_out = msa_topk_select(
+        score, topk, num_valid_pages=nvp, force_begin_blocks=fb, force_end_blocks=fe
+    )
+    direct = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
+    _get_compiled_topk(topk, True)(score, direct, nvp, fb, fe, S, H)
+    torch.cuda.synchronize()
+    forced = set(range(fb)) | set(range(nvp - fe, nvp))
+    for h in range(H):
+        for qi in range(0, S, 7):
+            assert forced <= set(direct[qi, h][direct[qi, h] >= 0].tolist())
+    assert torch.equal(api_out, direct), "count-rank != chunked selection"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1701,30 +1701,3 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
     assert torch.equal(outs[0], outs[3]), "chunked != count-rank on NaN scores"
     assert torch.equal(outs[5], outs[6]), "tiled chunked nondeterministic on NaN"
     assert torch.equal(outs[0], outs[5]), "tiled chunked != count-rank on NaN scores"
-
-
-def test_msa_topk_select_countrank_near_block_cap():
-    """Count-rank near its 128-block ceiling with forced blocks is only reachable
-    through the dispatcher via the scratch-cap fallback (multi-million-row grids),
-    so pin the kernel directly and check it still matches the chunked selection."""
-    _skip_if_unsupported()
-    from flashinfer.msa_ops import msa_topk_select
-    from flashinfer.msa_ops.sparse_topk_select import _get_compiled_topk
-
-    dev = "cuda"
-    H, S, topk = 2, 96, 16
-    nvp, fb, fe = 120, 3, 2
-    torch.manual_seed(11)
-    score = torch.randn(H, 128, S, device=dev, dtype=torch.float32)
-    score[:, nvp:, :] = float("-inf")
-    api_out = msa_topk_select(
-        score, topk, num_valid_pages=nvp, force_begin_blocks=fb, force_end_blocks=fe
-    )
-    direct = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
-    _get_compiled_topk(topk, True)(score, direct, nvp, fb, fe, S, H)
-    torch.cuda.synchronize()
-    forced = set(range(fb)) | set(range(nvp - fe, nvp))
-    for h in range(H):
-        for qi in range(0, S, 7):
-            assert forced <= set(direct[qi, h][direct[qi, h] >= 0].tolist())
-    assert torch.equal(api_out, direct), "count-rank != chunked selection"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -883,10 +883,12 @@ def test_sparse_decode_nvfp4_scale_size_guard():
 # ---------------------------------------------------------------------------
 
 
-# nvp = P - 56 lands each P on a different kernel: P=88 count-rank (<= 32
-# middle blocks), P=256 chunked, P=2560 radix (past the chunked coverage).
-@pytest.mark.parametrize("P", [88, 256, 2560])
-def test_msa_topk_select_forced_and_clamped(P):
+# nvp = P - 56 lands each case on a different kernel: P=88 count-rank with a
+# tiny middle region, P=128 count-rank with a multi-pass scan (the S=1200 grid
+# is past the chunked row cap), P=256 chunked, P=2560 radix (past the chunked
+# block coverage).
+@pytest.mark.parametrize("P,S", [(88, 64), (128, 1200), (256, 64), (2560, 64)])
+def test_msa_topk_select_forced_and_clamped(P, S):
     """Forced begin/end blocks are always selected within the topk budget;
     num_valid_pages clamps the candidate range."""
     _skip_if_unsupported()
@@ -894,7 +896,7 @@ def test_msa_topk_select_forced_and_clamped(P):
 
     torch.manual_seed(120)
     dev = "cuda"
-    H, S = 2, 64
+    H = 2
     topk, nvp, fb, fe = 16, P - 56, 3, 2
     max_score = torch.randn(H, P, S, dtype=torch.float32, device=dev)
     max_score[:, nvp:, :] = float("-inf")
@@ -911,8 +913,9 @@ def test_msa_topk_select_forced_and_clamped(P):
     )
     torch.cuda.synchronize()
     forced = set(range(fb)) | set(range(nvp - fe, nvp))
+    q_step = max(1, S // 64)  # sample rows when S is large
     for h in range(H):
-        for qi in range(S):
+        for qi in range(0, S, q_step):
             row = out[qi, h]
             valid = row[row >= 0]
             assert valid.numel() == topk

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -883,10 +883,11 @@ def test_sparse_decode_nvfp4_scale_size_guard():
 # ---------------------------------------------------------------------------
 
 
-# nvp = P - 56 lands each case on a different kernel: P=88 count-rank with a
-# tiny middle region, P=128 count-rank with a multi-pass scan (the S=1200 grid
-# is past the chunked row cap), P=256 chunked, P=2560 radix (past the chunked
-# block coverage).
+# nvp = P - 56 lands each case on a different dispatch: P=88 count-rank with
+# a tiny middle region, P=128 with S=1200 chunked on a full grid (rows past
+# the chunking-policy boundary, longest-chunk regime), P=256 chunked on a
+# small grid (short-chunk regime), P=2560 radix (past the chunked block
+# coverage).
 @pytest.mark.parametrize("P,S", [(88, 64), (128, 1200), (256, 64), (2560, 64)])
 def test_msa_topk_select_forced_and_clamped(P, S):
     """Forced begin/end blocks are always selected within the topk budget;
@@ -1831,11 +1832,12 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
     chunk_len = (P + num_chunks - 1) // num_chunks
     cand_key = torch.empty(S, H, num_chunks * topk, dtype=torch.int32, device=dev)
     cand_idx = torch.empty_like(cand_key)
-    for _ in range(2):
+    for tiled in (False, False, True):
         out = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
-        _get_compiled_topk_chunked(topk)(
+        _get_compiled_topk_chunked(topk, tiled)(
             score, cand_key, cand_idx, out, P, 0, 0, num_chunks, chunk_len, S, H
         )
         outs.append(out.cpu())
     assert torch.equal(outs[3], outs[4]), "chunked nondeterministic on NaN"
     assert torch.equal(outs[0], outs[3]), "chunked != count-rank on NaN scores"
+    assert torch.equal(outs[0], outs[5]), "tiled chunked != count-rank on NaN scores"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1191,6 +1191,7 @@ def test_msa_proxy_score(B, Hq, Hkv, seqs_q, seqs_k, causal):
         (3, 8, 2, 8, 2048, True, False),  # group 4 (Hq/Hkv), q_len 8 -> key-major
         (2, 4, 1, 16, 4096, False, False),  # non-causal packed
         (2, 4, 1, 8, 4096, True, True),  # explicit q_offset masks mid-sequence
+        (2, 4, 1, 16, 4096, True, True),  # explicit q_offset, row-major packed
     ],
 )
 def test_msa_proxy_score_decode_packed(

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -884,11 +884,10 @@ def test_sparse_decode_nvfp4_scale_size_guard():
 
 
 # nvp = P - 56 lands each case on a different dispatch: P=88 count-rank with
-# a tiny middle region, P=128 with S=1200 chunked on a full grid (rows past
-# the chunking-policy boundary, longest-chunk regime), P=256 chunked on a
-# small grid (short-chunk regime), P=2560 radix (past the chunked block
-# coverage).
-@pytest.mark.parametrize("P,S", [(88, 64), (128, 1200), (256, 64), (2560, 64)])
+# a tiny middle region, P=128 with S=2400 the q-tiled chunked kernel (queries
+# past the tiled boundary, with a ragged 32-query tail), P=256 chunked on a
+# small grid (row-per-CTA), P=2560 radix (past the chunked block coverage).
+@pytest.mark.parametrize("P,S", [(88, 64), (128, 2400), (256, 64), (2560, 64)])
 def test_msa_topk_select_forced_and_clamped(P, S):
     """Forced begin/end blocks are always selected within the topk budget;
     num_valid_pages clamps the candidate range."""
@@ -1186,15 +1185,18 @@ def test_msa_proxy_score(B, Hq, Hkv, seqs_q, seqs_k, causal):
 
 
 @pytest.mark.parametrize(
-    "B,Hq,Hkv,seqlen_q,seqlen_k,causal",
+    "B,Hq,Hkv,seqlen_q,seqlen_k,causal,explicit_qoff",
     [
-        (4, 4, 1, 1, 8192, True),  # group 4, q_len 1 -> stream (bf16 single-token)
-        (2, 4, 1, 16, 4096, True),  # group 4, q_len at the gate edge (16) -> packed
-        (3, 8, 2, 8, 2048, True),  # group 4 (Hq/Hkv), q_len 8 -> key-major
-        (2, 4, 1, 16, 4096, False),  # non-causal packed
+        (4, 4, 1, 1, 8192, True, False),  # group 4, q_len 1 -> stream
+        (2, 4, 1, 16, 4096, True, False),  # group 4, gate-edge q_len 16 -> packed
+        (3, 8, 2, 8, 2048, True, False),  # group 4 (Hq/Hkv), q_len 8 -> key-major
+        (2, 4, 1, 16, 4096, False, False),  # non-causal packed
+        (2, 4, 1, 8, 4096, True, True),  # explicit q_offset masks mid-sequence
     ],
 )
-def test_msa_proxy_score_decode_packed(B, Hq, Hkv, seqlen_q, seqlen_k, causal):
+def test_msa_proxy_score_decode_packed(
+    B, Hq, Hkv, seqlen_q, seqlen_k, causal, explicit_qoff
+):
     """Short-q decode dispatches the head-fused kernels: key-major for fused
     multi-token tiles of at most 32 rows, packed row-major above. Group 4 with
     q_len <= 16 is the MiniMax-M3 indexer shape."""
@@ -1209,11 +1211,36 @@ def test_msa_proxy_score_decode_packed(B, Hq, Hkv, seqlen_q, seqlen_k, causal):
     total_q, total_k = int(cu_q[-1]), int(cu_k[-1])
     q = torch.randn(total_q, Hq, 128, dtype=torch.bfloat16, device=dev) / 3
     k = torch.randn(total_k, Hkv, 128, dtype=torch.bfloat16, device=dev) / 3
-    out = msa_proxy_score(q, k, cu_q, cu_k, causal=causal)
+    qoff = None
+    if explicit_qoff:
+        # Positions strictly inside each sequence so the causal limit bites.
+        qoff = torch.tensor(
+            [seqlen_k // 2 + 37 * b for b in range(B)], dtype=torch.int32, device=dev
+        )
+    out = msa_proxy_score(q, k, cu_q, cu_k, causal=causal, q_offset=qoff)
     torch.cuda.synchronize()
-    ref = _ref_proxy_score(
-        q.cpu(), k.cpu(), cu_q.cpu(), cu_k.cpu(), causal, out.shape[1]
-    )
+    if explicit_qoff:
+        # Same reference, with the causal diagonal moved to the given offset:
+        # query token t of batch b may see kv positions <= t + qoff[b].
+        mkt = out.shape[1]
+        G = Hq // Hkv
+        ref = torch.full((Hq, mkt, total_q), float("-inf"), dtype=torch.float32)
+        for b in range(B):
+            qlo = b * seqlen_q
+            for h in range(Hq):
+                kb = k[b * seqlen_k : (b + 1) * seqlen_k, h // G].float().cpu()
+                s = q[qlo : qlo + seqlen_q, h].float().cpu() @ kb.T
+                qi = torch.arange(seqlen_q).unsqueeze(1) + int(qoff[b])
+                ki = torch.arange(seqlen_k).unsqueeze(0)
+                s = s.masked_fill(ki > qi, float("-inf"))
+                for t in range(-(-seqlen_k // BLK_KV)):
+                    ref[h, t, qlo : qlo + seqlen_q] = s[
+                        :, t * BLK_KV : (t + 1) * BLK_KV
+                    ].amax(dim=1)
+    else:
+        ref = _ref_proxy_score(
+            q.cpu(), k.cpu(), cu_q.cpu(), cu_k.cpu(), causal, out.shape[1]
+        )
     got = out.cpu()
     assert ((got == float("-inf")) == (ref == float("-inf"))).all(), "-inf pattern"
     fin = ref != float("-inf")
@@ -1832,7 +1859,7 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
     chunk_len = (P + num_chunks - 1) // num_chunks
     cand_key = torch.empty(S, H, num_chunks * topk, dtype=torch.int32, device=dev)
     cand_idx = torch.empty_like(cand_key)
-    for tiled in (False, False, True):
+    for tiled in (False, False, True, True):
         out = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
         _get_compiled_topk_chunked(topk, tiled)(
             score, cand_key, cand_idx, out, P, 0, 0, num_chunks, chunk_len, S, H
@@ -1840,4 +1867,32 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
         outs.append(out.cpu())
     assert torch.equal(outs[3], outs[4]), "chunked nondeterministic on NaN"
     assert torch.equal(outs[0], outs[3]), "chunked != count-rank on NaN scores"
+    assert torch.equal(outs[5], outs[6]), "tiled chunked nondeterministic on NaN"
     assert torch.equal(outs[0], outs[5]), "tiled chunked != count-rank on NaN scores"
+
+
+def test_msa_topk_select_countrank_near_block_cap():
+    """Count-rank near its 128-block ceiling with forced blocks is only reachable
+    through the dispatcher via the scratch-cap fallback (multi-million-row grids),
+    so pin the kernel directly and check it still matches the chunked selection."""
+    _skip_if_unsupported()
+    from flashinfer.msa_ops import msa_topk_select
+    from flashinfer.msa_ops.sparse_topk_select import _get_compiled_topk
+
+    dev = "cuda"
+    H, S, topk = 2, 96, 16
+    nvp, fb, fe = 120, 3, 2
+    torch.manual_seed(11)
+    score = torch.randn(H, 128, S, device=dev, dtype=torch.float32)
+    score[:, nvp:, :] = float("-inf")
+    api_out = msa_topk_select(
+        score, topk, num_valid_pages=nvp, force_begin_blocks=fb, force_end_blocks=fe
+    )
+    direct = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
+    _get_compiled_topk(topk, True)(score, direct, nvp, fb, fe, S, H)
+    torch.cuda.synchronize()
+    forced = set(range(fb)) | set(range(nvp - fe, nvp))
+    for h in range(H):
+        for qi in range(0, S, 7):
+            assert forced <= set(direct[qi, h][direct[qi, h] >= 0].tolist())
+    assert torch.equal(api_out, direct), "count-rank != chunked selection"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -1868,30 +1868,3 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
     assert torch.equal(outs[0], outs[3]), "chunked != count-rank on NaN scores"
     assert torch.equal(outs[5], outs[6]), "tiled chunked nondeterministic on NaN"
     assert torch.equal(outs[0], outs[5]), "tiled chunked != count-rank on NaN scores"
-
-
-def test_msa_topk_select_countrank_near_block_cap():
-    """Count-rank near its 128-block ceiling with forced blocks is only reachable
-    through the dispatcher via the scratch-cap fallback (multi-million-row grids),
-    so pin the kernel directly and check it still matches the chunked selection."""
-    _skip_if_unsupported()
-    from flashinfer.msa_ops import msa_topk_select
-    from flashinfer.msa_ops.sparse_topk_select import _get_compiled_topk
-
-    dev = "cuda"
-    H, S, topk = 2, 96, 16
-    nvp, fb, fe = 120, 3, 2
-    torch.manual_seed(11)
-    score = torch.randn(H, 128, S, device=dev, dtype=torch.float32)
-    score[:, nvp:, :] = float("-inf")
-    api_out = msa_topk_select(
-        score, topk, num_valid_pages=nvp, force_begin_blocks=fb, force_end_blocks=fe
-    )
-    direct = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
-    _get_compiled_topk(topk, True)(score, direct, nvp, fb, fe, S, H)
-    torch.cuda.synchronize()
-    forced = set(range(fb)) | set(range(nvp - fe, nvp))
-    for h in range(H):
-        for qi in range(0, S, 7):
-            assert forced <= set(direct[qi, h][direct[qi, h] >= 0].tolist())
-    assert torch.equal(api_out, direct), "count-rank != chunked selection"

--- a/tests/msa_ops/test_msa_ops.py
+++ b/tests/msa_ops/test_msa_ops.py
@@ -883,8 +883,9 @@ def test_sparse_decode_nvfp4_scale_size_guard():
 # ---------------------------------------------------------------------------
 
 
-# P=128 exercises the count-rank kernel, P=256 the radix kernel (crossover at 128).
-@pytest.mark.parametrize("P", [128, 256])
+# nvp = P - 56 lands each P on a different kernel: P=88 count-rank (<= 32
+# middle blocks), P=256 chunked, P=2560 radix (past the chunked coverage).
+@pytest.mark.parametrize("P", [88, 256, 2560])
 def test_msa_topk_select_forced_and_clamped(P):
     """Forced begin/end blocks are always selected within the topk budget;
     num_valid_pages clamps the candidate range."""
@@ -1798,10 +1799,13 @@ def test_fp8_q_decode():
 
 
 def test_msa_topk_select_countrank_matches_radix_on_nan():
-    """Both kernels must produce the same, deterministic selection even when the
-    proxy emits NaN scores (count-rank ranks on the radix bit-key)."""
+    """All three kernels must produce the same, deterministic selection even
+    when the proxy emits NaN scores (all rank on the radix bit-key)."""
     _skip_if_unsupported()
-    from flashinfer.msa_ops.sparse_topk_select import _get_compiled_topk
+    from flashinfer.msa_ops.sparse_topk_select import (
+        _get_compiled_topk,
+        _get_compiled_topk_chunked,
+    )
 
     dev = "cuda"
     H, P, S, topk = 2, 100, 64, 16
@@ -1819,3 +1823,16 @@ def test_msa_topk_select_countrank_matches_radix_on_nan():
         outs.append(out.cpu())
     assert torch.equal(outs[0], outs[2]), "count-rank nondeterministic on NaN"
     assert torch.equal(outs[0], outs[1]), "count-rank != radix on NaN scores"
+
+    num_chunks = 2
+    chunk_len = (P + num_chunks - 1) // num_chunks
+    cand_key = torch.empty(S, H, num_chunks * topk, dtype=torch.int32, device=dev)
+    cand_idx = torch.empty_like(cand_key)
+    for _ in range(2):
+        out = torch.empty(S, H, topk, dtype=torch.int32, device=dev)
+        _get_compiled_topk_chunked(topk)(
+            score, cand_key, cand_idx, out, P, 0, 0, num_chunks, chunk_len, S, H
+        )
+        outs.append(out.cpu())
+    assert torch.equal(outs[3], outs[4]), "chunked nondeterministic on NaN"
+    assert torch.equal(outs[0], outs[3]), "chunked != count-rank on NaN scores"

--- a/tests/msa_ops/test_proxy_fp4.py
+++ b/tests/msa_ops/test_proxy_fp4.py
@@ -58,11 +58,12 @@ def _dequant_128x4(xq, sf_flat, mul, rows, d=128):
     return vals * sc.repeat_interleave(16, dim=1) * mul
 
 
-def _ref_proxy_fp4(q_deq, k_deq, seqlen_q, seqlen_k, group_size, causal):
+def _ref_proxy_fp4(q_deq, k_deq, seqlen_q, seqlen_k, group_size, causal, q_off=None):
     """Block-max proxy on pre-dequantized bf16 Q/K, single sequence -> [Hq, nb, Sq]."""
     Hq = q_deq.shape[1]
     nb = (seqlen_k + BLK_KV - 1) // BLK_KV
-    q_off = seqlen_k - seqlen_q  # right-aligned causal
+    if q_off is None:
+        q_off = seqlen_k - seqlen_q  # right-aligned causal
     out = torch.full((Hq, nb, seqlen_q), -float("inf"), dtype=torch.float32)
     for h in range(Hq):
         kv = h // group_size
@@ -78,19 +79,19 @@ def _ref_proxy_fp4(q_deq, k_deq, seqlen_q, seqlen_k, group_size, causal):
 
 
 def _dequant_qk(q_fp4, q_scale, inv_q, k_fp4, k_scale, inv_k):
-    """Dequant packed Q/K to bf16; both global scales fold into Q, as in the kernel."""
+    """Dequant packed Q/K; both global scales fold into Q, as in the kernel.
+
+    Kept in float32: the kernel's fp4 x scale products never round through
+    bf16, and a bf16-rounded reference misses tolerance on boundary blocks
+    whose causal limit leaves a single near-cancelling dot product."""
     Sq, Hq, _ = q_fp4.shape
     Sk, Hkv, _ = k_fp4.shape
-    q_deq = (
-        _dequant_128x4(q_fp4.reshape(-1, 64), q_scale, inv_q * inv_k, Sq * Hq)
-        .reshape(Sq, Hq, 128)
-        .to(torch.bfloat16)
-    )
-    k_deq = (
-        _dequant_128x4(k_fp4.reshape(-1, 64), k_scale, 1.0, Sk * Hkv)
-        .reshape(Sk, Hkv, 128)
-        .to(torch.bfloat16)
-    )
+    q_deq = _dequant_128x4(
+        q_fp4.reshape(-1, 64), q_scale, inv_q * inv_k, Sq * Hq
+    ).reshape(Sq, Hq, 128)
+    k_deq = _dequant_128x4(
+        k_fp4.reshape(-1, 64), k_scale, 1.0, Sk * Hkv
+    ).reshape(Sk, Hkv, 128)
     return q_deq, k_deq
 
 
@@ -257,8 +258,11 @@ def test_proxy_fp4_paged():
     assert rel < 5e-2, f"paged max rel err {rel}"
 
 
-@pytest.mark.parametrize("B,seqlen_q", [(1, 8), (2, 5), (3, 1)])
-def test_proxy_fp4_decode_packed(B, seqlen_q):
+@pytest.mark.parametrize(
+    "B,seqlen_q,explicit_qoff",
+    [(1, 8, False), (2, 5, False), (3, 1, False), (2, 5, True)],
+)
+def test_proxy_fp4_decode_packed(B, seqlen_q, explicit_qoff):
     """group_size 16, q_len <= 8 dispatches the packed fp4 tensor-core kernel."""
     _skip_if_unsupported()
     from flashinfer.msa_ops import msa_proxy_score_fp4
@@ -280,6 +284,12 @@ def test_proxy_fp4_decode_packed(B, seqlen_q):
     q_fp4, q_scale, inv_q = _quantize_qk_to_nvfp4(q)
     k_fp4, k_scale, inv_k = _quantize_qk_to_nvfp4(k)
 
+    qoff = None
+    if explicit_qoff:
+        # Positions strictly inside each sequence so the causal limit bites.
+        qoff = torch.tensor(
+            [seqlen_k // 2 + 37 * b for b in range(B)], dtype=torch.int32, device=dev
+        )
     out = msa_proxy_score_fp4(
         q_fp4,
         k_fp4,
@@ -290,6 +300,7 @@ def test_proxy_fp4_decode_packed(B, seqlen_q):
         cu_q,
         cu_k,
         causal=True,
+        q_offset=qoff,
     )
     torch.cuda.synchronize()
     assert out.shape == (Hq, nb, total_q)
@@ -302,7 +313,15 @@ def test_proxy_fp4_decode_packed(B, seqlen_q):
     for b in range(B):
         qsl = slice(b * seqlen_q, (b + 1) * seqlen_q)
         ksl = slice(b * seqlen_k, (b + 1) * seqlen_k)
-        ref = _ref_proxy_fp4(q_deq[qsl], k_deq[ksl], seqlen_q, seqlen_k, 16, True)
+        ref = _ref_proxy_fp4(
+            q_deq[qsl],
+            k_deq[ksl],
+            seqlen_q,
+            seqlen_k,
+            16,
+            True,
+            q_off=int(qoff[b]) if qoff is not None else None,
+        )
         sub = got[:, :, qsl]
         finite = torch.isfinite(ref)
         assert (torch.isfinite(sub) == finite).all(), f"mask mismatch b={b}"

--- a/tests/msa_ops/test_proxy_fp4.py
+++ b/tests/msa_ops/test_proxy_fp4.py
@@ -58,11 +58,12 @@ def _dequant_128x4(xq, sf_flat, mul, rows, d=128):
     return vals * sc.repeat_interleave(16, dim=1) * mul
 
 
-def _ref_proxy_fp4(q_deq, k_deq, seqlen_q, seqlen_k, group_size, causal):
+def _ref_proxy_fp4(q_deq, k_deq, seqlen_q, seqlen_k, group_size, causal, q_off=None):
     """Block-max proxy on pre-dequantized bf16 Q/K, single sequence -> [Hq, nb, Sq]."""
     Hq = q_deq.shape[1]
     nb = (seqlen_k + BLK_KV - 1) // BLK_KV
-    q_off = seqlen_k - seqlen_q  # right-aligned causal
+    if q_off is None:
+        q_off = seqlen_k - seqlen_q  # right-aligned causal
     out = torch.full((Hq, nb, seqlen_q), -float("inf"), dtype=torch.float32)
     for h in range(Hq):
         kv = h // group_size
@@ -78,18 +79,18 @@ def _ref_proxy_fp4(q_deq, k_deq, seqlen_q, seqlen_k, group_size, causal):
 
 
 def _dequant_qk(q_fp4, q_scale, inv_q, k_fp4, k_scale, inv_k):
-    """Dequant packed Q/K to bf16; both global scales fold into Q, as in the kernel."""
+    """Dequant packed Q/K; both global scales fold into Q, as in the kernel.
+
+    Kept in float32: the kernel's fp4 x scale products never round through
+    bf16, and a bf16-rounded reference misses tolerance on boundary blocks
+    whose causal limit leaves a single near-cancelling dot product."""
     Sq, Hq, _ = q_fp4.shape
     Sk, Hkv, _ = k_fp4.shape
-    q_deq = (
-        _dequant_128x4(q_fp4.reshape(-1, 64), q_scale, inv_q * inv_k, Sq * Hq)
-        .reshape(Sq, Hq, 128)
-        .to(torch.bfloat16)
-    )
-    k_deq = (
-        _dequant_128x4(k_fp4.reshape(-1, 64), k_scale, 1.0, Sk * Hkv)
-        .reshape(Sk, Hkv, 128)
-        .to(torch.bfloat16)
+    q_deq = _dequant_128x4(
+        q_fp4.reshape(-1, 64), q_scale, inv_q * inv_k, Sq * Hq
+    ).reshape(Sq, Hq, 128)
+    k_deq = _dequant_128x4(k_fp4.reshape(-1, 64), k_scale, 1.0, Sk * Hkv).reshape(
+        Sk, Hkv, 128
     )
     return q_deq, k_deq
 
@@ -383,8 +384,11 @@ def test_proxy_fp4_paged():
     assert rel < 5e-2, f"paged max rel err {rel}"
 
 
-@pytest.mark.parametrize("B,seqlen_q", [(1, 8), (2, 5), (3, 1)])
-def test_proxy_fp4_decode_packed(B, seqlen_q):
+@pytest.mark.parametrize(
+    "B,seqlen_q,explicit_qoff",
+    [(1, 8, False), (2, 5, False), (3, 1, False), (2, 5, True)],
+)
+def test_proxy_fp4_decode_packed(B, seqlen_q, explicit_qoff):
     """group_size 16, q_len <= 8 dispatches the packed fp4 tensor-core kernel."""
     _skip_if_unsupported()
     from flashinfer.msa_ops import msa_proxy_score_fp4
@@ -406,6 +410,12 @@ def test_proxy_fp4_decode_packed(B, seqlen_q):
     q_fp4, q_scale, inv_q = _quantize_qk_to_nvfp4(q)
     k_fp4, k_scale, inv_k = _quantize_qk_to_nvfp4(k)
 
+    qoff = None
+    if explicit_qoff:
+        # Positions strictly inside each sequence so the causal limit bites.
+        qoff = torch.tensor(
+            [seqlen_k // 2 + 37 * b for b in range(B)], dtype=torch.int32, device=dev
+        )
     out = msa_proxy_score_fp4(
         q_fp4,
         k_fp4,
@@ -416,6 +426,7 @@ def test_proxy_fp4_decode_packed(B, seqlen_q):
         cu_q,
         cu_k,
         causal=True,
+        q_offset=qoff,
     )
     torch.cuda.synchronize()
     assert out.shape == (Hq, nb, total_q)
@@ -428,7 +439,15 @@ def test_proxy_fp4_decode_packed(B, seqlen_q):
     for b in range(B):
         qsl = slice(b * seqlen_q, (b + 1) * seqlen_q)
         ksl = slice(b * seqlen_k, (b + 1) * seqlen_k)
-        ref = _ref_proxy_fp4(q_deq[qsl], k_deq[ksl], seqlen_q, seqlen_k, 16, True)
+        ref = _ref_proxy_fp4(
+            q_deq[qsl],
+            k_deq[ksl],
+            seqlen_q,
+            seqlen_k,
+            16,
+            True,
+            q_off=int(qoff[b]) if qoff is not None else None,
+        )
         sub = got[:, :, qsl]
         finite = torch.isfinite(ref)
         assert (torch.isfinite(sub) == finite).all(), f"mask mismatch b={b}"

--- a/tests/msa_ops/test_proxy_fp4.py
+++ b/tests/msa_ops/test_proxy_fp4.py
@@ -285,13 +285,9 @@ def test_proxy_fp4_paged_varlen(Hq, Hkv, seqs_q):
     mkt = max(-(-s // BLK_KV) for s in seqs_k)
     assert out.shape == (Hq, mkt, total_q)
 
-    q_deq = (
-        _dequant_128x4(
-            q_fp4.reshape(-1, 64).cpu(), q_scale.cpu(), inv_q * inv_k, total_q * Hq
-        )
-        .reshape(total_q, Hq, 128)
-        .to(torch.bfloat16)
-    )
+    q_deq = _dequant_128x4(
+        q_fp4.reshape(-1, 64).cpu(), q_scale.cpu(), inv_q * inv_k, total_q * Hq
+    ).reshape(total_q, Hq, 128)
     # Blocks past a request's own extent stay -inf, so build the padded oracle.
     ref = torch.full((Hq, mkt, total_q), -float("inf"), dtype=torch.float32)
     for b, sk in enumerate(seqs_k):

--- a/tests/msa_ops/test_proxy_fp4.py
+++ b/tests/msa_ops/test_proxy_fp4.py
@@ -59,7 +59,7 @@ def _dequant_128x4(xq, sf_flat, mul, rows, d=128):
 
 
 def _ref_proxy_fp4(q_deq, k_deq, seqlen_q, seqlen_k, group_size, causal, q_off=None):
-    """Block-max proxy on pre-dequantized bf16 Q/K, single sequence -> [Hq, nb, Sq]."""
+    """Block-max proxy on pre-dequantized Q/K, single sequence -> [Hq, nb, Sq]."""
     Hq = q_deq.shape[1]
     nb = (seqlen_k + BLK_KV - 1) // BLK_KV
     if q_off is None:

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -73,6 +73,7 @@ msa_proxy_score_fp4_h4_kv1.json
 msa_proxy_score_h4_kv1_d128.json
 msa_sparse_attention_h64_kv4_d128_topk16.json
 msa_sparse_decode_attention_h64_kv4_d128_topk16.json
+msa_topk_select_h4_topk16.json
 mxfp8_grouped_quantize_k4096.json
 nvfp4_kv_dequantize_paged_h2_dk64_dv128_ps4.json
 nvfp4_kv_dequantize_paged_hnd_h2_dk64_dv128_ps4.json
@@ -2075,6 +2076,11 @@ with contextlib.suppress(Exception):
             _idx_cu_k,
             causal=True,
         )
+
+    # msa_proxy_score output format; 256 blocks = 32k-token context
+    _ts_score = torch.randn(_idx_Hq, 256, _idx_tq, dtype=torch.float32, device=_msa_dev)
+    with contextlib.suppress(Exception):
+        _msa.msa_topk_select(_ts_score, 16)
 
     # block ids ascending and in range per (kv-head, query): the msa_topk_select format
     _sp_Hq, _sp_Hkv, _sp_topk = 64, 4, 16

--- a/tests/trace/fi_trace_out/msa_topk_select_h4_topk16.json
+++ b/tests/trace/fi_trace_out/msa_topk_select_h4_topk16.json
@@ -1,0 +1,82 @@
+{
+  "name": "msa_topk_select_h4_topk16",
+  "description": "MSA block selection: per-(query token, head) top-k KV blocks by proxy score, ascending indices with -1 tail padding; consumes msa_proxy_score output and feeds msa_sparse_attention.",
+  "op_type": "msa_topk",
+  "tags": [
+    "fi_api:flashinfer.msa_ops.sparse_topk_select.msa_topk_select",
+    "status:verified",
+    "stage:indexer",
+    "sparse:topk"
+  ],
+  "axes": {
+    "num_qo_heads": {
+      "type": "const",
+      "value": 4
+    },
+    "max_k_tiles": {
+      "type": "var",
+      "description": "Number of candidate KV-block columns."
+    },
+    "total_q": {
+      "type": "var",
+      "description": "Total query tokens across the batch."
+    },
+    "topk": {
+      "type": "const",
+      "value": 16
+    }
+  },
+  "constraints": [
+    "max_score.shape[0] == num_qo_heads",
+    "max_score.shape[1] == max_k_tiles",
+    "max_score.shape[2] == total_q"
+  ],
+  "inputs": {
+    "max_score": {
+      "shape": [
+        "num_qo_heads",
+        "max_k_tiles",
+        "total_q"
+      ],
+      "dtype": "float32",
+      "description": "Per-(head, KV-block, query) proxy scores; invalid tiles -inf."
+    },
+    "topk": {
+      "shape": null,
+      "dtype": "int32",
+      "description": "KV blocks selected per (token, head)."
+    },
+    "num_valid_pages": {
+      "shape": [
+        "total_q"
+      ],
+      "dtype": "int32",
+      "optional": true,
+      "description": "Per-token valid KV pages; a scalar int is also accepted batch-wide."
+    },
+    "force_begin_blocks": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true
+    },
+    "force_end_blocks": {
+      "shape": null,
+      "dtype": "int32",
+      "optional": true
+    }
+  },
+  "outputs": {
+    "block_indices": {
+      "shape": [
+        "total_q",
+        "num_qo_heads",
+        "topk"
+      ],
+      "dtype": "int32",
+      "description": "Ascending selected KV-block ids; -1 tail padding."
+    }
+  },
+  "reference": "from __future__ import annotations\nimport math\nimport torch\nimport torch.nn.functional as F\n\n@torch.no_grad()\ndef _msa_topk_select_reference(\n    max_score, topk, num_valid_pages=None, force_begin_blocks=0, force_end_blocks=0\n):\n    \"\"\"Top-k KV blocks per (query, head): forced begin/end blocks always kept,\n    the rest by score rank within [0, num_valid_pages); ascending, -1 padded.\"\"\"\n    H, P, S = max_score.shape\n    if num_valid_pages is None:\n        nvps = torch.full((S,), P, dtype=torch.long)\n    elif isinstance(num_valid_pages, torch.Tensor):\n        nvps = num_valid_pages.long().clamp(0, P).cpu()\n    else:\n        nvps = torch.full((S,), max(0, min(int(num_valid_pages), P)), dtype=torch.long)\n    scores = max_score.float().cpu()\n    out = torch.full((S, H, topk), -1, dtype=torch.int32)\n    for q in range(S):\n        nvp = int(nvps[q])\n        mid_end = max(nvp - force_end_blocks, force_begin_blocks)\n        forced = set(range(min(force_begin_blocks, nvp))) | set(range(mid_end, nvp))\n        free = topk - len(forced)\n        for h in range(H):\n            mid = scores[h, force_begin_blocks:mid_end, q]\n            k = min(free, mid.numel())\n            picked = (torch.topk(mid, k).indices + force_begin_blocks).tolist()\n            sel = sorted(forced | set(picked))\n            out[q, h, : len(sel)] = torch.tensor(sel, dtype=torch.int32)\n    return out.to(max_score.device)\n",
+  "check": "def _msa_topk_select_check(\n    reference_outputs,\n    actual_outputs,\n    max_score=None,\n    num_valid_pages=None,\n    force_begin_blocks=0,\n    force_end_blocks=0,\n    **_unused,\n):\n    \"\"\"Near-tied scores make the selected index set ambiguous (see the\n    msa_topk_select docstring), so with ``max_score`` rows are compared by\n    their selected score multisets against the reference, plus forced-block\n    membership (a tied block must not displace a forced one). Without\n    ``max_score``, exact equality.\"\"\"\n\n    # Nested: the JSON-embedded source must be self-contained.\n    def unwrap(x):\n        if isinstance(x, dict):\n            x = next(iter(x.values()))\n        if isinstance(x, (list, tuple)):\n            x = x[0]\n        return x\n\n    ref = unwrap(reference_outputs)\n    act = unwrap(actual_outputs)\n    if not (isinstance(ref, torch.Tensor) and isinstance(act, torch.Tensor)):\n        return False\n    if ref.shape != act.shape:\n        return False\n    ref, act = ref.cpu(), act.cpu()\n    scores = None if max_score is None else max_score.float().cpu()\n    S, H, _ = act.shape\n    nvps = None\n    if scores is not None:\n        P = scores.shape[1]\n        if num_valid_pages is None:\n            nvps = torch.full((S,), P, dtype=torch.long)\n        elif isinstance(num_valid_pages, torch.Tensor):\n            nvps = num_valid_pages.long().clamp(0, P).cpu()\n        else:\n            nvps = torch.full(\n                (S,), max(0, min(int(num_valid_pages), P)), dtype=torch.long\n            )\n    for q in range(S):\n        for h in range(H):\n            r, a = ref[q, h], act[q, h]\n            av = a[a >= 0]\n            # Valid entries must form a strictly ascending prefix, -1 tail only.\n            if (\n                (a[: av.numel()] != av).any()\n                or (a[av.numel() :] != -1).any()\n                or (av.diff() <= 0).any()\n            ):\n                return False\n            rv = r[r >= 0]\n            if av.numel() != rv.numel():\n                return False\n            if scores is None:\n                if not torch.equal(av, rv):\n                    return False\n                continue\n            nvp = int(nvps[q])\n            if (av >= nvp).any():\n                return False\n            mid_end = max(nvp - force_end_blocks, force_begin_blocks)\n            forced = set(range(min(force_begin_blocks, nvp))) | set(range(mid_end, nvp))\n            if not forced <= set(av.tolist()):\n                return False\n            got = scores[h, av.long(), q].sort(descending=True).values\n            exp = scores[h, rv.long(), q].sort(descending=True).values\n            # rtol absorbs the radix kernel's dropped low key bits (<= 3 ulp).\n            if not torch.allclose(got, exp, rtol=1e-5, atol=0.0, equal_nan=True):\n                return False\n    return True\n",
+  "init": "from __future__ import annotations\nimport math\nimport torch\n\n# ----- shared init helpers -----\n# Copyright (c) 2025 by FlashInfer team.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\"\"\"Shared helpers used by ``TraceTemplate.init`` functions.\n\nThis module contains the small set of input-construction patterns that\nrecur across many templates (paged-KV cache index arrays, ragged indptr,\nRoPE pos_ids and cos/sin caches, sampling probs). Each helper is short and\ndocumented; init functions in ``templates/<category>.py`` call into here so\nthe per-template init bodies stay focused on shape/dtype, not boilerplate.\n\nThe full source of this module is **inlined into every dumped JSON's\n``\"init\"`` field** by ``flashinfer/trace/template.py:_render_init_source``,\nso downstream consumers don't need flashinfer installed to re-run the init\nsnippets.\n\"\"\"\n\n\nfrom typing import Optional, Tuple\n\nimport torch\n\n\ndef make_paged_kv_indices(\n    batch_size: int,\n    num_pages_per_seq: int,\n    page_size: int,\n    *,\n    device: str = \"cuda\",\n) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:\n    \"\"\"Return ``(kv_indptr, kv_indices, kv_last_page_len)`` for a uniform batch.\n\n    Every sequence is assigned exactly ``num_pages_per_seq`` pages, fully\n    populated (last-page length == page_size).\n\n    Invariants\n    ----------\n    - ``kv_indptr.shape == (batch_size + 1,)``, dtype int32, monotonic, [0]=0.\n    - ``kv_indices == arange(0, batch_size * num_pages_per_seq)``, int32.\n    - ``kv_last_page_len == full(batch_size, page_size)``, int32.\n    \"\"\"\n    total_pages = batch_size * num_pages_per_seq\n    kv_indptr = (\n        torch.arange(batch_size + 1, dtype=torch.int32, device=device)\n        * num_pages_per_seq\n    )\n    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)\n    kv_last_page_len = torch.full(\n        (batch_size,), page_size, dtype=torch.int32, device=device\n    )\n    return kv_indptr, kv_indices, kv_last_page_len\n\n\ndef make_ragged_indptr(\n    seg_lens,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.int32,\n) -> torch.Tensor:\n    \"\"\"Return cumulative-sum ``indptr`` of length ``len(seg_lens)+1``.\n\n    ``seg_lens`` may be a list / tuple / 1-D tensor of segment lengths.\n    \"\"\"\n    if isinstance(seg_lens, torch.Tensor):\n        lens = seg_lens.to(device=device, dtype=dtype)\n    else:\n        lens = torch.tensor(list(seg_lens), dtype=dtype, device=device)\n    indptr = torch.zeros(lens.numel() + 1, dtype=dtype, device=device)\n    indptr[1:] = torch.cumsum(lens, dim=0).to(dtype)\n    return indptr\n\n\ndef make_uniform_qo_indptr(\n    batch_size: int,\n    qo_len: int,\n    *,\n    device: str = \"cuda\",\n) -> torch.Tensor:\n    \"\"\"Return ``[0, qo_len, 2*qo_len, ..., batch_size*qo_len]`` int32.\"\"\"\n    return torch.arange(batch_size + 1, dtype=torch.int32, device=device) * qo_len\n\n\ndef make_pos_ids(\n    nnz: int,\n    max_seq_len: Optional[int] = None,\n    *,\n    device: str = \"cuda\",\n) -> torch.Tensor:\n    \"\"\"Return ``[0, 1, ..., nnz-1] (% max_seq_len)`` as int32 on ``device``.\n\n    If ``max_seq_len`` is None, no wrapping is applied.\n    \"\"\"\n    pos = torch.arange(nnz, dtype=torch.int32, device=device)\n    if max_seq_len is not None:\n        pos = pos % max_seq_len\n    return pos\n\n\ndef make_rope_cos_sin_cache(\n    max_seq_len: int,\n    rope_dim: int,\n    *,\n    base: float = 1e4,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return concatenated ``[cos | sin]`` cache of shape ``[max_seq_len, rope_dim]``.\"\"\"\n    t = torch.arange(max_seq_len, dtype=torch.float32, device=device)\n    inv = 1.0 / (\n        base\n        ** (torch.arange(0, rope_dim, 2, dtype=torch.float32, device=device) / rope_dim)\n    )\n    freqs = t.unsqueeze(-1) * inv.unsqueeze(0)\n    cache = torch.cat([torch.cos(freqs), torch.sin(freqs)], dim=-1)\n    return cache.to(dtype)\n\n\ndef make_probs(\n    batch_size: int,\n    vocab_size: int,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return a ``[batch_size, vocab_size]`` probability distribution.\n\n    Uses ``softmax(randn(...))`` so each row sums to 1.0. This mirrors the\n    pattern used throughout ``tests/utils/test_sampling.py``.\n    \"\"\"\n    return torch.softmax(\n        torch.randn(batch_size, vocab_size, dtype=torch.float32, device=device),\n        dim=-1,\n    ).to(dtype)\n\n\ndef make_logits(\n    batch_size: int,\n    vocab_size: int,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return ``randn(batch_size, vocab_size)`` logits.\"\"\"\n    return torch.randn(batch_size, vocab_size, dtype=dtype, device=device)\n\n\ndef fp8_safe_randn(\n    *shape: int,\n    scale: float = 0.1,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.bfloat16,\n) -> torch.Tensor:\n    \"\"\"``randn(*shape) * scale`` \u2014 keeps values in the FP8/FP4 representable range.\n\n    Tests for fp8/fp4 paths typically multiply ``randn`` by 0.1 to avoid\n    saturation when quantizing. Use this helper to mirror that convention.\n    \"\"\"\n    return (torch.randn(*shape, dtype=dtype, device=device) * scale).to(dtype)\n\n\ndef per_tensor_fp8_quantize(\n    x: torch.Tensor,\n    *,\n    fp8_dtype: torch.dtype = torch.float8_e4m3fn,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Per-tensor FP8 quantization, mirroring ``tests/utils_fp8.py:to_float8``.\n\n    Returns ``(x_fp8, inv_scale)`` where ``inv_scale`` is the dequant\n    multiplier (``float \u2248 fp8 * inv_scale``).\n    \"\"\"\n    finfo = torch.finfo(fp8_dtype)\n    amax = x.abs().amax().clamp(min=1e-12)\n    scale = finfo.max / amax\n    x_q = (x.float() * scale).clamp(min=finfo.min, max=finfo.max).to(fp8_dtype)\n    return x_q, scale.float().reciprocal()\n\n\ndef fp8_block_quant_1d(\n    x_bf16: torch.Tensor,\n    block: int = 128,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Quantize ``[T, H]`` activations into FP8 with per-``(token, block)``\n    column-block scales. Returns ``(x_fp8, scales)`` where\n    ``scales`` has shape ``[T, H // block]``.\n\n    Mirrors ``_fp8_block_quant_1d`` in\n    ``tests/moe/test_dpsk_fused_moe_fp8.py``.\n    \"\"\"\n    assert x_bf16.dim() == 2\n    T, H = x_bf16.shape\n    assert H % block == 0\n    nb = H // block\n    finfo = torch.finfo(torch.float8_e4m3fn)\n    max_fp8 = finfo.max\n    x_f32 = x_bf16.to(torch.float32)\n    x_fp8 = torch.empty((T, H), dtype=torch.float8_e4m3fn, device=x_bf16.device)\n    scales = torch.empty((T, nb), dtype=torch.float32, device=x_bf16.device)\n    for j in range(nb):\n        sl = slice(j * block, (j + 1) * block)\n        blk = x_f32[:, sl]\n        amax = torch.amax(torch.abs(blk), dim=1)\n        s = torch.where(amax > 0, amax / max_fp8, torch.ones_like(amax))\n        x_fp8[:, sl] = (blk / s.unsqueeze(1)).to(torch.float8_e4m3fn)\n        scales[:, j] = s\n    return x_fp8, scales\n\n\ndef fp8_block_quant_2d(\n    w_bf16: torch.Tensor,\n    block: int = 128,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Quantize weights ``[..., R, C]`` with 2-D ``block \u00d7 block`` scales.\n\n    Returns ``(w_fp8, scales)`` where ``scales`` has shape\n    ``[..., R // block, C // block]``. Mirrors ``_fp8_block_quant_2d`` in\n    ``tests/moe/test_dpsk_fused_moe_fp8.py``.\n    \"\"\"\n    assert w_bf16.dim() >= 2\n    *prefix, R, C = w_bf16.shape\n    assert R % block == 0 and C % block == 0\n    nb_r, nb_c = R // block, C // block\n    finfo = torch.finfo(torch.float8_e4m3fn)\n    max_fp8 = finfo.max\n    w_f32 = w_bf16.to(torch.float32).contiguous()\n    prefix_ndim = len(prefix)\n    reshaped = w_f32.reshape(*prefix, nb_r, block, nb_c, block)\n    permute_dims = tuple(range(prefix_ndim)) + (\n        prefix_ndim,\n        prefix_ndim + 2,\n        prefix_ndim + 1,\n        prefix_ndim + 3,\n    )\n    blocks = reshaped.permute(permute_dims).contiguous()\n    amax = torch.amax(torch.abs(blocks), dim=(-1, -2))\n    scales = torch.where(\n        amax > 0, amax / max_fp8, torch.ones_like(amax, dtype=torch.float32)\n    )\n    q_blocks = (blocks / scales.unsqueeze(-1).unsqueeze(-1)).to(torch.float8_e4m3fn)\n    inv_permute = [0] * (prefix_ndim + 4)\n    for i, p in enumerate(permute_dims):\n        inv_permute[p] = i\n    w_fp8 = q_blocks.permute(*inv_permute).reshape(*prefix, R, C).contiguous()\n    return w_fp8, scales\n\n\n__all__ = [\n    \"make_paged_kv_indices\",\n    \"make_ragged_indptr\",\n    \"make_uniform_qo_indptr\",\n    \"make_pos_ids\",\n    \"make_rope_cos_sin_cache\",\n    \"make_probs\",\n    \"make_logits\",\n    \"fp8_safe_randn\",\n    \"per_tensor_fp8_quantize\",\n    \"fp8_block_quant_1d\",\n    \"fp8_block_quant_2d\",\n]\n\n# ----- init -----\ndef _msa_topk_select_init(\n    *,\n    total_q: int,\n    max_k_tiles: int = 256,\n    num_qo_heads: int = 4,\n    topk: int = 16,\n    device: str = \"cuda\",\n    seed: int = 0,\n):\n    \"\"\"Random proxy scores; defaults follow MiniMax-M3 (4 index heads) at a\n    32k-token context (256 KV blocks of 128).\"\"\"\n    torch.manual_seed(seed)\n    max_score = torch.randn(\n        num_qo_heads, max_k_tiles, total_q, dtype=torch.float32, device=device\n    )\n    return {\"max_score\": max_score, \"topk\": topk}\n"
+}

--- a/tests/trace/template_registry.py
+++ b/tests/trace/template_registry.py
@@ -75,6 +75,7 @@ _TRACE_REGISTRATION_MODULES = (
     "flashinfer.msa_ops.proxy_score",
     "flashinfer.msa_ops.sparse_decode",
     "flashinfer.msa_ops.sparse_prefill",
+    "flashinfer.msa_ops.sparse_topk_select",
     "flashinfer.norm",
     "flashinfer.nvfp4_attention_sm120",
     "flashinfer.page",


### PR DESCRIPTION
## 📌 Description

Follow-up to #3655, which enabled MiniMax Sparse Attention (MSA) on SM120/SM121. The indexer (proxy score + top-k, the two ops that pick each query's KV blocks) stayed behind vLLM in a few regimes there. All of the gaps traced to `msa_topk_select` and its wrapper rather than to the proxy kernel:

- At decode with small batches, the top-k launches one CTA per (query, head) row, which is 4 CTAs at batch 1, leaving the GPU nearly idle. At 32k context those rows also fall into the radix kernel, which costs about as much as the proxy itself.
- At long-sequence prefill, the top-k reads scores with strided accesses, and the radix kernel re-reads them once per digit pass.
- The packed decode wrappers built the causal-offset tensor with three small torch kernels per call, about as costly as the top-k itself at short sequence lengths.

Changes:

- A new chunked top-k. A partial kernel ranks 64-block chunks independently, one CTA per (query, head, chunk), and a merge kernel then re-ranks the surviving candidates for each row. Both use the same ordering as the existing top-k kernels, so selections are identical. The merge launches with PDL to overlap with the partial kernel.
- A q-tiled variant of the partial kernel for large grids. It covers 32 queries per CTA so that every score load is one coalesced line, which extends the chunked path to prefill under a 128 MB scratch cap; larger grids keep the radix kernel.
- The packed decode kernels (bf16 and NVFP4) now compute the causal offset in-kernel when `q_offset` is not given, removing the wrapper's torch launches from the decode path.

The kernel choice depends only on shapes, so it is CUDA-graph safe; a new test covers graph capture on the chunked path.

### Performance

Measured as in #3655: median GPU time over CUDA-graph replays (CUPTI), with the L2 cache flushed between replays so one replay cannot reuse the previous replay's data. The baseline is vLLM's MiniMax-M3 Triton MSA kernels on the same GPUs and shapes. Each cell is an RTX PRO 6000 Server / RTX 5080 / GB10 triple, and speedup = vLLM time / FlashInfer time, so higher is better. "Before" is main as of #3655. The MTP columns run the same call with 4 draft tokens per request, as in a speculative-decoding verify step.

Indexer decode (proxy + top-k), batch 1:

| S | before | after | before (4-token MTP) | after (4-token MTP) |
|--:|:--:|:--:|:--:|:--:|
| 2k | 1.31 / 1.43 / 1.33 | 1.31 / 1.42 / 1.38 | 0.73 / 0.71 / 0.91 | 1.20 / 1.12 / 1.29 |
| 4k | 1.40 / 1.39 / 1.21 | 1.43 / 1.38 / 1.24 | 0.87 / 0.86 / 1.03 | 1.39 / 1.29 / 1.33 |
| 8k | 1.18 / 1.10 / 1.08 | 1.28 / 1.22 / 1.10 | 0.82 / 0.90 / 0.95 | 1.26 / 1.34 / 1.11 |
| 16k | 1.18 / 1.09 / 1.02 | 1.25 / 1.17 / 1.09 | 0.95 / 0.85 / 0.97 | 1.34 / 1.19 / 1.09 |
| 32k | 0.90 / 0.98 / 0.98 | 1.08 / 1.11 / 1.03 | 0.95 / 0.94 / 0.96 | 1.36 / 1.30 / 1.07 |

Indexer prefill, batch 1 (the 2k and 4k rows keep the old kernels and are unchanged within noise):

| S | before | after |
|--:|:--:|:--:|
| 8k | 1.04 / 1.14 / 1.01 | 1.06 / 1.18 / 1.02 |
| 16k | 1.04 / 1.18 / 1.02 | 1.19 / 1.25 / 1.16 |
| 32k | 0.90 / 1.08 / 0.89 | 1.16 / 1.28 / 1.19 |

Measured against the kernels this PR replaces:

- The new top-k alone is 1.4-2.2x faster at decode (batch 1 to 128) and 1.2-2.1x faster at 8k-32k prefill.
- The proxy kernel is untouched, so shapes where it dominates do not move: at batch 128 the end-to-end ratio stays at 1.00-1.03 vs vLLM.
- The optional NVFP4 decode path also speeds up because its wrapper sheds the same torch launches.

## 🔍 Related Issues

Follow-up to #3655.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

All 155 tests in `tests/msa_ops/` pass on an RTX 5080 (SM120) after rebasing onto current main. This PR adds tests for:

- the dispatch boundaries between the three top-k kernels
- selection identity between the chunked and existing kernels, including NaN scores, forced blocks, and the ragged q-tile tail
- CUDA-graph capture on the chunked path
- explicit `q_offset` on both packed decode kernels

It also moves the paged-varlen fp4 test's reference to float32: the kernel's fp4 x scale products never round through bf16, so the bf16-rounded reference misses the 5e-2 tolerance on causal-boundary blocks (16 of 40 seeds on an RTX 5080, including the checked-in seed). The same treatment the other fp4 tests already use.

`compute-sanitizer` racecheck and memcheck are clean on the new kernels.

## Reviewer Notes

- Per-token `num_valid_pages` calls (added by #4324) stay on the single-kernel paths: the chunked kernels' geometry is host-derived from the scalar count.
- Selection identity across the top-k kernels (same bit-key and tie order) is pinned by tests.
- The row-per-CTA and q-tiled partial kernels keep separate bodies on purpose: the row-per-CTA binary is production-validated.
- Deferred for the same reason: skipping the redundant sentinel prefill of the candidate scratch, and sharing the forced-slot fill across the three kernels.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added chunked top-k selection for large candidate sets, including tiled execution and forced-page handling.
  - Added optional default query-offset handling for packed decode with right-aligned causal masking.
  - Added tracing support for MSA top-k selection.

- **Bug Fixes**
  - Improved causal masking consistency across packed decode formats.
  - Preserved sentinel results and selected-score correctness during top-k selection.

- **Tests**
  - Expanded coverage for large contexts, query offsets, chunked selection, tracing, and CUDA graph execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->