### PR TITLE
Revert "[Bugfix] Skip autotuning for small token counts on SM100 to prevent TMA crash"

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1305,10 +1305,6 @@ def get_trtllm_moe_sm100_module():
             moe_inputs = MoeRunnerInputs.from_list(inputs)
             num_tokens = moe_inputs.hidden_states.shape[0]
 
-            major, _ = get_compute_capability(moe_inputs.hidden_states.device)
-            if major == 10 and num_tokens * self.top_k < 2 * self.num_local_experts:
-                return []
-
             has_gemm1_lora_delta = moe_inputs.gemm1_lora_delta is not None
 
             # Enumerate valid tactics for the fused (routed + shared) expert


### PR DESCRIPTION
Reverts flashinfer-ai/flashinfer#3837

See https://github.com/flashinfer-ai/flashinfer/pull/3837#issuecomment-5008426962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored valid Mixture-of-Experts execution tactics for certain TensorRT-LLM configurations.
  * Improved handling of workloads with fewer tokens relative to the number of local experts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->