### PR TITLE
fix(fused_moe): avoid repeated runner setup in host dispatch

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -24,6 +24,7 @@
 #include <memory>
 #include <set>
 #include <tuple>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -517,7 +518,8 @@ class FusedMoeLauncher {
   Tensor workspace_fc2;
   Tensor output;
   int64_t moe_tactic{-1};
-  std::shared_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner> moe_runner;
+  // Non-owning; points into the thread-local runner cache in prepare_moe_common().
+  tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner* moe_runner{nullptr};
 
   void prepare_moe_common(int64_t& moe_tactic) {
     using RunnerType = tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner;
@@ -541,45 +543,47 @@ class FusedMoeLauncher {
 
     // A Runner contains only constructor-derived kernel metadata and config indices. Reuse it on
     // the same host thread instead of rebuilding and filtering the global config table per call.
-    using RunnerCacheKey =
-        std::tuple<int64_t, int64_t, bool, int32_t, int64_t, bool, int64_t, int64_t, bool, bool,
-                   bool, bool, bool, int32_t, int32_t, int32_t>;
-    static thread_local std::map<RunnerCacheKey, std::shared_ptr<RunnerType>> runnerCache;
-    RunnerCacheKey const runnerKey{static_cast<int64_t>(this->mDtypeAct),
-                                   static_cast<int64_t>(this->mDtypeWeights),
-                                   args->mUseDeepSeekFp8,
-                                   static_cast<int32_t>(tile_tokens_dim),
-                                   static_cast<int64_t>(this->activation_type),
-                                   this->use_shuffled_weight,
-                                   static_cast<int64_t>(this->weight_layout),
-                                   static_cast<int64_t>(args->gemm1_bias_type),
-                                   usePerTokenScalingGemm1,
-                                   usePerTokenScalingGemm2,
-                                   usePerChannelScalingGemm1,
-                                   usePerChannelScalingGemm2,
-                                   useWeightsOnlyConstructor,
-                                   std::get<0>(device_version),
-                                   std::get<1>(device_version),
-                                   hidden_states.device().device_id};
+    std::tuple const runnerKey{static_cast<int64_t>(this->mDtypeAct),
+                               static_cast<int64_t>(this->mDtypeWeights),
+                               args->mUseDeepSeekFp8,
+                               static_cast<int32_t>(tile_tokens_dim),
+                               static_cast<int64_t>(this->activation_type),
+                               this->use_shuffled_weight,
+                               static_cast<int64_t>(this->weight_layout),
+                               static_cast<int64_t>(args->gemm1_bias_type),
+                               usePerTokenScalingGemm1,
+                               usePerTokenScalingGemm2,
+                               usePerChannelScalingGemm1,
+                               usePerChannelScalingGemm2,
+                               useWeightsOnlyConstructor,
+                               std::get<0>(device_version),
+                               std::get<1>(device_version),
+                               hidden_states.device().device_id};
+    using RunnerCacheKey = std::remove_const_t<decltype(runnerKey)>;
+    static thread_local std::map<RunnerCacheKey, RunnerType> runnerCache;
 
     auto runnerIt = runnerCache.find(runnerKey);
     if (runnerIt == runnerCache.end()) {
-      std::shared_ptr<RunnerType> runner;
       if (useWeightsOnlyConstructor) {
-        runner = std::make_shared<RunnerType>(
-            this->mDtypeWeights, args->mUseDeepSeekFp8, static_cast<int32_t>(tile_tokens_dim),
-            this->use_shuffled_weight, this->weight_layout, usePerTokenScalingGemm1,
-            usePerTokenScalingGemm2, usePerChannelScalingGemm1, usePerChannelScalingGemm2);
+        runnerIt =
+            runnerCache
+                .try_emplace(runnerKey, this->mDtypeWeights, args->mUseDeepSeekFp8,
+                             static_cast<int32_t>(tile_tokens_dim), this->use_shuffled_weight,
+                             this->weight_layout, usePerTokenScalingGemm1, usePerTokenScalingGemm2,
+                             usePerChannelScalingGemm1, usePerChannelScalingGemm2)
+                .first;
       } else {
-        runner = std::make_shared<RunnerType>(
-            this->mDtypeAct, this->mDtypeWeights, args->mUseDeepSeekFp8,
-            static_cast<int32_t>(tile_tokens_dim), this->activation_type, this->use_shuffled_weight,
-            this->weight_layout, args->gemm1_bias_type, usePerTokenScalingGemm1,
-            usePerTokenScalingGemm2, usePerChannelScalingGemm1, usePerChannelScalingGemm2);
+        runnerIt =
+            runnerCache
+                .try_emplace(runnerKey, this->mDtypeAct, this->mDtypeWeights, args->mUseDeepSeekFp8,
+                             static_cast<int32_t>(tile_tokens_dim), this->activation_type,
+                             this->use_shuffled_weight, this->weight_layout, args->gemm1_bias_type,
+                             usePerTokenScalingGemm1, usePerTokenScalingGemm2,
+                             usePerChannelScalingGemm1, usePerChannelScalingGemm2)
+                .first;
       }
-      runnerIt = runnerCache.emplace(runnerKey, std::move(runner)).first;
     }
-    moe_runner = runnerIt->second;
+    moe_runner = &runnerIt->second;
 
     int32_t const effectiveTopK = args->top_k + args->num_fused_shared_experts;
     int32_t const effectiveLocalExperts = args->local_num_experts + args->num_fused_shared_experts;

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -20,7 +20,10 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <map>
+#include <memory>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -514,7 +517,7 @@ class FusedMoeLauncher {
   Tensor workspace_fc2;
   Tensor output;
   int64_t moe_tactic{-1};
-  std::unique_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner> moe_runner;
+  std::shared_ptr<tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner> moe_runner;
 
   void prepare_moe_common(int64_t& moe_tactic) {
     using RunnerType = tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner;
@@ -530,18 +533,53 @@ class FusedMoeLauncher {
     // gemm1 bias, use the weights-only Runner constructor to match the original kernel
     // path and numerics. DSFp8 + biasMn routes through the unified constructor below
     // (which accepts gemm1_bias_type).
-    if (this->mDtypeAct == btg::Dtype::E4m3 && this->mDtypeWeights == btg::Dtype::E4m3 &&
-        args->mUseDeepSeekFp8 && args->gemm1_bias_type == batchedGemm::gemm::BiasType::None) {
-      moe_runner = std::make_unique<RunnerType>(this->mDtypeWeights, args->mUseDeepSeekFp8,
-                                                (int32_t)tile_tokens_dim, this->use_shuffled_weight,
-                                                this->weight_layout, usePerTokenScalingGemm1,
-                                                usePerTokenScalingGemm2, false, false);
-    } else {
-      moe_runner = std::make_unique<RunnerType>(
-          this->mDtypeAct, this->mDtypeWeights, args->mUseDeepSeekFp8, (int32_t)tile_tokens_dim,
-          this->activation_type, this->use_shuffled_weight, this->weight_layout,
-          args->gemm1_bias_type, usePerTokenScalingGemm1, usePerTokenScalingGemm2);
+    bool const useWeightsOnlyConstructor =
+        this->mDtypeAct == btg::Dtype::E4m3 && this->mDtypeWeights == btg::Dtype::E4m3 &&
+        args->mUseDeepSeekFp8 && args->gemm1_bias_type == batchedGemm::gemm::BiasType::None;
+    bool constexpr usePerChannelScalingGemm1 = false;
+    bool constexpr usePerChannelScalingGemm2 = false;
+
+    // A Runner contains only constructor-derived kernel metadata and config indices. Reuse it on
+    // the same host thread instead of rebuilding and filtering the global config table per call.
+    using RunnerCacheKey =
+        std::tuple<int64_t, int64_t, bool, int32_t, int64_t, bool, int64_t, int64_t, bool, bool,
+                   bool, bool, bool, int32_t, int32_t, int32_t>;
+    static thread_local std::map<RunnerCacheKey, std::shared_ptr<RunnerType>> runnerCache;
+    RunnerCacheKey const runnerKey{static_cast<int64_t>(this->mDtypeAct),
+                                   static_cast<int64_t>(this->mDtypeWeights),
+                                   args->mUseDeepSeekFp8,
+                                   static_cast<int32_t>(tile_tokens_dim),
+                                   static_cast<int64_t>(this->activation_type),
+                                   this->use_shuffled_weight,
+                                   static_cast<int64_t>(this->weight_layout),
+                                   static_cast<int64_t>(args->gemm1_bias_type),
+                                   usePerTokenScalingGemm1,
+                                   usePerTokenScalingGemm2,
+                                   usePerChannelScalingGemm1,
+                                   usePerChannelScalingGemm2,
+                                   useWeightsOnlyConstructor,
+                                   std::get<0>(device_version),
+                                   std::get<1>(device_version),
+                                   hidden_states.device().device_id};
+
+    auto runnerIt = runnerCache.find(runnerKey);
+    if (runnerIt == runnerCache.end()) {
+      std::shared_ptr<RunnerType> runner;
+      if (useWeightsOnlyConstructor) {
+        runner = std::make_shared<RunnerType>(
+            this->mDtypeWeights, args->mUseDeepSeekFp8, static_cast<int32_t>(tile_tokens_dim),
+            this->use_shuffled_weight, this->weight_layout, usePerTokenScalingGemm1,
+            usePerTokenScalingGemm2, usePerChannelScalingGemm1, usePerChannelScalingGemm2);
+      } else {
+        runner = std::make_shared<RunnerType>(
+            this->mDtypeAct, this->mDtypeWeights, args->mUseDeepSeekFp8,
+            static_cast<int32_t>(tile_tokens_dim), this->activation_type, this->use_shuffled_weight,
+            this->weight_layout, args->gemm1_bias_type, usePerTokenScalingGemm1,
+            usePerTokenScalingGemm2, usePerChannelScalingGemm1, usePerChannelScalingGemm2);
+      }
+      runnerIt = runnerCache.emplace(runnerKey, std::move(runner)).first;
     }
+    moe_runner = runnerIt->second;
 
     int32_t const effectiveTopK = args->top_k + args->num_fused_shared_experts;
     int32_t const effectiveLocalExperts = args->local_num_experts + args->num_fused_shared_experts;
@@ -551,13 +589,10 @@ class FusedMoeLauncher {
                                                           args->intermediate_size,
                                                           effectiveLocalExperts, args->num_tokens);
     }
-    auto valid_cfgs =
-        moe_runner->getValidConfigIndices(effectiveTopK, args->hidden_size, args->intermediate_size,
-                                          effectiveLocalExperts, args->num_tokens);
-    auto valid_it = std::find(valid_cfgs.begin(), valid_cfgs.end(), moe_tactic);
-    FLASHINFER_CHECK(valid_it != valid_cfgs.end(), "Invalid MoE tactic ", moe_tactic,
-                     " for tile_N=", tile_tokens_dim, ". Number of valid tactics for this tile is ",
-                     valid_cfgs.size(),
+    FLASHINFER_CHECK(moe_runner->isValidConfigIndex(moe_tactic, effectiveTopK, args->hidden_size,
+                                                    args->intermediate_size, effectiveLocalExperts,
+                                                    args->num_tokens),
+                     "Invalid MoE tactic ", moe_tactic, " for tile_N=", tile_tokens_dim,
                      ". This often indicates a stale or mismatched autotuner cache entry.");
     this->moe_tactic = moe_tactic;
 
@@ -596,6 +631,7 @@ class FusedMoeLauncher {
   virtual Array<Tensor> run(int64_t moe_tactic, bool enable_pdl = true,
                             bool use_routing_scales_on_input = false,
                             bool use_deep_seek_fp8 = false, bool return_activation_output = false) {
+    ffi::CUDADeviceGuard device_guard(hidden_states.device().device_id);
     check_routing();
     prepare_routing();
 
@@ -1429,6 +1465,7 @@ class Fp8BlockScaleLauncher : public FusedMoeLauncher {
   Array<Tensor> run(int64_t moe_tactic, bool enable_pdl = true,
                     bool use_routing_scales_on_input = false, bool use_deep_seek_fp8 = false,
                     bool return_activation_output = false) override {
+    ffi::CUDADeviceGuard device_guard(hidden_states.device().device_id);
     check_routing();
     prepare_routing();
 
@@ -1988,6 +2025,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
   Array<Tensor> run(int64_t moe_tactic, bool enable_pdl = true,
                     bool use_routing_scales_on_input = false, bool use_deep_seek_fp8 = false,
                     bool return_activation_output = false) override {
+    ffi::CUDADeviceGuard device_guard(hidden_states.device().device_id);
     TVM_FFI_ICHECK(!return_activation_output)
         << "return_activation_output is not supported for FP4 block-scale MoE";
     check_routing();

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -773,6 +773,21 @@ std::vector<int64_t> Runner::getValidConfigIndices(int32_t topK, int32_t hiddenS
   return validIndices;
 }
 
+bool Runner::isValidConfigIndex(int64_t configIndex, int32_t topK, int32_t hiddenSize,
+                                int32_t intermediateSize, int32_t numLocalExperts,
+                                int32_t numTokens) const {
+  if (configIndex < 0 || configIndex >= static_cast<int64_t>(mPassingConfigs.size())) {
+    return false;
+  }
+
+  auto const& config = mPassingConfigs[configIndex];
+  return mPermuteGemm1.isValidConfigIndex(static_cast<int32_t>(config.gemm1Config), topK,
+                                          hiddenSize, intermediateSize, numLocalExperts,
+                                          numTokens) &&
+         mGemm2.isValidConfigIndex(static_cast<int32_t>(config.gemm2Config), topK, hiddenSize,
+                                   intermediateSize, numLocalExperts, numTokens);
+}
+
 int64_t Runner::getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize,
                                            int32_t intermediateSize, int32_t numLocalExperts,
                                            int32_t numTokens) const {

--- a/include/flashinfer/trtllm/fused_moe/runner.h
+++ b/include/flashinfer/trtllm/fused_moe/runner.h
@@ -443,6 +443,10 @@ class Runner {
                                                            int32_t numLocalExperts,
                                                            int32_t numTokens) const;
 
+  [[nodiscard]] bool isValidConfigIndex(int64_t configIndex, int32_t topK, int32_t hiddenSize,
+                                        int32_t intermediateSize, int32_t numLocalExperts,
+                                        int32_t numTokens) const;
+
   [[nodiscard]] int64_t getDefaultValidConfigIndex(int32_t topK, int32_t hiddenSize,
                                                    int32_t intermediateSize,
                                                    int32_t numLocalExperts,


### PR DESCRIPTION
## Description

The fused MoE launch path constructs a `MoE::Runner` for every invocation. Runner construction filters the global GEMM config table and builds the Cartesian GEMM1/GEMM2 tactic set. After a tactic is selected, the launcher also materializes and scans the complete valid-tactic list to validate that single index.

This work remains on the warmed CPU launch path. The artifact update in #3973 increased the global config set from 1,696 to 2,516 entries and the tile-128 joint tactic set from 16 to 64, making the existing per-call work visible in serving throughput.

This change:

- caches constructor-derived `MoE::Runner` instances per host thread, keyed by the current constructor options, SM version, and CUDA device;
- establishes a CUDA device guard before Runner lookup, construction, validation, and launch;
- adds `Runner::isValidConfigIndex()` to validate only the selected GEMM1/GEMM2 pair instead of enumerating the complete valid set.

Runtime tensors, workspaces, streams, and shapes are not cached. Default tactic selection continues to use `getDefaultValidConfigIndex()`, followed by the same O(1) selected-pair validation used for explicit tactics. The BMM artifact, tactic selection policy, selected kernels, and 2CTA behavior are unchanged.

## Validation

### Same-dispatch GB300 microbenchmark

A same-GPU `stock / fixed / fixed / stock` ABBA comparison used the same artifact, default tactic path, and identical GEMM1/GEMM2 kernel symbols in both arms.

| Token bucket | Total latency, fixed - stock | Non-CUDA residual, fixed - stock | Captured CUDA, fixed - stock |
|---:|---:|---:|---:|
| 8K | -0.430 ms | -0.441 ms | +0.010 ms |
| 32K | -0.416 ms | -0.416 ms | -0.0002 ms |

The non-CUDA residual is total operator latency minus captured CUDA kernel time. The improvement is isolated to host dispatch; dispatched kernels and their measured CUDA time remain unchanged within the benchmark threshold.

### End-to-end serving

The end-to-end comparison used Qwen3.5-397B-A17B-NVFP4 on GB300 with disaggregated TP4 prefill and TP4 decode, prefill concurrency 96, and two 900-second measurements per arm in `R-B-H-H-B-R` order. All measurement windows completed with zero request errors.

- **R:** v0.6.12 compatibility baseline
- **B:** v0.6.15 stock
- **H:** v0.6.15 with this change

| Geometric-mean comparison | Result |
|---|---:|
| B vs. R | -6.090% |
| H vs. B | +6.118% |
| H vs. R | -0.344% |

The v0.6.12 arm includes only an API compatibility backport required by the newer serving stack; it does not modify the fused MoE artifact, tuning path, or runtime dispatch.

## Checks

- repository pre-commit checks for the modified files;
- GB300 JIT compilation of the cache and selected-pair path on v0.6.15;
- artifact, tactic, and kernel-symbol parity in the same-dispatch microbenchmark;
- two-repeat GB300 TP4 end-to-end validation on v0.6.15.

The branch is rebased onto current `main`. Additional constructor-path, multi-thread, and multi-device tests remain to be added before marking the PR ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mixture-of-experts configuration validation by using a direct validity check for selected tactics, rejecting invalid configurations reliably.
  - Ensured MoE execution runs on the correct CUDA device across fused MoE execution paths.

- **Performance**
  - Added per-thread caching of compatible MoE runner instances to reduce repeated setup overhead during repeated executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->