### PR TITLE
Add check for XQA tensor contiguity to avoid silent error

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3041,6 +3041,7 @@ def trtllm_batch_decode_with_kv_cache(
     ----------
     query : torch.Tensor
         query tensor with shape [num_tokens, num_heads, head_dim], num_tokens = total query tokens in the batch.
+        The tensor must be contiguous when using the ``xqa`` backend.
 
     kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         If kv_cache is a single tensor, it should be a tensor with shape [num_pages, 1 or 2, num_kv_heads, page_size, head_dim] if :attr:`kv_layout` is ``HND``,
@@ -3096,6 +3097,7 @@ def trtllm_batch_decode_with_kv_cache(
 
     out :  Optional[Union[torch.Tensor, FP4Tensor]] = None
         output tensor, if not provided, will be allocated with ``out_dtype``, if ``out_dtype`` is not provided, will use the type of ``query``.
+        A caller-provided output tensor must be contiguous when using the ``xqa`` backend.
 
     out_dtype : Optional[Union[torch.dtype, str]] = None
         output dtype, if not provided, will use the type of ``out``. For nvfp4, use string ``nvfp4``.
@@ -3545,6 +3547,7 @@ def xqa_batch_decode_with_kv_cache(
     ----------
     query : torch.Tensor
         query tensor with shape [num_tokens, num_heads, head_dim], num_tokens = batch_size * q_len_per_request
+        The tensor must be contiguous.
 
     kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         If kv_cache is a single tensor, it should be a tensor with shape [num_pages, 1 or 2, page_size, num_kv_heads, head_dim] if :attr:`kv_layout` is ``NHD``,
@@ -3576,6 +3579,7 @@ def xqa_batch_decode_with_kv_cache(
 
     out :  Optional[torch.Tensor] = None
         output tensor, if not provided, will be allocated with ``query.dtype``.
+        A caller-provided output tensor must be contiguous.
 
     sinks : Optional[torch.Tensor] = None
         additional value per head in the denominator of the softmax.
@@ -3657,6 +3661,13 @@ def xqa_batch_decode_with_kv_cache(
     kv_scale_value = bmm2_scale * o_scale
     q_scale_value = bmm1_scale / kv_scale_value * (head_dim**0.5)
 
+    # XQA indexes query and output as packed buffers without using their strides.
+    if not query.is_contiguous():
+        raise ValueError("query must be contiguous")
+    if out is not None:
+        check_shape_dtype_device(out, query.shape, None, query.device, "out")
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
     if q_len_per_req > 1:
         batch_size = query.shape[0] // q_len_per_req
         query = query.view(batch_size, q_len_per_req, query.shape[1], query.shape[2])

--- a/tests/attention/test_trtllm_gen_attention_decode_xqa.py
+++ b/tests/attention/test_trtllm_gen_attention_decode_xqa.py
@@ -19,6 +19,9 @@ live in the decode file and are imported here.
 """
 
 import pytest
+import torch
+
+import flashinfer
 
 from tests.attention.test_trtllm_gen_attention_decode import (
     _test_trtllm_batch_decode,
@@ -121,3 +124,138 @@ def test_trtllm_batch_decode(
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
     )
+
+
+@pytest.mark.parametrize("q_len_per_req", [1, 2])
+def test_xqa_query_and_output_contiguity_contract(monkeypatch, q_len_per_req):
+    batch_size = 2
+    num_qo_heads = 8
+    num_kv_heads = 2
+    head_dim = 128
+    num_tokens = batch_size * q_len_per_req
+    device = torch.device("cuda")
+
+    non_contiguous_query = torch.randn(
+        num_tokens,
+        head_dim,
+        num_qo_heads,
+        dtype=torch.float16,
+        device=device,
+    ).transpose(1, 2)
+    assert not non_contiguous_query.is_contiguous()
+
+    kv_cache = tuple(
+        torch.randn(
+            batch_size,
+            1,
+            num_kv_heads,
+            head_dim,
+            dtype=torch.float16,
+            device=device,
+        )
+        for _ in range(2)
+    )
+    workspace_buffer = torch.empty(
+        8 * 1024 * 1024 + 1, dtype=torch.uint8, device=device
+    )
+    block_tables = torch.arange(batch_size, dtype=torch.int32, device=device).view(
+        batch_size, 1
+    )
+    seq_lens = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+    captured = {}
+
+    def capture_xqa(query, _k, _v, _block_tables, _seq_lens, out, *_args, **_kwargs):
+        captured["query"] = query
+        captured["out"] = out
+
+    monkeypatch.setattr(flashinfer.decode, "xqa", capture_xqa)
+
+    with pytest.raises(ValueError, match="query must be contiguous"):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            non_contiguous_query,
+            kv_cache,
+            workspace_buffer,
+            block_tables,
+            seq_lens,
+            max_seq_len=1,
+            backend="xqa",
+            kv_layout="NHD",
+            enable_pdl=False,
+            q_len_per_req=q_len_per_req,
+        )
+    assert not captured
+
+    query = non_contiguous_query.contiguous()
+    output = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+        query,
+        kv_cache,
+        workspace_buffer,
+        block_tables,
+        seq_lens,
+        max_seq_len=1,
+        backend="xqa",
+        kv_layout="NHD",
+        enable_pdl=False,
+        q_len_per_req=q_len_per_req,
+    )
+
+    assert output.is_contiguous()
+    assert captured["query"].is_contiguous()
+    assert captured["out"].is_contiguous()
+
+    non_contiguous_out = torch.empty(
+        num_tokens,
+        head_dim,
+        num_qo_heads,
+        dtype=query.dtype,
+        device=device,
+    ).transpose(1, 2)
+    with pytest.raises(ValueError, match="out must be contiguous"):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query,
+            kv_cache,
+            workspace_buffer,
+            block_tables,
+            seq_lens,
+            max_seq_len=1,
+            out=non_contiguous_out,
+            backend="xqa",
+            kv_layout="NHD",
+            enable_pdl=False,
+            q_len_per_req=q_len_per_req,
+        )
+
+    invalid_shape_out = torch.empty(
+        (*query.shape[:-1], head_dim - 1), dtype=query.dtype, device=device
+    )
+    with pytest.raises(ValueError, match="Invalid shape of out"):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query,
+            kv_cache,
+            workspace_buffer,
+            block_tables,
+            seq_lens,
+            max_seq_len=1,
+            out=invalid_shape_out,
+            backend="xqa",
+            kv_layout="NHD",
+            enable_pdl=False,
+            q_len_per_req=q_len_per_req,
+        )
+
+    invalid_device_out = torch.empty(query.shape, dtype=query.dtype, device="cpu")
+    with pytest.raises(ValueError, match="Invalid device of out"):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query,
+            kv_cache,
+            workspace_buffer,
+            block_tables,
+            seq_lens,
+            max_seq_len=1,
+            out=invalid_device_out,
+            backend="xqa",
+            kv_layout="NHD",
+            enable_pdl=False,
+            q_len_per_req=q_len_per_req,
+        )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

https://github.com/sgl-project/sglang/pull/31667#issuecomment-5015651839

## 🔍 Related Issues

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter XQA decode validation now enforces that `query` is contiguous and that any caller-provided `out` is contiguous and matches expected shape/device requirements.

* **Tests**
  * Expanded long-running XQA coverage with a new contract-focused test verifying contiguity enforcement for both `query` and `out`, along with the expected error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->