### PR TITLE
test(triton): cover + harden the Triton RMSNorm path (adds a bit-identical single-load fast path)

### DIFF
--- a/benchmarks/bench_triton_rmsnorm.py
+++ b/benchmarks/bench_triton_rmsnorm.py
@@ -1,0 +1,137 @@
+"""Benchmark the Triton RMSNorm single-load fast path against the general
+two-pass kernel.
+
+`flashinfer.triton.norm.rms_norm` dispatches the plain (no-residual, no-scale,
+contiguous, hidden <= 8192) path to `rms_norm_single_pass_kernel`, which loads
+each row once and reuses it for both the sum-of-squares reduction and the
+normalize step (1 read + 1 write) instead of the general kernel's 2 reads + 1
+write. This script times both over a sweep of hidden sizes and token counts and
+reports effective memory bandwidth so the speedup is reproducible.
+
+    python benchmarks/bench_triton_rmsnorm.py
+    python benchmarks/bench_triton_rmsnorm.py --hidden-sizes 4096 8192 --dtypes bfloat16
+"""
+
+import argparse
+
+import numpy as np
+import torch
+import triton
+
+from flashinfer.testing.utils import bench_gpu_time
+from flashinfer.triton.kernels.norm import rms_norm_kernel
+from flashinfer.triton.norm import rms_norm
+
+
+def _general_two_pass(x, weight, out, eps):
+    """Invoke the general two-pass kernel directly (the pre-fast-path path)."""
+    b, n = x.shape
+    block_size = triton.next_power_of_2(n)
+    num_warps = max(8, min(32, block_size // 256))
+    rms_norm_kernel[(b,)](
+        n=n,
+        b=b,
+        x_ptr=x,
+        x_stride=x.stride(0),
+        x_scale_ptr=None,
+        r_ptr=None,
+        r_stride=0,
+        w_ptr=weight,
+        o_ptr=out,
+        o_stride=out.stride(0),
+        o_scale_ptr=None,
+        EPS=eps,
+        BLOCK_SIZE=block_size,
+        HAS_IN_SCALE=False,
+        HAS_OUT_SCALE=False,
+        HAS_OUTPUT=True,
+        HAS_RESIDUAL=False,
+        num_warps=num_warps,
+    )
+
+
+@torch.inference_mode()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--token-counts", nargs="+", type=int, default=[1, 128, 2048, 8192]
+    )
+    parser.add_argument(
+        "--hidden-sizes",
+        nargs="+",
+        type=int,
+        default=[1024, 2048, 3072, 4096, 5120, 7168, 8192],
+    )
+    parser.add_argument(
+        "--dtypes",
+        nargs="+",
+        choices=["float16", "bfloat16"],
+        default=["float16", "bfloat16"],
+    )
+    parser.add_argument(
+        "--repeat", type=int, default=5, help="outer timing runs, aggregated by mean"
+    )
+    parser.add_argument(
+        "--iters", type=int, default=100, help="measured iterations per run"
+    )
+    args = parser.parse_args()
+
+    def median_ms(fn):
+        # Fixed iteration count so the protocol is deterministic ("repeat R x
+        # iters I") rather than the adaptive default; median over the run.
+        return np.median(bench_gpu_time(fn, repeat_iters=args.iters))
+
+    eps = 1e-6
+    all_speedups = []
+    for dtype_str in args.dtypes:
+        dtype = getattr(torch, dtype_str)
+        for hidden_size in args.hidden_sizes:
+            for tokens in args.token_counts:
+                x = torch.randn((tokens, hidden_size), dtype=dtype, device="cuda")
+                weight = torch.randn(hidden_size, dtype=dtype, device="cuda")
+                out = torch.empty_like(x)
+
+                # Correctness: the fast path is bit-identical to the general one.
+                out_fast = torch.empty_like(x)
+                rms_norm(x, weight, out_fast, eps)
+                out_general = torch.empty_like(x)
+                _general_two_pass(x, weight, out_general, eps)
+                assert torch.equal(out_fast, out_general), "fast != general"
+
+                row_bytes = tokens * hidden_size * x.element_size()
+                w_bytes = hidden_size * x.element_size()
+
+                # repeat outer runs, then average (mirrors the reported table).
+                before_runs = [
+                    median_ms(lambda: _general_two_pass(x, weight, out, eps))
+                    for _ in range(args.repeat)
+                ]
+                after_runs = [
+                    median_ms(lambda: rms_norm(x, weight, out, eps))
+                    for _ in range(args.repeat)
+                ]
+                before_ms = float(np.mean(before_runs))
+                after_ms = float(np.mean(after_runs))
+                # AFTER moves 2 units (1 read + 1 write); BEFORE moves 3.
+                after_bw = (2 * row_bytes + w_bytes) / (after_ms * 1e-3)
+                speedup = before_ms / after_ms if after_ms else float("nan")
+                all_speedups.append(speedup)
+                print(
+                    f"tokens: {tokens:5}, hidden: {hidden_size:5}, "
+                    f"dtype: {dtype_str:8}, before: {before_ms * 1e3:6.1f}us, "
+                    f"after: {after_ms * 1e3:6.1f}us, speedup: {speedup:5.3f}x, "
+                    f"after_bw: {after_bw * 1e-9:7.1f}GB/s"
+                )
+        print("---")
+
+    if all_speedups:
+        geomean = float(np.exp(np.mean(np.log(all_speedups))))
+        print(
+            f"speedup geomean: {geomean:.3f}x "
+            f"(range {min(all_speedups):.3f}-{max(all_speedups):.3f}x) "
+            f"over {len(all_speedups)} shapes, repeat {args.repeat} x {args.iters} iters"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer/triton/kernels/norm.py
+++ b/flashinfer/triton/kernels/norm.py
@@ -75,3 +75,42 @@ def rms_norm_kernel(
         if HAS_OUT_SCALE:
             result = scale_and_clamp(result, o_scale, output_dtype)
         tl.store(o_row + offsets, result, mask=mask)
+
+
+@triton.jit
+def rms_norm_single_pass_kernel(
+    n,
+    x_ptr,
+    x_stride,
+    w_ptr,
+    o_ptr,
+    o_stride,
+    EPS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+) -> None:
+    """Single-load RMS norm for the plain path (no residual / no in-out scale).
+
+    The whole row fits in one ``BLOCK_SIZE`` tile, so ``x`` is loaded into
+    registers once, reused for both the sum-of-squares reduction and the
+    normalize+weight step. This removes the second global read of ``x`` that
+    the general :func:`rms_norm_kernel` performs, which matters on this
+    bandwidth-bound operator (1 read + 1 write instead of 2 reads + 1 write).
+
+    The arithmetic order matches ``rms_norm_kernel`` exactly, so results are
+    bit-identical to the general path.
+    """
+    i = tl.program_id(axis=0).to(tl.int64)
+
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n
+
+    x = tl.load(x_ptr + i * x_stride + offsets, mask=mask, other=0.0).to(tl.float32)
+
+    rms = tl.rsqrt(tl.sum(x * x) / n + EPS)
+
+    w = tl.load(w_ptr + offsets, mask=mask).to(tl.float32)
+
+    # Multiply x with RMS on float32, matching rms_norm_kernel's order so the
+    # HF cast behaviour (and numerics) are preserved.
+    result = w * (x * rms)
+    tl.store(o_ptr + i * o_stride + offsets, result, mask=mask)

--- a/flashinfer/triton/norm.py
+++ b/flashinfer/triton/norm.py
@@ -3,7 +3,15 @@ from typing import Optional
 import torch
 import triton  # type: ignore[import]
 
-from flashinfer.triton.kernels.norm import rms_norm_kernel
+from flashinfer.triton.kernels.norm import (
+    rms_norm_kernel,
+    rms_norm_single_pass_kernel,
+)
+
+# Above this hidden size the whole row no longer fits comfortably in registers,
+# so the single-pass fast path is disabled to avoid register spills and the
+# general (streaming-capable) kernel is used instead.
+_SINGLE_PASS_MAX_HIDDEN = 8192
 
 
 def rms_norm(
@@ -21,8 +29,37 @@ def rms_norm(
 
     b, n = x.shape
 
+    # Both kernels address the hidden dimension with a bare element index
+    # (`ptr + offsets`), i.e. they assume it is contiguous; only the row stride
+    # is passed through. Reject a non-contiguous hidden dim rather than silently
+    # reading the wrong elements.
+    if x.stride(1) != 1 or out.stride(1) != 1 or weight.stride(0) != 1:
+        raise ValueError(
+            "rms_norm requires a contiguous hidden dimension for x, out, and "
+            "weight (stride 1 along the last axis)."
+        )
+
     block_size = triton.next_power_of_2(n)
     num_warps = max(8, min(32, block_size // 256))
+
+    # Guarded single-load fast path: no input/output scale, and the hidden dim
+    # fits safely in one tile. The whole row is then loaded once into registers
+    # and reused for both the reduction and the normalize step, avoiding the
+    # second global read of x that the general kernel performs. Results are
+    # bit-identical to the general path.
+    if in_scale is None and out_scale is None and n <= _SINGLE_PASS_MAX_HIDDEN:
+        rms_norm_single_pass_kernel[(b,)](
+            n=n,
+            x_ptr=x,
+            x_stride=x.stride(0),
+            w_ptr=weight,
+            o_ptr=out,
+            o_stride=out.stride(0),
+            EPS=eps,
+            BLOCK_SIZE=block_size,
+            num_warps=num_warps,
+        )
+        return
 
     rms_norm_kernel[(b,)](
         n=n,

--- a/flashinfer/triton/norm.py
+++ b/flashinfer/triton/norm.py
@@ -100,6 +100,25 @@ def rms_norm_add_residual(
     b, n = x.shape
 
     assert x.shape == residual.shape
+
+    # Same contiguity contract as `rms_norm` above: `rms_norm_kernel` indexes the
+    # hidden dimension of x, residual, weight and the output with a bare element
+    # offset. Note the residual is also *written* by the kernel (`r = r + x` is
+    # stored back), so a non-contiguous residual would corrupt the caller's tensor
+    # rather than merely produce a wrong result.
+    if (
+        x.stride(1) != 1
+        or residual.stride(1) != 1
+        or weight.stride(0) != 1
+        or (x_out is not None and x_out.stride(1) != 1)
+    ):
+        raise ValueError(
+            "rms_norm_add_residual requires a contiguous hidden dimension for x, "
+            "residual, x_out, and weight (stride 1 along the last axis)."
+        )
+
+    # Checked after the contiguity guard: a strided view typically also has a
+    # different row stride, and the ValueError above names the actual problem.
     assert x.stride(0) == residual.stride(0)
 
     block_size = triton.next_power_of_2(n)

--- a/scripts/task_jit_run_tests_part3.sh
+++ b/scripts/task_jit_run_tests_part3.sh
@@ -16,3 +16,7 @@ fi
 # Run each test file separately to isolate CUDA memory issues
 pytest -s tests/utils/test_sampling.py
 pytest -s tests/utils/test_topk.py
+# Triton RMSNorm single-load fast path. Placed in shard 3 for A10G (SM86)
+# coverage; the test self-skips below SM80 (the supported Triton version's
+# floor), so it is a no-op on the T4/SM75 leg of this shard.
+pytest -s tests/utils/test_triton_norm.py

--- a/tests/utils/test_triton_norm.py
+++ b/tests/utils/test_triton_norm.py
@@ -1,0 +1,182 @@
+"""
+Copyright (c) 2024 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+triton = pytest.importorskip("triton")
+
+from flashinfer.triton.kernels.norm import rms_norm_kernel  # noqa: E402
+from flashinfer.triton.norm import (  # noqa: E402
+    _SINGLE_PASS_MAX_HIDDEN,
+    rms_norm,
+    rms_norm_add_residual,
+)
+
+pytestmark = [
+    pytest.mark.skipif(
+        not torch.cuda.is_available(),
+        reason="Triton rms_norm requires a CUDA device",
+    ),
+    pytest.mark.skipif(
+        torch.cuda.is_available() and torch.cuda.get_device_capability()[0] < 8,
+        reason="The supported Triton version requires SM80 or newer (bf16 cases "
+        "also need Ampere+); Turing/SM75 is out of range",
+    ),
+]
+
+
+def torch_rms_norm(x, w, eps=1e-6):
+    orig_dtype = x.dtype
+    x = x.float()
+    variance = x.pow(2).mean(dim=-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    # Match the kernel: cast to the narrow dtype only after the weight multiply.
+    x = (x * w.float()).to(orig_dtype)
+    return x
+
+
+def _general_kernel_rms_norm(x, w, eps):
+    """Invoke the general two-pass kernel directly (bypassing the fast-path
+    dispatch) to obtain the reference the fast path must match bit-for-bit."""
+    b, n = x.shape
+    out = torch.empty_like(x)
+    block_size = triton.next_power_of_2(n)
+    num_warps = max(8, min(32, block_size // 256))
+    rms_norm_kernel[(b,)](
+        n=n,
+        b=b,
+        x_ptr=x,
+        x_stride=x.stride(0),
+        x_scale_ptr=None,
+        r_ptr=None,
+        r_stride=0,
+        w_ptr=w,
+        o_ptr=out,
+        o_stride=out.stride(0),
+        o_scale_ptr=None,
+        EPS=eps,
+        BLOCK_SIZE=block_size,
+        HAS_IN_SCALE=False,
+        HAS_OUT_SCALE=False,
+        HAS_OUTPUT=True,
+        HAS_RESIDUAL=False,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 16, 128, 4096])
+@pytest.mark.parametrize("hidden_size", [1024, 2048, 3072, 4096, 5120, 7168, 8192])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_triton_rms_norm_fastpath(batch_size, hidden_size, dtype):
+    """The single-load fast path is numerically correct and bit-identical to
+    the general two-pass kernel."""
+    torch.manual_seed(0)
+    eps = 1e-6
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    w = torch.randn(hidden_size, dtype=dtype, device="cuda")
+
+    out = torch.empty_like(x)
+    rms_norm(x, w, out, eps)
+
+    # Correctness against a plain torch reference.
+    ref = torch_rms_norm(x, w, eps)
+    torch.testing.assert_close(out, ref, rtol=1e-3, atol=1e-3)
+
+    # Bit-exact equivalence with the general kernel it replaces.
+    general = _general_kernel_rms_norm(x, w, eps)
+    assert torch.equal(out, general), "fast path diverged from general kernel"
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_triton_rms_norm_large_hidden_fallback(dtype):
+    """Hidden dims above the fast-path cap fall back to the general kernel and
+    stay correct."""
+    torch.manual_seed(0)
+    eps = 1e-6
+    hidden_size = _SINGLE_PASS_MAX_HIDDEN * 2  # 16384, above the cap
+    x = torch.randn(8, hidden_size, dtype=dtype, device="cuda")
+    w = torch.randn(hidden_size, dtype=dtype, device="cuda")
+
+    out = torch.empty_like(x)
+    rms_norm(x, w, out, eps)
+
+    ref = torch_rms_norm(x, w, eps)
+    torch.testing.assert_close(out, ref, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("which", ["x", "out", "weight"])
+def test_triton_rms_norm_noncontiguous_rejected(which):
+    """A non-contiguous hidden dimension (inner stride != 1) is rejected: both
+    kernels index the hidden dim with a bare element offset and would otherwise
+    read the wrong elements."""
+    torch.manual_seed(0)
+    eps = 1e-6
+    dtype = torch.float16
+    batch_size, hidden_size = 16, 4096
+
+    def strided_2d():
+        # Slice out every other column so the inner stride is 2.
+        base = torch.randn(batch_size, hidden_size * 2, dtype=dtype, device="cuda")
+        return base[:, ::2]
+
+    def strided_1d():
+        base = torch.randn(hidden_size * 2, dtype=dtype, device="cuda")
+        return base[::2]
+
+    x = (
+        strided_2d()
+        if which == "x"
+        else torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    )
+    out = strided_2d() if which == "out" else torch.empty_like(x)
+    w = (
+        strided_1d()
+        if which == "weight"
+        else torch.randn(hidden_size, dtype=dtype, device="cuda")
+    )
+
+    assert x.stride(1) != 1 or out.stride(1) != 1 or w.stride(0) != 1
+    with pytest.raises(ValueError):
+        rms_norm(x, w, out, eps)
+
+
+def test_triton_rms_norm_residual_unaffected():
+    """The fused residual path is untouched by the fast-path dispatch."""
+    torch.manual_seed(0)
+    eps = 1e-6
+    batch_size, hidden_size = 16, 4096
+    dtype = torch.float16
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    residual = torch.randn_like(x)
+    w = torch.randn(hidden_size, dtype=dtype, device="cuda")
+
+    # Reference: r = r + x; out = rmsnorm(r)
+    r_ref = (residual.float() + x.float()).to(dtype)
+    out_ref = torch_rms_norm(r_ref, w, eps)
+
+    x_work = x.clone()
+    r_work = residual.clone()
+    out = torch.empty_like(x)
+    rms_norm_add_residual(x_work, r_work, w, eps, x_out=out)
+
+    torch.testing.assert_close(r_work, r_ref, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(out, out_ref, rtol=1e-3, atol=1e-3)
+
+
+if __name__ == "__main__":
+    test_triton_rms_norm_fastpath(16, 4096, torch.float16)

--- a/tests/utils/test_triton_norm.py
+++ b/tests/utils/test_triton_norm.py
@@ -25,6 +25,7 @@ from flashinfer.triton.norm import (  # noqa: E402
     rms_norm,
     rms_norm_add_residual,
 )
+from flashinfer.utils import get_compute_capability  # noqa: E402
 
 pytestmark = [
     pytest.mark.skipif(
@@ -32,7 +33,11 @@ pytestmark = [
         reason="Triton rms_norm requires a CUDA device",
     ),
     pytest.mark.skipif(
-        torch.cuda.is_available() and torch.cuda.get_device_capability()[0] < 8,
+        # The is_available() guard must stay: get_compute_capability raises on a
+        # non-CUDA device, and skipif conditions are evaluated at collection time
+        # even on CPU-only hosts.
+        torch.cuda.is_available()
+        and get_compute_capability(torch.device("cuda"))[0] < 8,
         reason="The supported Triton version requires SM80 or newer (bf16 cases "
         "also need Ampere+); Turing/SM75 is out of range",
     ),
@@ -153,6 +158,45 @@ def test_triton_rms_norm_noncontiguous_rejected(which):
     assert x.stride(1) != 1 or out.stride(1) != 1 or w.stride(0) != 1
     with pytest.raises(ValueError):
         rms_norm(x, w, out, eps)
+
+
+@pytest.mark.parametrize("which", ["x", "residual", "weight", "x_out"])
+def test_triton_rms_norm_add_residual_noncontiguous_rejected(which):
+    """`rms_norm_add_residual` shares `rms_norm_kernel` and so shares the
+    contiguous-hidden-dim contract. The residual is additionally *written* by the
+    kernel, so a non-contiguous residual would corrupt the caller's tensor."""
+    torch.manual_seed(0)
+    eps = 1e-6
+    dtype = torch.float16
+    batch_size, hidden_size = 16, 4096
+
+    def strided_2d():
+        # Slice out every other column so the inner stride is 2.
+        base = torch.randn(batch_size, hidden_size * 2, dtype=dtype, device="cuda")
+        return base[:, ::2]
+
+    def dense_2d():
+        return torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+
+    x = strided_2d() if which == "x" else dense_2d()
+    residual = strided_2d() if which == "residual" else dense_2d()
+    w = (
+        torch.randn(hidden_size * 2, dtype=dtype, device="cuda")[::2]
+        if which == "weight"
+        else torch.randn(hidden_size, dtype=dtype, device="cuda")
+    )
+    # x_out=None is a valid in-place request, so only pass one when it is the
+    # tensor under test or when the case needs a destination.
+    x_out = strided_2d() if which == "x_out" else None
+
+    assert (
+        x.stride(1) != 1
+        or residual.stride(1) != 1
+        or w.stride(0) != 1
+        or (x_out is not None and x_out.stride(1) != 1)
+    )
+    with pytest.raises(ValueError):
+        rms_norm_add_residual(x, residual, w, eps, x_out=x_out)
 
 
 def test_triton_rms_norm_residual_unaffected():


### PR DESCRIPTION
# [triton] Cover and harden the Triton RMSNorm path (+ a bit-identical single-load fast path)

## What this PR is actually for

**Retitled and rewritten after review.** This started as a perf PR. The measured
speedup turned out to be ~1.08×, which is not worth anyone's review bandwidth on its own,
so this description now leads with what I think does stand up:

1. **First test coverage for the Triton norm path.** `flashinfer/triton/norm.py` and
   `flashinfer/triton/kernels/norm.py` had **no tests at all** before this PR. The new
   `tests/utils/test_triton_norm.py` pins the numerics of the existing general kernel
   against a float32 PyTorch reference, and asserts the new fast path is **`torch.equal`
   bit-identical** to the kernel it replaces — not merely close.
2. **A silently-mishandled input class becomes an explicit error.** Both kernels index the
   hidden dimension with a bare element offset (`ptr + offsets`), passing through only the
   row stride — i.e. they have always assumed `stride(-1) == 1`. A caller passing a strided
   view got wrong results with no diagnostic. Both public entry points now raise
   `ValueError` instead.
3. A guarded single-load fast path, worth ~1.08× geomean, byte-identical everywhere.

If (1) and (2) aren't worth the review time either, I'm happy to close this — see
[the review response](#issuecomment-5166010833). I'd rather withdraw it than push a
marginal perf claim.

## The contiguity issue (raised in review, expanded)

Review flagged that guarding only the fast path was insufficient, which was correct.
`rms_norm_kernel` is shared by both public entry points and addresses `x`, `residual`,
`weight` and the output contiguously, so both needed the check.

The residual is the sharp case, because the kernel **writes** it back:

```python
if HAS_RESIDUAL:
    r = tl.load(r_row + offsets, mask=mask, other=0.0).to(tl.float32)
    x += r
    tl.store(r_row + offsets, x, mask=mask)   # <-- caller's tensor
```

A non-contiguous `residual` therefore corrupts the caller's own buffer, rather than only
returning a wrong value. Both `rms_norm` and `rms_norm_add_residual` now reject a
non-unit inner stride on every tensor they touch (`x`, `out`/`x_out`, `residual`,
`weight`).

In `rms_norm_add_residual` the guard is deliberately ordered **before** the pre-existing
`assert x.stride(0) == residual.stride(0)`: a strided view usually also has a different
row stride, so with the natural ordering most rejection cases surfaced as a bare
`AssertionError` and the informative `ValueError` was unreachable.

This is a pre-existing assumption of the general kernel being made explicit. No currently
correct call is newly rejected — any input this now rejects was already producing wrong
results or corrupting memory.

## The fast path

`rms_norm_kernel` always launches a single tile per row (`BLOCK_SIZE = next_power_of_2(n)`),
yet walks `x` **twice**: once to accumulate the sum of squares, then again from global
memory to produce the normalized output. On the plain path that second read is redundant —
the row was in registers a moment earlier.

`rms_norm_single_pass_kernel` is selected by `rms_norm(...)` only when all of:

- no fused residual;
- no input scale and no output scale/clamp (`in_scale is None and out_scale is None`);
- contiguous hidden dim (now enforced for both paths, as above);
- `n <= 8192`, so the row fits one tile without excessive register pressure.

It loads the row once, reuses it for both the reduction and the normalize+weight step, and
stores — 1 read + 1 write instead of 2 + 1. The arithmetic (fp32 reduction,
`w * (x * rms)` with the narrowing cast after the weight multiply) matches the general
kernel exactly, so output is byte-for-byte identical.

Residual fusion, quantized in/out (fp8 scale + clamp), and hidden dims above 8192 fall
back to `rms_norm_kernel`, **unchanged**. The wrapper already branched on residual/scale
flags in Python, so dispatch is a single early `if` — no new public API, no signature change.

## Tests

`tests/utils/test_triton_norm.py`, new here:

- **fast path** over hidden dims 1024–8192 (1024, 2048, 3072, 4096, 5120, 7168, 8192) ×
  decode/prefill token counts × fp16/bf16 — checked against a float32 PyTorch reference
  **and** `torch.equal` against the general kernel (bit-exact);
- **large-hidden fallback** (16384) stays correct;
- **non-contiguous rejection** for `rms_norm` (`x` / `out` / `weight`) and for
  `rms_norm_add_residual` (`x` / `residual` / `weight` / `x_out`, including the in-place
  `x_out=None` form);
- the **fused-residual** numerics are unaffected by the dispatch change.

Wired into CI shard 3 (A10G / SM86). Self-skips below SM80 — the supported Triton
version's floor, and the bf16 cases need Ampere+ — so it is a no-op on the T4/SM75 leg of
that shard rather than a spurious failure.

## Benchmark

`benchmarks/bench_triton_rmsnorm.py` (added here) times the fast path against the general
kernel over the sweep above, asserting `torch.equal` on every workload and reporting
effective bandwidth. Defaults to `--repeat 5 --iters 100`.

Measured (torch 2.12.0+cu130, triton 3.7.0, CUDA-event median, repeat 5×100):

| GPU | byte-equal | speedup geomean | range |
|---|:--:|--:|--:|
| A100-SXM4-80GB | 56/56 | **1.078×** | 1.026–1.198× |
| H100 80GB HBM3 | 56/56 | **1.092×** | 1.053–1.185× |

All 112 measurements (56 shapes × 2 GPUs) are byte-identical to the current kernel and
none regresses.

**Why this is only ~1.08×, not the ~1.5× the traffic count implies.** Within a single
row's program the second load of `x` mostly hits L1/L2 — the row was resident microseconds
earlier — so what is saved is L2 bandwidth and load instructions, not a full HBM read. An
earlier revision of this PR quoted 1.55×; that figure came from a benchmark that did not
control for the warm cache and **overstated the effect**. The numbers above are the honest
ones. The gain is largest on mid-size bandwidth-bound shapes and smallest on the largest
shapes, which are already HBM-saturated.

## Risk

The general kernel is untouched and the fast path is guarded, so the blast radius is the
plain contiguous path — the one that was doing the redundant read.

On register pressure: the fast path launches with the **same** `BLOCK_SIZE` and `num_warps`
the general kernel already uses, and holds one `BLOCK_SIZE` fp32 vector live (`x`) where
the general kernel held one live too (`square_sum`) and re-materialized `x` in its second
loop. It does not raise the live-register footprint relative to the existing kernel; the
`n <= 8192` cap bounds that shared footprint conservatively rather than introducing a new
one. Measured on A100 and H100 (Ampere + Hopper). The shared block-size argument suggests
it holds on other SM80+ parts (A10G/L4/etc.), but those were **not** measured. Pre-Ampere
(Turing/SM75) is outside the supported Triton stack's SM80 floor, so the test self-skips
there rather than asserting behaviour.

Measured with `triton==3.7.0`; other Triton versions may schedule the load/reduce
differently, but the output is bit-identical regardless.

## AI assistance disclosure

Prepared with AI assistance (Claude). A human reviewed every changed line and ran the
tests and benchmarks above; the correctness argument and the measured numbers — including
the retraction of the earlier 1.55× figure — have been checked and are defended by the
submitter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved RMSNorm performance for supported configurations by reducing memory traffic with a single-pass GPU execution path.
  - Automatically falls back to the general implementation for larger hidden dimensions or scaled inputs.

- **Bug Fixes**
  - Added validation to reject tensors with unsupported hidden-dimension layouts instead of producing incorrect results.

- **Tests**
  - Added GPU coverage for numerical accuracy, fallback behavior, layout validation, and residual normalization compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
