### PR TITLE
feat(msa): accept K/V views split from a packed paged KV cache

### DIFF
--- a/benchmarks/routines/sparse_attention.py
+++ b/benchmarks/routines/sparse_attention.py
@@ -47,6 +47,11 @@ _ROUTINE_BACKENDS = {
 
 def run_sparse_attention_test(args):
     """Route an MSA routine to its test function."""
+    if args.kv_layout != "flat" and args.routine not in (
+        "MSASparseAttention",
+        "MSASparseDecode",
+    ):
+        raise ValueError(f"--kv_layout {args.kv_layout} unsupported for {args.routine}")
     if args.routine == "MSAProxyScore":
         return testMSAProxyScore(args)
     elif args.routine == "MSASparseAttention":
@@ -105,6 +110,17 @@ def parse_sparse_attention_args(line, parser):
         default="bfloat16",
         help="KV dtype: bfloat16/float16/fp8_e4m3/nvfp4 (prefill/decode/pipeline).",
     )
+    parser.add_argument(
+        "--kv_layout",
+        type=str,
+        default="flat",
+        choices=["flat", "paged", "packed"],
+        help=(
+            "KV storage for prefill/decode: flat varlen, a paged cache, or "
+            "K/V views split from a paged cache that packs K|V per token "
+            "(vLLM's layout). paged/packed exclude nvfp4."
+        ),
+    )
     args = parser.parse_args(line)
     if args.verbose >= 1:
         print(f"[INFO] {args = }")
@@ -145,6 +161,27 @@ def _rand_q2k(batch_size, s_qo, s_kv, num_kv_heads, topk, device):
             sel = torch.randperm(nb, device=device)[:nsel].sort().values
             idx[h, qi, :nsel] = sel.to(torch.int32)
     return idx
+
+
+def _paged_kv(bs, s_kv, num_kv_heads, q_dtype, kv_dtype, device, packed):
+    """Paged K/V (contiguous, or views split from a packed K|V cache) plus the
+    paged-call kwargs."""
+    if kv_dtype not in (torch.bfloat16, torch.float16, torch.float8_e4m3fn):
+        raise ValueError("--kv_layout paged/packed excludes nvfp4")
+    pages_per_req = -(-s_kv // BLK_KV)
+    num_pages = bs * pages_per_req
+    cache = (
+        torch.randn(num_pages, num_kv_heads, BLK_KV, 256, device=device, dtype=q_dtype)
+        / 3
+    ).to(kv_dtype)
+    k, v = cache.split(128, dim=-1)
+    if not packed:
+        k, v = k.contiguous(), v.contiguous()
+    page_table = torch.arange(num_pages, dtype=torch.int32, device=device).view(
+        bs, pages_per_req
+    )
+    seqused_k = torch.full((bs,), s_kv, dtype=torch.int32, device=device)
+    return k, v, dict(page_table=page_table, seqused_k=seqused_k)
 
 
 def _maybe_quantize_kv(k, v, kv_dtype):
@@ -361,7 +398,12 @@ def testMSASparseAttention(args):
     v = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
     cu_q, cu_k = _cu_seqlens(bs, s_qo, device), _cu_seqlens(bs, s_kv, device)
     q2k = _rand_q2k(bs, s_qo, s_kv, Hkv, args.topk, device)
-    k_in, v_in, extra = _maybe_quantize_kv(k, v, kv_dtype)
+    if args.kv_layout != "flat":
+        k_in, v_in, extra = _paged_kv(
+            bs, s_kv, Hkv, q_dtype, kv_dtype, device, args.kv_layout == "packed"
+        )
+    else:
+        k_in, v_in, extra = _maybe_quantize_kv(k, v, kv_dtype)
     scale = 1.0 / math.sqrt(128)
 
     def run(_b):
@@ -418,7 +460,13 @@ def testMSASparseDecode(args):
     v = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
     cu_k = _cu_seqlens(bs, s_kv, device)
     q2k = _rand_q2k(bs, 1, s_kv, Hkv, args.topk, device)
-    k_in, v_in, extra = _maybe_quantize_kv(k, v, kv_dtype)
+    if args.kv_layout != "flat":
+        k_in, v_in, extra = _paged_kv(
+            bs, s_kv, Hkv, q_dtype, kv_dtype, device, args.kv_layout == "packed"
+        )
+    else:
+        k_in, v_in, extra = _maybe_quantize_kv(k, v, kv_dtype)
+        extra = dict(cu_seqlens_k=cu_k, **extra)
     scale = 1.0 / math.sqrt(128)
 
     def run(_b):
@@ -427,7 +475,6 @@ def testMSASparseDecode(args):
             k_in,
             v_in,
             q2k,
-            cu_seqlens_k=cu_k,
             seqlen_q=1,
             causal=args.causal,
             softmax_scale=scale,

--- a/benchmarks/routines/sparse_attention.py
+++ b/benchmarks/routines/sparse_attention.py
@@ -394,8 +394,6 @@ def testMSASparseAttention(args):
     kv_dtype = dtype_str_to_torch_dtype(args.kv_dtype)
     total_q, total_kv = bs * s_qo, bs * s_kv
     q = torch.randn(total_q, Hq, 128, device=device, dtype=q_dtype) / 3
-    k = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
-    v = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
     cu_q, cu_k = _cu_seqlens(bs, s_qo, device), _cu_seqlens(bs, s_kv, device)
     q2k = _rand_q2k(bs, s_qo, s_kv, Hkv, args.topk, device)
     if args.kv_layout != "flat":
@@ -403,6 +401,8 @@ def testMSASparseAttention(args):
             bs, s_kv, Hkv, q_dtype, kv_dtype, device, args.kv_layout == "packed"
         )
     else:
+        k = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
+        v = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
         k_in, v_in, extra = _maybe_quantize_kv(k, v, kv_dtype)
     scale = 1.0 / math.sqrt(128)
 
@@ -456,17 +456,16 @@ def testMSASparseDecode(args):
     kv_dtype = dtype_str_to_torch_dtype(args.kv_dtype)
     total_q, total_kv = bs, bs * s_kv  # one query token per request
     q = torch.randn(total_q, Hq, 128, device=device, dtype=q_dtype) / 3
-    k = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
-    v = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
-    cu_k = _cu_seqlens(bs, s_kv, device)
     q2k = _rand_q2k(bs, 1, s_kv, Hkv, args.topk, device)
     if args.kv_layout != "flat":
         k_in, v_in, extra = _paged_kv(
             bs, s_kv, Hkv, q_dtype, kv_dtype, device, args.kv_layout == "packed"
         )
     else:
+        k = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
+        v = torch.randn(total_kv, Hkv, 128, device=device, dtype=q_dtype) / 3
         k_in, v_in, extra = _maybe_quantize_kv(k, v, kv_dtype)
-        extra = dict(cu_seqlens_k=cu_k, **extra)
+        extra = dict(cu_seqlens_k=_cu_seqlens(bs, s_kv, device), **extra)
     scale = 1.0 / math.sqrt(128)
 
     def run(_b):

--- a/flashinfer/msa_ops/__init__.py
+++ b/flashinfer/msa_ops/__init__.py
@@ -8,7 +8,13 @@ from .sparse_prefill import msa_sparse_attention
 from .sparse_decode import msa_sparse_decode_attention
 from .sparse_topk_select import msa_topk_select
 
+# Capability flag for callers (e.g. vLLM): the sparse attention ops accept K/V
+# views split from a paged cache that packs K and V in one 2*head_dim content
+# dim per token.
+SUPPORTS_PACKED_KV = True
+
 __all__ = [
+    "SUPPORTS_PACKED_KV",
     "msa_proxy_score",
     "msa_proxy_score_fp4",
     "msa_sparse_attention",

--- a/flashinfer/msa_ops/_common.py
+++ b/flashinfer/msa_ops/_common.py
@@ -90,29 +90,15 @@ def _resolve_packed_kv(k, v, head_dim, *, paged, kv_nvfp4):
     """Shared wrapper plumbing: detect packed K/V split views (paged,
     non-NVFP4 only) via :func:`_packed_kv_view`, enforcing contiguity for
     every other input."""
-    packed = None if kv_nvfp4 or not paged else _packed_kv_view_cached(k, v, head_dim)
+    packed = None if kv_nvfp4 or not paged else _packed_kv_view(k, v, head_dim)
     if packed is None and not (k.is_contiguous() and v.is_contiguous()):
         raise ValueError("k/v must be contiguous")
     return packed
 
 
-# Cached views pin their storage, hence the small cap.
-_PACKED_VIEW_CACHE: dict = {}
-
-
-def _packed_kv_view_cached(k, v, head_dim):
-    """Memoized :func:`_packed_kv_view`: callers pass the same cache views
-    every step, and the per-call detection cost lands on the decode hot path."""
-    if k.is_contiguous() and v.is_contiguous():
-        return None
-    key = (k.data_ptr(), v.data_ptr(), k.shape, k.stride(), v.stride(), k.dtype)
-    hit = _PACKED_VIEW_CACHE.get(key)
-    if hit is None:
-        if len(_PACKED_VIEW_CACHE) >= 32:
-            _PACKED_VIEW_CACHE.clear()
-        hit = _packed_kv_view(k, v, head_dim)
-        _PACKED_VIEW_CACHE[key] = hit
-    return hit
+# Geometry only, never tensors: a cached view would pin the KV cache's
+# storage, and plain-tuple entries cannot go stale.
+_PACKED_GEO_CACHE: dict = {}
 
 
 def _packed_kv_view(k, v, head_dim):
@@ -123,46 +109,64 @@ def _packed_kv_view(k, v, head_dim):
     stride_order)``: the storage re-viewed as a 5-D cache with K at plane 0
     and V at plane 1 of dim 3, plus its dim ranks for ``cute.compile``. The
     view must be compact, meaning its strides telescope in some dim order (a
-    permuted-contiguous NHD cache qualifies); any other layout raises."""
+    permuted-contiguous NHD cache qualifies); any other layout raises. The
+    geometry is memoized because this runs on the decode hot path."""
     if k.is_contiguous() and v.is_contiguous():
         return None
+    key = (
+        tuple(k.shape),
+        k.stride(),
+        v.stride(),
+        v.data_ptr() - k.data_ptr(),
+        k.element_size(),
+        head_dim,
+    )
+    geo = _PACKED_GEO_CACHE.get(key)
+    if geo is None:
+        geo = _packed_kv_geometry(head_dim, key)
+        if len(_PACKED_GEO_CACHE) >= 64:
+            _PACKED_GEO_CACHE.clear()
+        _PACKED_GEO_CACHE[key] = geo
+    shape, strides, rank = geo
+    return k.as_strided(shape, strides), rank
+
+
+def _packed_kv_geometry(head_dim, key):
+    """Validate a non-contiguous K/V pair as packed split views and return the
+    packed ``(shape, strides, stride_order)`` as plain tuples."""
+    k_shape, k_strides, v_strides, ptr_diff, elt, _ = key
     if (
-        k.ndim != 4
-        or k.stride() != v.stride()
-        or k.stride(-1) != 1
-        or v.data_ptr() - k.data_ptr() != head_dim * k.element_size()
+        len(k_shape) != 4
+        or k_strides != v_strides
+        or k_strides[-1] != 1
+        or ptr_diff != head_dim * elt
     ):
         raise ValueError(
             "k/v must be contiguous, or K/V views split from a paged KV cache "
             "that packs K and V in one 2*head_dim content dim per token"
         )
-    num_pages, num_kv_heads, page, _ = k.shape
-    packed = k.as_strided(
-        (num_pages, num_kv_heads, page, 2, head_dim),
-        (k.stride(0), k.stride(1), k.stride(2), head_dim, 1),
-    )
+    num_pages, num_kv_heads, page, _ = k_shape
+    shape = (num_pages, num_kv_heads, page, 2, head_dim)
+    raw = (k_strides[0], k_strides[1], k_strides[2], head_dim, 1)
     # Sized strides must telescope: the kernel derives addresses from the
     # compact layout. Size-1 dims carry arbitrary strides, so they rank
     # outermost (inner they would break the kernel's static alignment proof)
     # and get rebuilt strides.
-    ones = [i for i in range(5) if packed.shape[i] == 1]
-    sized = sorted(
-        (i for i in range(5) if packed.shape[i] > 1), key=lambda i: packed.stride(i)
-    )
+    ones = [i for i in range(5) if shape[i] == 1]
+    sized = sorted((i for i in range(5) if shape[i] > 1), key=lambda i: raw[i])
     strides = [0] * 5
     expected = 1
     for i in sized:
-        if packed.stride(i) != expected:
+        if raw[i] != expected:
             raise ValueError(
                 "packed K/V views must cover a compact KV cache, got strides "
-                f"{tuple(packed.stride())} for shape {tuple(packed.shape)}"
+                f"{raw} for shape {shape}"
             )
         strides[i] = expected
-        expected *= packed.shape[i]
+        expected *= shape[i]
     for i in ones:
         strides[i] = expected
-    packed = k.as_strided(packed.shape, strides)
     rank = [0] * 5
     for pos, dim in enumerate(sized + ones):
         rank[dim] = pos
-    return packed, tuple(rank)
+    return shape, tuple(strides), tuple(rank)

--- a/flashinfer/msa_ops/_common.py
+++ b/flashinfer/msa_ops/_common.py
@@ -90,10 +90,29 @@ def _resolve_packed_kv(k, v, head_dim, *, paged, kv_nvfp4):
     """Shared wrapper plumbing: detect packed K/V split views (paged,
     non-NVFP4 only) via :func:`_packed_kv_view`, enforcing contiguity for
     every other input."""
-    packed = None if kv_nvfp4 or not paged else _packed_kv_view(k, v, head_dim)
+    packed = None if kv_nvfp4 or not paged else _packed_kv_view_cached(k, v, head_dim)
     if packed is None and not (k.is_contiguous() and v.is_contiguous()):
         raise ValueError("k/v must be contiguous")
     return packed
+
+
+# Cached views pin their storage, hence the small cap.
+_PACKED_VIEW_CACHE: dict = {}
+
+
+def _packed_kv_view_cached(k, v, head_dim):
+    """Memoized :func:`_packed_kv_view`: callers pass the same cache views
+    every step, and the per-call detection cost lands on the decode hot path."""
+    if k.is_contiguous() and v.is_contiguous():
+        return None
+    key = (k.data_ptr(), v.data_ptr(), k.shape, k.stride(), v.stride(), k.dtype)
+    hit = _PACKED_VIEW_CACHE.get(key)
+    if hit is None:
+        if len(_PACKED_VIEW_CACHE) >= 32:
+            _PACKED_VIEW_CACHE.clear()
+        hit = _packed_kv_view(k, v, head_dim)
+        _PACKED_VIEW_CACHE[key] = hit
+    return hit
 
 
 def _packed_kv_view(k, v, head_dim):

--- a/flashinfer/msa_ops/_common.py
+++ b/flashinfer/msa_ops/_common.py
@@ -69,16 +69,81 @@ def _cutlass_dtype(torch_dtype: torch.dtype):
     }[torch_dtype]
 
 
-def _fake(dtype, shape, align=16):
-    """Make a fake compact row-major tensor for ``cute.compile``.
+def _fake(dtype, shape, align=16, stride_order=None):
+    """Make a fake compact tensor for ``cute.compile`` (row-major by default).
 
     Compiling against symbolic shapes (``cute.sym_int()``) yields one kernel
     that accepts torch tensors of any matching-rank shape at runtime."""
     import cutlass.cute as cute
 
+    if stride_order is None:
+        stride_order = tuple(reversed(range(len(shape))))
     return cute.runtime.make_fake_compact_tensor(
         dtype,
         shape,
-        stride_order=tuple(reversed(range(len(shape)))),
+        stride_order=stride_order,
         assumed_align=align,
     )
+
+
+def _resolve_packed_kv(k, v, head_dim, *, paged, kv_nvfp4):
+    """Shared wrapper plumbing: detect packed K/V split views (paged,
+    non-NVFP4 only) via :func:`_packed_kv_view`, enforcing contiguity for
+    every other input."""
+    packed = None if kv_nvfp4 or not paged else _packed_kv_view(k, v, head_dim)
+    if packed is None and not (k.is_contiguous() and v.is_contiguous()):
+        raise ValueError("k/v must be contiguous")
+    return packed
+
+
+def _packed_kv_view(k, v, head_dim):
+    """Recover the packed cache behind K/V views split from a paged KV cache
+    that stores K and V in one ``2 * head_dim`` content dim per token.
+
+    Returns ``None`` when both tensors are plain contiguous, else ``(packed,
+    stride_order)``: the storage re-viewed as a 5-D cache with K at plane 0
+    and V at plane 1 of dim 3, plus its dim ranks for ``cute.compile``. The
+    view must be compact, meaning its strides telescope in some dim order (a
+    permuted-contiguous NHD cache qualifies); any other layout raises."""
+    if k.is_contiguous() and v.is_contiguous():
+        return None
+    if (
+        k.ndim != 4
+        or k.stride() != v.stride()
+        or k.stride(-1) != 1
+        or v.data_ptr() - k.data_ptr() != head_dim * k.element_size()
+    ):
+        raise ValueError(
+            "k/v must be contiguous, or K/V views split from a paged KV cache "
+            "that packs K and V in one 2*head_dim content dim per token"
+        )
+    num_pages, num_kv_heads, page, _ = k.shape
+    packed = k.as_strided(
+        (num_pages, num_kv_heads, page, 2, head_dim),
+        (k.stride(0), k.stride(1), k.stride(2), head_dim, 1),
+    )
+    # Sized strides must telescope: the kernel derives addresses from the
+    # compact layout. Size-1 dims carry arbitrary strides, so they rank
+    # outermost (inner they would break the kernel's static alignment proof)
+    # and get rebuilt strides.
+    ones = [i for i in range(5) if packed.shape[i] == 1]
+    sized = sorted(
+        (i for i in range(5) if packed.shape[i] > 1), key=lambda i: packed.stride(i)
+    )
+    strides = [0] * 5
+    expected = 1
+    for i in sized:
+        if packed.stride(i) != expected:
+            raise ValueError(
+                "packed K/V views must cover a compact KV cache, got strides "
+                f"{tuple(packed.stride())} for shape {tuple(packed.shape)}"
+            )
+        strides[i] = expected
+        expected *= packed.shape[i]
+    for i in ones:
+        strides[i] = expected
+    packed = k.as_strided(packed.shape, strides)
+    rank = [0] * 5
+    for pos, dim in enumerate(sized + ones):
+        rank[dim] = pos
+    return packed, tuple(rank)

--- a/flashinfer/msa_ops/_common.py
+++ b/flashinfer/msa_ops/_common.py
@@ -87,9 +87,8 @@ def _fake(dtype, shape, align=16, stride_order=None):
 
 
 def _resolve_packed_kv(k, v, head_dim, *, paged, kv_nvfp4):
-    """Shared wrapper plumbing: detect packed K/V split views (paged,
-    non-NVFP4 only) via :func:`_packed_kv_view`, enforcing contiguity for
-    every other input."""
+    """Detect packed K/V split views (accepted on the paged, non-NVFP4 path
+    only); any other non-contiguous K/V raises."""
     packed = None if kv_nvfp4 or not paged else _packed_kv_view(k, v, head_dim)
     if packed is None and not (k.is_contiguous() and v.is_contiguous()):
         raise ValueError("k/v must be contiguous")
@@ -107,8 +106,8 @@ def _packed_kv_view(k, v, head_dim):
 
     Returns ``None`` when both tensors are plain contiguous, else ``(packed,
     stride_order)``: the storage re-viewed as a 5-D cache with K at plane 0
-    and V at plane 1 of dim 3, plus its dim ranks for ``cute.compile``. The
-    view must be compact, meaning its strides telescope in some dim order (a
+    and V at plane 1 of dim 3, plus the dim order for ``cute.compile``. The
+    views must cover their storage contiguously in some dim order (a
     permuted-contiguous NHD cache qualifies); any other layout raises. The
     geometry is memoized because this runs on the decode hot path."""
     if k.is_contiguous() and v.is_contiguous():
@@ -148,14 +147,12 @@ def _packed_kv_geometry(head_dim, key):
     num_pages, num_kv_heads, page, _ = k_shape
     shape = (num_pages, num_kv_heads, page, 2, head_dim)
     raw = (k_strides[0], k_strides[1], k_strides[2], head_dim, 1)
-    # Sized strides must telescope: the kernel derives addresses from the
-    # compact layout. Size-1 dims carry arbitrary strides, so they rank
-    # outermost (inner they would break the kernel's static alignment proof)
-    # and get rebuilt strides.
     ones = [i for i in range(5) if shape[i] == 1]
     sized = sorted((i for i in range(5) if shape[i] > 1), key=lambda i: raw[i])
     strides = [0] * 5
     expected = 1
+    # The kernel computes addresses as if the cache were contiguous, so the
+    # sized dims' strides must multiply out exactly in some dim order.
     for i in sized:
         if raw[i] != expected:
             raise ValueError(
@@ -164,6 +161,9 @@ def _packed_kv_geometry(head_dim, key):
             )
         strides[i] = expected
         expected *= shape[i]
+    # Size-1 dims arrive with arbitrary strides: rebuild them, and order the
+    # dims outermost so they cannot break the alignment cute.compile proves
+    # for the inner dims.
     for i in ones:
         strides[i] = expected
     rank = [0] * 5

--- a/flashinfer/msa_ops/cute_dsl/sparse_decode_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/sparse_decode_sm12x.py
@@ -49,9 +49,12 @@ class SparseDecodeForwardSm12x:
         q_fp8: bool = False,
         fused: bool = False,
         qoff_default: bool = False,
+        kv_packed: bool = False,
     ):
         if head_dim != 128 or blk_kv != 128:
             raise ValueError("only head_dim=blk_kv=128 supported")
+        if kv_packed and (not paged or kv_nvfp4):
+            raise ValueError("kv_packed requires the paged bf16/fp16/fp8 path")
         if group_size > 16:
             raise ValueError("group_size must be <= 16")
         self._head_dim = head_dim
@@ -72,6 +75,9 @@ class SparseDecodeForwardSm12x:
         self._kv_nvfp4 = kv_nvfp4
         self._q_fp8 = q_fp8
         self._fused = fused
+        # K/V packed in one cache: mK/mV are the same 5-D tensor
+        # (pages, Hkv, blk, 2, d); K is plane 0 of dim 3 and V plane 1.
+        self._kv_packed = kv_packed
         # Right-aligned decode (q_offset=None): the offset is seqlen_k - seqlen_q,
         # computed in-kernel so the wrapper launches no helper kernels to build it.
         self._qoff_default = qoff_default
@@ -82,6 +88,12 @@ class SparseDecodeForwardSm12x:
         self.cta_sync_barrier = pipeline.NamedBarrier(
             barrier_id=1, num_threads=num_threads
         )
+
+    def _paged_kv_block(self, mK, mV, page, kv_head):
+        """(128, d) K/V block views for one page; picks the planes when packed."""
+        if cutlass.const_expr(self._kv_packed):
+            return mK[page, kv_head, None, 0, None], mV[page, kv_head, None, 1, None]
+        return mK[page, kv_head, None, None], mV[page, kv_head, None, None]
 
     @cute.jit
     def __call__(
@@ -463,8 +475,9 @@ class SparseDecodeForwardSm12x:
                         ld_blk = mQ2K[kv_head, qi, ld_it]
                         if cutlass.const_expr(self._paged):
                             ld_page = mPageTable[batch_idx, ld_blk]
-                            ld_mK = mK[ld_page, kv_head, None, None]
-                            ld_mV = mV[ld_page, kv_head, None, None]
+                            ld_mK, ld_mV = self._paged_kv_block(
+                                mK, mV, ld_page, kv_head
+                            )
                         else:
                             ld_mK = cute.domain_offset(
                                 (k_start + ld_blk * self._blk_kv, 0),
@@ -626,8 +639,7 @@ class SparseDecodeForwardSm12x:
                     kv_block = mQ2K[kv_head, qi, it]
                     if cutlass.const_expr(self._paged):
                         page = mPageTable[batch_idx, kv_block]
-                        mK_blk = mK[page, kv_head, None, None]  # (128, d)
-                        mV_blk = mV[page, kv_head, None, None]
+                        mK_blk, mV_blk = self._paged_kv_block(mK, mV, page, kv_head)
                     else:
                         mK_blk = cute.domain_offset(
                             (k_start + kv_block * self._blk_kv, 0),
@@ -1002,8 +1014,7 @@ class SparseDecodeForwardSm12x:
             kv_block = mQ2K[kv_head, qi, it]
             if cutlass.const_expr(self._paged):
                 page = mPageTable[batch_idx, kv_block]
-                mK_blk = mK[page, kv_head, None, None]  # (128, d)
-                mV_blk = mV[page, kv_head, None, None]
+                mK_blk, mV_blk = self._paged_kv_block(mK, mV, page, kv_head)
             else:
                 mK_blk = cute.domain_offset(
                     (k_start + kv_block * self._blk_kv, 0), mK[None, kv_head, None]

--- a/flashinfer/msa_ops/cute_dsl/sparse_prefill_sm12x.py
+++ b/flashinfer/msa_ops/cute_dsl/sparse_prefill_sm12x.py
@@ -42,6 +42,7 @@ class SparsePrefillSm12x:
         paged: bool = False,
         kv_fp8: bool = False,
         kv_nvfp4: bool = False,
+        kv_packed: bool = False,
     ):
         if head_dim != 128 or n_block_size != 128:
             raise ValueError("only head_dim == n_block_size == 128 is supported")
@@ -49,6 +50,8 @@ class SparsePrefillSm12x:
             raise ValueError("group_size must divide m_block_size")
         if kv_fp8 and kv_nvfp4:
             raise ValueError("kv_fp8 and kv_nvfp4 are mutually exclusive")
+        if kv_packed and (not paged or kv_nvfp4):
+            raise ValueError("kv_packed requires the paged bf16/fp16/fp8 path")
         self._head_dim = head_dim
         self._m_block_size = m_block_size
         self._n_block_size = n_block_size
@@ -64,10 +67,19 @@ class SparsePrefillSm12x:
         # the K/V HBM read shrinks to ~1 / ~0.5 byte per element.
         self._kv_fp8 = kv_fp8
         self._kv_nvfp4 = kv_nvfp4
+        # K/V packed in one cache: mK/mV are the same 5-D tensor
+        # (pages, Hkv, blk, 2, d); K is plane 0 of dim 3 and V plane 1.
+        self._kv_packed = kv_packed
         self._q_smem_stride = head_dim + 8
         self.cta_sync_barrier = pipeline.NamedBarrier(
             barrier_id=1, num_threads=num_threads
         )
+
+    def _paged_kv_block(self, mK, mV, page, kv_head):
+        """(128, d) K/V block views for one page; picks the planes when packed."""
+        if cutlass.const_expr(self._kv_packed):
+            return mK[page, kv_head, None, 0, None], mV[page, kv_head, None, 1, None]
+        return mK[page, kv_head, None, None], mV[page, kv_head, None, None]
 
     def _make_skv_layout(self):
         """Bank-swizzled K/V SMEM layout."""
@@ -97,8 +109,7 @@ class SparsePrefillSm12x:
         bf16 path fills. Rows past ``seqlen_k`` are zero-filled (epilogue masks)."""
         if cutlass.const_expr(self._paged):
             page = mPageTable[batch_idx, kv_block]
-            mK_h8 = mK[page, kv_head, None, None]
-            mV_h8 = mV[page, kv_head, None, None]
+            mK_h8, mV_h8 = self._paged_kv_block(mK, mV, page, kv_head)
             row_off = cutlass.Int32(0)
         else:
             mK_h8 = cute.domain_offset((k_start, 0), mK[None, kv_head, None])
@@ -551,13 +562,15 @@ class SparsePrefillSm12x:
                     # bf16/fp16: cp.async load. Paged remaps the block through the
                     # page table (block coord 0); flat reuses the batch tile.
                     if cutlass.const_expr(self._paged):
+                        page = mPageTable[batch_idx, kv_block]
+                        mK_pg, mV_pg = self._paged_kv_block(mK, mV, page, kv_head)
                         gK_b = cute.local_tile(
-                            mK[mPageTable[batch_idx, kv_block], kv_head, None, None],
+                            mK_pg,
                             (self._n_block_size, self._head_dim),
                             (None, 0),
                         )
                         gV_b = cute.local_tile(
-                            mV[mPageTable[batch_idx, kv_block], kv_head, None, None],
+                            mV_pg,
                             (self._n_block_size, self._head_dim),
                             (None, 0),
                         )

--- a/flashinfer/msa_ops/sparse_decode.py
+++ b/flashinfer/msa_ops/sparse_decode.py
@@ -435,8 +435,8 @@ def msa_sparse_decode_attention(
         ksf_dev = k_scale.reshape(-1).contiguous()
         vsf_dev = v_scale.reshape(-1).contiguous()
     else:
-        # Packed K/V views: the kernel gets the underlying compact 5-D cache
-        # for both arguments and picks the K/V plane itself.
+        # Packed K/V views: the kernel gets the whole packed 5-D cache as
+        # both arguments and picks the K/V plane itself.
         k_pass, v_pass = (k, v) if packed_kv is None else (packed_kv[0], packed_kv[0])
         ksf_dev = _dummy_tensors(dev.index)[1]
         vsf_dev = ksf_dev

--- a/flashinfer/msa_ops/sparse_decode.py
+++ b/flashinfer/msa_ops/sparse_decode.py
@@ -27,7 +27,7 @@ import torch
 
 from ..api_logging import flashinfer_api
 from ..trace.templates.msa import msa_sparse_decode_attention_trace
-from ._common import _compile_cache, _cutlass_dtype, _fake
+from ._common import _compile_cache, _cutlass_dtype, _fake, _resolve_packed_kv
 
 
 def _get_compiled_combine(
@@ -206,6 +206,9 @@ def msa_sparse_decode_attention(
         Paged: ``(num_pages, num_kv_heads, 128, 128)`` with ``page_table``
         and ``seqused_k``; or flat varlen ``(total_k, num_kv_heads, 128)``
         with ``cu_seqlens_k``. May be fp8 E4M3 (upconverted in-kernel).
+        On the paged path, ``k``/``v`` may also be views split from a cache
+        that packs K and V in one ``2 * head_dim`` content dim per token
+        (see ``SUPPORTS_PACKED_KV``).
     q2k_indices : torch.Tensor
         ``(num_kv_heads, batch_size * seqlen_q, topk)`` int32, ascending,
         ``-1`` tail-padded (the format produced by
@@ -232,8 +235,9 @@ def msa_sparse_decode_attention(
         cache layout: ``(token, head)`` order for flat K/V, ``(page, head,
         token)`` for paged.
     k_global_scale, v_global_scale : float, optional
-        NVFP4 global dequant scales; folded into the softmax scale and the
-        output scale respectively, so the kernel applies only block scales.
+        Global dequant scales. ``k_global_scale`` folds into the softmax
+        scale (NVFP4 K only); ``v_global_scale`` scales the output for any
+        KV dtype (e.g. an fp8 per-tensor V descale).
     q_offset : int or torch.Tensor, optional
         Optional query-position offset used by causal alignment.
     partial_dtype : torch.dtype, optional
@@ -358,6 +362,8 @@ def msa_sparse_decode_attention(
     if v.shape != k.shape or v.dtype != k.dtype:
         raise ValueError("v must have the same shape and dtype as k")
 
+    packed_kv = _resolve_packed_kv(k, v, head_dim, paged=paged, kv_nvfp4=kv_nvfp4)
+
     if kv_nvfp4:
         # The kernel walks the swizzled 128x4 scale layout (rows padded to a
         # multiple of 128), so an undersized scale tensor reads out of bounds.
@@ -429,10 +435,13 @@ def msa_sparse_decode_attention(
         ksf_dev = k_scale.reshape(-1).contiguous()
         vsf_dev = v_scale.reshape(-1).contiguous()
     else:
-        k_pass, v_pass = k, v
+        # Packed K/V views: the kernel gets the underlying compact 5-D cache
+        # for both arguments and picks the K/V plane itself.
+        k_pass, v_pass = (k, v) if packed_kv is None else (packed_kv[0], packed_kv[0])
         ksf_dev = _dummy_tensors(dev.index)[1]
         vsf_dev = ksf_dev
 
+    kv_stride_order = None if packed_kv is None else packed_kv[1]
     key = (
         "decode",
         str(q.dtype),
@@ -446,6 +455,7 @@ def msa_sparse_decode_attention(
         str(partial_dtype),
         fused,
         qoff_default,
+        kv_stride_order,
     )
     compiled = _compile_cache.get(key)
     if compiled is None:
@@ -462,7 +472,13 @@ def msa_sparse_decode_attention(
         s_ptq, s_phq = cute.sym_int(), cute.sym_int()  # mOp/mLse (split partials)
         s_sc0, s_sc1 = cute.sym_int(), cute.sym_int()  # mSplitCounts
         s_otq, s_ohq = cute.sym_int(), cute.sym_int()  # mOut/mLseOut (fused)
-        kv_shape = (s_tk, s_hkv, 128, kv_word) if paged else (s_tk, s_hkv, kv_word)
+        kv_shape: tuple
+        if kv_stride_order is not None:
+            kv_shape = (s_tk, s_hkv, 128, 2, kv_word)
+        elif paged:
+            kv_shape = (s_tk, s_hkv, 128, kv_word)
+        else:
+            kv_shape = (s_tk, s_hkv, kv_word)
         stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
         kernel_obj = SparseDecodeForwardSm12x(
             head_dim=head_dim,
@@ -476,12 +492,13 @@ def msa_sparse_decode_attention(
             q_fp8=q_fp8,
             fused=fused,
             qoff_default=qoff_default,
+            kv_packed=kv_stride_order is not None,
         )
         compiled = cute.compile(
             kernel_obj,
             _fake(q_in_cdt, (s_tq, s_hq, head_dim)),
-            _fake(kv_cdt, kv_shape),
-            _fake(kv_cdt, kv_shape),
+            _fake(kv_cdt, kv_shape, stride_order=kv_stride_order),
+            _fake(kv_cdt, kv_shape, stride_order=kv_stride_order),
             _fake(i32, (s_pb, s_pm), align=4),
             _fake(u8, (s_ksf,), align=4),
             _fake(u8, (s_vsf,), align=4),

--- a/flashinfer/msa_ops/sparse_prefill.py
+++ b/flashinfer/msa_ops/sparse_prefill.py
@@ -425,8 +425,8 @@ def _msa_sparse_prefill(
         ksf_dev = k_scale.reshape(-1).contiguous()
         vsf_dev = v_scale.reshape(-1).contiguous()
     else:
-        # Packed K/V views: the kernel gets the underlying compact 5-D cache
-        # for both arguments and picks the K/V plane itself.
+        # Packed K/V views: the kernel gets the whole packed 5-D cache as
+        # both arguments and picks the K/V plane itself.
         k_pass, v_pass = (k, v) if packed_kv is None else (packed_kv[0], packed_kv[0])
         ksf_dev = torch.zeros(1, dtype=torch.uint8, device=dev)
         vsf_dev = ksf_dev

--- a/flashinfer/msa_ops/sparse_prefill.py
+++ b/flashinfer/msa_ops/sparse_prefill.py
@@ -27,6 +27,7 @@ from ._common import (
     _cutlass_dtype,
     _fake,
     _q_offset_tensor,
+    _resolve_packed_kv,
 )
 
 
@@ -92,7 +93,9 @@ def msa_sparse_attention(
     page_table : Optional[torch.Tensor], default=None
         Enables the paged-KV path. ``page_table`` has shape
         ``(batch_size, max_pages)`` and maps batch-local KV block indices to
-        pages. Requires ``seqused_k``.
+        pages. Requires ``seqused_k``. ``k``/``v`` may also be views split
+        from a cache that packs K and V in one ``2 * head_dim`` content dim
+        per token (see ``SUPPORTS_PACKED_KV``).
     seqused_k : Optional[torch.Tensor], default=None
         Int32 tensor of shape ``(batch_size,)`` giving the valid KV length per
         sequence in the paged path.
@@ -110,9 +113,11 @@ def msa_sparse_attention(
         NVFP4 block scales for V, with the same dtype, layout, and row-order
         contract as ``k_scale``.
     k_global_scale : Optional[float], default=None
-        Per-tensor NVFP4 global dequantization scale for K.
+        Global dequant scale for K; folds into the softmax scale (NVFP4 K
+        only).
     v_global_scale : Optional[float], default=None
-        Per-tensor NVFP4 global dequantization scale for V.
+        Global dequant scale applied to the output, for any KV dtype (e.g. an
+        fp8 per-tensor V descale).
     q_offset : optional
         Optional per-query offset tensor used by specific MSA workflows.
     return_temperature_lse : bool, default=False
@@ -209,9 +214,9 @@ def msa_sparse_attention(
     for name, t in (("k", k), ("v", v), ("q2k_indices", q2k_indices)):
         if t.device != q.device:
             raise ValueError(f"{name} must be on the same device as q ({q.device})")
-    for name, t in (("q", q), ("k", k), ("v", v)):
-        if not t.is_contiguous():
-            raise ValueError(f"{name} must be contiguous")
+    if not q.is_contiguous():
+        raise ValueError("q must be contiguous")
+    packed_kv = _resolve_packed_kv(k, v, head_dim, paged=paged, kv_nvfp4=kv_nvfp4)
 
     dev = q.device
     cu_q_dev = cu_seqlens_q.to(dev, non_blocking=True)
@@ -239,6 +244,7 @@ def msa_sparse_attention(
         k_scale=k_scale,
         v_scale=v_scale,
         v_global_scale=v_global_scale,
+        packed_kv=packed_kv,
     )
 
 
@@ -394,6 +400,7 @@ def _msa_sparse_prefill(
     k_scale=None,
     v_scale=None,
     v_global_scale=None,
+    packed_kv=None,
 ):
     """Union-tile prefill path. See
     :class:`...cute_dsl.sparse_prefill_sm12x.SparsePrefillSm12x`."""
@@ -418,7 +425,9 @@ def _msa_sparse_prefill(
         ksf_dev = k_scale.reshape(-1).contiguous()
         vsf_dev = v_scale.reshape(-1).contiguous()
     else:
-        k_pass, v_pass = k, v
+        # Packed K/V views: the kernel gets the underlying compact 5-D cache
+        # for both arguments and picks the K/V plane itself.
+        k_pass, v_pass = (k, v) if packed_kv is None else (packed_kv[0], packed_kv[0])
         ksf_dev = torch.zeros(1, dtype=torch.uint8, device=dev)
         vsf_dev = ksf_dev
     # V's global scale is applied to the output here, since prefill has no combine
@@ -446,6 +455,7 @@ def _msa_sparse_prefill(
     lse2 = _lse_buf(need_lse)
     lse2_t = _lse_buf(return_temperature_lse)
 
+    kv_stride_order = None if packed_kv is None else packed_kv[1]
     key = (
         "sparse_prefill",
         str(q.dtype),
@@ -459,6 +469,7 @@ def _msa_sparse_prefill(
         kv_nvfp4,
         need_lse,
         return_temperature_lse,
+        kv_stride_order,
     )
     compiled = _compile_cache.get(key)
     if compiled is None:
@@ -469,7 +480,12 @@ def _msa_sparse_prefill(
         f32 = _cutlass_dtype(torch.float32)
         s = [cute.sym_int() for _ in range(19)]
         kv_last = k_pass.shape[-1]  # head_dim (bf16/fp8) or 16 int32 words (NVFP4)
-        kv_shape = (s[9], s[10], _BLK_KV, kv_last) if paged else (s[2], s[3], kv_last)
+        if kv_stride_order is not None:
+            kv_shape = (s[9], s[10], _BLK_KV, 2, kv_last)
+        elif paged:
+            kv_shape = (s[9], s[10], _BLK_KV, kv_last)
+        else:
+            kv_shape = (s[2], s[3], kv_last)
         kernel_obj = SparsePrefillSm12x(
             head_dim=head_dim,
             m_block_size=m_block,
@@ -482,12 +498,13 @@ def _msa_sparse_prefill(
             paged=paged,
             kv_fp8=kv_fp8,
             kv_nvfp4=kv_nvfp4,
+            kv_packed=kv_stride_order is not None,
         )
         compiled = cute.compile(
             kernel_obj,
             _fake(cdt, (s[0], s[1], head_dim)),
-            _fake(kdt, kv_shape),
-            _fake(kdt, kv_shape),
+            _fake(kdt, kv_shape, stride_order=kv_stride_order),
+            _fake(kdt, kv_shape, stride_order=kv_stride_order),
             _fake(u8, (s[13],), align=4),
             _fake(u8, (s[14],), align=4),
             _fake(cdt, (s[0], s[1], head_dim)),

--- a/tests/msa_ops/test_packed_kv.py
+++ b/tests/msa_ops/test_packed_kv.py
@@ -1,0 +1,136 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Packed-KV tests: MSA sparse attention over K/V views split from a paged cache
+that packs K and V in one 2*head_dim content dim per token (vLLM's layout).
+"""
+
+import pytest
+import torch
+
+from flashinfer.utils import is_sm12x_supported
+
+B, HQ, HD, TOPK, PAGES_PER_REQ = 4, 8, 128, 16, 20
+NUM_PAGES = B * PAGES_PER_REQ
+SEQ_LEN = PAGES_PER_REQ * 128
+
+
+def _skip_if_unsupported():
+    if not torch.cuda.is_available() or not is_sm12x_supported(torch.device("cuda")):
+        pytest.skip("MSA ops require SM120 or SM121 and CUDA >= 12.8")
+
+
+def _split_cache(dtype, layout, hkv):
+    """Packed cache split into K/V views, plus contiguous reference copies."""
+    if layout == "HND":
+        packed = torch.randn(
+            NUM_PAGES, hkv, 128, 2 * HD, device="cuda", dtype=torch.bfloat16
+        )
+    else:  # NHD: heads inner of tokens
+        packed = torch.randn(
+            NUM_PAGES, 128, hkv, 2 * HD, device="cuda", dtype=torch.bfloat16
+        ).permute(0, 2, 1, 3)
+    packed = packed.to(dtype)
+    k_view, v_view = packed.split(HD, dim=-1)
+    return k_view, v_view, k_view.contiguous(), v_view.contiguous()
+
+
+def _page_table_and_seqused():
+    ptab = torch.arange(NUM_PAGES, device="cuda", dtype=torch.int32).view(
+        B, PAGES_PER_REQ
+    )
+    seqused = torch.full((B,), SEQ_LEN, device="cuda", dtype=torch.int32)
+    return ptab, seqused
+
+
+def _indices(total_q, hkv):
+    idx = torch.sort(
+        torch.randperm(PAGES_PER_REQ, device="cuda")[:TOPK].to(torch.int32)
+    )[0]
+    return idx.view(1, 1, TOPK).expand(hkv, total_q, TOPK).contiguous()
+
+
+@pytest.mark.parametrize("hkv", [1, 2])
+@pytest.mark.parametrize("layout", ["HND", "NHD"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_packed_kv_decode_matches_contiguous(layout, dtype, hkv):
+    _skip_if_unsupported()
+    from flashinfer.msa_ops import msa_sparse_decode_attention
+
+    torch.manual_seed(0)
+    k_view, v_view, k_cont, v_cont = _split_cache(dtype, layout, hkv)
+    ptab, seqused = _page_table_and_seqused()
+    q = torch.randn(B, HQ, HD, device="cuda", dtype=torch.bfloat16)
+    idx = _indices(B, hkv)
+
+    ref = msa_sparse_decode_attention(
+        q, k_cont, v_cont, idx, page_table=ptab, seqused_k=seqused, seqlen_q=1
+    )
+    out = msa_sparse_decode_attention(
+        q, k_view, v_view, idx, page_table=ptab, seqused_k=seqused, seqlen_q=1
+    )
+    torch.testing.assert_close(out, ref, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("hkv", [1, 2])
+@pytest.mark.parametrize("layout", ["HND", "NHD"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_packed_kv_prefill_matches_contiguous(layout, dtype, hkv):
+    _skip_if_unsupported()
+    from flashinfer.msa_ops import msa_sparse_attention
+
+    torch.manual_seed(0)
+    k_view, v_view, k_cont, v_cont = _split_cache(dtype, layout, hkv)
+    ptab, seqused = _page_table_and_seqused()
+    total_q = 200
+    q = torch.randn(total_q, HQ, HD, device="cuda", dtype=torch.bfloat16)
+    cu_q = torch.tensor([0, 50, 120, 160, total_q], device="cuda", dtype=torch.int32)
+    idx = _indices(total_q, hkv)
+
+    ref = msa_sparse_attention(
+        q, k_cont, v_cont, idx, cu_q, causal=True, page_table=ptab, seqused_k=seqused
+    )
+    out = msa_sparse_attention(
+        q, k_view, v_view, idx, cu_q, causal=True, page_table=ptab, seqused_k=seqused
+    )
+    torch.testing.assert_close(out, ref, rtol=0.0, atol=0.0)
+
+
+def test_packed_kv_flag_exported():
+    import flashinfer.msa_ops as msa_ops
+
+    assert msa_ops.SUPPORTS_PACKED_KV is True
+
+
+def test_unrelated_strided_views_rejected():
+    """Strided K/V that are not split from one packed cache must raise, since
+    the kernels would otherwise read them at the wrong addresses."""
+    _skip_if_unsupported()
+    from flashinfer.msa_ops import msa_sparse_decode_attention
+
+    torch.manual_seed(0)
+    ptab, seqused = _page_table_and_seqused()
+    q = torch.randn(B, HQ, HD, device="cuda", dtype=torch.bfloat16)
+    idx = _indices(B, 2)
+    k_bad = torch.randn(NUM_PAGES, 2, 128, 2 * HD, device="cuda", dtype=torch.bfloat16)[
+        :, :, :, :HD
+    ]
+    v_bad = torch.randn(NUM_PAGES, 2, 128, 2 * HD, device="cuda", dtype=torch.bfloat16)[
+        :, :, :, HD:
+    ]
+    with pytest.raises(ValueError):
+        msa_sparse_decode_attention(
+            q, k_bad, v_bad, idx, page_table=ptab, seqused_k=seqused, seqlen_q=1
+        )

--- a/tests/msa_ops/test_packed_kv.py
+++ b/tests/msa_ops/test_packed_kv.py
@@ -134,3 +134,22 @@ def test_unrelated_strided_views_rejected():
         msa_sparse_decode_attention(
             q, k_bad, v_bad, idx, page_table=ptab, seqused_k=seqused, seqlen_q=1
         )
+
+
+def test_packed_kv_detection_memoized():
+    """The memoized detection must match a fresh computation and hold no
+    tensors (a cached view would pin the KV cache's storage)."""
+    _skip_if_unsupported()
+    from flashinfer.msa_ops import _common
+
+    k, v, _, _ = _split_cache(torch.bfloat16, "HND", 2)
+    _common._PACKED_GEO_CACHE.clear()
+    miss, miss_rank = _common._packed_kv_view(k, v, HD)
+    assert len(_common._PACKED_GEO_CACHE) == 1
+    hit, hit_rank = _common._packed_kv_view(k, v, HD)
+    assert hit_rank == miss_rank
+    assert hit.shape == miss.shape
+    assert hit.stride() == miss.stride()
+    assert hit.data_ptr() == miss.data_ptr()
+    for cached in _common._PACKED_GEO_CACHE.values():
+        assert not any(torch.is_tensor(x) for x in cached)


### PR DESCRIPTION
## 📌 Description

Lets `msa_sparse_attention` and `msa_sparse_decode_attention` accept K/V views split from a paged KV cache that packs K and V in one `2 * head_dim` content dim per token. This is vLLM's KV-cache layout for MiniMax-M3 (vllm-project/vllm#44455), so it unblocks the vLLM integration of the MSA attend on SM120/SM121 (vllm-project/vllm#48994).

Design:

- The wrappers detect the split-view pattern and hand the kernel the whole packed cache; a `kv_packed` kernel variant reads K from the first half and V from the second half of each token's row. The contiguous path is unchanged.
- Packed views are accepted for paged bf16/fp16/fp8 caches only; NVFP4 and non-paged inputs still require contiguous K/V, since vLLM's packed cache is paged and never NVFP4, so nothing produces those combinations.
- The detection result is memoized so repeated calls with the same cache views skip it.
- Callers probe the capability via the new `msa_ops.SUPPORTS_PACKED_KV` flag.
- Also documents that `v_global_scale` applies to any KV dtype, which packed-cache callers rely on for the fp8 V descale.

### Performance

Each cell is the median time of the same op over 30 iterations with random block selections on a packed cache, divided by the same measurement on a contiguous cache (1.00 = accepting the packed layout costs nothing). Rows cover decode and prefill shapes at the two KV-cache dtypes the packed path accepts, bf16 and fp8. topk is 16, the MiniMax-M3 default; the head shape (8 query / 2 KV heads) is kept small so the kernels stay short and any per-call overhead would show. B=1 cells vary by a few percent between runs.

| shape (KV dtype, batch B, KV length S) | RTX 5080 | RTX PRO 6000 | GB10 |
|---|---|---|---|
| decode bf16 B=1 S=8192 | 1.01 | 0.98 | 0.80* |
| decode fp8 B=1 S=8192 | 1.04 | 1.02 | n/a** |
| decode bf16 B=8 S=8192 | 0.98 | 1.02 | 1.03 |
| decode fp8 B=8 S=8192 | 1.02 | 0.99 | n/a** |
| decode bf16 B=64 S=8192 | 0.98 | 1.01 | 0.99 |
| decode fp8 B=64 S=8192 | 1.00 | 1.01 | n/a** |
| decode bf16 B=256 S=8192 | 1.01 | 0.99 | 1.01 |
| decode fp8 B=256 S=8192 | 1.00 | 1.02 | n/a** |
| decode bf16 B=8 S=32768 | 1.01 | 1.03 | 1.09* |
| decode fp8 B=8 S=32768 | 1.02 | 1.05 | n/a** |
| prefill bf16 B=4 Q=512 S=8192 | 1.00 | 1.00 | 0.99 |
| prefill fp8 B=4 Q=512 S=8192 | 1.00 | 1.00 | n/a** |

\* Short GB10 runs vary a lot between repeats, likely because the board shifts clocks under its shared CPU/GPU power budget; read the starred cells as parity within that noise.

\** fp8 KV kernels currently fail to compile on SM121 with cutlass-dsl 4.5.2; this reproduces without this PR.

## 🔍 Related Issues

Follow-up to #3655 (MSA for SM120/SM121); enables the vLLM MiniMax-M3 integration in vllm-project/vllm#48994.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

- New `tests/msa_ops/test_packed_kv.py`: decode and prefill on packed split views vs contiguous copies, across HND/NHD cache layouts, MQA and GQA, and bf16/fp8; plus the capability flag, the memoized detection, and rejection of strided views that are not packed splits.
- RTX 5080 (two units) and RTX PRO 6000 (SM120): every packed case matches its contiguous reference bit-exactly, and the full `tests/msa_ops` suite passes.
- GB10 (SM121): the bf16 cases pass bit-exactly; fp8 does not compile there (see the performance footnote).

## Reviewer Notes

- Most of the diff is plumbing for the second compiled kernel variant, where mistakes fail loudly at compile or launch time. The exception is `_packed_kv_view` in `_common.py`: it reinterprets the caller's memory under new strides, so if it accepts a layout it should reject, the result is silently wrong attention output rather than an error. That function and its memoization are the parts to review closely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended sparse attention benchmarks with a `--kv_layout` option supporting `flat`, `paged`, and `packed`.
  * Added packed-KV cache view support for sparse prefill and decode.
  * Exported a capability flag so applications can detect packed-KV support.
* **Bug Fixes**
  * Added validation for supported `kv_layout`/dtype combinations and for valid packed-KV view layouts.
  * Improved decode execution to correctly propagate packed-KV metadata.
* **Tests**
  * Added SM120-121 tests covering packed-KV behavior, layout/dtype coverage, and invalid view rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->