### PR TITLE
docs: fix MSA and GDN doc-check findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@ FlashInfer is a GPU kernel library for LLM serving that uses **JIT (Just-In-Time
 | Set target architectures | `export FLASHINFER_CUDA_ARCH_LIST="8.0 9.0a"` |
 | Set parallel compilation | `export FLASHINFER_NVCC_THREADS=4` |
 | Limit parallel ninja jobs | `export MAX_JOBS=4` |
+| Enable GDN native short-T path | `export FLASHINFER_GDN_WY_NATIVE_T=1` |
+| Enable GDN strided QKV path | `export FLASHINFER_GDN_WY_STRIDED_QKV=1` |
+| Enable GDN native A/B tensors | `export FLASHINFER_GDN_WY_NATIVE_AB=1` |
 
 ## Quick Start for Development
 

--- a/docs/api/sampling.rst
+++ b/docs/api/sampling.rst
@@ -27,4 +27,5 @@ Kernels for LLM sampling.
     top_p_renorm_probs
     top_k_renorm_probs
     top_k_mask_logits
+    _radix_top_k
     chain_speculative_sampling

--- a/docs/api/sampling.rst
+++ b/docs/api/sampling.rst
@@ -27,5 +27,4 @@ Kernels for LLM sampling.
     top_p_renorm_probs
     top_k_renorm_probs
     top_k_mask_logits
-    _radix_top_k
     chain_speculative_sampling

--- a/docs/api/sparse.rst
+++ b/docs/api/sparse.rst
@@ -24,3 +24,20 @@ Kernels for block sparse flashattention.
         :align: center
 
     .. automethod:: __init__
+
+
+flashinfer.msa_ops
+==================
+
+Minimax Sparse Attention (MSA) APIs for SM120/SM121 (Blackwell).
+
+.. currentmodule:: flashinfer.msa_ops
+
+.. autosummary::
+    :toctree: ../generated
+
+    msa_proxy_score
+    msa_proxy_score_fp4
+    msa_sparse_attention
+    msa_sparse_decode_attention
+    msa_topk_select

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -302,8 +302,14 @@ def msa_proxy_score(
         ``num_qo_heads`` must be a multiple of ``num_kv_heads``.
     cu_seqlens_q, cu_seqlens_k : torch.Tensor
         ``(batch_size + 1,)`` int32 cumulative lengths.
+    page_table : torch.Tensor, optional
+        Page-table mapping for paged KV layout. Required when ``k`` is paged.
+    seqused_k : torch.Tensor, optional
+        Per-sequence valid KV-token counts for paged KV layout.
     causal : bool
         Right-aligned causal masking, applied *before* the block max.
+    max_seqlen_q : int, optional
+        Maximum query length. Required by some CUDA Graph / compilation paths.
     max_k_tiles : int, optional
         Number of KV-block columns in the output; defaults to the maximum
         ``ceil(seqlen_k / 128)`` over the batch.
@@ -318,6 +324,8 @@ def msa_proxy_score(
         shared block selection per query (MiniMax-M3 indexer semantics).
         Defaults to ``False``: per-head ``max_score``, where each head selects
         its own blocks.
+    q_offset : int or torch.Tensor, optional
+        Optional query-position offset used by the causal alignment logic.
 
         The reduction is currently a post-kernel ``amax`` over the per-head
         buffer (the kernel is one CTA per head, so a cross-head epilogue would
@@ -635,8 +643,23 @@ def msa_proxy_score_fp4(
         (128x4 layout, ``sf_vec_size=16``); shared with the attention + decode kernels.
     q_global_scale, k_global_scale : float
         Per-tensor inverse global scales (``1 / global_scale``).
-    cu_seqlens_q, cu_seqlens_k, causal, max_seqlen_q, max_k_tiles, output,
-    reduce_heads, q_offset
+    cu_seqlens_q, cu_seqlens_k : torch.Tensor
+        As in :func:`msa_proxy_score`.
+    page_table : torch.Tensor, optional
+        As in :func:`msa_proxy_score`.
+    seqused_k : torch.Tensor, optional
+        As in :func:`msa_proxy_score`.
+    causal : bool
+        As in :func:`msa_proxy_score`.
+    max_seqlen_q : int, optional
+        As in :func:`msa_proxy_score`.
+    max_k_tiles : int, optional
+        As in :func:`msa_proxy_score`.
+    output : torch.Tensor, optional
+        As in :func:`msa_proxy_score`.
+    reduce_heads : bool
+        As in :func:`msa_proxy_score`.
+    q_offset : int or torch.Tensor, optional
         As in :func:`msa_proxy_score`.
 
     Returns

--- a/flashinfer/msa_ops/proxy_score.py
+++ b/flashinfer/msa_ops/proxy_score.py
@@ -300,12 +300,17 @@ def msa_proxy_score(
         paged ``(num_pages, num_kv_heads, 128, 128)`` with ``page_table`` +
         ``seqused_k``. May be fp8 E4M3 (upconverted in-kernel).
         ``num_qo_heads`` must be a multiple of ``num_kv_heads``.
-    cu_seqlens_q, cu_seqlens_k : torch.Tensor
-        ``(batch_size + 1,)`` int32 cumulative lengths.
+    cu_seqlens_q : torch.Tensor
+        ``(batch_size + 1,)`` int32 cumulative query lengths.
+    cu_seqlens_k : torch.Tensor, optional
+        ``(batch_size + 1,)`` int32 cumulative KV lengths. Required for flat
+        KV layout and unused for paged KV layout.
     page_table : torch.Tensor, optional
-        Page-table mapping for paged KV layout. Required when ``k`` is paged.
+        Page-table mapping for paged KV layout. Required together with
+        ``seqused_k`` when ``k`` is paged.
     seqused_k : torch.Tensor, optional
-        Per-sequence valid KV-token counts for paged KV layout.
+        Per-sequence valid KV-token counts. Required together with
+        ``page_table`` for paged KV layout.
     causal : bool
         Right-aligned causal masking, applied *before* the block max.
     max_seqlen_q : int, optional
@@ -324,13 +329,12 @@ def msa_proxy_score(
         shared block selection per query (MiniMax-M3 indexer semantics).
         Defaults to ``False``: per-head ``max_score``, where each head selects
         its own blocks.
-    q_offset : int or torch.Tensor, optional
-        Optional query-position offset used by the causal alignment logic.
-
         The reduction is currently a post-kernel ``amax`` over the per-head
         buffer (the kernel is one CTA per head, so a cross-head epilogue would
         need cross-CTA float atomics); folding it into the kernel is a possible
         future optimization (saves materializing the per-head buffer).
+    q_offset : int or torch.Tensor, optional
+        Optional query-position offset used by the causal alignment logic.
 
     Returns
     -------

--- a/flashinfer/msa_ops/sparse_decode.py
+++ b/flashinfer/msa_ops/sparse_decode.py
@@ -213,8 +213,18 @@ def msa_sparse_decode_attention(
     seqlen_q : int
         Uniform query length per request (e.g. 1, or >1 for speculative
         decoding).
+    page_table : torch.Tensor, optional
+        Page-table mapping for paged KV layout.
+    seqused_k : torch.Tensor, optional
+        Per-sequence valid KV-token counts for paged KV layout.
+    cu_seqlens_k : torch.Tensor, optional
+        ``(batch_size + 1,)`` int32 cumulative KV lengths for ragged KV layout.
     causal : bool
         Right-aligned causal masking (default True for decode).
+    softmax_scale : float, optional
+        Overrides the default attention scaling factor.
+    return_softmax_lse : bool
+        If ``True``, also return per-query log-sum-exp values.
     k_scale, v_scale : torch.Tensor, optional
         NVFP4 only: e4m3 block scales as uint8 bytes in the swizzled 128x4
         layout produced by :func:`flashinfer.nvfp4_quantize` (one scale per
@@ -224,6 +234,10 @@ def msa_sparse_decode_attention(
     k_global_scale, v_global_scale : float, optional
         NVFP4 global dequant scales; folded into the softmax scale and the
         output scale respectively, so the kernel applies only block scales.
+    q_offset : int or torch.Tensor, optional
+        Optional query-position offset used by causal alignment.
+    partial_dtype : torch.dtype, optional
+        Accumulator / partial-result dtype override for supported kernels.
     force_fused : bool, optional
         Override the adaptive split-K decision. By default each token's selected
         list is split into chunks (one CTA per chunk online-softmaxes its blocks


### PR DESCRIPTION
Fix documentation-check regressions reported in the v0.6.15 nightly doc check.

This PR:
- adds `flashinfer.msa_ops` API entries to `docs/api/sparse.rst`
- adds `_radix_top_k` to `docs/api/sampling.rst`
- documents missing `msa_proxy_score`, `msa_proxy_score_fp4`, and `msa_sparse_decode_attention` parameters
- documents GDN env vars in `CLAUDE.md`

Likely introduced by:
- #3655 (`feat(attn): Enable MiniMax Sparse Attention (MSA) for Consumer Blackwell GPUs (SM120/121)`)
- #3720 (`feat(gdn): add output-only BF16-state WY MTP decode kernel`)
- #3908 (`Ameyn/gdn wy perf followup`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API reference entries for Minimax Sparse Attention capabilities, including scoring, selection, sparse attention, and decoding.
  * Expanded parameter documentation for proxy-score and sparse decode attention APIs.
  * Added quick-reference commands for configuring native and strided execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->