### PR TITLE
perf(sampling): reduce top-p target probability memory

### DIFF
--- a/csrc/renorm.cu
+++ b/csrc/renorm.cu
@@ -79,6 +79,7 @@ void top_p_renorm_probs(TensorView probs, TensorView renorm_probs,
   check_no_overlap(workspace, renorm_probs, "workspace", "renorm_probs");
   if (has_top_p_arr) {
     check_no_overlap(workspace, maybe_top_p_arr.value(), "workspace", "top_p");
+    check_no_overlap(renorm_probs, maybe_top_p_arr.value(), "renorm_probs", "top_p");
   }
   if (vocab_size >= sampling::air_top_p::NUM_BUCKETS &&
       reinterpret_cast<std::uintptr_t>(workspace.data_ptr()) %

--- a/csrc/renorm.cu
+++ b/csrc/renorm.cu
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <cstdint>
 #include <flashinfer/air_top_p.cuh>
 #include <flashinfer/sampling.cuh>
 
@@ -23,15 +24,69 @@ using namespace flashinfer;
 
 using tvm::ffi::Optional;
 
+namespace {
+
+struct MemoryRange {
+  std::uintptr_t begin;
+  std::uintptr_t end;
+};
+
+MemoryRange get_memory_range(const TensorView& tensor) {
+  auto begin = reinterpret_cast<std::uintptr_t>(tensor.data_ptr());
+  auto size = static_cast<std::uintptr_t>(tensor.numel() * get_element_size(tensor));
+  return {begin, begin + size};
+}
+
+bool overlaps(const MemoryRange& lhs, const MemoryRange& rhs) {
+  return lhs.begin < rhs.end && rhs.begin < lhs.end;
+}
+
+void check_no_overlap(const TensorView& lhs, const TensorView& rhs, const char* lhs_name,
+                      const char* rhs_name) {
+  if (overlaps(get_memory_range(lhs), get_memory_range(rhs))) {
+    TVM_FFI_THROW(ValueError) << lhs_name << " must not overlap " << rhs_name;
+  }
+}
+
+}  // namespace
+
 void top_p_renorm_probs(TensorView probs, TensorView renorm_probs,
                         Optional<TensorView> maybe_top_p_arr, double top_p_val,
                         bool is_deterministic, TensorView workspace) {
-  CHECK_INPUT(probs);
+  CHECK_INPUT_AND_TYPE(probs, dl_float32);
+  CHECK_INPUT_AND_TYPE(renorm_probs, dl_float32);
+  CHECK_INPUT_AND_TYPE(workspace, dl_uint8);
   CHECK_DIM(2, probs);  // probs: (batch_size, vocab_size)
+  CHECK_SHAPE(probs, renorm_probs);
+  CHECK_DEVICE(probs, renorm_probs);
+  CHECK_DEVICE(probs, workspace);
   unsigned int batch_size = probs.size(0);
   unsigned int vocab_size = probs.size(1);
   check_tensor_param(maybe_top_p_arr, probs);
   bool has_top_p_arr = maybe_top_p_arr.has_value();
+  if (has_top_p_arr) {
+    CHECK_INPUT_AND_TYPE(maybe_top_p_arr.value(), dl_float32);
+    CHECK_DEVICE(probs, maybe_top_p_arr.value());
+  }
+
+  auto probs_range = get_memory_range(probs);
+  auto renorm_probs_range = get_memory_range(renorm_probs);
+  if (overlaps(probs_range, renorm_probs_range) && (probs_range.begin != renorm_probs_range.begin ||
+                                                    probs_range.end != renorm_probs_range.end)) {
+    TVM_FFI_THROW(ValueError) << "probs and renorm_probs must either alias exactly or not overlap";
+  }
+  check_no_overlap(workspace, probs, "workspace", "probs");
+  check_no_overlap(workspace, renorm_probs, "workspace", "renorm_probs");
+  if (has_top_p_arr) {
+    check_no_overlap(workspace, maybe_top_p_arr.value(), "workspace", "top_p");
+  }
+  if (vocab_size >= sampling::air_top_p::NUM_BUCKETS &&
+      reinterpret_cast<std::uintptr_t>(workspace.data_ptr()) %
+              alignof(sampling::air_top_p::Counter<float>) !=
+          0) {
+    TVM_FFI_THROW(ValueError) << "workspace must be aligned to "
+                              << alignof(sampling::air_top_p::Counter<float>) << " bytes";
+  }
 
   ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());

--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -50,21 +50,39 @@ void softmax(TensorView workspace_buffer, TensorView logits, TensorView output,
   CHECK_INPUT(logits);
   CHECK_INPUT(output);
   CHECK_DIM(2, logits);  // logits: (batch_size, vocab_size)
+  CHECK_DIM(2, output);
+  CHECK_DEVICE(output, logits);
+  TVM_FFI_ICHECK(output.dtype() == dl_float32) << "softmax output must be float32";
+  TVM_FFI_ICHECK(logits.dtype() == dl_float32 || logits.dtype() == dl_float16 ||
+                 logits.dtype() == dl_bfloat16)
+      << "softmax logits must be float32, float16, or bfloat16";
+  TVM_FFI_ICHECK(output.size(0) == logits.size(0) && output.size(1) == logits.size(1))
+      << "softmax output shape must match logits";
   unsigned int batch_size = logits.size(0);
   unsigned int vocab_size = logits.size(1);
 
   bool has_temperature_arr = maybe_temperature_arr.has_value();
+  if (has_temperature_arr) {
+    CHECK_INPUT(maybe_temperature_arr.value());
+    CHECK_DEVICE(maybe_temperature_arr.value(), logits);
+    TVM_FFI_ICHECK(maybe_temperature_arr.value().dtype() == dl_float32)
+        << "softmax temperature must be float32";
+  }
 
   ffi::CUDADeviceGuard device_guard(logits.device().device_id);
   auto stream = get_stream(logits.device());
-  cudaError_t status = sampling::OnlineSoftmax<float>(
-      static_cast<float*>(logits.data_ptr()), static_cast<float*>(output.data_ptr()), batch_size,
-      vocab_size,
-      has_temperature_arr ? static_cast<float*>(maybe_temperature_arr.value().data_ptr()) : nullptr,
-      temperature_val, workspace_buffer.data_ptr(),
-      get_element_size(workspace_buffer) * workspace_buffer.size(0), enable_pdl, stream);
-  TVM_FFI_ICHECK(status == cudaSuccess)
-      << "OnlineSoftmax failed with error code " << cudaGetErrorString(status);
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP32_FP16(logits.dtype(), DTypeIn, [&] {
+    cudaError_t status = sampling::OnlineSoftmax<DTypeIn, float>(
+        static_cast<DTypeIn*>(logits.data_ptr()), static_cast<float*>(output.data_ptr()),
+        batch_size, vocab_size,
+        has_temperature_arr ? static_cast<float*>(maybe_temperature_arr.value().data_ptr())
+                            : nullptr,
+        temperature_val, workspace_buffer.data_ptr(),
+        get_element_size(workspace_buffer) * workspace_buffer.size(0), enable_pdl, stream);
+    TVM_FFI_ICHECK(status == cudaSuccess)
+        << "OnlineSoftmax failed with error code " << cudaGetErrorString(status);
+    return true;
+  });
 }
 
 void sampling_from_logits(TensorView logits, TensorView output, Optional<TensorView> maybe_indices,

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -205,6 +205,9 @@ from .sampling import (
     top_k_top_p_sampling_from_logits as top_k_top_p_sampling_from_logits,
 )
 from .sampling import top_k_top_p_sampling_from_probs as top_k_top_p_sampling_from_probs
+from .sampling import (
+    get_top_p_renorm_probs_workspace_size as get_top_p_renorm_probs_workspace_size,
+)
 from .sampling import top_p_renorm_probs as top_p_renorm_probs
 from .sampling import top_p_sampling_from_probs as top_p_sampling_from_probs
 from .tllm_enums import (

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -1829,16 +1829,6 @@ def get_top_p_renorm_probs_workspace_size(
     )
 
 
-def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
-    if lhs.device != rhs.device:
-        return False
-    lhs_begin = lhs.data_ptr()
-    rhs_begin = rhs.data_ptr()
-    lhs_end = lhs_begin + lhs.numel() * lhs.element_size()
-    rhs_end = rhs_begin + rhs.numel() * rhs.element_size()
-    return lhs_begin < rhs_end and rhs_begin < lhs_end
-
-
 @flashinfer_api(trace=top_p_renorm_probs_trace)
 def top_p_renorm_probs(
     probs: torch.Tensor,
@@ -1934,14 +1924,8 @@ def top_p_renorm_probs(
             "workspace must be a contiguous uint8 tensor on the same device "
             f"with at least {ws_size} elements"
         )
-    if vocab_size >= 2048 and workspace.data_ptr() % 128 != 0:
-        raise ValueError("workspace must be aligned to 128 bytes")
 
     top_p_args = _to_tensor_scalar_tuple(top_p)
-    for name, tensor in (("probs", probs), ("top_p", top_p_args[0])):
-        if tensor is not None and _tensors_overlap(workspace, tensor):
-            raise ValueError(f"workspace must not overlap {name}")
-
     if out is None:
         return get_sampling_module().top_p_renorm_probs(
             probs, *top_p_args, is_deterministic, workspace
@@ -1960,14 +1944,7 @@ def top_p_renorm_probs(
             "layout as probs"
         )
 
-    probs_begin = probs.data_ptr()
-    out_begin = out.data_ptr()
-    if _tensors_overlap(probs, out) and probs_begin != out_begin:
-        raise ValueError("probs and out must either alias exactly or not overlap")
-    if _tensors_overlap(workspace, out):
-        raise ValueError("workspace must not overlap out")
-
-    if out_begin == probs_begin:
+    if out is probs:
         get_sampling_module().top_p_renorm_probs_inplace(
             probs, *top_p_args, is_deterministic, workspace
         )

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -75,8 +75,12 @@ def get_sampling_module():
         temperature_val: float,
         enable_pdl: bool,
     ) -> torch.Tensor:
-        logits = logits.float()
-        probs = torch.empty_like(logits, device=logits.device)
+        if logits.dtype not in (torch.float32, torch.float16, torch.bfloat16):
+            raise TypeError(
+                "softmax logits must be float32, float16, or bfloat16, "
+                f"got {logits.dtype}"
+            )
+        probs = torch.empty_like(logits, device=logits.device, dtype=torch.float32)
         maybe_temperature_arr = (
             maybe_temperature_arr.float() if maybe_temperature_arr is not None else None
         )
@@ -511,6 +515,74 @@ def get_sampling_module():
     ) -> torch.Tensor:
         return torch.empty_like(probs)
 
+    @register_custom_op(
+        "flashinfer::top_p_renorm_probs_out",
+        mutates_args=("renorm_probs", "workspace"),
+    )
+    def top_p_renorm_probs_out(
+        probs: torch.Tensor,
+        renorm_probs: torch.Tensor,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        is_deterministic: bool,
+        workspace: torch.Tensor,
+    ) -> None:
+        maybe_top_p_arr = (
+            maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+        )
+        module.top_p_renorm_probs(
+            probs,
+            renorm_probs,
+            maybe_top_p_arr,
+            top_p_val,
+            is_deterministic,
+            workspace,
+        )
+
+    @register_fake_op("flashinfer::top_p_renorm_probs_out")
+    def _fake_top_p_renorm_probs_out(
+        probs: torch.Tensor,
+        renorm_probs: torch.Tensor,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        is_deterministic: bool,
+        workspace: torch.Tensor,
+    ) -> None:
+        pass
+
+    @register_custom_op(
+        "flashinfer::top_p_renorm_probs_inplace",
+        mutates_args=("probs", "workspace"),
+    )
+    def top_p_renorm_probs_inplace(
+        probs: torch.Tensor,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        is_deterministic: bool,
+        workspace: torch.Tensor,
+    ) -> None:
+        maybe_top_p_arr = (
+            maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+        )
+        module.top_p_renorm_probs(
+            probs,
+            probs,
+            maybe_top_p_arr,
+            top_p_val,
+            is_deterministic,
+            workspace,
+        )
+
+    @register_fake_op("flashinfer::top_p_renorm_probs_inplace")
+    def _fake_top_p_renorm_probs_inplace(
+        probs: torch.Tensor,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        is_deterministic: bool,
+        workspace: torch.Tensor,
+    ) -> None:
+        pass
+
     # torch library for top_k_renorm_probs
 
     @register_custom_op(
@@ -659,6 +731,8 @@ def get_sampling_module():
         min_p_sampling_from_probs=min_p_sampling_from_probs,
         top_k_top_p_sampling_from_probs=top_k_top_p_sampling_from_probs,
         top_p_renorm_probs=top_p_renorm_probs,
+        top_p_renorm_probs_out=top_p_renorm_probs_out,
+        top_p_renorm_probs_inplace=top_p_renorm_probs_inplace,
         top_k_renorm_probs=top_k_renorm_probs,
         top_k_mask_logits=top_k_mask_logits,
         chain_speculative_sampling=chain_speculative_sampling,
@@ -1738,11 +1812,33 @@ def top_k_top_p_sampling_from_probs(
         raise ValueError(f"Invalid filter_apply_order: {filter_apply_order}")
 
 
+def get_top_p_renorm_probs_workspace_size(
+    batch_size: int,
+    vocab_size: int,
+    is_deterministic: bool = False,
+) -> int:
+    """Return the AIR top-p workspace size in bytes."""
+    align256 = lambda x: ((x + 255) // 256) * 256
+    counter_size = 384  # sizeof(Counter<float>) with alignas(128) members
+    # buf_len = alignTo(vocab_size / (ratio * 8), 256), ratio = 4 for float32
+    buf_len = max(align256(vocab_size // 32), 256)
+    hist_entry_size = 8 if is_deterministic else 4  # uint64 vs float
+    return (
+        align256(counter_size * batch_size)
+        + align256(hist_entry_size * 2048 * batch_size)
+        + align256(4 * 2048 * batch_size)
+        + align256(4 * buf_len * batch_size)
+        + align256(4 * buf_len * batch_size)
+    )
+
+
 @flashinfer_api(trace=top_p_renorm_probs_trace)
 def top_p_renorm_probs(
     probs: torch.Tensor,
     top_p: Union[torch.Tensor, float],
     is_deterministic: bool = False,
+    out: Optional[torch.Tensor] = None,
+    workspace: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     r"""Fused GPU kernel for renormalizing probabilities by top-p thresholding.
 
@@ -1762,6 +1858,15 @@ def top_p_renorm_probs(
     is_deterministic: bool
         If True, use deterministic integer accumulation for reproducible results. Will affect performance.
         Default is False.
+    out: Optional[torch.Tensor]
+        Optional destination tensor. It must have the same shape, dtype, device,
+        and layout as ``probs``. Passing ``out=probs`` performs the final AIR
+        renormalization in place and avoids allocating another probability
+        tensor.
+    workspace: Optional[torch.Tensor]
+        Optional uint8 workspace. When omitted, a temporary workspace is
+        allocated. Reusing a caller-owned workspace avoids repeated allocator
+        traffic.
 
     Returns
     -------
@@ -1804,24 +1909,53 @@ def top_p_renorm_probs(
     """
     batch_size = probs.size(0)
     vocab_size = probs.size(1)
-    # Workspace size for AIR Top-P radix algorithm.
     # Must match GetAirTopPRenormWorkspaceSize in air_top_p.cuh.
-    align256 = lambda x: ((x + 255) // 256) * 256
-    counter_size = 384  # sizeof(Counter<float>) with alignas(128) members
-    # buf_len = alignTo(vocab_size / (ratio * 8), 256), ratio = 4 for float32
-    buf_len = max(align256(vocab_size // 32), 256)
-    hist_entry_size = 8 if is_deterministic else 4  # uint64 vs float
-    ws_size = (
-        align256(counter_size * batch_size)  # counters
-        + align256(hist_entry_size * 2048 * batch_size)  # histogram
-        + align256(4 * 2048 * batch_size)  # countHistogram
-        + align256(4 * buf_len * batch_size)  # buf1
-        + align256(4 * buf_len * batch_size)  # buf2
+    ws_size = get_top_p_renorm_probs_workspace_size(
+        batch_size,
+        vocab_size,
+        is_deterministic,
     )
-    workspace = torch.empty(ws_size, dtype=torch.uint8, device=probs.device)
-    return get_sampling_module().top_p_renorm_probs(
-        probs, *_to_tensor_scalar_tuple(top_p), is_deterministic, workspace
-    )
+    if workspace is None:
+        workspace = torch.empty(ws_size, dtype=torch.uint8, device=probs.device)
+    elif (
+        workspace.dtype != torch.uint8
+        or workspace.device != probs.device
+        or workspace.numel() < ws_size
+        or not workspace.is_contiguous()
+    ):
+        raise ValueError(
+            "workspace must be a contiguous uint8 tensor on the same device "
+            f"with at least {ws_size} elements"
+        )
+
+    if out is None:
+        return get_sampling_module().top_p_renorm_probs(
+            probs, *_to_tensor_scalar_tuple(top_p), is_deterministic, workspace
+        )
+
+    if probs.dtype != torch.float32:
+        raise TypeError(f"out= requires float32 probs, got {probs.dtype}")
+    if (
+        out.shape != probs.shape
+        or out.dtype != probs.dtype
+        or out.device != probs.device
+        or not out.is_contiguous()
+    ):
+        raise ValueError(
+            "out must have the same shape, dtype, device, and contiguous "
+            "layout as probs"
+        )
+
+    top_p_args = _to_tensor_scalar_tuple(top_p)
+    if out.data_ptr() == probs.data_ptr():
+        get_sampling_module().top_p_renorm_probs_inplace(
+            probs, *top_p_args, is_deterministic, workspace
+        )
+    else:
+        get_sampling_module().top_p_renorm_probs_out(
+            probs, out, *top_p_args, is_deterministic, workspace
+        )
+    return out
 
 
 top_p_renorm_prob = top_p_renorm_probs

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -76,10 +76,7 @@ def get_sampling_module():
         enable_pdl: bool,
     ) -> torch.Tensor:
         if logits.dtype not in (torch.float32, torch.float16, torch.bfloat16):
-            raise TypeError(
-                "softmax logits must be float32, float16, or bfloat16, "
-                f"got {logits.dtype}"
-            )
+            logits = logits.float()
         probs = torch.empty_like(logits, device=logits.device, dtype=torch.float32)
         maybe_temperature_arr = (
             maybe_temperature_arr.float() if maybe_temperature_arr is not None else None
@@ -1869,10 +1866,10 @@ def top_p_renorm_probs(
         If True, use deterministic integer accumulation for reproducible results. Will affect performance.
         Default is False.
     out: Optional[torch.Tensor]
-        Optional destination tensor. It must have the same shape, dtype, device,
-        and layout as ``probs``. Passing ``out=probs`` performs the final AIR
-        renormalization in place and avoids allocating another probability
-        tensor.
+        Optional destination tensor for float32 probabilities. It must have the
+        same shape, dtype, device, and layout as ``probs``. Passing
+        ``out=probs`` performs the final AIR renormalization in place and avoids
+        allocating another probability tensor.
     workspace: Optional[torch.Tensor]
         Optional uint8 workspace. When omitted, a temporary workspace is
         allocated. Reusing a caller-owned workspace avoids repeated allocator

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -1832,6 +1832,16 @@ def get_top_p_renorm_probs_workspace_size(
     )
 
 
+def _tensors_overlap(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+    if lhs.device != rhs.device:
+        return False
+    lhs_begin = lhs.data_ptr()
+    rhs_begin = rhs.data_ptr()
+    lhs_end = lhs_begin + lhs.numel() * lhs.element_size()
+    rhs_end = rhs_begin + rhs.numel() * rhs.element_size()
+    return lhs_begin < rhs_end and rhs_begin < lhs_end
+
+
 @flashinfer_api(trace=top_p_renorm_probs_trace)
 def top_p_renorm_probs(
     probs: torch.Tensor,
@@ -1927,10 +1937,17 @@ def top_p_renorm_probs(
             "workspace must be a contiguous uint8 tensor on the same device "
             f"with at least {ws_size} elements"
         )
+    if vocab_size >= 2048 and workspace.data_ptr() % 128 != 0:
+        raise ValueError("workspace must be aligned to 128 bytes")
+
+    top_p_args = _to_tensor_scalar_tuple(top_p)
+    for name, tensor in (("probs", probs), ("top_p", top_p_args[0])):
+        if tensor is not None and _tensors_overlap(workspace, tensor):
+            raise ValueError(f"workspace must not overlap {name}")
 
     if out is None:
         return get_sampling_module().top_p_renorm_probs(
-            probs, *_to_tensor_scalar_tuple(top_p), is_deterministic, workspace
+            probs, *top_p_args, is_deterministic, workspace
         )
 
     if probs.dtype != torch.float32:
@@ -1946,8 +1963,14 @@ def top_p_renorm_probs(
             "layout as probs"
         )
 
-    top_p_args = _to_tensor_scalar_tuple(top_p)
-    if out.data_ptr() == probs.data_ptr():
+    probs_begin = probs.data_ptr()
+    out_begin = out.data_ptr()
+    if _tensors_overlap(probs, out) and probs_begin != out_begin:
+        raise ValueError("probs and out must either alias exactly or not overlap")
+    if _tensors_overlap(workspace, out):
+        raise ValueError("workspace must not overlap out")
+
+    if out_begin == probs_begin:
         get_sampling_module().top_p_renorm_probs_inplace(
             probs, *top_p_args, is_deterministic, workspace
         )

--- a/flashinfer/trace/templates/sampling.py
+++ b/flashinfer/trace/templates/sampling.py
@@ -278,7 +278,7 @@ def _softmax_reference(logits, temperature=None, **_unused):
         else:
             t = float(temperature)
         x = x / t
-    return torch.softmax(x, dim=-1).to(logits.dtype)
+    return torch.softmax(x, dim=-1)
 
 
 def _softmax_init(
@@ -313,7 +313,7 @@ softmax_trace = TraceTemplate(
         ),
     },
     outputs={
-        "output": Tensor(["batch_size", "vocab_size"], dtype_from="logits"),
+        "output": Tensor(["batch_size", "vocab_size"], dtype="float32"),
     },
     tags=["status:verified"],
     reference=_softmax_reference,

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -289,9 +289,10 @@ __device__ __forceinline__ float GetMaxValue(float* in_data, uint32_t row_idx, u
   return temp_storage.max_val;
 }
 
-template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType, bool CACHE_INPUT>
-__global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* temperature_arr,
-                                         DType temperature_val, uint32_t d) {
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DTypeIn, typename DTypeOut,
+          bool CACHE_INPUT>
+__global__ void OnlineSoftmaxFusedKernel(DTypeIn* logits, DTypeOut* output, float* temperature_arr,
+                                         float temperature_val, uint32_t d) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
   const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
@@ -300,14 +301,14 @@ __global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* te
   extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
   auto& temp_storage = reinterpret_cast<TempStorage&>(smem);
 
-  DType* smem_vec_base = nullptr;
+  float* smem_vec_base = nullptr;
   if constexpr (CACHE_INPUT) {
-    constexpr size_t vec_alignment = alignof(vec_t<DType, VEC_SIZE>);
+    constexpr size_t vec_alignment = alignof(vec_t<float, VEC_SIZE>);
     size_t aligned_offset = round_up(sizeof(TempStorage), vec_alignment);
-    smem_vec_base = reinterpret_cast<DType*>(smem + aligned_offset);
+    smem_vec_base = reinterpret_cast<float*>(smem + aligned_offset);
   }
 
-  vec_t<DType, VEC_SIZE> logits_vec;
+  vec_t<float, VEC_SIZE> logits_vec;
 
   float running_max = -cuda::std::numeric_limits<float>::infinity();
   float running_denominator = 0.0f;
@@ -320,7 +321,7 @@ __global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* te
   // Pass 1: Compute running max and denominator
 #pragma unroll 2
   for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+    logits_vec.fill(-cuda::std::numeric_limits<float>::infinity());
     if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
       logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
 
@@ -374,7 +375,7 @@ __global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* te
   const float inv_denominator = 1.0f / running_denominator;
 
   // Pass 2: Normalize in place
-  vec_t<DType, VEC_SIZE> prob_vec;
+  vec_t<float, VEC_SIZE> prob_vec;
   for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
     if constexpr (CACHE_INPUT) {
       if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
@@ -394,7 +395,7 @@ __global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* te
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; ++j) {
       float p = __expf(static_cast<float>(logits_vec[j]) - final_max) * inv_denominator;
-      prob_vec[j] = static_cast<DType>(p);
+      prob_vec[j] = p;
     }
 
     if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
@@ -406,9 +407,9 @@ __global__ void OnlineSoftmaxFusedKernel(DType* logits, DType* output, DType* te
 #endif
 }
 
-template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
-__global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* partial_results,
-                                       DType* temperature_arr, float temperature_val, uint32_t d,
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DTypeIn>
+__global__ void OnlineSoftmaxMapKernel(DTypeIn* logits, PartialSoftmaxResult* partial_results,
+                                       float* temperature_arr, float temperature_val, uint32_t d,
                                        uint32_t num_slices) {
   const uint32_t bx = blockIdx.x;
   const uint32_t by = blockIdx.y;  // slice index
@@ -416,7 +417,7 @@ __global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* part
   float temperature = temperature_arr == nullptr ? temperature_val : temperature_arr[bx];
   const float inv_temp = (temperature == 0.f) ? 0.f : 1.f / temperature;
 
-  const uint32_t vec_alignment_elems = alignof(vec_t<DType, VEC_SIZE>) / sizeof(DType);
+  const uint32_t vec_alignment_elems = alignof(vec_t<DTypeIn, VEC_SIZE>) / sizeof(DTypeIn);
   const uint32_t slice_stride = round_up(ceil_div(d, num_slices), vec_alignment_elems);
   const uint32_t slice_start = by * slice_stride;
   const uint32_t slice_size = min((by + 1) * slice_stride, d) - slice_start;
@@ -427,7 +428,7 @@ __global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* part
   extern __shared__ __align__(alignof(TempStorage)) uint8_t smem[];
   auto& temp_storage = reinterpret_cast<TempStorage&>(smem);
 
-  vec_t<DType, VEC_SIZE> logits_vec;
+  vec_t<float, VEC_SIZE> logits_vec;
   float running_max = -cuda::std::numeric_limits<float>::infinity();
   float running_denominator = 0.0f;
   float threadlocal_running_denominator = 0.0f;
@@ -438,7 +439,7 @@ __global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* part
 
 #pragma unroll 2
   for (uint32_t i = 0; i < ceil_div(slice_size, BLOCK_THREADS * VEC_SIZE); ++i) {
-    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+    logits_vec.fill(-cuda::std::numeric_limits<float>::infinity());
 
     if ((i * BLOCK_THREADS + tx) * VEC_SIZE < slice_size) {
       logits_vec.cast_load(logits + bx * d + slice_start + (i * BLOCK_THREADS + tx) * VEC_SIZE);
@@ -491,10 +492,10 @@ __global__ void OnlineSoftmaxMapKernel(DType* logits, PartialSoftmaxResult* part
 #endif
 }
 
-template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DType>
-__global__ void OnlineSoftmaxReduceKernel(DType* logits, DType* output,
+template <uint32_t BLOCK_THREADS, uint32_t VEC_SIZE, typename DTypeIn, typename DTypeOut>
+__global__ void OnlineSoftmaxReduceKernel(DTypeIn* logits, DTypeOut* output,
                                           PartialSoftmaxResult* partial_results,
-                                          DType* temperature_arr, float temperature_val, uint32_t d,
+                                          float* temperature_arr, float temperature_val, uint32_t d,
                                           uint32_t num_slices) {
   const uint32_t bx = blockIdx.x;
   const uint32_t tx = threadIdx.x;
@@ -536,11 +537,11 @@ __global__ void OnlineSoftmaxReduceKernel(DType* logits, DType* output,
   const float inv_denominator = 1.0f / temp_storage.shared_state.denominator;
 
   // Apply normalization
-  vec_t<DType, VEC_SIZE> logits_vec;
-  vec_t<DType, VEC_SIZE> prob_vec;
+  vec_t<float, VEC_SIZE> logits_vec;
+  vec_t<float, VEC_SIZE> prob_vec;
 
   for (uint32_t i = 0; i < ceil_div(d, BLOCK_THREADS * VEC_SIZE); ++i) {
-    logits_vec.fill(-cuda::std::numeric_limits<DType>::infinity());
+    logits_vec.fill(-cuda::std::numeric_limits<float>::infinity());
 
     if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
       logits_vec.cast_load(logits + bx * d + (i * BLOCK_THREADS + tx) * VEC_SIZE);
@@ -550,7 +551,7 @@ __global__ void OnlineSoftmaxReduceKernel(DType* logits, DType* output,
     for (uint32_t j = 0; j < VEC_SIZE; ++j) {
       logits_vec[j] *= inv_temp;
       float p = __expf(static_cast<float>(logits_vec[j]) - final_max) * inv_denominator;
-      prob_vec[j] = static_cast<DType>(p);
+      prob_vec[j] = p;
     }
 
     if ((i * BLOCK_THREADS + tx) * VEC_SIZE < d) {
@@ -1320,16 +1321,16 @@ __global__ void TopKTopPSamplingFromProbKernel(DType* probs, IdType* top_k_arr, 
   }
 }
 
-template <typename DType>
-cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uint32_t d,
-                          DType* temperature_arr, DType temperature_val, void* workspace_buffer,
+template <typename DTypeIn, typename DTypeOut>
+cudaError_t OnlineSoftmax(DTypeIn* logits, DTypeOut* output, uint32_t batch_size, uint32_t d,
+                          float* temperature_arr, float temperature_val, void* workspace_buffer,
                           size_t workspace_buffer_size_in_bytes, bool enable_pdl,
                           cudaStream_t stream = 0) {
   constexpr uint32_t SMALL_BATCH_THRESHOLD = 128;
   constexpr uint32_t LARGE_VOCAB_THRESHOLD = 24576;
   constexpr uint32_t DEFAULT_SLICE_SIZE = 8192;
 
-  const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
+  const uint32_t vec_size = std::gcd(16 / sizeof(DTypeIn), d);
   auto compute_capacity = GetCudaComputeCapability();
 
   DISPATCH_COMPUTE_CAP_NUM_THREADS(
@@ -1352,7 +1353,7 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
           dim3 phase1_nthrs(BLOCK_THREADS);
           size_t smem_size = sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>);
 
-          auto phase1_kernel = OnlineSoftmaxMapKernel<BLOCK_THREADS, VEC_SIZE, DType>;
+          auto phase1_kernel = OnlineSoftmaxMapKernel<BLOCK_THREADS, VEC_SIZE, DTypeIn>;
           void* phase1_args[] = {&logits, &partial_results, &temperature_arr, &temperature_val,
                                  &d,      &num_slices};
 
@@ -1384,7 +1385,8 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
           dim3 phase2_nblks(batch_size);
           dim3 phase2_nthrs(BLOCK_THREADS);
 
-          auto phase2_kernel = OnlineSoftmaxReduceKernel<BLOCK_THREADS, VEC_SIZE, DType>;
+          auto phase2_kernel =
+              OnlineSoftmaxReduceKernel<BLOCK_THREADS, VEC_SIZE, DTypeIn, DTypeOut>;
           void* phase2_args[] = {&logits,          &output, &partial_results, &temperature_arr,
                                  &temperature_val, &d,      &num_slices};
 
@@ -1428,13 +1430,14 @@ cudaError_t OnlineSoftmax(DType* logits, DType* output, uint32_t batch_size, uin
           dim3 nthrs(BLOCK_THREADS);
           void* args[] = {&logits, &output, &temperature_arr, &temperature_val, &d};
 
-          const size_t smem_logits_bytes = (round_up(d, VEC_SIZE) + VEC_SIZE) * sizeof(DType);
+          const size_t smem_logits_bytes = (round_up(d, VEC_SIZE) + VEC_SIZE) * sizeof(float);
 
           uint32_t smem_size = sizeof(OnlineSoftmaxTempStorage<BLOCK_THREADS>) +
                                (cache_input ? smem_logits_bytes : 0);
 
           DISPATCH_SOFTMAX_CACHE_INPUT(cache_input, CACHE_INPUT, {
-            auto kernel = OnlineSoftmaxFusedKernel<BLOCK_THREADS, VEC_SIZE, DType, CACHE_INPUT>;
+            auto kernel =
+                OnlineSoftmaxFusedKernel<BLOCK_THREADS, VEC_SIZE, DTypeIn, DTypeOut, CACHE_INPUT>;
             FLASHINFER_CUDA_CALL(cudaFuncSetAttribute(
                 kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -76,6 +76,16 @@ def test_softmax(
     assert torch.allclose(probs, probs_ref, atol=1e-5)
 
 
+def test_softmax_bfloat16_input_float32_output():
+    torch.manual_seed(42)
+    logits = torch.randn(8, 154880, device="cuda:0", dtype=torch.bfloat16)
+    probs = flashinfer.sampling.softmax(logits)
+    probs_ref = torch.softmax(logits, dim=-1, dtype=torch.float32)
+
+    assert probs.dtype == torch.float32
+    torch.testing.assert_close(probs, probs_ref, rtol=2e-5, atol=1e-7)
+
+
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize(
     "distribution",
@@ -446,6 +456,41 @@ def test_top_p_renorm_probs(batch_size, vocab_size, p):
         rtol=1e-3,
         atol=1e-3,
     )
+
+
+def test_top_p_renorm_probs_out_and_inplace():
+    torch.manual_seed(42)
+    probs = torch.randn(8, 154880, device="cuda:0").softmax(dim=-1)
+    top_p = torch.full((8,), 0.95, device="cuda:0")
+    expected = flashinfer.sampling.top_p_renorm_probs(
+        probs, top_p, is_deterministic=True
+    )
+    workspace_size = flashinfer.sampling.get_top_p_renorm_probs_workspace_size(
+        *probs.shape, is_deterministic=True
+    )
+    workspace = torch.empty(workspace_size, dtype=torch.uint8, device=probs.device)
+
+    out = torch.empty_like(probs)
+    actual_out = flashinfer.sampling.top_p_renorm_probs(
+        probs,
+        top_p,
+        is_deterministic=True,
+        out=out,
+        workspace=workspace,
+    )
+    assert actual_out.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(actual_out, expected, rtol=0, atol=0)
+
+    inplace = probs.clone()
+    actual_inplace = flashinfer.sampling.top_p_renorm_probs(
+        inplace,
+        top_p,
+        is_deterministic=True,
+        out=inplace,
+        workspace=workspace,
+    )
+    assert actual_inplace.data_ptr() == inplace.data_ptr()
+    torch.testing.assert_close(actual_inplace, expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("batch_size", [4, 99, 989])

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -493,6 +493,54 @@ def test_top_p_renorm_probs_out_and_inplace():
     torch.testing.assert_close(actual_inplace, expected, rtol=0, atol=0)
 
 
+@pytest.mark.parametrize(
+    "case",
+    [
+        "unaligned_workspace",
+        "partial_out",
+        "workspace_probs",
+        "workspace_out",
+        "workspace_top_p",
+    ],
+)
+def test_top_p_renorm_probs_rejects_invalid_memory(case):
+    probs = torch.randn(2, 32768, device="cuda:0").softmax(dim=-1)
+    top_p = torch.full((2,), 0.95, device="cuda:0")
+    workspace_size = flashinfer.sampling.get_top_p_renorm_probs_workspace_size(
+        *probs.shape
+    )
+    workspace = torch.empty(workspace_size, dtype=torch.uint8, device=probs.device)
+    out = torch.empty_like(probs)
+
+    if case == "unaligned_workspace":
+        workspace = torch.empty(
+            workspace_size + 1, dtype=torch.uint8, device=probs.device
+        )[1:]
+        match = "workspace must be aligned"
+    elif case == "partial_out":
+        storage = torch.empty(probs.numel() + 1, device=probs.device)
+        probs = storage[:-1].view_as(probs)
+        out = storage[1:].view_as(probs)
+        match = "must either alias exactly or not overlap"
+    else:
+        storage = torch.empty(
+            max(probs.nbytes, workspace_size), dtype=torch.uint8, device=probs.device
+        )
+        workspace = storage[:workspace_size]
+        if case == "workspace_probs":
+            probs = storage[: probs.nbytes].view(torch.float32).view_as(probs)
+        elif case == "workspace_out":
+            out = storage[: out.nbytes].view(torch.float32).view_as(out)
+        else:
+            top_p = storage[: top_p.nbytes].view(torch.float32).view_as(top_p)
+        match = "workspace must not overlap"
+
+    with pytest.raises(ValueError, match=match):
+        flashinfer.sampling.top_p_renorm_probs(
+            probs, top_p, out=out, workspace=workspace
+        )
+
+
 @pytest.mark.parametrize("batch_size", [4, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 def test_top_p_renorm_probs_per_request(batch_size, vocab_size):

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -76,9 +76,10 @@ def test_softmax(
     assert torch.allclose(probs, probs_ref, atol=1e-5)
 
 
-def test_softmax_bfloat16_input_float32_output():
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float64])
+def test_softmax_input_float32_output(dtype):
     torch.manual_seed(42)
-    logits = torch.randn(8, 154880, device="cuda:0", dtype=torch.bfloat16)
+    logits = torch.randn(8, 154880, device="cuda:0", dtype=dtype)
     probs = flashinfer.sampling.softmax(logits)
     probs_ref = torch.softmax(logits, dim=-1, dtype=torch.float32)
 

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -502,10 +502,12 @@ def test_top_p_renorm_probs_out_and_inplace():
         "workspace_probs",
         "workspace_out",
         "workspace_top_p",
+        "top_p_out",
     ],
 )
 def test_top_p_renorm_probs_rejects_invalid_memory(case):
-    probs = torch.randn(2, 32768, device="cuda:0").softmax(dim=-1)
+    vocab_size = 1024 if case == "top_p_out" else 32768
+    probs = torch.randn(2, vocab_size, device="cuda:0").softmax(dim=-1)
     top_p = torch.full((2,), 0.95, device="cuda:0")
     workspace_size = flashinfer.sampling.get_top_p_renorm_probs_workspace_size(
         *probs.shape
@@ -523,6 +525,11 @@ def test_top_p_renorm_probs_rejects_invalid_memory(case):
         probs = storage[:-1].view_as(probs)
         out = storage[1:].view_as(probs)
         match = "must either alias exactly or not overlap"
+    elif case == "top_p_out":
+        storage = torch.empty(probs.numel(), device=probs.device)
+        out = storage.view_as(probs)
+        top_p = storage[: probs.size(0)]
+        match = "renorm_probs must not overlap top_p"
     else:
         storage = torch.empty(
             max(probs.nbytes, workspace_size), dtype=torch.uint8, device=probs.device


### PR DESCRIPTION
## 📌 Description

This PR optimizes `top_p_renorm_probs` by allowing the output tensor to alias the input, avoiding an unnecessary intermediate allocation.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

All 9 JIT pytest pass.

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->

## Benchmark Results

**Hardware:** 8× NVIDIA H200 (sm90), CUDA 13.0, PyTorch 2.11.0, FlashInfer 0.6.15

### Reproduce

```bash
# 1. Baseline
git checkout 82784bb1
pip install -e .
python bench_top_p_renorm.py --variant base --output base.json --correctness

# 2. This PR
git checkout 608090e4
pip install -e .
python bench_top_p_renorm.py --variant pr --output pr.json --correctness

# 3. Compare
python3 -c "
import json
base = json.load(open('base.json'))
pr = json.load(open('pr.json'))
print('rows | speedup | mem_reduction')
for b,p in zip(base['performance'], pr['performance']):
    sp = b['cupti_median_ms'] / p['cupti_median_ms']
    mem = (1 - p['peak_extra_mib'] / b['peak_extra_mib']) * 100
    print(f'{b[\"rows\"]:>4} | {sp:.2f}x   | {mem:.0f}%')
"
```

<details>
<summary><code>bench_top_p_renorm.py</code> (self-contained benchmark script)</summary>

```python
#!/usr/bin/env python3
"""Correctness and performance benchmark for top_p_renorm_probs."""

from __future__ import annotations

import argparse
import gc
import json
import statistics
from pathlib import Path

import torch
import flashinfer
from flashinfer.testing import bench_gpu_time

MIB = 1024 * 1024


def torch_top_p_reference(probs: torch.Tensor, top_p: float) -> torch.Tensor:
    sorted_probs, sorted_idx = torch.sort(probs, dim=-1, descending=True)
    cumulative = torch.cumsum(sorted_probs, dim=-1)
    keep = cumulative - sorted_probs < top_p
    filtered = torch.where(keep, sorted_probs, torch.zeros_like(sorted_probs))
    filtered /= filtered.sum(dim=-1, keepdim=True)
    result = torch.zeros_like(probs)
    result.scatter_(1, sorted_idx, filtered)
    return result


def event_times_ms(fn, warmups: int, iterations: int) -> list[float]:
    for _ in range(warmups):
        fn()
    torch.cuda.synchronize()
    starts = [torch.cuda.Event(enable_timing=True) for _ in range(iterations)]
    ends = [torch.cuda.Event(enable_timing=True) for _ in range(iterations)]
    for start, end in zip(starts, ends):
        start.record()
        fn()
        end.record()
    torch.cuda.synchronize()
    return [start.elapsed_time(end) for start, end in zip(starts, ends)]


def summarize(times: list[float]) -> dict[str, float]:
    ordered = sorted(times)
    return {
        "median_ms": statistics.median(times),
        "mean_ms": statistics.mean(times),
        "std_ms": statistics.pstdev(times),
        "p05_ms": ordered[int(0.05 * (len(ordered) - 1))],
        "p95_ms": ordered[int(0.95 * (len(ordered) - 1))],
    }


def measure_peak_extra_mib(fn) -> float:
    gc.collect()
    torch.cuda.empty_cache()
    torch.cuda.synchronize()
    baseline = torch.cuda.memory_allocated()
    torch.cuda.reset_peak_memory_stats()
    output = fn()
    torch.cuda.synchronize()
    peak = torch.cuda.max_memory_allocated()
    del output
    return (peak - baseline) / MIB


def run_correctness(rows: int, vocab_size: int, top_p: float) -> dict:
    torch.manual_seed(42 + rows)
    logits = torch.randn(rows, vocab_size, device="cuda", dtype=torch.bfloat16)
    probs = flashinfer.sampling.softmax(logits)
    assert probs.dtype == torch.float32

    workspace_size = flashinfer.sampling.get_top_p_renorm_probs_workspace_size(
        rows, vocab_size
    )
    workspace = torch.empty(workspace_size, dtype=torch.uint8, device="cuda")

    default = flashinfer.sampling.top_p_renorm_probs(probs, top_p)
    out = torch.empty_like(probs)
    returned = flashinfer.sampling.top_p_renorm_probs(
        probs, top_p, out=out, workspace=workspace
    )
    assert returned.data_ptr() == out.data_ptr()

    inplace = probs.clone()
    returned_inplace = flashinfer.sampling.top_p_renorm_probs(
        inplace, top_p, out=inplace, workspace=workspace
    )
    assert returned_inplace.data_ptr() == inplace.data_ptr()

    reference = torch_top_p_reference(probs, top_p)
    torch_probs = torch.softmax(logits, dim=-1, dtype=torch.float32)
    torch_pipeline_reference = torch_top_p_reference(torch_probs, top_p)
    torch.cuda.synchronize()

    max_abs_vs_reference = (inplace - reference).abs().max().item()
    max_row_sum_error = (inplace.sum(dim=-1) - 1.0).abs().max().item()

    torch.testing.assert_close(default, out, rtol=0, atol=0)
    torch.testing.assert_close(default, inplace, rtol=0, atol=0)
    if max_abs_vs_reference >= 1e-3:
        raise AssertionError(f"max elementwise error too high: {max_abs_vs_reference}")
    if max_row_sum_error >= 2e-6:
        raise AssertionError(f"row sum error too high: {max_row_sum_error}")

    return {
        "rows": rows,
        "max_abs_default_vs_out": (default - out).abs().max().item(),
        "max_abs_default_vs_inplace": (default - inplace).abs().max().item(),
        "max_abs_vs_reference": max_abs_vs_reference,
        "max_row_sum_error": max_row_sum_error,
        "workspace_mib": workspace_size / MIB,
    }


def run_performance(
    variant: str, rows: int, vocab_size: int, top_p: float,
    warmups: int, iterations: int,
) -> dict:
    torch.manual_seed(1234 + rows)
    logits = torch.randn(rows, vocab_size, device="cuda", dtype=torch.bfloat16)

    if variant == "base":
        def pipeline():
            probs = flashinfer.sampling.softmax(logits)
            return flashinfer.sampling.top_p_renorm_probs(probs, top_p)
    elif variant == "pr":
        workspace_size = flashinfer.sampling.get_top_p_renorm_probs_workspace_size(
            rows, vocab_size
        )
        workspace = torch.empty(workspace_size, dtype=torch.uint8, device="cuda")
        def pipeline():
            probs = flashinfer.sampling.softmax(logits)
            return flashinfer.sampling.top_p_renorm_probs(
                probs, top_p, out=probs, workspace=workspace
            )
    else:
        raise ValueError(f"unknown variant: {variant}")

    for _ in range(3):
        pipeline()
    torch.cuda.synchronize()

    peak_extra_mib = measure_peak_extra_mib(pipeline)
    times = event_times_ms(pipeline, warmups, iterations)
    try:
        cupti_times = bench_gpu_time(
            pipeline, enable_cupti=True,
            dry_run_iters=warmups, repeat_iters=iterations, cold_l2_cache=False,
        )
        cupti_median_ms = statistics.median(cupti_times)
        cupti_std_ms = statistics.pstdev(cupti_times)
    except Exception:
        cupti_median_ms, cupti_std_ms = None, None

    return {
        "variant": variant, "rows": rows, "vocab_size": vocab_size, "top_p": top_p,
        "peak_extra_mib": peak_extra_mib,
        "cupti_median_ms": cupti_median_ms, "cupti_std_ms": cupti_std_ms,
        **summarize(times),
    }


def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--variant", choices=("base", "pr"), required=True)
    parser.add_argument("--vocab-size", type=int, default=154880)
    parser.add_argument("--top-p", type=float, default=0.95)
    parser.add_argument("--rows", type=int, nargs="+", default=[4, 32, 128, 512])
    parser.add_argument("--warmups", type=int, default=20)
    parser.add_argument("--iterations", type=int, default=100)
    parser.add_argument("--correctness", action="store_true")
    parser.add_argument("--output", type=Path, required=True)
    args = parser.parse_args()

    payload = {
        "environment": {
            "torch": torch.__version__,
            "cuda": torch.version.cuda,
            "flashinfer": getattr(flashinfer, "__version__", "unknown"),
            "gpu": torch.cuda.get_device_name(0),
            "capability": torch.cuda.get_device_capability(0),
            "variant": args.variant,
        },
        "performance": [
            run_performance(
                args.variant, r, args.vocab_size, args.top_p,
                args.warmups, args.iterations,
            )
            for r in args.rows
        ],
    }
    if args.correctness:
        payload["correctness"] = [
            run_correctness(r, args.vocab_size, args.top_p) for r in args.rows
        ]
    args.output.parent.mkdir(parents=True, exist_ok=True)
    args.output.write_text(json.dumps(payload, indent=2) + "\n")
    print(json.dumps(payload, indent=2))


if __name__ == "__main__":
    main()
```

</details>

### Performance (CUPTI GPU-hardware timings)

vocab_size=154880, top_p=0.95, 100 iterations after 20 warmups:

| rows | Base (ms) | PR (ms) | Speedup | Extra Alloc Base (MiB) | Extra Alloc PR (MiB) | Memory Reduction |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 0.130 | 0.126 | **1.04×** | 4.94 | 2.36 | **−52%** |
| 32 | 0.196 | 0.189 | **1.04×** | 39.51 | 18.91 | **−52%** |
| 128 | 0.530 | 0.467 | **1.14×** | 158.80 | 76.00 | **−52%** |
| 512 | 1.721 | 1.463 | **1.18×** | 632.19 | 302.50 | **−52%** |

### Correctness

- `default` / `explicit-out` / `inplace` outputs are **bit-identical**.
- Max elementwise error vs. Torch top-p reference: **≤ 2.18×10⁻⁶**.
- Max row-sum error: **≤ 3.58×10⁻⁷**.
- All 9 JIT pytest pass.
