### PR TITLE
fix(benchmark): don't fail non-trtllm mm_fp4 backends on unaligned n

### DIFF
--- a/benchmarks/routines/gemm.py
+++ b/benchmarks/routines/gemm.py
@@ -1356,12 +1356,23 @@ def testMmFp4(args):
         input_fp4, input_inv_s = flashinfer.mxfp4_quantize(input)
         mat2_fp4, mat2_inv_s = flashinfer.mxfp4_quantize(mat2)
 
-    mat2_fp4_trtllm, mat2_inv_s_trtllm = flashinfer.nvfp4_quantize(
-        mat2,
-        global_sf_mat2,
-        sfLayout=flashinfer.SfLayout.layout_128x4,
-        do_shuffle=True,
-    )
+    # The trtllm backend consumes a shuffled weight/scale layout. Prepare it
+    # only when that backend is requested: the shuffle requires n to be a
+    # multiple of 128, and an unaligned n must not fail the other backends.
+    mat2_fp4_trtllm, mat2_inv_s_trtllm = None, None
+    if "trtllm" in backends:
+        try:
+            mat2_fp4_trtllm, mat2_inv_s_trtllm = flashinfer.nvfp4_quantize(
+                mat2,
+                global_sf_mat2,
+                sfLayout=flashinfer.SfLayout.layout_128x4,
+                do_shuffle=True,
+            )
+        except Exception as e:
+            print(
+                f"[INFO] trtllm backend does not support this configuration: {type(e).__name__}: {e}"
+            )
+            backends.remove("trtllm")
 
     if args.verbose >= 2:
         print(f"[VVERBOSE] {input_fp4.shape = }")
@@ -1419,7 +1430,7 @@ def testMmFp4(args):
 
     if len(backends) == 0:
         print("[ERROR] No backends passed validation. Exiting.")
-        return
+        return res
 
     def run_backend(
         backend,
@@ -1698,7 +1709,7 @@ def testMmBf16Fp4(args):
 
     if len(backends) == 0:
         print("[ERROR] No backends passed validation. Exiting.")
-        return
+        return []
 
     autotune_supported_backends = ["cudnn", "cute-dsl"]
     cache_path = getattr(args, "autotune_cache", None)


### PR DESCRIPTION

<!-- .github/pull_request_template.md -->

## 📌 Description

- nvfp4_quantize(do_shuffle=True) requires n % 128 == 0, but its output is only consumed by the trtllm backend
- prepare the shuffled weight/scale tensors only when trtllm is requested
- on shuffle failure, drop only the trtllm backend with the standard unsupported-configuration message instead of failing the whole test case
- return the result list instead of None when no backend passes validation, so the harness reports the skip instead of "'NoneType' is not iterable"


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP4 benchmark handling when the optional TensorRT-LLM backend is unavailable or fails validation.
  * Avoided unnecessary FP4 weight preparation for unselected backends.
  * Ensured benchmark routines consistently return empty results when no valid backends remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->