### PR TITLE
fix(gemm): prevent out-of-bounds read in MaskedScheduler

### DIFF
--- a/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
+++ b/flashinfer/gemm/kernels/grouped_gemm_masked_blackwell.py
@@ -313,44 +313,49 @@ class MaskedScheduler:
         ]
         accum_tile_m = self._accum_tile_m
         batch_idx = self._current_batch_idx
+        num_batches = self.params.masked_m.shape[0]
 
-        while (
-            (
-                accum_tile_m
-                + cute.ceil_div(
-                    self.params.masked_m[batch_idx],
-                    self.params.c_tiler[1 if cutlass.const_expr(is_swap_ab) else 0],
-                )
-            )
-            * num_tiles_n
-            <= current_work_linear_idx
-            and batch_idx < self.params.masked_m.shape[0]
-        ):
-            if cutlass.const_expr(
-                (dsm_pending_packed is not None)
-                and (self.params.dst_signals is not None)
-            ):
-                dsm_pending_packed = with_byte(
-                    dsm_pending_packed,
-                    index=batch_idx,
-                    value=dsm_counter + (num_c_stage - 1),
-                )
-
-            accum_tile_m += cute.ceil_div(
+        # NOTE: `masked_m[batch_idx]` must only be read under a control-flow
+        # guard that `batch_idx` is in bounds. A combined condition like
+        # `masked_m[batch_idx] ... and batch_idx < num_batches` is NOT safe:
+        # dynamic `and` in the DSL may evaluate both operands (no Python
+        # short-circuit), so `masked_m[num_batches]` could be read
+        # out-of-bounds once all batches are consumed, causing illegal
+        # memory access (CUDA error 700).
+        keep_running = batch_idx < num_batches
+        while keep_running:
+            num_tiles_m_cur = cute.ceil_div(
                 self.params.masked_m[batch_idx],
                 self.params.c_tiler[1 if cutlass.const_expr(is_swap_ab) else 0],
             )
-            batch_idx += Int32(1)
+            if (accum_tile_m + num_tiles_m_cur) * num_tiles_n <= (
+                current_work_linear_idx
+            ):
+                if cutlass.const_expr(
+                    (dsm_pending_packed is not None)
+                    and (self.params.dst_signals is not None)
+                ):
+                    dsm_pending_packed = with_byte(
+                        dsm_pending_packed,
+                        index=batch_idx,
+                        value=dsm_counter + (num_c_stage - 1),
+                    )
+
+                accum_tile_m += num_tiles_m_cur
+                batch_idx += Int32(1)
+                keep_running = batch_idx < num_batches
+            else:
+                keep_running = cutlass.Boolean(False)
 
         self._accum_tile_m = accum_tile_m
         self._current_batch_idx = batch_idx
 
-        is_valid = self._current_batch_idx < self.params.masked_m.shape[0]
+        is_valid = batch_idx < num_batches
         if is_valid:
             is_valid = (
-                self._accum_tile_m
+                accum_tile_m
                 + cute.ceil_div(
-                    self.params.masked_m[self._current_batch_idx],
+                    self.params.masked_m[batch_idx],
                     self.params.c_tiler[1 if cutlass.const_expr(is_swap_ab) else 0],
                 )
             ) * num_tiles_n > current_work_linear_idx
@@ -361,14 +366,14 @@ class MaskedScheduler:
         if cutlass.const_expr(is_swap_ab):
             cur_cluster_coord = (
                 current_work_linear_idx % num_tiles_n,
-                current_work_linear_idx // num_tiles_n - self._accum_tile_m,
-                self._current_batch_idx,
+                current_work_linear_idx // num_tiles_n - accum_tile_m,
+                batch_idx,
             )
         else:
             cur_cluster_coord = (
-                current_work_linear_idx // num_tiles_n - self._accum_tile_m,
+                current_work_linear_idx // num_tiles_n - accum_tile_m,
                 current_work_linear_idx % num_tiles_n,
-                self._current_batch_idx,
+                batch_idx,
             )
 
         # cur_tile_coord is a tuple of i32 values

--- a/tests/gemm/test_cute_dsl_blockscaled_gemm.py
+++ b/tests/gemm/test_cute_dsl_blockscaled_gemm.py
@@ -263,6 +263,57 @@ def test_blockscaled_gemm_python_interface(
 @pytest.mark.skipif(
     not is_cute_dsl_available(), reason="Please `pip install nvidia-cutlass-dsl`"
 )
+def test_grouped_gemm_nt_masked_scheduler_empty_experts():
+    """Regression test for draining MaskedScheduler past empty experts."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    dev = torch.device("cuda:0")
+    if not (is_sm100a_supported(dev) or is_sm100f_supported(dev)):
+        pytest.skip("NVFP4 grouped GEMM requires SM100")
+
+    sf_vec = 16
+    m, n, k, num_experts = 128, 128, 256, 4
+    k_packed, num_m_tiles, num_k_sf = k // 2, m // 128, k // sf_vec
+    num_k_sf_tiles = num_k_sf // 4
+    sf_shape = (32, 4, num_m_tiles, 4, num_k_sf_tiles, num_experts)
+
+    a = torch.full((m, k_packed, num_experts), 0x11, dtype=torch.uint8, device=dev)
+    b = torch.full((n, k_packed, num_experts), 0x11, dtype=torch.uint8, device=dev)
+    sfa = torch.ones(sf_shape, dtype=torch.float8_e4m3fn, device=dev)
+    sfb = torch.ones(sf_shape, dtype=torch.float8_e4m3fn, device=dev)
+    sentinel = 13.0
+
+    def run(masked_m_values):
+        output = torch.full(
+            (num_experts, m, n), sentinel, dtype=torch.bfloat16, device=dev
+        ).permute(1, 2, 0)
+        masked_m = torch.tensor(masked_m_values, dtype=torch.int32, device=dev)
+        grouped_gemm_nt_masked(
+            (a, sfa),
+            (b, sfb),
+            output,
+            masked_m,
+            ab_dtype="float4_e2m1fn",
+            sf_dtype="float8_e4m3fn",
+            c_dtype="bfloat16",
+            sf_vec_size=sf_vec,
+        )
+        # Surface asynchronous illegal memory accesses in the test process.
+        torch.cuda.synchronize()
+        return output.permute(2, 0, 1).clone()
+
+    full = run([m] * num_experts)
+    trailing_empty = run([m, 0, 0, 0])
+    torch.testing.assert_close(trailing_empty[0], full[0], atol=0.0, rtol=0.0)
+    assert torch.all(trailing_empty[1:] == sentinel)
+
+    all_empty = run([0] * num_experts)
+    assert torch.all(all_empty == sentinel)
+
+
+@pytest.mark.skipif(
+    not is_cute_dsl_available(), reason="Please `pip install nvidia-cutlass-dsl`"
+)
 def test_grouped_gemm_nt_masked_output_layout_contract():
     """Regression test for issue #3103.
 


### PR DESCRIPTION
## 📌 Description

`MaskedScheduler._get_current_work_for_linear_idx` could read
`masked_m[num_batches]` after draining all experts.

The previous loop condition accessed `masked_m[batch_idx]` before checking
whether `batch_idx` was in bounds. Simply reordering the operands is not
sufficient because dynamic boolean operations in CuTe DSL do not guarantee
Python short-circuit evaluation.

This PR:

- guards the loop with an explicit loop-carried `keep_running` value;
- reads `masked_m[batch_idx]` only after confirming that `batch_idx` is in bounds;
- reuses the updated local scheduler state after the loop;
- adds an SM100 regression test covering trailing-empty and all-empty expert
  masks.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing.

Added `test_grouped_gemm_nt_masked_scheduler_empty_experts`, covering:

- all experts populated;
- one populated expert followed by empty experts: `[128, 0, 0, 0]`;
- all experts empty: `[0, 0, 0, 0]`;
- explicit CUDA synchronization to surface asynchronous kernel errors;
- sentinel checks to verify that empty expert outputs remain untouched.

### Compute Sanitizer A/B Verification

Tested on NVIDIA L20D, Blackwell SM103, compute capability 10.3.

Before the fix:

- normal CUDA smoke tests completed successfully;
- `compute-sanitizer --tool memcheck` reported an invalid 4-byte global read;
- the read occurred at the first byte past the 16-byte `masked_m` allocation,
  corresponding to `masked_m[4]`;
- `ERROR SUMMARY: 132 errors`;
- exit code: 99.

After the fix:

- all-populated, trailing-empty, and all-empty cases completed successfully;
- functional output checks passed;
- `ERROR SUMMARY: 0 errors`;
- exit code: 0.

## Reviewer Notes

Please focus on the explicit CuTe DSL control flow around the
`batch_idx == num_batches` scheduler-drain boundary.

The standalone compute-sanitizer reproducer was used only for A/B validation
and is intentionally not included in this PR.

This change was developed with AI assistance. The patch and Blackwell A/B
results were manually reviewed and validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed masked grouped GEMM scheduling to avoid out-of-bounds reads when all work is consumed.
  * Corrected masked scheduler behavior when some or all experts have no assigned work, preventing invalid memory access errors.
  * Ensured outputs remain correct for active experts and sentinel values are preserved for empty experts.
* **Tests**
  * Added a regression test covering full, partially empty, and entirely empty expert workloads (skips when backend/hardware requirements aren’t met).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->