### PR TITLE
test(comm): make checkpoint worker importable

### DIFF
--- a/tests/comm/test_trtllm_allreduce_checkpoint.py
+++ b/tests/comm/test_trtllm_allreduce_checkpoint.py
@@ -1,4 +1,6 @@
 import socket
+import sys
+from pathlib import Path
 
 import pytest
 import torch
@@ -139,6 +141,12 @@ def _run_worker(
 def test_graph_replay_after_symmetric_memory_remap(
     num_tokens: int, use_oneshot: bool
 ) -> None:
+    # mp.spawn starts fresh interpreters that need to re-import this module;
+    # ensure the repo root is on sys.path so 'tests.comm' is findable.
+    repo_root = str(Path(__file__).resolve().parents[2])
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+
     mp.spawn(
         _run_worker,
         args=(2, _free_port(), num_tokens, use_oneshot),


### PR DESCRIPTION
## Description

PR #3968 added `tests/comm/test_trtllm_allreduce_checkpoint.py` to the multi-node communication test job. That exposed a test-environment failure before any worker or kernel code runs:

```text
ModuleNotFoundError: No module named 'tests'
```

`pytest.ini` uses `--import-mode=importlib`, and `torch.multiprocessing.spawn` serializes the worker as `tests.comm.test_trtllm_allreduce_checkpoint._run_worker`. Fresh Python interpreters must be able to import that qualified module while unpickling the process target.

Add the repository root to the parent process's `sys.path` immediately before `mp.spawn`. Python copies that path into spawn preparation data and restores it in each child before unpickling the worker. This follows the existing pattern in `tests/comm/test_all_gather_matmul.py`.

This is a test harness/environment fix only; worker, checkpoint, graph replay, all-reduce, and kernel behavior are unchanged.

## Related Issues

- Follow-up to #3968, which enabled this test in multi-node CI.
- #3966's missing-coverage request was addressed by #3968 and can be closed.

## Tests

Passed:

- `git diff --check`
- `pre-commit run --files tests/comm/test_trtllm_allreduce_checkpoint.py`
- Python syntax compilation
- Repository-root/path assertion (`parents[2]` resolves to the checkout root containing `tests/__init__.py`)
- Standard-library `multiprocessing` spawn smoke test: a fresh child successfully imported a module-qualified `tests.comm.*` target after the parent inserted the temporary repo root into `sys.path`

The full two-GPU checkpoint replay test was not run locally because the available Python environment does not have Torch or pytest installed. The multi-node CI job enabled by #3968 provides the end-to-end validation.

## Checklist

- [x] The change is limited to the affected test harness.
- [x] Pre-commit checks pass for the changed file.
- [x] The commit includes a DCO sign-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved multiprocessing test reliability by ensuring child processes can correctly locate and import the test package during graph replay validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->