### PR TITLE
fix: avoid SM120 MXFP8 MXFP4 autotune crash

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -632,7 +632,17 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             use_wfp4afp8_humming=use_wfp4afp8_humming,
         )
 
-        if profile_ids is None:
+        if (
+            profile_ids is None
+            and backend in ("120", "121")
+            and use_mxfp8_act_scaling
+            and fc1_expert_weights.dtype == torch.int64
+        ):
+            # The SM120 profiler cannot safely construct MXFP8 x MXFP4 TMA
+            # inputs yet. Profiling these tactics can poison the CUDA context,
+            # so use the runner's fallback tactics for this mode.
+            gemm_tactic_1, gemm_tactic_2 = -1, -1
+        elif profile_ids is None:
             tuner = AutoTuner.get()
             MoERunner.refine_tuning_config(tune_max_num_tokens)
 

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -934,7 +934,17 @@ def get_cutlass_fused_moe_module(backend: str = "100", use_fast_build: bool = Fa
             use_wfp4afp8_humming=use_wfp4afp8_humming,
         )
 
-        if profile_ids is None:
+        if (
+            profile_ids is None
+            and backend in ("120", "121")
+            and use_mxfp8_act_scaling
+            and fc1_expert_weights.dtype == torch.int64
+        ):
+            # The SM120 profiler cannot safely construct MXFP8 x MXFP4 TMA
+            # inputs yet. Profiling these tactics can poison the CUDA context,
+            # so use the runner's fallback tactics for this mode.
+            gemm_tactic_1, gemm_tactic_2 = -1, -1
+        elif profile_ids is None:
             tuner = AutoTuner.get()
             MoERunner.refine_tuning_config(tune_max_num_tokens)
 

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -1512,6 +1512,7 @@ def test_moe_mxfp8_mxfp4(
     alpha,
     beta,
     limit,
+    use_autotune=False,
 ):
     """
     Test MoE with MXFP8 activations and MXFP4 weights.
@@ -1562,21 +1563,22 @@ def test_moe_mxfp8_mxfp4(
         beta_t = None
 
     # Call cutlass_fused_moe with MXFP8 activations and MXFP4 weights
-    _ = fused_moe.cutlass_fused_moe(
-        mxfp8_x,
-        selected_experts.to(torch.int),
-        routing_weights,
-        mxfp4_w1.contiguous().view(torch.long),
-        mxfp4_w2.contiguous().view(torch.long),
-        otype,
-        swiglu_alpha=alpha_t,
-        swiglu_limit=limit_t,
-        swiglu_beta=beta_t,
-        quant_scales=quant_scales,
-        input_sf=mxfp8_x_sf,
-        use_mxfp8_act_scaling=True,
-        output=flash_output,
-    )
+    with autotune(True) if use_autotune else nullcontext():
+        _ = fused_moe.cutlass_fused_moe(
+            mxfp8_x,
+            selected_experts.to(torch.int),
+            routing_weights,
+            mxfp4_w1.contiguous().view(torch.long),
+            mxfp4_w2.contiguous().view(torch.long),
+            otype,
+            swiglu_alpha=alpha_t,
+            swiglu_limit=limit_t,
+            swiglu_beta=beta_t,
+            quant_scales=quant_scales,
+            input_sf=mxfp8_x_sf,
+            use_mxfp8_act_scaling=True,
+            output=flash_output,
+        )
 
     dq_mxfp8_x = (
         mxfp8_dequantize_host(
@@ -1620,6 +1622,25 @@ def test_moe_mxfp8_mxfp4(
     )
 
     torch.testing.assert_close(ref_output, flash_output, rtol=1e-1, atol=1e-1)
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability() not in [(12, 0), (12, 1)],
+    reason="Regression test is specific to SM120/SM121 autotuning",
+)
+def test_moe_mxfp8_mxfp4_autotune_sm120():
+    test_moe_mxfp8_mxfp4(
+        batch_size=1,
+        hidden_size=128,
+        num_experts=2,
+        top_k=2,
+        intermediate_size=128,
+        otype=torch.bfloat16,
+        alpha=None,
+        beta=None,
+        limit=None,
+        use_autotune=True,
+    )
 
 
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -1570,7 +1570,7 @@ def test_moe_mxfp8_mxfp4(
     alpha,
     beta,
     limit,
-    use_autotune,
+    use_autotune=False,
 ):
     """
     Test MoE with MXFP8 activations and MXFP4 weights.
@@ -1680,6 +1680,25 @@ def test_moe_mxfp8_mxfp4(
     )
 
     torch.testing.assert_close(ref_output, flash_output, rtol=1e-1, atol=1e-1)
+
+
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability() not in [(12, 0), (12, 1)],
+    reason="Regression test is specific to SM120/SM121 autotuning",
+)
+def test_moe_mxfp8_mxfp4_autotune_sm120():
+    test_moe_mxfp8_mxfp4(
+        batch_size=1,
+        hidden_size=128,
+        num_experts=2,
+        top_k=2,
+        intermediate_size=128,
+        otype=torch.bfloat16,
+        alpha=None,
+        beta=None,
+        limit=None,
+        use_autotune=True,
+    )
 
 
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)


### PR DESCRIPTION
## Summary
- skip unsafe SM120/SM121 MXFP8 x MXFP4 profiling and use fallback tactics
- add focused autotune regression coverage

Fixes #4049

## Testing
- focused autotune and non-autotune MXFP8 x MXFP4 tests on SM120
- `ruff check` and `ruff format --check` on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fused Mixture-of-Experts execution on SM120/SM121 for MXFP8 activations with MXFP4 weights by skipping unsupported profiling/tactic autotuning in a specific configuration.

- **Tests**
  - Added a `use_autotune` option to the MXFP8/MXFP4 test to run with autotuning enabled or disabled.
  - Introduced an SM120/SM121-targeted regression test to validate the autotuned path on supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->