### PR TITLE
perf(moe): phase NVFP4 dispatch payload copies at EP4/EP8/EP16

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -425,9 +425,9 @@ __global__ void moeA2ADispatchKernel(
     int local_num_tokens, int rank_id, int ep_size, int num_experts, int eplb_stats_num_experts,
     bool enable_pdl) {
   static_assert(!COMPACT_EP4 || TOP_K > kEp4Size);
-  static_assert(!PHASE_H2048_NVFP4 || (COMPACT_EP4 && TOP_K == 22));
+  static_assert(!PHASE_H2048_NVFP4 || TOP_K == 22);
   static_assert(!PHASE_NVFP4_PAYLOADS ||
-                (COMPACT_EP4 && TOP_K % 2 == 0 &&
+                (TOP_K > kEp4Size && TOP_K % 2 == 0 &&
                  TOP_K * static_cast<int>(sizeof(int32_t)) / kDispatchMetadataVectorBytes <=
                      kDispatchHalfWarpSize));
   static_assert(!PHASE_H2048_NVFP4 || !PHASE_NVFP4_PAYLOADS);
@@ -791,15 +791,20 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
       max_payload_bytes_per_token = kernel_ptrs.payload_bytes_per_token[i];
     }
   }
+  bool const supports_phased_nvfp4 =
+      params.ep_size == kEp4Size || params.ep_size == 8 || params.ep_size == 16;
+  bool const phased_nvfp4_layout =
+      supports_phased_nvfp4 &&
+      isPhasedNvfp4PayloadLayout(kernel_ptrs, params.num_payloads, params.top_k);
+
   // Small payloads do not have enough 16-byte vectors to use larger CTAs. A GB200
   // sweep found 128 threads faster than both 64 and 256 at prefill token counts.
-  if (use_compact_ep4 && max_payload_bytes_per_token <= kCompactDispatchMaxPayloadBytes &&
+  if ((use_compact_ep4 || phased_nvfp4_layout) &&
+      max_payload_bytes_per_token <= kCompactDispatchMaxPayloadBytes &&
       block_size > kCompactDispatchBlockSize) {
     block_size = kCompactDispatchBlockSize;
   }
-  bool const phase_nvfp4_payloads =
-      use_compact_ep4 && block_size == kCompactDispatchBlockSize &&
-      isPhasedNvfp4PayloadLayout(kernel_ptrs, params.num_payloads, params.top_k);
+  bool const phase_nvfp4_payloads = phased_nvfp4_layout && block_size == kCompactDispatchBlockSize;
 
   // Configure kernel launch: one block per token
   int grid_size = params.local_num_tokens;
@@ -812,28 +817,55 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
     SWITCH_BOOL(params.enable_eplb, EPLB_STATS, {
       if (phase_nvfp4_payloads && params.top_k == 22 &&
           kernel_ptrs.payload_bytes_per_token[0] == kNvfp4H2048ActivationBytes) {
-        int shared_bytes = kEp4Size * (int)sizeof(int);
-        auto kernel_fn =
-            moeA2ADispatchKernel<22, EPLB_STATS, ENABLE_RANK_MASK, true, true>;
-        launchWithPdlWhenEnabled(
-            "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
-            shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
-            params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
-            params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts,
-            params.enable_pdl);
+        if (use_compact_ep4) {
+          int shared_bytes = kEp4Size * (int)sizeof(int);
+          auto kernel_fn =
+              moeA2ADispatchKernel<22, EPLB_STATS, ENABLE_RANK_MASK, true, true>;
+          launchWithPdlWhenEnabled(
+              "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
+              shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
+              params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
+              params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts,
+              params.enable_pdl);
+        } else {
+          int shared_bytes = 2 * params.top_k * (int)sizeof(int);
+          auto kernel_fn =
+              moeA2ADispatchKernel<22, EPLB_STATS, ENABLE_RANK_MASK, false, true>;
+          launchWithPdlWhenEnabled(
+              "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
+              shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
+              params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
+              params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts,
+              params.enable_pdl);
+        }
       } else if (phase_nvfp4_payloads) {
-        int shared_bytes = kEp4Size * (int)sizeof(int);
-        SWITCH_TOP_K(
-            params.top_k, TOP_K, if constexpr (TOP_K > kEp4Size && TOP_K % 2 == 0) {
-              auto kernel_fn = moeA2ADispatchKernel<TOP_K, EPLB_STATS, ENABLE_RANK_MASK, true,
-                                                    false, true>;
-              launchWithPdlWhenEnabled(
-                  "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
-                  shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
-                  params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
-                  params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts,
-                  params.enable_pdl);
-            })
+        if (use_compact_ep4) {
+          int shared_bytes = kEp4Size * (int)sizeof(int);
+          SWITCH_TOP_K(
+              params.top_k, TOP_K, if constexpr (TOP_K > kEp4Size && TOP_K % 2 == 0) {
+                auto kernel_fn = moeA2ADispatchKernel<TOP_K, EPLB_STATS, ENABLE_RANK_MASK, true,
+                                                      false, true>;
+                launchWithPdlWhenEnabled(
+                    "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
+                    shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
+                    params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
+                    params.ep_rank, params.ep_size, params.num_experts,
+                    params.eplb_stats_num_experts, params.enable_pdl);
+              })
+        } else {
+          int shared_bytes = 2 * params.top_k * (int)sizeof(int);
+          SWITCH_TOP_K(
+              params.top_k, TOP_K, if constexpr (TOP_K > kEp4Size && TOP_K % 2 == 0) {
+                auto kernel_fn = moeA2ADispatchKernel<TOP_K, EPLB_STATS, ENABLE_RANK_MASK, false,
+                                                      false, true>;
+                launchWithPdlWhenEnabled(
+                    "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
+                    shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
+                    params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
+                    params.ep_rank, params.ep_size, params.num_experts,
+                    params.eplb_stats_num_experts, params.enable_pdl);
+              })
+        }
       } else if (use_compact_ep4) {
         int shared_bytes = kEp4Size * (int)sizeof(int);
         SWITCH_TOP_K(

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -831,32 +831,30 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
                          "Invalid H2048/top-k-22 NVFP4 dispatch payload layout");
         if (use_compact_ep4) {
           int shared_bytes = kEp4Size * (int)sizeof(int);
-          auto kernel_fn =
-              moeA2ADispatchKernel<22, EPLB_STATS, ENABLE_RANK_MASK, true, true>;
-          launchWithPdlWhenEnabled(
-              "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
-              shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
-              params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
-              params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts,
-              params.enable_pdl);
+          auto kernel_fn = moeA2ADispatchKernel<22, EPLB_STATS, ENABLE_RANK_MASK, true, true>;
+          launchWithPdlWhenEnabled("moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size,
+                                   block_size, shared_bytes, params.stream,
+                                   params.token_selected_experts, kernel_ptrs, params.num_payloads,
+                                   params.max_tokens_per_rank, params.local_num_tokens,
+                                   params.ep_rank, params.ep_size, params.num_experts,
+                                   params.eplb_stats_num_experts, params.enable_pdl);
         } else {
           int shared_bytes = 2 * params.top_k * (int)sizeof(int);
-          auto kernel_fn =
-              moeA2ADispatchKernel<22, EPLB_STATS, ENABLE_RANK_MASK, false, true>;
-          launchWithPdlWhenEnabled(
-              "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
-              shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
-              params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
-              params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts,
-              params.enable_pdl);
+          auto kernel_fn = moeA2ADispatchKernel<22, EPLB_STATS, ENABLE_RANK_MASK, false, true>;
+          launchWithPdlWhenEnabled("moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size,
+                                   block_size, shared_bytes, params.stream,
+                                   params.token_selected_experts, kernel_ptrs, params.num_payloads,
+                                   params.max_tokens_per_rank, params.local_num_tokens,
+                                   params.ep_rank, params.ep_size, params.num_experts,
+                                   params.eplb_stats_num_experts, params.enable_pdl);
         }
       } else if (phase_nvfp4_payloads) {
         if (use_compact_ep4) {
           int shared_bytes = kEp4Size * (int)sizeof(int);
           SWITCH_TOP_K(
               params.top_k, TOP_K, if constexpr (TOP_K > kEp4Size && TOP_K % 2 == 0) {
-                auto kernel_fn = moeA2ADispatchKernel<TOP_K, EPLB_STATS, ENABLE_RANK_MASK, true,
-                                                      false, true>;
+                auto kernel_fn =
+                    moeA2ADispatchKernel<TOP_K, EPLB_STATS, ENABLE_RANK_MASK, true, false, true>;
                 launchWithPdlWhenEnabled(
                     "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
                     shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
@@ -868,8 +866,8 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
           int shared_bytes = 2 * params.top_k * (int)sizeof(int);
           SWITCH_TOP_K(
               params.top_k, TOP_K, if constexpr (TOP_K > kEp4Size && TOP_K % 2 == 0) {
-                auto kernel_fn = moeA2ADispatchKernel<TOP_K, EPLB_STATS, ENABLE_RANK_MASK, false,
-                                                      false, true>;
+                auto kernel_fn =
+                    moeA2ADispatchKernel<TOP_K, EPLB_STATS, ENABLE_RANK_MASK, false, false, true>;
                 launchWithPdlWhenEnabled(
                     "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
                     shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -37,6 +37,16 @@ using tensorrt_llm::common::launchWithPdlWhenEnabled;
 constexpr int kEp4Size = 4;
 constexpr int kCompactDispatchMaxPayloadBytes = 1024;
 constexpr int kCompactDispatchBlockSize = 128;
+constexpr int kDispatchWideVectorBytes = 16;
+constexpr int kDispatchMetadataVectorBytes = 8;
+constexpr int kDispatchHalfWarpSize = 16;
+constexpr int kNvfp4ActivationToScaleRatio = 8;
+constexpr int kNvfp4H2048ActivationBytes = 2048 / 2;
+constexpr int kNvfp4H2048ScaleBytes = 2048 / 16;
+constexpr int kTopK22MetadataBytes = 22 * sizeof(int32_t);
+constexpr int kNvfp4H2048ActivationWorkers = kNvfp4H2048ActivationBytes / 16;
+constexpr int kNvfp4H2048ScaleWorkers = kNvfp4H2048ScaleBytes / 16;
+constexpr int kTopK22MetadataWorkers = kTopK22MetadataBytes / 8;
 
 #ifndef DISABLE_TIMEOUT
 #define DISABLE_TIMEOUT 0
@@ -46,6 +56,29 @@ constexpr int kCompactDispatchBlockSize = 128;
 template <typename T>
 __host__ __device__ inline T ceilDiv(T m, T n) {
   return (m + n - 1) / n;
+}
+
+// The phased schedule reserves two warps for packed activations, one for scales,
+// and splits the last warp between the two routing-metadata payloads.
+static bool isPhasedNvfp4PayloadLayout(DispatchKernelPointers const& ptrs, int num_payloads,
+                                       int top_k) {
+  if (num_payloads != 4 || top_k <= kEp4Size) {
+    return false;
+  }
+
+  int const activation_bytes = ptrs.payload_bytes_per_token[0];
+  int const scale_bytes = ptrs.payload_bytes_per_token[1];
+  int const metadata_bytes = top_k * static_cast<int>(sizeof(int32_t));
+  bool const validated_top_k_layout = top_k < 22 || activation_bytes == kNvfp4H2048ActivationBytes;
+  return validated_top_k_layout && activation_bytes > 0 &&
+         activation_bytes <= kCompactDispatchMaxPayloadBytes &&
+         activation_bytes % kDispatchWideVectorBytes == 0 && scale_bytes > 0 &&
+         scale_bytes % kDispatchWideVectorBytes == 0 &&
+         activation_bytes == kNvfp4ActivationToScaleRatio * scale_bytes &&
+         metadata_bytes % kDispatchMetadataVectorBytes == 0 &&
+         metadata_bytes / kDispatchMetadataVectorBytes <= kDispatchHalfWarpSize &&
+         ptrs.payload_bytes_per_token[2] == metadata_bytes &&
+         ptrs.payload_bytes_per_token[3] == metadata_bytes;
 }
 
 // Macros for concise launch-time specialization
@@ -291,8 +324,8 @@ template <int VEC_SIZE, int TOP_K>
 __device__ void vectorized_dispatch_impl(uint8_t const* src_ptr, int bytes_per_token, int rank_id,
                                          int max_tokens_per_rank, int payload_idx,
                                          DispatchKernelPointers const& ptrs,
-                                         int const* topk_target_ranks,
-                                         int const* topk_send_indices) {
+                                         int const* topk_target_ranks, int const* topk_send_indices,
+                                         int worker_idx, int num_workers) {
   using flashinfer::vec_t;
 
   // Precompute destination base pointers per k
@@ -314,8 +347,8 @@ __device__ void vectorized_dispatch_impl(uint8_t const* src_ptr, int bytes_per_t
   }
 
   // TODO: process all payloads. index could be reused.
-  int const stride = blockDim.x * VEC_SIZE;
-  for (int offset = threadIdx.x * VEC_SIZE; offset < bytes_per_token; offset += stride) {
+  int const stride = num_workers * VEC_SIZE;
+  for (int offset = worker_idx * VEC_SIZE; offset < bytes_per_token; offset += stride) {
     vec_t<uint8_t, VEC_SIZE> v;
     v.load(src_ptr + offset);
 
@@ -337,19 +370,24 @@ __device__ void vectorized_dispatch(uint8_t const* src_ptr, int bytes_per_token,
                                     int const* topk_target_ranks, int const* topk_send_indices) {
   if (bytes_per_token % 16 == 0) {
     vectorized_dispatch_impl<16, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
-                                        payload_idx, ptrs, topk_target_ranks, topk_send_indices);
+                                        payload_idx, ptrs, topk_target_ranks, topk_send_indices,
+                                        threadIdx.x, blockDim.x);
   } else if (bytes_per_token % 8 == 0) {
     vectorized_dispatch_impl<8, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
-                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices);
+                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices,
+                                       threadIdx.x, blockDim.x);
   } else if (bytes_per_token % 4 == 0) {
     vectorized_dispatch_impl<4, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
-                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices);
+                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices,
+                                       threadIdx.x, blockDim.x);
   } else if (bytes_per_token % 2 == 0) {
     vectorized_dispatch_impl<2, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
-                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices);
+                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices,
+                                       threadIdx.x, blockDim.x);
   } else {
     vectorized_dispatch_impl<1, TOP_K>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
-                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices);
+                                       payload_idx, ptrs, topk_target_ranks, topk_send_indices,
+                                       threadIdx.x, blockDim.x);
   }
 }
 
@@ -377,7 +415,8 @@ __global__ void moeA2APrepareDispatchKernel(int* send_counters, int* local_token
 // One CTA processes one token and all its payloads.
 // ============================================================================
 
-template <int TOP_K, bool ENABLE_EPLB, bool ENABLE_RANK_MASK, bool COMPACT_EP4>
+template <int TOP_K, bool ENABLE_EPLB, bool ENABLE_RANK_MASK, bool COMPACT_EP4,
+          bool PHASE_H2048_NVFP4 = false, bool PHASE_NVFP4_PAYLOADS = false>
 __global__ void moeA2ADispatchKernel(
     int32_t const* token_selected_experts,  // [local_num_tokens, TOP_K]
     const DispatchKernelPointers ptrs,      // Struct containing all kernel pointers
@@ -386,6 +425,12 @@ __global__ void moeA2ADispatchKernel(
     int local_num_tokens, int rank_id, int ep_size, int num_experts, int eplb_stats_num_experts,
     bool enable_pdl) {
   static_assert(!COMPACT_EP4 || TOP_K > kEp4Size);
+  static_assert(!PHASE_H2048_NVFP4 || (COMPACT_EP4 && TOP_K == 22));
+  static_assert(!PHASE_NVFP4_PAYLOADS ||
+                (COMPACT_EP4 && TOP_K % 2 == 0 &&
+                 TOP_K * static_cast<int>(sizeof(int32_t)) / kDispatchMetadataVectorBytes <=
+                     kDispatchHalfWarpSize));
+  static_assert(!PHASE_H2048_NVFP4 || !PHASE_NVFP4_PAYLOADS);
   int thread_idx = threadIdx.x;
   int local_token_idx = blockIdx.x;
 
@@ -490,14 +535,76 @@ __global__ void moeA2ADispatchKernel(
       }
     }
 
-    // Perform a single source load and fan out to each unique destination.
-    for (int payload_idx = 0; payload_idx < num_payloads; payload_idx++) {
-      uint8_t const* src_data = static_cast<uint8_t const*>(ptrs.src_data_ptrs[payload_idx]);
-      int bytes_per_token = ptrs.payload_bytes_per_token[payload_idx];
-      uint8_t const* src_ptr = src_data + local_token_idx * bytes_per_token;
+    if constexpr (PHASE_H2048_NVFP4) {
+      // Keep compile-time bounds for the measured Nemotron H2048 target.
+      int warp_id = thread_idx / warpSize;
+      int lane_id = thread_idx % warpSize;
+      if (warp_id < 2) {
+        auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[0]) +
+                          static_cast<size_t>(local_token_idx) * kNvfp4H2048ActivationBytes;
+        vectorized_dispatch_impl<16, NUM_DESTINATIONS>(
+            src, kNvfp4H2048ActivationBytes, rank_id, max_tokens_per_rank, 0, ptrs, target_ranks,
+            send_indices, thread_idx, kNvfp4H2048ActivationWorkers);
+      } else if (warp_id == 2 && lane_id < kNvfp4H2048ScaleWorkers) {
+        auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[1]) +
+                          static_cast<size_t>(local_token_idx) * kNvfp4H2048ScaleBytes;
+        vectorized_dispatch_impl<16, NUM_DESTINATIONS>(
+            src, kNvfp4H2048ScaleBytes, rank_id, max_tokens_per_rank, 1, ptrs, target_ranks,
+            send_indices, lane_id, kNvfp4H2048ScaleWorkers);
+      } else if (warp_id == 3 && lane_id < 2 * kTopK22MetadataWorkers) {
+        bool second_tail = lane_id >= kTopK22MetadataWorkers;
+        int payload_idx = second_tail ? 3 : 2;
+        int worker_idx = second_tail ? lane_id - kTopK22MetadataWorkers : lane_id;
+        auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[payload_idx]) +
+                          static_cast<size_t>(local_token_idx) * kTopK22MetadataBytes;
+        vectorized_dispatch_impl<8, NUM_DESTINATIONS>(
+            src, kTopK22MetadataBytes, rank_id, max_tokens_per_rank, payload_idx, ptrs,
+            target_ranks, send_indices, worker_idx, kTopK22MetadataWorkers);
+      }
+    } else if constexpr (PHASE_NVFP4_PAYLOADS) {
+      // Match warps to the NVFP4 payload widths instead of making all 128
+      // threads materialize destination pointers for every payload.
+      int const activation_bytes = ptrs.payload_bytes_per_token[0];
+      int const scale_bytes = ptrs.payload_bytes_per_token[1];
+      constexpr int METADATA_BYTES = TOP_K * sizeof(int32_t);
+      constexpr int METADATA_WORKERS = METADATA_BYTES / kDispatchMetadataVectorBytes;
+      int const activation_workers = activation_bytes / kDispatchWideVectorBytes;
+      int const scale_workers = scale_bytes / kDispatchWideVectorBytes;
+      int warp_id = thread_idx / warpSize;
+      int lane_id = thread_idx % warpSize;
+      if (warp_id < 2 && thread_idx < activation_workers) {
+        auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[0]) +
+                          static_cast<size_t>(local_token_idx) * activation_bytes;
+        vectorized_dispatch_impl<kDispatchWideVectorBytes, NUM_DESTINATIONS>(
+            src, activation_bytes, rank_id, max_tokens_per_rank, 0, ptrs, target_ranks,
+            send_indices, thread_idx, activation_workers);
+      } else if (warp_id == 2 && lane_id < scale_workers) {
+        auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[1]) +
+                          static_cast<size_t>(local_token_idx) * scale_bytes;
+        vectorized_dispatch_impl<kDispatchWideVectorBytes, NUM_DESTINATIONS>(
+            src, scale_bytes, rank_id, max_tokens_per_rank, 1, ptrs, target_ranks, send_indices,
+            lane_id, scale_workers);
+      } else if (warp_id == 3 && lane_id < 2 * METADATA_WORKERS) {
+        bool second_tail = lane_id >= METADATA_WORKERS;
+        int payload_idx = second_tail ? 3 : 2;
+        int worker_idx = second_tail ? lane_id - METADATA_WORKERS : lane_id;
+        auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[payload_idx]) +
+                          static_cast<size_t>(local_token_idx) * METADATA_BYTES;
+        vectorized_dispatch_impl<kDispatchMetadataVectorBytes, NUM_DESTINATIONS>(
+            src, METADATA_BYTES, rank_id, max_tokens_per_rank, payload_idx, ptrs, target_ranks,
+            send_indices, worker_idx, METADATA_WORKERS);
+      }
+    } else {
+      // Perform a single source load and fan out to each unique destination.
+      for (int payload_idx = 0; payload_idx < num_payloads; payload_idx++) {
+        uint8_t const* src_data = static_cast<uint8_t const*>(ptrs.src_data_ptrs[payload_idx]);
+        int bytes_per_token = ptrs.payload_bytes_per_token[payload_idx];
+        uint8_t const* src_ptr = src_data + local_token_idx * bytes_per_token;
 
-      vectorized_dispatch<NUM_DESTINATIONS>(src_ptr, bytes_per_token, rank_id, max_tokens_per_rank,
-                                            payload_idx, ptrs, target_ranks, send_indices);
+        vectorized_dispatch<NUM_DESTINATIONS>(src_ptr, bytes_per_token, rank_id,
+                                              max_tokens_per_rank, payload_idx, ptrs, target_ranks,
+                                              send_indices);
+      }
     }
 
     __syncthreads();
@@ -690,6 +797,9 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
       block_size > kCompactDispatchBlockSize) {
     block_size = kCompactDispatchBlockSize;
   }
+  bool const phase_nvfp4_payloads =
+      use_compact_ep4 && block_size == kCompactDispatchBlockSize &&
+      isPhasedNvfp4PayloadLayout(kernel_ptrs, params.num_payloads, params.top_k);
 
   // Configure kernel launch: one block per token
   int grid_size = params.local_num_tokens;
@@ -700,7 +810,31 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
   }
   SWITCH_BOOL(params.enable_rank_mask, ENABLE_RANK_MASK, {
     SWITCH_BOOL(params.enable_eplb, EPLB_STATS, {
-      if (use_compact_ep4) {
+      if (phase_nvfp4_payloads && params.top_k == 22 &&
+          kernel_ptrs.payload_bytes_per_token[0] == kNvfp4H2048ActivationBytes) {
+        int shared_bytes = kEp4Size * (int)sizeof(int);
+        auto kernel_fn =
+            moeA2ADispatchKernel<22, EPLB_STATS, ENABLE_RANK_MASK, true, true>;
+        launchWithPdlWhenEnabled(
+            "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
+            shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
+            params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
+            params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts,
+            params.enable_pdl);
+      } else if (phase_nvfp4_payloads) {
+        int shared_bytes = kEp4Size * (int)sizeof(int);
+        SWITCH_TOP_K(
+            params.top_k, TOP_K, if constexpr (TOP_K > kEp4Size && TOP_K % 2 == 0) {
+              auto kernel_fn = moeA2ADispatchKernel<TOP_K, EPLB_STATS, ENABLE_RANK_MASK, true,
+                                                    false, true>;
+              launchWithPdlWhenEnabled(
+                  "moeA2ADispatchKernel", params.enable_pdl, kernel_fn, grid_size, block_size,
+                  shared_bytes, params.stream, params.token_selected_experts, kernel_ptrs,
+                  params.num_payloads, params.max_tokens_per_rank, params.local_num_tokens,
+                  params.ep_rank, params.ep_size, params.num_experts, params.eplb_stats_num_experts,
+                  params.enable_pdl);
+            })
+      } else if (use_compact_ep4) {
         int shared_bytes = kEp4Size * (int)sizeof(int);
         SWITCH_TOP_K(
             params.top_k, TOP_K, if constexpr (TOP_K > kEp4Size) {

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -35,8 +35,11 @@ using tensorrt_llm::common::launchWithPdlWhenEnabled;
 #define DISABLE_SYNC_FOR_PROFILING 0
 
 constexpr int kEp4Size = 4;
+// Two 32-thread warps can cover at most 64 16-byte activation vectors.
 constexpr int kCompactDispatchMaxPayloadBytes = 1024;
 constexpr int kCompactDispatchBlockSize = 128;
+constexpr int kDispatchWarpSize = 32;
+constexpr int kDispatchActivationWarps = 2;
 constexpr int kDispatchWideVectorBytes = 16;
 constexpr int kDispatchMetadataVectorBytes = 8;
 constexpr int kDispatchHalfWarpSize = 16;
@@ -44,9 +47,13 @@ constexpr int kNvfp4ActivationToScaleRatio = 8;
 constexpr int kNvfp4H2048ActivationBytes = 2048 / 2;
 constexpr int kNvfp4H2048ScaleBytes = 2048 / 16;
 constexpr int kTopK22MetadataBytes = 22 * sizeof(int32_t);
-constexpr int kNvfp4H2048ActivationWorkers = kNvfp4H2048ActivationBytes / 16;
-constexpr int kNvfp4H2048ScaleWorkers = kNvfp4H2048ScaleBytes / 16;
-constexpr int kTopK22MetadataWorkers = kTopK22MetadataBytes / 8;
+constexpr int kNvfp4H2048ActivationWorkers = kNvfp4H2048ActivationBytes / kDispatchWideVectorBytes;
+constexpr int kNvfp4H2048ScaleWorkers = kNvfp4H2048ScaleBytes / kDispatchWideVectorBytes;
+constexpr int kTopK22MetadataWorkers = kTopK22MetadataBytes / kDispatchMetadataVectorBytes;
+static_assert(kCompactDispatchMaxPayloadBytes % kDispatchWideVectorBytes == 0);
+static_assert(kCompactDispatchMaxPayloadBytes / kDispatchWideVectorBytes <=
+              kDispatchActivationWarps * kDispatchWarpSize);
+static_assert(kCompactDispatchBlockSize == (kDispatchActivationWarps + 2) * kDispatchWarpSize);
 
 #ifndef DISABLE_TIMEOUT
 #define DISABLE_TIMEOUT 0
@@ -59,7 +66,8 @@ __host__ __device__ inline T ceilDiv(T m, T n) {
 }
 
 // The phased schedule reserves two warps for packed activations, one for scales,
-// and splits the last warp between the two routing-metadata payloads.
+// and splits the last warp between the two routing-metadata payloads. The
+// activation cap intentionally limits this path to hidden sizes up to 2048.
 static bool isPhasedNvfp4PayloadLayout(DispatchKernelPointers const& ptrs, int num_payloads,
                                        int top_k) {
   if (num_payloads != 4 || top_k <= kEp4Size) {
@@ -539,19 +547,19 @@ __global__ void moeA2ADispatchKernel(
       // Keep compile-time bounds for the measured Nemotron H2048 target.
       int warp_id = thread_idx / warpSize;
       int lane_id = thread_idx % warpSize;
-      if (warp_id < 2) {
+      if (warp_id < kDispatchActivationWarps) {
         auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[0]) +
                           static_cast<size_t>(local_token_idx) * kNvfp4H2048ActivationBytes;
         vectorized_dispatch_impl<16, NUM_DESTINATIONS>(
             src, kNvfp4H2048ActivationBytes, rank_id, max_tokens_per_rank, 0, ptrs, target_ranks,
             send_indices, thread_idx, kNvfp4H2048ActivationWorkers);
-      } else if (warp_id == 2 && lane_id < kNvfp4H2048ScaleWorkers) {
+      } else if (warp_id == kDispatchActivationWarps && lane_id < kNvfp4H2048ScaleWorkers) {
         auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[1]) +
                           static_cast<size_t>(local_token_idx) * kNvfp4H2048ScaleBytes;
         vectorized_dispatch_impl<16, NUM_DESTINATIONS>(
             src, kNvfp4H2048ScaleBytes, rank_id, max_tokens_per_rank, 1, ptrs, target_ranks,
             send_indices, lane_id, kNvfp4H2048ScaleWorkers);
-      } else if (warp_id == 3 && lane_id < 2 * kTopK22MetadataWorkers) {
+      } else if (warp_id == kDispatchActivationWarps + 1 && lane_id < 2 * kTopK22MetadataWorkers) {
         bool second_tail = lane_id >= kTopK22MetadataWorkers;
         int payload_idx = second_tail ? 3 : 2;
         int worker_idx = second_tail ? lane_id - kTopK22MetadataWorkers : lane_id;
@@ -572,19 +580,19 @@ __global__ void moeA2ADispatchKernel(
       int const scale_workers = scale_bytes / kDispatchWideVectorBytes;
       int warp_id = thread_idx / warpSize;
       int lane_id = thread_idx % warpSize;
-      if (warp_id < 2 && thread_idx < activation_workers) {
+      if (warp_id < kDispatchActivationWarps && thread_idx < activation_workers) {
         auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[0]) +
                           static_cast<size_t>(local_token_idx) * activation_bytes;
         vectorized_dispatch_impl<kDispatchWideVectorBytes, NUM_DESTINATIONS>(
             src, activation_bytes, rank_id, max_tokens_per_rank, 0, ptrs, target_ranks,
             send_indices, thread_idx, activation_workers);
-      } else if (warp_id == 2 && lane_id < scale_workers) {
+      } else if (warp_id == kDispatchActivationWarps && lane_id < scale_workers) {
         auto const* src = static_cast<uint8_t const*>(ptrs.src_data_ptrs[1]) +
                           static_cast<size_t>(local_token_idx) * scale_bytes;
         vectorized_dispatch_impl<kDispatchWideVectorBytes, NUM_DESTINATIONS>(
             src, scale_bytes, rank_id, max_tokens_per_rank, 1, ptrs, target_ranks, send_indices,
             lane_id, scale_workers);
-      } else if (warp_id == 3 && lane_id < 2 * METADATA_WORKERS) {
+      } else if (warp_id == kDispatchActivationWarps + 1 && lane_id < 2 * METADATA_WORKERS) {
         bool second_tail = lane_id >= METADATA_WORKERS;
         int payload_idx = second_tail ? 3 : 2;
         int worker_idx = second_tail ? lane_id - METADATA_WORKERS : lane_id;
@@ -817,6 +825,10 @@ void moe_a2a_dispatch_launch(MoeA2ADispatchParams const& params) {
     SWITCH_BOOL(params.enable_eplb, EPLB_STATS, {
       if (phase_nvfp4_payloads && params.top_k == 22 &&
           kernel_ptrs.payload_bytes_per_token[0] == kNvfp4H2048ActivationBytes) {
+        FLASHINFER_CHECK(kernel_ptrs.payload_bytes_per_token[1] == kNvfp4H2048ScaleBytes &&
+                             kernel_ptrs.payload_bytes_per_token[2] == kTopK22MetadataBytes &&
+                             kernel_ptrs.payload_bytes_per_token[3] == kTopK22MetadataBytes,
+                         "Invalid H2048/top-k-22 NVFP4 dispatch payload layout");
         if (use_compact_ep4) {
           int shared_bytes = kEp4Size * (int)sizeof(int);
           auto kernel_fn =

--- a/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/csrc/nv_internal/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -77,6 +77,8 @@ static bool isPhasedNvfp4PayloadLayout(DispatchKernelPointers const& ptrs, int n
   int const activation_bytes = ptrs.payload_bytes_per_token[0];
   int const scale_bytes = ptrs.payload_bytes_per_token[1];
   int const metadata_bytes = top_k * static_cast<int>(sizeof(int32_t));
+  // Smaller top-k layouts support runtime activation widths (including H1024).
+  // Top-k 22 is restricted to the measured H2048 configuration.
   bool const validated_top_k_layout = top_k < 22 || activation_bytes == kNvfp4H2048ActivationBytes;
   return validated_top_k_layout && activation_bytes > 0 &&
          activation_bytes <= kCompactDispatchMaxPayloadBytes &&
@@ -354,7 +356,8 @@ __device__ void vectorized_dispatch_impl(uint8_t const* src_ptr, int bytes_per_t
     dst_base_k[k] = dst_data + base_token;
   }
 
-  // TODO: process all payloads. index could be reused.
+  // The caller assigns a worker subset to this payload. Only those workers pay
+  // the per-destination pointer setup and copy cost.
   int const stride = num_workers * VEC_SIZE;
   for (int offset = worker_idx * VEC_SIZE; offset < bytes_per_token; offset += stride) {
     vec_t<uint8_t, VEC_SIZE> v;

--- a/tests/comm/test_mnnvl_moe_alltoall.py
+++ b/tests/comm/test_mnnvl_moe_alltoall.py
@@ -207,8 +207,11 @@ def make_nvfp4_payloads(
     token_selected_experts: torch.Tensor,
     lora_ids: torch.Tensor | None = None,
 ) -> tuple[list, int]:
-    """Create the four NV FP4 payloads exactly as in single-GPU test, with an
-    optional 5th LoRA adapter ID payload."""
+    """Create the production NVFP4 dispatch wire layout.
+
+    Dispatch copies opaque bytes, so uint8 scale patterns avoid requiring FP8
+    arithmetic while preserving the production one-byte scale width.
+    """
     payloads = []
     # Payload 0: Packed FP4 tokens (uint8)
     packed_hidden_size = hidden_size // 2
@@ -217,21 +220,24 @@ def make_nvfp4_payloads(
     )
     payloads.append(packed_hidden_states)
 
-    # Payload 1: Scaling factors (fp8)
+    # Payload 1: One-byte scaling factors (FP8 on the production path)
     num_elts_per_sf = 16
     num_scaling_factors = hidden_size // num_elts_per_sf
-    scaling_factors = torch.randn(
-        local_num_tokens, num_scaling_factors, dtype=torch.float32, device="cuda"
-    )  #  .to(torch.float8_e4m3fn) TODO: Test failed.
-    scaling_factors += rank
+    scaling_factors = torch.randint(
+        0,
+        256,
+        (local_num_tokens, num_scaling_factors),
+        dtype=torch.uint8,
+        device="cuda",
+    )
     payloads.append(scaling_factors)
 
     # Payload 2: token_selected_experts
     payloads.append(token_selected_experts)
 
-    # Payload 3: token_final_scales (bfloat16)
+    # Payload 3: FP32 routing weights, matching the production wire width
     token_final_scales = torch.rand(
-        local_num_tokens, top_k, dtype=torch.bfloat16, device="cuda"
+        local_num_tokens, top_k, dtype=torch.float32, device="cuda"
     )
 
     # Construct the data to contain info about send rank and local_token_idx, which is used for debugging
@@ -609,7 +615,7 @@ def verify_dispatch(
                     assert torch.all(token_expert_ids == invalid_token_expert_id)
 
 
-def moe_a2a_dispatch_test_impl(distribution, top_k, use_lora=False):
+def moe_a2a_dispatch_test_impl(distribution, top_k, use_lora=False, hidden_size=1024):
     """Test MoE A2A dispatch operation."""
     comm = MPI.COMM_WORLD
     world_size = comm.Get_size()
@@ -630,7 +636,6 @@ def moe_a2a_dispatch_test_impl(distribution, top_k, use_lora=False):
     except Exception:
         pytest.skip("MNNVL not supported on this system")
 
-    hidden_size = 1024
     num_experts_per_rank = max(8, (top_k + ep_size - 1) // ep_size)
     invalid_token_expert_id = -1
 
@@ -707,6 +712,11 @@ def moe_a2a_dispatch_test_impl(distribution, top_k, use_lora=False):
 def test_moe_a2a_dispatch(distribution, top_k, use_lora):
     """Test MoE A2A dispatch operation."""
     safe_run(moe_a2a_dispatch_test_impl, distribution, top_k, use_lora)
+
+
+def test_moe_a2a_dispatch_phased_h2048_nvfp4():
+    """Exercise the specialized H2048/top-k-22 NVFP4 dispatch layout."""
+    safe_run(moe_a2a_dispatch_test_impl, "uniform", 22, False, 2048)
 
 
 def create_lora_weights(num_adapters, hidden_size, device, dtype=torch.bfloat16):

--- a/tests/comm/test_mnnvl_moe_alltoall.py
+++ b/tests/comm/test_mnnvl_moe_alltoall.py
@@ -207,7 +207,8 @@ def make_nvfp4_payloads(
     token_selected_experts: torch.Tensor,
     lora_ids: torch.Tensor | None = None,
 ) -> tuple[list, int]:
-    """Create the production NVFP4 dispatch wire layout.
+    """Create the production NVFP4 dispatch wire layout, with an optional
+    fifth LoRA adapter-ID payload.
 
     Dispatch copies opaque bytes, so uint8 scale patterns avoid requiring FP8
     arithmetic while preserving the production one-byte scale width.
@@ -715,7 +716,10 @@ def test_moe_a2a_dispatch(distribution, top_k, use_lora):
 
 
 def test_moe_a2a_dispatch_phased_h2048_nvfp4():
-    """Exercise the specialized H2048/top-k-22 NVFP4 dispatch layout."""
+    """Exercise the specialized H2048/top-k-22 NVFP4 dispatch kernel."""
+    ep_size = MPI.COMM_WORLD.Get_size()
+    if ep_size not in (4, 8, 16):
+        pytest.skip("phased NVFP4 dispatch requires EP4, EP8, or EP16")
     safe_run(moe_a2a_dispatch_test_impl, "uniform", 22, False, 2048)
 
 
@@ -951,5 +955,5 @@ def test_moe_a2a_dispatch_moe_combine(distribution, top_k, use_lora):
 
 
 if __name__ == "__main__":
-    # Run with: mpirun -n 2 python -m pytest tests/comm/test_mnnvl_a2a.py -v
+    # Run with: mpirun -n 4 python -m pytest tests/comm/test_mnnvl_moe_alltoall.py -v
     pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary

Follow-up to #3846. The generic dispatch kernel makes every CTA thread build remote destination pointers for every payload before determining whether that thread owns any bytes. NVFP4 has four predictably asymmetric payloads, so this change gives each payload only the workers it needs:

- two warps for packed activations;
- the required lanes of one warp for scales;
- two lane groups in the final warp for expert IDs and routing weights.

EP4 retains its compact per-rank destination list. EP8 and EP16 retain the existing top-k-sized representation; only their copy schedule changes. The phased path is gated to EP `{4, 8, 16}`, a 128-thread CTA, and validated four-payload NVFP4 layouts. Unsupported EP sizes, top-k values, widths, and payload layouts use the existing generic kernel.

The H2048/top-k-22 target retains compile-time payload widths. Validated smaller layouts use the same schedule with runtime activation and scale widths.

## Performance

### Single op

GB200, H2048, top-k 22, CUDA graphs. EP8 and EP16 are true global expert-parallel groups spanning two and four nodes.

| Global EP | Nodes | Tokens/rank | Baseline | Candidate | Delta |
|---:|---:|---:|---:|---:|---:|
| 4 | 1 | 1 | 13.480 us | 12.862 us | -4.58% |
| 4 | 1 | 4 | 14.408 us | 13.490 us | -6.37% |
| 4 | 1 | 64 | 16.511 us | 15.284 us | -7.43% |
| 4 | 1 | 512 | 18.155 us | 17.804 us | -1.93% |
| 4 | 1 | 8192 | 55.072 us | 54.689 us | -0.70% |
| 8 | 2 | 1 | 16.270 us | 13.877 us | -14.71% |
| 8 | 2 | 4 | 18.394 us | 14.679 us | -20.20% |
| 8 | 2 | 64 | 21.253 us | 17.358 us | -18.33% |
| 8 | 2 | 512 | 40.520 us | 27.275 us | -32.69% |
| 8 | 2 | 1024 | 64.713 us | 37.797 us | -41.59% |
| 8 | 2 | 8192 | 308.292 us | 96.494 us | -68.70% |
| 16 | 4 | 1 | 18.107 us | 15.733 us | -13.11% |
| 16 | 4 | 4 | 21.639 us | 17.328 us | -19.92% |
| 16 | 4 | 64 | 25.264 us | 20.652 us | -18.26% |
| 16 | 4 | 512 | 55.275 us | 41.484 us | -24.95% |
| 16 | 4 | 1024 | 100.321 us | 68.156 us | -32.06% |
| 16 | 4 | 8192 | 373.115 us | 176.750 us | -52.63% |

### E2e workload

On the **Nemotron Ultra NVFP4 end-to-end** workload (2 GB200 nodes, TP1/DP8/EP8, FlashInfer one-sided, CUDA graphs, ISL/OSL 8192/8, concurrency 8), mean TTFT improves from 860.8 ms to 839.9 ms (**-2.43%**, 95% CI [-3.44%, -1.41%]). Throughput (+0.62%) and TPOT are statistically on par.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for additional phased NVFP4 layouts in Mixture-of-Experts all-to-all dispatch.
  * Added a specialized H2048 phased dispatch path, including top‑k=22 configurations.
* **Performance**
  * Improved dispatch efficiency by optimizing activation, scale, and routing-metadata movement.
* **Bug Fixes**
  * Strengthened validation to ensure payload layouts match runtime settings.
* **Tests**
  * Updated NVFP4 payload generation and expanded phased H2048 coverage across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->