### PR TITLE
fix: uniform multi-token trtllm-gen decode mis-indexes packed Q/O without cum_seq_lens_q (#3929)

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3022,6 +3022,18 @@ def _get_uniform_cum_seq_lens_q(
     key = (batch_size, q_len, device.index)
     t = _uniform_cum_seq_lens_cache.get(key)
     if t is None:
+        if torch.cuda.is_current_stream_capturing():
+            # The tensor would be allocated from the capture's private memory
+            # pool and then cached: correct within this graph, but any other
+            # graph hitting the cache later would bake a pointer whose contents
+            # only this graph's replays maintain.
+            warnings.warn(
+                "cum_seq_lens_q synthesized during CUDA-graph capture for "
+                f"(batch_size={batch_size}, q_len_per_req={q_len}); run an "
+                "eager warmup call with the same shape before capturing so the "
+                "cached layout tensor lives outside the capture pool.",
+                stacklevel=3,
+            )
         t = torch.arange(
             0, (batch_size + 1) * q_len, q_len, dtype=torch.int32, device=device
         )

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3001,6 +3001,34 @@ def get_trtllm_gen_decode_module(*args):
     )
 
 
+# The trtllm-gen grouped-token generation kernels (KeepsMmaAbForGeneration,
+# tileSizeQ 64/128) index Q/O with a PADDED per-request token stride
+# (tileSizeQ / numHeadsQPerKv) when cum_seq_lens_q is absent, while the tensors
+# are PACKED at q_len_per_req tokens per request. For q_len_per_req values that
+# do not divide the token group (e.g. q_len 5/6/7 with GQA group size 8), every
+# request > 0 is read/written at inflated offsets: outputs are silently
+# misplaced on every launch and late requests write past `out` (an asynchronous
+# illegal memory access whenever a stray write leaves mapped VA — see #3929).
+# Always hand the kernels an explicit packed layout instead of the fallback.
+_uniform_cum_seq_lens_cache: dict = {}
+
+
+def _get_uniform_cum_seq_lens_q(
+    batch_size: int, q_len: int, device: torch.device
+) -> torch.Tensor:
+    # Cached per (batch_size, q_len, device) so CUDA-graph capture bakes a
+    # stable, pre-existing tensor (cache misses normally happen during eager
+    # warmup, outside capture).
+    key = (batch_size, q_len, device.index)
+    t = _uniform_cum_seq_lens_cache.get(key)
+    if t is None:
+        t = torch.arange(
+            0, (batch_size + 1) * q_len, q_len, dtype=torch.int32, device=device
+        )
+        _uniform_cum_seq_lens_cache[key] = t
+    return t
+
+
 @flashinfer_api(trace=trtllm_batch_decode_trace_dispatch)
 def trtllm_batch_decode_with_kv_cache(
     query: torch.Tensor,
@@ -3424,6 +3452,15 @@ def trtllm_batch_decode_with_kv_cache(
         if q_len_per_req is not None:
             max_q_len = q_len_per_req
             batch_size = query.size(0) // q_len_per_req
+            if cum_seq_lens_q is None and q_len_per_req > 1:
+                # Route multi-token uniform decode through the packed var-seq
+                # layout: the uniform fallback mis-indexes packed Q/O whenever
+                # q_len_per_req does not divide the kernel's token group,
+                # silently corrupting outputs and writing out of bounds
+                # (#3929). See _get_uniform_cum_seq_lens_q above.
+                cum_seq_lens_q = _get_uniform_cum_seq_lens_q(
+                    batch_size, q_len_per_req, query.device
+                )
         else:
             assert max_q_len is not None
             batch_size = cum_seq_lens_q.size(0) - 1

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3019,7 +3019,7 @@ def _get_uniform_cum_seq_lens_q(
     # Cached per (batch_size, q_len, device) so CUDA-graph capture bakes a
     # stable, pre-existing tensor (cache misses normally happen during eager
     # warmup, outside capture).
-    key = (batch_size, q_len, device.index)
+    key = (batch_size, q_len, device)
     t = _uniform_cum_seq_lens_cache.get(key)
     if t is None:
         if torch.cuda.is_current_stream_capturing():

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1744,7 +1744,7 @@ def test_trtllm_batch_decode_spec(
     )
 
 
-@pytest.mark.parametrize("q_len_per_req", [5, 6, 7])
+@pytest.mark.parametrize("q_len_per_req", [5, 6, 7, 8])
 def test_trtllm_batch_decode_uniform_qlen_packed_layout(q_len_per_req):
     """Regression test for #3929: uniform multi-token decode (q_len_per_req
     only, no cum_seq_lens_q) must index packed Q/O correctly when
@@ -1753,6 +1753,10 @@ def test_trtllm_batch_decode_uniform_qlen_packed_layout(q_len_per_req):
     every request > 0 was read/written at padded offsets: batched outputs
     diverged from per-request outputs and late requests wrote past `out`
     (asynchronous illegal memory access when the stray write left mapped VA).
+
+    q_len_per_req=8 (divides the token group; correct before the synthesis
+    too) is the control locking output+LSE equivalence of the var-seq routing
+    for previously-working shapes.
     """
     compute_capability = get_compute_capability(torch.device(device="cuda"))
     if compute_capability[0] != 10:
@@ -1788,13 +1792,14 @@ def test_trtllm_batch_decode_uniform_qlen_packed_layout(q_len_per_req):
             bmm2_scale=1.0,
             q_len_per_req=q_len_per_req,
             out_dtype=dtype,
+            return_lse=True,
         )
 
-    batched = run(q, block_tables, seq_lens)
+    batched, batched_lse = run(q, block_tables, seq_lens)
     torch.cuda.synchronize()
     for req in range(batch_size):
         lo, hi = req * q_len_per_req, (req + 1) * q_len_per_req
-        single = run(
+        single, single_lse = run(
             q[lo:hi].contiguous(),
             block_tables[req : req + 1].contiguous(),
             seq_lens[req : req + 1].contiguous(),
@@ -1802,4 +1807,7 @@ def test_trtllm_batch_decode_uniform_qlen_packed_layout(q_len_per_req):
         torch.cuda.synchronize()
         torch.testing.assert_close(
             batched[lo:hi].float(), single.float(), atol=2e-2, rtol=2e-2
+        )
+        torch.testing.assert_close(
+            batched_lse[lo:hi].float(), single_lse.float(), atol=2e-2, rtol=2e-2
         )

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1742,3 +1742,64 @@ def test_trtllm_batch_decode_spec(
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
     )
+
+
+@pytest.mark.parametrize("q_len_per_req", [5, 6, 7])
+def test_trtllm_batch_decode_uniform_qlen_packed_layout(q_len_per_req):
+    """Regression test for #3929: uniform multi-token decode (q_len_per_req
+    only, no cum_seq_lens_q) must index packed Q/O correctly when
+    q_len_per_req does not divide the grouped-token kernel's token group
+    (tileSizeQ / numHeadsQPerKv). Before the packed cum_seq_lens_q synthesis,
+    every request > 0 was read/written at padded offsets: batched outputs
+    diverged from per-request outputs and late requests wrote past `out`
+    (asynchronous illegal memory access when the stray write left mapped VA).
+    """
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] != 10:
+        pytest.skip("trtllm-gen decode kernels require SM100-class GPUs")
+    torch.manual_seed(42)
+    batch_size, page_size, max_seq_len = 10, 64, 1024
+    num_pages_per_seq = max_seq_len // page_size
+    dtype = torch.bfloat16
+    device = GPU_DEVICE
+    # GQA8, head_dim 512: numHeadsQPerKv * q_len_per_req in (40, 48, 56)
+    # selects the tileSizeQ=64 KeepsMmaAbForGeneration kernels (the family
+    # with the padded uniform fallback).
+    q = torch.randn(batch_size * q_len_per_req, 16, 512, dtype=dtype, device=device)
+    k = torch.randn(
+        num_pages_per_seq * batch_size, 2, page_size, 512, dtype=dtype, device=device
+    )
+    v = torch.randn_like(k)
+    block_tables = torch.arange(
+        num_pages_per_seq * batch_size, dtype=torch.int32, device=device
+    ).view(batch_size, num_pages_per_seq)
+    seq_lens = torch.full((batch_size,), max_seq_len, dtype=torch.int32, device=device)
+    workspace = torch.zeros(256 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    def run(q_, block_tables_, seq_lens_):
+        return flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query=q_,
+            kv_cache=(k, v),
+            workspace_buffer=workspace,
+            block_tables=block_tables_,
+            seq_lens=seq_lens_,
+            max_seq_len=max_seq_len,
+            bmm1_scale=512**-0.5,
+            bmm2_scale=1.0,
+            q_len_per_req=q_len_per_req,
+            out_dtype=dtype,
+        )
+
+    batched = run(q, block_tables, seq_lens)
+    torch.cuda.synchronize()
+    for req in range(batch_size):
+        lo, hi = req * q_len_per_req, (req + 1) * q_len_per_req
+        single = run(
+            q[lo:hi].contiguous(),
+            block_tables[req : req + 1].contiguous(),
+            seq_lens[req : req + 1].contiguous(),
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            batched[lo:hi].float(), single.float(), atol=2e-2, rtol=2e-2
+        )

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -1778,7 +1778,7 @@ def test_trtllm_batch_decode_uniform_qlen_packed_layout(q_len_per_req):
         num_pages_per_seq * batch_size, dtype=torch.int32, device=device
     ).view(batch_size, num_pages_per_seq)
     seq_lens = torch.full((batch_size,), max_seq_len, dtype=torch.int32, device=device)
-    workspace = torch.zeros(256 * 1024 * 1024, dtype=torch.int8, device=device)
+    workspace, _ = create_workspace_buffers(device)
 
     def run(q_, block_tables_, seq_lens_):
         return flashinfer.decode.trtllm_batch_decode_with_kv_cache(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fixes #3929.

`trtllm_batch_decode_with_kv_cache` with only `q_len_per_req` (no `cum_seq_lens_q`) mis-indexes packed Q/O whenever `q_len_per_req` does not divide the grouped-token kernel's token group: the `KeepsMmaAbForGeneration` kernels (tileSizeQ 64/128) fall back to a **padded** per-request stride (`tileSizeQ / numHeadsQPerKv`, kernelParams.h "allows paddings in the end"; same fallback in `fmhaReduction.cu:69`), while the tensors are **packed** at `q_len_per_req`. Every request > 0 is read/written at inflated offsets — outputs are **silently misplaced on every launch** (e.g. q_len 5/6/7 at GQA group 8), and late requests write past `out`: an async IMA whenever a stray write leaves mapped VA.

This is the #3929 mechanism. CUDA graphs never caused it — multi-bs capture only churns the allocator layout until a stray write becomes visible. compute-sanitizer on a **fully eager** dense multi-bs run shows 4730+ `Invalid __global__ write` in `fmhaReductionKernel<64, 256, ...>` (the final-O store); `CUDA_MODULE_LOADING=EAGER`, 4× workspace, fresh/zeroed workspace, private mempools all change nothing; `q_len_per_req=4` (Swaps path, `numTokensPerCtaQ=1` → packed stride) is unaffected.

**Fix:** when the caller provides only `q_len_per_req > 1`, synthesize the packed `cum_seq_lens_q` (cached per `(batch_size, q_len, device)` so CUDA-graph capture bakes a stable tensor) and take the var-seq path, which indexes packed layouts correctly. `fmhaReduction.cu`'s null fallback could additionally be changed to `batchIdx * mMaxSeqLenQ`, but the closed cubins share the padded fallback, so the API-level synthesis is the complete fix. The MLA entry (`trtllm_batch_decode_with_kv_cache_mla`) has the same uniform fallback pattern; left for a follow-up since no failing MLA geometry has been demonstrated (its common Swaps geometries use the packed stride already).

### Reproduce (B200 / SM100, verified on v0.6.14 and current main @ f212ec82)

Minimal — one **eager** call in a fresh process, no CUDA graphs:

```python
import torch, flashinfer
bs, q_len, page, max_seq = 10, 6, 64, 1024          # GQA8, hd=512 -> tileSizeQ=64 KeepsMmaAb
n_pages = max_seq // page
q  = torch.randn(bs * q_len, 16, 512, dtype=torch.bfloat16, device="cuda")
k  = torch.randn(n_pages * bs, 2, page, 512, dtype=torch.bfloat16, device="cuda")
v  = torch.randn_like(k)
bt = torch.arange(n_pages * bs, dtype=torch.int32, device="cuda").view(bs, n_pages)
sl = torch.full((bs,), max_seq, dtype=torch.int32, device="cuda")
ws = torch.zeros(256 << 20, dtype=torch.int8, device="cuda")
out = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
    query=q, kv_cache=(k, v), workspace_buffer=ws, block_tables=bt, seq_lens=sl,
    max_seq_len=max_seq, bmm1_scale=512**-0.5, bmm2_scale=1.0,
    q_len_per_req=q_len, out_dtype=torch.bfloat16)
torch.cuda.synchronize()
```

Before this PR:

```
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

Under compute-sanitizer (also reproducible with the #3929 gist, and with all CUDA-graph usage removed):

```
========= Invalid __global__ write of size 16 bytes
=========     at void tensorrt_llm::kernels::fmhaReductionKernel<(int)64, (int)256, (bool)0, __nv_bfloat16, __nv_bfloat16>(...)
=========     by thread (64,0,0) in block (2,2,9)
=========     Access to 0x73b0d4a22800 is out of bounds
=========     and is 141,313 bytes after the nearest allocation ...
=========     Host Frame: tensorrt_llm::kernels::runFmhaReduction(...)
========= ERROR SUMMARY: 4311 errors
```

Even when nothing crashes, results are wrong: comparing the batched call against per-request calls (identical inputs) shows every request > 0 diverging. Note the replay-vs-eager check in #3929 could never catch this — both sides are misplaced identically.

### After this PR (same B200, current main + this change)

- Minimal repro above: **passes**; batched vs per-request outputs match for all 10 requests (`q_len_per_req` ∈ {5, 6, 7}).
- Full #3929 gist (hybrid SWA+full stack, 12 descending batch sizes, capture + replay each round): **`all ok`**, per-round replay-vs-eager checks 60/60, and
  ```
  ========= ERROR SUMMARY: 0 errors
  ```
  under `compute-sanitizer --tool memcheck` for the entire run.
- Also validated end-to-end in SGLang (Gemma-4-class GQA spec-verify geometry is the affected family; the workaround `cum_seq_lens_q`+`max_q_len` passed the same suites).

## 🔍 Related Issues

Fixes #3929. Related: #3343, #3511 (missing-cubin reports for the same kernel family), #3393 (added these kernels).

## 🧪 Tests

- [x] Regression test added: `test_trtllm_batch_decode_uniform_qlen_packed_layout` (batched vs single-request equality at the failing geometry, `q_len_per_req` ∈ {5, 6, 7}).
- [x] `pre-commit run` on changed files passes (ruff check/format, mypy).

## Reviewer Notes

Severity: any MTP/EAGLE-style deployment using this entry point with `num_draft_tokens` ∈ {5, 6, 7} on GQA-8 geometries (e.g. Gemma-4 heads) has been silently producing corrupted outputs since 0.6.11, crashing only when a stray write happens to leave mapped memory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect token/Q/O indexing during multi-token uniform decoding with the TRT-LLM-Gen backend when per-request query length exceeds 1.
  * Improved consistency between batched decoding outputs (including log-sum-exp) and equivalent per-request decoding.

* **Tests**
  * Added a regression test validating uniform query-length packed layouts across several `q_len_per_req` values on supported GPU hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->