### PR TITLE
fix(gemm): validate tensorwide bmm_fp8 scales

### DIFF
--- a/csrc/bmm_fp8.cu
+++ b/csrc/bmm_fp8.cu
@@ -20,6 +20,18 @@
 
 #include "tvm_ffi_utils.h"
 
+namespace {
+
+void check_bmm_fp8_scale(TensorView scale, TensorView operand, const char* name) {
+  TVM_FFI_ICHECK_EQ(scale.device().device_type, kDLCUDA) << name << " must be a CUDA tensor";
+  TVM_FFI_ICHECK_EQ(scale.device().device_id, operand.device().device_id)
+      << name << " must be on the same CUDA device as its operand";
+  TVM_FFI_ICHECK_EQ(scale.dtype(), dl_float32) << name << " must have dtype float32";
+  TVM_FFI_ICHECK_EQ(scale.numel(), 1) << name << " must contain exactly one element";
+}
+
+}  // namespace
+
 void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, TensorView B_scale,
              TensorView workspace_buffer, int64_t cublas_handle) {
   CHECK_CUDA(A);
@@ -32,6 +44,8 @@ void bmm_fp8(TensorView A, TensorView B, TensorView D, TensorView A_scale, Tenso
   TVM_FFI_ICHECK(A.size(2) == B.size(1)) << "Incompatible matrix sizes";
   TVM_FFI_ICHECK(A.size(1) == D.size(1) && B.size(2) == D.size(2))
       << "Result tensor has incorrect shape";
+  check_bmm_fp8_scale(A_scale, A, "A_scale");
+  check_bmm_fp8_scale(B_scale, B, "B_scale");
 
   // PyTorch is row major by default. cuBLASLt is column major by default.
   // We need row major D as expected.
@@ -77,6 +91,8 @@ int64_t bmm_fp8_get_algos(TensorView A, TensorView B, TensorView D, TensorView A
   TVM_FFI_ICHECK(A.size(2) == B.size(1)) << "Incompatible matrix sizes";
   TVM_FFI_ICHECK(A.size(1) == D.size(1) && B.size(2) == D.size(2))
       << "Result tensor has incorrect shape";
+  check_bmm_fp8_scale(A_scale, A, "A_scale");
+  check_bmm_fp8_scale(B_scale, B, "B_scale");
 
   int64_t result = 0;
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP8(B.dtype(), b_type, [&] {
@@ -118,6 +134,8 @@ void bmm_fp8_run_with_algo(TensorView A, TensorView B, TensorView D, TensorView 
   TVM_FFI_ICHECK(A.size(2) == B.size(1)) << "Incompatible matrix sizes";
   TVM_FFI_ICHECK(A.size(1) == D.size(1) && B.size(2) == D.size(2))
       << "Result tensor has incorrect shape";
+  check_bmm_fp8_scale(A_scale, A, "A_scale");
+  check_bmm_fp8_scale(B_scale, B, "B_scale");
 
   int64_t max_algos =
       algo_buffer.numel() * get_element_size(algo_buffer) / flashinfer::bmm_fp8::kAlgoBytes;

--- a/csrc/fp8_gemm_cutlass.cu
+++ b/csrc/fp8_gemm_cutlass.cu
@@ -90,6 +90,12 @@ void fp8_bmm_impl(TensorView mat1, TensorView mat2, TensorView scale_a, TensorVi
   CHECK_INPUT(mat2);
   CHECK_INPUT(scale_a);
   CHECK_INPUT(scale_b);
+  CHECK_INPUT_TYPE(scale_a, dl_float32);
+  CHECK_INPUT_TYPE(scale_b, dl_float32);
+  CHECK_DEVICE(mat1, scale_a);
+  CHECK_DEVICE(mat2, scale_b);
+  TVM_FFI_ICHECK_EQ(scale_a.numel(), 1) << "scale_a must contain exactly one element";
+  TVM_FFI_ICHECK_EQ(scale_b.numel(), 1) << "scale_b must contain exactly one element";
 
   int mat2_k_scale = 1;
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -6774,6 +6774,21 @@ def _cutlass_bmm_fp8_requirement(
     return True
 
 
+def _validate_bmm_fp8_scale(
+    scale: torch.Tensor, operand: torch.Tensor, name: str
+) -> None:
+    if scale.numel() != 1:
+        raise ValueError(
+            f"{name} must contain exactly one element, got {scale.numel()}"
+        )
+    if scale.dtype != torch.float32:
+        raise ValueError(f"{name} must have dtype torch.float32, got {scale.dtype}")
+    if not scale.is_cuda or scale.device != operand.device:
+        raise ValueError(
+            f"{name} must be a CUDA tensor on {operand.device}, got {scale.device}"
+        )
+
+
 def _check_bmm_fp8_problem_size(
     A: torch.Tensor,
     B: torch.Tensor,
@@ -6783,6 +6798,8 @@ def _check_bmm_fp8_problem_size(
     out: Optional[torch.Tensor] = None,
     backend: Literal["cudnn", "cublas", "cutlass", "auto"] = "cublas",
 ):
+    _validate_bmm_fp8_scale(A_scale, A, "A_scale")
+    _validate_bmm_fp8_scale(B_scale, B, "B_scale")
     _validate_fp8_output_dtype(dtype)
     return True
 
@@ -6847,10 +6864,13 @@ def bmm_fp8(
         Mat2 tensor, shape (b, k, n), should be column major, fp8 e4m3 or fp8 e5m2.
 
     A_scale: torch.Tensor
-        Scale tensor for A, float.
+        Tensorwide scale for A. Must contain exactly one ``torch.float32`` value
+        on the same CUDA device as A.
 
     B_scale: torch.Tensor
-        Scale tensor for B, float.
+        Tensorwide scale for B. Must contain exactly one ``torch.float32`` value
+        on the same CUDA device as B. Use :func:`gemm_fp8_nt_groupwise` for
+        groupwise scales.
 
     dtype: torch.dtype
         out dtype, bf16 or fp16.

--- a/tests/gemm/test_bmm_fp8.py
+++ b/tests/gemm/test_bmm_fp8.py
@@ -7,6 +7,39 @@ from flashinfer.utils import get_compute_capability
 from tests.utils_fp8 import to_float8
 
 
+@pytest.mark.parametrize("scale_name", ["A_scale", "B_scale"])
+@pytest.mark.parametrize(
+    "invalid_scale, error",
+    [
+        ("non_scalar", "must contain exactly one element"),
+        ("wrong_dtype", "must have dtype torch.float32"),
+        ("wrong_device", "must be a CUDA tensor on"),
+    ],
+)
+def test_bmm_fp8_rejects_invalid_tensorwide_scale(scale_name, invalid_scale, error):
+    A = torch.empty((1, 1, 16), dtype=torch.float8_e4m3fn, device="cuda")
+    B = torch.empty((1, 16, 16), dtype=torch.float8_e4m3fn, device="cuda")
+    scales = {
+        "A_scale": torch.ones((), dtype=torch.float32, device="cuda"),
+        "B_scale": torch.ones((), dtype=torch.float32, device="cuda"),
+    }
+    if invalid_scale == "non_scalar":
+        scales[scale_name] = torch.ones((1, 2), dtype=torch.float32, device="cuda")
+    elif invalid_scale == "wrong_dtype":
+        scales[scale_name] = torch.ones((), dtype=torch.float16, device="cuda")
+    else:
+        scales[scale_name] = torch.ones((), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match=rf"{scale_name} {error}"):
+        bmm_fp8(
+            A,
+            B,
+            scales["A_scale"],
+            scales["B_scale"],
+            torch.bfloat16,
+        )
+
+
 @pytest.mark.parametrize("b", [1, 16])
 @pytest.mark.parametrize("m", [1, 48, 128])
 @pytest.mark.parametrize("n", [64, 80, 10304])


### PR DESCRIPTION
## 📌 Description

`bmm_fp8` now enforces the tensorwide scale contract shared by its cuBLAS, cuDNN, CUTLASS, and `auto` paths.

| Backend | Scale interpretation |
|---|---|
| cuBLASLt | Default tensorwide FP32 scalar |
| cuDNN | FP32 tensor shaped `(1, 1, 1)` |
| SM100 CUTLASS | Scalar-broadcast epilogue |
| SM120 CUTLASS | Can reach groupwise internals |
| Public `bmm_fp8` contract | One FP32 CUDA value per operand |

Because `backend="auto"` may choose any compatible runner, `A_scale` and `B_scale` must each contain one `torch.float32` value on the same CUDA device as the corresponding operand. Groupwise scaling remains available through `gemm_fp8_nt_groupwise`.

Previously, arbitrary scale tensors passed the common backend check. This made scale semantics dependent on backend selection and allowed non-float32 storage to reach `float*` casts.

This change:

- validates both scales before backend dispatch;
- repeats dtype, device, and element-count checks at the cuBLAS and SM100 CUTLASS FFI boundaries;
- documents the tensorwide contract and directs groupwise callers to the groupwise API;
- adds public regression cases for non-scalar, wrong-dtype, and wrong-device scales.

Valid scalar behavior is unchanged. This does not change `mm_fp8`.

## 🔍 Related Issues

Fixes #4052.

#3085 concerns a separate cuBLAS autotuning segfault.

## 🧪 Tests

- Added six public validation cases covering both scales with non-scalar, wrong-dtype, and wrong-device inputs
- `pre-commit run --files csrc/bmm_fp8.cu csrc/fp8_gemm_cutlass.cu flashinfer/gemm/gemm_base.py tests/gemm/test_bmm_fp8.py`
- `python3 -m py_compile flashinfer/gemm/gemm_base.py tests/gemm/test_bmm_fp8.py`
- Direct CUDA compilation of the cuBLAS translation unit passed
- `git diff --check` passed

## Reviewer Notes

No contiguity restriction was added: once `numel() == 1`, tensor stride does not change the scalar pointer contract.

The intentional compatibility change is that undocumented non-scalar scales passed through `bmm_fp8` on SM120 are rejected. The explicit groupwise API remains available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FP8 batched matrix multiplication now validates scale inputs more consistently.
  * Clear errors are reported when scales have the wrong dtype, device, or number of elements.
  * Scale tensors must be single-value `float32` CUDA tensors on the same device as their corresponding inputs.

* **Documentation**
  * Updated FP8 BMM parameter documentation to describe scale requirements.

* **Tests**
  * Added coverage for invalid FP8 scale configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->