### PR TITLE
fix(norm): clamp CUDA FP8 quantization to the output dtype range

### DIFF
--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 #include <numeric>
+#include <type_traits>
 
 #include "flashinfer/trtllm/common/cudaTypeUtils.cuh"
 #include "flashinfer/trtllm/common/cudaUtils.h"
@@ -32,6 +33,12 @@ namespace flashinfer {
 namespace norm {
 
 using namespace tensorrt_llm::common;
+
+template <typename T>
+constexpr float fp8_max() {
+  static_assert(std::is_same<T, __nv_fp8_e4m3>::value || std::is_same<T, __nv_fp8_e5m2>::value);
+  return std::is_same<T, __nv_fp8_e5m2>::value ? 57344.0f : 448.0f;
+}
 
 template <uint32_t VEC_SIZE, typename T>
 __global__ void RMSNormKernel(T* __restrict__ input, T* __restrict__ weight, T* __restrict__ output,
@@ -159,6 +166,7 @@ __global__ void RMSNormQuantKernel(T* __restrict__ input, T* __restrict__ weight
   const uint32_t num_threads = num_warps * warp_size;
   const uint32_t rounds = ceil_div(d, VEC_SIZE * num_threads);
   const float scale_inv = 1.0f / scale[0];
+  constexpr float output_max = fp8_max<O>();
   extern __shared__ float smem[];
 
   float sum_sq = 0.f;
@@ -214,7 +222,7 @@ __global__ void RMSNormQuantKernel(T* __restrict__ input, T* __restrict__ weight
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
       output_vec[j] =
           float(input_vec[j]) * rms_rcp * (weight_bias + float(weight_vec[j])) * scale_inv;
-      output_vec[j] = fmaxf(-448.0f, fminf(output_vec[j], 448.0f));
+      output_vec[j] = fmaxf(-output_max, fminf(output_vec[j], output_max));
     }
     if ((i * num_threads + thread_id) * VEC_SIZE < d) {
       output_vec.cast_store(output + bx * stride_output + i * num_threads * VEC_SIZE +
@@ -528,6 +536,7 @@ __global__ void FusedAddRMSNormQuantKernel(T* __restrict__ input, T* __restrict_
   const uint32_t num_threads = num_warps * warp_size;
   const uint32_t rounds = ceil_div(d, VEC_SIZE * num_threads);
   const float scale_inv = 1.0f / scale[0];
+  constexpr float output_max = fp8_max<O>();
   extern __shared__ float smem[];
   float* smem_x = smem + ceil_div(num_warps, 4) * 4;
 
@@ -598,7 +607,7 @@ __global__ void FusedAddRMSNormQuantKernel(T* __restrict__ input, T* __restrict_
 #pragma unroll
     for (uint32_t j = 0; j < VEC_SIZE; j++) {
       output_vec[j] = x_vec[j] * rms_rcp * (weight_bias + float(weight_vec[j])) * scale_inv;
-      output_vec[j] = fmaxf(-448.0f, fminf(output_vec[j], 448.0f));
+      output_vec[j] = fmaxf(-output_max, fminf(output_vec[j], output_max));
     }
     if ((i * num_threads + thread_id) * VEC_SIZE < d) {
       output_vec.cast_store(output + bx * stride_output + i * num_threads * VEC_SIZE +

--- a/include/flashinfer/norm.cuh
+++ b/include/flashinfer/norm.cuh
@@ -36,7 +36,8 @@ using namespace tensorrt_llm::common;
 
 template <typename T>
 constexpr float fp8_max() {
-  static_assert(std::is_same<T, __nv_fp8_e4m3>::value || std::is_same<T, __nv_fp8_e5m2>::value);
+  static_assert(std::is_same<T, __nv_fp8_e4m3>::value || std::is_same<T, __nv_fp8_e5m2>::value,
+                "T must be __nv_fp8_e4m3 or __nv_fp8_e5m2");
   return std::is_same<T, __nv_fp8_e5m2>::value ? 57344.0f : 448.0f;
 }
 

--- a/tests/utils/test_norm.py
+++ b/tests/utils/test_norm.py
@@ -162,8 +162,6 @@ def test_norm_quant(
     ids=["e4m3", "e5m2"],
 )
 def test_norm_quant_respects_output_dtype_range(out_dtype):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA is required")
     if not flashinfer.norm._USE_CUDA_NORM:
         pytest.skip("legacy CUDA norm backend is required")
 
@@ -174,7 +172,8 @@ def test_norm_quant_respects_output_dtype_range(out_dtype):
     )
     out = torch.empty_like(x, dtype=out_dtype)
 
-    flashinfer.norm.rmsnorm_quant(out, x, weight, 1.0, enable_pdl=False)
+    scale = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+    flashinfer.norm.rmsnorm_quant(out, x, weight, scale, enable_pdl=False)
 
     expected = min(value_between_fp8_ranges, torch.finfo(out_dtype).max)
     torch.testing.assert_close(
@@ -297,8 +296,6 @@ def test_fused_add_rmsnorm_quant(
     ids=["e4m3", "e5m2"],
 )
 def test_fused_add_rmsnorm_quant_respects_output_dtype_range(out_dtype):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA is required")
     if not flashinfer.norm._USE_CUDA_NORM:
         pytest.skip("legacy CUDA norm backend is required")
 
@@ -310,8 +307,9 @@ def test_fused_add_rmsnorm_quant_respects_output_dtype_range(out_dtype):
     )
     out = torch.empty_like(x, dtype=out_dtype)
 
+    scale = torch.tensor([1.0], dtype=torch.float32, device="cuda")
     flashinfer.norm.fused_add_rmsnorm_quant(
-        out, x, residual, weight, 1.0, enable_pdl=False
+        out, x, residual, weight, scale, enable_pdl=False
     )
 
     expected = min(value_between_fp8_ranges, torch.finfo(out_dtype).max)

--- a/tests/utils/test_norm.py
+++ b/tests/utils/test_norm.py
@@ -156,6 +156,32 @@ def test_norm_quant(
     torch.testing.assert_close(y_ref.float(), y.float(), rtol=1, atol=1)
 
 
+@pytest.mark.parametrize(
+    "out_dtype",
+    [torch.float8_e4m3fn, torch.float8_e5m2],
+    ids=["e4m3", "e5m2"],
+)
+def test_norm_quant_respects_output_dtype_range(out_dtype):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if not flashinfer.norm._USE_CUDA_NORM:
+        pytest.skip("legacy CUDA norm backend is required")
+
+    x = torch.ones(1, 128, dtype=torch.float16, device="cuda")
+    value_between_fp8_ranges = 1024.0
+    weight = torch.full(
+        (128,), value_between_fp8_ranges, dtype=torch.float16, device="cuda"
+    )
+    out = torch.empty_like(x, dtype=out_dtype)
+
+    flashinfer.norm.rmsnorm_quant(out, x, weight, 1.0, enable_pdl=False)
+
+    expected = min(value_between_fp8_ranges, torch.finfo(out_dtype).max)
+    torch.testing.assert_close(
+        out.float(), torch.full_like(x, expected), rtol=0, atol=0
+    )
+
+
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("num_heads", [4, 7, 16])
 @pytest.mark.parametrize("head_dim", [64, 128, 256, 512])
@@ -263,6 +289,35 @@ def test_fused_add_rmsnorm_quant(
 
     torch.testing.assert_close(y.float(), x_native.float(), rtol=1, atol=1)
     torch.testing.assert_close(residual_fused, residual_native, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "out_dtype",
+    [torch.float8_e4m3fn, torch.float8_e5m2],
+    ids=["e4m3", "e5m2"],
+)
+def test_fused_add_rmsnorm_quant_respects_output_dtype_range(out_dtype):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if not flashinfer.norm._USE_CUDA_NORM:
+        pytest.skip("legacy CUDA norm backend is required")
+
+    x = torch.ones(1, 128, dtype=torch.float16, device="cuda")
+    residual = torch.zeros_like(x)
+    value_between_fp8_ranges = 1024.0
+    weight = torch.full(
+        (128,), value_between_fp8_ranges, dtype=torch.float16, device="cuda"
+    )
+    out = torch.empty_like(x, dtype=out_dtype)
+
+    flashinfer.norm.fused_add_rmsnorm_quant(
+        out, x, residual, weight, 1.0, enable_pdl=False
+    )
+
+    expected = min(value_between_fp8_ranges, torch.finfo(out_dtype).max)
+    torch.testing.assert_close(
+        out.float(), torch.full_like(x, expected), rtol=0, atol=0
+    )
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])


### PR DESCRIPTION
## 📌 Description

The legacy CUDA implementations of `rmsnorm_quant` and `fused_add_rmsnorm_quant` clamped every FP8 output to ±448. That bound is correct for E4M3 but not E5M2, whose finite range extends to ±57344.

| Output type | Finite maximum | Input to clamp | Previous output | Correct output |
|---|---:|---:|---:|---:|
| E4M3 | 448 | 1024 | 448 | 448 |
| E5M2 | 57344 | 1024 | 448 | 1024 |

```text
previous = clamp(1024, -448, 448) = 448
correct  = clamp(1024, -57344, 57344) = 1024
```

This change adds a compile-time FP8 range helper and applies the selected output type in both kernels:

- E4M3 remains clamped to ±448.
- E5M2 is clamped to ±57344.
- Unsupported output template types fail at compile time.

Public regression tests use 1024, a value between the formats' maximum ranges, and cover both APIs with E4M3 and E5M2.

The CuTe DSL implementation, backend routing, and INT8 behavior are unchanged.

## 🔍 Related Issues

Fixes #4053.

## 🧪 Tests

- Added E4M3 and E5M2 regressions for `rmsnorm_quant` and `fused_add_rmsnorm_quant`
- Focused pre-commit hooks passed
- `python3 -m compileall -q tests/utils/test_norm.py`
- `git diff --check` passed

## Reviewer Notes

The core invariant is in `fp8_max<T>()`: only CUDA E4M3 and E5M2 output types are accepted, and both kernels use the selected value symmetrically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FP8 quantized RMSNorm and fused add+RMSNorm to clamp outputs using the selected FP8 format’s maximum finite magnitude (instead of a fixed range), preventing out-of-range values.
* **Tests**
  * Added CUDA-gated regression tests validating correct FP8 clamping for both FP8 e4m3 and e5m2 output types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->